### PR TITLE
8313593: Generational ZGC: NMT assert when the heap fails to expand

### DIFF
--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
@@ -310,7 +310,9 @@ bool ZPhysicalMemoryManager::commit(ZPhysicalMemory& pmem) {
     const size_t committed = _backing.commit(segment.start(), segment.size());
 
     // Register with NMT
-    ZNMT::commit(segment.start(), committed);
+    if (committed > 0) {
+      ZNMT::commit(segment.start(), committed);
+    }
 
     // Register committed segment
     if (!pmem.commit_segment(i, committed)) {
@@ -336,7 +338,9 @@ bool ZPhysicalMemoryManager::uncommit(ZPhysicalMemory& pmem) {
     const size_t uncommitted = _backing.uncommit(segment.start(), segment.size());
 
     // Unregister with NMT
-    ZNMT::uncommit(segment.start(), uncommitted);
+    if (uncommitted > 0) {
+      ZNMT::uncommit(segment.start(), uncommitted);
+    }
 
     // Deregister uncommitted segment
     if (!pmem.uncommit_segment(i, uncommitted)) {


### PR DESCRIPTION
The following assert is hit when the ZGC fails to commit more memory for the heap:

assert(size > 0) failed: Invalid size
...
V  [libjvm.so+0x185d157]  VirtualMemoryTracker::add_committed_region(unsigned char*, unsigned long, NativeCallStack const&)+0x4d7  (virtualMemoryTracker.cpp:428)
V  [libjvm.so+0x19c1f33]  ZNMT::process_fake_mapping(zoffset, unsigned long, bool)+0xa3  (memTracker.hpp:168)
V  [libjvm.so+0x19db817]  ZPhysicalMemoryManager::commit(ZPhysicalMemory&)+0x47  (zPhysicalMemory.cpp:312)
V  [libjvm.so+0x19d1e4b]  ZPageAllocator::alloc_page_finalize(ZPageAllocation*)+0x6b  (zPageAllocator.cpp:427)

The problem is that we still call the NMT reporting code even when the committed size is zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313593](https://bugs.openjdk.org/browse/JDK-8313593): Generational ZGC: NMT assert when the heap fails to expand (**Bug** - P2)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15120/head:pull/15120` \
`$ git checkout pull/15120`

Update a local copy of the PR: \
`$ git checkout pull/15120` \
`$ git pull https://git.openjdk.org/jdk.git pull/15120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15120`

View PR using the GUI difftool: \
`$ git pr show -t 15120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15120.diff">https://git.openjdk.org/jdk/pull/15120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15120#issuecomment-1661647261)