### PR TITLE
8313274: [BACKOUT] Relax prerequisites for java.base-jmod target

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -971,8 +971,7 @@ else
   # When creating the BUILDJDK, we don't need to add hashes to java.base, thus
   # we don't need to depend on all other jmods
   ifneq ($(CREATING_BUILDJDK), true)
-    java.base-jmod: jrtfs-jar $(filter-out java.base-jmod \
-        $(addsuffix -jmod, $(call FindAllUpgradeableModules)), $(JMOD_TARGETS))
+    java.base-jmod: jrtfs-jar $(filter-out java.base-jmod, $(JMOD_TARGETS))
   endif
 
   # If not already set, set the JVM target so that the JVM will be built.


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix https://bugs.openjdk.org/browse/JDK-8313274? 

The commit in this PR reverts the commit that was introduced in https://github.com/openjdk/jdk/pull/14561. Martin, in the 8313274 JBS issue, notes that the failure started happening with that change.

The issue can be consistently reproduced using `--with-jobs=1` during `bash configure` and then triggering a build using `make images`. After the revert of that commit, the build now passes with both `--with-jobs=1` and without the `--with-jobs` option (in which case it uses 8 jobs on my setup). 

The other PR where this commit was introduced noted that:

> Fixing this won't impact the build much, but certainly won't hurt either.

which I think meant that the change in that PR is mostly a good to have. Given that it does cause these unexpected failures, the proposal in this PR is to revert that change until we have a better way to do that change (if we want to do it).

tier testing is currently in progress with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313274](https://bugs.openjdk.org/browse/JDK-8313274): [BACKOUT] Relax prerequisites for java.base-jmod target (**Sub-task** - P1)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15118/head:pull/15118` \
`$ git checkout pull/15118`

Update a local copy of the PR: \
`$ git checkout pull/15118` \
`$ git pull https://git.openjdk.org/jdk.git pull/15118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15118`

View PR using the GUI difftool: \
`$ git pr show -t 15118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15118.diff">https://git.openjdk.org/jdk/pull/15118.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15118#issuecomment-1661613946)