### PR TITLE
8313592: RISC-V: Link libatomic statically

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -112,7 +112,7 @@ AC_DEFUN([LIB_SETUP_JVM_LIBS],
   # Because RISC-V only has word-sized atomics, it requires libatomic where
   # other common architectures do not, so link libatomic by default.
   if test "x$OPENJDK_$1_OS" = xlinux && test "x$OPENJDK_$1_CPU" = xriscv64; then
-    BASIC_JVM_LIBS_$1="$BASIC_JVM_LIBS_$1 -latomic"
+    BASIC_JVM_LIBS_$1="$BASIC_JVM_LIBS_$1 -l:libatomic.a"
   fi
 ])
 


### PR DESCRIPTION
Currently, RISC-V differs from other platforms in that it requires the linkage to libatomic.so to support sub-word atomic operations. However, because it is linked dynamically, it will depend on the installation of libatomic.so on the system where the Java application will run, which no other platform require.

Instead of dynamically linking, we can statically link so that there is no dependency at run-time as it's already statically linked into libjvm.so.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313592](https://bugs.openjdk.org/browse/JDK-8313592): RISC-V: Link libatomic statically (**Task** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15119/head:pull/15119` \
`$ git checkout pull/15119`

Update a local copy of the PR: \
`$ git checkout pull/15119` \
`$ git pull https://git.openjdk.org/jdk.git pull/15119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15119`

View PR using the GUI difftool: \
`$ git pr show -t 15119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15119.diff">https://git.openjdk.org/jdk/pull/15119.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15119#issuecomment-1661618161)