### PR TITLE
JDK-8313602: increase timeout for jdk/classfile/CorpusTest.java

### DIFF
--- a/test/jdk/jdk/classfile/CorpusTest.java
+++ b/test/jdk/jdk/classfile/CorpusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @test
  * @summary Testing Classfile on small Corpus.
  * @build helpers.* testdata.*
- * @run junit/othervm -Djunit.jupiter.execution.parallel.enabled=true CorpusTest
+ * @run junit/othervm/timeout=480 -Djunit.jupiter.execution.parallel.enabled=true CorpusTest
  */
 import helpers.ClassRecord;
 import helpers.ClassRecord.CompatibilityFilter;


### PR DESCRIPTION
On some slow machines (e.g. Alpine) we see sporadic timeouts of the jdk/classfile/CorpusTest.java test, even with an increased standard timeout factor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313602](https://bugs.openjdk.org/browse/JDK-8313602): increase timeout for jdk/classfile/CorpusTest.java (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15122/head:pull/15122` \
`$ git checkout pull/15122`

Update a local copy of the PR: \
`$ git checkout pull/15122` \
`$ git pull https://git.openjdk.org/jdk.git pull/15122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15122`

View PR using the GUI difftool: \
`$ git pr show -t 15122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15122.diff">https://git.openjdk.org/jdk/pull/15122.diff</a>

</details>
