### PR TITLE
8256379: Replace SIZE_FORMAT with 'z' length modifier

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/x/xGlobals_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/x/xGlobals_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ static size_t probe_valid_max_address_bit() {
       munmap(result_addr, page_size);
     }
   }
-  log_info_p(gc, init)("Probing address space for the highest valid bit: " SIZE_FORMAT, max_address_bit);
+  log_info_p(gc, init)("Probing address space for the highest valid bit: %zu", max_address_bit);
   return MAX2(max_address_bit, MINIMUM_MAX_ADDRESS_BIT);
 #else // LINUX
   return DEFAULT_MAX_ADDRESS_BIT;

--- a/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
@@ -83,7 +83,7 @@ static size_t probe_valid_max_address_bit() {
       munmap(result_addr, page_size);
     }
   }
-  log_info_p(gc, init)("Probing address space for the highest valid bit: " SIZE_FORMAT, max_address_bit);
+  log_info_p(gc, init)("Probing address space for the highest valid bit: %zu", max_address_bit);
   return MAX2(max_address_bit, MINIMUM_MAX_ADDRESS_BIT);
 #else // LINUX
   return DEFAULT_MAX_ADDRESS_BIT;

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -287,7 +287,7 @@ void MachPrologNode::format( PhaseRegAlloc *ra_, outputStream *st ) const {
   }
   st->print_cr("PUSH   R_FP|R_LR_LR"); st->print("\t");
   if (framesize != 0) {
-    st->print   ("SUB    R_SP, R_SP, " SIZE_FORMAT,framesize);
+    st->print   ("SUB    R_SP, R_SP, %zu",framesize);
   }
 
   if (C->stub_function() == NULL && BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
@@ -367,7 +367,7 @@ void MachEpilogNode::format( PhaseRegAlloc *ra_, outputStream *st ) const {
   framesize -= 2*wordSize;
 
   if (framesize != 0) {
-    st->print("ADD    R_SP, R_SP, " SIZE_FORMAT "\n\t",framesize);
+    st->print("ADD    R_SP, R_SP, %zu\n\t",framesize);
   }
   st->print("POP    R_FP|R_LR_LR");
 

--- a/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zAddress_ppc.cpp
@@ -82,7 +82,7 @@ static size_t probe_valid_max_address_bit() {
       munmap(result_addr, page_size);
     }
   }
-  log_info_p(gc, init)("Probing address space for the highest valid bit: " SIZE_FORMAT, max_address_bit);
+  log_info_p(gc, init)("Probing address space for the highest valid bit: %zu", max_address_bit);
   return MAX2(max_address_bit, MINIMUM_MAX_ADDRESS_BIT);
 #else // LINUX
   return DEFAULT_MAX_ADDRESS_BIT;

--- a/src/hotspot/cpu/riscv/gc/x/xGlobals_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/x/xGlobals_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -191,7 +191,7 @@ static size_t probe_valid_max_address_bit() {
       munmap(result_addr, page_size);
     }
   }
-  log_info_p(gc, init)("Probing address space for the highest valid bit: " SIZE_FORMAT, max_address_bit);
+  log_info_p(gc, init)("Probing address space for the highest valid bit: %zu", max_address_bit);
   return MAX2(max_address_bit, MINIMUM_MAX_ADDRESS_BIT);
 #else // LINUX
   return DEFAULT_MAX_ADDRESS_BIT;

--- a/src/hotspot/cpu/riscv/gc/z/zAddress_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zAddress_riscv.cpp
@@ -84,7 +84,7 @@ static size_t probe_valid_max_address_bit() {
       munmap(result_addr, page_size);
     }
   }
-  log_info_p(gc, init)("Probing address space for the highest valid bit: " SIZE_FORMAT, max_address_bit);
+  log_info_p(gc, init)("Probing address space for the highest valid bit: %zu", max_address_bit);
   return MAX2(max_address_bit, MINIMUM_MAX_ADDRESS_BIT);
 #else // LINUX
   return DEFAULT_MAX_ADDRESS_BIT;

--- a/src/hotspot/cpu/s390/macroAssembler_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.inline.hpp
@@ -75,7 +75,7 @@ inline void MacroAssembler::load_address(Register d, const Address &a) {
   } else if (Displacement::is_validDisp(a.disp())) {
     z_lay(d, a.disp(), a.indexOrR0(), a.baseOrR0());
   } else {
-    guarantee(false, "displacement = " SIZE_FORMAT_X ", out of range for LA/LAY", a.disp());
+    guarantee(false, "displacement = 0x%zx, out of range for LA/LAY", a.disp());
   }
 }
 

--- a/src/hotspot/cpu/x86/gc/z/zAddress_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/gc/z/zAddress_x86.inline.hpp
@@ -32,7 +32,7 @@ inline uintptr_t ZPointer::remap_bits(uintptr_t colored) {
 
 inline constexpr int ZPointer::load_shift_lookup(uintptr_t value) {
   const size_t index = load_shift_lookup_index(value);
-  assert(index == 0 || is_power_of_2(index), "Incorrect load shift: " SIZE_FORMAT, index);
+  assert(index == 0 || is_power_of_2(index), "Incorrect load shift: %zu", index);
   return ZPointerLoadShiftTable[index];
 }
 

--- a/src/hotspot/os/aix/loadlib_aix.cpp
+++ b/src/hotspot/os/aix/loadlib_aix.cpp
@@ -202,7 +202,7 @@ static bool reload_table() {
     }
   }
 
-  trcVerbose("loadquery buffer size is " SIZE_FORMAT ".", buflen);
+  trcVerbose("loadquery buffer size is %zu.", buflen);
 
   // Iterate over the loadquery result. For details see sys/ldr.h on AIX.
   ldi = (struct ld_info*) buffer;
@@ -259,7 +259,7 @@ static bool reload_table() {
       lm->is_in_vm = true;
     }
 
-    trcVerbose("entry: %p " SIZE_FORMAT ", %p " SIZE_FORMAT ", %s %s %s, %d",
+    trcVerbose("entry: %p %zu, %p %zu, %s %s %s, %d",
       lm->text, lm->text_len,
       lm->data, lm->data_len,
       lm->path, lm->shortname,

--- a/src/hotspot/os/bsd/gc/x/xPhysicalMemoryBacking_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/x/xPhysicalMemoryBacking_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@ bool XPhysicalMemoryBacking::commit_inner(size_t offset, size_t length) const {
   assert(is_aligned(offset, os::vm_page_size()), "Invalid offset");
   assert(is_aligned(length, os::vm_page_size()), "Invalid length");
 
-  log_trace(gc, heap)("Committing memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Committing memory: %zuM-%zuM (%zuM)",
                       offset / M, (offset + length) / M, length / M);
 
   const uintptr_t addr = _base + offset;
@@ -148,7 +148,7 @@ size_t XPhysicalMemoryBacking::uncommit(size_t offset, size_t length) const {
   assert(is_aligned(offset, os::vm_page_size()), "Invalid offset");
   assert(is_aligned(length, os::vm_page_size()), "Invalid length");
 
-  log_trace(gc, heap)("Uncommitting memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Uncommitting memory: %zuM-%zuM (%zuM)",
                       offset / M, (offset + length) / M, length / M);
 
   const uintptr_t start = _base + offset;

--- a/src/hotspot/os/bsd/gc/z/zPhysicalMemoryBacking_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zPhysicalMemoryBacking_bsd.cpp
@@ -102,7 +102,7 @@ bool ZPhysicalMemoryBacking::commit_inner(zoffset offset, size_t length) const {
   assert(is_aligned(untype(offset), os::vm_page_size()), "Invalid offset");
   assert(is_aligned(length, os::vm_page_size()), "Invalid length");
 
-  log_trace(gc, heap)("Committing memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Committing memory: %zuM-%zuM (%zuM)",
                       untype(offset) / M, untype(offset) + length / M, length / M);
 
   const uintptr_t addr = _base + untype(offset);
@@ -149,7 +149,7 @@ size_t ZPhysicalMemoryBacking::uncommit(zoffset offset, size_t length) const {
   assert(is_aligned(untype(offset), os::vm_page_size()), "Invalid offset");
   assert(is_aligned(length, os::vm_page_size()), "Invalid length");
 
-  log_trace(gc, heap)("Uncommitting memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Uncommitting memory: %zuM-%zuM (%zuM)",
                       untype(offset) / M, untype(offset) + length / M, length / M);
 
   const uintptr_t start = _base + untype(offset);

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -716,7 +716,7 @@ bool os::create_attached_thread(JavaThread* thread) {
   PosixSignals::hotspot_sigmask(thread);
 
   log_info(os, thread)("Thread attached (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT
-                       ", stack: " PTR_FORMAT " - " PTR_FORMAT " (" SIZE_FORMAT "K) ).",
+                       ", stack: " PTR_FORMAT " - " PTR_FORMAT " (%zuK) ).",
                        os::current_thread_id(), (uintx) pthread_self(),
                        p2i(thread->stack_base()), p2i(thread->stack_end()), thread->stack_size() / K);
   return true;
@@ -1379,7 +1379,7 @@ void os::print_memory_info(outputStream* st) {
   size_t size = sizeof(swap_usage);
 
   st->print("Memory:");
-  st->print(" " SIZE_FORMAT "k page", os::vm_page_size()>>10);
+  st->print(" %zuk page", os::vm_page_size()>>10);
 
   st->print(", physical " UINT64_FORMAT "k",
             os::physical_memory() >> 10);
@@ -1506,7 +1506,7 @@ void os::jvm_path(char *buf, jint buflen) {
 
 static void warn_fail_commit_memory(char* addr, size_t size, bool exec,
                                     int err) {
-  warning("INFO: os::commit_memory(" INTPTR_FORMAT ", " SIZE_FORMAT
+  warning("INFO: os::commit_memory(" INTPTR_FORMAT ", %zu"
           ", %d) failed; error='%s' (errno=%d)", (intptr_t)addr, size, exec,
            os::errno_name(err), err);
 }

--- a/src/hotspot/os/linux/gc/x/xPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/x/xPhysicalMemoryBacking_linux.cpp
@@ -338,7 +338,7 @@ void XPhysicalMemoryBacking::warn_max_map_count(size_t max_capacity) const {
   }
 
   size_t actual_max_map_count = 0;
-  const int result = fscanf(file, SIZE_FORMAT, &actual_max_map_count);
+  const int result = fscanf(file, "%zu", &actual_max_map_count);
   fclose(file);
   if (result != 1) {
     // Failed to read file, skip check

--- a/src/hotspot/os/linux/gc/x/xPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/x/xPhysicalMemoryBacking_linux.cpp
@@ -181,13 +181,13 @@ XPhysicalMemoryBacking::XPhysicalMemoryBacking(size_t max_capacity) :
 
   // Make sure the filesystem block size is compatible
   if (XGranuleSize % _block_size != 0) {
-    log_error_p(gc)("Filesystem backing the heap has incompatible block size (" SIZE_FORMAT ")",
+    log_error_p(gc)("Filesystem backing the heap has incompatible block size (%zu)",
                     _block_size);
     return;
   }
 
   if (is_hugetlbfs() && _block_size != XGranuleSize) {
-    log_error_p(gc)("%s filesystem has unexpected block size " SIZE_FORMAT " (expected " SIZE_FORMAT ")",
+    log_error_p(gc)("%s filesystem has unexpected block size %zu (expected %zu)",
                     XFILESYSTEM_HUGETLBFS, _block_size, XGranuleSize);
     return;
   }
@@ -312,7 +312,7 @@ void XPhysicalMemoryBacking::warn_available_space(size_t max_capacity) const {
     return;
   }
 
-  log_info_p(gc, init)("Available space on backing filesystem: " SIZE_FORMAT "M", _available / M);
+  log_info_p(gc, init)("Available space on backing filesystem: %zuM", _available / M);
 
   // Warn if the filesystem doesn't currently have enough space available to hold
   // the max heap size. The max heap size will be capped if we later hit this limit
@@ -320,9 +320,9 @@ void XPhysicalMemoryBacking::warn_available_space(size_t max_capacity) const {
   if (_available < max_capacity) {
     log_warning_p(gc)("***** WARNING! INCORRECT SYSTEM CONFIGURATION DETECTED! *****");
     log_warning_p(gc)("Not enough space available on the backing filesystem to hold the current max Java heap");
-    log_warning_p(gc)("size (" SIZE_FORMAT "M). Please adjust the size of the backing filesystem accordingly "
+    log_warning_p(gc)("size (%zuM). Please adjust the size of the backing filesystem accordingly "
                       "(available", max_capacity / M);
-    log_warning_p(gc)("space is currently " SIZE_FORMAT "M). Continuing execution with the current filesystem "
+    log_warning_p(gc)("space is currently %zuM). Continuing execution with the current filesystem "
                       "size could", _available / M);
     log_warning_p(gc)("lead to a premature OutOfMemoryError being thrown, due to failure to commit memory.");
   }
@@ -355,9 +355,9 @@ void XPhysicalMemoryBacking::warn_max_map_count(size_t max_capacity) const {
   if (actual_max_map_count < required_max_map_count) {
     log_warning_p(gc)("***** WARNING! INCORRECT SYSTEM CONFIGURATION DETECTED! *****");
     log_warning_p(gc)("The system limit on number of memory mappings per process might be too low for the given");
-    log_warning_p(gc)("max Java heap size (" SIZE_FORMAT "M). Please adjust %s to allow for at",
+    log_warning_p(gc)("max Java heap size (%zuM). Please adjust %s to allow for at",
                       max_capacity / M, filename);
-    log_warning_p(gc)("least " SIZE_FORMAT " mappings (current limit is " SIZE_FORMAT "). Continuing execution "
+    log_warning_p(gc)("least %zu mappings (current limit is %zu). Continuing execution "
                       "with the current", required_max_map_count, actual_max_map_count);
     log_warning_p(gc)("limit could lead to a premature OutOfMemoryError being thrown, due to failure to map memory.");
   }
@@ -592,7 +592,7 @@ XErrno XPhysicalMemoryBacking::fallocate(bool punch_hole, size_t offset, size_t 
 }
 
 bool XPhysicalMemoryBacking::commit_inner(size_t offset, size_t length) const {
-  log_trace(gc, heap)("Committing memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Committing memory: %zuM-%zuM (%zuM)",
                       offset / M, (offset + length) / M, length / M);
 
 retry:
@@ -692,7 +692,7 @@ size_t XPhysicalMemoryBacking::commit(size_t offset, size_t length) const {
 }
 
 size_t XPhysicalMemoryBacking::uncommit(size_t offset, size_t length) const {
-  log_trace(gc, heap)("Uncommitting memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Uncommitting memory: %zuM-%zuM (%zuM)",
                       offset / M, (offset + length) / M, length / M);
 
   const XErrno err = fallocate(true /* punch_hole */, offset, length);

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -339,7 +339,7 @@ void ZPhysicalMemoryBacking::warn_max_map_count(size_t max_capacity) const {
   }
 
   size_t actual_max_map_count = 0;
-  const int result = fscanf(file, SIZE_FORMAT, &actual_max_map_count);
+  const int result = fscanf(file, "%zu", &actual_max_map_count);
   fclose(file);
   if (result != 1) {
     // Failed to read file, skip check

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -182,13 +182,13 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity)
 
   // Make sure the filesystem block size is compatible
   if (ZGranuleSize % _block_size != 0) {
-    log_error_p(gc)("Filesystem backing the heap has incompatible block size (" SIZE_FORMAT ")",
+    log_error_p(gc)("Filesystem backing the heap has incompatible block size (%zu)",
                     _block_size);
     return;
   }
 
   if (is_hugetlbfs() && _block_size != ZGranuleSize) {
-    log_error_p(gc)("%s filesystem has unexpected block size " SIZE_FORMAT " (expected " SIZE_FORMAT ")",
+    log_error_p(gc)("%s filesystem has unexpected block size %zu (expected %zu)",
                     ZFILESYSTEM_HUGETLBFS, _block_size, ZGranuleSize);
     return;
   }
@@ -313,7 +313,7 @@ void ZPhysicalMemoryBacking::warn_available_space(size_t max_capacity) const {
     return;
   }
 
-  log_info_p(gc, init)("Available space on backing filesystem: " SIZE_FORMAT "M", _available / M);
+  log_info_p(gc, init)("Available space on backing filesystem: %zuM", _available / M);
 
   // Warn if the filesystem doesn't currently have enough space available to hold
   // the max heap size. The max heap size will be capped if we later hit this limit
@@ -321,9 +321,9 @@ void ZPhysicalMemoryBacking::warn_available_space(size_t max_capacity) const {
   if (_available < max_capacity) {
     log_warning_p(gc)("***** WARNING! INCORRECT SYSTEM CONFIGURATION DETECTED! *****");
     log_warning_p(gc)("Not enough space available on the backing filesystem to hold the current max Java heap");
-    log_warning_p(gc)("size (" SIZE_FORMAT "M). Please adjust the size of the backing filesystem accordingly "
+    log_warning_p(gc)("size (%zuM). Please adjust the size of the backing filesystem accordingly "
                       "(available", max_capacity / M);
-    log_warning_p(gc)("space is currently " SIZE_FORMAT "M). Continuing execution with the current filesystem "
+    log_warning_p(gc)("space is currently %zuM). Continuing execution with the current filesystem "
                       "size could", _available / M);
     log_warning_p(gc)("lead to a premature OutOfMemoryError being thrown, due to failure to commit memory.");
   }
@@ -356,9 +356,9 @@ void ZPhysicalMemoryBacking::warn_max_map_count(size_t max_capacity) const {
   if (actual_max_map_count < required_max_map_count) {
     log_warning_p(gc)("***** WARNING! INCORRECT SYSTEM CONFIGURATION DETECTED! *****");
     log_warning_p(gc)("The system limit on number of memory mappings per process might be too low for the given");
-    log_warning_p(gc)("max Java heap size (" SIZE_FORMAT "M). Please adjust %s to allow for at",
+    log_warning_p(gc)("max Java heap size (%zuM). Please adjust %s to allow for at",
                       max_capacity / M, filename);
-    log_warning_p(gc)("least " SIZE_FORMAT " mappings (current limit is " SIZE_FORMAT "). Continuing execution "
+    log_warning_p(gc)("least %zu mappings (current limit is %zu). Continuing execution "
                       "with the current", required_max_map_count, actual_max_map_count);
     log_warning_p(gc)("limit could lead to a premature OutOfMemoryError being thrown, due to failure to map memory.");
   }
@@ -593,7 +593,7 @@ ZErrno ZPhysicalMemoryBacking::fallocate(bool punch_hole, zoffset offset, size_t
 }
 
 bool ZPhysicalMemoryBacking::commit_inner(zoffset offset, size_t length) const {
-  log_trace(gc, heap)("Committing memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Committing memory: %zuM-%zuM (%zuM)",
                       untype(offset) / M, untype(offset + length) / M, length / M);
 
 retry:
@@ -693,7 +693,7 @@ size_t ZPhysicalMemoryBacking::commit(zoffset offset, size_t length) const {
 }
 
 size_t ZPhysicalMemoryBacking::uncommit(zoffset offset, size_t length) const {
-  log_trace(gc, heap)("Uncommitting memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Uncommitting memory: %zuM-%zuM (%zuM)",
                       untype(offset) / M, untype(offset + length) / M, length / M);
 
   const ZErrno err = fallocate(true /* punch_hole */, offset, length);

--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -95,7 +95,7 @@ static bool read_number_file(const char* file, size_t* out) {
   bool rc = false;
   if (f != nullptr) {
     uint64_t i = 0;
-    if (::fscanf(f, SIZE_FORMAT, out) == 1) {
+    if (::fscanf(f, "%zu", out) == 1) {
       rc = true;
     }
     ::fclose(f);

--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -155,7 +155,7 @@ void StaticHugePageSupport::scan_os() {
     // that only exposes /proc/meminfo but not /sys/kernel/mm/hugepages. In that case, we are not
     // sure about the state of hugepage support by the kernel, so we won't use static hugepages.
     if (!_pagesizes.contains(_default_hugepage_size)) {
-      log_info(pagesize)("Unexpected configuration: default pagesize (" SIZE_FORMAT ") "
+      log_info(pagesize)("Unexpected configuration: default pagesize (%zu) "
                          "has no associated directory in /sys/kernel/mm/hugepages..", _default_hugepage_size);
       _inconsistent = true;
     }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1384,7 +1384,7 @@ void os::Linux::capture_initial_stack(size_t max_size) {
                       uintptr_t(&rlim) < stack_top;
 
     log_info(os, thread)("Capturing initial stack in %s thread: req. size: %zuK, actual size: "
-                         SIZE_FORMAT "K, top=" INTPTR_FORMAT ", bottom=" INTPTR_FORMAT,
+                         "%zuK, top=" INTPTR_FORMAT ", bottom=" INTPTR_FORMAT,
                          primordial ? "primordial" : "user", max_size / K,  _initial_thread_stack_size / K,
                          stack_top, intptr_t(_initial_thread_stack_bottom));
   }
@@ -4032,7 +4032,7 @@ bool os::Linux::commit_memory_special(size_t bytes,
   }
 
   log_debug(pagesize)("Commit special mapping: " PTR_FORMAT ", size=%zu%s, page size="
-                      SIZE_FORMAT "%s",
+                      "%zu%s",
                       p2i(addr), byte_size_in_exact_unit(bytes),
                       exact_unit_for_byte_size(bytes),
                       byte_size_in_exact_unit(page_size),

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -899,7 +899,7 @@ char* os::Posix::describe_pthread_attr(char* buf, size_t buflen, const pthread_a
   // Work around glibc stack guard issue, see os::create_thread() in os_linux.cpp.
   LINUX_ONLY(if (os::Linux::adjustStackSizeForGuardPages()) stack_size -= guard_size;)
   pthread_attr_getdetachstate(attr, &detachstate);
-  jio_snprintf(buf, buflen, "stacksize: " SIZE_FORMAT "k, guardsize: " SIZE_FORMAT "k, %s",
+  jio_snprintf(buf, buflen, "stacksize: %zuk, guardsize: %zuk, %s",
     stack_size / K, guard_size / K,
     (detachstate == PTHREAD_CREATE_DETACHED ? "detached" : "joinable"));
   return buf;

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1096,7 +1096,7 @@ static void unmap_shared(char* addr, size_t bytes) {
     res = ::munmap(addr, bytes);
   }
   if (res != 0) {
-    log_info(os)("os::release_memory failed (" PTR_FORMAT ", " SIZE_FORMAT ")", p2i(addr), bytes);
+    log_info(os)("os::release_memory failed (" PTR_FORMAT ", %zu)", p2i(addr), bytes);
   }
 }
 
@@ -1228,7 +1228,7 @@ static void mmap_attach_shared(int vmid, char** addr, size_t* sizep, TRAPS) {
   *addr = mapAddress;
   *sizep = size;
 
-  log_debug(perf, memops)("mapped " SIZE_FORMAT " bytes for vmid %d at "
+  log_debug(perf, memops)("mapped %zu bytes for vmid %d at "
                           INTPTR_FORMAT, size, vmid, p2i((void*)mapAddress));
 }
 

--- a/src/hotspot/os/windows/gc/x/xMapper_windows.cpp
+++ b/src/hotspot/os/windows/gc/x/xMapper_windows.cpp
@@ -56,7 +56,7 @@
 // they will be split before being used.
 
 #define fatal_error(msg, addr, size)                  \
-  fatal(msg ": " PTR_FORMAT " " SIZE_FORMAT "M (%d)", \
+  fatal(msg ": " PTR_FORMAT " %zuM (%d)", \
         (addr), (size) / M, GetLastError())
 
 uintptr_t XMapper::reserve(uintptr_t addr, size_t size) {
@@ -250,7 +250,7 @@ void XMapper::unreserve_for_shared_awe(uintptr_t addr, size_t size) {
     );
 
   if (!res) {
-    fatal("Failed to unreserve memory: " PTR_FORMAT " " SIZE_FORMAT "M (%d)",
+    fatal("Failed to unreserve memory: " PTR_FORMAT " %zuM (%d)",
           addr, size / M, GetLastError());
   }
 }

--- a/src/hotspot/os/windows/gc/x/xPhysicalMemoryBacking_windows.cpp
+++ b/src/hotspot/os/windows/gc/x/xPhysicalMemoryBacking_windows.cpp
@@ -156,10 +156,10 @@ public:
     size_t npages_res = npages;
     const bool res = AllocateUserPhysicalPages(XAWESection, &npages_res, &_page_array[index]);
     if (!res) {
-      fatal("Failed to allocate physical memory " SIZE_FORMAT "M @ " PTR_FORMAT " (%d)",
+      fatal("Failed to allocate physical memory %zuM @ " PTR_FORMAT " (%d)",
             size / M, offset, GetLastError());
     } else {
-      log_debug(gc)("Allocated physical memory: " SIZE_FORMAT "M @ " PTR_FORMAT, size / M, offset);
+      log_debug(gc)("Allocated physical memory: %zuM @ " PTR_FORMAT, size / M, offset);
     }
 
     // AllocateUserPhysicalPages might not be able to allocate the requested amount of memory.
@@ -174,7 +174,7 @@ public:
     size_t npages_res = npages;
     const bool res = FreeUserPhysicalPages(XAWESection, &npages_res, &_page_array[index]);
     if (!res) {
-      fatal("Failed to uncommit physical memory " SIZE_FORMAT "M @ " PTR_FORMAT " (%d)",
+      fatal("Failed to uncommit physical memory %zuM @ " PTR_FORMAT " (%d)",
             size, offset, GetLastError());
     }
 
@@ -187,7 +187,7 @@ public:
 
     const bool res = MapUserPhysicalPages((char*)addr, npages, &_page_array[index]);
     if (!res) {
-      fatal("Failed to map view " PTR_FORMAT " " SIZE_FORMAT "M @ " PTR_FORMAT " (%d)",
+      fatal("Failed to map view " PTR_FORMAT " %zuM @ " PTR_FORMAT " (%d)",
             addr, size / M, offset, GetLastError());
     }
   }
@@ -197,7 +197,7 @@ public:
 
     const bool res = MapUserPhysicalPages((char*)addr, npages, nullptr);
     if (!res) {
-      fatal("Failed to unmap view " PTR_FORMAT " " SIZE_FORMAT "M (%d)",
+      fatal("Failed to unmap view " PTR_FORMAT " %zuM (%d)",
             addr, size / M, GetLastError());
     }
   }
@@ -223,14 +223,14 @@ void XPhysicalMemoryBacking::warn_commit_limits(size_t max_capacity) const {
 }
 
 size_t XPhysicalMemoryBacking::commit(size_t offset, size_t length) {
-  log_trace(gc, heap)("Committing memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Committing memory: %zuM-%zuM (%zuM)",
                       offset / M, (offset + length) / M, length / M);
 
   return _impl->commit(offset, length);
 }
 
 size_t XPhysicalMemoryBacking::uncommit(size_t offset, size_t length) {
-  log_trace(gc, heap)("Uncommitting memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Uncommitting memory: %zuM-%zuM (%zuM)",
                       offset / M, (offset + length) / M, length / M);
 
   return _impl->uncommit(offset, length);

--- a/src/hotspot/os/windows/gc/z/zMapper_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zMapper_windows.cpp
@@ -57,7 +57,7 @@
 // they will be split before being used.
 
 #define fatal_error(msg, addr, size)                  \
-  fatal(msg ": " PTR_FORMAT " " SIZE_FORMAT "M (%d)", \
+  fatal(msg ": " PTR_FORMAT " %zuM (%d)", \
         (addr), (size) / M, GetLastError())
 
 zaddress_unsafe ZMapper::reserve(zaddress_unsafe addr, size_t size) {
@@ -251,7 +251,7 @@ void ZMapper::unreserve_for_shared_awe(zaddress_unsafe addr, size_t size) {
     );
 
   if (!res) {
-    fatal("Failed to unreserve memory: " PTR_FORMAT " " SIZE_FORMAT "M (%d)",
+    fatal("Failed to unreserve memory: " PTR_FORMAT " %zuM (%d)",
           untype(addr), size / M, GetLastError());
   }
 }

--- a/src/hotspot/os/windows/gc/z/zPhysicalMemoryBacking_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zPhysicalMemoryBacking_windows.cpp
@@ -157,10 +157,10 @@ public:
     size_t npages_res = npages;
     const bool res = AllocateUserPhysicalPages(ZAWESection, &npages_res, &_page_array[index]);
     if (!res) {
-      fatal("Failed to allocate physical memory " SIZE_FORMAT "M @ " PTR_FORMAT " (%d)",
+      fatal("Failed to allocate physical memory %zuM @ " PTR_FORMAT " (%d)",
             size / M, untype(offset), GetLastError());
     } else {
-      log_debug(gc)("Allocated physical memory: " SIZE_FORMAT "M @ " PTR_FORMAT, size / M, untype(offset));
+      log_debug(gc)("Allocated physical memory: %zuM @ " PTR_FORMAT, size / M, untype(offset));
     }
 
     // AllocateUserPhysicalPages might not be able to allocate the requested amount of memory.
@@ -175,7 +175,7 @@ public:
     size_t npages_res = npages;
     const bool res = FreeUserPhysicalPages(ZAWESection, &npages_res, &_page_array[index]);
     if (!res) {
-      fatal("Failed to uncommit physical memory " SIZE_FORMAT "M @ " PTR_FORMAT " (%d)",
+      fatal("Failed to uncommit physical memory %zuM @ " PTR_FORMAT " (%d)",
             size, untype(offset), GetLastError());
     }
 
@@ -188,7 +188,7 @@ public:
 
     const bool res = MapUserPhysicalPages((char*)untype(addr), npages, &_page_array[index]);
     if (!res) {
-      fatal("Failed to map view " PTR_FORMAT " " SIZE_FORMAT "M @ " PTR_FORMAT " (%d)",
+      fatal("Failed to map view " PTR_FORMAT " %zuM @ " PTR_FORMAT " (%d)",
             untype(addr), size / M, untype(offset), GetLastError());
     }
   }
@@ -198,7 +198,7 @@ public:
 
     const bool res = MapUserPhysicalPages((char*)untype(addr), npages, nullptr);
     if (!res) {
-      fatal("Failed to unmap view " PTR_FORMAT " " SIZE_FORMAT "M (%d)",
+      fatal("Failed to unmap view " PTR_FORMAT " %zuM (%d)",
             addr, size / M, GetLastError());
     }
   }
@@ -224,14 +224,14 @@ void ZPhysicalMemoryBacking::warn_commit_limits(size_t max_capacity) const {
 }
 
 size_t ZPhysicalMemoryBacking::commit(zoffset offset, size_t length) {
-  log_trace(gc, heap)("Committing memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Committing memory: %zuM-%zuM (%zuM)",
                       untype(offset) / M, (untype(offset) + length) / M, length / M);
 
   return _impl->commit(offset, length);
 }
 
 size_t ZPhysicalMemoryBacking::uncommit(zoffset offset, size_t length) {
-  log_trace(gc, heap)("Uncommitting memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
+  log_trace(gc, heap)("Uncommitting memory: %zuM-%zuM (%zuM)",
                       untype(offset) / M, (untype(offset) + length) / M, length / M);
 
   return _impl->uncommit(offset, length);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -195,12 +195,12 @@ struct PreserveLastError {
 static LPVOID virtualAlloc(LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect) {
   LPVOID result = ::VirtualAlloc(lpAddress, dwSize, flAllocationType, flProtect);
   if (result != nullptr) {
-    log_trace(os)("VirtualAlloc(" PTR_FORMAT ", " SIZE_FORMAT ", %x, %x) returned " PTR_FORMAT "%s.",
+    log_trace(os)("VirtualAlloc(" PTR_FORMAT ", %zu, %x, %x) returned " PTR_FORMAT "%s.",
                   p2i(lpAddress), dwSize, flAllocationType, flProtect, p2i(result),
                   ((lpAddress != nullptr && result != lpAddress) ? " <different base!>" : ""));
   } else {
     PreserveLastError ple;
-    log_info(os)("VirtualAlloc(" PTR_FORMAT ", " SIZE_FORMAT ", %x, %x) failed (%u).",
+    log_info(os)("VirtualAlloc(" PTR_FORMAT ", %zu, %x, %x) failed (%u).",
                   p2i(lpAddress), dwSize, flAllocationType, flProtect, ple.v);
   }
   return result;
@@ -210,11 +210,11 @@ static LPVOID virtualAlloc(LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationTy
 static BOOL virtualFree(LPVOID lpAddress, SIZE_T dwSize, DWORD  dwFreeType) {
   BOOL result = ::VirtualFree(lpAddress, dwSize, dwFreeType);
   if (result != FALSE) {
-    log_trace(os)("VirtualFree(" PTR_FORMAT ", " SIZE_FORMAT ", %x) succeeded",
+    log_trace(os)("VirtualFree(" PTR_FORMAT ", %zu, %x) succeeded",
                   p2i(lpAddress), dwSize, dwFreeType);
   } else {
     PreserveLastError ple;
-    log_info(os)("VirtualFree(" PTR_FORMAT ", " SIZE_FORMAT ", %x) failed (%u).",
+    log_info(os)("VirtualFree(" PTR_FORMAT ", %zu, %x) failed (%u).",
                  p2i(lpAddress), dwSize, dwFreeType, ple.v);
   }
   return result;
@@ -225,12 +225,12 @@ static LPVOID virtualAllocExNuma(HANDLE hProcess, LPVOID lpAddress, SIZE_T dwSiz
                                  DWORD  flProtect, DWORD  nndPreferred) {
   LPVOID result = ::VirtualAllocExNuma(hProcess, lpAddress, dwSize, flAllocationType, flProtect, nndPreferred);
   if (result != nullptr) {
-    log_trace(os)("VirtualAllocExNuma(" PTR_FORMAT ", " SIZE_FORMAT ", %x, %x, %x) returned " PTR_FORMAT "%s.",
+    log_trace(os)("VirtualAllocExNuma(" PTR_FORMAT ", %zu, %x, %x, %x) returned " PTR_FORMAT "%s.",
                   p2i(lpAddress), dwSize, flAllocationType, flProtect, nndPreferred, p2i(result),
                   ((lpAddress != nullptr && result != lpAddress) ? " <different base!>" : ""));
   } else {
     PreserveLastError ple;
-    log_info(os)("VirtualAllocExNuma(" PTR_FORMAT ", " SIZE_FORMAT ", %x, %x, %x) failed (%u).",
+    log_info(os)("VirtualAllocExNuma(" PTR_FORMAT ", %zu, %x, %x, %x) failed (%u).",
                  p2i(lpAddress), dwSize, flAllocationType, flProtect, nndPreferred, ple.v);
   }
   return result;
@@ -242,12 +242,12 @@ static LPVOID mapViewOfFileEx(HANDLE hFileMappingObject, DWORD  dwDesiredAccess,
   LPVOID result = ::MapViewOfFileEx(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh,
                                     dwFileOffsetLow, dwNumberOfBytesToMap, lpBaseAddress);
   if (result != nullptr) {
-    log_trace(os)("MapViewOfFileEx(" PTR_FORMAT ", " SIZE_FORMAT ") returned " PTR_FORMAT "%s.",
+    log_trace(os)("MapViewOfFileEx(" PTR_FORMAT ", %zu) returned " PTR_FORMAT "%s.",
                   p2i(lpBaseAddress), dwNumberOfBytesToMap, p2i(result),
                   ((lpBaseAddress != nullptr && result != lpBaseAddress) ? " <different base!>" : ""));
   } else {
     PreserveLastError ple;
-    log_info(os)("MapViewOfFileEx(" PTR_FORMAT ", " SIZE_FORMAT ") failed (%u).",
+    log_info(os)("MapViewOfFileEx(" PTR_FORMAT ", %zu) failed (%u).",
                  p2i(lpBaseAddress), dwNumberOfBytesToMap, ple.v);
   }
   return result;
@@ -539,7 +539,7 @@ unsigned __stdcall os::win32::thread_native_entry(void* t) {
     res = 20115;    // java thread
   }
 
-  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", stacksize: " SIZE_FORMAT "k).", os::current_thread_id(), thread->stack_size() / K);
+  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", stacksize: %zuk).", os::current_thread_id(), thread->stack_size() / K);
 
 #ifdef USE_VECTORED_EXCEPTION_HANDLING
   // Any exception is caught by the Vectored Exception Handler, so VM can
@@ -624,7 +624,7 @@ bool os::create_attached_thread(JavaThread* thread) {
   thread->set_osthread(osthread);
 
   log_info(os, thread)("Thread attached (tid: " UINTX_FORMAT ", stack: "
-                       PTR_FORMAT " - " PTR_FORMAT " (" SIZE_FORMAT "K) ).",
+                       PTR_FORMAT " - " PTR_FORMAT " (%zuK) ).",
                        os::current_thread_id(), p2i(thread->stack_base()),
                        p2i(thread->stack_end()), thread->stack_size() / K);
 
@@ -657,7 +657,7 @@ static char* describe_beginthreadex_attributes(char* buf, size_t buflen,
   if (stacksize == 0) {
     ss.print("stacksize: default, ");
   } else {
-    ss.print("stacksize: " SIZE_FORMAT "k, ", stacksize / K);
+    ss.print("stacksize: %zuk, ", stacksize / K);
   }
   ss.print("flags: ");
   #define PRINT_FLAG(f) if (initflag & f) ss.print( #f " ");
@@ -1968,7 +1968,7 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
 
 void os::print_memory_info(outputStream* st) {
   st->print("Memory:");
-  st->print(" " SIZE_FORMAT "k page", os::vm_page_size()>>10);
+  st->print(" %zuk page", os::vm_page_size()>>10);
 
   // Use GlobalMemoryStatusEx() because GlobalMemoryStatus() may return incorrect
   // value if total memory is larger than 4GB
@@ -3462,7 +3462,7 @@ static char* find_aligned_address(size_t size, size_t alignment) {
 }
 
 static char* reserve_large_pages_aligned(size_t size, size_t alignment, bool exec) {
-  log_debug(pagesize)("Reserving large pages at an aligned address, alignment=" SIZE_FORMAT "%s",
+  log_debug(pagesize)("Reserving large pages at an aligned address, alignment=%zu%s",
                       byte_size_in_exact_unit(alignment), exact_unit_for_byte_size(alignment));
 
   // Will try to find a suitable address at most 20 times. The reason we need to try
@@ -3519,7 +3519,7 @@ static void warn_fail_commit_memory(char* addr, size_t bytes, bool exec) {
   int err = os::get_last_error();
   char buf[256];
   size_t buf_len = os::lasterror(buf, sizeof(buf));
-  warning("INFO: os::commit_memory(" PTR_FORMAT ", " SIZE_FORMAT
+  warning("INFO: os::commit_memory(" PTR_FORMAT ", %zu"
           ", %d) failed; error='%s' (DOS error/errno=%d)", addr, bytes,
           exec, buf_len != 0 ? buf : "<no_error_string>", err);
 }
@@ -3749,7 +3749,7 @@ bool os::protect_memory(char* addr, size_t bytes, ProtType prot,
     int err = os::get_last_error();
     char buf[256];
     size_t buf_len = os::lasterror(buf, sizeof(buf));
-    warning("INFO: os::protect_memory(" PTR_FORMAT ", " SIZE_FORMAT
+    warning("INFO: os::protect_memory(" PTR_FORMAT ", %zu"
           ") failed; error='%s' (DOS error/errno=%d)", addr, bytes,
           buf_len != 0 ? buf : "<no_error_string>", err);
   }

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1561,7 +1561,7 @@ static size_t sharedmem_filesize(const char* filename, TRAPS) {
 
   if ((statbuf.st_size == 0) || (statbuf.st_size % os::vm_page_size() != 0)) {
     if (PrintMiscellaneous && Verbose) {
-      warning("unexpected file size: size = " SIZE_FORMAT "\n",
+      warning("unexpected file size: size = %zu\n",
               statbuf.st_size);
     }
     THROW_MSG_0(vmSymbols::java_io_IOException(),
@@ -1660,7 +1660,7 @@ static void open_file_mapping(int vmid, char** addrp, size_t* sizep, TRAPS) {
   // invalidating the mapped view of the file
   CloseHandle(fmh);
 
-  log_debug(perf, memops)("mapped " SIZE_FORMAT " bytes for vmid %d at "
+  log_debug(perf, memops)("mapped %zu bytes for vmid %d at "
                           INTPTR_FORMAT, size, vmid, mapAddress);
 }
 

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -313,10 +313,10 @@ size_t ArchiveBuilder::estimate_archive_size() {
   // allow fragmentation at the end of each dump region
   total += _total_dump_regions * MetaspaceShared::core_region_alignment();
 
-  log_info(cds)("_estimated_hashtable_bytes = " SIZE_FORMAT " + " SIZE_FORMAT " = " SIZE_FORMAT,
+  log_info(cds)("_estimated_hashtable_bytes = %zu + %zu = %zu",
                 symbol_table_est, dictionary_est, _estimated_hashtable_bytes);
-  log_info(cds)("_estimated_metaspaceobj_bytes = " SIZE_FORMAT, _estimated_metaspaceobj_bytes);
-  log_info(cds)("total estimate bytes = " SIZE_FORMAT, total);
+  log_info(cds)("_estimated_metaspaceobj_bytes = %zu", _estimated_metaspaceobj_bytes);
+  log_info(cds)("total estimate bytes = %zu", total);
 
   return align_up(total, MetaspaceShared::core_region_alignment());
 }
@@ -325,14 +325,14 @@ address ArchiveBuilder::reserve_buffer() {
   size_t buffer_size = estimate_archive_size();
   ReservedSpace rs(buffer_size, MetaspaceShared::core_region_alignment(), os::vm_page_size());
   if (!rs.is_reserved()) {
-    log_error(cds)("Failed to reserve " SIZE_FORMAT " bytes of output buffer.", buffer_size);
+    log_error(cds)("Failed to reserve %zu bytes of output buffer.", buffer_size);
     MetaspaceShared::unrecoverable_writing_error();
   }
 
   // buffer_bottom is the lowest address of the 2 core regions (rw, ro) when
   // we are copying the class metadata into the buffer.
   address buffer_bottom = (address)rs.base();
-  log_info(cds)("Reserved output buffer space at " PTR_FORMAT " [" SIZE_FORMAT " bytes]",
+  log_info(cds)("Reserved output buffer space at " PTR_FORMAT " [%zu bytes]",
                 p2i(buffer_bottom), buffer_size);
   _shared_rs = rs;
 
@@ -575,7 +575,7 @@ void ArchiveBuilder::verify_estimate_size(size_t estimate, const char* which) {
   size_t used = size_t(top - bottom) + _other_region_used_bytes;
   int diff = int(estimate) - int(used);
 
-  log_info(cds)("%s estimate = " SIZE_FORMAT " used = " SIZE_FORMAT "; diff = %d bytes", which, estimate, used, diff);
+  log_info(cds)("%s estimate = %zu used = %zu; diff = %d bytes", which, estimate, used, diff);
   assert(diff >= 0, "Estimate is too small");
 
   _last_verified_top = top;
@@ -1020,7 +1020,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
 
     log_as_hex(last_obj_base, last_obj_end, last_obj_base + buffer_to_runtime_delta());
     if (last_obj_end < region_end) {
-      log_debug(cds, map)(PTR_FORMAT ": @@ Misc data " SIZE_FORMAT " bytes",
+      log_debug(cds, map)(PTR_FORMAT ": @@ Misc data %zu bytes",
                           p2i(last_obj_end + buffer_to_runtime_delta()),
                           size_t(region_end - last_obj_end));
       log_as_hex(last_obj_end, region_end, last_obj_end + buffer_to_runtime_delta());
@@ -1071,7 +1071,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
         byte_size = ArchiveHeapWriter::heap_roots_word_size() * BytesPerWord;
       } else if ((byte_size = ArchiveHeapWriter::get_filler_size_at(start)) > 0) {
         // We have a filler oop, which also does not exist in BufferOffsetToSourceObjectTable.
-        st.print_cr("filler " SIZE_FORMAT " bytes", byte_size);
+        st.print_cr("filler %zu bytes", byte_size);
       } else {
         ShouldNotReachHere();
       }
@@ -1164,7 +1164,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
           print_oop_with_requested_addr_cr(&st, source_obj_array->obj_at(i));
         }
       } else {
-        st.print_cr(" - fields (" SIZE_FORMAT " words):", source_oop->size());
+        st.print_cr(" - fields (%zu words):", source_oop->size());
         ArchivedFieldPrinter print_field(heap_info, &st, source_oop);
         InstanceKlass::cast(source_klass)->print_nonstatic_fields(&print_field);
       }

--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -218,7 +218,7 @@ void ArchiveHeapWriter::copy_roots_to_buffer(GrowableArrayCHeap<oop, mtClassShar
       * arrayOop->obj_at_addr<oop>(i) = o;
     }
   }
-  log_info(cds, heap)("archived obj roots[%d] = " SIZE_FORMAT " bytes, klass = %p, obj = %p", length, byte_size, k, mem);
+  log_info(cds, heap)("archived obj roots[%d] = %zu bytes, klass = %p, obj = %p", length, byte_size, k, mem);
 
   _heap_roots_offset = _buffer_used;
   _buffer_used = new_used;
@@ -237,7 +237,7 @@ void ArchiveHeapWriter::copy_source_objs_to_buffer(GrowableArrayCHeap<oop, mtCla
 
   copy_roots_to_buffer(roots);
 
-  log_info(cds)("Size of heap region = " SIZE_FORMAT " bytes, %d objects, %d roots",
+  log_info(cds)("Size of heap region = %zu bytes, %d objects, %d roots",
                 _buffer_used, _source_objs->length() + 1, roots->length());
 }
 
@@ -299,7 +299,7 @@ void ArchiveHeapWriter::maybe_fill_gc_region_gap(size_t required_byte_size) {
     ensure_buffer_space(filler_end);
 
     int array_length = filler_array_length(fill_bytes);
-    log_info(cds, heap)("Inserting filler obj array of %d elements (" SIZE_FORMAT " bytes total) @ buffer offset " SIZE_FORMAT,
+    log_info(cds, heap)("Inserting filler obj array of %d elements (%zu bytes total) @ buffer offset %zu",
                         array_length, fill_bytes, _buffer_used);
     HeapWord* filler = init_filler_array_at_buffer_top(array_length, fill_bytes);
     _buffer_used = filler_end;
@@ -582,7 +582,7 @@ void ArchiveHeapWriter::compute_ptrmap(ArchiveHeapInfo* heap_info) {
   }
 
   heap_info->ptrmap()->resize(max_idx + 1);
-  log_info(cds, heap)("calculate_ptrmap: marked %d non-null native pointers for heap region (" SIZE_FORMAT " bits)",
+  log_info(cds, heap)("calculate_ptrmap: marked %d non-null native pointers for heap region (%zu bits)",
                       num_non_null_ptrs, size_t(heap_info->ptrmap()->size()));
 }
 

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -190,7 +190,7 @@ void DumpRegion::commit_to(char* newtop) {
   assert(commit <= uncommitted, "sanity");
 
   if (!_vs->expand_by(commit, false)) {
-    log_error(cds)("Failed to expand shared space to " SIZE_FORMAT " bytes",
+    log_error(cds)("Failed to expand shared space to %zu bytes",
                     need_committed_size);
     MetaspaceShared::unrecoverable_writing_error();
   }

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -349,7 +349,7 @@ void DynamicArchiveBuilder::write_archive(char* serialized_data) {
   size_t file_size = pointer_delta(top, base, sizeof(char));
 
   log_info(cds, dynamic)("Written dynamic archive " PTR_FORMAT " - " PTR_FORMAT
-                         " [" UINT32_FORMAT " bytes header, " SIZE_FORMAT " bytes total]",
+                         " [" UINT32_FORMAT " bytes header, %zu bytes total]",
                          p2i(base), p2i(top), _header->header_size(), file_size);
 
   log_info(cds, dynamic)("%d klasses; %d symbols", klasses()->length(), symbols()->length());

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -263,7 +263,7 @@ void FileMapHeader::print(outputStream* st) {
   }
   st->print_cr("============ end regions ======== ");
 
-  st->print_cr("- core_region_alignment:          " SIZE_FORMAT, _core_region_alignment);
+  st->print_cr("- core_region_alignment:          %zu", _core_region_alignment);
   st->print_cr("- obj_alignment:                  %d", _obj_alignment);
   st->print_cr("- narrow_oop_base:                " INTPTR_FORMAT, p2i(_narrow_oop_base));
   st->print_cr("- narrow_oop_base:                " INTPTR_FORMAT, p2i(_narrow_oop_base));
@@ -273,10 +273,10 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- narrow_oop_mode:                %d", _narrow_oop_mode);
   st->print_cr("- compressed_oops:                %d", _compressed_oops);
   st->print_cr("- compressed_class_ptrs:          %d", _compressed_class_ptrs);
-  st->print_cr("- cloned_vtables_offset:          " SIZE_FORMAT_X, _cloned_vtables_offset);
-  st->print_cr("- serialized_data_offset:         " SIZE_FORMAT_X, _serialized_data_offset);
+  st->print_cr("- cloned_vtables_offset:          0x%zx", _cloned_vtables_offset);
+  st->print_cr("- serialized_data_offset:         0x%zx", _serialized_data_offset);
   st->print_cr("- jvm_ident:                      %s", _jvm_ident);
-  st->print_cr("- shared_path_table_offset:       " SIZE_FORMAT_X, _shared_path_table_offset);
+  st->print_cr("- shared_path_table_offset:       0x%zx", _shared_path_table_offset);
   st->print_cr("- app_class_paths_start_index:    %d", _app_class_paths_start_index);
   st->print_cr("- app_module_paths_start_index:   %d", _app_module_paths_start_index);
   st->print_cr("- num_module_paths:               %d", _num_module_paths);
@@ -287,11 +287,11 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- has_non_jar_in_classpath:       %d", _has_non_jar_in_classpath);
   st->print_cr("- requested_base_address:         " INTPTR_FORMAT, p2i(_requested_base_address));
   st->print_cr("- mapped_base_address:            " INTPTR_FORMAT, p2i(_mapped_base_address));
-  st->print_cr("- heap_roots_offset:              " SIZE_FORMAT, _heap_roots_offset);
+  st->print_cr("- heap_roots_offset:              %zu", _heap_roots_offset);
   st->print_cr("- allow_archiving_with_java_agent:%d", _allow_archiving_with_java_agent);
   st->print_cr("- use_optimized_module_handling:  %d", _use_optimized_module_handling);
   st->print_cr("- use_full_module_graph           %d", _use_full_module_graph);
-  st->print_cr("- ptrmap_size_in_bits:            " SIZE_FORMAT, _ptrmap_size_in_bits);
+  st->print_cr("- ptrmap_size_in_bits:            %zu", _ptrmap_size_in_bits);
 }
 
 void SharedClassPathEntry::init_as_non_existent(const char* path, TRAPS) {
@@ -1374,7 +1374,7 @@ bool FileMapInfo::init_from_file(int fd) {
 
 void FileMapInfo::seek_to_position(size_t pos) {
   if (os::lseek(_fd, (long)pos, SEEK_SET) < 0) {
-    log_error(cds)("Unable to seek to position " SIZE_FORMAT, pos);
+    log_error(cds)("Unable to seek to position %zu", pos);
     MetaspaceShared::unrecoverable_loading_error();
   }
 }
@@ -1525,11 +1525,11 @@ void FileMapRegion::print(outputStream* st, int region_index) {
   st->print_cr("- is_heap_region:                 %d", _is_heap_region);
   st->print_cr("- is_bitmap_region:               %d", _is_bitmap_region);
   st->print_cr("- mapped_from_file:               %d", _mapped_from_file);
-  st->print_cr("- file_offset:                    " SIZE_FORMAT_X, _file_offset);
-  st->print_cr("- mapping_offset:                 " SIZE_FORMAT_X, _mapping_offset);
-  st->print_cr("- used:                           " SIZE_FORMAT, _used);
-  st->print_cr("- oopmap_offset:                  " SIZE_FORMAT_X, _oopmap_offset);
-  st->print_cr("- oopmap_size_in_bits:            " SIZE_FORMAT, _oopmap_size_in_bits);
+  st->print_cr("- file_offset:                    0x%zx", _file_offset);
+  st->print_cr("- mapping_offset:                 0x%zx", _mapping_offset);
+  st->print_cr("- used:                           %zu", _used);
+  st->print_cr("- oopmap_offset:                  0x%zx", _oopmap_offset);
+  st->print_cr("- oopmap_size_in_bits:            %zu", _oopmap_size_in_bits);
   st->print_cr("- mapped_base:                    " INTPTR_FORMAT, p2i(_mapped_base));
 }
 
@@ -1880,7 +1880,7 @@ bool FileMapInfo::relocate_pointers_in_core_regions(intx addr_delta) {
     return false; // OOM, or CRC check failure
   } else {
     size_t ptrmap_size_in_bits = header()->ptrmap_size_in_bits();
-    log_debug(cds, reloc)("mapped relocation bitmap @ " INTPTR_FORMAT " (" SIZE_FORMAT " bits)",
+    log_debug(cds, reloc)("mapped relocation bitmap @ " INTPTR_FORMAT " (%zu bits)",
                           p2i(bitmap_base), ptrmap_size_in_bits);
 
     BitMapView ptrmap((BitMap::bm_word_t*)bitmap_base, ptrmap_size_in_bits);
@@ -2008,13 +2008,13 @@ bool FileMapInfo::can_use_heap_region() {
   address archive_narrow_klass_base = (address)header()->mapped_base_address();
   const int archive_narrow_klass_shift = ArchiveHeapWriter::precomputed_narrow_klass_shift;
 
-  log_info(cds)("CDS archive was created with max heap size = " SIZE_FORMAT "M, and the following configuration:",
+  log_info(cds)("CDS archive was created with max heap size = %zuM, and the following configuration:",
                 max_heap_size()/M);
   log_info(cds)("    narrow_klass_base at mapping start address, narrow_klass_shift = %d",
                 archive_narrow_klass_shift);
   log_info(cds)("    narrow_oop_mode = %d, narrow_oop_base = " PTR_FORMAT ", narrow_oop_shift = %d",
                 narrow_oop_mode(), p2i(narrow_oop_base()), narrow_oop_shift());
-  log_info(cds)("The current max heap size = " SIZE_FORMAT "M, HeapRegion::GrainBytes = " SIZE_FORMAT,
+  log_info(cds)("The current max heap size = %zuM, HeapRegion::GrainBytes = %zu",
                 MaxHeapSize/M, HeapRegion::GrainBytes);
   log_info(cds)("    narrow_klass_base = " PTR_FORMAT ", narrow_klass_shift = %d",
                 p2i(CompressedKlassPointers::base()), CompressedKlassPointers::shift());
@@ -2133,7 +2133,7 @@ bool FileMapInfo::map_heap_region_impl() {
   if (base == nullptr || base != addr) {
     dealloc_heap_region();
     log_info(cds)("UseSharedSpaces: Unable to map at required address in java heap. "
-                  INTPTR_FORMAT ", size = " SIZE_FORMAT " bytes",
+                  INTPTR_FORMAT ", size = %zu bytes",
                   p2i(addr), _mapped_heap_memregion.byte_size());
     return false;
   }

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -270,7 +270,7 @@ bool HeapShared::archive_object(oop obj) {
   }
 
   if (ArchiveHeapWriter::is_too_large_to_archive(obj->size())) {
-    log_debug(cds, heap)("Cannot archive, object (" PTR_FORMAT ") is too large: " SIZE_FORMAT,
+    log_debug(cds, heap)("Cannot archive, object (" PTR_FORMAT ") is too large: %zu",
                          p2i(obj), obj->size());
     return false;
   } else {
@@ -1102,7 +1102,7 @@ class WalkOopAndArchiveClosure: public BasicOopIterateClosure {
 
       if (!_record_klasses_only && log_is_enabled(Debug, cds, heap)) {
         ResourceMark rm;
-        log_debug(cds, heap)("(%d) %s[" SIZE_FORMAT "] ==> " PTR_FORMAT " size " SIZE_FORMAT " %s", _level,
+        log_debug(cds, heap)("(%d) %s[%zu] ==> " PTR_FORMAT " size %zu %s", _level,
                              _referencing_obj->klass()->external_name(), field_delta,
                              p2i(obj), obj->size() * HeapWordSize, obj->klass()->external_name());
         if (log_is_enabled(Trace, cds, heap)) {
@@ -1176,7 +1176,7 @@ bool HeapShared::archive_reachable_objects_from(int level,
       ResourceMark rm;
       log_error(cds, heap)(
         "Cannot archive the sub-graph referenced from %s object ("
-        PTR_FORMAT ") size " SIZE_FORMAT ", skipped.",
+        PTR_FORMAT ") size %zu, skipped.",
         orig_obj->klass()->external_name(), p2i(orig_obj), orig_obj->size() * HeapWordSize);
       if (level == 1) {
         // Don't archive a subgraph root that's too big. For archives static fields, that's OK

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -243,7 +243,7 @@ static char* compute_shared_base(size_t cds_max) {
 
 void MetaspaceShared::initialize_for_static_dump() {
   assert(DumpSharedSpaces, "should be called for dump time only");
-  log_info(cds)("Core region alignment: " SIZE_FORMAT, core_region_alignment());
+  log_info(cds)("Core region alignment: %zu", core_region_alignment());
   // The max allowed size for CDS archive. We use this to limit SharedBaseAddress
   // to avoid address space wrap around.
   size_t cds_max;
@@ -264,7 +264,7 @@ void MetaspaceShared::initialize_for_static_dump() {
   size_t symbol_rs_size = LP64_ONLY(3 * G) NOT_LP64(128 * M);
   _symbol_rs = ReservedSpace(symbol_rs_size);
   if (!_symbol_rs.is_reserved()) {
-    log_error(cds)("Unable to reserve memory for symbols: " SIZE_FORMAT " bytes.", symbol_rs_size);
+    log_error(cds)("Unable to reserve memory for symbols: %zu bytes.", symbol_rs_size);
     MetaspaceShared::unrecoverable_writing_error();
   }
   _symbol_region.init(&_symbol_rs, &_symbol_vs);
@@ -654,7 +654,7 @@ void MetaspaceShared::preload_and_dump() {
   if (HAS_PENDING_EXCEPTION) {
     if (PENDING_EXCEPTION->is_a(vmClasses::OutOfMemoryError_klass())) {
       log_error(cds)("Out of memory. Please run with a larger Java heap, current MaxHeapSize = "
-                     SIZE_FORMAT "M", MaxHeapSize/M);
+                     "%zuM", MaxHeapSize/M);
       MetaspaceShared::unrecoverable_writing_error();
     } else {
       log_error(cds)("%s: %s", PENDING_EXCEPTION->klass()->external_name(),
@@ -678,15 +678,15 @@ void MetaspaceShared::adjust_heap_sizes_for_dumping() {
   julong max_heap_size = (julong)(4 * G);
 
   if (MinHeapSize > max_heap_size) {
-    log_debug(cds)("Setting MinHeapSize to 4G for CDS dumping, original size = " SIZE_FORMAT "M", MinHeapSize/M);
+    log_debug(cds)("Setting MinHeapSize to 4G for CDS dumping, original size = %zuM", MinHeapSize/M);
     FLAG_SET_ERGO(MinHeapSize, max_heap_size);
   }
   if (InitialHeapSize > max_heap_size) {
-    log_debug(cds)("Setting InitialHeapSize to 4G for CDS dumping, original size = " SIZE_FORMAT "M", InitialHeapSize/M);
+    log_debug(cds)("Setting InitialHeapSize to 4G for CDS dumping, original size = %zuM", InitialHeapSize/M);
     FLAG_SET_ERGO(InitialHeapSize, max_heap_size);
   }
   if (MaxHeapSize > max_heap_size) {
-    log_debug(cds)("Setting MaxHeapSize to 4G for CDS dumping, original size = " SIZE_FORMAT "M", MaxHeapSize/M);
+    log_debug(cds)("Setting MaxHeapSize to 4G for CDS dumping, original size = %zuM", MaxHeapSize/M);
     FLAG_SET_ERGO(MaxHeapSize, max_heap_size);
   }
 }
@@ -918,7 +918,7 @@ void MetaspaceShared::initialize_runtime_shared_and_meta_spaces() {
   FileMapInfo* dynamic_mapinfo = nullptr;
 
   if (static_mapinfo != nullptr) {
-    log_info(cds)("Core region alignment: " SIZE_FORMAT, static_mapinfo->core_region_alignment());
+    log_info(cds)("Core region alignment: %zu", static_mapinfo->core_region_alignment());
     dynamic_mapinfo = open_dynamic_archive();
 
     // First try to map at the requested address
@@ -1072,9 +1072,9 @@ MapArchiveResult MetaspaceShared::map_archives(FileMapInfo* static_mapinfo, File
     }
 #endif // ASSERT
 
-    log_info(cds)("Reserved archive_space_rs [" INTPTR_FORMAT " - " INTPTR_FORMAT "] (" SIZE_FORMAT ") bytes",
+    log_info(cds)("Reserved archive_space_rs [" INTPTR_FORMAT " - " INTPTR_FORMAT "] (%zu) bytes",
                    p2i(archive_space_rs.base()), p2i(archive_space_rs.end()), archive_space_rs.size());
-    log_info(cds)("Reserved class_space_rs   [" INTPTR_FORMAT " - " INTPTR_FORMAT "] (" SIZE_FORMAT ") bytes",
+    log_info(cds)("Reserved class_space_rs   [" INTPTR_FORMAT " - " INTPTR_FORMAT "] (%zu) bytes",
                    p2i(class_space_rs.base()), p2i(class_space_rs.end()), class_space_rs.size());
 
     if (MetaspaceShared::use_windows_memory_mapping()) {
@@ -1299,8 +1299,7 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
   const size_t class_space_size = CompressedClassSpaceSize;
   assert(CompressedClassSpaceSize > 0 &&
          is_aligned(CompressedClassSpaceSize, class_space_alignment),
-         "CompressedClassSpaceSize malformed: "
-         SIZE_FORMAT, CompressedClassSpaceSize);
+         "CompressedClassSpaceSize malformed: %zu", CompressedClassSpaceSize);
 
   const size_t ccs_begin_offset = align_up(base_address + archive_space_size,
                                            class_space_alignment) - base_address;
@@ -1402,8 +1401,8 @@ MapArchiveResult MetaspaceShared::map_archive(FileMapInfo* mapinfo, char* mapped
 
   mapinfo->set_is_mapped(false);
   if (mapinfo->core_region_alignment() != (size_t)core_region_alignment()) {
-    log_info(cds)("Unable to map CDS archive -- core_region_alignment() expected: " SIZE_FORMAT
-                  " actual: " SIZE_FORMAT, mapinfo->core_region_alignment(), core_region_alignment());
+    log_info(cds)("Unable to map CDS archive -- core_region_alignment() expected: %zu"
+                  " actual: %zu", mapinfo->core_region_alignment(), core_region_alignment());
     return MAP_ARCHIVE_OTHER_FAILURE;
   }
 
@@ -1571,7 +1570,7 @@ void MetaspaceShared::print_on(outputStream* st) {
     address static_top = (address)_shared_metaspace_static_top;
     address top = (address)MetaspaceObj::shared_metaspace_top();
     st->print("[" PTR_FORMAT "-" PTR_FORMAT "-" PTR_FORMAT "), ", p2i(base), p2i(static_top), p2i(top));
-    st->print("size " SIZE_FORMAT ", ", top - base);
+    st->print("size %zu, ", top - base);
     st->print("SharedBaseAddress: " PTR_FORMAT ", ArchiveRelocationMode: %d.", SharedBaseAddress, ArchiveRelocationMode);
   } else {
     st->print("CDS archive(s) not mapped");

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -58,7 +58,7 @@ Dictionary::Dictionary(ClassLoaderData* loader_data, size_t table_size)
 
   size_t start_size_log_2 = MAX2(ceil_log2(table_size), (size_t)2); // 2 is minimum size even though some dictionaries only have one entry
   size_t current_size = ((size_t)1) << start_size_log_2;
-  log_info(class, loader, data)("Dictionary start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
+  log_info(class, loader, data)("Dictionary start size: %zu (%zu)",
                                 current_size, start_size_log_2);
   _table = new ConcurrentTable(start_size_log_2, END_SIZE, REHASH_LEN);
 }

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1163,8 +1163,8 @@ void java_lang_Class::fixup_module_field(Klass* k, Handle module) {
 
 void java_lang_Class::set_oop_size(HeapWord* java_class, size_t size) {
   assert(_oop_size_offset != 0, "must be set");
-  assert(size > 0, "Oop size must be greater than zero, not " SIZE_FORMAT, size);
-  assert(size <= INT_MAX, "Lossy conversion: " SIZE_FORMAT, size);
+  assert(size > 0, "Oop size must be greater than zero, not %zu", size);
+  assert(size <= INT_MAX, "Lossy conversion: %zu", size);
   *(int*)(((char*)java_class) + _oop_size_offset) = (int)size;
 }
 

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -228,7 +228,7 @@ class StringTableLookupOop : public StackObj {
 void StringTable::create_table() {
   size_t start_size_log_2 = ceil_log2(StringTableSize);
   _current_size = ((size_t)1) << start_size_log_2;
-  log_trace(stringtable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
+  log_trace(stringtable)("Start size: %zu (%zu)",
                          _current_size, start_size_log_2);
   _local_table = new StringTableHash(start_size_log_2, END_SIZE, REHASH_LEN, true);
   _oop_storage = OopStorageSet::create_weak("StringTable Weak", mtSymbol);
@@ -424,7 +424,7 @@ void StringTable::grow(JavaThread* jt) {
   }
   gt.done(jt);
   _current_size = table_size();
-  log_debug(stringtable)("Grown to size:" SIZE_FORMAT, _current_size);
+  log_debug(stringtable)("Grown to size:%zu", _current_size);
 }
 
 struct StringTableDoDelete : StackObj {
@@ -473,7 +473,7 @@ void StringTable::clean_dead_entries(JavaThread* jt) {
 }
 
 void StringTable::gc_notification(size_t num_dead) {
-  log_trace(stringtable)("Uncleaned items:" SIZE_FORMAT, num_dead);
+  log_trace(stringtable)("Uncleaned items:%zu", num_dead);
 
   if (has_work()) {
     return;
@@ -802,7 +802,7 @@ oop StringTable::lookup_shared(const jchar* name, int len) {
 void StringTable::allocate_shared_strings_array(TRAPS) {
   assert(DumpSharedSpaces, "must be");
   if (_items_count > (size_t)max_jint) {
-    fatal("Too many strings to be archived: " SIZE_FORMAT, _items_count);
+    fatal("Too many strings to be archived: %zu", _items_count);
   }
 
   int total = (int)_items_count;
@@ -825,7 +825,7 @@ void StringTable::allocate_shared_strings_array(TRAPS) {
       // This can only happen if you have an extremely large number of classes that
       // refer to more than 16384 * 16384 = 26M interned strings! Not a practical concern
       // but bail out for safety.
-      log_error(cds)("Too many strings to be archived: " SIZE_FORMAT, _items_count);
+      log_error(cds)("Too many strings to be archived: %zu", _items_count);
       MetaspaceShared::unrecoverable_writing_error();
     }
 

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -211,7 +211,7 @@ private:
 void SymbolTable::create_table ()  {
   size_t start_size_log_2 = ceil_log2(SymbolTableSize);
   _current_size = ((size_t)1) << start_size_log_2;
-  log_trace(symboltable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
+  log_trace(symboltable)("Start size: %zu (%zu)",
                          _current_size, start_size_log_2);
   _local_table = new SymbolTableHash(start_size_log_2, END_SIZE, REHASH_LEN, true);
 
@@ -707,7 +707,7 @@ void SymbolTable::grow(JavaThread* jt) {
   }
   gt.done(jt);
   _current_size = table_size();
-  log_debug(symboltable)("Grown to size:" SIZE_FORMAT, _current_size);
+  log_debug(symboltable)("Grown to size:%zu", _current_size);
 }
 
 struct SymbolTableDoDelete : StackObj {
@@ -756,7 +756,7 @@ void SymbolTable::clean_dead_entries(JavaThread* jt) {
 
   Atomic::add(&_symbols_counted, stdc._processed);
 
-  log_debug(symboltable)("Cleaned " SIZE_FORMAT " of " SIZE_FORMAT,
+  log_debug(symboltable)("Cleaned %zu of %zu",
                          stdd._deleted, stdc._processed);
 }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -581,7 +581,7 @@ CodeBlob* CodeCache::allocate(int size, CodeBlobType code_blob_type, bool handle
       } else {
         tty->print("CodeCache");
       }
-      tty->print_cr(" extended to [" INTPTR_FORMAT ", " INTPTR_FORMAT "] (" SSIZE_FORMAT " bytes)",
+      tty->print_cr(" extended to [" INTPTR_FORMAT ", " INTPTR_FORMAT "] (%zd bytes)",
                     (intptr_t)heap->low_boundary(), (intptr_t)heap->high(),
                     (address)heap->high() - (address)heap->low_boundary());
     }
@@ -1521,10 +1521,10 @@ void CodeCache::print_memory_overhead() {
   }
   // Print bytes that are allocated in the freelist
   ttyLocker ttl;
-  tty->print_cr("Number of elements in freelist: " SSIZE_FORMAT,       freelists_length());
-  tty->print_cr("Allocated in freelist:          " SSIZE_FORMAT "kB",  bytes_allocated_in_freelists()/K);
-  tty->print_cr("Unused bytes in CodeBlobs:      " SSIZE_FORMAT "kB",  (wasted_bytes/K));
-  tty->print_cr("Segment map size:               " SSIZE_FORMAT "kB",  allocated_segments()/K); // 1 byte per segment
+  tty->print_cr("Number of elements in freelist: %zd",       freelists_length());
+  tty->print_cr("Allocated in freelist:          %zdkB",  bytes_allocated_in_freelists()/K);
+  tty->print_cr("Unused bytes in CodeBlobs:      %zdkB",  (wasted_bytes/K));
+  tty->print_cr("Segment map size:               %zdkB",  allocated_segments()/K); // 1 byte per segment
 }
 
 //------------------------------------------------------------------------------------------------

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -181,17 +181,17 @@ void CodeCache::check_heap_sizes(size_t non_nmethod_size, size_t profiled_size, 
   size_t total_size = non_nmethod_size + profiled_size + non_profiled_size;
   // Prepare error message
   const char* error = "Invalid code heap sizes";
-  err_msg message("NonNMethodCodeHeapSize (" SIZE_FORMAT "K) + ProfiledCodeHeapSize (" SIZE_FORMAT "K)"
-                  " + NonProfiledCodeHeapSize (" SIZE_FORMAT "K) = " SIZE_FORMAT "K",
+  err_msg message("NonNMethodCodeHeapSize (%zuK) + ProfiledCodeHeapSize (%zuK)"
+                  " + NonProfiledCodeHeapSize (%zuK) = %zuK",
           non_nmethod_size/K, profiled_size/K, non_profiled_size/K, total_size/K);
 
   if (total_size > cache_size) {
     // Some code heap sizes were explicitly set: total_size must be <= cache_size
-    message.append(" is greater than ReservedCodeCacheSize (" SIZE_FORMAT "K).", cache_size/K);
+    message.append(" is greater than ReservedCodeCacheSize (%zuK).", cache_size/K);
     vm_exit_during_initialization(error, message);
   } else if (all_set && total_size != cache_size) {
     // All code heap sizes were explicitly set: total_size must equal cache_size
-    message.append(" is not equal to ReservedCodeCacheSize (" SIZE_FORMAT "K).", cache_size/K);
+    message.append(" is not equal to ReservedCodeCacheSize (%zuK).", cache_size/K);
     vm_exit_during_initialization(error, message);
   }
 }
@@ -300,7 +300,7 @@ void CodeCache::initialize_heaps() {
   uint min_code_cache_size = CodeCacheMinimumUseSpace DEBUG_ONLY(* 3);
   if (non_nmethod_size < min_code_cache_size) {
     vm_exit_during_initialization(err_msg(
-        "Not enough space in non-nmethod code heap to run VM: " SIZE_FORMAT "K < " SIZE_FORMAT "K",
+        "Not enough space in non-nmethod code heap to run VM: %zuK < %zuK",
         non_nmethod_size/K, min_code_cache_size/K));
   }
 
@@ -371,7 +371,7 @@ ReservedCodeSpace CodeCache::reserve_heap_memory(size_t size, size_t rs_ps) {
   const size_t rs_size = align_up(size, rs_align);
   ReservedCodeSpace rs(rs_size, rs_align, rs_ps);
   if (!rs.is_reserved()) {
-    vm_exit_during_initialization(err_msg("Could not reserve enough space for code cache (" SIZE_FORMAT "K)",
+    vm_exit_during_initialization(err_msg("Could not reserve enough space for code cache (%zuK)",
                                           rs_size/K));
   }
 
@@ -455,7 +455,7 @@ void CodeCache::add_heap(ReservedSpace rs, const char* name, CodeBlobType code_b
   size_t size_initial = MIN2((size_t)InitialCodeCacheSize, rs.size());
   size_initial = align_up(size_initial, os::vm_page_size());
   if (!heap->reserve(rs, size_initial, CodeCacheSegmentSize)) {
-    vm_exit_during_initialization(err_msg("Could not reserve enough space in %s (" SIZE_FORMAT "K)",
+    vm_exit_during_initialization(err_msg("Could not reserve enough space in %s (%zuK)",
                                           heap->name(), size_initial/K));
   }
 
@@ -1741,8 +1741,8 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
     } else {
       st->print("CodeCache:");
     }
-    st->print_cr(" size=" SIZE_FORMAT "Kb used=" SIZE_FORMAT
-                 "Kb max_used=" SIZE_FORMAT "Kb free=" SIZE_FORMAT "Kb",
+    st->print_cr(" size=%zuKb used=%zu"
+                 "Kb max_used=%zuKb free=%zuKb",
                  total/K, (total - heap->unallocated_capacity())/K,
                  heap->max_allocated_capacity()/K, heap->unallocated_capacity()/K);
 
@@ -1794,7 +1794,7 @@ void CodeCache::print_layout(outputStream* st) {
 
 void CodeCache::log_state(outputStream* st) {
   st->print(" total_blobs='" UINT32_FORMAT "' nmethods='" UINT32_FORMAT "'"
-            " adapters='" UINT32_FORMAT "' free_code_cache='" SIZE_FORMAT "'",
+            " adapters='" UINT32_FORMAT "' free_code_cache='%zu'",
             blob_count(), nmethod_count(), adapter_count(),
             unallocated_capacity());
 }

--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -370,7 +370,7 @@ void CodeHeapState::prepare_StatArray(outputStream* out, size_t nElem, size_t gr
   if (StatArray == nullptr) {
     //---<  just do nothing if allocation failed  >---
     out->print_cr("Statistics could not be collected for %s, probably out of memory.", heapName);
-    out->print_cr("Current granularity is " SIZE_FORMAT " bytes. Try a coarser granularity.", granularity);
+    out->print_cr("Current granularity is %zu bytes. Try a coarser granularity.", granularity);
     alloc_granules = 0;
     granule_size   = 0;
   } else {
@@ -621,11 +621,11 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
                 "   collected data to be consistent. Only the method names and signatures\n"
                 "   are retrieved at print time. That may lead to rare cases where the\n"
                 "   name of a method is no longer available, e.g. because it was unloaded.\n");
-  ast->print_cr("   CodeHeap committed size " SIZE_FORMAT "K (" SIZE_FORMAT "M), reserved size " SIZE_FORMAT "K (" SIZE_FORMAT "M), %d%% occupied.",
+  ast->print_cr("   CodeHeap committed size %zuK (%zuM), reserved size %zuK (%zuM), %d%% occupied.",
                 size/(size_t)K, size/(size_t)M, res_size/(size_t)K, res_size/(size_t)M, (unsigned int)(100.0*size/res_size));
-  ast->print_cr("   CodeHeap allocation segment size is " SIZE_FORMAT " bytes. This is the smallest possible granularity.", seg_size);
-  ast->print_cr("   CodeHeap (committed part) is mapped to " SIZE_FORMAT " granules of size " SIZE_FORMAT " bytes.", granules, granularity);
-  ast->print_cr("   Each granule takes " SIZE_FORMAT " bytes of C heap, that is " SIZE_FORMAT "K in total for statistics data.", sizeof(StatElement), (sizeof(StatElement)*granules)/(size_t)K);
+  ast->print_cr("   CodeHeap allocation segment size is %zu bytes. This is the smallest possible granularity.", seg_size);
+  ast->print_cr("   CodeHeap (committed part) is mapped to %zu granules of size %zu bytes.", granules, granularity);
+  ast->print_cr("   Each granule takes %zu bytes of C heap, that is %zuK in total for statistics data.", sizeof(StatElement), (sizeof(StatElement)*granules)/(size_t)K);
   ast->print_cr("   The number of granules is limited to %dk, requiring a granules size of at least %d bytes for a 1GB heap.", (unsigned int)(max_granules/K), (unsigned int)(G/max_granules));
   BUFFEREDSTREAM_FLUSH("\n")
 
@@ -697,10 +697,10 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
         insane = true; ast->print_cr("Sanity check: HeapBlock @%p outside used range (%p)", (char*)h, low_bound + size);
       }
       if (ix_end   >= granules) {
-        insane = true; ast->print_cr("Sanity check: end index (%d) out of bounds (" SIZE_FORMAT ")", ix_end, granules);
+        insane = true; ast->print_cr("Sanity check: end index (%d) out of bounds (%zu)", ix_end, granules);
       }
       if (size     != heap->capacity()) {
-        insane = true; ast->print_cr("Sanity check: code heap capacity has changed (" SIZE_FORMAT "K to " SIZE_FORMAT "K)", size/(size_t)K, heap->capacity()/(size_t)K);
+        insane = true; ast->print_cr("Sanity check: code heap capacity has changed (%zuK to %zuK)", size/(size_t)K, heap->capacity()/(size_t)K);
       }
       if (ix_beg   >  ix_end) {
         insane = true; ast->print_cr("Sanity check: end index (%d) lower than begin index (%d)", ix_end, ix_beg);
@@ -1125,7 +1125,7 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
     ast->print_cr("   The aggregate step collects information about all free blocks in CodeHeap.\n"
                   "   Subsequent print functions create their output based on this snapshot.\n");
     ast->print_cr("   Free space in %s is distributed over %d free blocks.", heapName, nBlocks_free);
-    ast->print_cr("   Each free block takes " SIZE_FORMAT " bytes of C heap for statistics data, that is " SIZE_FORMAT "K in total.", sizeof(FreeBlk), (sizeof(FreeBlk)*nBlocks_free)/K);
+    ast->print_cr("   Each free block takes %zu bytes of C heap for statistics data, that is %zuK in total.", sizeof(FreeBlk), (sizeof(FreeBlk)*nBlocks_free)/K);
     BUFFEREDSTREAM_FLUSH("\n")
 
     //----------------------------------------
@@ -2080,7 +2080,7 @@ void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
       size_t end_ix = (ix+granules_per_line <= alloc_granules) ? ix+granules_per_line : alloc_granules;
       ast->cr();
       ast->print_cr("--------------------------------------------------------------------");
-      ast->print_cr("Address range [" INTPTR_FORMAT "," INTPTR_FORMAT "), " SIZE_FORMAT "k", p2i(low_bound+ix*granule_size), p2i(low_bound + end_ix*granule_size), (end_ix - ix)*granule_size/(size_t)K);
+      ast->print_cr("Address range [" INTPTR_FORMAT "," INTPTR_FORMAT "), %zuk", p2i(low_bound+ix*granule_size), p2i(low_bound + end_ix*granule_size), (end_ix - ix)*granule_size/(size_t)K);
       ast->print_cr("--------------------------------------------------------------------");
       BUFFEREDSTREAM_FLUSH_AUTO("")
     }

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -160,7 +160,7 @@ struct java_nmethod_stats_struct {
     if (nmethod_count == 0)  return;
     tty->print_cr("Statistics for %u bytecoded nmethods for %s:", nmethod_count, name);
     if (total_size != 0)          tty->print_cr(" total in heap  = %u", total_size);
-    if (nmethod_count != 0)       tty->print_cr(" header         = " SIZE_FORMAT, nmethod_count * sizeof(nmethod));
+    if (nmethod_count != 0)       tty->print_cr(" header         = %zu", nmethod_count * sizeof(nmethod));
     if (relocation_size != 0)     tty->print_cr(" relocation     = %u", relocation_size);
     if (consts_size != 0)         tty->print_cr(" constants      = %u", consts_size);
     if (insts_size != 0)          tty->print_cr(" main code      = %u", insts_size);
@@ -1448,7 +1448,7 @@ void nmethod::flush() {
   // completely deallocate this method
   Events::log(Thread::current(), "flushing nmethod " INTPTR_FORMAT, p2i(this));
   log_debug(codecache)("*flushing %s nmethod %3d/" INTPTR_FORMAT ". Live blobs:" UINT32_FORMAT
-                       "/Free CodeCache:" SIZE_FORMAT "Kb",
+                       "/Free CodeCache:%zuKb",
                        is_osr_method() ? "osr" : "",_compile_id, p2i(this), CodeCache::blob_count(),
                        CodeCache::unallocated_capacity(CodeCache::get_code_blob_type(this))/1024);
 

--- a/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonArguments.cpp
@@ -46,7 +46,7 @@ void EpsilonArguments::initialize() {
   }
 
   if (EpsilonMaxTLABSize < MinTLABSize) {
-    log_warning(gc)("EpsilonMaxTLABSize < MinTLABSize, adjusting it to " SIZE_FORMAT, MinTLABSize);
+    log_warning(gc)("EpsilonMaxTLABSize < MinTLABSize, adjusting it to %zu", MinTLABSize);
     EpsilonMaxTLABSize = MinTLABSize;
   }
 

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -103,7 +103,7 @@ EpsilonHeap* EpsilonHeap::heap() {
 }
 
 HeapWord* EpsilonHeap::allocate_work(size_t size, bool verbose) {
-  assert(is_object_aligned(size), "Allocation size should be aligned: " SIZE_FORMAT, size);
+  assert(is_object_aligned(size), "Allocation size should be aligned: %zu", size);
 
   HeapWord* res = nullptr;
   while (true) {
@@ -213,18 +213,18 @@ HeapWord* EpsilonHeap::allocate_new_tlab(size_t min_size,
 
   // Check that adjustments did not break local and global invariants
   assert(is_object_aligned(size),
-         "Size honors object alignment: " SIZE_FORMAT, size);
+         "Size honors object alignment: %zu", size);
   assert(min_size <= size,
-         "Size honors min size: "  SIZE_FORMAT " <= " SIZE_FORMAT, min_size, size);
+         "Size honors min size: "  SIZE_FORMAT " <= %zu", min_size, size);
   assert(size <= _max_tlab_size,
-         "Size honors max size: "  SIZE_FORMAT " <= " SIZE_FORMAT, size, _max_tlab_size);
+         "Size honors max size: "  SIZE_FORMAT " <= %zu", size, _max_tlab_size);
   assert(size <= CollectedHeap::max_tlab_size(),
-         "Size honors global max size: "  SIZE_FORMAT " <= " SIZE_FORMAT, size, CollectedHeap::max_tlab_size());
+         "Size honors global max size: "  SIZE_FORMAT " <= %zu", size, CollectedHeap::max_tlab_size());
 
   if (log_is_enabled(Trace, gc)) {
     ResourceMark rm;
-    log_trace(gc)("TLAB size for \"%s\" (Requested: " SIZE_FORMAT "K, Min: " SIZE_FORMAT
-                          "K, Max: " SIZE_FORMAT "K, Ergo: " SIZE_FORMAT "K) -> " SIZE_FORMAT "K",
+    log_trace(gc)("TLAB size for \"%s\" (Requested: %zuK, Min: %zu"
+                          "K, Max: %zuK, Ergo: %zuK) -> %zuK",
                   thread->name(),
                   requested_size * HeapWordSize / K,
                   min_size * HeapWordSize / K,
@@ -320,7 +320,7 @@ void EpsilonHeap::print_heap_info(size_t used) const {
   size_t committed = capacity();
 
   if (reserved != 0) {
-    log_info(gc)("Heap: " SIZE_FORMAT "%s reserved, " SIZE_FORMAT "%s (%.2f%%) committed, "
+    log_info(gc)("Heap: %zu%s reserved, %zu%s (%.2f%%) committed, "
                  SIZE_FORMAT "%s (%.2f%%) used",
             byte_size_in_proper_unit(reserved),  proper_unit_for_byte_size(reserved),
             byte_size_in_proper_unit(committed), proper_unit_for_byte_size(committed),
@@ -339,7 +339,7 @@ void EpsilonHeap::print_metaspace_info() const {
   size_t used      = stats.used();
 
   if (reserved != 0) {
-    log_info(gc, metaspace)("Metaspace: " SIZE_FORMAT "%s reserved, " SIZE_FORMAT "%s (%.2f%%) committed, "
+    log_info(gc, metaspace)("Metaspace: %zu%s reserved, %zu%s (%.2f%%) committed, "
                             SIZE_FORMAT "%s (%.2f%%) used",
             byte_size_in_proper_unit(reserved),  proper_unit_for_byte_size(reserved),
             byte_size_in_proper_unit(committed), proper_unit_for_byte_size(committed),

--- a/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.cpp
@@ -215,11 +215,11 @@ HeapWord* EpsilonHeap::allocate_new_tlab(size_t min_size,
   assert(is_object_aligned(size),
          "Size honors object alignment: %zu", size);
   assert(min_size <= size,
-         "Size honors min size: "  SIZE_FORMAT " <= %zu", min_size, size);
+         "Size honors min size: "  "%zu <= %zu", min_size, size);
   assert(size <= _max_tlab_size,
-         "Size honors max size: "  SIZE_FORMAT " <= %zu", size, _max_tlab_size);
+         "Size honors max size: "  "%zu <= %zu", size, _max_tlab_size);
   assert(size <= CollectedHeap::max_tlab_size(),
-         "Size honors global max size: "  SIZE_FORMAT " <= %zu", size, CollectedHeap::max_tlab_size());
+         "Size honors global max size: "  "%zu <= %zu", size, CollectedHeap::max_tlab_size());
 
   if (log_is_enabled(Trace, gc)) {
     ResourceMark rm;
@@ -321,7 +321,7 @@ void EpsilonHeap::print_heap_info(size_t used) const {
 
   if (reserved != 0) {
     log_info(gc)("Heap: %zu%s reserved, %zu%s (%.2f%%) committed, "
-                 SIZE_FORMAT "%s (%.2f%%) used",
+                 "%zu%s (%.2f%%) used",
             byte_size_in_proper_unit(reserved),  proper_unit_for_byte_size(reserved),
             byte_size_in_proper_unit(committed), proper_unit_for_byte_size(committed),
             committed * 100.0 / reserved,
@@ -340,7 +340,7 @@ void EpsilonHeap::print_metaspace_info() const {
 
   if (reserved != 0) {
     log_info(gc, metaspace)("Metaspace: %zu%s reserved, %zu%s (%.2f%%) committed, "
-                            SIZE_FORMAT "%s (%.2f%%) used",
+                            "%zu%s (%.2f%%) used",
             byte_size_in_proper_unit(reserved),  proper_unit_for_byte_size(reserved),
             byte_size_in_proper_unit(committed), proper_unit_for_byte_size(committed),
             committed * 100.0 / reserved,

--- a/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
+++ b/src/hotspot/share/gc/epsilon/epsilonInitLogger.cpp
@@ -46,13 +46,13 @@ void EpsilonInitLogger::print_gc_specific() {
 
   if (UseTLAB) {
     size_t max_tlab = EpsilonHeap::heap()->max_tlab_size() * HeapWordSize;
-    log_info(gc, init)("TLAB Size Max: " SIZE_FORMAT "%s",
+    log_info(gc, init)("TLAB Size Max: %zu%s",
                        byte_size_in_exact_unit(max_tlab), exact_unit_for_byte_size(max_tlab));
     if (EpsilonElasticTLAB) {
       log_info(gc, init)("TLAB Size Elasticity: %.2fx", EpsilonTLABElasticity);
     }
     if (EpsilonElasticTLABDecay) {
-      log_info(gc, init)("TLAB Size Decay Time: " SIZE_FORMAT "ms", EpsilonTLABDecayTime);
+      log_info(gc, init)("TLAB Size Decay Time: %zums", EpsilonTLABDecayTime);
     }
   } else {
     log_info(gc, init)("TLAB: Disabled");

--- a/src/hotspot/share/gc/g1/g1AllocRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.cpp
@@ -237,10 +237,10 @@ void G1AllocRegion::trace(const char* str, size_t min_word_size, size_t desired_
 
     if (detailed_info) {
       if (result != nullptr) {
-        out->print(" min " SIZE_FORMAT " desired " SIZE_FORMAT " actual " SIZE_FORMAT " " PTR_FORMAT,
+        out->print(" min %zu desired %zu actual %zu " PTR_FORMAT,
                      min_word_size, desired_word_size, actual_word_size, p2i(result));
       } else if (min_word_size != 0) {
-        out->print(" min " SIZE_FORMAT " desired " SIZE_FORMAT, min_word_size, desired_word_size);
+        out->print(" min %zu desired %zu", min_word_size, desired_word_size);
       }
     }
     out->cr();
@@ -336,7 +336,7 @@ HeapRegion* MutatorAllocRegion::release() {
     _wasted_bytes += retire_internal(_retained_alloc_region, false);
     _retained_alloc_region = nullptr;
   }
-  log_debug(gc, alloc, region)("Mutator Allocation stats, regions: %u, wasted size: " SIZE_FORMAT "%s (%4.1f%%)",
+  log_debug(gc, alloc, region)("Mutator Allocation stats, regions: %u, wasted size: %zu%s (%4.1f%%)",
                                count(),
                                byte_size_in_proper_unit(_wasted_bytes),
                                proper_unit_for_byte_size(_wasted_bytes),

--- a/src/hotspot/share/gc/g1/g1AllocRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.inline.hpp
@@ -31,7 +31,7 @@
 
 #define assert_alloc_region(p, message)                                  \
   do {                                                                   \
-    assert((p), "[%s] %s c: %u r: " PTR_FORMAT " u: " SIZE_FORMAT,       \
+    assert((p), "[%s] %s c: %u r: " PTR_FORMAT " u: %zu",       \
            _name, (message), _count, p2i(_alloc_region),                 \
            _used_bytes_before);                                          \
   } while (0)

--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -214,7 +214,7 @@ HeapWord* G1Allocator::par_allocate_during_gc(G1HeapRegionAttr dest,
   size_t temp = 0;
   HeapWord* result = par_allocate_during_gc(dest, word_size, word_size, &temp, node_index);
   assert(result == nullptr || temp == word_size,
-         "Requested " SIZE_FORMAT " words, but got " SIZE_FORMAT " at " PTR_FORMAT,
+         "Requested %zu words, but got %zu at " PTR_FORMAT,
          word_size, temp, p2i(result));
   return result;
 }

--- a/src/hotspot/share/gc/g1/g1BiasedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.cpp
@@ -48,20 +48,20 @@ address G1BiasedMappedArrayBase::create_new_base_array(size_t length, size_t ele
 #ifndef PRODUCT
 void G1BiasedMappedArrayBase::verify_index(idx_t index) const {
   guarantee(_base != nullptr, "Array not initialized");
-  guarantee(index < length(), "Index out of bounds index: " SIZE_FORMAT " length: " SIZE_FORMAT, index, length());
+  guarantee(index < length(), "Index out of bounds index: %zu length: %zu", index, length());
 }
 
 void G1BiasedMappedArrayBase::verify_biased_index(idx_t biased_index) const {
   guarantee(_biased_base != nullptr, "Array not initialized");
   guarantee(biased_index >= bias() && biased_index < (bias() + length()),
-            "Biased index out of bounds, index: " SIZE_FORMAT " bias: " SIZE_FORMAT " length: " SIZE_FORMAT,
+            "Biased index out of bounds, index: %zu bias: %zu length: %zu",
             biased_index, bias(), length());
 }
 
 void G1BiasedMappedArrayBase::verify_biased_index_inclusive_end(idx_t biased_index) const {
   guarantee(_biased_base != nullptr, "Array not initialized");
   guarantee(biased_index >= bias() && biased_index <= (bias() + length()),
-            "Biased index out of inclusive bounds, index: " SIZE_FORMAT " bias: " SIZE_FORMAT " length: " SIZE_FORMAT,
+            "Biased index out of inclusive bounds, index: %zu bias: %zu length: %zu",
             biased_index, bias(), length());
 }
 

--- a/src/hotspot/share/gc/g1/g1BiasedArray.hpp
+++ b/src/hotspot/share/gc/g1/g1BiasedArray.hpp
@@ -72,12 +72,12 @@ protected:
   void initialize(HeapWord* bottom, HeapWord* end, size_t target_elem_size_in_bytes, size_t mapping_granularity_in_bytes) {
     assert(mapping_granularity_in_bytes > 0, "just checking");
     assert(is_power_of_2(mapping_granularity_in_bytes),
-           "mapping granularity must be power of 2, is " SIZE_FORMAT, mapping_granularity_in_bytes);
+           "mapping granularity must be power of 2, is %zu", mapping_granularity_in_bytes);
     assert((uintptr_t)bottom % mapping_granularity_in_bytes == 0,
-           "bottom mapping area address must be a multiple of mapping granularity " SIZE_FORMAT ", is  " PTR_FORMAT,
+           "bottom mapping area address must be a multiple of mapping granularity %zu, is  " PTR_FORMAT,
            mapping_granularity_in_bytes, p2i(bottom));
     assert((uintptr_t)end % mapping_granularity_in_bytes == 0,
-           "end mapping area address must be a multiple of mapping granularity " SIZE_FORMAT ", is " PTR_FORMAT,
+           "end mapping area address must be a multiple of mapping granularity %zu, is " PTR_FORMAT,
            mapping_granularity_in_bytes, p2i(end));
     size_t num_target_elems = pointer_delta(end, bottom, mapping_granularity_in_bytes);
     idx_t bias = (uintptr_t)bottom / mapping_granularity_in_bytes;

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -45,17 +45,17 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
   _offset_array = (u_char*)bot_reserved.start();
 
   log_trace(gc, bot)("G1BlockOffsetTable::G1BlockOffsetTable: ");
-  log_trace(gc, bot)("    rs.base(): " PTR_FORMAT "  rs.size(): " SIZE_FORMAT "  rs end(): " PTR_FORMAT,
+  log_trace(gc, bot)("    rs.base(): " PTR_FORMAT "  rs.size(): %zu  rs end(): " PTR_FORMAT,
                      p2i(bot_reserved.start()), bot_reserved.byte_size(), p2i(bot_reserved.end()));
 }
 
 #ifdef ASSERT
 void G1BlockOffsetTable::check_index(size_t index, const char* msg) const {
   assert((index) < (_reserved.word_size() >> BOTConstants::log_card_size_in_words()),
-         "%s - index: " SIZE_FORMAT ", _vs.committed_size: " SIZE_FORMAT,
+         "%s - index: %zu, _vs.committed_size: %zu",
          msg, (index), (_reserved.word_size() >> BOTConstants::log_card_size_in_words()));
   assert(G1CollectedHeap::heap()->is_in(address_for_index_raw(index)),
-         "Index " SIZE_FORMAT " corresponding to " PTR_FORMAT
+         "Index %zu corresponding to " PTR_FORMAT
          " (%u) is not in committed area.",
          (index),
          p2i(address_for_index_raw(index)),
@@ -261,7 +261,7 @@ void G1BlockOffsetTablePart::verify() const {
         size_t obj_size = _hr->block_size(obj);
         obj_end = obj + obj_size;
         guarantee(obj_end > obj && obj_end <= _hr->top(),
-                  "Invalid object end. obj: " PTR_FORMAT " obj_size: " SIZE_FORMAT " obj_end: " PTR_FORMAT " top: " PTR_FORMAT,
+                  "Invalid object end. obj: " PTR_FORMAT " obj_size: %zu obj_end: " PTR_FORMAT " top: " PTR_FORMAT,
                   p2i(obj), obj_size, p2i(obj_end), p2i(_hr->top()));
       }
     } else {
@@ -273,7 +273,7 @@ void G1BlockOffsetTablePart::verify() const {
 
       size_t max_backskip = current_card - start_card;
       guarantee(backskip <= max_backskip,
-                "Going backwards beyond the start_card. start_card: " SIZE_FORMAT " current_card: " SIZE_FORMAT " backskip: " SIZE_FORMAT,
+                "Going backwards beyond the start_card. start_card: %zu current_card: %zu backskip: %zu",
                 start_card, current_card, backskip);
 
       HeapWord* backskip_address = _bot->address_for_index(current_card - backskip);
@@ -289,7 +289,7 @@ void G1BlockOffsetTablePart::print_on(outputStream* out) {
   size_t from_index = _bot->index_for(_hr->bottom());
   size_t to_index = _bot->index_for(_hr->end());
   out->print_cr(">> BOT for area [" PTR_FORMAT "," PTR_FORMAT ") "
-                "cards [" SIZE_FORMAT "," SIZE_FORMAT ")",
+                "cards [%zu,%zu)",
                 p2i(_hr->bottom()), p2i(_hr->end()), from_index, to_index);
   for (size_t i = from_index; i < to_index; ++i) {
     out->print_cr("  entry " SIZE_FORMAT_W(8) " | " PTR_FORMAT " : %3u",

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ private:
 
   void check_offset(size_t offset, const char* msg) const {
     assert(offset < BOTConstants::card_size_in_words(),
-           "%s - offset: " SIZE_FORMAT ", N_words: %u",
+           "%s - offset: %zu, N_words: %u",
            msg, offset, BOTConstants::card_size_in_words());
   }
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -465,7 +465,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
         // We successfully scheduled a collection which failed to allocate. No
         // point in trying to allocate further. We'll just return null.
         log_trace(gc, alloc)("%s: Successfully scheduled collection failing to allocate "
-                             SIZE_FORMAT " words", Thread::current()->name(), word_size);
+                             "%zu words", Thread::current()->name(), word_size);
         return nullptr;
       }
       log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating %zu words",
@@ -474,7 +474,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
       // Failed to schedule a collection.
       if (gclocker_retry_count > GCLockerRetryAllocationCount) {
         log_warning(gc, alloc)("%s: Retried waiting for GCLocker too often allocating "
-                               SIZE_FORMAT " words", Thread::current()->name(), word_size);
+                               "%zu words", Thread::current()->name(), word_size);
         return nullptr;
       }
       log_trace(gc, alloc)("%s: Stall until clear", Thread::current()->name());
@@ -723,7 +723,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
         // We successfully scheduled a collection which failed to allocate. No
         // point in trying to allocate further. We'll just return null.
         log_trace(gc, alloc)("%s: Successfully scheduled collection failing to allocate "
-                             SIZE_FORMAT " words", Thread::current()->name(), word_size);
+                             "%zu words", Thread::current()->name(), word_size);
         return nullptr;
       }
       log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating %zu",
@@ -732,7 +732,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
       // Failed to schedule a collection.
       if (gclocker_retry_count > GCLockerRetryAllocationCount) {
         log_warning(gc, alloc)("%s: Retried waiting for GCLocker too often allocating "
-                               SIZE_FORMAT " words", Thread::current()->name(), word_size);
+                               "%zu words", Thread::current()->name(), word_size);
         return nullptr;
       }
       log_trace(gc, alloc)("%s: Stall until clear", Thread::current()->name());

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -176,11 +176,11 @@ HeapRegion* G1CollectedHeap::new_region(size_t word_size,
     // safepoint.
     assert(SafepointSynchronize::is_at_safepoint(), "invariant");
 
-    log_debug(gc, ergo, heap)("Attempt heap expansion (region allocation request failed). Allocation request: " SIZE_FORMAT "B",
+    log_debug(gc, ergo, heap)("Attempt heap expansion (region allocation request failed). Allocation request: %zuB",
                               word_size * HeapWordSize);
 
     assert(word_size * HeapWordSize < HeapRegion::GrainBytes,
-           "This kind of expansion should never be more than one region. Size: " SIZE_FORMAT,
+           "This kind of expansion should never be more than one region. Size: %zu",
            word_size * HeapWordSize);
     if (expand_single_region(node_index)) {
       // Given that expand_single_region() succeeded in expanding the heap, and we
@@ -332,7 +332,7 @@ G1CollectedHeap::humongous_obj_allocate_initialize_regions(HeapRegion* first_hr,
 }
 
 size_t G1CollectedHeap::humongous_obj_size_in_regions(size_t word_size) {
-  assert(is_humongous(word_size), "Object of size " SIZE_FORMAT " must be humongous here", word_size);
+  assert(is_humongous(word_size), "Object of size %zu must be humongous here", word_size);
   return align_up(word_size, HeapRegion::GrainWords) / HeapRegion::GrainWords;
 }
 
@@ -355,7 +355,7 @@ HeapWord* G1CollectedHeap::humongous_obj_allocate(size_t word_size) {
     humongous_start = _hrm.expand_and_allocate_humongous(obj_regions);
     if (humongous_start != nullptr) {
       // We managed to find a region by expanding the heap.
-      log_debug(gc, ergo, heap)("Heap expansion (humongous allocation request). Allocation request: " SIZE_FORMAT "B",
+      log_debug(gc, ergo, heap)("Heap expansion (humongous allocation request). Allocation request: %zuB",
                                 word_size * HeapWordSize);
       policy()->record_new_heap_size(num_regions());
     } else {
@@ -468,7 +468,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
                              SIZE_FORMAT " words", Thread::current()->name(), word_size);
         return nullptr;
       }
-      log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating " SIZE_FORMAT " words",
+      log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating %zu words",
                            Thread::current()->name(), word_size);
     } else {
       // Failed to schedule a collection.
@@ -502,7 +502,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_slow(size_t word_size) {
     // Give a warning if we seem to be looping forever.
     if ((QueuedAllocationWarningCount > 0) &&
         (try_count % QueuedAllocationWarningCount == 0)) {
-      log_warning(gc, alloc)("%s:  Retried allocation %u times for " SIZE_FORMAT " words",
+      log_warning(gc, alloc)("%s:  Retried allocation %u times for %zu words",
                              Thread::current()->name(), try_count, word_size);
     }
   }
@@ -535,8 +535,8 @@ HeapWord* G1CollectedHeap::alloc_archive_region(size_t word_size, HeapWord* pref
   MemRegion reserved = _hrm.reserved();
 
   if (reserved.word_size() <= word_size) {
-    log_info(gc, heap)("Unable to allocate regions as archive heap is too large; size requested = " SIZE_FORMAT
-                       " bytes, heap = " SIZE_FORMAT " bytes", word_size, reserved.word_size());
+    log_info(gc, heap)("Unable to allocate regions as archive heap is too large; size requested = %zu"
+                       " bytes, heap = %zu bytes", word_size, reserved.word_size());
     return nullptr;
   }
 
@@ -554,7 +554,7 @@ HeapWord* G1CollectedHeap::alloc_archive_region(size_t word_size, HeapWord* pref
   }
   increase_used(word_size * HeapWordSize);
   if (commits != 0) {
-    log_debug(gc, ergo, heap)("Attempt heap expansion (allocate archive regions). Total size: " SIZE_FORMAT "B",
+    log_debug(gc, ergo, heap)("Attempt heap expansion (allocate archive regions). Total size: %zuB",
                               HeapRegion::GrainWords * HeapWordSize * commits);
   }
 
@@ -613,7 +613,7 @@ void G1CollectedHeap::dealloc_archive_regions(MemRegion range) {
   iterate_regions_in_range(range, dealloc_archive_region);
 
   if (shrink_count != 0) {
-    log_debug(gc, ergo, heap)("Attempt heap shrinking (CDS archive regions). Total size: " SIZE_FORMAT "B",
+    log_debug(gc, ergo, heap)("Attempt heap shrinking (CDS archive regions). Total size: %zuB",
                               HeapRegion::GrainWords * HeapWordSize * shrink_count);
     // Explicit uncommit.
     uncommit_regions(shrink_count);
@@ -726,7 +726,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
                              SIZE_FORMAT " words", Thread::current()->name(), word_size);
         return nullptr;
       }
-      log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating " SIZE_FORMAT "",
+      log_trace(gc, alloc)("%s: Unsuccessfully scheduled collection allocating %zu",
                            Thread::current()->name(), word_size);
     } else {
       // Failed to schedule a collection.
@@ -755,7 +755,7 @@ HeapWord* G1CollectedHeap::attempt_allocation_humongous(size_t word_size) {
 
     if ((QueuedAllocationWarningCount > 0) &&
         (try_count % QueuedAllocationWarningCount == 0)) {
-      log_warning(gc, alloc)("%s: Retried allocation %u times for " SIZE_FORMAT " words",
+      log_warning(gc, alloc)("%s: Retried allocation %u times for %zu words",
                              Thread::current()->name(), try_count, word_size);
     }
   }
@@ -1063,7 +1063,7 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
   _verifier->verify_region_sets_optional();
 
   size_t expand_bytes = MAX2(word_size * HeapWordSize, MinHeapDeltaBytes);
-  log_debug(gc, ergo, heap)("Attempt heap expansion (allocation request failed). Allocation request: " SIZE_FORMAT "B",
+  log_debug(gc, ergo, heap)("Attempt heap expansion (allocation request failed). Allocation request: %zuB",
                             word_size * HeapWordSize);
 
 
@@ -1081,7 +1081,7 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
   aligned_expand_bytes = align_up(aligned_expand_bytes,
                                        HeapRegion::GrainBytes);
 
-  log_debug(gc, ergo, heap)("Expand the heap. requested expansion amount: " SIZE_FORMAT "B expansion amount: " SIZE_FORMAT "B",
+  log_debug(gc, ergo, heap)("Expand the heap. requested expansion amount: %zuB expansion amount: %zuB",
                             expand_bytes, aligned_expand_bytes);
 
   if (is_maximal_no_gc()) {
@@ -1130,7 +1130,7 @@ void G1CollectedHeap::shrink_helper(size_t shrink_bytes) {
   uint num_regions_removed = _hrm.shrink_by(num_regions_to_remove);
   size_t shrunk_bytes = num_regions_removed * HeapRegion::GrainBytes;
 
-  log_debug(gc, ergo, heap)("Shrink the heap. requested shrinking amount: " SIZE_FORMAT "B aligned shrinking amount: " SIZE_FORMAT "B actual amount shrunk: " SIZE_FORMAT "B",
+  log_debug(gc, ergo, heap)("Shrink the heap. requested shrinking amount: %zuB aligned shrinking amount: %zuB actual amount shrunk: %zuB",
                             shrink_bytes, aligned_shrink_bytes, shrunk_bytes);
   if (num_regions_removed > 0) {
     log_debug(gc, heap)("Uncommittable regions after shrink: %u", num_regions_removed);
@@ -2199,18 +2199,18 @@ void G1CollectedHeap::print_heap_regions() const {
 void G1CollectedHeap::print_on(outputStream* st) const {
   size_t heap_used = Heap_lock->owned_by_self() ? used() : used_unlocked();
   st->print(" %-20s", "garbage-first heap");
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total %zuK, used %zuK",
             capacity()/K, heap_used/K);
   st->print(" [" PTR_FORMAT ", " PTR_FORMAT ")",
             p2i(_hrm.reserved().start()),
             p2i(_hrm.reserved().end()));
   st->cr();
-  st->print("  region size " SIZE_FORMAT "K, ", HeapRegion::GrainBytes / K);
+  st->print("  region size %zuK, ", HeapRegion::GrainBytes / K);
   uint young_regions = young_regions_count();
-  st->print("%u young (" SIZE_FORMAT "K), ", young_regions,
+  st->print("%u young (%zuK), ", young_regions,
             (size_t) young_regions * HeapRegion::GrainBytes / K);
   uint survivor_regions = survivor_regions_count();
-  st->print("%u survivors (" SIZE_FORMAT "K)", survivor_regions,
+  st->print("%u survivors (%zuK)", survivor_regions,
             (size_t) survivor_regions * HeapRegion::GrainBytes / K);
   st->cr();
   if (_numa->is_enabled()) {
@@ -2776,7 +2776,7 @@ void G1CollectedHeap::increase_used(size_t bytes) {
 
 void G1CollectedHeap::decrease_used(size_t bytes) {
   assert(_summary_bytes_used >= bytes,
-         "invariant: _summary_bytes_used: " SIZE_FORMAT " should be >= bytes: " SIZE_FORMAT,
+         "invariant: _summary_bytes_used: %zu should be >= bytes: %zu",
          _summary_bytes_used, bytes);
   _summary_bytes_used -= bytes;
 }
@@ -2965,7 +2965,7 @@ HeapRegion* G1CollectedHeap::alloc_highest_free_region() {
 
   if (index != G1_NO_HRM_INDEX) {
     if (expanded) {
-      log_debug(gc, ergo, heap)("Attempt heap expansion (requested address range outside heap bounds). region size: " SIZE_FORMAT "B",
+      log_debug(gc, ergo, heap)("Attempt heap expansion (requested address range outside heap bounds). region size: %zuB",
                                 HeapRegion::GrainWords * HeapWordSize);
     }
     return _hrm.allocate_free_regions_starting_at(index, 1);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -364,8 +364,8 @@ private:
   do {                                                                        \
     size_t cur_used_bytes = g1h->used();                                      \
     size_t recal_used_bytes = g1h->recalculate_used();                        \
-    assert(cur_used_bytes == recal_used_bytes, "Used(" SIZE_FORMAT ") is not" \
-           " same as recalculated used(" SIZE_FORMAT ").",                    \
+    assert(cur_used_bytes == recal_used_bytes, "Used(%zu) is not" \
+           " same as recalculated used(%zu).",                    \
            cur_used_bytes, recal_used_bytes);                                 \
   } while (0)
 #else

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -280,7 +280,7 @@ double G1CollectionSet::finalize_young_part(double target_pause_time_ms, G1Survi
 
   size_t pending_cards = _policy->pending_cards_at_gc_start();
 
-  log_trace(gc, ergo, cset)("Start choosing CSet. Pending cards: " SIZE_FORMAT " target pause time: %1.2fms",
+  log_trace(gc, ergo, cset)("Start choosing CSet. Pending cards: %zu target pause time: %1.2fms",
                             pending_cards, target_pause_time_ms);
 
   // The young list is laid with the survivor regions from the previous

--- a/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetChooser.cpp
@@ -215,7 +215,7 @@ class G1BuildCandidateRegionsTask : public WorkerTask {
       num_pruned++;
     }
 
-    log_debug(gc, ergo, cset)("Pruned %u regions out of %u, leaving " SIZE_FORMAT " bytes waste (allowed " SIZE_FORMAT ")",
+    log_debug(gc, ergo, cset)("Pruned %u regions out of %u, leaving %zu bytes waste (allowed %zu)",
                               num_pruned,
                               num_candidates,
                               wasted_bytes,

--- a/src/hotspot/share/gc/g1/g1CommittedRegionMap.cpp
+++ b/src/hotspot/share/gc/g1/g1CommittedRegionMap.cpp
@@ -233,7 +233,7 @@ void G1CommittedRegionMap::verify_free_range(uint start, uint end) const {
 
 void G1CommittedRegionMap::verify_no_inactive_regons() const {
   BitMap::idx_t first_inactive = _inactive.find_first_set_bit(0);
-  assert(first_inactive == _inactive.size(), "Should be no inactive regions, but was at index: " SIZE_FORMAT, first_inactive);
+  assert(first_inactive == _inactive.size(), "Should be no inactive regions, but was at index: %zu", first_inactive);
 }
 
 void G1CommittedRegionMap::verify_active_count(uint start, uint end, uint expected) const {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1669,7 +1669,7 @@ void G1ConcurrentMark::weak_refs_work() {
     // We can not trust g1_is_alive and the contents of the heap if the marking stack
     // overflowed while processing references. Exit the VM.
     fatal("Overflow during reference processing, can not continue. Current mark stack depth: "
-          SIZE_FORMAT ", MarkStackSize: %zu, MarkStackSizeMax: %zu. "
+          "%zu, MarkStackSize: %zu, MarkStackSizeMax: %zu. "
           "Please increase MarkStackSize and/or MarkStackSizeMax and restart.",
           _global_mark_stack.size(), MarkStackSize, MarkStackSizeMax);
     return;

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -92,7 +92,7 @@ inline void G1CMMarkStack::iterate(Fn fn) const {
 
   TaskQueueEntryChunk* cur = _chunk_list;
   while (cur != nullptr) {
-    guarantee(num_chunks <= _chunks_in_chunk_list, "Found " SIZE_FORMAT " oop chunks which is more than there should be", num_chunks);
+    guarantee(num_chunks <= _chunks_in_chunk_list, "Found %zu oop chunks which is more than there should be", num_chunks);
 
     for (size_t i = 0; i < EntriesPerChunk; ++i) {
       if (cur->data[i].is_null()) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkObjArrayProcessor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ size_t G1CMObjArrayProcessor::process_array_slice(objArrayOop obj, HeapWord* sta
 }
 
 size_t G1CMObjArrayProcessor::process_obj(oop obj) {
-  assert(should_be_sliced(obj), "Must be an array object %d and large " SIZE_FORMAT, obj->is_objArray(), obj->size());
+  assert(should_be_sliced(obj), "Must be an array object %d and large %zu", obj->is_objArray(), obj->size());
 
   return process_array_slice(objArrayOop(obj), cast_from_oop<HeapWord*>(obj), objArrayOop(obj)->size());
 }

--- a/src/hotspot/share/gc/g1/g1DirtyCardQueue.cpp
+++ b/src/hotspot/share/gc/g1/g1DirtyCardQueue.cpp
@@ -172,7 +172,7 @@ void G1DirtyCardQueueSet::verify_num_cards() const {
     actual += buffer_capacity() - cur->index();
   }
   assert(actual == Atomic::load(&_num_cards),
-         "Num entries in completed buffers should be " SIZE_FORMAT " but are " SIZE_FORMAT,
+         "Num entries in completed buffers should be %zu but are %zu",
          Atomic::load(&_num_cards), actual);
 }
 #endif // ASSERT
@@ -469,7 +469,7 @@ void G1DirtyCardQueueSet::handle_refined_buffer(BufferNode* node,
                                                 bool fully_processed) {
   if (fully_processed) {
     assert(node->index() == buffer_capacity(),
-           "Buffer not fully consumed: index: " SIZE_FORMAT ", size: " SIZE_FORMAT,
+           "Buffer not fully consumed: index: %zu, size: %zu",
            node->index(), buffer_capacity());
     deallocate_buffer(node);
   } else {

--- a/src/hotspot/share/gc/g1/g1FromCardCache.cpp
+++ b/src/hotspot/share/gc/g1/g1FromCardCache.cpp
@@ -57,7 +57,7 @@ void G1FromCardCache::initialize(uint max_reserved_regions) {
 
 void G1FromCardCache::invalidate(uint start_idx, size_t new_num_regions) {
   guarantee((size_t)start_idx + new_num_regions <= max_uintx,
-            "Trying to invalidate beyond maximum region, from %u size " SIZE_FORMAT,
+            "Trying to invalidate beyond maximum region, from %u size %zu",
             start_idx, new_num_regions);
   uint end_idx = (start_idx + (uint)new_num_regions);
   assert(end_idx <= _max_reserved_regions, "Must be within max.");
@@ -73,7 +73,7 @@ void G1FromCardCache::invalidate(uint start_idx, size_t new_num_regions) {
 void G1FromCardCache::print(outputStream* out) {
   for (uint i = 0; i < num_par_rem_sets(); i++) {
     for (uint j = 0; j < _max_reserved_regions; j++) {
-      out->print_cr("_from_card_cache[%u][%u] = " SIZE_FORMAT ".",
+      out->print_cr("_from_card_cache[%u][%u] = %zu.",
                     i, j, at(i, j));
     }
   }

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
@@ -93,7 +93,7 @@ inline bool G1DetermineCompactionQueueClosure::do_heap_region(HeapRegion* hr) {
 
       // Too many live objects in the region; skip compacting it.
       _collector->update_from_compacting_to_skip_compacting(hr->hrm_index());
-      log_trace(gc, phases)("Phase 2: skip compaction region index: %u, live words: " SIZE_FORMAT,
+      log_trace(gc, phases)("Phase 2: skip compaction region index: %u, live words: %zu",
                             hr->hrm_index(), _collector->live_words(hr->hrm_index()));
     }
   }

--- a/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
+++ b/src/hotspot/share/gc/g1/g1GCPhaseTimes.cpp
@@ -397,7 +397,7 @@ void G1GCPhaseTimes::trace_time(const char* name, double value) const {
 }
 
 void G1GCPhaseTimes::trace_count(const char* name, size_t value) const {
-  log_trace(gc, phases)("      %s: " SIZE_FORMAT, name, value);
+  log_trace(gc, phases)("      %s: %zu", name, value);
 }
 
 double G1GCPhaseTimes::print_pre_evacuate_collection_set() const {

--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ static void log_expansion(double short_term_pause_time_ratio,
   log_debug(gc, ergo, heap)("Heap expansion: "
                             "short term pause time ratio %1.2f%% long term pause time ratio %1.2f%% "
                             "threshold %1.2f%% pause time ratio %1.2f%% fully expanded %s "
-                            "resize by " SIZE_FORMAT "B",
+                            "resize by %zuB",
                             short_term_pause_time_ratio * 100.0,
                             long_term_pause_time_ratio * 100.0,
                             threshold * 100.0,
@@ -225,8 +225,8 @@ size_t G1HeapSizingPolicy::full_collection_resize_amount(bool& expand) {
   // This assert only makes sense here, before we adjust them
   // with respect to the min and max heap size.
   assert(minimum_desired_capacity <= maximum_desired_capacity,
-         "minimum_desired_capacity = " SIZE_FORMAT ", "
-         "maximum_desired_capacity = " SIZE_FORMAT,
+         "minimum_desired_capacity = %zu, "
+         "maximum_desired_capacity = %zu",
          minimum_desired_capacity, maximum_desired_capacity);
 
   // Should not be greater than the heap max size. No need to adjust
@@ -243,8 +243,8 @@ size_t G1HeapSizingPolicy::full_collection_resize_amount(bool& expand) {
     size_t expand_bytes = minimum_desired_capacity - capacity_after_gc;
 
     log_debug(gc, ergo, heap)("Attempt heap expansion (capacity lower than min desired capacity). "
-                              "Capacity: " SIZE_FORMAT "B occupancy: " SIZE_FORMAT "B live: " SIZE_FORMAT "B "
-                              "min_desired_capacity: " SIZE_FORMAT "B (" UINTX_FORMAT " %%)",
+                              "Capacity: %zuB occupancy: %zuB live: %zuB "
+                              "min_desired_capacity: %zuB (" UINTX_FORMAT " %%)",
                               capacity_after_gc, used_after_gc, _g1h->used(), minimum_desired_capacity, MinHeapFreeRatio);
 
     expand = true;
@@ -255,8 +255,8 @@ size_t G1HeapSizingPolicy::full_collection_resize_amount(bool& expand) {
     size_t shrink_bytes = capacity_after_gc - maximum_desired_capacity;
 
     log_debug(gc, ergo, heap)("Attempt heap shrinking (capacity higher than max desired capacity). "
-                              "Capacity: " SIZE_FORMAT "B occupancy: " SIZE_FORMAT "B live: " SIZE_FORMAT "B "
-                              "maximum_desired_capacity: " SIZE_FORMAT "B (" UINTX_FORMAT " %%)",
+                              "Capacity: %zuB occupancy: %zuB live: %zuB "
+                              "maximum_desired_capacity: %zuB (" UINTX_FORMAT " %%)",
                               capacity_after_gc, used_after_gc, _g1h->used(), maximum_desired_capacity, MaxHeapFreeRatio);
 
     expand = false;

--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -96,7 +96,7 @@ public:
       _usage._humongous_used += r->used();
       _usage._humongous_region_count++;
     } else {
-      assert(r->used() == 0, "Expected used to be 0 but it was " SIZE_FORMAT, r->used());
+      assert(r->used() == 0, "Expected used to be 0 but it was %zu", r->used());
     }
     return false;
   }
@@ -109,7 +109,7 @@ static void log_regions(const char* msg, size_t before_length, size_t after_leng
   if (lt.is_enabled()) {
     LogStream ls(lt);
 
-    ls.print("%s regions: " SIZE_FORMAT "->" SIZE_FORMAT "("  SIZE_FORMAT ")",
+    ls.print("%s regions: %zu->%zu("  SIZE_FORMAT ")",
              msg, before_length, after_length, capacity);
     // Not null only if gc+heap+numa at Debug level is enabled.
     if (before_per_node_length != nullptr && after_per_node_length != nullptr) {
@@ -141,12 +141,12 @@ void G1HeapTransition::print() {
     DetailedUsageClosure blk;
     _g1_heap->heap_region_iterate(&blk);
     usage = blk._usage;
-    assert(usage._eden_region_count == 0, "Expected no eden regions, but got " SIZE_FORMAT, usage._eden_region_count);
-    assert(usage._survivor_region_count == after._survivor_length, "Expected survivors to be " SIZE_FORMAT " but was " SIZE_FORMAT,
+    assert(usage._eden_region_count == 0, "Expected no eden regions, but got %zu", usage._eden_region_count);
+    assert(usage._survivor_region_count == after._survivor_length, "Expected survivors to be %zu but was %zu",
         after._survivor_length, usage._survivor_region_count);
-    assert(usage._old_region_count == after._old_length, "Expected old to be " SIZE_FORMAT " but was " SIZE_FORMAT,
+    assert(usage._old_region_count == after._old_length, "Expected old to be %zu but was %zu",
         after._old_length, usage._old_region_count);
-    assert(usage._humongous_region_count == after._humongous_length, "Expected humongous to be " SIZE_FORMAT " but was " SIZE_FORMAT,
+    assert(usage._humongous_region_count == after._humongous_length, "Expected humongous to be %zu but was %zu",
         after._humongous_length, usage._humongous_region_count);
   }
 
@@ -156,17 +156,17 @@ void G1HeapTransition::print() {
 
   log_regions("Survivor", _before._survivor_length, after._survivor_length, survivor_capacity_length_before_gc,
               _before._survivor_length_per_node, after._survivor_length_per_node);
-  log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
+  log_trace(gc, heap)(" Used: %zuK, Waste: %zuK",
       usage._survivor_used / K, ((after._survivor_length * HeapRegion::GrainBytes) - usage._survivor_used) / K);
 
-  log_info(gc, heap)("Old regions: " SIZE_FORMAT "->" SIZE_FORMAT,
+  log_info(gc, heap)("Old regions: %zu->%zu",
                      _before._old_length, after._old_length);
-  log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
+  log_trace(gc, heap)(" Used: %zuK, Waste: %zuK",
       usage._old_used / K, ((after._old_length * HeapRegion::GrainBytes) - usage._old_used) / K);
 
-  log_info(gc, heap)("Humongous regions: " SIZE_FORMAT "->" SIZE_FORMAT,
+  log_info(gc, heap)("Humongous regions: %zu->%zu",
                      _before._humongous_length, after._humongous_length);
-  log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
+  log_trace(gc, heap)(" Used: %zuK, Waste: %zuK",
       usage._humongous_used / K, ((after._humongous_length * HeapRegion::GrainBytes) - usage._humongous_used) / K);
 
   MetaspaceUtils::print_metaspace_change(_before._meta_sizes);

--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -109,7 +109,7 @@ static void log_regions(const char* msg, size_t before_length, size_t after_leng
   if (lt.is_enabled()) {
     LogStream ls(lt);
 
-    ls.print("%s regions: %zu->%zu("  SIZE_FORMAT ")",
+    ls.print("%s regions: %zu->%zu("  "%zu)",
              msg, before_length, after_length, capacity);
     // Not null only if gc+heap+numa at Debug level is enabled.
     if (before_per_node_length != nullptr && after_per_node_length != nullptr) {

--- a/src/hotspot/share/gc/g1/g1IHOPControl.cpp
+++ b/src/hotspot/share/gc/g1/g1IHOPControl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ G1IHOPControl::G1IHOPControl(double initial_ihop_percent,
 }
 
 void G1IHOPControl::update_target_occupancy(size_t new_target_occupancy) {
-  log_debug(gc, ihop)("Target occupancy update: old: " SIZE_FORMAT "B, new: " SIZE_FORMAT "B",
+  log_debug(gc, ihop)("Target occupancy update: old: %zuB, new: %zuB",
                       _target_occupancy, new_target_occupancy);
   _target_occupancy = new_target_occupancy;
 }
@@ -54,8 +54,8 @@ void G1IHOPControl::update_allocation_info(double allocation_time_s, size_t addi
 void G1IHOPControl::print() {
   assert(_target_occupancy > 0, "Target occupancy still not updated yet.");
   size_t cur_conc_mark_start_threshold = get_conc_mark_start_threshold();
-  log_debug(gc, ihop)("Basic information (value update), threshold: " SIZE_FORMAT "B (%1.2f), target occupancy: " SIZE_FORMAT "B, current occupancy: " SIZE_FORMAT "B, "
-                      "recent allocation size: " SIZE_FORMAT "B, recent allocation duration: %1.2fms, recent old gen allocation rate: %1.2fB/s, recent marking phase length: %1.2fms",
+  log_debug(gc, ihop)("Basic information (value update), threshold: %zuB (%1.2f), target occupancy: %zuB, current occupancy: %zuB, "
+                      "recent allocation size: %zuB, recent allocation duration: %1.2fms, recent old gen allocation rate: %1.2fB/s, recent marking phase length: %1.2fms",
                       cur_conc_mark_start_threshold,
                       percent_of(cur_conc_mark_start_threshold, _target_occupancy),
                       _target_occupancy,
@@ -169,8 +169,8 @@ void G1AdaptiveIHOPControl::update_marking_length(double marking_length_s) {
 void G1AdaptiveIHOPControl::print() {
   G1IHOPControl::print();
   size_t actual_target = actual_target_threshold();
-  log_debug(gc, ihop)("Adaptive IHOP information (value update), threshold: " SIZE_FORMAT "B (%1.2f), internal target occupancy: " SIZE_FORMAT "B, "
-                      "occupancy: " SIZE_FORMAT "B, additional buffer size: " SIZE_FORMAT "B, predicted old gen allocation rate: %1.2fB/s, "
+  log_debug(gc, ihop)("Adaptive IHOP information (value update), threshold: %zuB (%1.2f), internal target occupancy: %zuB, "
+                      "occupancy: %zuB, additional buffer size: %zuB, predicted old gen allocation rate: %1.2fB/s, "
                       "predicted marking phase length: %1.2fms, prediction active: %s",
                       get_conc_mark_start_threshold(),
                       percent_of(get_conc_mark_start_threshold(), actual_target),

--- a/src/hotspot/share/gc/g1/g1InitLogger.cpp
+++ b/src/hotspot/share/gc/g1/g1InitLogger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 void G1InitLogger::print_heap() {
-  log_info_p(gc, init)("Heap Region Size: " SIZE_FORMAT "M", G1HeapRegionSize / M);
+  log_info_p(gc, init)("Heap Region Size: %zuM", G1HeapRegionSize / M);
   GCInitLogger::print_heap();
 }
 

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -286,12 +286,12 @@ void G1MonitoringSupport::recalculate_sizes() {
   _eden_space_used = MIN2(_eden_space_used, _eden_space_committed);
   // _survivor_space_used is calculated during a safepoint and _survivor_space_committed
   // is calculated from survivor region count * heap region size.
-  assert(_survivor_space_used <= _survivor_space_committed, "Survivor used bytes(" SIZE_FORMAT
-         ") should be less than or equal to survivor committed(" SIZE_FORMAT ")",
+  assert(_survivor_space_used <= _survivor_space_committed, "Survivor used bytes(%zu"
+         ") should be less than or equal to survivor committed(%zu)",
          _survivor_space_used, _survivor_space_committed);
   // _old_gen_committed is calculated in terms of _old_gen_used value.
-  assert(_old_gen_used <= _old_gen_committed, "Old gen used bytes(" SIZE_FORMAT
-         ") should be less than or equal to old gen committed(" SIZE_FORMAT ")",
+  assert(_old_gen_used <= _old_gen_committed, "Old gen used bytes(%zu"
+         ") should be less than or equal to old gen committed(%zu)",
          _old_gen_used, _old_gen_committed);
 }
 

--- a/src/hotspot/share/gc/g1/g1NUMA.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMA.cpp
@@ -216,7 +216,7 @@ void G1NUMA::request_memory_on_node(void* aligned_address, size_t size_in_bytes,
   uint node_index = preferred_node_index_for_index(region_index);
 
   assert(is_aligned(aligned_address, page_size()), "Given address (" PTR_FORMAT ") should be aligned.", p2i(aligned_address));
-  assert(is_aligned(size_in_bytes, page_size()), "Given size (" SIZE_FORMAT ") should be aligned.", size_in_bytes);
+  assert(is_aligned(size_in_bytes, page_size()), "Given size (%zu) should be aligned.", size_in_bytes);
 
   log_trace(gc, heap, numa)("Request memory [" PTR_FORMAT ", " PTR_FORMAT ") to be NUMA id (%d)",
                             p2i(aligned_address), p2i((char*)aligned_address + size_in_bytes), _node_ids[node_index]);

--- a/src/hotspot/share/gc/g1/g1NUMAStats.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMAStats.cpp
@@ -162,7 +162,7 @@ static const char* phase_to_explanatory_string(G1NUMAStats::NodeDataItems phase)
   }
 }
 
-#define RATE_TOTAL_FORMAT "%0.0f%% " SIZE_FORMAT "/" SIZE_FORMAT
+#define RATE_TOTAL_FORMAT "%0.0f%% %zu/%zu"
 
 void G1NUMAStats::print_info(G1NUMAStats::NodeDataItems phase) {
   LogTarget(Info, gc, heap, numa) lt;

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -48,13 +48,13 @@ void G1PageBasedVirtualSpace::initialize_with_page_size(ReservedSpace rs, size_t
   vmassert(page_size > 0, "Page size must be non-zero.");
 
   guarantee(is_aligned(rs.base(), page_size),
-            "Reserved space base " PTR_FORMAT " is not aligned to requested page size " SIZE_FORMAT, p2i(rs.base()), page_size);
+            "Reserved space base " PTR_FORMAT " is not aligned to requested page size %zu", p2i(rs.base()), page_size);
   guarantee(is_aligned(used_size, os::vm_page_size()),
-            "Given used reserved space size needs to be OS page size aligned (" SIZE_FORMAT " bytes) but is " SIZE_FORMAT, os::vm_page_size(), used_size);
+            "Given used reserved space size needs to be OS page size aligned (%zu bytes) but is %zu", os::vm_page_size(), used_size);
   guarantee(used_size <= rs.size(),
-            "Used size of reserved space " SIZE_FORMAT " bytes is smaller than reservation at " SIZE_FORMAT " bytes", used_size, rs.size());
+            "Used size of reserved space %zu bytes is smaller than reservation at %zu bytes", used_size, rs.size());
   guarantee(is_aligned(rs.size(), page_size),
-            "Expected that the virtual space is size aligned, but " SIZE_FORMAT " is not aligned to page size " SIZE_FORMAT, rs.size(), page_size);
+            "Expected that the virtual space is size aligned, but %zu is not aligned to page size %zu", rs.size(), page_size);
 
   _low_boundary  = rs.base();
   _high_boundary = _low_boundary + used_size;
@@ -125,15 +125,15 @@ size_t G1PageBasedVirtualSpace::page_size() const {
 
 bool G1PageBasedVirtualSpace::is_after_last_page(size_t index) const {
   guarantee(index <= _committed.size(),
-            "Given boundary page " SIZE_FORMAT " is beyond managed page count " SIZE_FORMAT, index, _committed.size());
+            "Given boundary page %zu is beyond managed page count %zu", index, _committed.size());
   return index == _committed.size();
 }
 
 void G1PageBasedVirtualSpace::commit_preferred_pages(size_t start, size_t num_pages) {
   vmassert(num_pages > 0, "No full pages to commit");
   vmassert(start + num_pages <= _committed.size(),
-           "Tried to commit area from page " SIZE_FORMAT " to page " SIZE_FORMAT " "
-           "that is outside of managed space of " SIZE_FORMAT " pages",
+           "Tried to commit area from page %zu to page %zu "
+           "that is outside of managed space of %zu pages",
            start, start + num_pages, _committed.size());
 
   char* start_addr = page_start(start);
@@ -151,9 +151,9 @@ void G1PageBasedVirtualSpace::commit_tail() {
 
 void G1PageBasedVirtualSpace::commit_internal(size_t start_page, size_t end_page) {
   guarantee(start_page < end_page,
-            "Given start page " SIZE_FORMAT " is larger or equal to end page " SIZE_FORMAT, start_page, end_page);
+            "Given start page %zu is larger or equal to end page %zu", start_page, end_page);
   guarantee(end_page <= _committed.size(),
-            "Given end page " SIZE_FORMAT " is beyond end of managed page amount of " SIZE_FORMAT, end_page, _committed.size());
+            "Given end page %zu is beyond end of managed page amount of %zu", end_page, _committed.size());
 
   size_t pages = end_page - start_page;
   bool need_to_commit_tail = is_after_last_page(end_page) && is_last_page_partial();
@@ -180,7 +180,7 @@ char* G1PageBasedVirtualSpace::bounded_end_addr(size_t end_page) const {
 bool G1PageBasedVirtualSpace::commit(size_t start_page, size_t size_in_pages) {
   // We need to make sure to commit all pages covered by the given area.
   guarantee(is_area_uncommitted(start_page, size_in_pages),
-            "Specified area is not uncommitted, start page: " SIZE_FORMAT ", page count: " SIZE_FORMAT,
+            "Specified area is not uncommitted, start page: %zu, page count: %zu",
             start_page, size_in_pages);
 
   bool zero_filled = true;
@@ -202,7 +202,7 @@ bool G1PageBasedVirtualSpace::commit(size_t start_page, size_t size_in_pages) {
 
 void G1PageBasedVirtualSpace::uncommit_internal(size_t start_page, size_t end_page) {
   guarantee(start_page < end_page,
-            "Given start page " SIZE_FORMAT " is larger or equal to end page " SIZE_FORMAT, start_page, end_page);
+            "Given start page %zu is larger or equal to end page %zu", start_page, end_page);
 
   char* start_addr = page_start(start_page);
   os::uncommit_memory(start_addr, pointer_delta(bounded_end_addr(end_page), start_addr, sizeof(char)));
@@ -210,7 +210,7 @@ void G1PageBasedVirtualSpace::uncommit_internal(size_t start_page, size_t end_pa
 
 void G1PageBasedVirtualSpace::uncommit(size_t start_page, size_t size_in_pages) {
   guarantee(is_area_committed(start_page, size_in_pages),
-            "Specified area is not committed, start page: " SIZE_FORMAT ", page count: " SIZE_FORMAT,
+            "Specified area is not committed, start page: %zu, page count: %zu",
             start_page, size_in_pages);
 
   size_t end_page = start_page + size_in_pages;
@@ -240,9 +240,9 @@ void G1PageBasedVirtualSpace::print_on(outputStream* out) {
   out->print   ("Virtual space:");
   if (_special) out->print(" (pinned in memory)");
   out->cr();
-  out->print_cr(" - committed: " SIZE_FORMAT, committed_size());
-  out->print_cr(" - reserved:  " SIZE_FORMAT, reserved_size());
-  out->print_cr(" - preferred page size: " SIZE_FORMAT, _page_size);
+  out->print_cr(" - committed: %zu", committed_size());
+  out->print_cr(" - reserved:  %zu", reserved_size());
+  out->print_cr(" - preferred page size: %zu", _page_size);
   out->print_cr(" - [low_b, high_b]: [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(_low_boundary), p2i(_high_boundary));
 }
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ inline void G1ParScanThreadState::remember_root_into_optional_region(T* p) {
   oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
   uint index = _g1h->heap_region_containing(o)->index_in_opt_cset();
   assert(index < _max_num_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _max_num_optional_regions);
+         "Trying to access optional region idx %u beyond %zu", index, _max_num_optional_regions);
   _oops_into_optional_regions[index].push_root(p);
 }
 
@@ -84,14 +84,14 @@ inline void G1ParScanThreadState::remember_reference_into_optional_region(T* p) 
   oop o = RawAccess<IS_NOT_NULL>::oop_load(p);
   uint index = _g1h->heap_region_containing(o)->index_in_opt_cset();
   assert(index < _max_num_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT, index, _max_num_optional_regions);
+         "Trying to access optional region idx %u beyond %zu", index, _max_num_optional_regions);
   _oops_into_optional_regions[index].push_oop(p);
   verify_task(p);
 }
 
 G1OopStarChunkedList* G1ParScanThreadState::oops_into_optional_region(const HeapRegion* hr) {
   assert(hr->index_in_opt_cset() < _max_num_optional_regions,
-         "Trying to access optional region idx %u beyond " SIZE_FORMAT " " HR_FORMAT,
+         "Trying to access optional region idx %u beyond %zu " HR_FORMAT,
          hr->index_in_opt_cset(), _max_num_optional_regions, HR_FORMAT_PARAMS(hr));
   return &_oops_into_optional_regions[hr->index_in_opt_cset()];
 }

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -570,8 +570,8 @@ void G1Policy::record_full_collection_end() {
 
 static void log_refinement_stats(const char* kind, const G1ConcurrentRefineStats& stats) {
   log_debug(gc, refine, stats)
-           ("%s refinement: %.2fms, refined: " SIZE_FORMAT
-            ", precleaned: " SIZE_FORMAT ", dirtied: " SIZE_FORMAT,
+           ("%s refinement: %.2fms, refined: %zu"
+            ", precleaned: %zu, dirtied: %zu",
             kind,
             stats.refinement_time().seconds() * MILLIUNITS,
             stats.refined_cards(),
@@ -708,7 +708,7 @@ bool G1Policy::need_to_start_conc_mark(const char* source, size_t alloc_word_siz
   bool result = false;
   if (marking_request_bytes > marking_initiating_used_threshold) {
     result = collector_state()->in_young_only_phase();
-    log_debug(gc, ergo, ihop)("%s occupancy: " SIZE_FORMAT "B allocation request: " SIZE_FORMAT "B threshold: " SIZE_FORMAT "B (%1.2f) source: %s",
+    log_debug(gc, ergo, ihop)("%s occupancy: %zuB allocation request: %zuB threshold: %zuB (%1.2f) source: %s",
                               result ? "Request concurrent cycle initiation (occupancy higher than threshold)" : "Do not request concurrent cycle initiation (still doing mixed collections)",
                               cur_used_bytes, alloc_byte_size, marking_initiating_used_threshold, (double) marking_initiating_used_threshold / _g1h->capacity() * 100, source);
   }

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -91,7 +91,7 @@ class G1RegionsLargerThanCommitSizeMapper : public G1RegionToSpaceMapper {
 
   virtual void commit_regions(uint start_idx, size_t num_regions, WorkerThreads* pretouch_workers) {
     guarantee(is_range_uncommitted(start_idx, num_regions),
-              "Range not uncommitted, start: %u, num_regions: " SIZE_FORMAT,
+              "Range not uncommitted, start: %u, num_regions: %zu",
               start_idx, num_regions);
 
     const size_t start_page = (size_t)start_idx * _pages_per_region;
@@ -113,7 +113,7 @@ class G1RegionsLargerThanCommitSizeMapper : public G1RegionToSpaceMapper {
 
   virtual void uncommit_regions(uint start_idx, size_t num_regions) {
     guarantee(is_range_committed(start_idx, num_regions),
-             "Range not committed, start: %u, num_regions: " SIZE_FORMAT,
+             "Range not committed, start: %u, num_regions: %zu",
               start_idx, num_regions);
 
     _storage.uncommit((size_t)start_idx * _pages_per_region, num_regions * _pages_per_region);

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -112,7 +112,7 @@ public:
   // dirty card, i.e. actually needs scanning.
   bool chunk_needs_scan(uint const region_idx, uint const card_in_region) const {
     size_t const idx = ((size_t)region_idx << _log_scan_chunks_per_region) + (card_in_region >> _scan_chunks_shift);
-    assert(idx < _num_total_scan_chunks, "Index " SIZE_FORMAT " out of bounds " SIZE_FORMAT,
+    assert(idx < _num_total_scan_chunks, "Index %zu out of bounds %zu",
            idx, _num_total_scan_chunks);
     return _region_scan_chunks[idx];
   }
@@ -356,7 +356,7 @@ public:
 
   void set_chunk_dirty(size_t const card_idx) {
     assert((card_idx >> _scan_chunks_shift) < _num_total_scan_chunks,
-           "Trying to access index " SIZE_FORMAT " out of bounds " SIZE_FORMAT,
+           "Trying to access index %zu out of bounds %zu",
            card_idx >> _scan_chunks_shift, _num_total_scan_chunks);
     size_t const chunk_idx = card_idx >> _scan_chunks_shift;
     _region_scan_chunks[chunk_idx] = true;
@@ -1360,7 +1360,7 @@ void G1RemSet::print_merge_heap_roots_stats() {
     size_t total_old_region_cards =
       (g1h->num_regions() - (g1h->num_free_regions() - g1h->collection_set()->cur_length())) * HeapRegion::CardsPerRegion;
 
-    ls.print_cr("Visited cards " SIZE_FORMAT " Total dirty " SIZE_FORMAT " (%.2lf%%) Total old " SIZE_FORMAT " (%.2lf%%)",
+    ls.print_cr("Visited cards %zu Total dirty %zu (%.2lf%%) Total old %zu (%.2lf%%)",
                 num_visited_cards,
                 total_dirty_region_cards,
                 percent_of(num_visited_cards, total_dirty_region_cards),
@@ -1393,7 +1393,7 @@ void G1RemSet::merge_heap_roots(bool initial_evacuation) {
 
   {
     G1MergeHeapRootsTask cl(_scan_state, num_workers, initial_evacuation);
-    log_debug(gc, ergo)("Running %s using %u workers for " SIZE_FORMAT " regions",
+    log_debug(gc, ergo)("Running %s using %u workers for %zu regions",
                         cl.name(), num_workers, increment_length);
     workers->run_task(&cl, num_workers);
   }
@@ -1426,7 +1426,7 @@ inline void check_card_ptr(CardTable::CardValue* card_ptr, G1CardTable* ct) {
 #ifdef ASSERT
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
   assert(g1h->is_in(ct->addr_for(card_ptr)),
-         "Card at " PTR_FORMAT " index " SIZE_FORMAT " representing heap at " PTR_FORMAT " (%u) must be in committed heap",
+         "Card at " PTR_FORMAT " index %zu representing heap at " PTR_FORMAT " (%u) must be in committed heap",
          p2i(card_ptr),
          ct->index_for(ct->addr_for(card_ptr)),
          p2i(ct->addr_for(card_ptr)),

--- a/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetSummary.cpp
@@ -153,29 +153,29 @@ public:
   size_t code_root_elems() const { return _code_root_elems; }
 
   void print_rs_mem_info_on(outputStream * out, size_t total) {
-    out->print_cr("    " SIZE_FORMAT_W(8) " (%5.1f%%) by " SIZE_FORMAT " "
-                  "(" SIZE_FORMAT ") %s regions unused " SIZE_FORMAT,
+    out->print_cr("    " SIZE_FORMAT_W(8) " (%5.1f%%) by %zu "
+                  "(%zu) %s regions unused %zu",
                   rs_mem_size(), rs_mem_size_percent_of(total),
                   amount_tracked(), amount(),
                   _name, rs_unused_mem_size());
   }
 
   void print_cards_occupied_info_on(outputStream * out, size_t total) {
-    out->print_cr("     " SIZE_FORMAT_W(8) " (%5.1f%%) entries by " SIZE_FORMAT " "
-                  "(" SIZE_FORMAT ") %s regions",
+    out->print_cr("     " SIZE_FORMAT_W(8) " (%5.1f%%) entries by %zu "
+                  "(%zu) %s regions",
                   cards_occupied(), cards_occupied_percent_of(total),
                   amount_tracked(), amount(), _name);
   }
 
   void print_code_root_mem_info_on(outputStream * out, size_t total) {
-    out->print_cr("    " SIZE_FORMAT_W(8) "%s (%5.1f%%) by " SIZE_FORMAT " %s regions",
+    out->print_cr("    " SIZE_FORMAT_W(8) "%s (%5.1f%%) by %zu %s regions",
         byte_size_in_proper_unit(code_root_mem_size()),
         proper_unit_for_byte_size(code_root_mem_size()),
         code_root_mem_size_percent_of(total), amount(), _name);
   }
 
   void print_code_root_elems_info_on(outputStream * out, size_t total) {
-    out->print_cr("     " SIZE_FORMAT_W(8) " (%5.1f%%) elements by " SIZE_FORMAT " %s regions",
+    out->print_cr("     " SIZE_FORMAT_W(8) " (%5.1f%%) elements by %zu %s regions",
         code_root_elems(), code_root_elems_percent_of(total), amount(), _name);
   }
 };
@@ -258,8 +258,8 @@ public:
     RegionTypeCounter* counters[] = { &_young, &_humongous, &_free, &_old, nullptr };
 
     out->print_cr(" Current rem set statistics");
-    out->print_cr("  Total per region rem sets sizes = " SIZE_FORMAT
-                  " Max = " SIZE_FORMAT " unused = " SIZE_FORMAT,
+    out->print_cr("  Total per region rem sets sizes = %zu"
+                  " Max = %zu unused = %zu",
                   total_rs_mem_sz(),
                   max_rs_mem_sz(),
                   total_rs_unused_mem_sz());
@@ -267,7 +267,7 @@ public:
       (*current)->print_rs_mem_info_on(out, total_rs_mem_sz());
     }
 
-    out->print_cr("    " SIZE_FORMAT " occupied cards represented.",
+    out->print_cr("    %zu occupied cards represented.",
                   total_cards_occupied());
     for (RegionTypeCounter** current = &counters[0]; *current != nullptr; current++) {
       (*current)->print_cards_occupied_info_on(out, total_cards_occupied());
@@ -276,7 +276,7 @@ public:
     // Largest sized rem set region statistics
     HeapRegionRemSet* rem_set = max_rs_mem_sz_region()->rem_set();
     out->print_cr("    Region with largest rem set = " HR_FORMAT ", "
-                  "size = " SIZE_FORMAT " occupied = " SIZE_FORMAT,
+                  "size = %zu occupied = %zu",
                   HR_FORMAT_PARAMS(max_rs_mem_sz_region()),
                   rem_set->mem_size(),
                   rem_set->occupied());
@@ -287,8 +287,8 @@ public:
 
     // Code root statistics
     HeapRegionRemSet* max_code_root_rem_set = max_code_root_mem_sz_region()->rem_set();
-    out->print_cr("  Total heap region code root sets sizes = " SIZE_FORMAT "%s."
-                  "  Max = " SIZE_FORMAT "%s.",
+    out->print_cr("  Total heap region code root sets sizes = %zu%s."
+                  "  Max = %zu%s.",
                   byte_size_in_proper_unit(total_code_root_mem_sz()),
                   proper_unit_for_byte_size(total_code_root_mem_sz()),
                   byte_size_in_proper_unit(max_code_root_rem_set->code_roots_mem_size()),
@@ -297,14 +297,14 @@ public:
       (*current)->print_code_root_mem_info_on(out, total_code_root_mem_sz());
     }
 
-    out->print_cr("    " SIZE_FORMAT " code roots represented.",
+    out->print_cr("    %zu code roots represented.",
                   total_code_root_elems());
     for (RegionTypeCounter** current = &counters[0]; *current != nullptr; current++) {
       (*current)->print_code_root_elems_info_on(out, total_code_root_elems());
     }
 
     out->print_cr("    Region with largest amount of code roots = " HR_FORMAT ", "
-                  "size = " SIZE_FORMAT "%s, num_slots = " SIZE_FORMAT ".",
+                  "size = %zu%s, num_slots = %zu.",
                   HR_FORMAT_PARAMS(max_code_root_mem_sz_region()),
                   byte_size_in_proper_unit(max_code_root_rem_set->code_roots_mem_size()),
                   proper_unit_for_byte_size(max_code_root_rem_set->code_roots_mem_size()),

--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -84,7 +84,7 @@ void G1SurvRateGroup::stop_adding_regions() {
 
 void G1SurvRateGroup::record_surviving_words(int age_in_group, size_t surv_words) {
   guarantee(0 <= age_in_group && (size_t)age_in_group < _num_added_regions,
-            "age_in_group is %d not between 0 and " SIZE_FORMAT, age_in_group, _num_added_regions);
+            "age_in_group is %d not between 0 and %zu", age_in_group, _num_added_regions);
 
   double surv_rate = (double)surv_words / HeapRegion::GrainWords;
   _surv_rate_predictors[age_in_group]->add(surv_rate);

--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
@@ -82,7 +82,7 @@ void G1UncommitRegionTask::report_execution(Tickspan time, uint regions) {
   _summary_region_count += regions;
   _summary_duration += time;
 
-  log_trace(gc, heap)("Concurrent Uncommit: " SIZE_FORMAT "%s, %u regions, %1.3fms",
+  log_trace(gc, heap)("Concurrent Uncommit: %zu%s, %u regions, %1.3fms",
                       byte_size_in_proper_unit(regions * HeapRegion::GrainBytes),
                       proper_unit_for_byte_size(regions * HeapRegion::GrainBytes),
                       regions,
@@ -90,7 +90,7 @@ void G1UncommitRegionTask::report_execution(Tickspan time, uint regions) {
 }
 
 void G1UncommitRegionTask::report_summary() {
-  log_debug(gc, heap)("Concurrent Uncommit Summary: " SIZE_FORMAT "%s, %u regions, %1.3fms",
+  log_debug(gc, heap)("Concurrent Uncommit Summary: %zu%s, %u regions, %1.3fms",
                       byte_size_in_proper_unit(_summary_region_count * HeapRegion::GrainBytes),
                       proper_unit_for_byte_size(_summary_region_count * HeapRegion::GrainBytes),
                       _summary_region_count,

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -193,7 +193,7 @@ public:
               "Only eagerly reclaiming type arrays is supported, but the object "
               PTR_FORMAT " is not.", p2i(r->bottom()));
 
-    log_debug(gc, humongous)("Reclaimed humongous region %u (object size " SIZE_FORMAT " @ " PTR_FORMAT ")",
+    log_debug(gc, humongous)("Reclaimed humongous region %u (object size %zu @ " PTR_FORMAT ")",
                              region_index,
                              obj->size() * HeapWordSize,
                              p2i(r->bottom())

--- a/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGenSizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ G1YoungGenSizer::G1YoungGenSizer() : _sizer_kind(SizerDefaults),
 
   if (NewSize > MaxNewSize) {
     if (FLAG_IS_CMDLINE(MaxNewSize)) {
-      log_warning(gc, ergo)("NewSize (" SIZE_FORMAT "k) is greater than the MaxNewSize (" SIZE_FORMAT "k). "
-                            "A new max generation size of " SIZE_FORMAT "k will be used.",
+      log_warning(gc, ergo)("NewSize (%zuk) is greater than the MaxNewSize (%zuk). "
+                            "A new max generation size of %zuk will be used.",
                             NewSize/K, MaxNewSize/K, NewSize/K);
     }
     FLAG_SET_ERGO(MaxNewSize, NewSize);

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -398,7 +398,7 @@ bool HeapRegion::verify_code_roots(VerifyOption vo) const {
   if (is_empty()) {
     bool has_code_roots = code_roots_length > 0;
     if (has_code_roots) {
-      log_error(gc, verify)("region " HR_FORMAT " is empty but has " SIZE_FORMAT " code root entries",
+      log_error(gc, verify)("region " HR_FORMAT " is empty but has %zu code root entries",
                             HR_FORMAT_PARAMS(this), code_roots_length);
     }
     return has_code_roots;
@@ -407,7 +407,7 @@ bool HeapRegion::verify_code_roots(VerifyOption vo) const {
   if (is_continues_humongous()) {
     bool has_code_roots = code_roots_length > 0;
     if (has_code_roots) {
-      log_error(gc, verify)("region " HR_FORMAT " is a continuation of a humongous region but has " SIZE_FORMAT " code root entries",
+      log_error(gc, verify)("region " HR_FORMAT " is a continuation of a humongous region but has %zu code root entries",
                             HR_FORMAT_PARAMS(this), code_roots_length);
     }
     return has_code_roots;

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -92,7 +92,7 @@ G1MonotonicArenaMemoryStats HeapRegionRemSet::card_set_memory_stats() const {
 }
 
 void HeapRegionRemSet::print_static_mem_size(outputStream* out) {
-  out->print_cr("  Static structures = " SIZE_FORMAT, HeapRegionRemSet::static_mem_size());
+  out->print_cr("  Static structures = %zu", HeapRegionRemSet::static_mem_size());
 }
 
 // Code roots support

--- a/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
+++ b/src/hotspot/share/gc/g1/jvmFlagConstraintsG1.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ JVMFlag::Error G1HeapRegionSizeConstraintFunc(size_t value, bool verbose) {
   // Default value of G1HeapRegionSize=0 means will be set ergonomically.
   if (FLAG_IS_CMDLINE(G1HeapRegionSize) && (value < HeapRegionBounds::min_size())) {
     JVMFlag::printError(verbose,
-                        "G1HeapRegionSize (" SIZE_FORMAT ") must be "
+                        "G1HeapRegionSize (%zu) must be "
                         "greater than or equal to ergonomic heap region minimum size\n",
                         value);
     return JVMFlag::VIOLATES_CONSTRAINT;
@@ -169,7 +169,7 @@ JVMFlag::Error NewSizeConstraintFuncG1(size_t value, bool verbose) {
   // So maximum of NewSize should be 'max_juint * 1M'
   if (UseG1GC && (value > (max_juint * 1 * M))) {
     JVMFlag::printError(verbose,
-                        "NewSize (" SIZE_FORMAT ") must be less than ergonomic maximum value\n",
+                        "NewSize (%zu) must be less than ergonomic maximum value\n",
                         value);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -113,7 +113,7 @@ void MutableNUMASpace::ensure_parsability() {
         while (words_left_to_fill > 0) {
           size_t words_to_fill = MIN2(words_left_to_fill, CollectedHeap::filler_array_max_size());
           assert(words_to_fill >= CollectedHeap::min_fill_size(),
-                 "Remaining size (" SIZE_FORMAT ") is too small to fill (based on " SIZE_FORMAT " and " SIZE_FORMAT ")",
+                 "Remaining size (%zu) is too small to fill (based on %zu and %zu)",
                  words_to_fill, words_left_to_fill, CollectedHeap::filler_array_max_size());
           CollectedHeap::fill_with_object(cur_top, words_to_fill);
           cur_top += words_to_fill;
@@ -642,8 +642,8 @@ void MutableNUMASpace::print_on(outputStream* st) const {
       for (int i = 0; i < lgrp_spaces()->length(); i++) {
         lgrp_spaces()->at(i)->accumulate_statistics(page_size());
       }
-      st->print("    local/remote/unbiased/uncommitted: " SIZE_FORMAT "K/"
-                SIZE_FORMAT "K/" SIZE_FORMAT "K/" SIZE_FORMAT "K\n",
+      st->print("    local/remote/unbiased/uncommitted: %zuK/"
+                SIZE_FORMAT "K/%zuK/%zuK\n",
                 ls->space_stats()->_local_space / K,
                 ls->space_stats()->_remote_space / K,
                 ls->space_stats()->_unbiased_space / K,

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -643,7 +643,7 @@ void MutableNUMASpace::print_on(outputStream* st) const {
         lgrp_spaces()->at(i)->accumulate_statistics(page_size());
       }
       st->print("    local/remote/unbiased/uncommitted: %zuK/"
-                SIZE_FORMAT "K/%zuK/%zuK\n",
+                "%zuK/%zuK/%zuK\n",
                 ls->space_stats()->_local_space / K,
                 ls->space_stats()->_remote_space / K,
                 ls->space_stats()->_unbiased_space / K,

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -242,7 +242,7 @@ void MutableSpace::object_iterate(ObjectClosure* cl) {
 
 void MutableSpace::print_short() const { print_short_on(tty); }
 void MutableSpace::print_short_on( outputStream* st) const {
-  st->print(" space " SIZE_FORMAT "K, %d%% used", capacity_in_bytes() / K,
+  st->print(" space %zuK, %d%% used", capacity_in_bytes() / K,
             (int) ((double) used_in_bytes() * 100 / capacity_in_bytes()));
 }
 

--- a/src/hotspot/share/gc/parallel/parallelInitLogger.cpp
+++ b/src/hotspot/share/gc/parallel/parallelInitLogger.cpp
@@ -29,9 +29,9 @@
 
 void ParallelInitLogger::print_heap() {
   log_info_p(gc, init)("Alignments:"
-                       " Space " SIZE_FORMAT "%s,"
-                       " Generation " SIZE_FORMAT "%s,"
-                       " Heap " SIZE_FORMAT "%s",
+                       " Space %zu%s,"
+                       " Generation %zu%s,"
+                       " Heap %zu%s",
                        byte_size_in_exact_unit(SpaceAlignment), exact_unit_for_byte_size(SpaceAlignment),
                        byte_size_in_exact_unit(GenAlignment), exact_unit_for_byte_size(GenAlignment),
                        byte_size_in_exact_unit(HeapAlignment), exact_unit_for_byte_size(HeapAlignment));

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -386,7 +386,7 @@ HeapWord* ParallelScavengeHeap::mem_allocate(
     if ((result == nullptr) && (QueuedAllocationWarningCount > 0) &&
         (loop_count % QueuedAllocationWarningCount == 0)) {
       log_warning(gc)("ParallelScavengeHeap::mem_allocate retries %d times", loop_count);
-      log_warning(gc)("\tsize=" SIZE_FORMAT, size);
+      log_warning(gc)("\tsize=%zu", size);
     }
   }
 

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -177,7 +177,7 @@ bool PSAdaptiveSizePolicy::should_full_GC(size_t old_free_in_bytes) {
   // A similar test is done in the scavenge's should_attempt_scavenge().  If
   // this is changed, decide if that test should also be changed.
   bool result = padded_average_promoted_in_bytes() > (float) old_free_in_bytes;
-  log_trace(gc, ergo)("%s after scavenge average_promoted " SIZE_FORMAT " padded_average_promoted " SIZE_FORMAT " free in old gen " SIZE_FORMAT,
+  log_trace(gc, ergo)("%s after scavenge average_promoted %zu padded_average_promoted %zu free in old gen %zu",
                       result ? "Full" : "No full",
                       (size_t) average_promoted_in_bytes(),
                       (size_t) padded_average_promoted_in_bytes(),
@@ -336,12 +336,12 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
   if (desired_eden_size > eden_limit) {
     log_debug(gc, ergo)(
           "PSAdaptiveSizePolicy::compute_eden_space_size limits:"
-          " desired_eden_size: " SIZE_FORMAT
-          " old_eden_size: " SIZE_FORMAT
-          " eden_limit: " SIZE_FORMAT
-          " cur_eden: " SIZE_FORMAT
-          " max_eden_size: " SIZE_FORMAT
-          " avg_young_live: " SIZE_FORMAT,
+          " desired_eden_size: %zu"
+          " old_eden_size: %zu"
+          " eden_limit: %zu"
+          " cur_eden: %zu"
+          " max_eden_size: %zu"
+          " avg_young_live: %zu",
           desired_eden_size, _eden_size, eden_limit, cur_eden,
           max_eden_size, (size_t)avg_young_live()->average());
   }
@@ -379,15 +379,15 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
                       _avg_major_interval->average(),
                       gc_pause_goal_sec());
 
-  log_debug(gc, ergo)("Live_space: " SIZE_FORMAT " free_space: " SIZE_FORMAT,
+  log_debug(gc, ergo)("Live_space: %zu free_space: %zu",
                       live_space(), free_space());
 
-  log_trace(gc, ergo)("Base_footprint: " SIZE_FORMAT " avg_young_live: " SIZE_FORMAT " avg_old_live: " SIZE_FORMAT,
+  log_trace(gc, ergo)("Base_footprint: %zu avg_young_live: %zu avg_old_live: %zu",
                       (size_t)_avg_base_footprint->average(),
                       (size_t)avg_young_live()->average(),
                       (size_t)avg_old_live()->average());
 
-  log_debug(gc, ergo)("Old eden_size: " SIZE_FORMAT " desired_eden_size: " SIZE_FORMAT,
+  log_debug(gc, ergo)("Old eden_size: %zu desired_eden_size: %zu",
                       _eden_size, desired_eden_size);
 
   set_eden_size(desired_eden_size);
@@ -514,11 +514,11 @@ void PSAdaptiveSizePolicy::compute_old_gen_free_space(
     size_t free_in_old_gen = (size_t)(max_old_gen_size - avg_old_live()->average());
     log_debug(gc, ergo)(
           "PSAdaptiveSizePolicy::compute_old_gen_free_space limits:"
-          " desired_promo_size: " SIZE_FORMAT
-          " promo_limit: " SIZE_FORMAT
-          " free_in_old_gen: " SIZE_FORMAT
-          " max_old_gen_size: " SIZE_FORMAT
-          " avg_old_live: " SIZE_FORMAT,
+          " desired_promo_size: %zu"
+          " promo_limit: %zu"
+          " free_in_old_gen: %zu"
+          " max_old_gen_size: %zu"
+          " avg_old_live: %zu",
           desired_promo_size, promo_limit, free_in_old_gen,
           max_old_gen_size, (size_t) avg_old_live()->average());
   }
@@ -551,15 +551,15 @@ void PSAdaptiveSizePolicy::compute_old_gen_free_space(
                       gc_pause_goal_sec());
 
   // Footprint stats
-  log_debug(gc, ergo)("Live_space: " SIZE_FORMAT " free_space: " SIZE_FORMAT,
+  log_debug(gc, ergo)("Live_space: %zu free_space: %zu",
                       live_space(), free_space());
 
-  log_trace(gc, ergo)("Base_footprint: " SIZE_FORMAT " avg_young_live: " SIZE_FORMAT " avg_old_live: " SIZE_FORMAT,
+  log_trace(gc, ergo)("Base_footprint: %zu avg_young_live: %zu avg_old_live: %zu",
                       (size_t)_avg_base_footprint->average(),
                       (size_t)avg_young_live()->average(),
                       (size_t)avg_old_live()->average());
 
-  log_debug(gc, ergo)("Old promo_size: " SIZE_FORMAT " desired_promo_size: " SIZE_FORMAT,
+  log_debug(gc, ergo)("Old promo_size: %zu desired_promo_size: %zu",
                       _promo_size, desired_promo_size);
 
   set_promo_size(desired_promo_size);
@@ -642,7 +642,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_pause_time(bool is_full_gc,
   log_trace(gc, ergo)(
     "PSAdaptiveSizePolicy::adjust_promo_for_pause_time "
     "adjusting gen sizes for major pause (avg %f goal %f). "
-    "desired_promo_size " SIZE_FORMAT " promo delta " SIZE_FORMAT,
+    "desired_promo_size %zu promo delta %zu",
     _avg_major_pause->average(), gc_pause_goal_sec(),
     *desired_promo_size_ptr, promo_heap_delta);
 }
@@ -661,7 +661,7 @@ void PSAdaptiveSizePolicy::adjust_eden_for_pause_time(bool is_full_gc,
   log_trace(gc, ergo)(
     "PSAdaptiveSizePolicy::adjust_eden_for_pause_time "
     "adjusting gen sizes for major pause (avg %f goal %f). "
-    "desired_eden_size " SIZE_FORMAT " eden delta " SIZE_FORMAT,
+    "desired_eden_size %zu eden delta %zu",
     _avg_major_pause->average(), gc_pause_goal_sec(),
     *desired_eden_size_ptr, eden_heap_delta);
 }
@@ -677,7 +677,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_throughput(bool is_full_gc,
     return;
   }
 
-  log_trace(gc, ergo)("PSAdaptiveSizePolicy::adjust_promo_for_throughput(is_full: %d, promo: " SIZE_FORMAT "): mutator_cost %f  major_gc_cost %f minor_gc_cost %f",
+  log_trace(gc, ergo)("PSAdaptiveSizePolicy::adjust_promo_for_throughput(is_full: %d, promo: %zu): mutator_cost %f  major_gc_cost %f minor_gc_cost %f",
                       is_full_gc, *desired_promo_size_ptr, mutator_cost(), major_gc_cost(), minor_gc_cost());
 
   // Tenured generation
@@ -691,7 +691,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_throughput(bool is_full_gc,
       double scale_by_ratio = major_gc_cost() / gc_cost();
       scaled_promo_heap_delta =
         (size_t) (scale_by_ratio * (double) promo_heap_delta);
-      log_trace(gc, ergo)("Scaled tenured increment: " SIZE_FORMAT " by %f down to " SIZE_FORMAT,
+      log_trace(gc, ergo)("Scaled tenured increment: %zu by %f down to %zu",
                           promo_heap_delta, scale_by_ratio, scaled_promo_heap_delta);
     } else if (major_gc_cost() >= 0.0) {
       // Scaling is not going to work.  If the major gc time is the
@@ -746,7 +746,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_throughput(bool is_full_gc,
         _old_gen_change_for_major_throughput++;
     }
 
-    log_trace(gc, ergo)("Adjusting tenured gen for throughput (avg %f goal %f). desired_promo_size " SIZE_FORMAT " promo_delta " SIZE_FORMAT ,
+    log_trace(gc, ergo)("Adjusting tenured gen for throughput (avg %f goal %f). desired_promo_size %zu promo_delta " SIZE_FORMAT ,
                         mutator_cost(),
                         _throughput_goal,
                         *desired_promo_size_ptr, scaled_promo_heap_delta);
@@ -764,7 +764,7 @@ void PSAdaptiveSizePolicy::adjust_eden_for_throughput(bool is_full_gc,
     return;
   }
 
-  log_trace(gc, ergo)("PSAdaptiveSizePolicy::adjust_eden_for_throughput(is_full: %d, cur_eden: " SIZE_FORMAT "): mutator_cost %f  major_gc_cost %f minor_gc_cost %f",
+  log_trace(gc, ergo)("PSAdaptiveSizePolicy::adjust_eden_for_throughput(is_full: %d, cur_eden: %zu): mutator_cost %f  major_gc_cost %f minor_gc_cost %f",
                       is_full_gc, *desired_eden_size_ptr, mutator_cost(), major_gc_cost(), minor_gc_cost());
 
   // Young generation
@@ -777,7 +777,7 @@ void PSAdaptiveSizePolicy::adjust_eden_for_throughput(bool is_full_gc,
     assert(scale_by_ratio <= 1.0 && scale_by_ratio >= 0.0, "Scaling is wrong");
     scaled_eden_heap_delta =
       (size_t) (scale_by_ratio * (double) eden_heap_delta);
-    log_trace(gc, ergo)("Scaled eden increment: " SIZE_FORMAT " by %f down to " SIZE_FORMAT,
+    log_trace(gc, ergo)("Scaled eden increment: %zu by %f down to %zu",
                         eden_heap_delta, scale_by_ratio, scaled_eden_heap_delta);
   } else if (minor_gc_cost() >= 0.0) {
     // Scaling is not going to work.  If the minor gc time is the
@@ -831,7 +831,7 @@ void PSAdaptiveSizePolicy::adjust_eden_for_throughput(bool is_full_gc,
       _young_gen_change_for_minor_throughput++;
   }
 
-    log_trace(gc, ergo)("Adjusting eden for throughput (avg %f goal %f). desired_eden_size " SIZE_FORMAT " eden delta " SIZE_FORMAT,
+    log_trace(gc, ergo)("Adjusting eden for throughput (avg %f goal %f). desired_eden_size %zu eden delta %zu",
                         mutator_cost(), _throughput_goal, *desired_eden_size_ptr, scaled_eden_heap_delta);
 }
 
@@ -848,9 +848,9 @@ size_t PSAdaptiveSizePolicy::adjust_promo_for_footprint(
   log_trace(gc, ergo)(
     "AdaptiveSizePolicy::adjust_promo_for_footprint "
     "adjusting tenured gen for footprint. "
-    "starting promo size " SIZE_FORMAT
-    " reduced promo size " SIZE_FORMAT
-    " promo delta " SIZE_FORMAT,
+    "starting promo size %zu"
+    " reduced promo size %zu"
+    " promo delta %zu",
     desired_promo_size, reduced_size, change );
 
   assert(reduced_size <= desired_promo_size, "Inconsistent result");
@@ -870,9 +870,9 @@ size_t PSAdaptiveSizePolicy::adjust_eden_for_footprint(
   log_trace(gc, ergo)(
     "AdaptiveSizePolicy::adjust_eden_for_footprint "
     "adjusting eden for footprint. "
-    " starting eden size " SIZE_FORMAT
-    " reduced eden size " SIZE_FORMAT
-    " eden delta " SIZE_FORMAT,
+    " starting eden size %zu"
+    " reduced eden size %zu"
+    " eden delta %zu",
     desired_eden_size, reduced_size, change);
 
   assert(reduced_size <= desired_eden_size, "Inconsistent result");
@@ -1057,7 +1057,7 @@ uint PSAdaptiveSizePolicy::compute_survivor_space_size_and_threshold(
   log_debug(gc, ergo)("avg_survived_padded_avg: %f", _avg_survived->padded_average());
 
   log_trace(gc, ergo)("avg_promoted_avg: %f  avg_promoted_dev: %f", avg_promoted()->average(), avg_promoted()->deviation());
-  log_debug(gc, ergo)("avg_promoted_padded_avg: %f  avg_pretenured_padded_avg: %f  tenuring_thresh: %d  target_size: " SIZE_FORMAT,
+  log_debug(gc, ergo)("avg_promoted_padded_avg: %f  avg_pretenured_padded_avg: %f  tenuring_thresh: %d  target_size: %zu",
                       avg_promoted()->padded_average(),
                       _avg_pretenured->padded_average(),
                       tenuring_threshold, target_size);

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -1080,7 +1080,7 @@ void PSAdaptiveSizePolicy::update_averages(bool is_survivor_overflow,
   }
   avg_promoted()->sample(promoted);
 
-  log_trace(gc, ergo)("AdaptiveSizePolicy::update_averages:  survived: "  SIZE_FORMAT "  promoted: "  SIZE_FORMAT "  overflow: %s",
+  log_trace(gc, ergo)("AdaptiveSizePolicy::update_averages:  survived: "  "%zu  promoted: "  SIZE_FORMAT "  overflow: %s",
                       survived, promoted, is_survivor_overflow ? "true" : "false");
 }
 

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -746,7 +746,7 @@ void PSAdaptiveSizePolicy::adjust_promo_for_throughput(bool is_full_gc,
         _old_gen_change_for_major_throughput++;
     }
 
-    log_trace(gc, ergo)("Adjusting tenured gen for throughput (avg %f goal %f). desired_promo_size %zu promo_delta " SIZE_FORMAT ,
+    log_trace(gc, ergo)("Adjusting tenured gen for throughput (avg %f goal %f). desired_promo_size %zu promo_delta %zu",
                         mutator_cost(),
                         _throughput_goal,
                         *desired_promo_size_ptr, scaled_promo_heap_delta);
@@ -1080,7 +1080,7 @@ void PSAdaptiveSizePolicy::update_averages(bool is_survivor_overflow,
   }
   avg_promoted()->sample(promoted);
 
-  log_trace(gc, ergo)("AdaptiveSizePolicy::update_averages:  survived: "  "%zu  promoted: "  SIZE_FORMAT "  overflow: %s",
+  log_trace(gc, ergo)("AdaptiveSizePolicy::update_averages:  survived: %zu  promoted: %zu  overflow: %s",
                       survived, promoted, is_survivor_overflow ? "true" : "false");
 }
 

--- a/src/hotspot/share/gc/parallel/psClosure.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psClosure.inline.hpp
@@ -45,7 +45,7 @@ public:
       oop new_obj = o->forwardee();
       if (log_develop_is_enabled(Trace, gc, scavenge)) {
         ResourceMark rm; // required by internal_name()
-        log_develop_trace(gc, scavenge)("{%s %s " PTR_FORMAT " -> " PTR_FORMAT " (" SIZE_FORMAT ")}",
+        log_develop_trace(gc, scavenge)("{%s %s " PTR_FORMAT " -> " PTR_FORMAT " (%zu)}",
                                         "forwarding",
                                         new_obj->klass()->internal_name(), p2i((void *)o), p2i((void *)new_obj), new_obj->size());
       }

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -247,7 +247,7 @@ bool PSOldGen::expand_by(size_t bytes) {
   if (result) {
     size_t new_mem_size = virtual_space()->committed_size();
     size_t old_mem_size = new_mem_size - bytes;
-    log_debug(gc)("Expanding %s from " SIZE_FORMAT "K by " SIZE_FORMAT "K to " SIZE_FORMAT "K",
+    log_debug(gc)("Expanding %s from %zuK by %zuK to %zuK",
                   name(), old_mem_size/K, bytes/K, new_mem_size/K);
   }
 
@@ -278,7 +278,7 @@ void PSOldGen::shrink(size_t bytes) {
 
     size_t new_mem_size = virtual_space()->committed_size();
     size_t old_mem_size = new_mem_size + bytes;
-    log_debug(gc)("Shrinking %s from " SIZE_FORMAT "K by " SIZE_FORMAT "K to " SIZE_FORMAT "K",
+    log_debug(gc)("Shrinking %s from %zuK by %zuK to %zuK",
                   name(), old_mem_size/K, bytes/K, new_mem_size/K);
   }
 }
@@ -308,9 +308,9 @@ void PSOldGen::resize(size_t desired_free_space) {
   const size_t current_size = capacity_in_bytes();
 
   log_trace(gc, ergo)("AdaptiveSizePolicy::old generation size: "
-    "desired free: " SIZE_FORMAT " used: " SIZE_FORMAT
-    " new size: " SIZE_FORMAT " current size " SIZE_FORMAT
-    " gen limits: " SIZE_FORMAT " / " SIZE_FORMAT,
+    "desired free: %zu used: %zu"
+    " new size: %zu current size %zu"
+    " gen limits: %zu / %zu",
     desired_free_space, used_in_bytes(), new_size, current_size,
     max_gen_size(), min_gen_size());
 
@@ -328,7 +328,7 @@ void PSOldGen::resize(size_t desired_free_space) {
     shrink(change_bytes);
   }
 
-  log_trace(gc, ergo)("AdaptiveSizePolicy::old generation size: collection: %d (" SIZE_FORMAT ") -> (" SIZE_FORMAT ") ",
+  log_trace(gc, ergo)("AdaptiveSizePolicy::old generation size: collection: %d (%zu) -> (%zu) ",
                       ParallelScavengeHeap::heap()->total_collections(),
                       size_before,
                       virtual_space()->committed_size());
@@ -366,7 +366,7 @@ void PSOldGen::post_resize() {
 void PSOldGen::print() const { print_on(tty);}
 void PSOldGen::print_on(outputStream* st) const {
   st->print(" %-15s", name());
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total %zuK, used %zuK",
               capacity_in_bytes()/K, used_in_bytes()/K);
   st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
                 p2i(virtual_space()->low_boundary()),

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -286,7 +286,7 @@ print_generic_summary_data(ParallelCompactData& summary_data,
     ++i;
   }
 
-  log_develop_trace(gc, compaction)("summary_data_bytes=" SIZE_FORMAT, total_words * HeapWordSize);
+  log_develop_trace(gc, compaction)("summary_data_bytes=%zu", total_words * HeapWordSize);
 }
 
 void
@@ -644,7 +644,7 @@ ParallelCompactData::summarize_split_space(size_t src_region,
                                          sr->partial_obj_size()));
     const size_t end_idx = addr_to_region_idx(target_end);
 
-    log_develop_trace(gc, compaction)("split:  clearing source_region field in [" SIZE_FORMAT ", " SIZE_FORMAT ")", beg_idx, end_idx);
+    log_develop_trace(gc, compaction)("split:  clearing source_region field in [%zu, %zu)", beg_idx, end_idx);
     for (size_t idx = beg_idx; idx < end_idx; ++idx) {
       _region_data[idx].set_source_region(0);
     }
@@ -666,9 +666,9 @@ ParallelCompactData::summarize_split_space(size_t src_region,
 
   if (log_develop_is_enabled(Trace, gc, compaction)) {
     const char * split_type = partial_obj_size == 0 ? "easy" : "hard";
-    log_develop_trace(gc, compaction)("%s split:  src=" PTR_FORMAT " src_c=" SIZE_FORMAT " pos=" SIZE_FORMAT,
+    log_develop_trace(gc, compaction)("%s split:  src=" PTR_FORMAT " src_c=%zu pos=%zu",
                                       split_type, p2i(source_next), split_region, partial_obj_size);
-    log_develop_trace(gc, compaction)("%s split:  dst=" PTR_FORMAT " dst_c=" SIZE_FORMAT " tn=" PTR_FORMAT,
+    log_develop_trace(gc, compaction)("%s split:  dst=" PTR_FORMAT " dst_c=%zu tn=" PTR_FORMAT,
                                       split_type, p2i(split_destination),
                                       addr_to_region_idx(split_destination),
                                       p2i(*target_next));
@@ -676,7 +676,7 @@ ParallelCompactData::summarize_split_space(size_t src_region,
     if (partial_obj_size != 0) {
       HeapWord* const po_beg = split_info.destination();
       HeapWord* const po_end = po_beg + split_info.partial_obj_size();
-      log_develop_trace(gc, compaction)("%s split:  po_beg=" PTR_FORMAT " " SIZE_FORMAT " po_end=" PTR_FORMAT " " SIZE_FORMAT,
+      log_develop_trace(gc, compaction)("%s split:  po_beg=" PTR_FORMAT " %zu po_end=" PTR_FORMAT " %zu",
                                         split_type,
                                         p2i(po_beg), addr_to_region_idx(po_beg),
                                         p2i(po_end), addr_to_region_idx(po_end));
@@ -876,16 +876,16 @@ bool PSParallelCompact::initialize() {
 
   if (!_mark_bitmap.initialize(mr)) {
     vm_shutdown_during_initialization(
-      err_msg("Unable to allocate " SIZE_FORMAT "KB bitmaps for parallel "
-      "garbage collection for the requested " SIZE_FORMAT "KB heap.",
+      err_msg("Unable to allocate %zuKB bitmaps for parallel "
+      "garbage collection for the requested %zuKB heap.",
       _mark_bitmap.reserved_byte_size()/K, mr.byte_size()/K));
     return false;
   }
 
   if (!_summary_data.initialize(mr)) {
     vm_shutdown_during_initialization(
-      err_msg("Unable to allocate " SIZE_FORMAT "KB card tables for parallel "
-      "garbage collection for the requested " SIZE_FORMAT "KB heap.",
+      err_msg("Unable to allocate %zuKB card tables for parallel "
+      "garbage collection for the requested %zuKB heap.",
       _summary_data.reserved_byte_size()/K, mr.byte_size()/K));
     return false;
   }
@@ -1085,11 +1085,11 @@ PSParallelCompact::compute_dense_prefix_via_density(const SpaceId id,
   const size_t deadwood_goal = size_t(space_capacity * deadwood_density);
 
   log_develop_debug(gc, compaction)(
-      "cur_dens=%5.3f dw_dens=%5.3f dw_goal=" SIZE_FORMAT,
+      "cur_dens=%5.3f dw_dens=%5.3f dw_goal=%zu",
       cur_density, deadwood_density, deadwood_goal);
   log_develop_debug(gc, compaction)(
-      "space_live=" SIZE_FORMAT " space_used=" SIZE_FORMAT " "
-      "space_cap=" SIZE_FORMAT,
+      "space_live=%zu space_used=%zu "
+      "space_cap=%zu",
       space_live, space_used,
       space_capacity);
 
@@ -1169,9 +1169,9 @@ void PSParallelCompact::print_dense_prefix_stats(const char* const algorithm,
 
   log_develop_debug(gc, compaction)(
       "%s=" PTR_FORMAT " dpc=" SIZE_FORMAT_W(5) " "
-      "spl=" SIZE_FORMAT " "
-      "d2l=" SIZE_FORMAT " d2l%%=%6.4f "
-      "d2r=" SIZE_FORMAT " l2r=" SIZE_FORMAT " "
+      "spl=%zu "
+      "d2l=%zu d2l%%=%6.4f "
+      "d2r=%zu l2r=%zu "
       "ratio=%10.8f",
       algorithm, p2i(addr), region_idx,
       space_live,
@@ -1387,13 +1387,13 @@ PSParallelCompact::compute_dense_prefix(const SpaceId id,
                                       dead_wood_max);
 
   log_develop_debug(gc, compaction)(
-      "space_live=" SIZE_FORMAT " space_used=" SIZE_FORMAT " "
-      "space_cap=" SIZE_FORMAT,
+      "space_live=%zu space_used=%zu "
+      "space_cap=%zu",
       space_live, space_used,
       space_capacity);
   log_develop_debug(gc, compaction)(
-      "dead_wood_limiter(%6.4f, " SIZE_FORMAT ")=%6.4f "
-      "dead_wood_max=" SIZE_FORMAT " dead_wood_limit=" SIZE_FORMAT,
+      "dead_wood_limiter(%6.4f, %zu)=%6.4f "
+      "dead_wood_max=%zu dead_wood_limit=%zu",
       density, min_percent_free, limiter,
       dead_wood_max, dead_wood_limit);
 
@@ -1546,9 +1546,9 @@ PSParallelCompact::summarize_space(SpaceId id, bool maximum_compaction)
     const HeapWord* nt_aligned_up = _summary_data.region_align_up(new_top);
     const size_t cr_words = pointer_delta(nt_aligned_up, dense_prefix_end);
     log_develop_trace(gc, compaction)(
-        "id=%d cap=" SIZE_FORMAT " dp=" PTR_FORMAT " "
-        "dp_region=" SIZE_FORMAT " " "dp_count=" SIZE_FORMAT " "
-        "cr_count=" SIZE_FORMAT " " "nt=" PTR_FORMAT,
+        "id=%d cap=%zu dp=" PTR_FORMAT " "
+        "dp_region=%zu " "dp_count=%zu "
+        "cr_count=%zu " "nt=" PTR_FORMAT,
         id, space->capacity_in_words(), p2i(dense_prefix_end),
         dp_region, dp_words / region_size,
         cr_words / region_size, p2i(new_top));
@@ -1564,9 +1564,9 @@ void PSParallelCompact::summary_phase_msg(SpaceId dst_space_id,
   log_develop_trace(gc, compaction)(
       "Summarizing %d [%s] into %d [%s]:  "
       "src=" PTR_FORMAT "-" PTR_FORMAT " "
-      SIZE_FORMAT "-" SIZE_FORMAT " "
+      SIZE_FORMAT "-%zu "
       "dst=" PTR_FORMAT "-" PTR_FORMAT " "
-      SIZE_FORMAT "-" SIZE_FORMAT,
+      SIZE_FORMAT "-%zu",
       src_space_id, space_names[src_space_id],
       dst_space_id, space_names[dst_space_id],
       p2i(src_beg), p2i(src_end),
@@ -1792,7 +1792,7 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
 
     if (UseAdaptiveSizePolicy) {
       log_debug(gc, ergo)("AdaptiveSizeStart: collection: %d ", heap->total_collections());
-      log_trace(gc, ergo)("old_gen_capacity: " SIZE_FORMAT " young_gen_capacity: " SIZE_FORMAT,
+      log_trace(gc, ergo)("old_gen_capacity: %zu young_gen_capacity: %zu",
                           old_gen->capacity_in_bytes(), young_gen->capacity_in_bytes());
 
       // Don't check if the size_policy is ready here.  Let
@@ -2489,7 +2489,7 @@ void PSParallelCompact::verify_complete(SpaceId space_id) {
   for (cur_region = beg_region; cur_region < new_top_region; ++cur_region) {
     const RegionData* const c = sd.region(cur_region);
     if (!c->completed()) {
-      log_warning(gc)("region " SIZE_FORMAT " not filled: destination_count=%u",
+      log_warning(gc)("region %zu not filled: destination_count=%u",
                       cur_region, c->destination_count());
       issued_a_warning = true;
     }
@@ -2498,7 +2498,7 @@ void PSParallelCompact::verify_complete(SpaceId space_id) {
   for (cur_region = new_top_region; cur_region < old_top_region; ++cur_region) {
     const RegionData* const c = sd.region(cur_region);
     if (!c->available()) {
-      log_warning(gc)("region " SIZE_FORMAT " not empty: destination_count=%u",
+      log_warning(gc)("region %zu not empty: destination_count=%u",
                       cur_region, c->destination_count());
       issued_a_warning = true;
     }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1564,9 +1564,9 @@ void PSParallelCompact::summary_phase_msg(SpaceId dst_space_id,
   log_develop_trace(gc, compaction)(
       "Summarizing %d [%s] into %d [%s]:  "
       "src=" PTR_FORMAT "-" PTR_FORMAT " "
-      SIZE_FORMAT "-%zu "
+      "%zu-%zu "
       "dst=" PTR_FORMAT "-" PTR_FORMAT " "
-      SIZE_FORMAT "-%zu",
+      "%zu-%zu",
       src_space_id, space_names[src_space_id],
       dst_space_id, space_names[dst_space_id],
       p2i(src_beg), p2i(src_end),
@@ -2150,7 +2150,7 @@ private:
 public:
   FillableRegionLogger() : _next_index(0), _enabled(log_develop_is_enabled(Trace, gc, compaction)), _total_regions(0) { }
   ~FillableRegionLogger() {
-    log.trace(SIZE_FORMAT " initially fillable regions", _total_regions);
+    log.trace("%zu initially fillable regions", _total_regions);
   }
 
   void print_line() {

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -517,7 +517,7 @@ bool PSScavenge::invoke_no_policy() {
         // Calculate the new survivor size and tenuring threshold
 
         log_debug(gc, ergo)("AdaptiveSizeStart:  collection: %d ", heap->total_collections());
-        log_trace(gc, ergo)("old_gen_capacity: " SIZE_FORMAT " young_gen_capacity: " SIZE_FORMAT,
+        log_trace(gc, ergo)("old_gen_capacity: %zu young_gen_capacity: %zu",
                             old_gen->capacity_in_bytes(), young_gen->capacity_in_bytes());
 
         if (UsePerfData) {
@@ -708,12 +708,12 @@ bool PSScavenge::should_attempt_scavenge() {
   size_t promotion_estimate = MIN2(avg_promoted, young_gen->used_in_bytes());
   bool result = promotion_estimate < old_gen->free_in_bytes();
 
-  log_trace(ergo)("%s scavenge: average_promoted " SIZE_FORMAT " padded_average_promoted " SIZE_FORMAT " free in old gen " SIZE_FORMAT,
+  log_trace(ergo)("%s scavenge: average_promoted %zu padded_average_promoted %zu free in old gen %zu",
                 result ? "Do" : "Skip", (size_t) policy->average_promoted_in_bytes(),
                 (size_t) policy->padded_average_promoted_in_bytes(),
                 old_gen->free_in_bytes());
   if (young_gen->used_in_bytes() < (size_t) policy->padded_average_promoted_in_bytes()) {
-    log_trace(ergo)(" padded_promoted_average is greater than maximum promotion = " SIZE_FORMAT, young_gen->used_in_bytes());
+    log_trace(ergo)(" padded_promoted_average is greater than maximum promotion = %zu", young_gen->used_in_bytes());
   }
 
   if (!result) {

--- a/src/hotspot/share/gc/parallel/psYoungGen.cpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.cpp
@@ -256,9 +256,9 @@ void PSYoungGen::resize(size_t eden_size, size_t survivor_size) {
     space_invariants();
 
     log_trace(gc, ergo)("Young generation size: "
-                        "desired eden: " SIZE_FORMAT " survivor: " SIZE_FORMAT
-                        " used: " SIZE_FORMAT " capacity: " SIZE_FORMAT
-                        " gen limits: " SIZE_FORMAT " / " SIZE_FORMAT,
+                        "desired eden: %zu survivor: %zu"
+                        " used: %zu capacity: %zu"
+                        " gen limits: %zu / %zu",
                         eden_size, survivor_size, used_in_bytes(), capacity_in_bytes(),
                         max_gen_size(), min_gen_size());
   }
@@ -315,15 +315,15 @@ bool PSYoungGen::resize_generation(size_t eden_size, size_t survivor_size) {
     }
   } else {
     if (orig_size == max_gen_size()) {
-      log_trace(gc)("PSYoung generation size at maximum: " SIZE_FORMAT "K", orig_size/K);
+      log_trace(gc)("PSYoung generation size at maximum: %zuK", orig_size/K);
     } else if (orig_size == min_gen_size()) {
-      log_trace(gc)("PSYoung generation size at minimum: " SIZE_FORMAT "K", orig_size/K);
+      log_trace(gc)("PSYoung generation size at minimum: %zuK", orig_size/K);
     }
   }
 
   if (size_changed) {
     post_resize();
-    log_trace(gc)("PSYoung generation size changed: " SIZE_FORMAT "K->" SIZE_FORMAT "K",
+    log_trace(gc)("PSYoung generation size changed: %zuK->%zuK",
                   orig_size/K, virtual_space()->committed_size()/K);
   }
 
@@ -420,21 +420,21 @@ void PSYoungGen::resize_spaces(size_t requested_eden_size,
     return;
   }
 
-  log_trace(gc, ergo)("PSYoungGen::resize_spaces(requested_eden_size: " SIZE_FORMAT ", requested_survivor_size: " SIZE_FORMAT ")",
+  log_trace(gc, ergo)("PSYoungGen::resize_spaces(requested_eden_size: %zu, requested_survivor_size: %zu)",
                       requested_eden_size, requested_survivor_size);
-  log_trace(gc, ergo)("    eden: [" PTR_FORMAT ".." PTR_FORMAT ") " SIZE_FORMAT,
+  log_trace(gc, ergo)("    eden: [" PTR_FORMAT ".." PTR_FORMAT ") %zu",
                       p2i(eden_space()->bottom()),
                       p2i(eden_space()->end()),
                       pointer_delta(eden_space()->end(),
                                     eden_space()->bottom(),
                                     sizeof(char)));
-  log_trace(gc, ergo)("    from: [" PTR_FORMAT ".." PTR_FORMAT ") " SIZE_FORMAT,
+  log_trace(gc, ergo)("    from: [" PTR_FORMAT ".." PTR_FORMAT ") %zu",
                       p2i(from_space()->bottom()),
                       p2i(from_space()->end()),
                       pointer_delta(from_space()->end(),
                                     from_space()->bottom(),
                                     sizeof(char)));
-  log_trace(gc, ergo)("      to: [" PTR_FORMAT ".." PTR_FORMAT ") " SIZE_FORMAT,
+  log_trace(gc, ergo)("      to: [" PTR_FORMAT ".." PTR_FORMAT ") %zu",
                       p2i(to_space()->bottom()),
                       p2i(to_space()->end()),
                       pointer_delta(  to_space()->end(),
@@ -525,15 +525,15 @@ void PSYoungGen::resize_spaces(size_t requested_eden_size,
 
     guarantee(to_start != to_end, "to space is zero sized");
 
-    log_trace(gc, ergo)("    [eden_start .. eden_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [eden_start .. eden_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(eden_start),
                         p2i(eden_end),
                         pointer_delta(eden_end, eden_start, sizeof(char)));
-    log_trace(gc, ergo)("    [from_start .. from_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [from_start .. from_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(from_start),
                         p2i(from_end),
                         pointer_delta(from_end, from_start, sizeof(char)));
-    log_trace(gc, ergo)("    [  to_start ..   to_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [  to_start ..   to_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(to_start),
                         p2i(to_end),
                         pointer_delta(  to_end,   to_start, sizeof(char)));
@@ -575,15 +575,15 @@ void PSYoungGen::resize_spaces(size_t requested_eden_size,
     eden_end = MAX2(eden_end, eden_start + SpaceAlignment);
     to_start = MAX2(to_start, eden_end);
 
-    log_trace(gc, ergo)("    [eden_start .. eden_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [eden_start .. eden_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(eden_start),
                         p2i(eden_end),
                         pointer_delta(eden_end, eden_start, sizeof(char)));
-    log_trace(gc, ergo)("    [  to_start ..   to_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [  to_start ..   to_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(to_start),
                         p2i(to_end),
                         pointer_delta(  to_end,   to_start, sizeof(char)));
-    log_trace(gc, ergo)("    [from_start .. from_end): [" PTR_FORMAT " .. " PTR_FORMAT ") " SIZE_FORMAT,
+    log_trace(gc, ergo)("    [from_start .. from_end): [" PTR_FORMAT " .. " PTR_FORMAT ") %zu",
                         p2i(from_start),
                         p2i(from_end),
                         pointer_delta(from_end, from_start, sizeof(char)));
@@ -660,7 +660,7 @@ void PSYoungGen::resize_spaces(size_t requested_eden_size,
 
   assert(from_space()->top() == old_from_top, "from top changed!");
 
-  log_trace(gc, ergo)("AdaptiveSizePolicy::survivor space sizes: collection: %d (" SIZE_FORMAT ", " SIZE_FORMAT ") -> (" SIZE_FORMAT ", " SIZE_FORMAT ") ",
+  log_trace(gc, ergo)("AdaptiveSizePolicy::survivor space sizes: collection: %d (%zu, %zu) -> (%zu, %zu) ",
                       ParallelScavengeHeap::heap()->total_collections(),
                       old_from, old_to,
                       from_space()->capacity_in_bytes(),
@@ -716,7 +716,7 @@ void PSYoungGen::object_iterate(ObjectClosure* blk) {
 void PSYoungGen::print() const { print_on(tty); }
 void PSYoungGen::print_on(outputStream* st) const {
   st->print(" %-15s", "PSYoungGen");
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total %zuK, used %zuK",
              capacity_in_bytes()/K, used_in_bytes()/K);
   virtual_space()->print_space_boundaries_on(st);
   st->print("  eden"); eden_space()->print_on(st);

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -612,11 +612,11 @@ void DefNewGeneration::compute_new_size() {
     gch->rem_set()->resize_covered_region(cmr);
 
     log_debug(gc, ergo, heap)(
-        "New generation size " SIZE_FORMAT "K->" SIZE_FORMAT "K [eden=" SIZE_FORMAT "K,survivor=" SIZE_FORMAT "K]",
+        "New generation size %zuK->%zuK [eden=%zuK,survivor=%zuK]",
         new_size_before/K, _virtual_space.committed_size()/K,
         eden()->capacity()/K, from()->capacity()/K);
     log_trace(gc, ergo, heap)(
-        "  [allowed " SIZE_FORMAT "K extra for %d threads]",
+        "  [allowed %zuK extra for %d threads]",
           thread_increase_size/K, threads_count);
       }
 }
@@ -690,7 +690,7 @@ HeapWord* DefNewGeneration::allocate_from_space(size_t size) {
     result = from()->allocate(size);
   }
 
-  log_trace(gc, alloc)("DefNewGeneration::allocate_from_space(" SIZE_FORMAT "):  will_fail: %s  heap_lock: %s  free: " SIZE_FORMAT "%s%s returns %s",
+  log_trace(gc, alloc)("DefNewGeneration::allocate_from_space(%zu):  will_fail: %s  heap_lock: %s  free: %zu%s%s returns %s",
                         size,
                         GenCollectedHeap::heap()->incremental_collection_will_fail(false /* don't consult_young */) ?
                           "true" : "false",
@@ -893,7 +893,7 @@ void DefNewGeneration::restore_preserved_marks() {
 }
 
 void DefNewGeneration::handle_promotion_failure(oop old) {
-  log_debug(gc, promotion)("Promotion failure size = " SIZE_FORMAT ") ", old->size());
+  log_debug(gc, promotion)("Promotion failure size = %zu) ", old->size());
 
   _promotion_failed = true;
   _promotion_failed_info.register_copy_failure(old->size());

--- a/src/hotspot/share/gc/serial/markSweep.cpp
+++ b/src/hotspot/share/gc/serial/markSweep.cpp
@@ -205,7 +205,7 @@ void MarkSweep::adjust_marks() {
 }
 
 void MarkSweep::restore_marks() {
-  log_trace(gc)("Restoring " SIZE_FORMAT " marks", _preserved_count + _preserved_overflow_stack_set.get()->size());
+  log_trace(gc)("Restoring %zu marks", _preserved_count + _preserved_overflow_stack_set.get()->size());
 
   // restore the marks we saved earlier
   for (size_t i = 0; i < _preserved_count; i++) {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ bool TenuredGeneration::grow_by(size_t bytes) {
 
     size_t new_mem_size = _virtual_space.committed_size();
     size_t old_mem_size = new_mem_size - bytes;
-    log_trace(gc, heap)("Expanding %s from " SIZE_FORMAT "K by " SIZE_FORMAT "K to " SIZE_FORMAT "K",
+    log_trace(gc, heap)("Expanding %s from %zuK by %zuK to %zuK",
                     name(), old_mem_size/K, bytes/K, new_mem_size/K);
   }
   return result;
@@ -139,7 +139,7 @@ void TenuredGeneration::shrink(size_t bytes) {
 
   size_t new_mem_size = _virtual_space.committed_size();
   size_t old_mem_size = new_mem_size + size;
-  log_trace(gc, heap)("Shrinking %s from " SIZE_FORMAT "K to " SIZE_FORMAT "K",
+  log_trace(gc, heap)("Shrinking %s from %zuK to %zuK",
                       name(), old_mem_size/K, new_mem_size/K);
 }
 
@@ -241,7 +241,7 @@ void TenuredGeneration::compute_new_size_inner() {
       assert(shrink_bytes <= max_shrink_bytes, "invalid shrink size");
       log_trace(gc, heap)("    shrinking:  initSize: %.1fK  maximum_desired_capacity: %.1fK",
                                initial_size() / (double) K, maximum_desired_capacity / (double) K);
-      log_trace(gc, heap)("    shrink_bytes: %.1fK  current_shrink_factor: " SIZE_FORMAT "  new shrink factor: " SIZE_FORMAT "  _min_heap_delta_bytes: %.1fK",
+      log_trace(gc, heap)("    shrink_bytes: %.1fK  current_shrink_factor: %zu  new shrink factor: %zu  _min_heap_delta_bytes: %.1fK",
                                shrink_bytes / (double) K,
                                current_shrink_factor,
                                _shrink_factor,
@@ -359,18 +359,18 @@ bool TenuredGeneration::should_collect(bool  full,
     return true;
   }
   if (should_allocate(size, is_tlab)) {
-    log_trace(gc)("TenuredGeneration::should_collect: because should_allocate(" SIZE_FORMAT ")", size);
+    log_trace(gc)("TenuredGeneration::should_collect: because should_allocate(%zu)", size);
     return true;
   }
   // If we don't have very much free space.
   // XXX: 10000 should be a percentage of the capacity!!!
   if (free() < 10000) {
-    log_trace(gc)("TenuredGeneration::should_collect: because free(): " SIZE_FORMAT, free());
+    log_trace(gc)("TenuredGeneration::should_collect: because free(): %zu", free());
     return true;
   }
   // If we had to expand to accommodate promotions from the young generation
   if (_capacity_at_prologue < capacity()) {
-    log_trace(gc)("TenuredGeneration::should_collect: because_capacity_at_prologue: " SIZE_FORMAT " < capacity(): " SIZE_FORMAT,
+    log_trace(gc)("TenuredGeneration::should_collect: because_capacity_at_prologue: %zu < capacity(): %zu",
         _capacity_at_prologue, capacity());
     return true;
   }
@@ -388,8 +388,8 @@ void TenuredGeneration::compute_new_size() {
   compute_new_size_inner();
 
   assert(used() == used_after_gc && used_after_gc <= capacity(),
-         "used: " SIZE_FORMAT " used_after_gc: " SIZE_FORMAT
-         " capacity: " SIZE_FORMAT, used(), used_after_gc, capacity());
+         "used: %zu used_after_gc: %zu"
+         " capacity: %zu", used(), used_after_gc, capacity());
 }
 
 void TenuredGeneration::update_gc_stats(Generation* current_generation,
@@ -425,7 +425,7 @@ bool TenuredGeneration::promotion_attempt_is_safe(size_t max_promotion_in_bytes)
   size_t av_promo  = (size_t)gc_stats()->avg_promoted()->padded_average();
   bool   res = (available >= av_promo) || (available >= max_promotion_in_bytes);
 
-  log_trace(gc)("Tenured: promo attempt is%s safe: available(" SIZE_FORMAT ") %s av_promo(" SIZE_FORMAT "), max_promo(" SIZE_FORMAT ")",
+  log_trace(gc)("Tenured: promo attempt is%s safe: available(%zu) %s av_promo(%zu), max_promo(%zu)",
     res? "":" not", available, res? ">=":"<", av_promo, max_promotion_in_bytes);
 
   return res;

--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp
@@ -337,12 +337,12 @@ class AdaptiveSizePolicySpaceOverheadTester: public GCOverheadTester {
 
     log_trace(gc, ergo)(
           "AdaptiveSizePolicySpaceOverheadTester::is_exceeded:"
-          " promo_limit: " SIZE_FORMAT
-          " max_eden_size: " SIZE_FORMAT
-          " total_free_limit: " SIZE_FORMAT
-          " max_old_gen_size: " SIZE_FORMAT
-          " max_eden_size: " SIZE_FORMAT
-          " mem_free_limit: " SIZE_FORMAT,
+          " promo_limit: %zu"
+          " max_eden_size: %zu"
+          " total_free_limit: %zu"
+          " max_old_gen_size: %zu"
+          " max_eden_size: %zu"
+          " mem_free_limit: %zu",
           promo_limit, _max_eden_size, total_free_limit,
           _max_old_gen_size, _max_eden_size,
           (size_t)mem_free_limit);

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -382,7 +382,7 @@ MetaWord* CollectedHeap::satisfy_failed_metadata_allocation(ClassLoaderData* loa
     if ((QueuedAllocationWarningCount > 0) &&
         (loop_count % QueuedAllocationWarningCount == 0)) {
       log_warning(gc, ergo)("satisfy_failed_metadata_allocation() retries %d times,"
-                            " size=" SIZE_FORMAT, loop_count, word_size);
+                            " size=%zu", loop_count, word_size);
     }
   } while (true);  // Until a GC is done
 }
@@ -451,7 +451,7 @@ CollectedHeap::fill_with_array(HeapWord* start, size_t words, bool zap)
 
   const size_t payload_size = words - filler_array_hdr_size();
   const size_t len = payload_size * HeapWordSize / sizeof(jint);
-  assert((int)len >= 0, "size too large " SIZE_FORMAT " becomes %d", words, (int)len);
+  assert((int)len >= 0, "size too large %zu becomes %d", words, (int)len);
 
   ObjArrayAllocator allocator(Universe::fillerArrayKlassObj(), words, (int)len, /* do_zero */ false);
   allocator.initialize(start);

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -102,7 +102,7 @@ void GCArguments::assert_size_info() {
 #endif // ASSERT
 
 void GCArguments::initialize_size_info() {
-  log_debug(gc, heap)("Minimum heap " SIZE_FORMAT "  Initial heap " SIZE_FORMAT "  Maximum heap " SIZE_FORMAT,
+  log_debug(gc, heap)("Minimum heap %zu  Initial heap %zu  Maximum heap %zu",
                       MinHeapSize, InitialHeapSize, MaxHeapSize);
 
   DEBUG_ONLY(assert_size_info();)
@@ -112,10 +112,10 @@ void GCArguments::initialize_heap_flags_and_sizes() {
   assert(SpaceAlignment != 0, "Space alignment not set up properly");
   assert(HeapAlignment != 0, "Heap alignment not set up properly");
   assert(HeapAlignment >= SpaceAlignment,
-         "HeapAlignment: " SIZE_FORMAT " less than SpaceAlignment: " SIZE_FORMAT,
+         "HeapAlignment: %zu less than SpaceAlignment: %zu",
          HeapAlignment, SpaceAlignment);
   assert(HeapAlignment % SpaceAlignment == 0,
-         "HeapAlignment: " SIZE_FORMAT " not aligned by SpaceAlignment: " SIZE_FORMAT,
+         "HeapAlignment: %zu not aligned by SpaceAlignment: %zu",
          HeapAlignment, SpaceAlignment);
 
   if (FLAG_IS_CMDLINE(MaxHeapSize)) {

--- a/src/hotspot/share/gc/shared/gcInitLogger.cpp
+++ b/src/hotspot/share/gc/shared/gcInitLogger.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ void GCInitLogger::print_large_pages() {
 void GCInitLogger::print_numa() {
   if (UseNUMA) {
     log_info_p(gc, init)("NUMA Support: Enabled");
-    log_info_p(gc, init)("NUMA Nodes: " SIZE_FORMAT, os::numa_get_groups_num());
+    log_info_p(gc, init)("NUMA Nodes: %zu", os::numa_get_groups_num());
   } else {
     log_info_p(gc, init)("NUMA Support: Disabled");
   }
@@ -91,11 +91,11 @@ void GCInitLogger::print_compressed_oops() {
 }
 
 void GCInitLogger::print_heap() {
-  log_info_p(gc, init)("Heap Min Capacity: " SIZE_FORMAT "%s",
+  log_info_p(gc, init)("Heap Min Capacity: %zu%s",
                        byte_size_in_exact_unit(MinHeapSize), exact_unit_for_byte_size(MinHeapSize));
-  log_info_p(gc, init)("Heap Initial Capacity: " SIZE_FORMAT "%s",
+  log_info_p(gc, init)("Heap Initial Capacity: %zu%s",
                        byte_size_in_exact_unit(InitialHeapSize), exact_unit_for_byte_size(InitialHeapSize));
-  log_info_p(gc, init)("Heap Max Capacity: " SIZE_FORMAT "%s",
+  log_info_p(gc, init)("Heap Max Capacity: %zu%s",
                        byte_size_in_exact_unit(MaxHeapSize), exact_unit_for_byte_size(MaxHeapSize));
 
   log_info_p(gc, init)("Pre-touch: %s", AlwaysPreTouch ? "Enabled" : "Disabled");

--- a/src/hotspot/share/gc/shared/gcTraceTime.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceTime.cpp
@@ -63,7 +63,7 @@ void GCTraceTimeLoggerImpl::log_end(Ticks end) {
     size_t used_before_m = _heap_usage_before / M;
     size_t used_m = heap->used() / M;
     size_t capacity_m = heap->capacity() / M;
-    out.print(" %zuM->%zuM("  SIZE_FORMAT "M)", used_before_m, used_m, capacity_m);
+    out.print(" %zuM->%zuM("  "%zuM)", used_before_m, used_m, capacity_m);
   }
 
   out.print_cr(" %.3fms", duration_in_ms);

--- a/src/hotspot/share/gc/shared/gcTraceTime.cpp
+++ b/src/hotspot/share/gc/shared/gcTraceTime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ void GCTraceTimeLoggerImpl::log_end(Ticks end) {
     size_t used_before_m = _heap_usage_before / M;
     size_t used_m = heap->used() / M;
     size_t capacity_m = heap->capacity() / M;
-    out.print(" " SIZE_FORMAT "M->" SIZE_FORMAT "M("  SIZE_FORMAT "M)", used_before_m, used_m, capacity_m);
+    out.print(" %zuM->%zuM("  SIZE_FORMAT "M)", used_before_m, used_m, capacity_m);
   }
 
   out.print_cr(" %.3fms", duration_in_ms);

--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -110,7 +110,7 @@ bool VM_GC_Operation::doit_prologue() {
   if (!is_init_completed()) {
     vm_exit_during_initialization(
       err_msg("GC triggered before VM initialization completed. Try increasing "
-              "NewSize, current value " SIZE_FORMAT "%s.",
+              "NewSize, current value %zu%s.",
               byte_size_in_proper_unit(NewSize),
               proper_unit_for_byte_size(NewSize)));
   }
@@ -283,7 +283,7 @@ void VM_CollectForMetadataAllocation::doit() {
     return;
   }
 
-  log_debug(gc)("After Metaspace GC failed to allocate size " SIZE_FORMAT, _size);
+  log_debug(gc)("After Metaspace GC failed to allocate size %zu", _size);
 
   if (GCLocker::is_active_and_needs_gc()) {
     set_gc_locked();

--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,13 +73,13 @@ void GenArguments::initialize_heap_flags_and_sizes() {
 
   assert(GenAlignment != 0, "Generation alignment not set up properly");
   assert(HeapAlignment >= GenAlignment,
-         "HeapAlignment: " SIZE_FORMAT " less than GenAlignment: " SIZE_FORMAT,
+         "HeapAlignment: %zu less than GenAlignment: %zu",
          HeapAlignment, GenAlignment);
   assert(GenAlignment % SpaceAlignment == 0,
-         "GenAlignment: " SIZE_FORMAT " not aligned by SpaceAlignment: " SIZE_FORMAT,
+         "GenAlignment: %zu not aligned by SpaceAlignment: %zu",
          GenAlignment, SpaceAlignment);
   assert(HeapAlignment % GenAlignment == 0,
-         "HeapAlignment: " SIZE_FORMAT " not aligned by GenAlignment: " SIZE_FORMAT,
+         "HeapAlignment: %zu not aligned by GenAlignment: %zu",
          HeapAlignment, GenAlignment);
 
   // All generational heaps have a young gen; handle those flags here
@@ -119,8 +119,8 @@ void GenArguments::initialize_heap_flags_and_sizes() {
       // Make sure there is room for an old generation
       size_t smaller_max_new_size = MaxHeapSize - GenAlignment;
       if (FLAG_IS_CMDLINE(MaxNewSize)) {
-        log_warning(gc, ergo)("MaxNewSize (" SIZE_FORMAT "k) is equal to or greater than the entire "
-                              "heap (" SIZE_FORMAT "k).  A new max generation size of " SIZE_FORMAT "k will be used.",
+        log_warning(gc, ergo)("MaxNewSize (%zuk) is equal to or greater than the entire "
+                              "heap (%zuk).  A new max generation size of %zuk will be used.",
                               MaxNewSize/K, MaxHeapSize/K, smaller_max_new_size/K);
       }
       FLAG_SET_ERGO(MaxNewSize, smaller_max_new_size);
@@ -138,8 +138,8 @@ void GenArguments::initialize_heap_flags_and_sizes() {
     // At this point this should only happen if the user specifies a large NewSize and/or
     // a small (but not too small) MaxNewSize.
     if (FLAG_IS_CMDLINE(MaxNewSize)) {
-      log_warning(gc, ergo)("NewSize (" SIZE_FORMAT "k) is greater than the MaxNewSize (" SIZE_FORMAT "k). "
-                            "A new max generation size of " SIZE_FORMAT "k will be used.",
+      log_warning(gc, ergo)("NewSize (%zuk) is greater than the MaxNewSize (%zuk). "
+                            "A new max generation size of %zuk will be used.",
                             NewSize/K, MaxNewSize/K, NewSize/K);
     }
     FLAG_SET_ERGO(MaxNewSize, NewSize);
@@ -267,7 +267,7 @@ void GenArguments::initialize_size_info() {
     }
   }
 
-  log_trace(gc, heap)("1: Minimum young " SIZE_FORMAT "  Initial young " SIZE_FORMAT "  Maximum young " SIZE_FORMAT,
+  log_trace(gc, heap)("1: Minimum young %zu  Initial young %zu  Maximum young %zu",
                       MinNewSize, initial_young_size, max_young_size);
 
   // At this point the minimum, initial and maximum sizes
@@ -300,7 +300,7 @@ void GenArguments::initialize_size_info() {
     // be within one generation alignment.
     if (initial_old_size > MaxOldSize) {
       log_warning(gc, ergo)("Inconsistency between maximum heap size and maximum "
-                            "generation sizes: using maximum heap = " SIZE_FORMAT
+                            "generation sizes: using maximum heap = %zu"
                             ", -XX:OldSize flag is being ignored",
                             MaxHeapSize);
       initial_old_size = MaxOldSize;
@@ -336,7 +336,7 @@ void GenArguments::initialize_size_info() {
       initial_young_size = desired_young_size;
     }
 
-    log_trace(gc, heap)("2: Minimum young " SIZE_FORMAT "  Initial young " SIZE_FORMAT "  Maximum young " SIZE_FORMAT,
+    log_trace(gc, heap)("2: Minimum young %zu  Initial young %zu  Maximum young %zu",
                         MinNewSize, initial_young_size, max_young_size);
   }
 
@@ -353,7 +353,7 @@ void GenArguments::initialize_size_info() {
     FLAG_SET_ERGO(OldSize, initial_old_size);
   }
 
-  log_trace(gc, heap)("Minimum old " SIZE_FORMAT "  Initial old " SIZE_FORMAT "  Maximum old " SIZE_FORMAT,
+  log_trace(gc, heap)("Minimum old %zu  Initial old %zu  Maximum old %zu",
                       MinOldSize, OldSize, MaxOldSize);
 
   DEBUG_ONLY(assert_size_info();)

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -150,7 +150,7 @@ ReservedHeapSpace GenCollectedHeap::allocate(size_t alignment) {
                                   "the maximum representable size");
   }
   assert(total_reserved % alignment == 0,
-         "Gen size; total_reserved=" SIZE_FORMAT ", alignment="
+         "Gen size; total_reserved=%zu, alignment="
          SIZE_FORMAT, total_reserved, alignment);
 
   ReservedHeapSpace heap_rs = Universe::reserve_heap(total_reserved, alignment);
@@ -353,7 +353,7 @@ HeapWord* GenCollectedHeap::mem_allocate_work(size_t size,
     if ((QueuedAllocationWarningCount > 0) &&
         (try_count % QueuedAllocationWarningCount == 0)) {
           log_warning(gc, ergo)("GenCollectedHeap::mem_allocate_work retries %d times,"
-                                " size=" SIZE_FORMAT " %s", try_count, size, is_tlab ? "(TLAB)" : "");
+                                " size=%zu %s", try_count, size, is_tlab ? "(TLAB)" : "");
     }
   }
 }
@@ -403,7 +403,7 @@ void GenCollectedHeap::collect_generation(Generation* gen, bool full, size_t siz
   // change top of some spaces.
   record_gen_tops_before_GC();
 
-  log_trace(gc)("%s invoke=%d size=" SIZE_FORMAT, heap()->is_young_gen(gen) ? "Young" : "Old", gen->stat_record()->invocations, size * HeapWordSize);
+  log_trace(gc)("%s invoke=%d size=%zu", heap()->is_young_gen(gen) ? "Young" : "Old", gen->stat_record()->invocations, size * HeapWordSize);
 
   if (run_verification && VerifyBeforeGC) {
     Universe::verify("Before GC");

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -150,8 +150,8 @@ ReservedHeapSpace GenCollectedHeap::allocate(size_t alignment) {
                                   "the maximum representable size");
   }
   assert(total_reserved % alignment == 0,
-         "Gen size; total_reserved=%zu, alignment="
-         SIZE_FORMAT, total_reserved, alignment);
+         "Gen size; total_reserved=%zu, alignment=%zu",
+          total_reserved, alignment);
 
   ReservedHeapSpace heap_rs = Universe::reserve_heap(total_reserved, alignment);
   size_t used_page_size = heap_rs.page_size();

--- a/src/hotspot/share/gc/shared/generation.cpp
+++ b/src/hotspot/share/gc/shared/generation.cpp
@@ -73,7 +73,7 @@ void Generation::print() const { print_on(tty); }
 
 void Generation::print_on(outputStream* st)  const {
   st->print(" %-20s", name());
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total %zuK, used %zuK",
              capacity()/K, used()/K);
   st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
               p2i(_virtual_space.low_boundary()),
@@ -137,7 +137,7 @@ size_t Generation::max_contiguous_available() const {
 bool Generation::promotion_attempt_is_safe(size_t max_promotion_in_bytes) const {
   size_t available = max_contiguous_available();
   bool   res = (available >= max_promotion_in_bytes);
-  log_trace(gc)("Generation: promo attempt is%s safe: available(" SIZE_FORMAT ") %s max_promo(" SIZE_FORMAT ")",
+  log_trace(gc)("Generation: promo attempt is%s safe: available(%zu) %s max_promo(%zu)",
                 res? "":" not", available, res? ">=":"<", max_promotion_in_bytes);
   return res;
 }

--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
+++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,8 +71,8 @@ static JVMFlag::Error MinPLABSizeBounds(const char* name, size_t value, bool ver
   if ((GCConfig::is_gc_selected(CollectedHeap::G1) || GCConfig::is_gc_selected(CollectedHeap::Parallel)) &&
       (value < PLAB::min_size())) {
     JVMFlag::printError(verbose,
-                        "%s (" SIZE_FORMAT ") must be "
-                        "greater than or equal to ergonomic PLAB minimum size (" SIZE_FORMAT ")\n",
+                        "%s (%zu) must be "
+                        "greater than or equal to ergonomic PLAB minimum size (%zu)\n",
                         name, value, PLAB::min_size());
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -84,8 +84,8 @@ JVMFlag::Error MaxPLABSizeBounds(const char* name, size_t value, bool verbose) {
   if ((GCConfig::is_gc_selected(CollectedHeap::G1) ||
        GCConfig::is_gc_selected(CollectedHeap::Parallel)) && (value > PLAB::max_size())) {
     JVMFlag::printError(verbose,
-                        "%s (" SIZE_FORMAT ") must be "
-                        "less than or equal to ergonomic PLAB maximum size (" SIZE_FORMAT ")\n",
+                        "%s (%zu) must be "
+                        "less than or equal to ergonomic PLAB maximum size (%zu)\n",
                         name, value, PLAB::max_size());
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -144,7 +144,7 @@ static JVMFlag::Error CheckMaxHeapSizeAndSoftRefLRUPolicyMSPerMB(size_t maxHeap,
   if ((softRef > 0) && ((maxHeap / M) > (max_uintx / softRef))) {
     JVMFlag::printError(verbose,
                         "Desired lifetime of SoftReferences cannot be expressed correctly. "
-                        "MaxHeapSize (" SIZE_FORMAT ") or SoftRefLRUPolicyMSPerMB "
+                        "MaxHeapSize (%zu) or SoftRefLRUPolicyMSPerMB "
                         "(" INTX_FORMAT ") is too large\n",
                         maxHeap, softRef);
     return JVMFlag::VIOLATES_CONSTRAINT;
@@ -161,8 +161,8 @@ JVMFlag::Error MarkStackSizeConstraintFunc(size_t value, bool verbose) {
   // value == 0 is handled by the range constraint.
   if (value > MarkStackSizeMax) {
     JVMFlag::printError(verbose,
-                        "MarkStackSize (" SIZE_FORMAT ") must be "
-                        "less than or equal to MarkStackSizeMax (" SIZE_FORMAT ")\n",
+                        "MarkStackSize (%zu) must be "
+                        "less than or equal to MarkStackSizeMax (%zu)\n",
                         value, MarkStackSizeMax);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {
@@ -253,8 +253,8 @@ static JVMFlag::Error MaxSizeForAlignment(const char* name, size_t value, size_t
   size_t aligned_max = ((max_uintx - alignment) & ~(alignment-1));
   if (value > aligned_max) {
     JVMFlag::printError(verbose,
-                        "%s (" SIZE_FORMAT ") must be "
-                        "less than or equal to aligned maximum value (" SIZE_FORMAT ")\n",
+                        "%s (%zu) must be "
+                        "less than or equal to aligned maximum value (%zu)\n",
                         name, value, aligned_max);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -308,8 +308,8 @@ JVMFlag::Error HeapBaseMinAddressConstraintFunc(size_t value, bool verbose) {
   // Check for this by ensuring that MaxHeapSize plus the requested min base address still fit within max_uintx.
   if (UseCompressedOops && FLAG_IS_ERGO(MaxHeapSize) && (value > (max_uintx - MaxHeapSize))) {
     JVMFlag::printError(verbose,
-                        "HeapBaseMinAddress (" SIZE_FORMAT ") or MaxHeapSize (" SIZE_FORMAT ") is too large. "
-                        "Sum of them must be less than or equal to maximum of size_t (" SIZE_FORMAT ")\n",
+                        "HeapBaseMinAddress (%zu) or MaxHeapSize (%zu) is too large. "
+                        "Sum of them must be less than or equal to maximum of size_t (%zu)\n",
                         value, MaxHeapSize, max_uintx);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -332,15 +332,15 @@ JVMFlag::Error MinTLABSizeConstraintFunc(size_t value, bool verbose) {
   // At least, alignment reserve area is needed.
   if (value < ThreadLocalAllocBuffer::alignment_reserve_in_bytes()) {
     JVMFlag::printError(verbose,
-                        "MinTLABSize (" SIZE_FORMAT ") must be "
-                        "greater than or equal to reserved area in TLAB (" SIZE_FORMAT ")\n",
+                        "MinTLABSize (%zu) must be "
+                        "greater than or equal to reserved area in TLAB (%zu)\n",
                         value, ThreadLocalAllocBuffer::alignment_reserve_in_bytes());
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
   if (value > (ThreadLocalAllocBuffer::max_size() * HeapWordSize)) {
     JVMFlag::printError(verbose,
-                        "MinTLABSize (" SIZE_FORMAT ") must be "
-                        "less than or equal to ergonomic TLAB maximum (" SIZE_FORMAT ")\n",
+                        "MinTLABSize (%zu) must be "
+                        "less than or equal to ergonomic TLAB maximum (%zu)\n",
                         value, ThreadLocalAllocBuffer::max_size() * HeapWordSize);
     return JVMFlag::VIOLATES_CONSTRAINT;
   }
@@ -352,15 +352,15 @@ JVMFlag::Error TLABSizeConstraintFunc(size_t value, bool verbose) {
   if (FLAG_IS_CMDLINE(TLABSize)) {
     if (value < MinTLABSize) {
       JVMFlag::printError(verbose,
-                          "TLABSize (" SIZE_FORMAT ") must be "
-                          "greater than or equal to MinTLABSize (" SIZE_FORMAT ")\n",
+                          "TLABSize (%zu) must be "
+                          "greater than or equal to MinTLABSize (%zu)\n",
                           value, MinTLABSize);
       return JVMFlag::VIOLATES_CONSTRAINT;
     }
     if (value > (ThreadLocalAllocBuffer::max_size() * HeapWordSize)) {
       JVMFlag::printError(verbose,
-                          "TLABSize (" SIZE_FORMAT ") must be "
-                          "less than or equal to ergonomic TLAB maximum size (" SIZE_FORMAT ")\n",
+                          "TLABSize (%zu) must be "
+                          "less than or equal to ergonomic TLAB maximum size (%zu)\n",
                           value, (ThreadLocalAllocBuffer::max_size() * HeapWordSize));
       return JVMFlag::VIOLATES_CONSTRAINT;
     }
@@ -378,7 +378,7 @@ JVMFlag::Error TLABWasteIncrementConstraintFunc(uintx value, bool verbose) {
     if (refill_waste_limit > (max_uintx - value)) {
       JVMFlag::printError(verbose,
                           "TLABWasteIncrement (" UINTX_FORMAT ") must be "
-                          "less than or equal to ergonomic TLAB waste increment maximum size(" SIZE_FORMAT ")\n",
+                          "less than or equal to ergonomic TLAB waste increment maximum size(%zu)\n",
                           value, (max_uintx - refill_waste_limit));
       return JVMFlag::VIOLATES_CONSTRAINT;
     }
@@ -391,7 +391,7 @@ JVMFlag::Error SurvivorRatioConstraintFunc(uintx value, bool verbose) {
       (value > (MaxHeapSize / SpaceAlignment))) {
     JVMFlag::printError(verbose,
                         "SurvivorRatio (" UINTX_FORMAT ") must be "
-                        "less than or equal to ergonomic SurvivorRatio maximum (" SIZE_FORMAT ")\n",
+                        "less than or equal to ergonomic SurvivorRatio maximum (%zu)\n",
                         value,
                         (MaxHeapSize / SpaceAlignment));
     return JVMFlag::VIOLATES_CONSTRAINT;
@@ -403,8 +403,8 @@ JVMFlag::Error SurvivorRatioConstraintFunc(uintx value, bool verbose) {
 JVMFlag::Error MetaspaceSizeConstraintFunc(size_t value, bool verbose) {
   if (value > MaxMetaspaceSize) {
     JVMFlag::printError(verbose,
-                        "MetaspaceSize (" SIZE_FORMAT ") must be "
-                        "less than or equal to MaxMetaspaceSize (" SIZE_FORMAT ")\n",
+                        "MetaspaceSize (%zu) must be "
+                        "less than or equal to MaxMetaspaceSize (%zu)\n",
                         value, MaxMetaspaceSize);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {
@@ -415,8 +415,8 @@ JVMFlag::Error MetaspaceSizeConstraintFunc(size_t value, bool verbose) {
 JVMFlag::Error MaxMetaspaceSizeConstraintFunc(size_t value, bool verbose) {
   if (value < MetaspaceSize) {
     JVMFlag::printError(verbose,
-                        "MaxMetaspaceSize (" SIZE_FORMAT ") must be "
-                        "greater than or equal to MetaspaceSize (" SIZE_FORMAT ")\n",
+                        "MaxMetaspaceSize (%zu) must be "
+                        "greater than or equal to MetaspaceSize (%zu)\n",
                         value, MaxMetaspaceSize);
     return JVMFlag::VIOLATES_CONSTRAINT;
   } else {

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -305,13 +305,13 @@ HeapWord* MemAllocator::mem_allocate_inside_tlab_slow(Allocation& allocation) co
   mem = Universe::heap()->allocate_new_tlab(min_tlab_size, new_tlab_size, &allocation._allocated_tlab_size);
   if (mem == nullptr) {
     assert(allocation._allocated_tlab_size == 0,
-           "Allocation failed, but actual size was updated. min: " SIZE_FORMAT
-           ", desired: " SIZE_FORMAT ", actual: " SIZE_FORMAT,
+           "Allocation failed, but actual size was updated. min: %zu"
+           ", desired: %zu, actual: %zu",
            min_tlab_size, new_tlab_size, allocation._allocated_tlab_size);
     return nullptr;
   }
   assert(allocation._allocated_tlab_size != 0, "Allocation succeeded but actual size not updated. mem at: "
-         PTR_FORMAT " min: " SIZE_FORMAT ", desired: " SIZE_FORMAT,
+         PTR_FORMAT " min: %zu, desired: %zu",
          p2i(mem), min_tlab_size, new_tlab_size);
 
   if (ZeroTLAB) {

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -572,7 +572,7 @@ bool OopStorage::expand_active_array() {
   assert_lock_strong(_allocation_mutex);
   ActiveArray* old_array = _active_array;
   size_t new_size = 2 * old_array->size();
-  log_debug(oopstorage, blocks)("%s: expand active array " SIZE_FORMAT,
+  log_debug(oopstorage, blocks)("%s: expand active array %zu",
                                 name(), new_size);
   ActiveArray* new_array = ActiveArray::create(new_size,
                                                memflags(),
@@ -1132,8 +1132,8 @@ bool OopStorage::BasicParState::claim_next_segment(IterationData* data) {
 
 bool OopStorage::BasicParState::finish_iteration(const IterationData* data) const {
   log_info(oopstorage, blocks, stats)
-          ("Parallel iteration on %s: blocks = " SIZE_FORMAT
-           ", processed = " SIZE_FORMAT " (%2.f%%)",
+          ("Parallel iteration on %s: blocks = %zu"
+           ", processed = %zu (%2.f%%)",
            _storage->name(), _block_count, data->_processed,
            percent_of(data->_processed, _block_count));
   return false;
@@ -1162,7 +1162,7 @@ void OopStorage::print_on(outputStream* st) const {
   double data_size = section_size * section_count;
   double alloc_percentage = percent_of((double)allocations, blocks * data_size);
 
-  st->print("%s: " SIZE_FORMAT " entries in " SIZE_FORMAT " blocks (%.F%%), " SIZE_FORMAT " bytes",
+  st->print("%s: %zu entries in %zu blocks (%.F%%), %zu bytes",
             name(), allocations, blocks, alloc_percentage, total_memory_usage());
   if (_concurrent_iteration_count > 0) {
     st->print(", concurrent iteration active");

--- a/src/hotspot/share/gc/shared/plab.cpp
+++ b/src/hotspot/share/gc/shared/plab.cpp
@@ -58,7 +58,7 @@ PLAB::PLAB(size_t desired_plab_sz_) :
   _end(nullptr), _hard_end(nullptr), _allocated(0), _wasted(0), _undo_wasted(0)
 {
   assert(min_size() > CollectedHeap::lab_alignment_reserve(),
-         "Minimum PLAB size " SIZE_FORMAT " must be larger than alignment reserve " SIZE_FORMAT " "
+         "Minimum PLAB size %zu must be larger than alignment reserve %zu "
          "to be able to contain objects", min_size(), CollectedHeap::lab_alignment_reserve());
 }
 

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,10 +66,10 @@ void PreservedMarks::restore_and_increment(volatile size_t* const total_size_add
 
 #ifndef PRODUCT
 void PreservedMarks::assert_empty() {
-  assert(_stack.is_empty(), "stack expected to be empty, size = " SIZE_FORMAT,
+  assert(_stack.is_empty(), "stack expected to be empty, size = %zu",
          _stack.size());
   assert(_stack.cache_size() == 0,
-         "stack expected to have no cached segments, cache size = " SIZE_FORMAT,
+         "stack expected to have no cached segments, cache size = %zu",
          _stack.cache_size());
 }
 #endif // ndef PRODUCT

--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -43,7 +43,7 @@ PretouchTask::PretouchTask(const char* task_name,
     _chunk_size(chunk_size) {
 
   assert(chunk_size >= page_size,
-         "Chunk size " SIZE_FORMAT " is smaller than page size " SIZE_FORMAT,
+         "Chunk size %zu is smaller than page size %zu",
          chunk_size, page_size);
 }
 
@@ -85,12 +85,12 @@ void PretouchTask::pretouch(const char* task_name, char* start_address, char* en
     size_t num_chunks = ((total_bytes - 1) / chunk_size) + 1;
 
     uint num_workers = (uint)MIN2(num_chunks, (size_t)pretouch_workers->max_workers());
-    log_debug(gc, heap)("Running %s with %u workers for " SIZE_FORMAT " work units pre-touching " SIZE_FORMAT "B.",
+    log_debug(gc, heap)("Running %s with %u workers for %zu work units pre-touching %zuB.",
                         task.name(), num_workers, num_chunks, total_bytes);
 
     pretouch_workers->run_task(&task, num_workers);
   } else {
-    log_debug(gc, heap)("Running %s pre-touching " SIZE_FORMAT "B.",
+    log_debug(gc, heap)("Running %s pre-touching %zuB.",
                         task.name(), total_bytes);
     task.work(0);
   }

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -574,7 +574,7 @@ void ReferenceProcessor::log_reflist_counts(DiscoveredList ref_lists[], uint num
   log_reflist("", ref_lists, num_active_queues);
 #ifdef ASSERT
   for (uint i = num_active_queues; i < _max_num_queues; i++) {
-    assert(ref_lists[i].length() == 0, SIZE_FORMAT " unexpected References in %u",
+    assert(ref_lists[i].length() == 0, "%zu unexpected References in %u",
            ref_lists[i].length(), i);
   }
 #endif

--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -175,7 +175,7 @@ size_t ReferenceProcessor::total_count(DiscoveredList lists[]) const {
 #ifdef ASSERT
 void ReferenceProcessor::verify_total_count_zero(DiscoveredList lists[], const char* type) {
   size_t count = total_count(lists);
-  assert(count == 0, "%ss must be empty but has " SIZE_FORMAT " elements", type, count);
+  assert(count == 0, "%ss must be empty but has %zu elements", type, count);
 }
 #endif
 
@@ -365,7 +365,7 @@ size_t ReferenceProcessor::process_discovered_list_work(DiscoveredList&    refs_
     refs_list.clear();
   }
 
-  log_develop_trace(gc, ref)(" Dropped " SIZE_FORMAT " active Refs out of " SIZE_FORMAT
+  log_develop_trace(gc, ref)(" Dropped %zu active Refs out of %zu"
                              " Refs in discovered list " PTR_FORMAT,
                              iter.removed(), iter.processed(), p2i(&refs_list));
   return iter.removed();
@@ -559,10 +559,10 @@ void ReferenceProcessor::log_reflist(const char* prefix, DiscoveredList list[], 
   LogStream ls(lt);
   ls.print("%s", prefix);
   for (uint i = 0; i < num_active_queues; i++) {
-    ls.print(SIZE_FORMAT " ", list[i].length());
+    ls.print("%zu ", list[i].length());
     total += list[i].length();
   }
-  ls.print_cr("(" SIZE_FORMAT ")", total);
+  ls.print_cr("(%zu)", total);
 }
 
 #ifndef PRODUCT
@@ -1093,7 +1093,7 @@ bool ReferenceProcessor::preclean_discovered_reflist(DiscoveredList&    refs_lis
   }
 
   if (iter.processed() > 0) {
-    log_develop_trace(gc, ref)(" Dropped " SIZE_FORMAT " Refs out of " SIZE_FORMAT " Refs in discovered list " PTR_FORMAT,
+    log_develop_trace(gc, ref)(" Dropped %zu Refs out of %zu Refs in discovered list " PTR_FORMAT,
                                iter.removed(), iter.processed(), p2i(&refs_list));
   }
   return false;

--- a/src/hotspot/share/gc/shared/satbMarkQueue.cpp
+++ b/src/hotspot/share/gc/shared/satbMarkQueue.cpp
@@ -54,8 +54,8 @@ static void print_satb_buffer(const char* name,
                               void** buf,
                               size_t index,
                               size_t capacity) {
-  tty->print_cr("  SATB BUFFER [%s] buf: " PTR_FORMAT " index: " SIZE_FORMAT
-                " capacity: " SIZE_FORMAT,
+  tty->print_cr("  SATB BUFFER [%s] buf: " PTR_FORMAT " index: %zu"
+                " capacity: %zu",
                 name, p2i(buf), index, capacity);
 }
 

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -474,7 +474,7 @@ void ContiguousSpace::compact() {
 void Space::print_short() const { print_short_on(tty); }
 
 void Space::print_short_on(outputStream* st) const {
-  st->print(" space " SIZE_FORMAT "K, %3d%% used", capacity() / K,
+  st->print(" space %zuK, %3d%% used", capacity() / K,
               (int) ((double) used() * 100 / capacity()));
 }
 

--- a/src/hotspot/share/gc/shared/space.inline.hpp
+++ b/src/hotspot/share/gc/shared/space.inline.hpp
@@ -115,7 +115,7 @@ public:
       obj->set_mark(obj->mark().set_marked());
 
       assert(dead_length == obj->size(), "bad filler object size");
-      log_develop_trace(gc, compaction)("Inserting object to dead space: " PTR_FORMAT ", " PTR_FORMAT ", " SIZE_FORMAT "b",
+      log_develop_trace(gc, compaction)("Inserting object to dead space: " PTR_FORMAT ", " PTR_FORMAT ", %zub",
           p2i(dead_start), p2i(dead_end), dead_length * HeapWordSize);
 
       return true;

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.cpp
@@ -164,7 +164,7 @@ void ThreadLocalAllocBuffer::resize() {
   size_t aligned_new_size = align_object_size(new_size);
 
   log_trace(gc, tlab)("TLAB new size: thread: " PTR_FORMAT " [id: %2d]"
-                      " refills %d  alloc: %8.6f desired_size: " SIZE_FORMAT " -> " SIZE_FORMAT,
+                      " refills %d  alloc: %8.6f desired_size: %zu -> %zu",
                       p2i(thread()), thread()->osthread()->thread_id(),
                       _target_refills, _allocation_fraction.average(), desired_size(), aligned_new_size);
 
@@ -263,7 +263,7 @@ void ThreadLocalAllocBuffer::startup_initialization() {
   guarantee(Thread::current()->is_Java_thread(), "tlab initialization thread not Java thread");
   Thread::current()->tlab().initialize();
 
-  log_develop_trace(gc, tlab)("TLAB min: " SIZE_FORMAT " initial: " SIZE_FORMAT " max: " SIZE_FORMAT,
+  log_develop_trace(gc, tlab)("TLAB min: %zu initial: %zu max: %zu",
                                min_size(), Thread::current()->tlab().initial_desired_size(), max_size());
 }
 
@@ -299,8 +299,8 @@ void ThreadLocalAllocBuffer::print_stats(const char* tag) {
   double waste_percent = percent_of(waste, _allocated_size);
   size_t tlab_used  = Universe::heap()->tlab_used(thrd);
   log.trace("TLAB: %s thread: " PTR_FORMAT " [id: %2d]"
-            " desired_size: " SIZE_FORMAT "KB"
-            " slow allocs: %d  refill waste: " SIZE_FORMAT "B"
+            " desired_size: %zuKB"
+            " slow allocs: %d  refill waste: %zuB"
             " alloc:%8.5f %8.0fKB refills: %d waste %4.1f%% gc: %dB"
             " slow: %dB",
             tag, p2i(thrd), thrd->osthread()->thread_id(),
@@ -451,8 +451,8 @@ void ThreadLocalAllocStats::publish() {
   const double waste_percent = percent_of(waste, _total_allocations);
   log_debug(gc, tlab)("TLAB totals: thrds: %d  refills: %d max: %d"
                       " slow allocs: %d max %d waste: %4.1f%%"
-                      " gc: " SIZE_FORMAT "B max: " SIZE_FORMAT "B"
-                      " slow: " SIZE_FORMAT "B max: " SIZE_FORMAT "B",
+                      " gc: %zuB max: %zuB"
+                      " slow: %zuB max: %zuB",
                       _allocating_threads, _total_refills, _max_refills,
                       _total_slow_allocations, _max_slow_allocations, waste_percent,
                       _total_gc_waste * HeapWordSize, _max_gc_waste * HeapWordSize,

--- a/src/hotspot/share/gc/shared/threadLocalAllocBuffer.inline.hpp
+++ b/src/hotspot/share/gc/shared/threadLocalAllocBuffer.inline.hpp
@@ -67,11 +67,11 @@ inline size_t ThreadLocalAllocBuffer::compute_size(size_t obj_size) {
   // Make sure there's enough room for object and filler int[].
   if (new_tlab_size < compute_min_size(obj_size)) {
     // If there isn't enough room for the allocation, return failure.
-    log_trace(gc, tlab)("ThreadLocalAllocBuffer::compute_size(" SIZE_FORMAT ") returns failure",
+    log_trace(gc, tlab)("ThreadLocalAllocBuffer::compute_size(%zu) returns failure",
                         obj_size);
     return 0;
   }
-  log_trace(gc, tlab)("ThreadLocalAllocBuffer::compute_size(" SIZE_FORMAT ") returns " SIZE_FORMAT,
+  log_trace(gc, tlab)("ThreadLocalAllocBuffer::compute_size(%zu) returns %zu",
                       obj_size, new_tlab_size);
   return new_tlab_size;
 }
@@ -92,9 +92,9 @@ void ThreadLocalAllocBuffer::record_slow_allocation(size_t obj_size) {
   _slow_allocations++;
 
   log_develop_trace(gc, tlab)("TLAB: %s thread: " PTR_FORMAT " [id: %2d]"
-                              " obj: " SIZE_FORMAT
-                              " free: " SIZE_FORMAT
-                              " waste: " SIZE_FORMAT,
+                              " obj: %zu"
+                              " free: %zu"
+                              " waste: %zu",
                               "slow", p2i(thread()), thread()->osthread()->thread_id(),
                               obj_size, free(), refill_waste_limit());
 }

--- a/src/hotspot/share/gc/shared/workerDataArray.cpp
+++ b/src/hotspot/share/gc/shared/workerDataArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,9 +49,9 @@ void WorkerDataArray<double>::WDAPrinter::summary(outputStream* out, double min,
 
 template <>
 void WorkerDataArray<size_t>::WDAPrinter::summary(outputStream* out, size_t min, double avg, size_t max, size_t diff, size_t sum, bool print_sum) {
-  out->print(" Min: " SIZE_FORMAT ", Avg: %4.1lf, Max: " SIZE_FORMAT ", Diff: " SIZE_FORMAT, min, avg, max, diff);
+  out->print(" Min: %zu, Avg: %4.1lf, Max: %zu, Diff: %zu", min, avg, max, diff);
   if (print_sum) {
-    out->print(", Sum: " SIZE_FORMAT, sum);
+    out->print(", Sum: %zu", sum);
   }
 }
 
@@ -75,7 +75,7 @@ void WorkerDataArray<size_t>::WDAPrinter::details(const WorkerDataArray<size_t>*
   for (uint i = 0; i < phase->_length; ++i) {
     size_t value = phase->get(i);
     if (value != phase->uninitialized()) {
-      out->print("  " SIZE_FORMAT, phase->get(i));
+      out->print("  %zu", phase->get(i));
     } else {
       out->print(" -");
     }

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -90,7 +90,7 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
   size_t min_garbage = (free_target > actual_free ? (free_target - actual_free) : 0);
 
   log_info(gc, ergo)("Adaptive CSet Selection. Target Free: %zu%s, Actual Free: "
-                     SIZE_FORMAT "%s, Max CSet: %zu%s, Min Garbage: %zu%s",
+                     "%zu%s, Max CSet: %zu%s, Min Garbage: %zu%s",
                      byte_size_in_proper_unit(free_target), proper_unit_for_byte_size(free_target),
                      byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free),
                      byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset),

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -89,8 +89,8 @@ void ShenandoahAdaptiveHeuristics::choose_collection_set_from_regiondata(Shenand
   size_t free_target = (capacity / 100 * ShenandoahMinFreeThreshold) + max_cset;
   size_t min_garbage = (free_target > actual_free ? (free_target - actual_free) : 0);
 
-  log_info(gc, ergo)("Adaptive CSet Selection. Target Free: " SIZE_FORMAT "%s, Actual Free: "
-                     SIZE_FORMAT "%s, Max CSet: " SIZE_FORMAT "%s, Min Garbage: " SIZE_FORMAT "%s",
+  log_info(gc, ergo)("Adaptive CSet Selection. Target Free: %zu%s, Actual Free: "
+                     SIZE_FORMAT "%s, Max CSet: %zu%s, Min Garbage: %zu%s",
                      byte_size_in_proper_unit(free_target), proper_unit_for_byte_size(free_target),
                      byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free),
                      byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset),
@@ -136,7 +136,7 @@ void ShenandoahAdaptiveHeuristics::record_success_concurrent() {
     z_score = (available - _available.avg()) / _available.sd();
   }
 
-  log_debug(gc, ergo)("Available: " SIZE_FORMAT " %sB, z-score=%.3f. Average available: %.1f %sB +/- %.1f %sB.",
+  log_debug(gc, ergo)("Available: %zu %sB, z-score=%.3f. Average available: %.1f %sB +/- %.1f %sB.",
                       byte_size_in_proper_unit(available), proper_unit_for_byte_size(available),
                       z_score,
                       byte_size_in_proper_unit(_available.avg()), proper_unit_for_byte_size(_available.avg()),
@@ -211,7 +211,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
 
   size_t min_threshold = capacity / 100 * ShenandoahMinFreeThreshold;
   if (available < min_threshold) {
-    log_info(gc)("Trigger: Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",
+    log_info(gc)("Trigger: Free (%zu%s) is below minimum threshold (%zu%s)",
                  byte_size_in_proper_unit(available),     proper_unit_for_byte_size(available),
                  byte_size_in_proper_unit(min_threshold), proper_unit_for_byte_size(min_threshold));
     return true;
@@ -221,7 +221,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   if (_gc_times_learned < max_learn) {
     size_t init_threshold = capacity / 100 * ShenandoahInitFreeThreshold;
     if (available < init_threshold) {
-      log_info(gc)("Trigger: Learning " SIZE_FORMAT " of " SIZE_FORMAT ". Free (" SIZE_FORMAT "%s) is below initial threshold (" SIZE_FORMAT "%s)",
+      log_info(gc)("Trigger: Learning %zu of %zu. Free (%zu%s) is below initial threshold (%zu%s)",
                    _gc_times_learned + 1, max_learn,
                    byte_size_in_proper_unit(available),      proper_unit_for_byte_size(available),
                    byte_size_in_proper_unit(init_threshold), proper_unit_for_byte_size(init_threshold));
@@ -243,13 +243,13 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   double avg_cycle_time = _gc_time_history->davg() + (_margin_of_error_sd * _gc_time_history->dsd());
   double avg_alloc_rate = _allocation_rate.upper_bound(_margin_of_error_sd);
   if (avg_cycle_time > allocation_headroom / avg_alloc_rate) {
-    log_info(gc)("Trigger: Average GC time (%.2f ms) is above the time for average allocation rate (%.0f %sB/s) to deplete free headroom (" SIZE_FORMAT "%s) (margin of error = %.2f)",
+    log_info(gc)("Trigger: Average GC time (%.2f ms) is above the time for average allocation rate (%.0f %sB/s) to deplete free headroom (%zu%s) (margin of error = %.2f)",
                  avg_cycle_time * 1000,
                  byte_size_in_proper_unit(avg_alloc_rate), proper_unit_for_byte_size(avg_alloc_rate),
                  byte_size_in_proper_unit(allocation_headroom), proper_unit_for_byte_size(allocation_headroom),
                  _margin_of_error_sd);
 
-    log_info(gc, ergo)("Free headroom: " SIZE_FORMAT "%s (free) - " SIZE_FORMAT "%s (spike) - " SIZE_FORMAT "%s (penalties) = " SIZE_FORMAT "%s",
+    log_info(gc, ergo)("Free headroom: %zu%s (free) - %zu%s (spike) - %zu%s (penalties) = %zu%s",
                        byte_size_in_proper_unit(available),           proper_unit_for_byte_size(available),
                        byte_size_in_proper_unit(spike_headroom),      proper_unit_for_byte_size(spike_headroom),
                        byte_size_in_proper_unit(penalties),           proper_unit_for_byte_size(penalties),
@@ -261,7 +261,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
 
   bool is_spiking = _allocation_rate.is_spiking(rate, _spike_threshold_sd);
   if (is_spiking && avg_cycle_time > allocation_headroom / rate) {
-    log_info(gc)("Trigger: Average GC time (%.2f ms) is above the time for instantaneous allocation rate (%.0f %sB/s) to deplete free headroom (" SIZE_FORMAT "%s) (spike threshold = %.2f)",
+    log_info(gc)("Trigger: Average GC time (%.2f ms) is above the time for instantaneous allocation rate (%.0f %sB/s) to deplete free headroom (%zu%s) (spike threshold = %.2f)",
                  avg_cycle_time * 1000,
                  byte_size_in_proper_unit(rate), proper_unit_for_byte_size(rate),
                  byte_size_in_proper_unit(allocation_headroom), proper_unit_for_byte_size(allocation_headroom),

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahCompactHeuristics.cpp
@@ -58,7 +58,7 @@ bool ShenandoahCompactHeuristics::should_start_gc() {
   size_t min_threshold = capacity / 100 * ShenandoahMinFreeThreshold;
 
   if (available < min_threshold) {
-    log_info(gc)("Trigger: Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",
+    log_info(gc)("Trigger: Free (%zu%s) is below minimum threshold (%zu%s)",
                  byte_size_in_proper_unit(available),     proper_unit_for_byte_size(available),
                  byte_size_in_proper_unit(min_threshold), proper_unit_for_byte_size(min_threshold));
     return true;
@@ -66,7 +66,7 @@ bool ShenandoahCompactHeuristics::should_start_gc() {
 
   size_t bytes_allocated = _space_info->bytes_allocated_since_gc_start();
   if (bytes_allocated > threshold_bytes_allocated) {
-    log_info(gc)("Trigger: Allocated since last cycle (" SIZE_FORMAT "%s) is larger than allocation threshold (" SIZE_FORMAT "%s)",
+    log_info(gc)("Trigger: Allocated since last cycle (%zu%s) is larger than allocation threshold (%zu%s)",
                  byte_size_in_proper_unit(bytes_allocated),           proper_unit_for_byte_size(bytes_allocated),
                  byte_size_in_proper_unit(threshold_bytes_allocated), proper_unit_for_byte_size(threshold_bytes_allocated));
     return true;
@@ -81,7 +81,7 @@ void ShenandoahCompactHeuristics::choose_collection_set_from_regiondata(Shenando
   // Do not select too large CSet that would overflow the available free space
   size_t max_cset = actual_free * 3 / 4;
 
-  log_info(gc, ergo)("CSet Selection. Actual Free: " SIZE_FORMAT "%s, Max CSet: " SIZE_FORMAT "%s",
+  log_info(gc, ergo)("CSet Selection. Actual Free: %zu%s, Max CSet: %zu%s",
                      byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free),
                      byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset));
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -122,7 +122,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
       bool reg_live = region->has_live();
       bool bm_live = ctx->is_marked(cast_to_oop(region->bottom()));
       assert(reg_live == bm_live,
-             "Humongous liveness and marks should agree. Region live: %s; Bitmap live: %s; Region Live Words: " SIZE_FORMAT,
+             "Humongous liveness and marks should agree. Region live: %s; Bitmap live: %s; Region Live Words: %zu",
              BOOL_TO_STR(reg_live), BOOL_TO_STR(bm_live), region->get_live_data_words());
 #endif
       if (!region->has_live()) {
@@ -143,7 +143,7 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
   // given the amount of immediately reclaimable garbage. If we do, figure out the collection set.
 
   assert (immediate_garbage <= total_garbage,
-          "Cannot have more immediate garbage than total garbage: " SIZE_FORMAT "%s vs " SIZE_FORMAT "%s",
+          "Cannot have more immediate garbage than total garbage: %zu%s vs %zu%s",
           byte_size_in_proper_unit(immediate_garbage), proper_unit_for_byte_size(immediate_garbage),
           byte_size_in_proper_unit(total_garbage),     proper_unit_for_byte_size(total_garbage));
 
@@ -158,9 +158,9 @@ void ShenandoahHeuristics::choose_collection_set(ShenandoahCollectionSet* collec
   size_t collectable_garbage = collection_set->garbage() + immediate_garbage;
   size_t collectable_garbage_percent = (total_garbage == 0) ? 0 : (collectable_garbage * 100 / total_garbage);
 
-  log_info(gc, ergo)("Collectable Garbage: " SIZE_FORMAT "%s (" SIZE_FORMAT "%%), "
-                     "Immediate: " SIZE_FORMAT "%s (" SIZE_FORMAT "%%), "
-                     "CSet: " SIZE_FORMAT "%s (" SIZE_FORMAT "%%)",
+  log_info(gc, ergo)("Collectable Garbage: %zu%s (%zu%%), "
+                     "Immediate: %zu%s (%zu%%), "
+                     "CSet: %zu%s (%zu%%)",
 
                      byte_size_in_proper_unit(collectable_garbage),
                      proper_unit_for_byte_size(collectable_garbage),

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahPassiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahPassiveHeuristics.cpp
@@ -60,7 +60,7 @@ void ShenandoahPassiveHeuristics::choose_collection_set_from_regiondata(Shenando
   size_t available = MAX2(max_capacity / 100 * ShenandoahEvacReserve, actual_free);
   size_t max_cset  = (size_t)(available / ShenandoahEvacWaste);
 
-  log_info(gc, ergo)("CSet Selection. Actual Free: " SIZE_FORMAT "%s, Max CSet: " SIZE_FORMAT "%s",
+  log_info(gc, ergo)("CSet Selection. Actual Free: %zu%s, Max CSet: %zu%s",
                      byte_size_in_proper_unit(actual_free), proper_unit_for_byte_size(actual_free),
                      byte_size_in_proper_unit(max_cset),    proper_unit_for_byte_size(max_cset));
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahStaticHeuristics.cpp
@@ -52,7 +52,7 @@ bool ShenandoahStaticHeuristics::should_start_gc() {
   size_t threshold_available = capacity / 100 * ShenandoahMinFreeThreshold;
 
   if (available < threshold_available) {
-    log_info(gc)("Trigger: Free (" SIZE_FORMAT "%s) is below minimum threshold (" SIZE_FORMAT "%s)",
+    log_info(gc)("Trigger: Free (%zu%s) is below minimum threshold (%zu%s)",
                  byte_size_in_proper_unit(available),           proper_unit_for_byte_size(available),
                  byte_size_in_proper_unit(threshold_available), proper_unit_for_byte_size(threshold_available));
     return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -57,7 +57,7 @@ void ShenandoahArguments::initialize() {
   if (UseLargePages) {
     size_t large_page_size = os::large_page_size();
     if ((align_up(MaxHeapSize, large_page_size) / large_page_size) < ShenandoahHeapRegion::MIN_NUM_REGIONS) {
-      warning("Large pages size (" SIZE_FORMAT "K) is too large to afford page-sized regions, disabling uncommit",
+      warning("Large pages size (%zuK) is too large to afford page-sized regions, disabling uncommit",
               os::large_page_size() / K);
       FLAG_SET_DEFAULT(ShenandoahUncommit, false);
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -150,7 +150,7 @@ ShenandoahHeapRegion* ShenandoahCollectionSet::next() {
 }
 
 void ShenandoahCollectionSet::print_on(outputStream* out) const {
-  out->print_cr("Collection Set : " SIZE_FORMAT "", count());
+  out->print_cr("Collection Set : %zu", count());
 
   debug_only(size_t regions = 0;)
   for (size_t index = 0; index < _heap->num_regions(); index ++) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -491,7 +491,7 @@ public:
   ShenandoahInitMarkUpdateRegionStateClosure() : _ctx(ShenandoahHeap::heap()->marking_context()) {}
 
   void heap_region_do(ShenandoahHeapRegion* r) {
-    assert(!r->has_live(), "Region " SIZE_FORMAT " should have no live data", r->index());
+    assert(!r->has_live(), "Region %zu should have no live data", r->index());
     if (r->is_active()) {
       // Check if region needs updating its TAMS. We have updated it already during concurrent
       // reset, so it is very likely we don't need to do another write here.
@@ -500,7 +500,7 @@ public:
       }
     } else {
       assert(_ctx->top_at_mark_start(r) == r->top(),
-             "Region " SIZE_FORMAT " should already have correct TAMS", r->index());
+             "Region %zu should already have correct TAMS", r->index());
     }
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -337,7 +337,7 @@ bool ShenandoahControlThread::check_soft_max_changed() const {
     new_soft_max = MAX2(heap->min_capacity(), new_soft_max);
     new_soft_max = MIN2(heap->max_capacity(), new_soft_max);
     if (new_soft_max != old_soft_max) {
-      log_info(gc)("Soft Max Heap Size: " SIZE_FORMAT "%s -> " SIZE_FORMAT "%s",
+      log_info(gc)("Soft Max Heap Size: %zu%s -> %zu%s",
                    byte_size_in_proper_unit(old_soft_max), proper_unit_for_byte_size(old_soft_max),
                    byte_size_in_proper_unit(new_soft_max), proper_unit_for_byte_size(new_soft_max)
       );
@@ -531,7 +531,7 @@ void ShenandoahControlThread::handle_alloc_failure(ShenandoahAllocRequest& req) 
 
   if (try_set_alloc_failure_gc()) {
     // Only report the first allocation failure
-    log_info(gc)("Failed to allocate %s, " SIZE_FORMAT "%s",
+    log_info(gc)("Failed to allocate %s, %zu%s",
                  req.type_string(),
                  byte_size_in_proper_unit(req.size() * HeapWordSize), proper_unit_for_byte_size(req.size() * HeapWordSize));
 
@@ -550,7 +550,7 @@ void ShenandoahControlThread::handle_alloc_failure_evac(size_t words) {
 
   if (try_set_alloc_failure_gc()) {
     // Only report the first allocation failure
-    log_info(gc)("Failed to allocate " SIZE_FORMAT "%s for evacuation",
+    log_info(gc)("Failed to allocate %zu%s for evacuation",
                  byte_size_in_proper_unit(words * HeapWordSize), proper_unit_for_byte_size(words * HeapWordSize));
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -45,18 +45,18 @@ void ShenandoahFreeSet::increase_used(size_t num_bytes) {
   shenandoah_assert_heaplocked();
   _used += num_bytes;
 
-  assert(_used <= _capacity, "must not use more than we have: used: " SIZE_FORMAT
-         ", capacity: " SIZE_FORMAT ", num_bytes: " SIZE_FORMAT, _used, _capacity, num_bytes);
+  assert(_used <= _capacity, "must not use more than we have: used: %zu"
+         ", capacity: %zu, num_bytes: %zu", _used, _capacity, num_bytes);
 }
 
 bool ShenandoahFreeSet::is_mutator_free(size_t idx) const {
-  assert (idx < _max, "index is sane: " SIZE_FORMAT " < " SIZE_FORMAT " (left: " SIZE_FORMAT ", right: " SIZE_FORMAT ")",
+  assert (idx < _max, "index is sane: %zu < %zu (left: %zu, right: %zu)",
           idx, _max, _mutator_leftmost, _mutator_rightmost);
   return _mutator_free_bitmap.at(idx);
 }
 
 bool ShenandoahFreeSet::is_collector_free(size_t idx) const {
-  assert (idx < _max, "index is sane: " SIZE_FORMAT " < " SIZE_FORMAT " (left: " SIZE_FORMAT ", right: " SIZE_FORMAT ")",
+  assert (idx < _max, "index is sane: %zu < %zu (left: %zu, right: %zu)",
           idx, _max, _collector_leftmost, _collector_rightmost);
   return _collector_free_bitmap.at(idx);
 }
@@ -140,7 +140,7 @@ HeapWord* ShenandoahFreeSet::allocate_single(ShenandoahAllocRequest& req, bool& 
 }
 
 HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, ShenandoahAllocRequest& req, bool& in_new_region) {
-  assert (!has_no_alloc_capacity(r), "Performance: should avoid full regions on this path: " SIZE_FORMAT, r->index());
+  assert (!has_no_alloc_capacity(r), "Performance: should avoid full regions on this path: %zu", r->index());
 
   if (_heap->is_concurrent_weak_root_in_progress() &&
       r->is_trash()) {
@@ -161,7 +161,7 @@ HeapWord* ShenandoahFreeSet::try_allocate_in(ShenandoahHeapRegion* r, Shenandoah
     }
     if (size >= req.min_size()) {
       result = r->allocate(size, req.type());
-      assert (result != nullptr, "Allocation must succeed: free " SIZE_FORMAT ", actual " SIZE_FORMAT, free, size);
+      assert (result != nullptr, "Allocation must succeed: free %zu, actual %zu", free, size);
     }
   } else {
     result = r->allocate(size, req.type());
@@ -490,7 +490,7 @@ void ShenandoahFreeSet::log_status() {
       size_t max_humongous = max_contig * ShenandoahHeapRegion::region_size_bytes();
       size_t free = capacity() - used();
 
-      ls.print("Free: " SIZE_FORMAT "%s, Max: " SIZE_FORMAT "%s regular, " SIZE_FORMAT "%s humongous, ",
+      ls.print("Free: %zu%s, Max: %zu%s regular, %zu%s humongous, ",
                byte_size_in_proper_unit(total_free),    proper_unit_for_byte_size(total_free),
                byte_size_in_proper_unit(max),           proper_unit_for_byte_size(max),
                byte_size_in_proper_unit(max_humongous), proper_unit_for_byte_size(max_humongous)
@@ -503,7 +503,7 @@ void ShenandoahFreeSet::log_status() {
       } else {
         frag_ext = 0;
       }
-      ls.print(SIZE_FORMAT "%% external, ", frag_ext);
+      ls.print("%zu%% external, ", frag_ext);
 
       size_t frag_int;
       if (mutator_count() > 0) {
@@ -511,7 +511,7 @@ void ShenandoahFreeSet::log_status() {
       } else {
         frag_int = 0;
       }
-      ls.print(SIZE_FORMAT "%% internal; ", frag_int);
+      ls.print("%zu%% internal; ", frag_int);
     }
 
     {
@@ -527,7 +527,7 @@ void ShenandoahFreeSet::log_status() {
         }
       }
 
-      ls.print_cr("Reserve: " SIZE_FORMAT "%s, Max: " SIZE_FORMAT "%s",
+      ls.print_cr("Reserve: %zu%s, Max: %zu%s",
                   byte_size_in_proper_unit(total_free), proper_unit_for_byte_size(total_free),
                   byte_size_in_proper_unit(max),        proper_unit_for_byte_size(max));
     }
@@ -547,7 +547,7 @@ HeapWord* ShenandoahFreeSet::allocate(ShenandoahAllocRequest& req, bool& in_new_
       case ShenandoahAllocRequest::_alloc_gclab:
       case ShenandoahAllocRequest::_alloc_tlab:
         in_new_region = false;
-        assert(false, "Trying to allocate TLAB larger than the humongous threshold: " SIZE_FORMAT " > " SIZE_FORMAT,
+        assert(false, "Trying to allocate TLAB larger than the humongous threshold: %zu > %zu",
                req.size(), ShenandoahHeapRegion::humongous_threshold_words());
         return nullptr;
       default:
@@ -576,13 +576,13 @@ size_t ShenandoahFreeSet::unsafe_peek_free() const {
 }
 
 void ShenandoahFreeSet::print_on(outputStream* out) const {
-  out->print_cr("Mutator Free Set: " SIZE_FORMAT "", mutator_count());
+  out->print_cr("Mutator Free Set: %zu", mutator_count());
   for (size_t index = _mutator_leftmost; index <= _mutator_rightmost; index++) {
     if (is_mutator_free(index)) {
       _heap->get_region(index)->print_on(out);
     }
   }
-  out->print_cr("Collector Free Set: " SIZE_FORMAT "", collector_count());
+  out->print_cr("Collector Free Set: %zu", collector_count());
   for (size_t index = _collector_leftmost; index <= _collector_rightmost; index++) {
     if (is_collector_free(index)) {
       _heap->get_region(index)->print_on(out);
@@ -684,26 +684,26 @@ double ShenandoahFreeSet::external_fragmentation() {
 void ShenandoahFreeSet::assert_bounds() const {
   // Performance invariants. Failing these would not break the free set, but performance
   // would suffer.
-  assert (_mutator_leftmost <= _max, "leftmost in bounds: "  SIZE_FORMAT " < " SIZE_FORMAT, _mutator_leftmost,  _max);
-  assert (_mutator_rightmost < _max, "rightmost in bounds: " SIZE_FORMAT " < " SIZE_FORMAT, _mutator_rightmost, _max);
+  assert (_mutator_leftmost <= _max, "leftmost in bounds: "  SIZE_FORMAT " < %zu", _mutator_leftmost,  _max);
+  assert (_mutator_rightmost < _max, "rightmost in bounds: %zu < %zu", _mutator_rightmost, _max);
 
-  assert (_mutator_leftmost == _max || is_mutator_free(_mutator_leftmost),  "leftmost region should be free: " SIZE_FORMAT,  _mutator_leftmost);
-  assert (_mutator_rightmost == 0   || is_mutator_free(_mutator_rightmost), "rightmost region should be free: " SIZE_FORMAT, _mutator_rightmost);
+  assert (_mutator_leftmost == _max || is_mutator_free(_mutator_leftmost),  "leftmost region should be free: %zu",  _mutator_leftmost);
+  assert (_mutator_rightmost == 0   || is_mutator_free(_mutator_rightmost), "rightmost region should be free: %zu", _mutator_rightmost);
 
   size_t beg_off = _mutator_free_bitmap.find_first_set_bit(0);
   size_t end_off = _mutator_free_bitmap.find_first_set_bit(_mutator_rightmost + 1);
-  assert (beg_off >= _mutator_leftmost, "free regions before the leftmost: " SIZE_FORMAT ", bound " SIZE_FORMAT, beg_off, _mutator_leftmost);
-  assert (end_off == _max,      "free regions past the rightmost: " SIZE_FORMAT ", bound " SIZE_FORMAT,  end_off, _mutator_rightmost);
+  assert (beg_off >= _mutator_leftmost, "free regions before the leftmost: %zu, bound %zu", beg_off, _mutator_leftmost);
+  assert (end_off == _max,      "free regions past the rightmost: %zu, bound %zu",  end_off, _mutator_rightmost);
 
-  assert (_collector_leftmost <= _max, "leftmost in bounds: "  SIZE_FORMAT " < " SIZE_FORMAT, _collector_leftmost,  _max);
-  assert (_collector_rightmost < _max, "rightmost in bounds: " SIZE_FORMAT " < " SIZE_FORMAT, _collector_rightmost, _max);
+  assert (_collector_leftmost <= _max, "leftmost in bounds: "  SIZE_FORMAT " < %zu", _collector_leftmost,  _max);
+  assert (_collector_rightmost < _max, "rightmost in bounds: %zu < %zu", _collector_rightmost, _max);
 
-  assert (_collector_leftmost == _max || is_collector_free(_collector_leftmost),  "leftmost region should be free: " SIZE_FORMAT,  _collector_leftmost);
-  assert (_collector_rightmost == 0   || is_collector_free(_collector_rightmost), "rightmost region should be free: " SIZE_FORMAT, _collector_rightmost);
+  assert (_collector_leftmost == _max || is_collector_free(_collector_leftmost),  "leftmost region should be free: %zu",  _collector_leftmost);
+  assert (_collector_rightmost == 0   || is_collector_free(_collector_rightmost), "rightmost region should be free: %zu", _collector_rightmost);
 
   beg_off = _collector_free_bitmap.find_first_set_bit(0);
   end_off = _collector_free_bitmap.find_first_set_bit(_collector_rightmost + 1);
-  assert (beg_off >= _collector_leftmost, "free regions before the leftmost: " SIZE_FORMAT ", bound " SIZE_FORMAT, beg_off, _collector_leftmost);
-  assert (end_off == _max,      "free regions past the rightmost: " SIZE_FORMAT ", bound " SIZE_FORMAT,  end_off, _collector_rightmost);
+  assert (beg_off >= _collector_leftmost, "free regions before the leftmost: %zu, bound %zu", beg_off, _collector_leftmost);
+  assert (end_off == _max,      "free regions past the rightmost: %zu, bound %zu",  end_off, _collector_rightmost);
 }
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFreeSet.cpp
@@ -684,7 +684,7 @@ double ShenandoahFreeSet::external_fragmentation() {
 void ShenandoahFreeSet::assert_bounds() const {
   // Performance invariants. Failing these would not break the free set, but performance
   // would suffer.
-  assert (_mutator_leftmost <= _max, "leftmost in bounds: "  SIZE_FORMAT " < %zu", _mutator_leftmost,  _max);
+  assert (_mutator_leftmost <= _max, "leftmost in bounds: "  "%zu < %zu", _mutator_leftmost,  _max);
   assert (_mutator_rightmost < _max, "rightmost in bounds: %zu < %zu", _mutator_rightmost, _max);
 
   assert (_mutator_leftmost == _max || is_mutator_free(_mutator_leftmost),  "leftmost region should be free: %zu",  _mutator_leftmost);
@@ -695,7 +695,7 @@ void ShenandoahFreeSet::assert_bounds() const {
   assert (beg_off >= _mutator_leftmost, "free regions before the leftmost: %zu, bound %zu", beg_off, _mutator_leftmost);
   assert (end_off == _max,      "free regions past the rightmost: %zu, bound %zu",  end_off, _mutator_rightmost);
 
-  assert (_collector_leftmost <= _max, "leftmost in bounds: "  SIZE_FORMAT " < %zu", _collector_leftmost,  _max);
+  assert (_collector_leftmost <= _max, "leftmost in bounds: "  "%zu < %zu", _collector_leftmost,  _max);
   assert (_collector_rightmost < _max, "rightmost in bounds: %zu < %zu", _collector_rightmost, _max);
 
   assert (_collector_leftmost == _max || is_collector_free(_collector_leftmost),  "leftmost region should be free: %zu",  _collector_leftmost);

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -499,7 +499,7 @@ public:
     if (r->is_empty_uncommitted()) {
       r->make_committed_bypass();
     }
-    assert (r->is_committed(), "only committed regions in heap now, see region " SIZE_FORMAT, r->index());
+    assert (r->is_committed(), "only committed regions in heap now, see region %zu", r->index());
 
     // Record current region occupancy: this communicates empty regions are free
     // to the rest of Full GC code.
@@ -522,16 +522,16 @@ public:
       oop humongous_obj = cast_to_oop(r->bottom());
       if (!_ctx->is_marked(humongous_obj)) {
         assert(!r->has_live(),
-               "Region " SIZE_FORMAT " is not marked, should not have live", r->index());
+               "Region %zu is not marked, should not have live", r->index());
         _heap->trash_humongous_region_at(r);
       } else {
         assert(r->has_live(),
-               "Region " SIZE_FORMAT " should have live", r->index());
+               "Region %zu should have live", r->index());
       }
     } else if (r->is_humongous_continuation()) {
       // If we hit continuation, the non-live humongous starts should have been trashed already
       assert(r->humongous_start_region()->has_live(),
-             "Region " SIZE_FORMAT " should have live", r->index());
+             "Region %zu should have live", r->index());
     } else if (r->is_regular()) {
       if (!r->has_live()) {
         r->make_trash_immediate();
@@ -667,8 +667,8 @@ void ShenandoahFullGC::distribute_slices(ShenandoahHeapRegionSet** worker_slices
     ShenandoahHeapRegion* r = it.next();
     while (r != nullptr) {
       size_t idx = r->index();
-      assert(ShenandoahPrepareForCompactionTask::is_candidate_region(r), "Sanity: " SIZE_FORMAT, idx);
-      assert(!map.at(idx), "No region distributed twice: " SIZE_FORMAT, idx);
+      assert(ShenandoahPrepareForCompactionTask::is_candidate_region(r), "Sanity: %zu", idx);
+      assert(!map.at(idx), "No region distributed twice: %zu", idx);
       map.at_put(idx, true);
       r = it.next();
     }
@@ -677,7 +677,7 @@ void ShenandoahFullGC::distribute_slices(ShenandoahHeapRegionSet** worker_slices
   for (size_t rid = 0; rid < n_regions; rid++) {
     bool is_candidate = ShenandoahPrepareForCompactionTask::is_candidate_region(heap->get_region(rid));
     bool is_distributed = map.at(rid);
-    assert(is_distributed || !is_candidate, "All candidates are distributed: " SIZE_FORMAT, rid);
+    assert(is_distributed || !is_candidate, "All candidates are distributed: %zu", rid);
   }
 #endif
 }
@@ -958,7 +958,7 @@ void ShenandoahFullGC::compact_humongous_objects() {
       size_t new_start = heap->heap_region_index_containing(old_obj->forwardee());
       size_t new_end   = new_start + num_regions - 1;
       assert(old_start != new_start, "must be real move");
-      assert(r->is_stw_move_allowed(), "Region " SIZE_FORMAT " should be movable", r->index());
+      assert(r->is_stw_move_allowed(), "Region %zu should be movable", r->index());
 
       Copy::aligned_conjoint_words(r->bottom(), heap->get_region(new_start)->bottom(), words_size);
       ContinuationGCSupport::relativize_stack_chunk(cast_to_oop<HeapWord*>(r->bottom()));

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -578,7 +578,7 @@ void ShenandoahHeap::print_on(outputStream* st) const {
                byte_size_in_proper_unit(soft_max_capacity()), proper_unit_for_byte_size(soft_max_capacity()),
                byte_size_in_proper_unit(committed()),    proper_unit_for_byte_size(committed()),
                byte_size_in_proper_unit(used()),         proper_unit_for_byte_size(used()));
-  st->print_cr(" %zu x " SIZE_FORMAT"%s regions",
+  st->print_cr(" %zu x %zu%s regions",
                num_regions(),
                byte_size_in_proper_unit(ShenandoahHeapRegion::region_size_bytes()),
                proper_unit_for_byte_size(ShenandoahHeapRegion::region_size_bytes()));

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -128,7 +128,7 @@ public:
     while (r != nullptr) {
       size_t start = r->index()       * ShenandoahHeapRegion::region_size_bytes() / MarkBitMap::heap_map_factor();
       size_t end   = (r->index() + 1) * ShenandoahHeapRegion::region_size_bytes() / MarkBitMap::heap_map_factor();
-      assert (end <= _bitmap_size, "end is sane: " SIZE_FORMAT " < " SIZE_FORMAT, end, _bitmap_size);
+      assert (end <= _bitmap_size, "end is sane: %zu < %zu", end, _bitmap_size);
 
       if (r->is_committed()) {
         os::pretouch_memory(_bitmap_base + start, _bitmap_base + end, _page_size);
@@ -156,7 +156,7 @@ jint ShenandoahHeap::initialize() {
 
   _num_regions = ShenandoahHeapRegion::region_count();
   assert(_num_regions == (max_byte_size / reg_size_bytes),
-         "Regions should cover entire heap exactly: " SIZE_FORMAT " != " SIZE_FORMAT "/" SIZE_FORMAT,
+         "Regions should cover entire heap exactly: %zu != %zu/%zu",
          _num_regions, max_byte_size, reg_size_bytes);
 
   // Now we know the number of regions, initialize the heuristics.
@@ -227,7 +227,7 @@ jint ShenandoahHeap::initialize() {
   guarantee(bitmap_bytes_per_region != 0,
             "Bitmap bytes per region should not be zero");
   guarantee(is_power_of_2(bitmap_bytes_per_region),
-            "Bitmap bytes per region should be power of two: " SIZE_FORMAT, bitmap_bytes_per_region);
+            "Bitmap bytes per region should be power of two: %zu", bitmap_bytes_per_region);
 
   if (bitmap_page_size > bitmap_bytes_per_region) {
     _bitmap_regions_per_slice = bitmap_page_size / bitmap_bytes_per_region;
@@ -238,11 +238,11 @@ jint ShenandoahHeap::initialize() {
   }
 
   guarantee(_bitmap_regions_per_slice >= 1,
-            "Should have at least one region per slice: " SIZE_FORMAT,
+            "Should have at least one region per slice: %zu",
             _bitmap_regions_per_slice);
 
   guarantee(((_bitmap_bytes_per_slice) % bitmap_page_size) == 0,
-            "Bitmap slices should be page-granular: bps = " SIZE_FORMAT ", page size = " SIZE_FORMAT,
+            "Bitmap slices should be page-granular: bps = %zu, page size = %zu",
             _bitmap_bytes_per_slice, bitmap_page_size);
 
   ReservedSpace bitmap(_bitmap_size, bitmap_page_size);
@@ -573,12 +573,12 @@ void ShenandoahHeap::reset_mark_bitmap() {
 
 void ShenandoahHeap::print_on(outputStream* st) const {
   st->print_cr("Shenandoah Heap");
-  st->print_cr(" " SIZE_FORMAT "%s max, " SIZE_FORMAT "%s soft max, " SIZE_FORMAT "%s committed, " SIZE_FORMAT "%s used",
+  st->print_cr(" %zu%s max, %zu%s soft max, %zu%s committed, %zu%s used",
                byte_size_in_proper_unit(max_capacity()), proper_unit_for_byte_size(max_capacity()),
                byte_size_in_proper_unit(soft_max_capacity()), proper_unit_for_byte_size(soft_max_capacity()),
                byte_size_in_proper_unit(committed()),    proper_unit_for_byte_size(committed()),
                byte_size_in_proper_unit(used()),         proper_unit_for_byte_size(used()));
-  st->print_cr(" " SIZE_FORMAT " x " SIZE_FORMAT"%s regions",
+  st->print_cr(" %zu x " SIZE_FORMAT"%s regions",
                num_regions(),
                byte_size_in_proper_unit(ShenandoahHeapRegion::region_size_bytes()),
                proper_unit_for_byte_size(ShenandoahHeapRegion::region_size_bytes()));
@@ -718,14 +718,14 @@ size_t ShenandoahHeap::max_capacity() const {
 size_t ShenandoahHeap::soft_max_capacity() const {
   size_t v = Atomic::load(&_soft_max_size);
   assert(min_capacity() <= v && v <= max_capacity(),
-         "Should be in bounds: " SIZE_FORMAT " <= " SIZE_FORMAT " <= " SIZE_FORMAT,
+         "Should be in bounds: %zu <= %zu <= %zu",
          min_capacity(), v, max_capacity());
   return v;
 }
 
 void ShenandoahHeap::set_soft_max_capacity(size_t v) {
   assert(min_capacity() <= v && v <= max_capacity(),
-         "Should be in bounds: " SIZE_FORMAT " <= " SIZE_FORMAT " <= " SIZE_FORMAT,
+         "Should be in bounds: %zu <= %zu <= %zu",
          min_capacity(), v, max_capacity());
   Atomic::store(&_soft_max_size, v);
 }
@@ -904,7 +904,7 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
     size_t actual = req.actual_size();
 
     assert (req.is_lab_alloc() || (requested == actual),
-            "Only LAB allocations are elastic: %s, requested = " SIZE_FORMAT ", actual = " SIZE_FORMAT,
+            "Only LAB allocations are elastic: %s, requested = %zu, actual = %zu",
             ShenandoahAllocRequest::alloc_type_to_string(req.type()), requested, actual);
 
     if (req.is_mutator_alloc()) {
@@ -1020,7 +1020,7 @@ private:
     ShenandoahConcurrentEvacuateRegionObjectClosure cl(_sh);
     ShenandoahHeapRegion* r;
     while ((r =_cs->claim_next()) != nullptr) {
-      assert(r->has_live(), "Region " SIZE_FORMAT " should have been reclaimed early", r->index());
+      assert(r->has_live(), "Region %zu should have been reclaimed early", r->index());
       _sh->marked_object_iterate(r, &cl);
 
       if (ShenandoahPacing) {
@@ -1568,7 +1568,7 @@ public:
   ShenandoahInitMarkUpdateRegionStateClosure() : _ctx(ShenandoahHeap::heap()->marking_context()) {}
 
   void heap_region_do(ShenandoahHeapRegion* r) {
-    assert(!r->has_live(), "Region " SIZE_FORMAT " should have no live data", r->index());
+    assert(!r->has_live(), "Region %zu should have no live data", r->index());
     if (r->is_active()) {
       // Check if region needs updating its TAMS. We have updated it already during concurrent
       // reset, so it is very likely we don't need to do another write here.
@@ -1577,7 +1577,7 @@ public:
       }
     } else {
       assert(_ctx->top_at_mark_start(r) == r->top(),
-             "Region " SIZE_FORMAT " should already have correct TAMS", r->index());
+             "Region %zu should already have correct TAMS", r->index());
     }
   }
 
@@ -1662,9 +1662,9 @@ public:
       // from-space-refs written from here on.
       r->set_update_watermark_at_safepoint(r->top());
     } else {
-      assert(!r->has_live(), "Region " SIZE_FORMAT " should have no live data", r->index());
+      assert(!r->has_live(), "Region %zu should have no live data", r->index());
       assert(_ctx->top_at_mark_start(r) == r->top(),
-             "Region " SIZE_FORMAT " should have correct TAMS", r->index());
+             "Region %zu should have correct TAMS", r->index());
     }
   }
 
@@ -1943,7 +1943,7 @@ void ShenandoahHeap::pin_object(JavaThread* thr, oop o) {
 void ShenandoahHeap::unpin_object(JavaThread* thr, oop o) {
   ShenandoahHeapRegion* r = heap_region_containing(o);
   assert(r != nullptr, "Sanity");
-  assert(r->pin_count() > 0, "Region " SIZE_FORMAT " should have non-zero pins", r->index());
+  assert(r->pin_count() > 0, "Region %zu should have non-zero pins", r->index());
   r->record_unpin();
 }
 
@@ -1973,7 +1973,7 @@ void ShenandoahHeap::assert_pinned_region_status() {
   for (size_t i = 0; i < num_regions(); i++) {
     ShenandoahHeapRegion* r = get_region(i);
     assert((r->is_pinned() && r->pin_count() > 0) || (!r->is_pinned() && r->pin_count() == 0),
-           "Region " SIZE_FORMAT " pinning status is inconsistent", i);
+           "Region %zu pinning status is inconsistent", i);
   }
 }
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -185,7 +185,7 @@ void ShenandoahHeapRegion::make_humongous_cont_bypass() {
 
 void ShenandoahHeapRegion::make_pinned() {
   shenandoah_assert_heaplocked();
-  assert(pin_count() > 0, "Should have pins: " SIZE_FORMAT, pin_count());
+  assert(pin_count() > 0, "Should have pins: %zu", pin_count());
 
   switch (_state) {
     case _regular:
@@ -207,7 +207,7 @@ void ShenandoahHeapRegion::make_pinned() {
 
 void ShenandoahHeapRegion::make_unpinned() {
   shenandoah_assert_heaplocked();
-  assert(pin_count() == 0, "Should not have pins: " SIZE_FORMAT, pin_count());
+  assert(pin_count() == 0, "Should not have pins: %zu", pin_count());
 
   switch (_state) {
     case _pinned:
@@ -483,33 +483,33 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
   size_t region_size;
   if (FLAG_IS_DEFAULT(ShenandoahRegionSize)) {
     if (ShenandoahMinRegionSize > max_heap_size / MIN_NUM_REGIONS) {
-      err_msg message("Max heap size (" SIZE_FORMAT "%s) is too low to afford the minimum number "
-                      "of regions (" SIZE_FORMAT ") of minimum region size (" SIZE_FORMAT "%s).",
+      err_msg message("Max heap size (%zu%s) is too low to afford the minimum number "
+                      "of regions (%zu) of minimum region size (%zu%s).",
                       byte_size_in_proper_unit(max_heap_size), proper_unit_for_byte_size(max_heap_size),
                       MIN_NUM_REGIONS,
                       byte_size_in_proper_unit(ShenandoahMinRegionSize), proper_unit_for_byte_size(ShenandoahMinRegionSize));
       vm_exit_during_initialization("Invalid -XX:ShenandoahMinRegionSize option", message);
     }
     if (ShenandoahMinRegionSize < MIN_REGION_SIZE) {
-      err_msg message("" SIZE_FORMAT "%s should not be lower than minimum region size (" SIZE_FORMAT "%s).",
+      err_msg message("%zu%s should not be lower than minimum region size (%zu%s).",
                       byte_size_in_proper_unit(ShenandoahMinRegionSize), proper_unit_for_byte_size(ShenandoahMinRegionSize),
                       byte_size_in_proper_unit(MIN_REGION_SIZE),         proper_unit_for_byte_size(MIN_REGION_SIZE));
       vm_exit_during_initialization("Invalid -XX:ShenandoahMinRegionSize option", message);
     }
     if (ShenandoahMinRegionSize < MinTLABSize) {
-      err_msg message("" SIZE_FORMAT "%s should not be lower than TLAB size size (" SIZE_FORMAT "%s).",
+      err_msg message("%zu%s should not be lower than TLAB size size (%zu%s).",
                       byte_size_in_proper_unit(ShenandoahMinRegionSize), proper_unit_for_byte_size(ShenandoahMinRegionSize),
                       byte_size_in_proper_unit(MinTLABSize),             proper_unit_for_byte_size(MinTLABSize));
       vm_exit_during_initialization("Invalid -XX:ShenandoahMinRegionSize option", message);
     }
     if (ShenandoahMaxRegionSize < MIN_REGION_SIZE) {
-      err_msg message("" SIZE_FORMAT "%s should not be lower than min region size (" SIZE_FORMAT "%s).",
+      err_msg message("%zu%s should not be lower than min region size (%zu%s).",
                       byte_size_in_proper_unit(ShenandoahMaxRegionSize), proper_unit_for_byte_size(ShenandoahMaxRegionSize),
                       byte_size_in_proper_unit(MIN_REGION_SIZE),         proper_unit_for_byte_size(MIN_REGION_SIZE));
       vm_exit_during_initialization("Invalid -XX:ShenandoahMaxRegionSize option", message);
     }
     if (ShenandoahMinRegionSize > ShenandoahMaxRegionSize) {
-      err_msg message("Minimum (" SIZE_FORMAT "%s) should be larger than maximum (" SIZE_FORMAT "%s).",
+      err_msg message("Minimum (%zu%s) should be larger than maximum (%zu%s).",
                       byte_size_in_proper_unit(ShenandoahMinRegionSize), proper_unit_for_byte_size(ShenandoahMinRegionSize),
                       byte_size_in_proper_unit(ShenandoahMaxRegionSize), proper_unit_for_byte_size(ShenandoahMaxRegionSize));
       vm_exit_during_initialization("Invalid -XX:ShenandoahMinRegionSize or -XX:ShenandoahMaxRegionSize", message);
@@ -525,21 +525,21 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
 
   } else {
     if (ShenandoahRegionSize > max_heap_size / MIN_NUM_REGIONS) {
-      err_msg message("Max heap size (" SIZE_FORMAT "%s) is too low to afford the minimum number "
-                              "of regions (" SIZE_FORMAT ") of requested size (" SIZE_FORMAT "%s).",
+      err_msg message("Max heap size (%zu%s) is too low to afford the minimum number "
+                              "of regions (%zu) of requested size (%zu%s).",
                       byte_size_in_proper_unit(max_heap_size), proper_unit_for_byte_size(max_heap_size),
                       MIN_NUM_REGIONS,
                       byte_size_in_proper_unit(ShenandoahRegionSize), proper_unit_for_byte_size(ShenandoahRegionSize));
       vm_exit_during_initialization("Invalid -XX:ShenandoahRegionSize option", message);
     }
     if (ShenandoahRegionSize < ShenandoahMinRegionSize) {
-      err_msg message("Heap region size (" SIZE_FORMAT "%s) should be larger than min region size (" SIZE_FORMAT "%s).",
+      err_msg message("Heap region size (%zu%s) should be larger than min region size (%zu%s).",
                       byte_size_in_proper_unit(ShenandoahRegionSize), proper_unit_for_byte_size(ShenandoahRegionSize),
                       byte_size_in_proper_unit(ShenandoahMinRegionSize),  proper_unit_for_byte_size(ShenandoahMinRegionSize));
       vm_exit_during_initialization("Invalid -XX:ShenandoahRegionSize option", message);
     }
     if (ShenandoahRegionSize > ShenandoahMaxRegionSize) {
-      err_msg message("Heap region size (" SIZE_FORMAT "%s) should be lower than max region size (" SIZE_FORMAT "%s).",
+      err_msg message("Heap region size (%zu%s) should be lower than max region size (%zu%s).",
                       byte_size_in_proper_unit(ShenandoahRegionSize), proper_unit_for_byte_size(ShenandoahRegionSize),
                       byte_size_in_proper_unit(ShenandoahMaxRegionSize),  proper_unit_for_byte_size(ShenandoahMaxRegionSize));
       vm_exit_during_initialization("Invalid -XX:ShenandoahRegionSize option", message);
@@ -679,7 +679,7 @@ void ShenandoahHeapRegion::record_pin() {
 }
 
 void ShenandoahHeapRegion::record_unpin() {
-  assert(pin_count() > 0, "Region " SIZE_FORMAT " should have non-zero pins", index());
+  assert(pin_count() > 0, "Region %zu should have non-zero pins", index());
   Atomic::sub(&_critical_pins, (size_t)1);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.inline.hpp
@@ -33,7 +33,7 @@
 
 HeapWord* ShenandoahHeapRegion::allocate(size_t size, ShenandoahAllocRequest::Type type) {
   shenandoah_assert_heaplocked_or_safepoint();
-  assert(is_object_aligned(size), "alloc size breaks alignment: " SIZE_FORMAT, size);
+  assert(is_object_aligned(size), "alloc size breaks alignment: %zu", size);
 
   HeapWord* obj = top();
   if (pointer_delta(end(), obj) >= size) {
@@ -86,7 +86,7 @@ inline void ShenandoahHeapRegion::internal_increase_live_data(size_t s) {
   size_t live_bytes = new_live_data * HeapWordSize;
   size_t used_bytes = used();
   assert(live_bytes <= used_bytes,
-         "can't have more live data than used: " SIZE_FORMAT ", " SIZE_FORMAT, live_bytes, used_bytes);
+         "can't have more live data than used: %zu, %zu", live_bytes, used_bytes);
 #endif
 }
 
@@ -108,7 +108,7 @@ inline bool ShenandoahHeapRegion::has_live() const {
 
 inline size_t ShenandoahHeapRegion::garbage() const {
   assert(used() >= get_live_data_bytes(),
-         "Live Data must be a subset of used() live: " SIZE_FORMAT " used: " SIZE_FORMAT,
+         "Live Data must be a subset of used() live: %zu used: %zu",
          get_live_data_bytes(), used());
 
   size_t result = used() - get_live_data_bytes();

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegionSet.cpp
@@ -81,7 +81,7 @@ ShenandoahHeapRegion* ShenandoahHeapRegionSetIterator::next() {
 }
 
 void ShenandoahHeapRegionSet::print_on(outputStream* out) const {
-  out->print_cr("Region Set : " SIZE_FORMAT "", count());
+  out->print_cr("Region Set : %zu", count());
   for (size_t index = 0; index < _heap->num_regions(); index++) {
     if (is_in(index)) {
       _heap->get_region(index)->print_on(out);

--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
@@ -43,18 +43,18 @@ void ShenandoahInitLogger::print_heap() {
   log_info(gc, init)("Heuristics: %s",
                      heap->heuristics()->name());
 
-  log_info(gc, init)("Heap Region Count: " SIZE_FORMAT,
+  log_info(gc, init)("Heap Region Count: %zu",
                      ShenandoahHeapRegion::region_count());
 
-  log_info(gc, init)("Heap Region Size: " SIZE_FORMAT "%s",
+  log_info(gc, init)("Heap Region Size: %zu%s",
                      byte_size_in_exact_unit(ShenandoahHeapRegion::region_size_bytes()),
                      exact_unit_for_byte_size(ShenandoahHeapRegion::region_size_bytes()));
 
-  log_info(gc, init)("TLAB Size Max: " SIZE_FORMAT "%s",
+  log_info(gc, init)("TLAB Size Max: %zu%s",
                      byte_size_in_exact_unit(ShenandoahHeapRegion::max_tlab_size_bytes()),
                      exact_unit_for_byte_size(ShenandoahHeapRegion::max_tlab_size_bytes()));
 
-  log_info(gc, init)("Humongous Object Threshold: " SIZE_FORMAT "%s",
+  log_info(gc, init)("Humongous Object Threshold: %zu%s",
           byte_size_in_exact_unit(ShenandoahHeapRegion::humongous_threshold_bytes()),
           exact_unit_for_byte_size(ShenandoahHeapRegion::humongous_threshold_bytes()));
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkBitMap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkBitMap.cpp
@@ -129,19 +129,19 @@ void ShenandoahMarkBitMap::check_mark(HeapWord* addr) const {
 
 void ShenandoahMarkBitMap::verify_index(idx_t bit) const {
   assert(bit < _size,
-         "BitMap index out of bounds: " SIZE_FORMAT " >= " SIZE_FORMAT,
+         "BitMap index out of bounds: %zu >= %zu",
          bit, _size);
 }
 
 void ShenandoahMarkBitMap::verify_limit(idx_t bit) const {
   assert(bit <= _size,
-         "BitMap limit out of bounds: " SIZE_FORMAT " > " SIZE_FORMAT,
+         "BitMap limit out of bounds: %zu > %zu",
          bit, _size);
 }
 
 void ShenandoahMarkBitMap::verify_range(idx_t beg, idx_t end) const {
   assert(beg <= end,
-         "BitMap range error: " SIZE_FORMAT " > " SIZE_FORMAT, beg, end);
+         "BitMap range error: %zu > %zu", beg, end);
   verify_limit(end);
 }
 #endif

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.cpp
@@ -83,7 +83,7 @@ void ShenandoahMarkingContext::clear_bitmap(ShenandoahHeapRegion* r) {
     _top_bitmaps[r->index()] = bottom;
   }
   assert(is_bitmap_clear_range(bottom, r->end()),
-         "Region " SIZE_FORMAT " should have no marks in bitmap", r->index());
+         "Region %zu should have no marks in bitmap", r->index());
 }
 
 bool ShenandoahMarkingContext::is_complete() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
@@ -74,7 +74,7 @@ inline void ShenandoahMarkingContext::capture_top_at_mark_start(ShenandoahHeapRe
          "Region " SIZE_FORMAT", TAMS updates should be monotonic: " PTR_FORMAT " -> " PTR_FORMAT,
          idx, p2i(old_tams), p2i(new_tams));
   assert(is_bitmap_clear_range(old_tams, new_tams),
-         "Region " SIZE_FORMAT ", bitmap should be clear while adjusting TAMS: " PTR_FORMAT " -> " PTR_FORMAT,
+         "Region %zu, bitmap should be clear while adjusting TAMS: " PTR_FORMAT " -> " PTR_FORMAT,
          idx, p2i(old_tams), p2i(new_tams));
 
   _top_at_mark_starts_base[idx] = new_tams;
@@ -91,7 +91,7 @@ inline HeapWord* ShenandoahMarkingContext::top_at_mark_start(ShenandoahHeapRegio
 
 inline void ShenandoahMarkingContext::reset_top_bitmap(ShenandoahHeapRegion* r) {
   assert(is_bitmap_clear_range(r->bottom(), r->end()),
-         "Region " SIZE_FORMAT " should have no marks in bitmap", r->index());
+         "Region %zu should have no marks in bitmap", r->index());
   _top_bitmaps[r->index()] = r->bottom();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMarkingContext.inline.hpp
@@ -71,7 +71,7 @@ inline void ShenandoahMarkingContext::capture_top_at_mark_start(ShenandoahHeapRe
   HeapWord* new_tams = r->top();
 
   assert(new_tams >= old_tams,
-         "Region " SIZE_FORMAT", TAMS updates should be monotonic: " PTR_FORMAT " -> " PTR_FORMAT,
+         "Region %zu, TAMS updates should be monotonic: " PTR_FORMAT " -> " PTR_FORMAT,
          idx, p2i(old_tams), p2i(new_tams));
   assert(is_bitmap_clear_range(old_tams, new_tams),
          "Region %zu, bitmap should be clear while adjusting TAMS: " PTR_FORMAT " -> " PTR_FORMAT,

--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
@@ -39,8 +39,8 @@ MemoryUsage ShenandoahMemoryPool::get_memory_usage() {
   size_t committed = _heap->committed();
 
   // These asserts can never fail: max is stable, and all updates to other values never overflow max.
-  assert(initial <= max,    "initial: "   "%zu, max: %zu", initial,   max);
-  assert(used <= max,       "used: "      "%zu, max: "%zu", used,      max);
+  assert(initial <= max,    "initial: %zu, max: %zu",   initial,   max);
+  assert(used <= max,       "used: %zu, max: %zu",      used,      max);
   assert(committed <= max,  "committed: %zu, max: %zu", committed, max);
 
   // Committed and used are updated concurrently and independently. They can momentarily break

--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
@@ -39,15 +39,15 @@ MemoryUsage ShenandoahMemoryPool::get_memory_usage() {
   size_t committed = _heap->committed();
 
   // These asserts can never fail: max is stable, and all updates to other values never overflow max.
-  assert(initial <= max,    "initial: "   "%zu, max: "       SIZE_FORMAT, initial,   max);
-  assert(used <= max,       "used: "      "%zu, max: "       SIZE_FORMAT, used,      max);
-  assert(committed <= max,  "committed: %zu, max: "       SIZE_FORMAT, committed, max);
+  assert(initial <= max,    "initial: "   "%zu, max: %zu", initial,   max);
+  assert(used <= max,       "used: "      "%zu, max: "%zu", used,      max);
+  assert(committed <= max,  "committed: %zu, max: %zu", committed, max);
 
   // Committed and used are updated concurrently and independently. They can momentarily break
   // the assert below, which would also fail in downstream code. To avoid that, adjust values
   // to make sense under the race. See JDK-8207200.
   committed = MAX2(used, committed);
-  assert(used <= committed, "used: "      "%zu, committed: %zu", used,      committed);
+  assert(used <= committed, "used: %zu, committed: %zu", used,      committed);
 
   return MemoryUsage(initial, used, committed, max);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
@@ -39,15 +39,15 @@ MemoryUsage ShenandoahMemoryPool::get_memory_usage() {
   size_t committed = _heap->committed();
 
   // These asserts can never fail: max is stable, and all updates to other values never overflow max.
-  assert(initial <= max,    "initial: "   SIZE_FORMAT ", max: "       SIZE_FORMAT, initial,   max);
-  assert(used <= max,       "used: "      SIZE_FORMAT ", max: "       SIZE_FORMAT, used,      max);
+  assert(initial <= max,    "initial: "   "%zu, max: "       SIZE_FORMAT, initial,   max);
+  assert(used <= max,       "used: "      "%zu, max: "       SIZE_FORMAT, used,      max);
   assert(committed <= max,  "committed: %zu, max: "       SIZE_FORMAT, committed, max);
 
   // Committed and used are updated concurrently and independently. They can momentarily break
   // the assert below, which would also fail in downstream code. To avoid that, adjust values
   // to make sense under the race. See JDK-8207200.
   committed = MAX2(used, committed);
-  assert(used <= committed, "used: "      SIZE_FORMAT ", committed: %zu", used,      committed);
+  assert(used <= committed, "used: "      "%zu, committed: %zu", used,      committed);
 
   return MemoryUsage(initial, used, committed, max);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMemoryPool.cpp
@@ -41,13 +41,13 @@ MemoryUsage ShenandoahMemoryPool::get_memory_usage() {
   // These asserts can never fail: max is stable, and all updates to other values never overflow max.
   assert(initial <= max,    "initial: "   SIZE_FORMAT ", max: "       SIZE_FORMAT, initial,   max);
   assert(used <= max,       "used: "      SIZE_FORMAT ", max: "       SIZE_FORMAT, used,      max);
-  assert(committed <= max,  "committed: " SIZE_FORMAT ", max: "       SIZE_FORMAT, committed, max);
+  assert(committed <= max,  "committed: %zu, max: "       SIZE_FORMAT, committed, max);
 
   // Committed and used are updated concurrently and independently. They can momentarily break
   // the assert below, which would also fail in downstream code. To avoid that, adjust values
   // to make sense under the race. See JDK-8207200.
   committed = MAX2(used, committed);
-  assert(used <= committed, "used: "      SIZE_FORMAT ", committed: " SIZE_FORMAT, used,      committed);
+  assert(used <= committed, "used: "      SIZE_FORMAT ", committed: %zu", used,      committed);
 
   return MemoryUsage(initial, used, committed, max);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahMetrics.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahMetrics.cpp
@@ -48,7 +48,7 @@ bool ShenandoahMetricsSnapshot::is_good_progress() {
   size_t free_actual   = _heap->free_set()->available();
   size_t free_expected = _heap->max_capacity() / 100 * ShenandoahCriticalFreeThreshold;
   bool prog_free = free_actual >= free_expected;
-  log_info(gc, ergo)("%s progress for free space: " SIZE_FORMAT "%s, need " SIZE_FORMAT "%s",
+  log_info(gc, ergo)("%s progress for free space: %zu%s, need %zu%s",
                      prog_free ? "Good" : "Bad",
                      byte_size_in_proper_unit(free_actual),   proper_unit_for_byte_size(free_actual),
                      byte_size_in_proper_unit(free_expected), proper_unit_for_byte_size(free_expected));
@@ -60,7 +60,7 @@ bool ShenandoahMetricsSnapshot::is_good_progress() {
   size_t progress_actual   = (_used_before > _used_after) ? _used_before - _used_after : 0;
   size_t progress_expected = ShenandoahHeapRegion::region_size_bytes();
   bool prog_used = progress_actual >= progress_expected;
-  log_info(gc, ergo)("%s progress for used space: " SIZE_FORMAT "%s, need " SIZE_FORMAT "%s",
+  log_info(gc, ergo)("%s progress for used space: %zu%s, need %zu%s",
                      prog_used ? "Good" : "Bad",
                      byte_size_in_proper_unit(progress_actual),   proper_unit_for_byte_size(progress_actual),
                      byte_size_in_proper_unit(progress_expected), proper_unit_for_byte_size(progress_expected));

--- a/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNumberSeq.cpp
@@ -143,12 +143,12 @@ void BinaryMagnitudeSeq::add(size_t val) {
 
   // Defensively saturate for product bits:
   if (mag < 0) {
-    assert (false, "bucket index (%d) underflow for value (" SIZE_FORMAT ")", mag, val);
+    assert (false, "bucket index (%d) underflow for value (%zu)", mag, val);
     mag = 0;
   }
 
   if (mag >= BitsPerSize_t) {
-    assert (false, "bucket index (%d) overflow for value (" SIZE_FORMAT ")", mag, val);
+    assert (false, "bucket index (%d) overflow for value (%zu)", mag, val);
     mag = BitsPerSize_t - 1;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -72,8 +72,8 @@ void ShenandoahPacer::setup_for_mark() {
 
   restart_with(non_taxable, tax);
 
-  log_info(gc, ergo)("Pacer for Mark. Expected Live: " SIZE_FORMAT "%s, Free: " SIZE_FORMAT "%s, "
-                     "Non-Taxable: " SIZE_FORMAT "%s, Alloc Tax Rate: %.1fx",
+  log_info(gc, ergo)("Pacer for Mark. Expected Live: %zu%s, Free: %zu%s, "
+                     "Non-Taxable: %zu%s, Alloc Tax Rate: %.1fx",
                      byte_size_in_proper_unit(live),        proper_unit_for_byte_size(live),
                      byte_size_in_proper_unit(free),        proper_unit_for_byte_size(free),
                      byte_size_in_proper_unit(non_taxable), proper_unit_for_byte_size(non_taxable),
@@ -96,8 +96,8 @@ void ShenandoahPacer::setup_for_evac() {
 
   restart_with(non_taxable, tax);
 
-  log_info(gc, ergo)("Pacer for Evacuation. Used CSet: " SIZE_FORMAT "%s, Free: " SIZE_FORMAT "%s, "
-                     "Non-Taxable: " SIZE_FORMAT "%s, Alloc Tax Rate: %.1fx",
+  log_info(gc, ergo)("Pacer for Evacuation. Used CSet: %zu%s, Free: %zu%s, "
+                     "Non-Taxable: %zu%s, Alloc Tax Rate: %.1fx",
                      byte_size_in_proper_unit(used),        proper_unit_for_byte_size(used),
                      byte_size_in_proper_unit(free),        proper_unit_for_byte_size(free),
                      byte_size_in_proper_unit(non_taxable), proper_unit_for_byte_size(non_taxable),
@@ -120,8 +120,8 @@ void ShenandoahPacer::setup_for_updaterefs() {
 
   restart_with(non_taxable, tax);
 
-  log_info(gc, ergo)("Pacer for Update Refs. Used: " SIZE_FORMAT "%s, Free: " SIZE_FORMAT "%s, "
-                     "Non-Taxable: " SIZE_FORMAT "%s, Alloc Tax Rate: %.1fx",
+  log_info(gc, ergo)("Pacer for Update Refs. Used: %zu%s, Free: %zu%s, "
+                     "Non-Taxable: %zu%s, Alloc Tax Rate: %.1fx",
                      byte_size_in_proper_unit(used),        proper_unit_for_byte_size(used),
                      byte_size_in_proper_unit(free),        proper_unit_for_byte_size(free),
                      byte_size_in_proper_unit(non_taxable), proper_unit_for_byte_size(non_taxable),
@@ -145,7 +145,7 @@ void ShenandoahPacer::setup_for_idle() {
 
   restart_with(initial, tax);
 
-  log_info(gc, ergo)("Pacer for Idle. Initial: " SIZE_FORMAT "%s, Alloc Tax Rate: %.1fx",
+  log_info(gc, ergo)("Pacer for Idle. Initial: %zu%s, Alloc Tax Rate: %.1fx",
                      byte_size_in_proper_unit(initial), proper_unit_for_byte_size(initial),
                      tax);
 }
@@ -161,7 +161,7 @@ void ShenandoahPacer::setup_for_reset() {
   size_t initial = _heap->max_capacity();
   restart_with(initial, 1.0);
 
-  log_info(gc, ergo)("Pacer for Reset. Non-Taxable: " SIZE_FORMAT "%s",
+  log_info(gc, ergo)("Pacer for Reset. Non-Taxable: %zu%s",
                      byte_size_in_proper_unit(initial), proper_unit_for_byte_size(initial));
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahReferenceProcessor.cpp
@@ -594,10 +594,10 @@ void ShenandoahReferenceProcessor::collect_statistics() {
                                    discovered[REF_FINAL],
                                    discovered[REF_PHANTOM]);
 
-  log_info(gc,ref)("Encountered references: Soft: " SIZE_FORMAT ", Weak: " SIZE_FORMAT ", Final: " SIZE_FORMAT ", Phantom: " SIZE_FORMAT,
+  log_info(gc,ref)("Encountered references: Soft: %zu, Weak: %zu, Final: %zu, Phantom: %zu",
                    encountered[REF_SOFT], encountered[REF_WEAK], encountered[REF_FINAL], encountered[REF_PHANTOM]);
-  log_info(gc,ref)("Discovered  references: Soft: " SIZE_FORMAT ", Weak: " SIZE_FORMAT ", Final: " SIZE_FORMAT ", Phantom: " SIZE_FORMAT,
+  log_info(gc,ref)("Discovered  references: Soft: %zu, Weak: %zu, Final: %zu, Phantom: %zu",
                    discovered[REF_SOFT], discovered[REF_WEAK], discovered[REF_FINAL], discovered[REF_PHANTOM]);
-  log_info(gc,ref)("Enqueued    references: Soft: " SIZE_FORMAT ", Weak: " SIZE_FORMAT ", Final: " SIZE_FORMAT ", Phantom: " SIZE_FORMAT,
+  log_info(gc,ref)("Enqueued    references: Soft: %zu, Weak: %zu, Final: %zu, Phantom: %zu",
                    enqueued[REF_SOFT], enqueued[REF_WEAK], enqueued[REF_FINAL], enqueued[REF_PHANTOM]);
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -684,14 +684,14 @@ void ShenandoahVerifier::verify_at_safepoint(const char *label,
     _heap->heap_region_iterate(&cl);
     size_t heap_used = _heap->used();
     guarantee(cl.used() == heap_used,
-              "%s: heap used size must be consistent: heap-used = " SIZE_FORMAT "%s, regions-used = " SIZE_FORMAT "%s",
+              "%s: heap used size must be consistent: heap-used = %zu%s, regions-used = %zu%s",
               label,
               byte_size_in_proper_unit(heap_used), proper_unit_for_byte_size(heap_used),
               byte_size_in_proper_unit(cl.used()), proper_unit_for_byte_size(cl.used()));
 
     size_t heap_committed = _heap->committed();
     guarantee(cl.committed() == heap_committed,
-              "%s: heap committed size must be consistent: heap-committed = " SIZE_FORMAT "%s, regions-committed = " SIZE_FORMAT "%s",
+              "%s: heap committed size must be consistent: heap-committed = %zu%s, regions-committed = %zu%s",
               label,
               byte_size_in_proper_unit(heap_committed), proper_unit_for_byte_size(heap_committed),
               byte_size_in_proper_unit(cl.committed()), proper_unit_for_byte_size(cl.committed()));
@@ -767,13 +767,13 @@ void ShenandoahVerifier::verify_at_safepoint(const char *label,
       if (reg_live != verf_live) {
         stringStream ss;
         r->print_on(&ss);
-        fatal("%s: Live data should match: region-live = " SIZE_FORMAT ", verifier-live = " UINT32_FORMAT "\n%s",
+        fatal("%s: Live data should match: region-live = %zu, verifier-live = " UINT32_FORMAT "\n%s",
               label, reg_live, verf_live, ss.freeze());
       }
     }
   }
 
-  log_info(gc)("Verify %s, Level " INTX_FORMAT " (" SIZE_FORMAT " reachable, " SIZE_FORMAT " marked)",
+  log_info(gc)("Verify %s, Level " INTX_FORMAT " (%zu reachable, %zu marked)",
                label, ShenandoahVerifyLevel, count_reachable, count_marked);
 
   FREE_C_HEAP_ARRAY(ShenandoahLivenessData, ld);

--- a/src/hotspot/share/gc/x/xArguments.cpp
+++ b/src/hotspot/share/gc/x/xArguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ void XArguments::initialize() {
   // Large page size must match granule size
   if (!FLAG_IS_DEFAULT(LargePageSizeInBytes) && LargePageSizeInBytes != XGranuleSize) {
     vm_exit_during_initialization(err_msg("Incompatible -XX:LargePageSizeInBytes, only "
-                                          SIZE_FORMAT "M large pages are supported by ZGC",
+                                          "%zuM large pages are supported by ZGC",
                                           XGranuleSize / M));
   }
 

--- a/src/hotspot/share/gc/x/xCollectedHeap.cpp
+++ b/src/hotspot/share/gc/x/xCollectedHeap.cpp
@@ -309,12 +309,12 @@ void XCollectedHeap::print_on_error(outputStream* st) const {
   st->print_cr("ZGC Globals:");
   st->print_cr(" GlobalPhase:       %u (%s)", XGlobalPhase, XGlobalPhaseToString());
   st->print_cr(" GlobalSeqNum:      %u", XGlobalSeqNum);
-  st->print_cr(" Offset Max:        " SIZE_FORMAT "%s (" PTR_FORMAT ")",
+  st->print_cr(" Offset Max:        %zu%s (" PTR_FORMAT ")",
                byte_size_in_exact_unit(XAddressOffsetMax),
                exact_unit_for_byte_size(XAddressOffsetMax),
                XAddressOffsetMax);
-  st->print_cr(" Page Size Small:   " SIZE_FORMAT "M", XPageSizeSmall / M);
-  st->print_cr(" Page Size Medium:  " SIZE_FORMAT "M", XPageSizeMedium / M);
+  st->print_cr(" Page Size Small:   %zuM", XPageSizeSmall / M);
+  st->print_cr(" Page Size Medium:  %zuM", XPageSizeMedium / M);
   st->cr();
   st->print_cr("ZGC Metadata Bits:");
   st->print_cr(" Good:              " PTR_FORMAT, XAddressGoodMask);

--- a/src/hotspot/share/gc/x/xDirector.cpp
+++ b/src/hotspot/share/gc/x/xDirector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ static XDriverRequest rule_warmup() {
   const double used_threshold_percent = (XStatCycle::nwarmup_cycles() + 1) * 0.1;
   const size_t used_threshold = soft_max_capacity * used_threshold_percent;
 
-  log_debug(gc, director)("Rule: Warmup %.0f%%, Used: " SIZE_FORMAT "MB, UsedThreshold: " SIZE_FORMAT "MB",
+  log_debug(gc, director)("Rule: Warmup %.0f%%, Used: %zuMB, UsedThreshold: %zuMB",
                           used_threshold_percent * 100, used / M, used_threshold / M);
 
   if (used < used_threshold) {
@@ -215,7 +215,7 @@ XDriverRequest rule_allocation_rate_dynamic() {
   const double time_until_gc = time_until_oom - actual_gc_duration - sample_interval;
 
   log_debug(gc, director)("Rule: Allocation Rate (Dynamic GC Workers), "
-                          "MaxAllocRate: %.1fMB/s (+/-%.1f%%), Free: " SIZE_FORMAT "MB, GCCPUTime: %.3f, "
+                          "MaxAllocRate: %.1fMB/s (+/-%.1f%%), Free: %zuMB, GCCPUTime: %.3f, "
                           "GCDuration: %.3fs, TimeUntilOOM: %.3fs, TimeUntilGC: %.3fs, GCWorkers: %u -> %u",
                           alloc_rate / M,
                           alloc_rate_sd_percent * 100,
@@ -275,7 +275,7 @@ static XDriverRequest rule_allocation_rate_static() {
   // time and end up starting the GC too late in the next interval.
   const double time_until_gc = time_until_oom - gc_duration - sample_interval;
 
-  log_debug(gc, director)("Rule: Allocation Rate (Static GC Workers), MaxAllocRate: %.1fMB/s, Free: " SIZE_FORMAT "MB, GCDuration: %.3fs, TimeUntilGC: %.3fs",
+  log_debug(gc, director)("Rule: Allocation Rate (Static GC Workers), MaxAllocRate: %.1fMB/s, Free: %zuMB, GCDuration: %.3fs, TimeUntilGC: %.3fs",
                           max_alloc_rate / M, free / M, gc_duration, time_until_gc);
 
   if (time_until_gc > 0) {
@@ -308,7 +308,7 @@ static XDriverRequest rule_high_usage() {
   const size_t free = free_including_headroom - MIN2(free_including_headroom, XHeuristics::relocation_headroom());
   const double free_percent = percent_of(free, soft_max_capacity);
 
-  log_debug(gc, director)("Rule: High Usage, Free: " SIZE_FORMAT "MB(%.1f%%)",
+  log_debug(gc, director)("Rule: High Usage, Free: %zuMB(%.1f%%)",
                           free / M, free_percent);
 
   if (free_percent > 5.0) {
@@ -341,7 +341,7 @@ static XDriverRequest rule_proactive() {
   const double time_since_last_gc_threshold = 5 * 60; // 5 minutes
   if (used < used_threshold && time_since_last_gc < time_since_last_gc_threshold) {
     // Don't even consider doing a proactive GC
-    log_debug(gc, director)("Rule: Proactive, UsedUntilEnabled: " SIZE_FORMAT "MB, TimeUntilEnabled: %.3fs",
+    log_debug(gc, director)("Rule: Proactive, UsedUntilEnabled: %zuMB, TimeUntilEnabled: %.3fs",
                             (used_threshold - used) / M,
                             time_since_last_gc_threshold - time_since_last_gc);
     return GCCause::_no_gc;

--- a/src/hotspot/share/gc/x/xHeap.cpp
+++ b/src/hotspot/share/gc/x/xHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,7 +184,7 @@ void XHeap::undo_alloc_page(XPage* page) {
   assert(page->is_allocating(), "Invalid page state");
 
   XStatInc(XCounterUndoPageAllocation);
-  log_trace(gc)("Undo page allocation, thread: " PTR_FORMAT " (%s), page: " PTR_FORMAT ", size: " SIZE_FORMAT,
+  log_trace(gc)("Undo page allocation, thread: " PTR_FORMAT " (%s), page: " PTR_FORMAT ", size: %zu",
                 XThread::id(), XThread::name(), p2i(page), page->size());
 
   free_page(page, false /* reclaimed */);
@@ -491,7 +491,7 @@ XServiceabilityCounters* XHeap::serviceability_counters() {
 }
 
 void XHeap::print_on(outputStream* st) const {
-  st->print_cr(" ZHeap           used " SIZE_FORMAT "M, capacity " SIZE_FORMAT "M, max capacity " SIZE_FORMAT "M",
+  st->print_cr(" ZHeap           used %zuM, capacity %zuM, max capacity %zuM",
                used() / M,
                capacity() / M,
                max_capacity() / M);

--- a/src/hotspot/share/gc/x/xLiveMap.cpp
+++ b/src/hotspot/share/gc/x/xLiveMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ void XLiveMap::reset(size_t index) {
       XStatInc(XCounterMarkSeqNumResetContention);
       contention = true;
 
-      log_trace(gc)("Mark seqnum reset contention, thread: " PTR_FORMAT " (%s), map: " PTR_FORMAT ", bit: " SIZE_FORMAT,
+      log_trace(gc)("Mark seqnum reset contention, thread: " PTR_FORMAT " (%s), map: " PTR_FORMAT ", bit: %zu",
                     XThread::id(), XThread::name(), p2i(this), index);
     }
   }
@@ -101,7 +101,7 @@ void XLiveMap::reset_segment(BitMap::idx_t segment) {
         XStatInc(XCounterMarkSegmentResetContention);
         contention = true;
 
-        log_trace(gc)("Mark segment reset contention, thread: " PTR_FORMAT " (%s), map: " PTR_FORMAT ", segment: " SIZE_FORMAT,
+        log_trace(gc)("Mark segment reset contention, thread: " PTR_FORMAT " (%s), map: " PTR_FORMAT ", segment: %zu",
                       XThread::id(), XThread::name(), p2i(this), segment);
       }
     }

--- a/src/hotspot/share/gc/x/xMark.cpp
+++ b/src/hotspot/share/gc/x/xMark.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,7 +141,7 @@ void XMark::start() {
     for (uint worker_id = 0; worker_id < _nworkers; worker_id++) {
       const XMarkStripe* const stripe = _stripes.stripe_for_worker(_nworkers, worker_id);
       const size_t stripe_id = _stripes.stripe_id(stripe);
-      log.print("  Worker %u(%u) -> Stripe " SIZE_FORMAT "(" SIZE_FORMAT ")",
+      log.print("  Worker %u(%u) -> Stripe %zu(%zu)",
                 worker_id, _nworkers, stripe_id, nstripes);
     }
   }
@@ -176,7 +176,7 @@ void XMark::push_partial_array(uintptr_t addr, size_t size, bool finalizable) {
   const uintptr_t length = size / oopSize;
   const XMarkStackEntry entry(offset, length, finalizable);
 
-  log_develop_trace(gc, marking)("Array push partial: " PTR_FORMAT " (" SIZE_FORMAT "), stripe: " SIZE_FORMAT,
+  log_develop_trace(gc, marking)("Array push partial: " PTR_FORMAT " (%zu), stripe: %zu",
                                  addr, size, _stripes.stripe_id(stripe));
 
   stacks->push(&_allocator, &_stripes, stripe, entry, false /* publish */);
@@ -186,7 +186,7 @@ void XMark::follow_small_array(uintptr_t addr, size_t size, bool finalizable) {
   assert(size <= XMarkPartialArrayMinSize, "Too large, should be split");
   const size_t length = size / oopSize;
 
-  log_develop_trace(gc, marking)("Array follow small: " PTR_FORMAT " (" SIZE_FORMAT ")", addr, size);
+  log_develop_trace(gc, marking)("Array follow small: " PTR_FORMAT " (%zu)", addr, size);
 
   XBarrier::mark_barrier_on_oop_array((oop*)addr, length, finalizable);
 }
@@ -204,8 +204,8 @@ void XMark::follow_large_array(uintptr_t addr, size_t size, bool finalizable) {
   const size_t    middle_size = align_down(end - middle_start, XMarkPartialArrayMinSize);
   const uintptr_t middle_end = middle_start + middle_size;
 
-  log_develop_trace(gc, marking)("Array follow large: " PTR_FORMAT "-" PTR_FORMAT" (" SIZE_FORMAT "), "
-                                 "middle: " PTR_FORMAT "-" PTR_FORMAT " (" SIZE_FORMAT ")",
+  log_develop_trace(gc, marking)("Array follow large: " PTR_FORMAT "-" PTR_FORMAT" (%zu), "
+                                 "middle: " PTR_FORMAT "-" PTR_FORMAT " (%zu)",
                                  start, end, size, middle_start, middle_end, middle_size);
 
   // Push unaligned trailing part

--- a/src/hotspot/share/gc/x/xMarkStack.cpp
+++ b/src/hotspot/share/gc/x/xMarkStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ void XMarkStripeSet::set_nstripes(size_t nstripes) {
   _nstripes = nstripes;
   _nstripes_mask = nstripes - 1;
 
-  log_debug(gc, marking)("Using " SIZE_FORMAT " mark stripes", _nstripes);
+  log_debug(gc, marking)("Using %zu mark stripes", _nstripes);
 }
 
 bool XMarkStripeSet::is_empty() const {

--- a/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
@@ -80,11 +80,11 @@ size_t XMarkStackSpace::expand_space() {
     // Expansion limit reached. This is a fatal error since we
     // currently can't recover from running out of mark stack space.
     fatal("Mark stack space exhausted. Use -XX:ZMarkStackSpaceLimit=<size> to increase the "
-          "maximum number of bytes allocated for mark stacks. Current limit is " SIZE_FORMAT "M.",
+          "maximum number of bytes allocated for mark stacks. Current limit is %zuM.",
           ZMarkStackSpaceLimit / M);
   }
 
-  log_debug(gc, marking)("Expanding mark stack space: " SIZE_FORMAT "M->" SIZE_FORMAT "M",
+  log_debug(gc, marking)("Expanding mark stack space: %zuM->%zuM",
                          old_size / M, new_size / M);
 
   // Expand
@@ -101,7 +101,7 @@ size_t XMarkStackSpace::shrink_space() {
 
   if (shrink_size > 0) {
     // Shrink
-    log_debug(gc, marking)("Shrinking mark stack space: " SIZE_FORMAT "M->" SIZE_FORMAT "M",
+    log_debug(gc, marking)("Shrinking mark stack space: %zuM->%zuM",
                            old_size / M, new_size / M);
 
     const uintptr_t shrink_start = _end - shrink_size;

--- a/src/hotspot/share/gc/x/xNMethod.cpp
+++ b/src/hotspot/share/gc/x/xNMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ void XNMethod::log_register(const nmethod* nm) {
   const XNMethodDataOops* const oops = gc_data(nm)->oops();
 
   log.print("Register NMethod: %s.%s (" PTR_FORMAT "), "
-            "Compiler: %s, Oops: %d, ImmediateOops: " SIZE_FORMAT ", NonImmediateOops: %s",
+            "Compiler: %s, Oops: %d, ImmediateOops: %zu, NonImmediateOops: %s",
             nm->method()->method_holder()->external_name(),
             nm->method()->name()->as_C_string(),
             p2i(nm),
@@ -129,7 +129,7 @@ void XNMethod::log_register(const nmethod* nm) {
     for (oop* p = begin; p < end; p++) {
       const oop o = Atomic::load(p); // C1 PatchingStub may replace it concurrently.
       const char* external_name = (o == nullptr) ? "N/A" : o->klass()->external_name();
-      log_oops.print("           Oop[" SIZE_FORMAT "] " PTR_FORMAT " (%s)",
+      log_oops.print("           Oop[%zu] " PTR_FORMAT " (%s)",
                      (p - begin), p2i(o), external_name);
     }
   }
@@ -139,7 +139,7 @@ void XNMethod::log_register(const nmethod* nm) {
     oop** const begin = oops->immediates_begin();
     oop** const end = oops->immediates_end();
     for (oop** p = begin; p < end; p++) {
-      log_oops.print("  ImmediateOop[" SIZE_FORMAT "] " PTR_FORMAT " @ " PTR_FORMAT " (%s)",
+      log_oops.print("  ImmediateOop[%zu] " PTR_FORMAT " @ " PTR_FORMAT " (%s)",
                      (p - begin), p2i(**p), p2i(*p), (**p)->klass()->external_name());
     }
   }

--- a/src/hotspot/share/gc/x/xNMethodTable.cpp
+++ b/src/hotspot/share/gc/x/xNMethodTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ void XNMethodTable::rebuild(size_t new_size) {
   assert(is_power_of_2(new_size), "Invalid size");
 
   log_debug(gc, nmethod)("Rebuilding NMethod Table: "
-                         SIZE_FORMAT "->" SIZE_FORMAT " entries, "
+                         SIZE_FORMAT "->%zu entries, "
                          SIZE_FORMAT "(%.0f%%->%.0f%%) registered, "
                          SIZE_FORMAT "(%.0f%%->%.0f%%) unregistered",
                          _size, new_size,

--- a/src/hotspot/share/gc/x/xNMethodTable.cpp
+++ b/src/hotspot/share/gc/x/xNMethodTable.cpp
@@ -111,9 +111,9 @@ void XNMethodTable::rebuild(size_t new_size) {
   assert(is_power_of_2(new_size), "Invalid size");
 
   log_debug(gc, nmethod)("Rebuilding NMethod Table: "
-                         SIZE_FORMAT "->%zu entries, "
-                         SIZE_FORMAT "(%.0f%%->%.0f%%) registered, "
-                         SIZE_FORMAT "(%.0f%%->%.0f%%) unregistered",
+                         "%zu->%zu entries, "
+                         "%zu(%.0f%%->%.0f%%) registered, "
+                         "%zu(%.0f%%->%.0f%%) unregistered",
                          _size, new_size,
                          _nregistered, percent_of(_nregistered, _size), percent_of(_nregistered, new_size),
                          _nunregistered, percent_of(_nunregistered, _size), 0.0);

--- a/src/hotspot/share/gc/x/xPageAllocator.cpp
+++ b/src/hotspot/share/gc/x/xPageAllocator.cpp
@@ -313,7 +313,7 @@ void XPageAllocator::decrease_capacity(size_t size, bool set_max_capacity) {
   if (set_max_capacity) {
     // Adjust current max capacity to avoid further attempts to increase capacity
     log_error_p(gc)("Forced to lower max Java heap size from "
-                    SIZE_FORMAT "M(%.0f%%) to %zuM(%.0f%%)",
+                    "%zuM(%.0f%%) to %zuM(%.0f%%)",
                     _current_max_capacity / M, percent_of(_current_max_capacity, _max_capacity),
                     _capacity / M, percent_of(_capacity, _max_capacity));
 

--- a/src/hotspot/share/gc/x/xPageAllocator.cpp
+++ b/src/hotspot/share/gc/x/xPageAllocator.cpp
@@ -157,11 +157,11 @@ XPageAllocator::XPageAllocator(XWorkers* workers,
     return;
   }
 
-  log_info_p(gc, init)("Min Capacity: " SIZE_FORMAT "M", min_capacity / M);
-  log_info_p(gc, init)("Initial Capacity: " SIZE_FORMAT "M", initial_capacity / M);
-  log_info_p(gc, init)("Max Capacity: " SIZE_FORMAT "M", max_capacity / M);
+  log_info_p(gc, init)("Min Capacity: %zuM", min_capacity / M);
+  log_info_p(gc, init)("Initial Capacity: %zuM", initial_capacity / M);
+  log_info_p(gc, init)("Max Capacity: %zuM", max_capacity / M);
   if (XPageSizeMedium > 0) {
-    log_info_p(gc, init)("Medium Page Size: " SIZE_FORMAT "M", XPageSizeMedium / M);
+    log_info_p(gc, init)("Medium Page Size: %zuM", XPageSizeMedium / M);
   } else {
     log_info_p(gc, init)("Medium Page Size: N/A");
   }
@@ -175,7 +175,7 @@ XPageAllocator::XPageAllocator(XWorkers* workers,
 
   // Pre-map initial capacity
   if (!prime_cache(workers, initial_capacity)) {
-    log_error_p(gc)("Failed to allocate initial Java heap (" SIZE_FORMAT "M)", initial_capacity / M);
+    log_error_p(gc)("Failed to allocate initial Java heap (%zuM)", initial_capacity / M);
     return;
   }
 
@@ -313,7 +313,7 @@ void XPageAllocator::decrease_capacity(size_t size, bool set_max_capacity) {
   if (set_max_capacity) {
     // Adjust current max capacity to avoid further attempts to increase capacity
     log_error_p(gc)("Forced to lower max Java heap size from "
-                    SIZE_FORMAT "M(%.0f%%) to " SIZE_FORMAT "M(%.0f%%)",
+                    SIZE_FORMAT "M(%.0f%%) to %zuM(%.0f%%)",
                     _current_max_capacity / M, percent_of(_current_max_capacity, _max_capacity),
                     _capacity / M, percent_of(_capacity, _max_capacity));
 
@@ -544,7 +544,7 @@ XPage* XPageAllocator::alloc_page_create(XPageAllocation* allocation) {
 
     // Update statistics
     XStatInc(XCounterPageCacheFlush, flushed);
-    log_debug(gc, heap)("Page Cache Flushed: " SIZE_FORMAT "M", flushed / M);
+    log_debug(gc, heap)("Page Cache Flushed: %zuM", flushed / M);
   }
 
   // Allocate any remaining physical memory. Capacity and used has

--- a/src/hotspot/share/gc/x/xRelocationSetSelector.cpp
+++ b/src/hotspot/share/gc/x/xRelocationSetSelector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ void XRelocationSetSelectorGroup::select_inner() {
     }
 
     log_trace(gc, reloc)("Candidate Relocation Set (%s Pages): %d->%d, "
-                         "%.1f%% relative defragmentation, " SIZE_FORMAT " forwarding entries, %s",
+                         "%.1f%% relative defragmentation, %zu forwarding entries, %s",
                          _name, from, to, diff_reclaimable, from_forwarding_entries,
                          (selected_from == from) ? "Selected" : "Rejected");
   }
@@ -161,7 +161,7 @@ void XRelocationSetSelectorGroup::select_inner() {
   _stats._relocate = selected_live_bytes;
   _stats._npages_selected = npages_selected;
 
-  log_trace(gc, reloc)("Relocation Set (%s Pages): %d->%d, %d skipped, " SIZE_FORMAT " forwarding entries",
+  log_trace(gc, reloc)("Relocation Set (%s Pages): %d->%d, %d skipped, %zu forwarding entries",
                        _name, selected_from, selected_to, npages - selected_from, selected_forwarding_entries);
 }
 

--- a/src/hotspot/share/gc/x/xStat.cpp
+++ b/src/hotspot/share/gc/x/xStat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1209,7 +1209,7 @@ void XStatMark::print() {
                         _ntrycomplete,
                         _ncontinue);
 
-  log_info(gc, marking)("Mark Stack Usage: " SIZE_FORMAT "M", _mark_stack_usage / M);
+  log_info(gc, marking)("Mark Stack Usage: %zuM", _mark_stack_usage / M);
 }
 
 //
@@ -1236,8 +1236,8 @@ void XStatRelocation::set_at_relocate_end(size_t small_in_place_count, size_t me
 void XStatRelocation::print(const char* name,
                             const XRelocationSetSelectorGroupStats& selector_group,
                             size_t in_place_count) {
-  log_info(gc, reloc)("%s Pages: " SIZE_FORMAT " / " SIZE_FORMAT "M, Empty: " SIZE_FORMAT "M, "
-                      "Relocated: " SIZE_FORMAT "M, In-Place: " SIZE_FORMAT,
+  log_info(gc, reloc)("%s Pages: %zu / %zuM, Empty: %zuM, "
+                      "Relocated: %zuM, In-Place: %zu",
                       name,
                       selector_group.npages_candidates(),
                       selector_group.total() / M,
@@ -1253,14 +1253,14 @@ void XStatRelocation::print() {
   }
   print("Large", _selector_stats.large(), 0 /* in_place_count */);
 
-  log_info(gc, reloc)("Forwarding Usage: " SIZE_FORMAT "M", _forwarding_usage / M);
+  log_info(gc, reloc)("Forwarding Usage: %zuM", _forwarding_usage / M);
 }
 
 //
 // Stat nmethods
 //
 void XStatNMethods::print() {
-  log_info(gc, nmethod)("NMethods: " SIZE_FORMAT " registered, " SIZE_FORMAT " unregistered",
+  log_info(gc, nmethod)("NMethods: %zu registered, %zu unregistered",
                         XNMethodTable::registered_nmethods(),
                         XNMethodTable::unregistered_nmethods());
 }
@@ -1272,7 +1272,7 @@ void XStatMetaspace::print() {
   MetaspaceCombinedStats stats = MetaspaceUtils::get_combined_statistics();
   log_info(gc, metaspace)("Metaspace: "
                           SIZE_FORMAT "M used, "
-                          SIZE_FORMAT "M committed, " SIZE_FORMAT "M reserved",
+                          SIZE_FORMAT "M committed, %zuM reserved",
                           stats.used() / M,
                           stats.committed() / M,
                           stats.reserved() / M);

--- a/src/hotspot/share/gc/x/xStat.cpp
+++ b/src/hotspot/share/gc/x/xStat.cpp
@@ -43,7 +43,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/ticks.hpp"
 
-#define XSIZE_FMT                       SIZE_FORMAT "M(%.0f%%)"
+#define XSIZE_FMT                       "%zuM(%.0f%%)"
 #define XSIZE_ARGS_WITH_MAX(size, max)  ((size) / M), (percent_of(size, max))
 #define XSIZE_ARGS(size)                XSIZE_ARGS_WITH_MAX(size, XStatHeap::max_capacity())
 
@@ -1198,11 +1198,11 @@ void XStatMark::set_at_mark_free(size_t mark_stack_usage) {
 
 void XStatMark::print() {
   log_info(gc, marking)("Mark: "
-                        SIZE_FORMAT " stripe(s), "
-                        SIZE_FORMAT " proactive flush(es), "
-                        SIZE_FORMAT " terminate flush(es), "
-                        SIZE_FORMAT " completion(s), "
-                        SIZE_FORMAT " continuation(s) ",
+                        "%zu stripe(s), "
+                        "%zu proactive flush(es), "
+                        "%zu terminate flush(es), "
+                        "%zu completion(s), "
+                        "%zu continuation(s) ",
                         _nstripes,
                         _nproactiveflush,
                         _nterminateflush,
@@ -1271,8 +1271,8 @@ void XStatNMethods::print() {
 void XStatMetaspace::print() {
   MetaspaceCombinedStats stats = MetaspaceUtils::get_combined_statistics();
   log_info(gc, metaspace)("Metaspace: "
-                          SIZE_FORMAT "M used, "
-                          SIZE_FORMAT "M committed, %zuM reserved",
+                          "%zuM used, "
+                          "%zuM committed, %zuM reserved",
                           stats.used() / M,
                           stats.committed() / M,
                           stats.reserved() / M);
@@ -1310,9 +1310,9 @@ void XStatReferences::set_phantom(size_t encountered, size_t discovered, size_t 
 
 void XStatReferences::print(const char* name, const XStatReferences::XCount& ref) {
   log_info(gc, ref)("%s: "
-                    SIZE_FORMAT " encountered, "
-                    SIZE_FORMAT " discovered, "
-                    SIZE_FORMAT " enqueued",
+                    "%zu encountered, "
+                    "%zu discovered, "
+                    "%zu enqueued",
                     name,
                     ref.encountered,
                     ref.discovered,

--- a/src/hotspot/share/gc/x/xUncommitter.cpp
+++ b/src/hotspot/share/gc/x/xUncommitter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ void XUncommitter::run_service() {
     if (uncommitted > 0) {
       // Update statistics
       XStatInc(XCounterUncommit, uncommitted);
-      log_info(gc, heap)("Uncommitted: " SIZE_FORMAT "M(%.0f%%)",
+      log_info(gc, heap)("Uncommitted: %zuM(%.0f%%)",
                          uncommitted / M, percent_of(uncommitted, XHeap::heap()->max_capacity()));
 
       // Send event

--- a/src/hotspot/share/gc/x/xUnmapper.cpp
+++ b/src/hotspot/share/gc/x/xUnmapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,11 +75,11 @@ bool XUnmapper::try_enqueue(XPage* page) {
       _warned_sync_unmapping = true;
       log_warning_p(gc)("WARNING: Encountered synchronous unmapping because asynchronous unmapping could not keep up");
     }
-    log_debug(gc, unmap)("Synchronous unmapping " SIZE_FORMAT "M page", page->size() / M);
+    log_debug(gc, unmap)("Synchronous unmapping %zuM page", page->size() / M);
     return false;
   }
 
-  log_trace(gc, unmap)("Asynchronous unmapping " SIZE_FORMAT "M page (" SIZE_FORMAT "M / " SIZE_FORMAT "M enqueued)",
+  log_trace(gc, unmap)("Asynchronous unmapping %zuM page (%zuM / %zuM enqueued)",
                        page->size() / M, _enqueued_bytes / M, queue_capacity() / M);
 
   _queue.insert_last(page);

--- a/src/hotspot/share/gc/x/xVirtualMemory.cpp
+++ b/src/hotspot/share/gc/x/xVirtualMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ XVirtualMemoryManager::XVirtualMemoryManager(size_t max_capacity) :
 
   // Check max supported heap size
   if (max_capacity > XAddressOffsetMax) {
-    log_error_p(gc)("Java heap too large (max supported heap size is " SIZE_FORMAT "G)",
+    log_error_p(gc)("Java heap too large (max supported heap size is %zuG)",
                     XAddressOffsetMax / G);
     return;
   }
@@ -171,7 +171,7 @@ bool XVirtualMemoryManager::reserve(size_t max_capacity) {
                        (contiguous ? "Contiguous" : "Discontiguous"),
                        (limit == XAddressOffsetMax ? "Unrestricted" : "Restricted"),
                        (reserved == size ? "Complete" : "Degraded"));
-  log_info_p(gc, init)("Address Space Size: " SIZE_FORMAT "M x " SIZE_FORMAT " = " SIZE_FORMAT "M",
+  log_info_p(gc, init)("Address Space Size: %zuM x %zu = %zuM",
                        reserved / M, XHeapViews, (reserved * XHeapViews) / M);
 
   // Record reserved

--- a/src/hotspot/share/gc/z/zAddress.cpp
+++ b/src/hotspot/share/gc/z/zAddress.cpp
@@ -108,7 +108,7 @@ void ZGlobalsPointers::initialize() {
   // Check max supported heap size
   if (MaxHeapSize > ZAddressOffsetMax) {
     vm_exit_during_initialization(
-        err_msg("Java heap too large (max supported heap size is " SIZE_FORMAT "G)",
+        err_msg("Java heap too large (max supported heap size is %zuG)",
                 ZAddressOffsetMax / G));
   }
 

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -171,7 +171,7 @@ void ZArguments::initialize() {
   // Large page size must match granule size
   if (!FLAG_IS_DEFAULT(LargePageSizeInBytes) && LargePageSizeInBytes != ZGranuleSize) {
     vm_exit_during_initialization(err_msg("Incompatible -XX:LargePageSizeInBytes, only "
-                                          SIZE_FORMAT "M large pages are supported by ZGC",
+                                          "%zuM large pages are supported by ZGC",
                                           ZGranuleSize / M));
   }
 

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -367,12 +367,12 @@ void ZCollectedHeap::print_on_error(outputStream* st) const {
   st->print_cr("ZGC Globals:");
   st->print_cr(" Young Collection:   %s/%u", ZGeneration::young()->phase_to_string(), ZGeneration::young()->seqnum());
   st->print_cr(" Old Collection:     %s/%u", ZGeneration::old()->phase_to_string(), ZGeneration::old()->seqnum());
-  st->print_cr(" Offset Max:         " SIZE_FORMAT "%s (" PTR_FORMAT ")",
+  st->print_cr(" Offset Max:         %zu%s (" PTR_FORMAT ")",
                byte_size_in_exact_unit(ZAddressOffsetMax),
                exact_unit_for_byte_size(ZAddressOffsetMax),
                ZAddressOffsetMax);
-  st->print_cr(" Page Size Small:    " SIZE_FORMAT "M", ZPageSizeSmall / M);
-  st->print_cr(" Page Size Medium:   " SIZE_FORMAT "M", ZPageSizeMedium / M);
+  st->print_cr(" Page Size Small:    %zuM", ZPageSizeSmall / M);
+  st->print_cr(" Page Size Medium:   %zuM", ZPageSizeMedium / M);
   st->cr();
   st->print_cr("ZGC Metadata Bits:");
   st->print_cr(" LoadGood:           " PTR_FORMAT, ZPointerLoadGoodMask);

--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -192,7 +192,7 @@ ZDriverRequest rule_minor_allocation_rate_dynamic(const ZDirectorStats& stats,
   const double time_until_gc = time_until_oom - actual_gc_duration;
 
   log_debug(gc, director)("Rule Minor: Allocation Rate (Dynamic GC Workers), "
-                          "MaxAllocRate: %.1fMB/s (+/-%.1f%%), Free: " SIZE_FORMAT "MB, GCCPUTime: %.3f, "
+                          "MaxAllocRate: %.1fMB/s (+/-%.1f%%), Free: %zuMB, GCCPUTime: %.3f, "
                           "GCDuration: %.3fs, TimeUntilOOM: %.3fs, TimeUntilGC: %.3fs, GCWorkers: %u",
                           alloc_rate / M,
                           alloc_rate_sd_percent * 100,
@@ -286,7 +286,7 @@ static bool rule_minor_allocation_rate_static(const ZDirectorStats& stats) {
   // time and end up starting the GC too late in the next interval.
   const double time_until_gc = time_until_oom - gc_duration;
 
-  log_debug(gc, director)("Rule Minor: Allocation Rate (Static GC Workers), MaxAllocRate: %.1fMB/s, Free: " SIZE_FORMAT "MB, GCDuration: %.3fs, TimeUntilGC: %.3fs",
+  log_debug(gc, director)("Rule Minor: Allocation Rate (Static GC Workers), MaxAllocRate: %.1fMB/s, Free: %zuMB, GCDuration: %.3fs, TimeUntilGC: %.3fs",
                           max_alloc_rate / M, free / M, gc_duration, time_until_gc);
 
   return time_until_gc <= 0;
@@ -384,7 +384,7 @@ static bool rule_minor_high_usage(const ZDirectorStats& stats) {
   const double free_percent = percent_of(free, soft_max_capacity);
 
   auto print_function = [&](size_t free, double free_percent) {
-    log_debug(gc, director)("Rule Minor: High Usage, Free: " SIZE_FORMAT "MB(%.1f%%)",
+    log_debug(gc, director)("Rule Minor: High Usage, Free: %zuMB(%.1f%%)",
                             free / M, free_percent);
   };
 
@@ -428,7 +428,7 @@ static bool rule_major_warmup(const ZDirectorStats& stats) {
   const double used_threshold_percent = (stats._old_stats._cycle._nwarmup_cycles + 1) * 0.1;
   const size_t used_threshold = soft_max_capacity * used_threshold_percent;
 
-  log_debug(gc, director)("Rule Major: Warmup %.0f%%, Used: " SIZE_FORMAT "MB, UsedThreshold: " SIZE_FORMAT "MB",
+  log_debug(gc, director)("Rule Major: Warmup %.0f%%, Used: %zuMB, UsedThreshold: %zuMB",
                           used_threshold_percent * 100, used / M, used_threshold / M);
 
   return used >= used_threshold;
@@ -568,7 +568,7 @@ static bool rule_major_proactive(const ZDirectorStats& stats) {
   const double time_since_last_gc_threshold = 5 * 60; // 5 minutes
   if (used < used_threshold && time_since_last_gc < time_since_last_gc_threshold) {
     // Don't even consider doing a proactive GC
-    log_debug(gc, director)("Rule Major: Proactive, UsedUntilEnabled: " SIZE_FORMAT "MB, TimeUntilEnabled: %.3fs",
+    log_debug(gc, director)("Rule Major: Proactive, UsedUntilEnabled: %zuMB, TimeUntilEnabled: %.3fs",
                             (used_threshold - used) / M,
                             time_since_last_gc_threshold - time_since_last_gc);
     return false;

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -355,7 +355,7 @@ void ZGeneration::log_phase_switch(Phase from, Phase to) {
     index += 1;
   }
 
-  assert(index < ARRAY_SIZE(str), "OOB: " SIZE_FORMAT " < " SIZE_FORMAT, index, ARRAY_SIZE(str));
+  assert(index < ARRAY_SIZE(str), "OOB: %zu < %zu", index, ARRAY_SIZE(str));
 
   Events::log_zgc_phase_switch("%-21s %4u", str[index], seqnum());
 }
@@ -786,8 +786,8 @@ uint ZGenerationYoung::compute_tenuring_threshold(ZRelocationSetSelectorStats st
   // if the GC is finding it hard to keep up with the allocation rate.
   const double tenuring_threshold_raw = young_life_decay_factor * young_log_residency;
 
-  log_trace(gc, reloc)("Young Allocated: " SIZE_FORMAT "M", young_allocated / M);
-  log_trace(gc, reloc)("Young Garbage: " SIZE_FORMAT "M", young_garbage / M);
+  log_trace(gc, reloc)("Young Allocated: %zuM", young_allocated / M);
+  log_trace(gc, reloc)("Young Garbage: %zuM", young_garbage / M);
   log_debug(gc, reloc)("Allocated To Garbage: %.1f", allocated_garbage_ratio);
   log_trace(gc, reloc)("Young Log: %.1f", young_log);
   log_trace(gc, reloc)("Young Residency Reciprocal: %.1f", young_residency_reciprocal);

--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -74,7 +74,7 @@ ZHeap::ZHeap()
 
   // Prime cache
   if (!_page_allocator.prime_cache(_old.workers(), InitialHeapSize)) {
-    log_error_p(gc)("Failed to allocate initial Java heap (" SIZE_FORMAT "M)", InitialHeapSize / M);
+    log_error_p(gc)("Failed to allocate initial Java heap (%zuM)", InitialHeapSize / M);
     return;
   }
 
@@ -237,7 +237,7 @@ void ZHeap::undo_alloc_page(ZPage* page) {
   assert(page->is_allocating(), "Invalid page state");
 
   ZStatInc(ZCounterUndoPageAllocation);
-  log_trace(gc)("Undo page allocation, thread: " PTR_FORMAT " (%s), page: " PTR_FORMAT ", size: " SIZE_FORMAT,
+  log_trace(gc)("Undo page allocation, thread: " PTR_FORMAT " (%s), page: " PTR_FORMAT ", size: %zu",
                 p2i(Thread::current()), ZUtils::thread_name(), p2i(page), page->size());
 
   free_page(page);
@@ -329,7 +329,7 @@ ZServiceabilityCounters* ZHeap::serviceability_counters() {
 }
 
 void ZHeap::print_on(outputStream* st) const {
-  st->print_cr(" ZHeap           used " SIZE_FORMAT "M, capacity " SIZE_FORMAT "M, max capacity " SIZE_FORMAT "M",
+  st->print_cr(" ZHeap           used %zuM, capacity %zuM, max capacity %zuM",
                used() / M,
                capacity() / M,
                max_capacity() / M);

--- a/src/hotspot/share/gc/z/zIndexDistributor.inline.hpp
+++ b/src/hotspot/share/gc/z/zIndexDistributor.inline.hpp
@@ -274,7 +274,7 @@ public:
     assert((levels_size(ClaimLevels - 1) << _last_level_segment_size_shift) == count, "Incorrectly setup");
 
 #if 0
-    tty->print_cr("ZIndexDistributorClaimTree count: %d byte size: " SIZE_FORMAT, count, claim_variables_size() + os::vm_page_size());
+    tty->print_cr("ZIndexDistributorClaimTree count: %d byte size: %zu", count, claim_variables_size() + os::vm_page_size());
 #endif
 
     memset(_malloced, 0, claim_variables_size() + os::vm_page_size());

--- a/src/hotspot/share/gc/z/zLiveMap.cpp
+++ b/src/hotspot/share/gc/z/zLiveMap.cpp
@@ -103,7 +103,7 @@ void ZLiveMap::reset_segment(BitMap::idx_t segment) {
         ZStatInc(ZCounterMarkSegmentResetContention);
         contention = true;
 
-        log_trace(gc)("Mark segment reset contention, thread: " PTR_FORMAT " (%s), map: " PTR_FORMAT ", segment: " SIZE_FORMAT,
+        log_trace(gc)("Mark segment reset contention, thread: " PTR_FORMAT " (%s), map: " PTR_FORMAT ", segment: %zu",
                       p2i(Thread::current()), ZUtils::thread_name(), p2i(this), segment);
       }
     }

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -135,7 +135,7 @@ void ZMark::start() {
     for (uint worker_id = 0; worker_id < _nworkers; worker_id++) {
       const ZMarkStripe* const stripe = _stripes.stripe_for_worker(_nworkers, worker_id);
       const size_t stripe_id = _stripes.stripe_id(stripe);
-      log.print("  Worker %u(%u) -> Stripe " SIZE_FORMAT "(" SIZE_FORMAT ")",
+      log.print("  Worker %u(%u) -> Stripe %zu(%zu)",
                 worker_id, _nworkers, stripe_id, nstripes);
     }
   }
@@ -194,7 +194,7 @@ void ZMark::push_partial_array(zpointer* addr, size_t length, bool finalizable) 
   const uintptr_t offset = encode_partial_array_offset(addr);
   const ZMarkStackEntry entry(offset, length, finalizable);
 
-  log_develop_trace(gc, marking)("Array push partial: " PTR_FORMAT " (" SIZE_FORMAT "), stripe: " SIZE_FORMAT,
+  log_develop_trace(gc, marking)("Array push partial: " PTR_FORMAT " (%zu), stripe: %zu",
                                  p2i(addr), length, _stripes.stripe_id(stripe));
 
   stacks->push(&_allocator, &_stripes, stripe, &_terminate, entry, false /* publish */);
@@ -213,7 +213,7 @@ static void mark_barrier_on_oop_array(volatile zpointer* p, size_t length, bool 
 void ZMark::follow_array_elements_small(zpointer* addr, size_t length, bool finalizable) {
   assert(length <= ZMarkPartialArrayMinLength, "Too large, should be split");
 
-  log_develop_trace(gc, marking)("Array follow small: " PTR_FORMAT " (" SIZE_FORMAT ")", p2i(addr), length);
+  log_develop_trace(gc, marking)("Array follow small: " PTR_FORMAT " (%zu)", p2i(addr), length);
 
   mark_barrier_on_oop_array(addr, length, finalizable, _generation->is_young());
 }
@@ -232,8 +232,8 @@ void ZMark::follow_array_elements_large(zpointer* addr, size_t length, bool fina
   const size_t    middle_length = align_down(end - middle_start, ZMarkPartialArrayMinLength);
   zpointer* const middle_end = middle_start + middle_length;
 
-  log_develop_trace(gc, marking)("Array follow large: " PTR_FORMAT "-" PTR_FORMAT" (" SIZE_FORMAT "), "
-                                 "middle: " PTR_FORMAT "-" PTR_FORMAT " (" SIZE_FORMAT ")",
+  log_develop_trace(gc, marking)("Array follow large: " PTR_FORMAT "-" PTR_FORMAT" (%zu), "
+                                 "middle: " PTR_FORMAT "-" PTR_FORMAT " (%zu)",
                                  p2i(start), p2i(end), length, p2i(middle_start), p2i(middle_end), middle_length);
 
   // Push unaligned trailing part

--- a/src/hotspot/share/gc/z/zMarkStack.cpp
+++ b/src/hotspot/share/gc/z/zMarkStack.cpp
@@ -54,7 +54,7 @@ void ZMarkStripeSet::set_nstripes(size_t nstripes) {
   // if they see the old or new values.
   Atomic::store(&_nstripes_mask, nstripes - 1);
 
-  log_debug(gc, marking)("Using " SIZE_FORMAT " mark stripes", nstripes);
+  log_debug(gc, marking)("Using %zu mark stripes", nstripes);
 }
 
 size_t ZMarkStripeSet::nstripes() const {

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -79,11 +79,11 @@ size_t ZMarkStackSpace::expand_space() {
     // Expansion limit reached. This is a fatal error since we
     // currently can't recover from running out of mark stack space.
     fatal("Mark stack space exhausted. Use -XX:ZMarkStackSpaceLimit=<size> to increase the "
-          "maximum number of bytes allocated for mark stacks. Current limit is " SIZE_FORMAT "M.",
+          "maximum number of bytes allocated for mark stacks. Current limit is %zuM.",
           ZMarkStackSpaceLimit / M);
   }
 
-  log_debug(gc, marking)("Expanding mark stack space: " SIZE_FORMAT "M->" SIZE_FORMAT "M",
+  log_debug(gc, marking)("Expanding mark stack space: %zuM->%zuM",
                          old_size / M, new_size / M);
 
   // Expand
@@ -100,7 +100,7 @@ size_t ZMarkStackSpace::shrink_space() {
 
   if (shrink_size > 0) {
     // Shrink
-    log_debug(gc, marking)("Shrinking mark stack space: " SIZE_FORMAT "M->" SIZE_FORMAT "M",
+    log_debug(gc, marking)("Shrinking mark stack space: %zuM->%zuM",
                            old_size / M, new_size / M);
 
     const uintptr_t shrink_start = _end - shrink_size;

--- a/src/hotspot/share/gc/z/zNMethodTable.cpp
+++ b/src/hotspot/share/gc/z/zNMethodTable.cpp
@@ -111,9 +111,9 @@ void ZNMethodTable::rebuild(size_t new_size) {
   assert(is_power_of_2(new_size), "Invalid size");
 
   log_debug(gc, nmethod)("Rebuilding NMethod Table: "
-                         SIZE_FORMAT "->%zu entries, "
-                         SIZE_FORMAT "(%.0f%%->%.0f%%) registered, "
-                         SIZE_FORMAT "(%.0f%%->%.0f%%) unregistered",
+                         "%zu->%zu entries, "
+                         "%zu(%.0f%%->%.0f%%) registered, "
+                         "%zu(%.0f%%->%.0f%%) unregistered",
                          _size, new_size,
                          _nregistered, percent_of(_nregistered, _size), percent_of(_nregistered, new_size),
                          _nunregistered, percent_of(_nunregistered, _size), 0.0);

--- a/src/hotspot/share/gc/z/zNMethodTable.cpp
+++ b/src/hotspot/share/gc/z/zNMethodTable.cpp
@@ -111,7 +111,7 @@ void ZNMethodTable::rebuild(size_t new_size) {
   assert(is_power_of_2(new_size), "Invalid size");
 
   log_debug(gc, nmethod)("Rebuilding NMethod Table: "
-                         SIZE_FORMAT "->" SIZE_FORMAT " entries, "
+                         SIZE_FORMAT "->%zu entries, "
                          SIZE_FORMAT "(%.0f%%->%.0f%%) registered, "
                          SIZE_FORMAT "(%.0f%%->%.0f%%) unregistered",
                          _size, new_size,

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -366,7 +366,7 @@ void ZPageAllocator::decrease_capacity(size_t size, bool set_max_capacity) {
   if (set_max_capacity) {
     // Adjust current max capacity to avoid further attempts to increase capacity
     log_error_p(gc)("Forced to lower max Java heap size from "
-                    SIZE_FORMAT "M(%.0f%%) to %zuM(%.0f%%)",
+                    "%zuM(%.0f%%) to %zuM(%.0f%%)",
                     _current_max_capacity / M, percent_of(_current_max_capacity, _max_capacity),
                     _capacity / M, percent_of(_capacity, _max_capacity));
 

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -205,12 +205,12 @@ ZPageAllocator::ZPageAllocator(size_t min_capacity,
     return;
   }
 
-  log_info_p(gc, init)("Min Capacity: " SIZE_FORMAT "M", min_capacity / M);
-  log_info_p(gc, init)("Initial Capacity: " SIZE_FORMAT "M", initial_capacity / M);
-  log_info_p(gc, init)("Max Capacity: " SIZE_FORMAT "M", max_capacity / M);
-  log_info_p(gc, init)("Soft Max Capacity: " SIZE_FORMAT "M", soft_max_capacity / M);
+  log_info_p(gc, init)("Min Capacity: %zuM", min_capacity / M);
+  log_info_p(gc, init)("Initial Capacity: %zuM", initial_capacity / M);
+  log_info_p(gc, init)("Max Capacity: %zuM", max_capacity / M);
+  log_info_p(gc, init)("Soft Max Capacity: %zuM", soft_max_capacity / M);
   if (ZPageSizeMedium > 0) {
-    log_info_p(gc, init)("Medium Page Size: " SIZE_FORMAT "M", ZPageSizeMedium / M);
+    log_info_p(gc, init)("Medium Page Size: %zuM", ZPageSizeMedium / M);
   } else {
     log_info_p(gc, init)("Medium Page Size: N/A");
   }
@@ -366,7 +366,7 @@ void ZPageAllocator::decrease_capacity(size_t size, bool set_max_capacity) {
   if (set_max_capacity) {
     // Adjust current max capacity to avoid further attempts to increase capacity
     log_error_p(gc)("Forced to lower max Java heap size from "
-                    SIZE_FORMAT "M(%.0f%%) to " SIZE_FORMAT "M(%.0f%%)",
+                    SIZE_FORMAT "M(%.0f%%) to %zuM(%.0f%%)",
                     _current_max_capacity / M, percent_of(_current_max_capacity, _max_capacity),
                     _capacity / M, percent_of(_capacity, _max_capacity));
 
@@ -607,7 +607,7 @@ ZPage* ZPageAllocator::alloc_page_create(ZPageAllocation* allocation) {
 
     // Update statistics
     ZStatInc(ZCounterPageCacheFlush, flushed);
-    log_debug(gc, heap)("Page Cache Flushed: " SIZE_FORMAT "M", flushed / M);
+    log_debug(gc, heap)("Page Cache Flushed: %zuM", flushed / M);
   }
 
   // Allocate any remaining physical memory. Capacity and used has

--- a/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
+++ b/src/hotspot/share/gc/z/zRelocationSetSelector.cpp
@@ -153,7 +153,7 @@ void ZRelocationSetSelectorGroup::select_inner() {
     }
 
     log_trace(gc, reloc)("Candidate Relocation Set (%s Pages): %d->%d, "
-                         "%.1f%% relative defragmentation, " SIZE_FORMAT " forwarding entries, %s, live %d",
+                         "%.1f%% relative defragmentation, %zu forwarding entries, %s, live %d",
                          _name, from, to, diff_reclaimable, from_forwarding_entries,
                          (selected_from == from) ? "Selected" : "Rejected",
                          int(page_live_bytes * 100 / page->size()));
@@ -175,7 +175,7 @@ void ZRelocationSetSelectorGroup::select_inner() {
     _stats[i]._npages_selected = npages_selected[i];
   }
 
-  log_debug(gc, reloc)("Relocation Set (%s Pages): %d->%d, %d skipped, " SIZE_FORMAT " forwarding entries",
+  log_debug(gc, reloc)("Relocation Set (%s Pages): %d->%d, %d skipped, %zu forwarding entries",
                        _name, selected_from, selected_to, npages - selected_from, selected_forwarding_entries);
 }
 

--- a/src/hotspot/share/gc/z/zRememberedSet.cpp
+++ b/src/hotspot/share/gc/z/zRememberedSet.cpp
@@ -223,5 +223,5 @@ bool ZRememberedSetContainingInLiveIterator::next(ZRememberedSetContaining* cont
 }
 
 void ZRememberedSetContainingInLiveIterator::print_statistics() const {
-  _page->log_msg(" (remembered iter count: " SIZE_FORMAT " skipped: " SIZE_FORMAT ")", _count, _count_skipped);
+  _page->log_msg(" (remembered iter count: %zu skipped: %zu)", _count, _count_skipped);
 }

--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -1453,7 +1453,7 @@ void ZStatMark::print() {
                         _ntrycomplete,
                         _ncontinue);
 
-  log_info(gc, marking)("Mark Stack Usage: " SIZE_FORMAT "M", _mark_stack_usage / M);
+  log_info(gc, marking)("Mark Stack Usage: %zuM", _mark_stack_usage / M);
 }
 
 //
@@ -1538,7 +1538,7 @@ void ZStatRelocation::print_page_summary() {
   }
   print_summary("Large", large_summary, 0 /* in_place_count */);
 
-  lt.print("Forwarding Usage: " SIZE_FORMAT "M", _forwarding_usage / M);
+  lt.print("Forwarding Usage: %zuM", _forwarding_usage / M);
 }
 
 void ZStatRelocation::print_age_table() {
@@ -1604,13 +1604,13 @@ void ZStatRelocation::print_age_table() {
 
     lt.print("%s", create_age_table()
               .left(ZTABLE_ARGS(total[i] - live[i]))
-              .left(SIZE_FORMAT_W(7) " / " SIZE_FORMAT,
+              .left(SIZE_FORMAT_W(7) " / %zu",
                     _selector_stats.small(age).npages_candidates(),
                     _selector_stats.small(age).npages_selected())
-              .left(SIZE_FORMAT_W(7) " / " SIZE_FORMAT,
+              .left(SIZE_FORMAT_W(7) " / %zu",
                     _selector_stats.medium(age).npages_candidates(),
                     _selector_stats.medium(age).npages_selected())
-              .left(SIZE_FORMAT_W(7) " / " SIZE_FORMAT,
+              .left(SIZE_FORMAT_W(7) " / %zu",
                     _selector_stats.large(age).npages_candidates(),
                     _selector_stats.large(age).npages_selected())
               .end());
@@ -1621,7 +1621,7 @@ void ZStatRelocation::print_age_table() {
 // Stat nmethods
 //
 void ZStatNMethods::print() {
-  log_info(gc, nmethod)("NMethods: " SIZE_FORMAT " registered, " SIZE_FORMAT " unregistered",
+  log_info(gc, nmethod)("NMethods: %zu registered, %zu unregistered",
                         ZNMethodTable::registered_nmethods(),
                         ZNMethodTable::unregistered_nmethods());
 }
@@ -1633,7 +1633,7 @@ void ZStatMetaspace::print() {
   const MetaspaceCombinedStats stats = MetaspaceUtils::get_combined_statistics();
   log_info(gc, metaspace)("Metaspace: "
                           SIZE_FORMAT "M used, "
-                          SIZE_FORMAT "M committed, " SIZE_FORMAT "M reserved",
+                          SIZE_FORMAT "M committed, %zuM reserved",
                           stats.used() / M,
                           stats.committed() / M,
                           stats.reserved() / M);

--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -46,7 +46,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/ticks.hpp"
 
-#define ZSIZE_FMT                       SIZE_FORMAT "M(%.0f%%)"
+#define ZSIZE_FMT                       "%zuM(%.0f%%)"
 #define ZSIZE_ARGS_WITH_MAX(size, max)  ((size) / M), (percent_of(size, max))
 #define ZSIZE_ARGS(size)                ZSIZE_ARGS_WITH_MAX(size, ZStatHeap::max_capacity())
 
@@ -1442,11 +1442,11 @@ void ZStatMark::at_mark_free(size_t mark_stack_usage) {
 
 void ZStatMark::print() {
   log_info(gc, marking)("Mark: "
-                        SIZE_FORMAT " stripe(s), "
-                        SIZE_FORMAT " proactive flush(es), "
-                        SIZE_FORMAT " terminate flush(es), "
-                        SIZE_FORMAT " completion(s), "
-                        SIZE_FORMAT " continuation(s) ",
+                        "%zu stripe(s), "
+                        "%zu proactive flush(es), "
+                        "%zu terminate flush(es), "
+                        "%zu completion(s), "
+                        "%zu continuation(s) ",
                         _nstripes,
                         _nproactiveflush,
                         _nterminateflush,
@@ -1632,8 +1632,8 @@ void ZStatNMethods::print() {
 void ZStatMetaspace::print() {
   const MetaspaceCombinedStats stats = MetaspaceUtils::get_combined_statistics();
   log_info(gc, metaspace)("Metaspace: "
-                          SIZE_FORMAT "M used, "
-                          SIZE_FORMAT "M committed, %zuM reserved",
+                          "%zuM used, "
+                          "%zuM committed, %zuM reserved",
                           stats.used() / M,
                           stats.committed() / M,
                           stats.reserved() / M);

--- a/src/hotspot/share/gc/z/zUncommitter.cpp
+++ b/src/hotspot/share/gc/z/zUncommitter.cpp
@@ -80,7 +80,7 @@ void ZUncommitter::run_thread() {
     if (uncommitted > 0) {
       // Update statistics
       ZStatInc(ZCounterUncommit, uncommitted);
-      log_info(gc, heap)("Uncommitted: " SIZE_FORMAT "M(%.0f%%)",
+      log_info(gc, heap)("Uncommitted: %zuM(%.0f%%)",
                          uncommitted / M, percent_of(uncommitted, ZHeap::heap()->max_capacity()));
 
       // Send event

--- a/src/hotspot/share/gc/z/zUnmapper.cpp
+++ b/src/hotspot/share/gc/z/zUnmapper.cpp
@@ -70,11 +70,11 @@ bool ZUnmapper::try_enqueue(ZPage* page) {
       _warned_sync_unmapping = true;
       log_warning_p(gc)("WARNING: Encountered synchronous unmapping because asynchronous unmapping could not keep up");
     }
-    log_debug(gc, unmap)("Synchronous unmapping " SIZE_FORMAT "M page", page->size() / M);
+    log_debug(gc, unmap)("Synchronous unmapping %zuM page", page->size() / M);
     return false;
   }
 
-  log_trace(gc, unmap)("Asynchronous unmapping " SIZE_FORMAT "M page (" SIZE_FORMAT "M / " SIZE_FORMAT "M enqueued)",
+  log_trace(gc, unmap)("Asynchronous unmapping %zuM page (%zuM / %zuM enqueued)",
                        page->size() / M, _enqueued_bytes / M, queue_capacity() / M);
 
   _queue.insert_last(page);

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -137,7 +137,7 @@ size_t ZVirtualMemoryManager::reserve_discontiguous(size_t size) {
 }
 
 bool ZVirtualMemoryManager::reserve_contiguous(zoffset start, size_t size) {
-  assert(is_aligned(size, ZGranuleSize), "Must be granule aligned " SIZE_FORMAT_X, size);
+  assert(is_aligned(size, ZGranuleSize), "Must be granule aligned 0x%zx", size);
 
   // Reserve address views
   const zaddress_unsafe addr = ZOffset::address_unsafe(start);
@@ -200,7 +200,7 @@ bool ZVirtualMemoryManager::reserve(size_t max_capacity) {
                        (contiguous ? "Contiguous" : "Discontiguous"),
                        (limit == ZAddressOffsetMax ? "Unrestricted" : "Restricted"),
                        (reserved == size ? "Complete" : "Degraded"));
-  log_info_p(gc, init)("Address Space Size: " SIZE_FORMAT "M", reserved / M);
+  log_info_p(gc, init)("Address Space Size: %zuM", reserved / M);
 
   // Record reserved
   _reserved = reserved;

--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -1318,7 +1318,7 @@ static u1* schema_extend_event_subklass_bytes(const InstanceKlass* ik,
   const jint new_buffer_size = extra_stream_bytes + orig_stream_size;
   u1* const new_buffer = NEW_RESOURCE_ARRAY_IN_THREAD_RETURN_NULL(THREAD, u1, new_buffer_size);
   if (new_buffer == nullptr) {
-    log_error(jfr, system) ("Thread local allocation (native) for " SIZE_FORMAT
+    log_error(jfr, system) ("Thread local allocation (native) for %zu"
       " bytes failed in JfrEventClassTransformer::on_klass_creation", static_cast<size_t>(new_buffer_size));
     return nullptr;
   }
@@ -1557,7 +1557,7 @@ static void cache_class_file_data(InstanceKlass* new_ik, const ClassFileStream* 
   JvmtiCachedClassFileData* p =
     (JvmtiCachedClassFileData*)NEW_C_HEAP_ARRAY_RETURN_NULL(u1, offset_of(JvmtiCachedClassFileData, data) + stream_len, mtInternal);
   if (p == nullptr) {
-    log_error(jfr, system)("Allocation using C_HEAP_ARRAY for " SIZE_FORMAT " bytes failed in JfrEventClassTransformer::cache_class_file_data",
+    log_error(jfr, system)("Allocation using C_HEAP_ARRAY for %zu bytes failed in JfrEventClassTransformer::cache_class_file_data",
       static_cast<size_t>(offset_of(JvmtiCachedClassFileData, data) + stream_len));
     return;
   }

--- a/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
@@ -103,7 +103,7 @@ static jclass* create_classes_array(jint classes_count, TRAPS) {
   if (nullptr == classes) {
     char error_buffer[ERROR_MSG_BUFFER_SIZE];
     jio_snprintf(error_buffer, ERROR_MSG_BUFFER_SIZE,
-      "Thread local allocation (native) of " SIZE_FORMAT " bytes failed "
+      "Thread local allocation (native) of %zu bytes failed "
       "in retransform classes", sizeof(jclass) * classes_count);
     log_error(jfr, system)("%s", error_buffer);
     JfrJavaSupport::throw_out_of_memory_error(error_buffer, CHECK_NULL);

--- a/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
@@ -107,7 +107,7 @@ static const size_t ERROR_MSG_BUFFER_SIZE = 256;
 static void log_error_and_throw_oom(jint new_bytes_length, TRAPS) {
   char error_buffer[ERROR_MSG_BUFFER_SIZE];
   jio_snprintf(error_buffer, ERROR_MSG_BUFFER_SIZE,
-    "Thread local allocation (native) for " SIZE_FORMAT " bytes failed in JfrUpcalls", (size_t)new_bytes_length);
+    "Thread local allocation (native) for %zu bytes failed in JfrUpcalls", (size_t)new_bytes_length);
   log_error(jfr, system)("%s", error_buffer);
   JfrJavaSupport::throw_out_of_memory_error(error_buffer, CHECK);
 }

--- a/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/bfsClosure.cpp
@@ -55,7 +55,7 @@ static void log_frontier_level_summary(size_t level,
                                        size_t edge_size) {
   const size_t nof_edges_in_frontier = high_idx - low_idx;
   log_trace(jfr, system)(
-      "BFS front: " SIZE_FORMAT " edges: " SIZE_FORMAT " size: " SIZE_FORMAT " [KB]",
+      "BFS front: %zu edges: %zu size: %zu [KB]",
       level,
       nof_edges_in_frontier,
       (nof_edges_in_frontier * edge_size) / K
@@ -85,14 +85,14 @@ void BFSClosure::log_dfs_fallback() const {
 
   // additional information about DFS fallover
   log_trace(jfr, system)(
-      "BFS front: " SIZE_FORMAT " filled edge queue at edge: " SIZE_FORMAT,
+      "BFS front: %zu filled edge queue at edge: %zu",
       _current_frontier_level,
       _dfs_fallback_idx
                         );
 
   const size_t nof_dfs_completed_edges = _edge_queue->bottom() - _dfs_fallback_idx;
   log_trace(jfr, system)(
-      "DFS to complete " SIZE_FORMAT " edges size: " SIZE_FORMAT " [KB]",
+      "DFS to complete %zu edges size: %zu [KB]",
       nof_dfs_completed_edges,
       (nof_dfs_completed_edges * edge_size) / K
                         );

--- a/src/hotspot/share/jfr/leakprofiler/chains/pathToGcRootsOperation.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/pathToGcRootsOperation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,9 +70,9 @@ static size_t edge_queue_memory_commit_size(size_t memory_reservation_bytes) {
 }
 
 static void log_edge_queue_summary(const EdgeQueue& edge_queue) {
-  log_trace(jfr, system)("EdgeQueue reserved size total: " SIZE_FORMAT " [KB]", edge_queue.reserved_size() / K);
-  log_trace(jfr, system)("EdgeQueue edges total: " SIZE_FORMAT, edge_queue.top());
-  log_trace(jfr, system)("EdgeQueue liveset total: " SIZE_FORMAT " [KB]", edge_queue.live_set() / K);
+  log_trace(jfr, system)("EdgeQueue reserved size total: %zu [KB]", edge_queue.reserved_size() / K);
+  log_trace(jfr, system)("EdgeQueue edges total: %zu", edge_queue.top());
+  log_trace(jfr, system)("EdgeQueue liveset total: %zu [KB]", edge_queue.live_set() / K);
   if (edge_queue.reserved_size() > 0) {
     log_trace(jfr, system)("EdgeQueue commit reserve ratio: %f\n",
       ((double)edge_queue.live_set() / (double)edge_queue.reserved_size()));

--- a/src/hotspot/share/jfr/recorder/storage/jfrEpochStorage.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrEpochStorage.inline.hpp
@@ -52,7 +52,7 @@ template <typename NodeType, template <typename> class RetrievalPolicy, bool Eag
 inline NodeType* JfrEpochStorageHost<NodeType, RetrievalPolicy, EagerReclaim>::acquire(size_t size, Thread* thread) {
   BufferPtr buffer = mspace_acquire_to_live_list(size, _mspace, thread);
   if (buffer == nullptr) {
-    log_warning(jfr)("Unable to allocate " SIZE_FORMAT " bytes of %s.", _mspace->min_element_size(), "epoch storage");
+    log_warning(jfr)("Unable to allocate %zu bytes of %s.", _mspace->min_element_size(), "epoch storage");
     return nullptr;
   }
   assert(buffer->acquired_by_self(), "invariant");

--- a/src/hotspot/share/jfr/recorder/storage/jfrMemorySpace.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrMemorySpace.inline.hpp
@@ -203,7 +203,7 @@ inline bool JfrMemorySpace< Client, RetrievalPolicy, FreeListType, FullListType,
 // allocations are even multiples of the mspace min size
 static inline size_t align_allocation_size(size_t requested_size, size_t min_element_size) {
   if (requested_size > static_cast<size_t>(min_intx)) {
-    assert(false, "requested size: " SIZE_FORMAT " is too large", requested_size);
+    assert(false, "requested size: %zu is too large", requested_size);
     return 0;
   }
   u8 alloc_size_bytes = min_element_size;

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -137,7 +137,7 @@ JfrStorageControl& JfrStorage::control() {
 }
 
 static void log_allocation_failure(const char* msg, size_t size) {
-  log_warning(jfr)("Unable to allocate " SIZE_FORMAT " bytes of %s.", size, msg);
+  log_warning(jfr)("Unable to allocate %zu bytes of %s.", size, msg);
 }
 
 BufferPtr JfrStorage::acquire_thread_local(Thread* thread, size_t size /* 0 */) {
@@ -326,8 +326,8 @@ static void log_discard(size_t pre_full_count, size_t post_full_count, size_t am
   if (log_is_enabled(Debug, jfr, system)) {
     const size_t number_of_discards = pre_full_count - post_full_count;
     if (number_of_discards > 0) {
-      log_debug(jfr, system)("Cleared " SIZE_FORMAT " full buffer(s) of " SIZE_FORMAT" bytes.", number_of_discards, amount);
-      log_debug(jfr, system)("Current number of full buffers " SIZE_FORMAT "", number_of_discards);
+      log_debug(jfr, system)("Cleared %zu full buffer(s) of %zu bytes.", number_of_discards, amount);
+      log_debug(jfr, system)("Current number of full buffers %zu", number_of_discards);
     }
   }
 }
@@ -565,7 +565,7 @@ static size_t process_full(Processor& processor, JfrFullList* list, JfrStorageCo
 static void log(size_t count, size_t amount, bool clear = false) {
   if (log_is_enabled(Debug, jfr, system)) {
     if (count > 0) {
-      log_debug(jfr, system)("%s " SIZE_FORMAT " full buffer(s) of " SIZE_FORMAT" B of data%s",
+      log_debug(jfr, system)("%s %zu full buffer(s) of %zuB of data%s",
         clear ? "Discarded" : "Wrote", count, amount, clear ? "." : " to chunk.");
     }
   }

--- a/src/hotspot/share/jfr/utilities/jfrAllocation.cpp
+++ b/src/hotspot/share/jfr/utilities/jfrAllocation.cpp
@@ -55,7 +55,7 @@ static void add(size_t alloc_size) {
   if (!JfrRecorder::is_created()) {
     const jlong total_allocated = atomic_add_jlong((jlong)alloc_size, &_allocated_bytes);
     const jlong current_live_set = atomic_add_jlong((jlong)alloc_size, &_live_set_bytes);
-    log_trace(jfr, system)("Allocation: [" SIZE_FORMAT "] bytes", alloc_size);
+    log_trace(jfr, system)("Allocation: [%zu] bytes", alloc_size);
     log_trace(jfr, system)("Total alloc [" JLONG_FORMAT "] bytes", total_allocated);
     log_trace(jfr, system)("Liveset:    [" JLONG_FORMAT "] bytes", current_live_set);
   }
@@ -65,7 +65,7 @@ static void subtract(size_t dealloc_size) {
   if (!JfrRecorder::is_created()) {
     const jlong total_deallocated = atomic_add_jlong((jlong)dealloc_size, &_deallocated_bytes);
     const jlong current_live_set = atomic_add_jlong(((jlong)dealloc_size * -1), &_live_set_bytes);
-    log_trace(jfr, system)("Deallocation: [" SIZE_FORMAT "] bytes", dealloc_size);
+    log_trace(jfr, system)("Deallocation: [%zu] bytes", dealloc_size);
     log_trace(jfr, system)("Total dealloc [" JLONG_FORMAT "] bytes", total_deallocated);
     log_trace(jfr, system)("Liveset:      [" JLONG_FORMAT "] bytes", current_live_set);
   }
@@ -79,7 +79,7 @@ static void hook_memory_deallocation(size_t dealloc_size) {
 static void hook_memory_allocation(const char* allocation, size_t alloc_size) {
   if (nullptr == allocation) {
     if (!JfrRecorder::is_created()) {
-      log_warning(jfr, system)("Memory allocation failed for size [" SIZE_FORMAT "] bytes", alloc_size);
+      log_warning(jfr, system)("Memory allocation failed for size [%zu] bytes", alloc_size);
       return;
     } else {
       // after critical startup, fail as by default

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -106,7 +106,7 @@ AsyncLogWriter::AsyncLogWriter()
   size_t size = AsyncLogBufferSize / 2;
   _buffer = new Buffer(size);
   _buffer_staging = new Buffer(size);
-  log_info(logging)("AsyncLogBuffer estimates memory use: " SIZE_FORMAT " bytes", size * 2);
+  log_info(logging)("AsyncLogBuffer estimates memory use: %zu bytes", size * 2);
   if (os::create_thread(this, os::asynclog_thread)) {
     _initialized = true;
   } else {

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -214,8 +214,8 @@ size_t LogConfiguration::add_output(LogOutput* output) {
 
 void LogConfiguration::delete_output(size_t idx) {
   assert(idx > 1 && idx < _n_outputs,
-         "idx must be in range 1 < idx < _n_outputs, but idx = " SIZE_FORMAT
-         " and _n_outputs = " SIZE_FORMAT, idx, _n_outputs);
+         "idx must be in range 1 < idx < _n_outputs, but idx = %zu"
+         " and _n_outputs = %zu", idx, _n_outputs);
   LogOutput* output = _outputs[idx];
   // Swap places with the last output and shrink the array
   _outputs[idx] = _outputs[--_n_outputs];
@@ -240,7 +240,7 @@ void LogConfiguration::delete_output(size_t idx) {
 //
 void LogConfiguration::configure_output(size_t idx, const LogSelectionList& selections, const LogDecorators& decorators) {
   assert(ConfigurationLock::current_thread_has_lock(), "Must hold configuration lock to call this function.");
-  assert(idx < _n_outputs, "Invalid index, idx = " SIZE_FORMAT " and _n_outputs = " SIZE_FORMAT, idx, _n_outputs);
+  assert(idx < _n_outputs, "Invalid index, idx = %zu and _n_outputs = %zu", idx, _n_outputs);
   LogOutput* output = _outputs[idx];
 
   output->_reconfigured = true;
@@ -351,7 +351,7 @@ void LogConfiguration::configure_stdout(LogLevelType level, int exact_match, ...
     }
   }
   assert(i < LogTag::MaxTags || static_cast<LogTagType>(va_arg(ap, int)) == LogTag::__NO_TAG,
-         "Too many tags specified! Can only have up to " SIZE_FORMAT " tags in a tag set.", LogTag::MaxTags);
+         "Too many tags specified! Can only have up to %zu tags in a tag set.", LogTag::MaxTags);
   va_end(ap);
 
   LogSelection selection(tags, !exact_match, level);
@@ -500,7 +500,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
   size_t idx;
   bool added = false;
   if (outputstr[0] == '#') { // Output specified using index
-    int ret = sscanf(outputstr + 1, SIZE_FORMAT, &idx);
+    int ret = sscanf(outputstr + 1, "%zu", &idx);
     if (ret != 1 || idx >= _n_outputs) {
       errstream->print_cr("Invalid output index '%s'", outputstr);
       return false;
@@ -560,7 +560,7 @@ void LogConfiguration::describe_available(outputStream* out) {
 void LogConfiguration::describe_current_configuration(outputStream* out) {
   out->print_cr("Log output configuration:");
   for (size_t i = 0; i < _n_outputs; i++) {
-    out->print(" #" SIZE_FORMAT ": ", i);
+    out->print(" #%zu: ", i);
     _outputs[i]->describe(out);
     if (_outputs[i]->is_reconfigured()) {
       out->print(" (reconfigured)");

--- a/src/hotspot/share/logging/logFileOutput.cpp
+++ b/src/hotspot/share/logging/logFileOutput.cpp
@@ -183,8 +183,8 @@ bool LogFileOutput::set_option(const char* key, const char* value, outputStream*
       julong longval;
       success = Arguments::atojulong(value, &longval);
       if (!success || (longval > SIZE_MAX)) {
-        errstream->print_cr("Invalid option: %s must be in range [0, "
-                            SIZE_FORMAT "]", FileSizeOptionKey, (size_t)SIZE_MAX);
+        errstream->print_cr("Invalid option: %s must be in range [0, %zu]",
+                            FileSizeOptionKey, (size_t)SIZE_MAX);
         success = false;
       } else {
         _rotate_size = static_cast<size_t>(longval);
@@ -214,7 +214,7 @@ bool LogFileOutput::initialize(const char* options, outputStream* errstream) {
   }
 
   log_trace(logging)("Initializing logging to file '%s' (filecount: %u"
-                     ", filesize: " SIZE_FORMAT " KiB).",
+                     ", filesize: %zu KiB).",
                      _file_name, _file_count, _rotate_size / K);
 
   if (_file_count > 0 && file_exist) {
@@ -460,7 +460,7 @@ char* LogFileOutput::make_file_name(const char* file_name,
 
 void LogFileOutput::describe(outputStream *out) {
   LogFileStreamOutput::describe(out);
-  out->print(",filecount=%u,filesize=" SIZE_FORMAT "%s,async=%s", _file_count,
+  out->print(",filecount=%u,filesize=%zu%s,async=%s", _file_count,
              byte_size_in_proper_unit(_rotate_size),
              proper_unit_for_byte_size(_rotate_size),
              LogConfiguration::is_async_mode() ? "true" : "false");

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -128,7 +128,7 @@ static LogSelection parse_internal(char *str, outputStream* errstream) {
     }
     if (ntags == LogTag::MaxTags) {
       if (errstream != nullptr) {
-        errstream->print_cr("Too many tags in log selection '%s' (can only have up to " SIZE_FORMAT " tags).",
+        errstream->print_cr("Too many tags in log selection '%s' (can only have up to %zu tags).",
                                str, LogTag::MaxTags);
       }
       return LogSelection::Invalid;

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -64,7 +64,7 @@ bool LogSelectionList::parse(const char* str, outputStream* errstream) {
   for (char *comma_pos = copy, *cur = copy; success && comma_pos != nullptr; cur = comma_pos + 1) {
     if (_nselections == MaxSelections) {
       if (errstream != nullptr) {
-        errstream->print_cr("Can not have more than " SIZE_FORMAT " log selections in a single configuration.",
+        errstream->print_cr("Can not have more than %zu log selections in a single configuration.",
                             MaxSelections);
       }
       success = false;

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -150,8 +150,7 @@ void* Chunk::operator new (size_t sizeofChunk, AllocFailType alloc_failmode, siz
   //   aligning (D)
 
   assert(sizeofChunk == sizeof(Chunk), "weird request size");
-  assert(is_aligned(length, ARENA_AMALLOC_ALIGNMENT), "chunk payload length misaligned: "
-         SIZE_FORMAT ".", length);
+  assert(is_aligned(length, ARENA_AMALLOC_ALIGNMENT), "chunk payload length misaligned: %zu.", length);
   // Try to reuse a freed chunk from the pool
   ChunkPool* pool = ChunkPool::get_pool_for_size(length);
   if (pool != nullptr) {

--- a/src/hotspot/share/memory/classLoaderMetaspace.cpp
+++ b/src/hotspot/share/memory/classLoaderMetaspace.cpp
@@ -121,8 +121,8 @@ MetaWord* ClassLoaderMetaspace::expand_and_allocate(size_t word_size, Metaspace:
     Metaspace::tracer()->report_gc_threshold(before, after,
                                   MetaspaceGCThresholdUpdater::ExpandAndAllocate);
     // Keeping both for now until I am sure the old variant (gc + metaspace) is not needed anymore
-    log_trace(gc, metaspace)("Increase capacity to GC from " SIZE_FORMAT " to " SIZE_FORMAT, before, after);
-    UL2(info, "GC threshold increased: " SIZE_FORMAT "->" SIZE_FORMAT ".", before, after);
+    log_trace(gc, metaspace)("Increase capacity to GC from %zu to %zu", before, after);
+    UL2(info, "GC threshold increased: %zu->%zu.", before, after);
   }
 
   return res;

--- a/src/hotspot/share/memory/guardedMemory.cpp
+++ b/src/hotspot/share/memory/guardedMemory.cpp
@@ -58,7 +58,7 @@ void GuardedMemory::print_on(outputStream* st) const {
     return;
   }
   st->print_cr("GuardedMemory(" PTR_FORMAT ") base_addr=" PTR_FORMAT
-      " tag=" PTR_FORMAT " user_size=" SIZE_FORMAT " user_data=" PTR_FORMAT,
+      " tag=" PTR_FORMAT " user_size=%zu user_data=" PTR_FORMAT,
       p2i(this), p2i(_base_addr), p2i(get_tag()), get_user_size(), p2i(get_user_ptr()));
 
   Guard* guard = get_head_guard();

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -213,18 +213,18 @@ void MetaspaceUtils::print_on(outputStream* out) {
   // Used from all GCs. It first prints out totals, then, separately, the class space portion.
   MetaspaceCombinedStats stats = get_combined_statistics();
   out->print_cr(" Metaspace       "
-                "used "      SIZE_FORMAT "K, "
-                "committed " SIZE_FORMAT "K, "
-                "reserved "  SIZE_FORMAT "K",
+                "used %zuK, "
+                "committed %zuK, "
+                "reserved %zuK",
                 stats.used()/K,
                 stats.committed()/K,
                 stats.reserved()/K);
 
   if (Metaspace::using_class_space()) {
     out->print_cr("  class space    "
-                  "used "      SIZE_FORMAT "K, "
-                  "committed " SIZE_FORMAT "K, "
-                  "reserved "  SIZE_FORMAT "K",
+                  "used %zuK, "
+                  "committed %zuK, "
+                  "reserved %zuK",
                   stats.class_space_stats().used()/K,
                   stats.class_space_stats().committed()/K,
                   stats.class_space_stats().reserved()/K);
@@ -382,7 +382,7 @@ bool MetaspaceGC::can_expand(size_t word_size, bool is_class) {
   if (is_class && Metaspace::using_class_space()) {
     size_t class_committed = MetaspaceUtils::committed_bytes(Metaspace::ClassType);
     if (class_committed + word_size * BytesPerWord > CompressedClassSpaceSize) {
-      log_trace(gc, metaspace, freelist)("Cannot expand %s metaspace by " SIZE_FORMAT " words (CompressedClassSpaceSize = " SIZE_FORMAT " words)",
+      log_trace(gc, metaspace, freelist)("Cannot expand %s metaspace by %zu words (CompressedClassSpaceSize = %zu words)",
                 (is_class ? "class" : "non-class"), word_size, CompressedClassSpaceSize / sizeof(MetaWord));
       return false;
     }
@@ -391,7 +391,7 @@ bool MetaspaceGC::can_expand(size_t word_size, bool is_class) {
   // Check if the user has imposed a limit on the metaspace memory.
   size_t committed_bytes = MetaspaceUtils::committed_bytes();
   if (committed_bytes + word_size * BytesPerWord > MaxMetaspaceSize) {
-    log_trace(gc, metaspace, freelist)("Cannot expand %s metaspace by " SIZE_FORMAT " words (MaxMetaspaceSize = " SIZE_FORMAT " words)",
+    log_trace(gc, metaspace, freelist)("Cannot expand %s metaspace by %zu words (MaxMetaspaceSize = %zu words)",
               (is_class ? "class" : "non-class"), word_size, MaxMetaspaceSize / sizeof(MetaWord));
     return false;
   }
@@ -404,14 +404,14 @@ size_t MetaspaceGC::allowed_expansion() {
   size_t capacity_until_gc = capacity_until_GC();
 
   assert(capacity_until_gc >= committed_bytes,
-         "capacity_until_gc: " SIZE_FORMAT " < committed_bytes: " SIZE_FORMAT,
+         "capacity_until_gc: %zu < committed_bytes: %zu",
          capacity_until_gc, committed_bytes);
 
   size_t left_until_max  = MaxMetaspaceSize - committed_bytes;
   size_t left_until_GC = capacity_until_gc - committed_bytes;
   size_t left_to_commit = MIN2(left_until_GC, left_until_max);
-  log_trace(gc, metaspace, freelist)("allowed expansion words: " SIZE_FORMAT
-            " (left_until_max: " SIZE_FORMAT ", left_until_GC: " SIZE_FORMAT ".",
+  log_trace(gc, metaspace, freelist)("allowed expansion words: %zu"
+            " (left_until_max: %zu, left_until_GC: %zu.",
             left_to_commit / BytesPerWord, left_until_max / BytesPerWord, left_until_GC / BytesPerWord);
 
   return left_to_commit / BytesPerWord;
@@ -475,7 +475,7 @@ void MetaspaceGC::compute_new_size() {
   // No expansion, now see if we want to shrink
   // We would never want to shrink more than this
   assert(capacity_until_GC >= minimum_desired_capacity,
-         SIZE_FORMAT " >= " SIZE_FORMAT,
+         "%zu >= %zu",
          capacity_until_GC, minimum_desired_capacity);
   size_t max_shrink_bytes = capacity_until_GC - minimum_desired_capacity;
 
@@ -509,7 +509,7 @@ void MetaspaceGC::compute_new_size() {
       shrink_bytes = align_down(shrink_bytes, Metaspace::commit_alignment());
 
       assert(shrink_bytes <= max_shrink_bytes,
-             "invalid shrink size " SIZE_FORMAT " not <= " SIZE_FORMAT,
+             "invalid shrink size %zu not <= %zu",
              shrink_bytes, max_shrink_bytes);
       if (current_shrink_factor == 0) {
         _shrink_factor = 10;
@@ -549,7 +549,7 @@ void Metaspace::print_compressed_class_space(outputStream* st) {
     MetaWord* base = VirtualSpaceList::vslist_class()->base_of_first_node();
     size_t size = VirtualSpaceList::vslist_class()->word_size_of_first_node();
     MetaWord* top = base + size;
-    st->print("Compressed class space mapped at: " PTR_FORMAT "-" PTR_FORMAT ", reserved size: " SIZE_FORMAT,
+    st->print("Compressed class space mapped at: " PTR_FORMAT "-" PTR_FORMAT ", reserved size: %zu",
                p2i(base), p2i(top), (top - base) * BytesPerWord);
     st->cr();
   }
@@ -558,10 +558,10 @@ void Metaspace::print_compressed_class_space(outputStream* st) {
 // Given a prereserved space, use that to set up the compressed class space list.
 void Metaspace::initialize_class_space(ReservedSpace rs) {
   assert(rs.size() >= CompressedClassSpaceSize,
-         SIZE_FORMAT " != " SIZE_FORMAT, rs.size(), CompressedClassSpaceSize);
+         "%zu != %zu", rs.size(), CompressedClassSpaceSize);
   assert(using_class_space(), "Must be using class space");
 
-  assert(rs.size() == CompressedClassSpaceSize, SIZE_FORMAT " != " SIZE_FORMAT,
+  assert(rs.size() == CompressedClassSpaceSize, "%zu != %zu",
          rs.size(), CompressedClassSpaceSize);
   assert(is_aligned(rs.base(), Metaspace::reserve_alignment()) &&
          is_aligned(rs.size(), Metaspace::reserve_alignment()),
@@ -722,7 +722,7 @@ void Metaspace::ergo_initialize() {
 
     if (adjusted_ccs_size != CompressedClassSpaceSize) {
       FLAG_SET_ERGO(CompressedClassSpaceSize, adjusted_ccs_size);
-      log_info(metaspace)("Setting CompressedClassSpaceSize to " SIZE_FORMAT ".",
+      log_info(metaspace)("Setting CompressedClassSpaceSize to %zu.",
                           CompressedClassSpaceSize);
     }
   }
@@ -792,7 +792,7 @@ void Metaspace::global_initialize() {
       if (!is_aligned(base, Metaspace::reserve_alignment())) {
         vm_exit_during_initialization(
             err_msg("CompressedClassSpaceBaseAddress=" PTR_FORMAT " invalid "
-                    "(must be aligned to " SIZE_FORMAT_X ").",
+                    "(must be aligned to 0x%zx).",
                     CompressedClassSpaceBaseAddress, Metaspace::reserve_alignment()));
       }
       rs = ReservedSpace(size, Metaspace::reserve_alignment(),
@@ -832,7 +832,7 @@ void Metaspace::global_initialize() {
     // ...failing that, give up.
     if (!rs.is_reserved()) {
       vm_exit_during_initialization(
-          err_msg("Could not allocate compressed class space: " SIZE_FORMAT " bytes",
+          err_msg("Could not allocate compressed class space: %zu bytes",
                    CompressedClassSpaceSize));
     }
 
@@ -894,7 +894,7 @@ size_t Metaspace::max_allocation_word_size() {
 MetaWord* Metaspace::allocate(ClassLoaderData* loader_data, size_t word_size,
                               MetaspaceObj::Type type) {
   assert(word_size <= Metaspace::max_allocation_word_size(),
-         "allocation size too large (" SIZE_FORMAT ")", word_size);
+         "allocation size too large (%zu)", word_size);
 
   assert(loader_data != nullptr, "Should never pass around a null loader_data. "
         "ClassLoaderData::the_null_class_loader_data() should have been used.");
@@ -960,7 +960,7 @@ void Metaspace::report_metadata_oome(ClassLoaderData* loader_data, size_t word_s
   // If result is still null, we are out of memory.
   Log(gc, metaspace, freelist, oom) log;
   if (log.is_info()) {
-    log.info("Metaspace (%s) allocation failed for size " SIZE_FORMAT,
+    log.info("Metaspace (%s) allocation failed for size %zu",
              is_class_space_allocation(mdtype) ? "class" : "data", word_size);
     ResourceMark rm;
     if (log.is_debug()) {

--- a/src/hotspot/share/memory/metaspace/binList.hpp
+++ b/src/hotspot/share/memory/metaspace/binList.hpp
@@ -85,7 +85,7 @@ class BinListImpl {
     {}
   };
 
-#define BLOCK_FORMAT          "Block @" PTR_FORMAT ": size: " SIZE_FORMAT ", next: " PTR_FORMAT
+#define BLOCK_FORMAT          "Block @" PTR_FORMAT ": size: %zu, next: " PTR_FORMAT
 #define BLOCK_FORMAT_ARGS(b)  p2i(b), (b)->_word_size, p2i((b)->_next)
 
   // Smallest block size must be large enough to hold a Block structure.
@@ -149,7 +149,7 @@ public:
   // Block may be larger. Real block size is returned in *p_real_word_size.
   MetaWord* remove_block(size_t word_size, size_t* p_real_word_size) {
     assert(word_size >= MinWordSize &&
-           word_size <= MaxWordSize, "bad block size " SIZE_FORMAT ".", word_size);
+           word_size <= MaxWordSize, "bad block size %zu.", word_size);
     int index = index_for_word_size(word_size);
     index = index_for_next_non_empty_list(index);
     if (index != -1) {

--- a/src/hotspot/share/memory/metaspace/blockTree.cpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.cpp
@@ -44,7 +44,7 @@ const size_t BlockTree::MinWordSize;
   ", left " PTR_FORMAT \
   ", right " PTR_FORMAT \
   ", next " PTR_FORMAT \
-  ", size " SIZE_FORMAT
+  ", size %zu"
 
 #define NODE_FORMAT_ARGS(n) \
   p2i(n), \

--- a/src/hotspot/share/memory/metaspace/blockTree.hpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.hpp
@@ -348,7 +348,7 @@ public:
   // Add a memory block to the tree. Its content will be overwritten.
   void add_block(MetaWord* p, size_t word_size) {
     DEBUG_ONLY(zap_range(p, word_size));
-    assert(word_size >= MinWordSize, "invalid block size " SIZE_FORMAT, word_size);
+    assert(word_size >= MinWordSize, "invalid block size %zu", word_size);
     Node* n = new(p) Node(word_size);
     if (_root == nullptr) {
       _root = n;
@@ -362,7 +362,7 @@ public:
   //  larger than that size. Upon return, *p_real_word_size contains the actual
   //  block size.
   MetaWord* remove_block(size_t word_size, size_t* p_real_word_size) {
-    assert(word_size >= MinWordSize, "invalid block size " SIZE_FORMAT, word_size);
+    assert(word_size >= MinWordSize, "invalid block size %zu", word_size);
 
     Node* n = find_closest_fit(word_size);
 

--- a/src/hotspot/share/memory/metaspace/chunkManager.cpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.cpp
@@ -141,7 +141,7 @@ Metachunk* ChunkManager::get_chunk_locked(chunklevel_t preferred_level, chunklev
   DEBUG_ONLY(chunklevel::check_valid_level(preferred_level);)
 
   UL2(debug, "requested chunk: pref_level: " CHKLVL_FORMAT
-     ", max_level: " CHKLVL_FORMAT ", min committed size: " SIZE_FORMAT ".",
+     ", max_level: " CHKLVL_FORMAT ", min committed size: %zu.",
      preferred_level, max_level, min_committed_words);
 
   // First, optimistically look for a chunk which is already committed far enough to hold min_word_size.
@@ -212,7 +212,7 @@ Metachunk* ChunkManager::get_chunk_locked(chunklevel_t preferred_level, chunklev
     const size_t to_commit = min_committed_words;
     if (c->committed_words() < to_commit) {
       if (c->ensure_committed_locked(to_commit) == false) {
-        UL2(info, "failed to commit " SIZE_FORMAT " words on chunk " METACHUNK_FORMAT ".",
+        UL2(info, "failed to commit %zu words on chunk " METACHUNK_FORMAT ".",
             to_commit,  METACHUNK_FORMAT_ARGS(c));
         return_chunk_locked(c);
         c = nullptr;
@@ -434,7 +434,7 @@ void ChunkManager::print_on(outputStream* st) const {
 
 void ChunkManager::print_on_locked(outputStream* st) const {
   assert_lock_strong(Metaspace_lock);
-  st->print_cr("cm %s: %d chunks, total word size: " SIZE_FORMAT ".", _name,
+  st->print_cr("cm %s: %d chunks, total word size: %zu.", _name,
                total_num_chunks(), total_word_size());
   _chunks.print_on(st);
 }

--- a/src/hotspot/share/memory/metaspace/chunklevel.cpp
+++ b/src/hotspot/share/memory/metaspace/chunklevel.cpp
@@ -36,7 +36,7 @@ using namespace chunklevel;
 
 chunklevel_t chunklevel::level_fitting_word_size(size_t word_size) {
   assert(MAX_CHUNK_WORD_SIZE >= word_size,
-         SIZE_FORMAT " - too large allocation size.", word_size * BytesPerWord);
+         "%zu - too large allocation size.", word_size * BytesPerWord);
   if (word_size <= MIN_CHUNK_WORD_SIZE) {
     return HIGHEST_CHUNK_LEVEL;
   }

--- a/src/hotspot/share/memory/metaspace/commitMask.cpp
+++ b/src/hotspot/share/memory/metaspace/commitMask.cpp
@@ -61,7 +61,7 @@ void CommitMask::check_pointer(const MetaWord* p) const {
 void CommitMask::check_pointer_aligned(const MetaWord* p) const {
   check_pointer(p);
   assert(is_aligned(p, _words_per_bit * BytesPerWord),
-         "Pointer " PTR_FORMAT " should be aligned to commit granule size " SIZE_FORMAT ".",
+         "Pointer " PTR_FORMAT " should be aligned to commit granule size %zu.",
          p2i(p), _words_per_bit * BytesPerWord);
 }
 // Given a range, check if it points into the range this bitmap covers,
@@ -69,7 +69,7 @@ void CommitMask::check_pointer_aligned(const MetaWord* p) const {
 void CommitMask::check_range(const MetaWord* start, size_t word_size) const {
   check_pointer_aligned(start);
   assert(is_aligned(word_size, _words_per_bit),
-         "Range " SIZE_FORMAT " should be aligned to commit granule size " SIZE_FORMAT ".",
+         "Range %zu should be aligned to commit granule size %zu.",
          word_size, _words_per_bit);
   check_pointer(start + word_size - 1);
 }

--- a/src/hotspot/share/memory/metaspace/freeBlocks.cpp
+++ b/src/hotspot/share/memory/metaspace/freeBlocks.cpp
@@ -31,7 +31,7 @@
 namespace metaspace {
 
 void FreeBlocks::add_block(MetaWord* p, size_t word_size) {
-  assert(word_size >= MinWordSize, "sanity (" SIZE_FORMAT ")", word_size);
+  assert(word_size >= MinWordSize, "sanity (%zu)", word_size);
   if (word_size > MaxSmallBlocksWordSize) {
     _tree.add_block(p, word_size);
   } else {
@@ -41,7 +41,7 @@ void FreeBlocks::add_block(MetaWord* p, size_t word_size) {
 
 MetaWord* FreeBlocks::remove_block(size_t requested_word_size) {
   assert(requested_word_size >= MinWordSize,
-      "requested_word_size too small (" SIZE_FORMAT ")", requested_word_size);
+      "requested_word_size too small (%zu)", requested_word_size);
   size_t real_size = 0;
   MetaWord* p = nullptr;
   if (requested_word_size > MaxSmallBlocksWordSize) {

--- a/src/hotspot/share/memory/metaspace/freeChunkList.cpp
+++ b/src/hotspot/share/memory/metaspace/freeChunkList.cpp
@@ -155,7 +155,7 @@ void FreeChunkListVector::print_on(outputStream* st) const {
     list_for_level(l)->print_on(st);
     st->cr();
   }
-  st->print_cr("total chunks: %d, total word size: " SIZE_FORMAT ".",
+  st->print_cr("total chunks: %d, total word size: %zu.",
                num_chunks(), word_size());
 }
 

--- a/src/hotspot/share/memory/metaspace/metachunk.cpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.cpp
@@ -101,7 +101,7 @@ bool Metachunk::commit_up_to(size_t new_committed_words) {
   assert(commit_to <= word_size(), "Sanity");
   if (commit_to > commit_from) {
     log_debug(metaspace)("Chunk " METACHUNK_FORMAT ": attempting to move commit line to "
-                         SIZE_FORMAT " words.", METACHUNK_FORMAT_ARGS(this), commit_to);
+                         "%zu words.", METACHUNK_FORMAT_ARGS(this), commit_to);
     if (!_vsnode->ensure_range_is_committed(base() + commit_from, commit_to - commit_from)) {
       DEBUG_ONLY(verify();)
       return false;
@@ -270,10 +270,10 @@ void Metachunk::verify() const {
 
   assert(base() != nullptr, "No base ptr");
   assert(committed_words() >= used_words(),
-         "mismatch: committed: " SIZE_FORMAT ", used: " SIZE_FORMAT ".",
+         "mismatch: committed: %zu, used: %zu.",
          committed_words(), used_words());
   assert(word_size() >= committed_words(),
-         "mismatch: word_size: " SIZE_FORMAT ", committed: " SIZE_FORMAT ".",
+         "mismatch: word_size: %zu, committed: %zu.",
          word_size(), committed_words());
 
   // Test base pointer
@@ -300,8 +300,8 @@ void Metachunk::verify() const {
 void Metachunk::print_on(outputStream* st) const {
   // Note: must also work with invalid/random data. (e.g. do not call word_size())
   st->print("Chunk @" PTR_FORMAT ", state %c, base " PTR_FORMAT ", "
-            "level " CHKLVL_FORMAT " (" SIZE_FORMAT " words), "
-            "used " SIZE_FORMAT " words, committed " SIZE_FORMAT " words.",
+            "level " CHKLVL_FORMAT " (%zu words), "
+            "used %zu words, committed %zu words.",
             p2i(this), get_state_char(), p2i(base()), level(),
             (chunklevel::is_valid_level(level()) ? chunklevel::word_size_for_level(level()) : SIZE_MAX),
             used_words(), committed_words());

--- a/src/hotspot/share/memory/metaspace/metachunk.hpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.hpp
@@ -362,7 +362,7 @@ public:
 #define METACHUNK_FORMAT                "@" PTR_FORMAT ", %c, base " PTR_FORMAT ", level " CHKLVL_FORMAT
 #define METACHUNK_FORMAT_ARGS(chunk)    p2i(chunk), chunk->get_state_char(), p2i(chunk->base()), chunk->level()
 
-#define METACHUNK_FULL_FORMAT                "@" PTR_FORMAT ", %c, base " PTR_FORMAT ", level " CHKLVL_FORMAT " (" SIZE_FORMAT "), used: " SIZE_FORMAT ", committed: " SIZE_FORMAT ", committed-free: " SIZE_FORMAT
+#define METACHUNK_FULL_FORMAT                "@" PTR_FORMAT ", %c, base " PTR_FORMAT ", level " CHKLVL_FORMAT " (%zu), used: %zu, committed: %zu, committed-free: %zu"
 #define METACHUNK_FULL_FORMAT_ARGS(chunk)    p2i(chunk), chunk->get_state_char(), p2i(chunk->base()), chunk->level(), chunk->word_size(), chunk->used_words(), chunk->committed_words(), chunk->free_below_committed_words()
 
 } // namespace metaspace

--- a/src/hotspot/share/memory/metaspace/metaspaceArena.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceArena.cpp
@@ -84,7 +84,7 @@ Metachunk* MetaspaceArena::allocate_new_chunk(size_t requested_word_size) {
 
   // Should this ever happen, we need to increase the maximum possible chunk size.
   guarantee(requested_word_size <= chunklevel::MAX_CHUNK_WORD_SIZE,
-            "Requested size too large (" SIZE_FORMAT ") - max allowed size per allocation is " SIZE_FORMAT ".",
+            "Requested size too large (%zu) - max allowed size per allocation is %zu.",
             requested_word_size, chunklevel::MAX_CHUNK_WORD_SIZE);
 
   const chunklevel_t max_level = chunklevel::level_fitting_word_size(requested_word_size);
@@ -152,7 +152,7 @@ MetaspaceArena::~MetaspaceArena() {
     c = c2;
   }
 
-  UL2(info, "returned %d chunks, total capacity " SIZE_FORMAT " words.",
+  UL2(info, "returned %d chunks, total capacity %zu words.",
       return_counter.count(), return_counter.total_size());
 
   _total_used_words_counter->decrement_by(return_counter.total_size());
@@ -221,7 +221,7 @@ bool MetaspaceArena::attempt_enlarge_current_chunk(size_t requested_word_size) {
 // At any point, if we hit a commit limit, we return null.
 MetaWord* MetaspaceArena::allocate(size_t requested_word_size) {
   MutexLocker cl(lock(), Mutex::_no_safepoint_check_flag);
-  UL2(trace, "requested " SIZE_FORMAT " words.", requested_word_size);
+  UL2(trace, "requested %zu words.", requested_word_size);
 
   MetaWord* p = nullptr;
   const size_t raw_word_size = get_raw_word_size_for_requested_word_size(requested_word_size);
@@ -231,7 +231,7 @@ MetaWord* MetaspaceArena::allocate(size_t requested_word_size) {
     p = _fbl->remove_block(raw_word_size);
     if (p != nullptr) {
       DEBUG_ONLY(InternalStats::inc_num_allocs_from_deallocated_blocks();)
-      UL2(trace, "taken from fbl (now: %d, " SIZE_FORMAT ").",
+      UL2(trace, "taken from fbl (now: %d, %zu).",
           _fbl->count(), _fbl->total_size());
       // Note: free blocks in freeblock dictionary still count as "used" as far as statistics go;
       // therefore we have no need to adjust any usage counters (see epilogue of allocate_inner())
@@ -293,7 +293,7 @@ MetaWord* MetaspaceArena::allocate_inner(size_t requested_word_size) {
     // chunk.
     if (!current_chunk_too_small) {
       if (!current_chunk()->ensure_committed_additional(raw_word_size)) {
-        UL2(info, "commit failure (requested size: " SIZE_FORMAT ")", raw_word_size);
+        UL2(info, "commit failure (requested size: %zu)", raw_word_size);
         commit_failure = true;
       }
     }
@@ -312,7 +312,7 @@ MetaWord* MetaspaceArena::allocate_inner(size_t requested_word_size) {
 
     Metachunk* new_chunk = allocate_new_chunk(raw_word_size);
     if (new_chunk != nullptr) {
-      UL2(debug, "allocated new chunk " METACHUNK_FORMAT " for requested word size " SIZE_FORMAT ".",
+      UL2(debug, "allocated new chunk " METACHUNK_FORMAT " for requested word size %zu.",
           METACHUNK_FORMAT_ARGS(new_chunk), requested_word_size);
 
       assert(new_chunk->free_below_committed_words() >= raw_word_size, "Sanity");
@@ -329,7 +329,7 @@ MetaWord* MetaspaceArena::allocate_inner(size_t requested_word_size) {
       p = current_chunk()->allocate(raw_word_size);
       assert(p != nullptr, "Allocation from chunk failed.");
     } else {
-      UL2(info, "failed to allocate new chunk for requested word size " SIZE_FORMAT ".", requested_word_size);
+      UL2(info, "failed to allocate new chunk for requested word size %zu.", requested_word_size);
     }
   }
 
@@ -362,7 +362,7 @@ void MetaspaceArena::deallocate_locked(MetaWord* p, size_t word_size) {
          "Pointer range not part of this Arena and cannot be deallocated: (" PTR_FORMAT ".." PTR_FORMAT ").",
          p2i(p), p2i(p + word_size));
 
-  UL2(trace, "deallocating " PTR_FORMAT ", word size: " SIZE_FORMAT ".",
+  UL2(trace, "deallocating " PTR_FORMAT ", word size: %zu.",
       p2i(p), word_size);
 
   size_t raw_word_size = get_raw_word_size_for_requested_word_size(word_size);
@@ -475,7 +475,7 @@ void MetaspaceArena::print_on(outputStream* st) const {
 
 void MetaspaceArena::print_on_locked(outputStream* st) const {
   assert_lock_strong(_lock);
-  st->print_cr("sm %s: %d chunks, total word size: " SIZE_FORMAT ", committed word size: " SIZE_FORMAT, _name,
+  st->print_cr("sm %s: %d chunks, total word size: %zu, committed word size: %zu", _name,
                _chunks.count(), _chunks.calc_word_size(), _chunks.calc_committed_word_size());
   _chunks.print_on(st);
   st->cr();

--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
@@ -98,9 +98,9 @@ void print_human_readable_size(outputStream* st, size_t byte_size, size_t scale,
 
   if (width == -1) {
     if (scale == 1) {
-      st->print(SIZE_FORMAT " bytes", byte_size);
+      st->print("%zu bytes", byte_size);
     } else if (scale == BytesPerWord) {
-      st->print(SIZE_FORMAT " words", byte_size / BytesPerWord);
+      st->print("%zu words", byte_size / BytesPerWord);
     } else {
       const char* display_unit = display_unit_for_scale(scale);
       float display_value = (float) byte_size / scale;

--- a/src/hotspot/share/memory/metaspace/metaspaceSettings.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceSettings.cpp
@@ -54,9 +54,9 @@ void Settings::ergo_initialize() {
 }
 
 void Settings::print_on(outputStream* st) {
-  st->print_cr(" - commit_granule_bytes: " SIZE_FORMAT ".", commit_granule_bytes());
-  st->print_cr(" - commit_granule_words: " SIZE_FORMAT ".", commit_granule_words());
-  st->print_cr(" - virtual_space_node_default_size: " SIZE_FORMAT ".", virtual_space_node_default_word_size());
+  st->print_cr(" - commit_granule_bytes: %zu.", commit_granule_bytes());
+  st->print_cr(" - commit_granule_words: %zu.", commit_granule_words());
+  st->print_cr(" - virtual_space_node_default_size: %zu.", virtual_space_node_default_word_size());
   st->print_cr(" - enlarge_chunks_in_place: %d.", (int)enlarge_chunks_in_place());
   st->print_cr(" - use_allocation_guard: %d.", (int)use_allocation_guard());
 }

--- a/src/hotspot/share/memory/metaspace/metaspaceStatistics.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceStatistics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -128,7 +128,7 @@ void InUseChunkStats::print_on(outputStream* st, size_t scale) const {
 void InUseChunkStats::verify() const {
   assert(_word_size >= _committed_words &&
       _committed_words == _used_words + _free_words + _waste_words,
-         "Sanity: cap " SIZE_FORMAT ", committed " SIZE_FORMAT ", used " SIZE_FORMAT ", free " SIZE_FORMAT ", waste " SIZE_FORMAT ".",
+         "Sanity: cap %zu, committed %zu, used %zu, free %zu, waste %zu.",
          _word_size, _committed_words, _used_words, _free_words, _waste_words);
 }
 #endif

--- a/src/hotspot/share/memory/metaspace/testHelpers.cpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.cpp
@@ -67,8 +67,8 @@ MetaspaceTestContext::MetaspaceTestContext(const char* name, size_t commit_limit
   _used_words_counter(),
   _rs()
 {
-  assert(is_aligned(reserve_limit, Metaspace::reserve_alignment_words()), "reserve_limit (" SIZE_FORMAT ") "
-                    "not aligned to metaspace reserve alignment (" SIZE_FORMAT ")",
+  assert(is_aligned(reserve_limit, Metaspace::reserve_alignment_words()), "reserve_limit (%zu) "
+                    "not aligned to metaspace reserve alignment (%zu)",
                     reserve_limit, Metaspace::reserve_alignment_words());
   if (reserve_limit > 0) {
     // have reserve limit -> non-expandable context

--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
@@ -150,7 +150,7 @@ void VirtualSpaceList::print_on(outputStream* st) const {
     vsn = vsn->next();
     n++;
   }
-  st->print_cr("- total %d nodes, " SIZE_FORMAT " reserved words, " SIZE_FORMAT " committed words.",
+  st->print_cr("- total %d nodes, %zu reserved words, %zu committed words.",
                n, reserved_words(), committed_words());
 }
 

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -63,7 +63,7 @@ void check_pointer_is_aligned_to_commit_granule(const MetaWord* p) {
 }
 void check_word_size_is_aligned_to_commit_granule(size_t word_size) {
   assert(is_aligned(word_size, Settings::commit_granule_words()),
-         "Not aligned to commit granule size: " SIZE_FORMAT ".", word_size);
+         "Not aligned to commit granule size: %zu.", word_size);
 }
 #endif
 
@@ -93,7 +93,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
   //  were we to commit the given address range completely.
   const size_t commit_increase_words = word_size - committed_words_in_range;
 
-  UL2(debug, "committing range " PTR_FORMAT ".." PTR_FORMAT "(" SIZE_FORMAT " words)",
+  UL2(debug, "committing range " PTR_FORMAT ".." PTR_FORMAT "(%zu words)",
       p2i(p), p2i(p + word_size), word_size);
 
   if (commit_increase_words == 0) {
@@ -116,7 +116,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
     os::pretouch_memory(p, p + word_size);
   }
 
-  UL2(debug, "... committed " SIZE_FORMAT " additional words.", commit_increase_words);
+  UL2(debug, "... committed %zu additional words.", commit_increase_words);
 
   // ... tell commit limiter...
   _commit_limiter->increase_committed(commit_increase_words);
@@ -178,7 +178,7 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
   const size_t committed_words_in_range = _commit_mask.get_committed_size_in_range(p, word_size);
   DEBUG_ONLY(check_word_size_is_aligned_to_commit_granule(committed_words_in_range);)
 
-  UL2(debug, "uncommitting range " PTR_FORMAT ".." PTR_FORMAT "(" SIZE_FORMAT " words)",
+  UL2(debug, "uncommitting range " PTR_FORMAT ".." PTR_FORMAT "(%zu words)",
       p2i(p), p2i(p + word_size), word_size);
 
   if (committed_words_in_range == 0) {
@@ -192,7 +192,7 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
     fatal("Failed to uncommit metaspace.");
   }
 
-  UL2(debug, "... uncommitted " SIZE_FORMAT " words.", committed_words_in_range);
+  UL2(debug, "... uncommitted %zu words.", committed_words_in_range);
 
   // ... tell commit limiter...
   _commit_limiter->decrease_committed(committed_words_in_range);
@@ -229,7 +229,7 @@ VirtualSpaceNode::VirtualSpaceNode(ReservedSpace rs, bool owns_rs, CommitLimiter
   _total_reserved_words_counter(reserve_counter),
   _total_committed_words_counter(commit_counter)
 {
-  UL2(debug, "born (word_size " SIZE_FORMAT ").", _word_size);
+  UL2(debug, "born (word_size %zu).", _word_size);
 
   // Update reserved counter in vslist
   _total_reserved_words_counter->increment_by(_word_size);

--- a/src/hotspot/share/memory/resourceArea.hpp
+++ b/src/hotspot/share/memory/resourceArea.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,7 +109,7 @@ public:
       // Reset size before deleting chunks.  Otherwise, the total
       // size could exceed the total chunk size.
       assert(size_in_bytes() > state._size_in_bytes,
-             "size: " SIZE_FORMAT ", saved size: " SIZE_FORMAT,
+             "size: %zu, saved size: %zu",
              size_in_bytes(), state._size_in_bytes);
       set_size_in_bytes(state._size_in_bytes);
       state._chunk->next_chop();

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -858,7 +858,7 @@ void Universe::initialize_tlab() {
 ReservedHeapSpace Universe::reserve_heap(size_t heap_size, size_t alignment) {
 
   assert(alignment <= Arguments::conservative_max_heap_alignment(),
-         "actual alignment " SIZE_FORMAT " must be within maximum heap alignment " SIZE_FORMAT,
+         "actual alignment %zu must be within maximum heap alignment %zu",
          alignment, Arguments::conservative_max_heap_alignment());
 
   size_t total_reserved = align_up(heap_size, alignment);
@@ -896,7 +896,7 @@ ReservedHeapSpace Universe::reserve_heap(size_t heap_size, size_t alignment) {
   }
 
   vm_exit_during_initialization(
-    err_msg("Could not reserve enough space for " SIZE_FORMAT "KB object heap",
+    err_msg("Could not reserve enough space for %zuKB object heap",
             total_reserved/K));
 
   // satisfy compiler

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -147,7 +147,7 @@ static void log_on_large_pages_failure(char* req_addr, size_t bytes) {
     // JVM style warning that we did not succeed in using large pages.
     char msg[128];
     jio_snprintf(msg, sizeof(msg), "Failed to reserve and commit memory using large pages. "
-                                   "req_addr: " PTR_FORMAT " bytes: " SIZE_FORMAT,
+                                   "req_addr: " PTR_FORMAT " bytes: %zu",
                                    req_addr, bytes);
     warning("%s", msg);
   }
@@ -161,7 +161,7 @@ static char* reserve_memory(char* requested_address, const size_t size,
   // important.  If the reservation fails, return null.
   if (requested_address != 0) {
     assert(is_aligned(requested_address, alignment),
-           "Requested address " PTR_FORMAT " must be aligned to " SIZE_FORMAT,
+           "Requested address " PTR_FORMAT " must be aligned to %zu",
            p2i(requested_address), alignment);
     base = attempt_map_or_reserve_memory_at(requested_address, size, fd, exec);
   } else {
@@ -185,8 +185,8 @@ static char* reserve_memory(char* requested_address, const size_t size,
 static char* reserve_memory_special(char* requested_address, const size_t size,
                                     const size_t alignment, const size_t page_size, bool exec) {
 
-  log_trace(pagesize)("Attempt special mapping: size: " SIZE_FORMAT "%s, "
-                      "alignment: " SIZE_FORMAT "%s",
+  log_trace(pagesize)("Attempt special mapping: size: %zu%s, "
+                      "alignment: %zu%s",
                       byte_size_in_exact_unit(size), exact_unit_for_byte_size(size),
                       byte_size_in_exact_unit(alignment), exact_unit_for_byte_size(alignment));
 
@@ -195,7 +195,7 @@ static char* reserve_memory_special(char* requested_address, const size_t size,
     // Check alignment constraints.
     assert(is_aligned(base, alignment),
            "reserve_memory_special() returned an unaligned address, base: " PTR_FORMAT
-           " alignment: " SIZE_FORMAT_X,
+           " alignment: 0x%zx",
            p2i(base), alignment);
   }
   return base;
@@ -403,7 +403,7 @@ void ReservedHeapSpace::try_reserve_heap(size_t size,
 
   // Try to reserve the memory for the heap.
   log_trace(gc, heap, coops)("Trying to allocate at address " PTR_FORMAT
-                             " heap of size " SIZE_FORMAT_X,
+                             " heap of size 0x%zx",
                              p2i(requested_address),
                              size);
 
@@ -596,7 +596,7 @@ void ReservedHeapSpace::initialize_compressed_heap(const size_t size, size_t ali
 
     // Last, desperate try without any placement.
     if (_base == nullptr) {
-      log_trace(gc, heap, coops)("Trying to allocate at address null heap of size " SIZE_FORMAT_X, size + noaccess_prefix);
+      log_trace(gc, heap, coops)("Trying to allocate at address null heap of size 0x%zx", size + noaccess_prefix);
       initialize(size + noaccess_prefix, alignment, page_size, nullptr, false);
     }
   }
@@ -836,7 +836,7 @@ static bool commit_expanded(char* start, size_t size, size_t alignment, bool pre
 
   debug_only(warning(
       "INFO: os::commit_memory(" PTR_FORMAT ", " PTR_FORMAT
-      " size=" SIZE_FORMAT ", executable=%d) failed",
+      " size=%zu, executable=%d) failed",
       p2i(start), p2i(start + size), size, executable);)
 
   return false;
@@ -1059,8 +1059,8 @@ void VirtualSpace::print_on(outputStream* out) const {
   out->print   ("Virtual space:");
   if (special()) out->print(" (pinned in memory)");
   out->cr();
-  out->print_cr(" - committed: " SIZE_FORMAT, committed_size());
-  out->print_cr(" - reserved:  " SIZE_FORMAT, reserved_size());
+  out->print_cr(" - committed: %zu", committed_size());
+  out->print_cr(" - reserved:  %zu", reserved_size());
   out->print_cr(" - [low, high]:     [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(low()), p2i(high()));
   out->print_cr(" - [low_b, high_b]: [" PTR_FORMAT ", " PTR_FORMAT "]",  p2i(low_boundary()), p2i(high_boundary()));
 }

--- a/src/hotspot/share/oops/array.hpp
+++ b/src/hotspot/share/oops/array.hpp
@@ -74,12 +74,12 @@ protected:
     assert(is_aligned(left, sizeof(T)), "Must be");
 
     size_t elements = left / sizeof(T);
-    assert(elements <= (size_t)INT_MAX, "number of elements " SIZE_FORMAT "doesn't fit into an int.", elements);
+    assert(elements <= (size_t)INT_MAX, "number of elements %zudoesn't fit into an int.", elements);
 
     int length = (int)elements;
 
     assert((size_t)size(length) * BytesPerWord == (size_t)bytes,
-           "Expected: " SIZE_FORMAT " got: " SIZE_FORMAT,
+           "Expected: %zu got: %zu",
            bytes, (size_t)size(length) * BytesPerWord);
 
     return length;
@@ -135,7 +135,7 @@ protected:
     size_t bytes = align_up(byte_sizeof(length), BytesPerWord);
     size_t words = bytes / BytesPerWord;
 
-    assert(words <= INT_MAX, "Overflow: " SIZE_FORMAT, words);
+    assert(words <= INT_MAX, "Overflow: %zu", words);
 
     return (int)words;
   }

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -109,7 +109,7 @@ bool CompressedKlassPointers::is_valid_base(address p) {
 
 void CompressedKlassPointers::print_mode(outputStream* st) {
   st->print_cr("Narrow klass base: " PTR_FORMAT ", Narrow klass shift: %d, "
-               "Narrow klass range: " SIZE_FORMAT_X, p2i(base()), shift(),
+               "Narrow klass range: 0x%zx", p2i(base()), shift(),
                range());
 }
 

--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -159,7 +159,7 @@ bool CompressedOops::base_overlaps() {
 }
 
 void CompressedOops::print_mode(outputStream* st) {
-  st->print("Heap address: " PTR_FORMAT ", size: " SIZE_FORMAT " MB",
+  st->print("Heap address: " PTR_FORMAT ", size: %zu MB",
             p2i(_heap_address_range.start()), _heap_address_range.byte_size()/M);
 
   st->print(", Compressed Oops mode: %s", mode_to_string(mode()));

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3693,7 +3693,7 @@ void InstanceKlass::oop_print_on(oop obj, outputStream* st) {
     }
   }
 
-  st->print_cr(BULLET"---- fields (total size " SIZE_FORMAT " words):", oop_size(obj));
+  st->print_cr(BULLET"---- fields (total size %zu words):", oop_size(obj));
   FieldPrinter print_field(st, obj);
   print_nonstatic_fields(&print_field);
 

--- a/src/hotspot/share/oops/instanceMirrorKlass.cpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.cpp
@@ -49,7 +49,7 @@ size_t InstanceMirrorKlass::instance_size(Klass* k) {
 instanceOop InstanceMirrorKlass::allocate_instance(Klass* k, TRAPS) {
   // Query before forming handle.
   size_t size = instance_size(k);
-  assert(size > 0, "total object size must be non-zero: " SIZE_FORMAT, size);
+  assert(size > 0, "total object size must be non-zero: %zu", size);
 
   // Since mirrors can be variable sized because of the static fields, store
   // the size in the mirror itself.

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -197,8 +197,8 @@ size_t oopDesc::size_given_klass(Klass* klass)  {
     }
   }
 
-  assert(s > 0, "Oop size must be greater than zero, not " SIZE_FORMAT, s);
-  assert(is_object_aligned(s), "Oop size is not properly aligned: " SIZE_FORMAT, s);
+  assert(s > 0, "Oop size must be greater than zero, not %zu", s);
+  assert(is_object_aligned(s), "Oop size is not properly aligned: %zu", s);
   return s;
 }
 

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -437,7 +437,7 @@ public:
     assert(obj == nullptr || dbg_is_good_oop(obj), "p: " PTR_FORMAT " obj: " PTR_FORMAT, p2i(p), p2i(obj));
     if (_chunk->has_bitmap()) {
       BitMap::idx_t index = _chunk->bit_index_for(p);
-      assert(_chunk->bitmap().at(index), "Bit not set at index " SIZE_FORMAT " corresponding to " PTR_FORMAT, index, p2i(p));
+      assert(_chunk->bitmap().at(index), "Bit not set at index %zu corresponding to " PTR_FORMAT, index, p2i(p));
     }
   }
 
@@ -522,7 +522,7 @@ public:
 
     oop obj = _chunk->load_oop(p);
     assert(obj == nullptr || dbg_is_good_oop(obj),
-           "p: " PTR_FORMAT " obj: " PTR_FORMAT " index: " SIZE_FORMAT,
+           "p: " PTR_FORMAT " obj: " PTR_FORMAT " index: %zu",
            p2i(p), p2i((oopDesc*)obj), index);
 
     return true; // continue processing

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -630,7 +630,7 @@ Parse::Parse(JVMState* caller, ciMethod* parse_method, float expected_uses)
   // for exiting control flow still refers to the inlined method.
   C->set_default_node_notes(caller_nn);
 
-  if (log)  log->done("parse nodes='%d' live='%d' memory='" SIZE_FORMAT "'",
+  if (log)  log->done("parse nodes='%d' live='%d' memory='%zu'",
                       C->unique(), C->live_nodes(), C->node_arena()->used());
 }
 

--- a/src/hotspot/share/prims/jvmtiEnter.xsl
+++ b/src/hotspot/share/prims/jvmtiEnter.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
- Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -1235,7 +1235,7 @@ static jvmtiError JNICALL
   <xsl:param name="name"/>
   <xsl:text> </xsl:text>
   <xsl:value-of select="$name"/>
-  <xsl:text>=" SIZE_FORMAT_X "</xsl:text>
+  <xsl:text>=0x%zx</xsl:text>
 </xsl:template>
 
 <xsl:template match="jfloat|jdouble" mode="traceInFormat">

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -102,7 +102,7 @@ volatile size_t          _items_count           = 0;
 
 void ResolvedMethodTable::create_table() {
   _local_table  = new ResolvedMethodTableHash(ResolvedMethodTableSizeLog, END_SIZE, GROW_HINT);
-  log_trace(membername, table)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
+  log_trace(membername, table)("Start size: %zu (%zu)",
                                _current_size, ResolvedMethodTableSizeLog);
   _oop_storage = OopStorageSet::create_weak("ResolvedMethodTable Weak", mtClass);
   _oop_storage->register_num_dead_callback(&gc_notification);
@@ -229,7 +229,7 @@ static const double PREF_AVG_LIST_LEN = 2.0;
 static const double CLEAN_DEAD_HIGH_WATER_MARK = 0.5;
 
 void ResolvedMethodTable::gc_notification(size_t num_dead) {
-  log_trace(membername, table)("Uncleaned items:" SIZE_FORMAT, num_dead);
+  log_trace(membername, table)("Uncleaned items:%zu", num_dead);
 
   if (has_work()) {
     return;
@@ -289,7 +289,7 @@ void ResolvedMethodTable::grow(JavaThread* jt) {
   }
   gt.done(jt);
   _current_size = table_size();
-  log_info(membername, table)("Grown to size:" SIZE_FORMAT, _current_size);
+  log_info(membername, table)("Grown to size:%zu", _current_size);
 }
 
 struct ResolvedMethodTableDoDelete : StackObj {

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -264,8 +264,8 @@ WB_ENTRY(jlong, WB_GetCompressedOopsMaxHeapSize(JNIEnv* env, jobject o)) {
 WB_END
 
 WB_ENTRY(void, WB_PrintHeapSizes(JNIEnv* env, jobject o)) {
-  tty->print_cr("Minimum heap " SIZE_FORMAT " Initial heap " SIZE_FORMAT " "
-                "Maximum heap " SIZE_FORMAT " Space alignment " SIZE_FORMAT " Heap alignment " SIZE_FORMAT,
+  tty->print_cr("Minimum heap %zu Initial heap %zu "
+                "Maximum heap %zu Space alignment %zu Heap alignment %zu",
                 MinHeapSize,
                 InitialHeapSize,
                 MaxHeapSize,

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1613,8 +1613,8 @@ void Arguments::set_heap_size() {
       if (!FLAG_IS_DEFAULT(HeapBaseMinAddress)) {
         if (HeapBaseMinAddress < DefaultHeapBaseMinAddress) {
           // matches compressed oops printing flags
-          log_debug(gc, heap, coops)("HeapBaseMinAddress must be at least " SIZE_FORMAT
-                                     " (" SIZE_FORMAT "G) which is greater than value given " SIZE_FORMAT,
+          log_debug(gc, heap, coops)("HeapBaseMinAddress must be at least %zu"
+                                     " (%zuG) which is greater than value given %zu",
                                      DefaultHeapBaseMinAddress,
                                      DefaultHeapBaseMinAddress/G,
                                      HeapBaseMinAddress);
@@ -1639,7 +1639,7 @@ void Arguments::set_heap_size() {
       if (reasonable_max > max_coop_heap) {
         if (FLAG_IS_ERGO(UseCompressedOops) && override_coop_limit) {
           log_info(cds)("UseCompressedOops and UseCompressedClassPointers have been disabled due to"
-            " max heap " SIZE_FORMAT " > compressed oop heap " SIZE_FORMAT ". "
+            " max heap %zu > compressed oop heap %zu. "
             "Please check the setting of MaxRAMPercentage %5.2f."
             ,(size_t)reasonable_max, (size_t)max_coop_heap, MaxRAMPercentage);
           FLAG_SET_ERGO(UseCompressedOops, false);
@@ -1650,7 +1650,7 @@ void Arguments::set_heap_size() {
     }
 #endif // _LP64
 
-    log_trace(gc, heap)("  Maximum heap size " SIZE_FORMAT, (size_t) reasonable_max);
+    log_trace(gc, heap)("  Maximum heap size %zu", (size_t) reasonable_max);
     FLAG_SET_ERGO(MaxHeapSize, (size_t)reasonable_max);
   }
 
@@ -1671,13 +1671,13 @@ void Arguments::set_heap_size() {
       reasonable_initial = MIN2(reasonable_initial, (julong)MaxHeapSize);
 
       FLAG_SET_ERGO(InitialHeapSize, (size_t)reasonable_initial);
-      log_trace(gc, heap)("  Initial heap size " SIZE_FORMAT, InitialHeapSize);
+      log_trace(gc, heap)("  Initial heap size %zu", InitialHeapSize);
     }
     // If the minimum heap size has not been set (via -Xms or -XX:MinHeapSize),
     // synchronize with InitialHeapSize to avoid errors with the default value.
     if (MinHeapSize == 0) {
       FLAG_SET_ERGO(MinHeapSize, MIN2((size_t)reasonable_minimum, InitialHeapSize));
-      log_trace(gc, heap)("  Minimum heap size " SIZE_FORMAT, MinHeapSize);
+      log_trace(gc, heap)("  Minimum heap size %zu", MinHeapSize);
     }
   }
 }
@@ -1869,7 +1869,7 @@ bool Arguments::check_vm_args_consistency() {
   if (TLABRefillWasteFraction == 0) {
     jio_fprintf(defaultStream::error_stream(),
                 "TLABRefillWasteFraction should be a denominator, "
-                "not " SIZE_FORMAT "\n",
+                "not %zu\n",
                 TLABRefillWasteFraction);
     status = false;
   }

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -309,7 +309,7 @@ static void print_objects(JavaThread* deoptee_thread,
     if (obj.is_null()) {
       st.print(" allocation failed");
     } else {
-      st.print(" allocated (" SIZE_FORMAT " bytes)", obj->size() * HeapWordSize);
+      st.print(" allocated (%zu bytes)", obj->size() * HeapWordSize);
     }
     st.cr();
 

--- a/src/hotspot/share/runtime/flags/jvmFlag.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.cpp
@@ -219,7 +219,7 @@ void JVMFlag::print_on(outputStream* st, bool withComments, bool printRanges) co
     } else if (is_uint64_t()) {
       st->print(UINT64_FORMAT, get_uint64_t());
     } else if (is_size_t()) {
-      st->print(SIZE_FORMAT, get_size_t());
+      st->print("%zu", get_size_t());
     } else if (is_double()) {
       st->print("%f", get_double());
     } else if (is_ccstr()) {

--- a/src/hotspot/share/runtime/flags/jvmFlag.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlag.cpp
@@ -423,7 +423,7 @@ void JVMFlag::print_as_flag(outputStream* st) const {
   } else if (is_uint64_t()) {
     st->print("-XX:%s=" UINT64_FORMAT, _name, get_uint64_t());
   } else if (is_size_t()) {
-    st->print("-XX:%s=" SIZE_FORMAT, _name, get_size_t());
+    st->print("-XX:%s=%zu", _name, get_size_t());
   } else if (is_double()) {
     st->print("-XX:%s=%f", _name, get_double());
   } else if (is_ccstr()) {

--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -244,8 +244,8 @@ class FlagAccessImpl_size_t : public RangedFlagAccessImpl<size_t, EventUnsignedL
 public:
   void range_error(const char* name, size_t value, size_t min, size_t max, bool verbose) const {
     JVMFlag::printError(verbose,
-                        "size_t %s=" SIZE_FORMAT " is outside the allowed range "
-                        "[ " SIZE_FORMAT " ... " SIZE_FORMAT " ]\n",
+                        "size_t %s=%zu is outside the allowed range "
+                        "[ %zu ... %zu ]\n",
                         name, value, min, max);
   }
   JVMFlag::Error typed_check_constraint(void* func, size_t value, bool verbose) const {

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -169,7 +169,7 @@ JVMFlag::Error CodeCacheSegmentSizeConstraintFunc(uintx value, bool verbose) {
   if (CodeCacheSegmentSize < sizeof(jdouble)) {
     JVMFlag::printError(verbose,
                         "CodeCacheSegmentSize  (" UINTX_FORMAT ") must be "
-                        "at least " SIZE_FORMAT " to align constants\n",
+                        "at least %zu to align constants\n",
                         CodeCacheSegmentSize, sizeof(jdouble));
     return JVMFlag::VIOLATES_CONSTRAINT;
   }

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -44,7 +44,7 @@ JVMFlag::Error ObjectAlignmentInBytesConstraintFunc(int value, bool verbose) {
   if (value >= (intx)os::vm_page_size()) {
     JVMFlag::printError(verbose,
                         "ObjectAlignmentInBytes (%d) must be "
-                        "less than page size (" SIZE_FORMAT ")\n",
+                        "less than page size (%zu)\n",
                         value, os::vm_page_size());
     return JVMFlag::VIOLATES_CONSTRAINT;
   }

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -530,7 +530,7 @@ void before_exit(JavaThread* thread, bool halt) {
   if (VerifyStringTableAtExit) {
     size_t fail_cnt = StringTable::verify_and_compare_entries();
     if (fail_cnt != 0) {
-      tty->print_cr("ERROR: fail_cnt=" SIZE_FORMAT, fail_cnt);
+      tty->print_cr("ERROR: fail_cnt=%zu", fail_cnt);
       guarantee(fail_cnt == 0, "unexpected StringTable verification failures");
     }
   }

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -255,7 +255,7 @@ bool JNIHandles::is_weak_global_handle(jobject handle) {
 void JNIHandles::print_on(outputStream* st) {
   assert(SafepointSynchronize::is_at_safepoint(), "must be at safepoint");
 
-  st->print_cr("JNI global refs: " SIZE_FORMAT ", weak refs: " SIZE_FORMAT,
+  st->print_cr("JNI global refs: %zu, weak refs: %zu",
                global_handles()->allocation_count(),
                weak_global_handles()->allocation_count());
   st->cr();

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1766,7 +1766,7 @@ char* os::attempt_reserve_memory_at(char* addr, size_t bytes, bool executable) {
     MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
   } else {
     log_debug(os)("Attempt to reserve memory at " INTPTR_FORMAT " for "
-                 SIZE_FORMAT " bytes failed, errno %d", p2i(addr), bytes, get_last_error());
+                 "%zu bytes failed, errno %d", p2i(addr), bytes, get_last_error());
   }
   return result;
 }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1047,9 +1047,9 @@ void os::print_summary_info(outputStream* st, char* buf, size_t buflen) {
   size_t mem = physical_memory()/G;
   if (mem == 0) {  // for low memory systems
     mem = physical_memory()/M;
-    st->print("%d cores, " SIZE_FORMAT "M, ", processor_count(), mem);
+    st->print("%d cores, %zuM, ", processor_count(), mem);
   } else {
-    st->print("%d cores, " SIZE_FORMAT "G, ", processor_count(), mem);
+    st->print("%d cores, %zuG, ", processor_count(), mem);
   }
   get_summary_os_info(buf, buflen);
   st->print_raw(buf);
@@ -1660,11 +1660,11 @@ void os::trace_page_sizes(const char* str,
                           const size_t page_size) {
 
   log_info(pagesize)("%s: "
-                     " min=" SIZE_FORMAT "%s"
-                     " max=" SIZE_FORMAT "%s"
+                     " min=%zu%s"
+                     " max=%zu%s"
                      " base=" PTR_FORMAT
-                     " size=" SIZE_FORMAT "%s"
-                     " page_size=" SIZE_FORMAT "%s",
+                     " size=%zu%s"
+                     " page_size=%zu%s",
                      str,
                      trace_page_size_params(region_min_size),
                      trace_page_size_params(region_max_size),
@@ -1681,11 +1681,11 @@ void os::trace_page_sizes_for_requested_size(const char* str,
                                              const size_t page_size) {
 
   log_info(pagesize)("%s:"
-                     " req_size=" SIZE_FORMAT "%s"
-                     " req_page_size=" SIZE_FORMAT "%s"
+                     " req_size=%zu%s"
+                     " req_page_size=%zu%s"
                      " base=" PTR_FORMAT
-                     " size=" SIZE_FORMAT "%s"
-                     " page_size=" SIZE_FORMAT "%s",
+                     " size=%zu%s"
+                     " page_size=%zu%s",
                      str,
                      trace_page_size_params(requested_size),
                      trace_page_size_params(requested_page_size),
@@ -1838,7 +1838,7 @@ bool os::release_memory(char* addr, size_t bytes) {
     res = pd_release_memory(addr, bytes);
   }
   if (!res) {
-    log_info(os)("os::release_memory failed (" PTR_FORMAT ", " SIZE_FORMAT ")", p2i(addr), bytes);
+    log_info(os)("os::release_memory failed (" PTR_FORMAT ", %zu)", p2i(addr), bytes);
   }
   return res;
 }
@@ -1979,17 +1979,17 @@ void os::naked_sleep(jlong millis) {
 ////// Implementation of PageSizes
 
 void os::PageSizes::add(size_t page_size) {
-  assert(is_power_of_2(page_size), "page_size must be a power of 2: " SIZE_FORMAT_X, page_size);
+  assert(is_power_of_2(page_size), "page_size must be a power of 2: 0x%zx", page_size);
   _v |= page_size;
 }
 
 bool os::PageSizes::contains(size_t page_size) const {
-  assert(is_power_of_2(page_size), "page_size must be a power of 2: " SIZE_FORMAT_X, page_size);
+  assert(is_power_of_2(page_size), "page_size must be a power of 2: 0x%zx", page_size);
   return (_v & page_size) != 0;
 }
 
 size_t os::PageSizes::next_smaller(size_t page_size) const {
-  assert(is_power_of_2(page_size), "page_size must be a power of 2: " SIZE_FORMAT_X, page_size);
+  assert(is_power_of_2(page_size), "page_size must be a power of 2: 0x%zx", page_size);
   size_t v2 = _v & (page_size - 1);
   if (v2 == 0) {
     return 0;
@@ -1998,7 +1998,7 @@ size_t os::PageSizes::next_smaller(size_t page_size) const {
 }
 
 size_t os::PageSizes::next_larger(size_t page_size) const {
-  assert(is_power_of_2(page_size), "page_size must be a power of 2: " SIZE_FORMAT_X, page_size);
+  assert(is_power_of_2(page_size), "page_size must be a power of 2: 0x%zx", page_size);
   if (page_size == max_power_of_2<size_t>()) { // Shift by 32/64 would be UB
     return 0;
   }
@@ -2033,11 +2033,11 @@ void os::PageSizes::print_on(outputStream* st) const {
       st->print_raw(", ");
     }
     if (sz < M) {
-      st->print(SIZE_FORMAT "k", sz / K);
+      st->print("%zuk", sz / K);
     } else if (sz < G) {
-      st->print(SIZE_FORMAT "M", sz / M);
+      st->print("%zuM", sz / M);
     } else {
-      st->print(SIZE_FORMAT "G", sz / G);
+      st->print("%zuG", sz / G);
     }
   }
   if (first) {
@@ -2071,7 +2071,7 @@ jint os::set_minimum_stack_sizes() {
     // ThreadStackSize so we go with "Java thread stack size" instead
     // of "ThreadStackSize" to be more friendly.
     tty->print_cr("\nThe Java thread stack size specified is too small. "
-                  "Specify at least " SIZE_FORMAT "k",
+                  "Specify at least %zuk",
                   _java_thread_min_stack_allowed / K);
     return JNI_ERR;
   }
@@ -2092,7 +2092,7 @@ jint os::set_minimum_stack_sizes() {
   if (stack_size_in_bytes != 0 &&
       stack_size_in_bytes < _compiler_thread_min_stack_allowed) {
     tty->print_cr("\nThe CompilerThreadStackSize specified is too small. "
-                  "Specify at least " SIZE_FORMAT "k",
+                  "Specify at least %zuk",
                   _compiler_thread_min_stack_allowed / K);
     return JNI_ERR;
   }
@@ -2104,7 +2104,7 @@ jint os::set_minimum_stack_sizes() {
   if (stack_size_in_bytes != 0 &&
       stack_size_in_bytes < _vm_internal_thread_min_stack_allowed) {
     tty->print_cr("\nThe VMThreadStackSize specified is too small. "
-                  "Specify at least " SIZE_FORMAT "k",
+                  "Specify at least %zuk",
                   _vm_internal_thread_min_stack_allowed / K);
     return JNI_ERR;
   }

--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -168,8 +168,8 @@ void PerfData::create_entry(BasicType dtype, size_t dsize, size_t vlen) {
   pdep->data_offset = (jint) data_start;
 
   log_debug(perf, datacreation)("name = %s, dtype = %d, variability = %d,"
-                                " units = %d, dsize = " SIZE_FORMAT ", vlen = " SIZE_FORMAT ","
-                                " pad_length = " SIZE_FORMAT ", size = " SIZE_FORMAT ", on_c_heap = %s,"
+                                " units = %d, dsize = %zu, vlen = %zu,"
+                                " pad_length = %zu, size = %zu, on_c_heap = %s,"
                                 " address = " INTPTR_FORMAT ","
                                 " data address = " INTPTR_FORMAT,
                                 cname, dtype, variability(),

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -97,8 +97,8 @@ void PerfMemory::initialize() {
                              os::vm_allocation_granularity());
 
   log_debug(perf, memops)("PerfDataMemorySize = %d,"
-                          " os::vm_allocation_granularity = " SIZE_FORMAT
-                          ", adjusted size = " SIZE_FORMAT,
+                          " os::vm_allocation_granularity = %zu"
+                          ", adjusted size = %zu",
                           PerfDataMemorySize,
                           os::vm_allocation_granularity(),
                           capacity);
@@ -127,7 +127,7 @@ void PerfMemory::initialize() {
     // the PerfMemory region was created as expected.
 
     log_debug(perf, memops)("PerfMemory created: address = " INTPTR_FORMAT ","
-                            " size = " SIZE_FORMAT,
+                            " size = %zu",
                             p2i(_start),
                             _capacity);
 
@@ -178,8 +178,8 @@ void PerfMemory::destroy() {
     //
     if (PrintMiscellaneous && Verbose) {
       warning("PerfMemory Overflow Occurred.\n"
-              "\tCapacity = " SIZE_FORMAT " bytes"
-              "  Used = " SIZE_FORMAT " bytes"
+              "\tCapacity = %zu bytes"
+              "  Used = %zu bytes"
               "  Overflow = " INT32_FORMAT " bytes"
               "\n\tUse -XX:PerfDataMemorySize=<size> to specify larger size.",
               PerfMemory::capacity(),

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -561,7 +561,7 @@ char* Reflection::verify_class_access_msg(const Klass* current_class,
           strlen(new_class_name) + 2*sizeof(uintx);
         msg = NEW_RESOURCE_ARRAY(char, len);
         jio_snprintf(msg, len - 1,
-          "class %s (in module %s) cannot access class %s (in unnamed module @" SIZE_FORMAT_X ") because module %s does not read unnamed module @" SIZE_FORMAT_X,
+          "class %s (in module %s) cannot access class %s (in unnamed module @0x%zx) because module %s does not read unnamed module @0x%zx",
           current_class_name, module_from_name, new_class_name, uintx(identity_hash),
           module_from_name, uintx(identity_hash));
       }
@@ -588,7 +588,7 @@ char* Reflection::verify_class_access_msg(const Klass* current_class,
           2*strlen(module_to_name) + strlen(package_name) + 2*sizeof(uintx);
         msg = NEW_RESOURCE_ARRAY(char, len);
         jio_snprintf(msg, len - 1,
-          "class %s (in unnamed module @" SIZE_FORMAT_X ") cannot access class %s (in module %s) because module %s does not export %s to unnamed module @" SIZE_FORMAT_X,
+          "class %s (in unnamed module @0x%zx) cannot access class %s (in module %s) because module %s does not export %s to unnamed module @0x%zx",
           current_class_name, uintx(identity_hash), new_class_name, module_to_name,
           module_to_name, package_name, uintx(identity_hash));
       }

--- a/src/hotspot/share/runtime/stackOverflow.cpp
+++ b/src/hotspot/share/runtime/stackOverflow.cpp
@@ -92,7 +92,7 @@ void StackOverflow::create_stack_guard_pages() {
   assert(is_aligned(len, os::vm_page_size()), "Stack size should be a multiple of page size");
 
   int must_commit = os::must_commit_stack_guard_pages();
-  // warning("Guarding at " PTR_FORMAT " for len " SIZE_FORMAT "\n", low_addr, len);
+  // warning("Guarding at " PTR_FORMAT " for len %zu\n", low_addr, len);
 
   if (must_commit && !os::create_stack_guard_pages((char *) low_addr, len)) {
     log_warning(os, thread)("Attempt to allocate stack guard pages failed.");

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1173,8 +1173,8 @@ static bool monitors_used_above_threshold(MonitorList* list) {
     size_t new_ceiling = ceiling + (ceiling * remainder) + 1;
     ObjectSynchronizer::set_in_use_list_ceiling(new_ceiling);
     log_info(monitorinflation)("Too many deflations without progress; "
-                               "bumping in_use_list_ceiling from " SIZE_FORMAT
-                               " to " SIZE_FORMAT, old_ceiling, new_ceiling);
+                               "bumping in_use_list_ceiling from %zu"
+                               " to %zu", old_ceiling, new_ceiling);
     _no_progress_cnt = 0;
     ceiling = new_ceiling;
   }
@@ -1182,8 +1182,8 @@ static bool monitors_used_above_threshold(MonitorList* list) {
   // Check if our monitor usage is above the threshold:
   size_t monitor_usage = (monitors_used * 100LL) / ceiling;
   if (int(monitor_usage) > MonitorUsedDeflationThreshold) {
-    log_info(monitorinflation)("monitors_used=" SIZE_FORMAT ", ceiling=" SIZE_FORMAT
-                               ", monitor_usage=" SIZE_FORMAT ", threshold=" INTX_FORMAT,
+    log_info(monitorinflation)("monitors_used=%zu, ceiling=%zu"
+                               ", monitor_usage=%zu, threshold=" INTX_FORMAT,
                                monitors_used, ceiling, monitor_usage, MonitorUsedDeflationThreshold);
     return true;
   }
@@ -1560,8 +1560,8 @@ void ObjectSynchronizer::chk_for_block_req(JavaThread* current, const char* op_n
   // A safepoint/handshake has started.
   if (ls != nullptr) {
     timer_p->stop();
-    ls->print_cr("pausing %s: %s=" SIZE_FORMAT ", in_use_list stats: ceiling="
-                 SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+    ls->print_cr("pausing %s: %s=%zu, in_use_list stats: ceiling="
+                 SIZE_FORMAT ", count=%zu, max=%zu",
                  op_name, cnt_name, cnt, in_use_list_ceiling(),
                  _in_use_list.count(), _in_use_list.max());
   }
@@ -1572,8 +1572,8 @@ void ObjectSynchronizer::chk_for_block_req(JavaThread* current, const char* op_n
   }
 
   if (ls != nullptr) {
-    ls->print_cr("resuming %s: in_use_list stats: ceiling=" SIZE_FORMAT
-                 ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT, op_name,
+    ls->print_cr("resuming %s: in_use_list stats: ceiling=%zu"
+                 ", count=%zu, max=%zu", op_name,
                  in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
     timer_p->start();
   }
@@ -1678,7 +1678,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
 
   elapsedTimer timer;
   if (ls != nullptr) {
-    ls->print_cr("begin deflating: in_use_list stats: ceiling=" SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+    ls->print_cr("begin deflating: in_use_list stats: ceiling=%zu, count=%zu, max=%zu",
                  in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
     timer.start();
   }
@@ -1700,9 +1700,9 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
     if (current->is_monitor_deflation_thread()) {
       if (ls != nullptr) {
         timer.stop();
-        ls->print_cr("before handshaking: unlinked_count=" SIZE_FORMAT
-                     ", in_use_list stats: ceiling=" SIZE_FORMAT ", count="
-                     SIZE_FORMAT ", max=" SIZE_FORMAT,
+        ls->print_cr("before handshaking: unlinked_count=%zu"
+                     ", in_use_list stats: ceiling=%zu, count="
+                     SIZE_FORMAT ", max=%zu",
                      unlinked_count, in_use_list_ceiling(),
                      _in_use_list.count(), _in_use_list.max());
       }
@@ -1719,7 +1719,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
 
       if (ls != nullptr) {
         ls->print_cr("after handshaking: in_use_list stats: ceiling="
-                     SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+                     SIZE_FORMAT ", count=%zu, max=%zu",
                      in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
         timer.start();
       }
@@ -1734,9 +1734,9 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
     if (current->is_Java_thread()) {
       if (ls != NULL) {
         timer.stop();
-        ls->print_cr("before setting blocked: unlinked_count=" SIZE_FORMAT
-                     ", in_use_list stats: ceiling=" SIZE_FORMAT ", count="
-                     SIZE_FORMAT ", max=" SIZE_FORMAT,
+        ls->print_cr("before setting blocked: unlinked_count=%zu"
+                     ", in_use_list stats: ceiling=%zu, count="
+                     SIZE_FORMAT ", max=%zu",
                      unlinked_count, in_use_list_ceiling(),
                      _in_use_list.count(), _in_use_list.max());
       }
@@ -1745,7 +1745,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
       ThreadBlockInVM tbivm(JavaThread::cast(current));
       if (ls != NULL) {
         ls->print_cr("after setting blocked: in_use_list stats: ceiling="
-                     SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+                     SIZE_FORMAT ", count=%zu, max=%zu",
                      in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
         timer.start();
       }
@@ -1761,13 +1761,13 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
   if (ls != nullptr) {
     timer.stop();
     if (deflated_count != 0 || unlinked_count != 0 || log_is_enabled(Debug, monitorinflation)) {
-      ls->print_cr("deflated_count=" SIZE_FORMAT ", {unlinked,deleted}_count=" SIZE_FORMAT " monitors in %3.7f secs",
+      ls->print_cr("deflated_count=%zu, {unlinked,deleted}_count=%zu monitors in %3.7f secs",
                    deflated_count, unlinked_count, timer.seconds());
     }
-    ls->print_cr("end deflating: in_use_list stats: ceiling=" SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
+    ls->print_cr("end deflating: in_use_list stats: ceiling=%zu, count=%zu, max=%zu",
                  in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
     if (table != nullptr) {
-      ls->print_cr("ObjectMonitorsHashtable: key_count=" SIZE_FORMAT ", om_count=" SIZE_FORMAT,
+      ls->print_cr("ObjectMonitorsHashtable: key_count=%zu, om_count=%zu",
                    table->key_count(), table->om_count());
     }
   }
@@ -1942,7 +1942,7 @@ void ObjectSynchronizer::audit_and_print_stats(bool on_exit) {
 void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
   size_t l_in_use_count = _in_use_list.count();
   size_t l_in_use_max = _in_use_list.max();
-  out->print_cr("count=" SIZE_FORMAT ", max=" SIZE_FORMAT, l_in_use_count,
+  out->print_cr("count=%zu, max=%zu", l_in_use_count,
                 l_in_use_max);
 
   size_t ck_in_use_count = 0;
@@ -1954,21 +1954,21 @@ void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
   }
 
   if (l_in_use_count == ck_in_use_count) {
-    out->print_cr("in_use_count=" SIZE_FORMAT " equals ck_in_use_count="
+    out->print_cr("in_use_count=%zu equals ck_in_use_count="
                   SIZE_FORMAT, l_in_use_count, ck_in_use_count);
   } else {
-    out->print_cr("WARNING: in_use_count=" SIZE_FORMAT " is not equal to "
-                  "ck_in_use_count=" SIZE_FORMAT, l_in_use_count,
+    out->print_cr("WARNING: in_use_count=%zu is not equal to "
+                  "ck_in_use_count=%zu", l_in_use_count,
                   ck_in_use_count);
   }
 
   size_t ck_in_use_max = _in_use_list.max();
   if (l_in_use_max == ck_in_use_max) {
-    out->print_cr("in_use_max=" SIZE_FORMAT " equals ck_in_use_max="
+    out->print_cr("in_use_max=%zu equals ck_in_use_max="
                   SIZE_FORMAT, l_in_use_max, ck_in_use_max);
   } else {
-    out->print_cr("WARNING: in_use_max=" SIZE_FORMAT " is not equal to "
-                  "ck_in_use_max=" SIZE_FORMAT, l_in_use_max, ck_in_use_max);
+    out->print_cr("WARNING: in_use_max=%zu is not equal to "
+                  "ck_in_use_max=%zu", l_in_use_max, ck_in_use_max);
   }
 }
 

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1561,7 +1561,7 @@ void ObjectSynchronizer::chk_for_block_req(JavaThread* current, const char* op_n
   if (ls != nullptr) {
     timer_p->stop();
     ls->print_cr("pausing %s: %s=%zu, in_use_list stats: ceiling="
-                 SIZE_FORMAT ", count=%zu, max=%zu",
+                 "%zu, count=%zu, max=%zu",
                  op_name, cnt_name, cnt, in_use_list_ceiling(),
                  _in_use_list.count(), _in_use_list.max());
   }
@@ -1702,7 +1702,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
         timer.stop();
         ls->print_cr("before handshaking: unlinked_count=%zu"
                      ", in_use_list stats: ceiling=%zu, count="
-                     SIZE_FORMAT ", max=%zu",
+                     "%zu, max=%zu",
                      unlinked_count, in_use_list_ceiling(),
                      _in_use_list.count(), _in_use_list.max());
       }
@@ -1719,7 +1719,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
 
       if (ls != nullptr) {
         ls->print_cr("after handshaking: in_use_list stats: ceiling="
-                     SIZE_FORMAT ", count=%zu, max=%zu",
+                     "%zu, count=%zu, max=%zu",
                      in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
         timer.start();
       }
@@ -1736,7 +1736,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
         timer.stop();
         ls->print_cr("before setting blocked: unlinked_count=%zu"
                      ", in_use_list stats: ceiling=%zu, count="
-                     SIZE_FORMAT ", max=%zu",
+                     "%zu, max=%zu",
                      unlinked_count, in_use_list_ceiling(),
                      _in_use_list.count(), _in_use_list.max());
       }
@@ -1745,7 +1745,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
       ThreadBlockInVM tbivm(JavaThread::cast(current));
       if (ls != NULL) {
         ls->print_cr("after setting blocked: in_use_list stats: ceiling="
-                     SIZE_FORMAT ", count=%zu, max=%zu",
+                     "%zu, count=%zu, max=%zu",
                      in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
         timer.start();
       }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1954,8 +1954,8 @@ void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
   }
 
   if (l_in_use_count == ck_in_use_count) {
-    out->print_cr("in_use_count=%zu equals ck_in_use_count="
-                  SIZE_FORMAT, l_in_use_count, ck_in_use_count);
+    out->print_cr("in_use_count=%zu equals ck_in_use_count=%zu",
+                  l_in_use_count, ck_in_use_count);
   } else {
     out->print_cr("WARNING: in_use_count=%zu is not equal to "
                   "ck_in_use_count=%zu", l_in_use_count,
@@ -1964,8 +1964,8 @@ void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
 
   size_t ck_in_use_max = _in_use_list.max();
   if (l_in_use_max == ck_in_use_max) {
-    out->print_cr("in_use_max=%zu equals ck_in_use_max="
-                  SIZE_FORMAT, l_in_use_max, ck_in_use_max);
+    out->print_cr("in_use_max=%zu equals ck_in_use_max=%zu",
+                  l_in_use_max, ck_in_use_max);
   } else {
     out->print_cr("WARNING: in_use_max=%zu is not equal to "
                   "ck_in_use_max=%zu", l_in_use_max, ck_in_use_max);

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -204,7 +204,7 @@ void Thread::call_run() {
   JFR_ONLY(Jfr::on_thread_start(this);)
 
   log_debug(os, thread)("Thread " UINTX_FORMAT " stack dimensions: "
-    PTR_FORMAT "-" PTR_FORMAT " (" SIZE_FORMAT "k).",
+    PTR_FORMAT "-" PTR_FORMAT " (%zuk).",
     os::current_thread_id(), p2i(stack_end()),
     p2i(stack_base()), stack_size()/1024);
 
@@ -457,7 +457,7 @@ void Thread::print_on(outputStream* st, bool print_extended_info) const {
               );
     if (is_Java_thread() && (PrintExtendedThreadInfo || print_extended_info)) {
       size_t allocated_bytes = (size_t) const_cast<Thread*>(this)->cooked_allocated_bytes();
-      st->print("allocated=" SIZE_FORMAT "%s ",
+      st->print("allocated=%zu%s ",
                 byte_size_in_proper_unit(allocated_bytes),
                 proper_unit_for_byte_size(allocated_bytes)
                 );

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -309,7 +309,7 @@ void JVMTIAgentLoadDCmd::execute(DCmdSource source, TRAPS) {
       char *opt = (char *)os::malloc(opt_len, mtInternal);
       if (opt == nullptr) {
         output()->print_cr("JVMTI agent attach failed: "
-                           "Could not allocate " SIZE_FORMAT " bytes for argument.",
+                           "Could not allocate %zu bytes for argument.",
                            opt_len);
         return;
       }

--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -123,7 +123,7 @@ char const* GZipCompressor::compress(char* in, size_t in_size, char* out, size_t
     char buf[128];
     // Write the block size used as a comment in the first gzip chunk, so the
     // code used to read it later can make a good choice of the buffer sizes it uses.
-    jio_snprintf(buf, sizeof(buf), "HPROF BLOCKSIZE=" SIZE_FORMAT, _block_size);
+    jio_snprintf(buf, sizeof(buf), "HPROF BLOCKSIZE=%zu", _block_size);
     *compressed_size = gzip_compress_func(in, in_size, out, out_size, tmp, tmp_size, _level,
                                           buf, &msg);
     _is_first = false;

--- a/src/hotspot/share/services/lowMemoryDetector.cpp
+++ b/src/hotspot/share/services/lowMemoryDetector.cpp
@@ -379,7 +379,7 @@ void SensorInfo::clear(int count, TRAPS) {
 
 #ifndef PRODUCT
 void SensorInfo::print() {
-  tty->print_cr("%s count = " SIZE_FORMAT " pending_triggers = %d pending_clears = %d",
+  tty->print_cr("%s count = %zu pending_triggers = %d pending_clears = %d",
                 (_sensor_on ? "on" : "off"),
                 _sensor_count, _pending_trigger_count, _pending_clear_count);
 }

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -262,7 +262,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
     } else {
       where = "just outside of";
     }
-    st->print_cr(PTR_FORMAT " %s %s malloced block starting at " PTR_FORMAT ", size " SIZE_FORMAT ", tag %s",
+    st->print_cr(PTR_FORMAT " %s %s malloced block starting at " PTR_FORMAT ", size %zu, tag %s",
                  p2i(p), where,
                  (block->is_dead() ? "dead" : "live"),
                  p2i(block + 1), // lets print the payload start, not the header

--- a/src/hotspot/share/services/nmtPreInit.cpp
+++ b/src/hotspot/share/services/nmtPreInit.cpp
@@ -132,7 +132,7 @@ void NMTPreInitAllocationTable::print_state(outputStream* st) const {
     num_entries += chain_len;
     longest_chain = MAX2(chain_len, longest_chain);
   }
-  st->print("entries: %d (primary: %d, empties: %d), sum bytes: " SIZE_FORMAT
+  st->print("entries: %d (primary: %d, empties: %d), sum bytes: %zu"
             ", longest chain length: %d",
             num_entries, num_primary_entries, table_size - num_primary_entries,
             sum_bytes, longest_chain);
@@ -143,7 +143,7 @@ void NMTPreInitAllocationTable::print_map(outputStream* st) const {
   for (int i = 0; i < table_size; i++) {
     st->print("[%d]: ", i);
     for (NMTPreInitAllocation* a = _entries[i]; a != nullptr; a = a->next) {
-      st->print( PTR_FORMAT "(" SIZE_FORMAT ") ", p2i(a->payload), a->size);
+      st->print( PTR_FORMAT "(%zu) ", p2i(a->payload), a->size);
     }
     st->cr();
   }

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -1,6 +1,6 @@
 
 /*
-* Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,7 @@ void ThreadIdTable::grow(JavaThread* jt) {
   }
   gt.done(jt);
   _current_size = table_size();
-  log_info(thread, table)("Grown to size:" SIZE_FORMAT, _current_size);
+  log_info(thread, table)("Grown to size:%zu", _current_size);
 }
 
 class ThreadIdTableLookup : public StackObj {

--- a/src/hotspot/share/services/writeableFlags.cpp
+++ b/src/hotspot/share/services/writeableFlags.cpp
@@ -175,7 +175,7 @@ JVMFlag::Error WriteableFlags::set_uint64_t_flag(const char* name, const char* a
 JVMFlag::Error WriteableFlags::set_size_t_flag(const char* name, const char* arg, JVMFlagOrigin origin, FormatBuffer<80>& err_msg) {
   size_t value;
 
-  if (sscanf(arg, SIZE_FORMAT, &value) == 1) {
+  if (sscanf(arg, "%zu", &value) == 1) {
     return set_flag_impl<JVM_FLAG_TYPE(size_t)>(name, value, origin, err_msg);
   }
   err_msg.print("flag value must be an unsigned integer");

--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -149,24 +149,24 @@ bm_word_t* CHeapBitMap::reallocate(bm_word_t* map, size_t old_size_in_words, siz
 #ifdef ASSERT
 void BitMap::verify_size(idx_t size_in_bits) {
   assert(size_in_bits <= max_size_in_bits(),
-         "out of bounds: " SIZE_FORMAT, size_in_bits);
+         "out of bounds: %zu", size_in_bits);
 }
 
 void BitMap::verify_index(idx_t bit) const {
   assert(bit < _size,
-         "BitMap index out of bounds: " SIZE_FORMAT " >= " SIZE_FORMAT,
+         "BitMap index out of bounds: %zu >= %zu",
          bit, _size);
 }
 
 void BitMap::verify_limit(idx_t bit) const {
   assert(bit <= _size,
-         "BitMap limit out of bounds: " SIZE_FORMAT " > " SIZE_FORMAT,
+         "BitMap limit out of bounds: %zu > %zu",
          bit, _size);
 }
 
 void BitMap::verify_range(idx_t beg, idx_t end) const {
   assert(beg <= end,
-         "BitMap range error: " SIZE_FORMAT " > " SIZE_FORMAT, beg, end);
+         "BitMap range error: %zu > %zu", beg, end);
   verify_limit(end);
 }
 #endif // #ifdef ASSERT
@@ -663,7 +663,7 @@ void BitMap::IteratorImpl::assert_not_empty() const {
 #ifndef PRODUCT
 
 void BitMap::print_on(outputStream* st) const {
-  st->print("Bitmap (" SIZE_FORMAT " bits):", size());
+  st->print("Bitmap (%zu bits):", size());
   for (idx_t index = 0; index < size(); index++) {
     if ((index % 64) == 0) {
       st->cr();

--- a/src/hotspot/share/utilities/chunkedList.hpp
+++ b/src/hotspot/share/utilities/chunkedList.hpp
@@ -73,7 +73,7 @@ template <class T, MEMFLAGS F> class ChunkedList : public CHeapObj<F> {
   }
 
   T at(size_t i) {
-    assert(i < size(), "IOOBE i: " SIZE_FORMAT " size(): " SIZE_FORMAT, i, size());
+    assert(i < size(), "IOOBE i: %zu size(): %zu", i, size());
     return _values[i];
   }
 };

--- a/src/hotspot/share/utilities/copy.cpp
+++ b/src/hotspot/share/utilities/copy.cpp
@@ -71,9 +71,9 @@ public:
     assert(src != nullptr, "address must not be null");
     assert(dst != nullptr, "address must not be null");
     assert(elem_size == 2 || elem_size == 4 || elem_size == 8,
-           "incorrect element size: " SIZE_FORMAT, elem_size);
+           "incorrect element size: %zu", elem_size);
     assert(is_aligned(byte_count, elem_size),
-           "byte_count " SIZE_FORMAT " must be multiple of element size " SIZE_FORMAT, byte_count, elem_size);
+           "byte_count %zu must be multiple of element size %zu", byte_count, elem_size);
 
     address src_end = (address)src + byte_count;
 
@@ -196,7 +196,7 @@ private:
     case 2: do_conjoint_swap<uint16_t,D,swap>(src, dst, byte_count); break;
     case 4: do_conjoint_swap<uint32_t,D,swap>(src, dst, byte_count); break;
     case 8: do_conjoint_swap<uint64_t,D,swap>(src, dst, byte_count); break;
-    default: guarantee(false, "do_conjoint_swap: Invalid elem_size " SIZE_FORMAT "\n", elem_size);
+    default: guarantee(false, "do_conjoint_swap: Invalid elem_size %zu\n", elem_size);
     }
   }
 };

--- a/src/hotspot/share/utilities/elfFile.cpp
+++ b/src/hotspot/share/utilities/elfFile.cpp
@@ -1860,7 +1860,7 @@ bool DwarfFile::MarkedDwarfFileReader::read_string(char* result, const size_t re
     if (next_byte == 0) {
       if (exceeded_buffer) {
         result[result_len - 1] = '\0'; // Mark end of string.
-        DWARF_LOG_ERROR("Tried to read " SIZE_FORMAT " bytes but exceeded buffer size of " SIZE_FORMAT ". Truncating string.",
+        DWARF_LOG_ERROR("Tried to read %zu bytes but exceeded buffer size of %zu. Truncating string.",
                         char_index, result_len);
       }
       return true;

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -355,7 +355,7 @@ void stringStream::write(const char* s, size_t len) {
   }
   const size_t reasonable_max_len = 1 * G;
   if (len >= reasonable_max_len) {
-    assert(false, "bad length? (" SIZE_FORMAT ")", len);
+    assert(false, "bad length? (%zu)", len);
     return;
   }
   size_t write_len = 0;

--- a/src/hotspot/share/utilities/tableStatistics.cpp
+++ b/src/hotspot/share/utilities/tableStatistics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,10 +134,10 @@ TableStatistics::~TableStatistics() { }
 void TableStatistics::print(outputStream* st, const char *table_name) {
   st->print_cr("%s statistics:", table_name);
   st->print_cr("Number of buckets       : %9" PRIuPTR " = %9" PRIuPTR
-               " bytes, each " SIZE_FORMAT,
+               " bytes, each %zu",
               _number_of_buckets, _bucket_bytes, _bucket_size);
   st->print_cr("Number of entries       : %9" PRIuPTR " = %9" PRIuPTR
-               " bytes, each " SIZE_FORMAT,
+               " bytes, each %zu",
                _number_of_entries, _entry_bytes, _entry_size);
   if (_literal_bytes != 0) {
     float literal_avg = (_number_of_entries <= 0) ? 0 : (_literal_bytes / _number_of_entries);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -209,8 +209,8 @@ void VMError::reattempt_test_hit_stack_limit(outputStream* st) {
     const size_t available_headroom   = stack_pointer - unguarded_stack_end;
     const size_t allocation_size      = available_headroom - _reattempt_required_stack_headroom + K;
 
-    st->print_cr("Current Stack Pointer: " PTR_FORMAT " alloca " SIZE_FORMAT
-                 " of " SIZE_FORMAT " bytes available unguarded stack space",
+    st->print_cr("Current Stack Pointer: " PTR_FORMAT " alloca %zu"
+                 " of %zu bytes available unguarded stack space",
                  p2i(stack_pointer), allocation_size, available_headroom);
 
     // Allocate byte blob on the stack. Make pointer volatile to avoid having
@@ -821,7 +821,7 @@ void VMError::report(outputStream* st, bool _verbose) {
           st->print((_id == (int)OOM_MALLOC_ERROR) ? "(malloc) failed to allocate " :
                     (_id == (int)OOM_MMAP_ERROR)   ? "(mmap) failed to map " :
                                                     "(mprotect) failed to protect ");
-          jio_snprintf(buf, sizeof(buf), SIZE_FORMAT, _size);
+          jio_snprintf(buf, sizeof(buf), "%zu", _size);
           st->print("%s", buf);
           st->print(" bytes");
           if (strlen(_detail_msg) > 0) {
@@ -988,7 +988,7 @@ void VMError::report(outputStream* st, bool _verbose) {
     if (fr.sp()) {
       st->print(",  sp=" PTR_FORMAT, p2i(fr.sp()));
       size_t free_stack_size = pointer_delta(fr.sp(), stack_bottom, 1024);
-      st->print(",  free space=" SIZE_FORMAT "k", free_stack_size);
+      st->print(",  free space=%zuk", free_stack_size);
     }
 
     st->cr();

--- a/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
+++ b/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
@@ -264,7 +264,9 @@ TEST(globalDefinitions, format_specifiers) {
   check_format(UINT64_FORMAT_W(-5),    (uint64_t)123,     "123  ");
 
   check_format(SSIZE_FORMAT,           (ssize_t)123,      "123");
+  check_format("%zd",                  (ssize_t)123,      "123");
   check_format(SSIZE_FORMAT,           (ssize_t)-123,     "-123");
+  check_format("%zd",                  (ssize_t)-123,     "-123");
   check_format(SSIZE_FORMAT,           (ssize_t)2147483647, "2147483647");
   check_format(SSIZE_FORMAT,           (ssize_t)-2147483647, "-2147483647");
   check_format(SSIZE_PLUS_FORMAT,      (ssize_t)123,      "+123");
@@ -274,17 +276,20 @@ TEST(globalDefinitions, format_specifiers) {
   check_format(SSIZE_FORMAT_W(5),      (ssize_t)123,      "  123");
   check_format(SSIZE_FORMAT_W(-5),     (ssize_t)123,      "123  ");
   check_format(SIZE_FORMAT,            (size_t)123u,      "123");
+  check_format("%zu",                  (size_t)123u,      "123");
   check_format(SIZE_FORMAT_X,          (size_t)0x123u,    "0x123");
   check_format(SIZE_FORMAT_X_0,        (size_t)0x123u,    "0x" LP64_ONLY("00000000") "00000123");
   check_format(SIZE_FORMAT_W(5),       (size_t)123u,      "  123");
   check_format(SIZE_FORMAT_W(-5),      (size_t)123u,      "123  ");
 
   check_format(INTX_FORMAT,            (intx)123,         "123");
+  check_format("%zd",                  (intx)123,         "123");
   check_format(INTX_FORMAT_X,          (intx)0x123,       "0x123");
   check_format(INTX_FORMAT_W(5),       (intx)123,         "  123");
   check_format(INTX_FORMAT_W(-5),      (intx)123,         "123  ");
 
   check_format(UINTX_FORMAT,           (uintx)123u,       "123");
+  check_format("%zu",                  (uintx)123,        "123");
   check_format(UINTX_FORMAT_X,         (uintx)0x123u,     "0x123");
   check_format(UINTX_FORMAT_W(5),      (uintx)123u,       "  123");
   check_format(UINTX_FORMAT_W(-5),     (uintx)123u,       "123  ");


### PR DESCRIPTION
Replace SIZE_FORMAT with %zu and SIZE_FORMAT_X with 0x%zx using a 4 line sed script:

  sed -e 's/" SIZE_FORMAT "/%zu/g' -e 's/" SIZE_FORMAT,/%zu",/' \
      -e 's/print(SIZE_FORMAT "/print("%zu/g' \
      -e 's/" SIZE_FORMAT_X "/0x%zx/g' -e 's/" SIZE_FORMAT_X,/0x%zx",/g' \
      -e 's/" SIZE_FORMAT$/%zu"/' \
       $f >$f.new

Minor fixups afterwards.  I didn't change SIZE_FORMAT_W(number) because it would have required a better sed script.

The definitions in globalDefinitions.hpp can be removed with a later PR, once all instances are cleaned out.  This is partial so that people start using %zu instead.

Tested with tier1 on Oracle supported platforms.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8256379](https://bugs.openjdk.org/browse/JDK-8256379): Replace SIZE_FORMAT with 'z' length modifier (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15115/head:pull/15115` \
`$ git checkout pull/15115`

Update a local copy of the PR: \
`$ git checkout pull/15115` \
`$ git pull https://git.openjdk.org/jdk.git pull/15115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15115`

View PR using the GUI difftool: \
`$ git pr show -t 15115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15115.diff">https://git.openjdk.org/jdk/pull/15115.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15115#issuecomment-1663124447)