### PR TITLE
8308850: Change JVM options with small ranges from 64 to 32 bits, for globals.hpp

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5774,7 +5774,7 @@ void MacroAssembler::clear_mem(Register base, Register cnt, Register tmp, XMMReg
   assert(base==rdi, "base register must be edi for rep stos");
   assert(tmp==rax,   "tmp register must be eax for rep stos");
   assert(cnt==rcx,   "cnt register must be ecx for rep stos");
-  assert(InitArrayShortSize % BytesPerLong == 0,
+  assert(InitArrayShortSize % (intx)BytesPerLong == 0,
     "InitArrayShortSize should be the multiple of BytesPerLong");
 
   Label DONE;
@@ -5784,7 +5784,7 @@ void MacroAssembler::clear_mem(Register base, Register cnt, Register tmp, XMMReg
 
   if (!is_large) {
     Label LOOP, LONG;
-    cmpptr(cnt, InitArrayShortSize/BytesPerLong);
+    cmpptr(cnt, (int)(InitArrayShortSize/(intx)BytesPerLong));
     jccb(Assembler::greater, LONG);
 
     NOT_LP64(shlptr(cnt, 1);) // convert to number of 32-bit words for 32-bit VM

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -2393,9 +2393,9 @@ address StubGenerator::generate_generic_copy(const char *name,
   const Register rklass_tmp = rdi;  // load_klass
 #endif
 
-  { int modulus = CodeEntryAlignment;
-    int target  = modulus - 5; // 5 = sizeof jmp(L_failed)
-    int advance = target - (__ offset() % modulus);
+  { intx modulus = CodeEntryAlignment;
+    intx target  = modulus - 5; // 5 = sizeof jmp(L_failed)
+    intx advance = target - (__ offset() % modulus);
     if (advance < 0)  advance += modulus;
     if (advance > 0)  __ nop(advance);
   }

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1866,8 +1866,8 @@ void VM_Version::get_processor_features() {
 #endif
 
   if (FLAG_IS_DEFAULT(ContendedPaddingWidth) &&
-     (cache_line_size > ContendedPaddingWidth))
-     ContendedPaddingWidth = cache_line_size;
+     ((int)cache_line_size > ContendedPaddingWidth))
+     ContendedPaddingWidth = (int)cache_line_size;
 
   // This machine allows unaligned memory accesses
   if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -464,7 +464,7 @@ void CodeBuffer::compute_final_layout(CodeBuffer* dest) const {
 
   {
     // not sure why this is here, but why not...
-    int alignSize = MAX2((intx) sizeof(jdouble), CodeEntryAlignment);
+    intx alignSize = MAX2((intx) sizeof(jdouble), CodeEntryAlignment);
     assert( (dest->_total_start - _insts.start()) % alignSize == 0, "copy must preserve alignment");
   }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -751,7 +751,7 @@ void CodeCache::update_cold_gc_count() {
   _unloading_allocation_rates.add(allocation_rate);
   _unloading_gc_intervals.add(gc_interval);
 
-  size_t aggressive_sweeping_free_threshold = StartAggressiveSweepingAt / 100.0 * max;
+  size_t aggressive_sweeping_free_threshold = (size_t)((double)StartAggressiveSweepingAt / 100.0) * max;
   if (free < aggressive_sweeping_free_threshold) {
     // We are already in the red zone; be very aggressive to avoid disaster
     // But not more aggressive than 2. This ensures that an nmethod must
@@ -768,7 +768,7 @@ void CodeCache::update_cold_gc_count() {
   double average_gc_interval = _unloading_gc_intervals.avg();
   double average_allocation_rate = _unloading_allocation_rates.avg();
   double time_to_aggressive = ((double)(free - aggressive_sweeping_free_threshold)) / average_allocation_rate;
-  double cold_timeout = time_to_aggressive / NmethodSweepActivity;
+  double cold_timeout = time_to_aggressive / (double)NmethodSweepActivity;
 
   // Convert time to GC cycles, and crop at INT_MAX. The reason for
   // that is that the _cold_gc_count will be added to an epoch number
@@ -800,7 +800,7 @@ void CodeCache::gc_on_allocation() {
   size_t max = max_capacity();
   size_t used = max - free;
   double free_ratio = double(free) / double(max);
-  if (free_ratio <= StartAggressiveSweepingAt / 100.0)  {
+  if (free_ratio <= (double)StartAggressiveSweepingAt / 100.0)  {
     // In case the GC is concurrent, we make sure only one thread requests the GC.
     if (Atomic::cmpxchg(&_unloading_threshold_gc_requested, false, true) == false) {
       log_info(codecache)("Triggering aggressive GC due to having only %.3f%% free memory", free_ratio * 100.0);

--- a/src/hotspot/share/code/icBuffer.hpp
+++ b/src/hotspot/share/code/icBuffer.hpp
@@ -64,7 +64,7 @@ class ICStub: public Stub {
 
   // ICStub_from_destination_address looks up Stub* address from code entry address,
   // which unfortunately means the stub head should be at the same alignment as the code.
-  static  int alignment()                        { return CodeEntryAlignment; }
+  static  intx alignment()                        { return CodeEntryAlignment; }
 
  public:
   // Creation

--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -914,7 +914,7 @@ bool CompilationPolicy::is_mature(Method* method) {
   if (mdo != nullptr) {
     int i = mdo->invocation_count();
     int b = mdo->backedge_count();
-    double k = ProfileMaturityPercentage / 100.0;
+    double k = (double)ProfileMaturityPercentage / 100.0;
     return CallPredicate::apply_scaled(mh, CompLevel_full_profile, i, b, k) || LoopPredicate::apply_scaled(mh, CompLevel_full_profile, i, b, k);
   }
   return false;

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -438,7 +438,7 @@ void CompilerConfig::set_jvmci_specific_flags() {
         // so that we can then double the computed stack size. Once
         // the stack size requirements of SVM are better understood,
         // this logic can be pushed down into os::create_thread.
-        int stack_size = CompilerThreadStackSize;
+        intx stack_size = CompilerThreadStackSize;
         if (stack_size == 0) {
           stack_size = VMThreadStackSize;
         }

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -101,7 +101,7 @@ void MutableSpace::initialize(MemRegion mr,
       // Limit the amount of page manipulation if necessary.
       if (NUMASpaceResizeRate > 0 && !AlwaysPreTouch) {
         const size_t change_size = head_size + tail_size;
-        const float setup_rate_words = NUMASpaceResizeRate >> LogBytesPerWord;
+        const float setup_rate_words = (float)(NUMASpaceResizeRate >> LogBytesPerWord);
         head_size = MIN2((size_t)(setup_rate_words * head_size / change_size),
                          head_size);
         tail_size = MIN2((size_t)(setup_rate_words * tail_size / change_size),

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ void TenuredGeneration::compute_new_size_inner() {
 
   // We don't have floating point command-line arguments
   // Note:  argument processing ensures that MinHeapFreeRatio < 100.
-  const double minimum_free_percentage = MinHeapFreeRatio / 100.0;
+  const double minimum_free_percentage = (double)MinHeapFreeRatio / 100.0;
   const double maximum_used_percentage = 1.0 - minimum_free_percentage;
 
   // Compute some numbers about the state of the heap.
@@ -206,7 +206,7 @@ void TenuredGeneration::compute_new_size_inner() {
   size_t max_shrink_bytes = capacity_after_gc - minimum_desired_capacity;
 
   if (MaxHeapFreeRatio < 100) {
-    const double maximum_free_percentage = MaxHeapFreeRatio / 100.0;
+    const double maximum_free_percentage = (double)MaxHeapFreeRatio / 100.0;
     const double minimum_used_percentage = 1.0 - maximum_free_percentage;
     const double max_tmp = used_after_gc / minimum_used_percentage;
     size_t maximum_desired_capacity = (size_t)MIN2(max_tmp, double(max_uintx));

--- a/src/hotspot/share/interpreter/templateInterpreter.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.cpp
@@ -50,7 +50,7 @@ void TemplateInterpreter::initialize_stub() {
   // 270+ interpreter codelets are generated and each of them is aligned to HeapWordSize,
   // plus their code section is aligned to CodeEntryAlignement. So we need additional size due to alignment.
   int max_aligned_codelets = 280;
-  int max_aligned_bytes = max_aligned_codelets * (HeapWordSize + CodeEntryAlignment);
+  int max_aligned_bytes = max_aligned_codelets * (HeapWordSize + (int)CodeEntryAlignment);
   _code = new StubQueue(new InterpreterCodeletInterface, code_size + max_aligned_bytes, nullptr,
                         "Interpreter");
 }

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -140,7 +140,7 @@ void JVMCI::initialize_globals() {
     if (JVMCIEventLogLevel > 0) {
       _events = new StringEventLog("JVMCI Events", "jvmci");
       if (JVMCIEventLogLevel > 1) {
-        int count = LogEventsBufferEntries;
+        uintx count = LogEventsBufferEntries;
         for (int i = 1; i < JVMCIEventLogLevel && i < max_EventLog_level; i++) {
           // Expand event buffer by 10x for each level above 1
           count = count * 10;

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -250,8 +250,8 @@ void JVMCIEnv::describe_pending_exception(outputStream* st) {
     // Use up to half the lines of the JVMCI event log to
     // show the stack trace.
     char* cursor = stack_trace;
-    int line = 0;
-    const int max_lines = LogEventsBufferEntries / 2;
+    uintx line = 0;
+    const uintx max_lines = LogEventsBufferEntries / 2;
     char* last_line = nullptr;
     while (*cursor != '\0') {
       char* eol = strchr(cursor, '\n');
@@ -275,7 +275,7 @@ void JVMCIEnv::describe_pending_exception(outputStream* st) {
     }
     if (last_line != nullptr) {
       if (line > max_lines) {
-        JVMCI_event_1("%s [elided %d more stack trace lines]", last_line, line - max_lines);
+        JVMCI_event_1("%s [elided %ld more stack trace lines]", last_line, line - max_lines);
       } else {
         JVMCI_event_1("%s", last_line);
       }

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -433,7 +433,7 @@ void MetaspaceGC::compute_new_size() {
   const size_t used_after_gc = MetaspaceUtils::committed_bytes();
   const size_t capacity_until_GC = MetaspaceGC::capacity_until_GC();
 
-  const double minimum_free_percentage = MinMetaspaceFreeRatio / 100.0;
+  const double minimum_free_percentage = (double)MinMetaspaceFreeRatio / 100.0;
   const double maximum_used_percentage = 1.0 - minimum_free_percentage;
 
   const double min_tmp = used_after_gc / maximum_used_percentage;
@@ -466,7 +466,7 @@ void MetaspaceGC::compute_new_size() {
       log_trace(gc, metaspace)("    expanding:  minimum_desired_capacity: %6.1fKB  expand_bytes: %6.1fKB  MinMetaspaceExpansion: %6.1fKB  new metaspace HWM:  %6.1fKB",
                                minimum_desired_capacity / (double) K,
                                expand_bytes / (double) K,
-                               MinMetaspaceExpansion / (double) K,
+                               (double)MinMetaspaceExpansion / (double) K,
                                new_capacity_until_GC / (double) K);
     }
     return;
@@ -481,7 +481,7 @@ void MetaspaceGC::compute_new_size() {
 
   // Should shrinking be considered?
   if (MaxMetaspaceFreeRatio < 100) {
-    const double maximum_free_percentage = MaxMetaspaceFreeRatio / 100.0;
+    const double maximum_free_percentage = (double)MaxMetaspaceFreeRatio / 100.0;
     const double minimum_used_percentage = 1.0 - maximum_free_percentage;
     const double max_tmp = used_after_gc / minimum_used_percentage;
     size_t maximum_desired_capacity = (size_t)MIN2(max_tmp, double(MaxMetaspaceSize));
@@ -517,9 +517,9 @@ void MetaspaceGC::compute_new_size() {
         _shrink_factor = MIN2(current_shrink_factor * 4, (uint) 100);
       }
       log_trace(gc, metaspace)("    shrinking:  initThreshold: %.1fK  maximum_desired_capacity: %.1fK",
-                               MetaspaceSize / (double) K, maximum_desired_capacity / (double) K);
+                               (double)MetaspaceSize / (double) K, maximum_desired_capacity / (double) K);
       log_trace(gc, metaspace)("    shrink_bytes: %.1fK  current_shrink_factor: %d  new shrink factor: %d  MinMetaspaceExpansion: %.1fK",
-                               shrink_bytes / (double) K, current_shrink_factor, _shrink_factor, MinMetaspaceExpansion / (double) K);
+                               shrink_bytes / (double) K, current_shrink_factor, _shrink_factor, (double)MinMetaspaceExpansion / (double) K);
     }
   }
 
@@ -708,7 +708,7 @@ void Metaspace::ergo_initialize() {
     // class space : non class space usage is about 1:6. With many small classes,
     // it can get as low as 1:2. It is not a big deal though since ccs is only
     // reserved and will be committed on demand only.
-    size_t max_ccs_size = MaxMetaspaceSize * 0.8;
+    size_t max_ccs_size = (size_t)((double)MaxMetaspaceSize * 0.8);
     size_t adjusted_ccs_size = MIN2(CompressedClassSpaceSize, max_ccs_size);
 
     // CCS must be aligned to root chunk size, and be at least the size of one

--- a/src/hotspot/share/oops/typeArrayKlass.cpp
+++ b/src/hotspot/share/oops/typeArrayKlass.cpp
@@ -343,7 +343,7 @@ void TypeArrayKlass::oop_print_on(oop obj, outputStream* st) {
 }
 
 void TypeArrayKlass::oop_print_elements_on(typeArrayOop ta, outputStream* st) {
-  int print_len = MIN2((intx) ta->length(), MaxElementPrintSize);
+  int print_len = MIN2( ta->length(), MaxElementPrintSize);
   switch (element_type()) {
     case T_BOOLEAN: print_boolean_array(ta, print_len, st); break;
     case T_CHAR:    print_char_array(ta, print_len, st);    break;

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -93,7 +93,7 @@ void MethodHandles::generate_adapters() {
   // The adapter entry is required to be aligned to CodeEntryAlignment.
   // So we need additional bytes due to alignment.
   int adapter_num = (int)Interpreter::method_handle_invoke_LAST - (int)Interpreter::method_handle_invoke_FIRST + 1;
-  int max_aligned_bytes = adapter_num * CodeEntryAlignment;
+  int max_aligned_bytes = adapter_num * (int)CodeEntryAlignment;
   _adapter_code = MethodHandlesAdapterBlob::create(adapter_code_size + max_aligned_bytes);
   CodeBuffer code(_adapter_code);
   MethodHandlesAdapterGenerator g(&code);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -204,7 +204,7 @@ const int ObjectAlignmentInBytes = 8;
           "Granularity to use for NUMA interleaving on Windows OS")         \
           constraint(NUMAInterleaveGranularityConstraintFunc, AtParse)      \
                                                                             \
-  product(uintx, NUMAChunkResizeWeight, 20,                                 \
+  product(uint, NUMAChunkResizeWeight, 20,                                  \
           "Percentage (0-100) used to weight the current sample when "      \
           "computing exponentially decaying average for "                   \
           "AdaptiveNUMAChunkSizing")                                        \
@@ -553,7 +553,7 @@ const int ObjectAlignmentInBytes = 8;
           "directory) of the dump file (defaults to java_pid<pid>.hprof "   \
           "in the working directory)")                                      \
                                                                             \
-  product(intx, HeapDumpGzipLevel, 0, MANAGEABLE,                           \
+  product(uint, HeapDumpGzipLevel, 0, MANAGEABLE,                           \
           "When HeapDumpOnOutOfMemoryError is on, the gzip compression "    \
           "level of the dump file. 0 (the default) disables gzip "          \
           "compression. Otherwise the level must be between 1 and 9.")      \
@@ -726,10 +726,10 @@ const int ObjectAlignmentInBytes = 8;
   /* because of overflow issue                                   */         \
   product(intx, MonitorDeflationMax, 1000000, DIAGNOSTIC,                   \
           "The maximum number of monitors to deflate, unlink and delete "   \
-          "at one time (minimum is 1024).")                      \
+          "at one time (minimum is 1024).")                                 \
           range(1024, max_jint)                                             \
                                                                             \
-  product(intx, MonitorUsedDeflationThreshold, 90, DIAGNOSTIC,              \
+  product(int, MonitorUsedDeflationThreshold, 90, DIAGNOSTIC,               \
           "Percentage of used monitors before triggering deflation (0 is "  \
           "off). The check is performed on GuaranteedSafepointInterval, "   \
           "AsyncDeflationInterval or GuaranteedAsyncDeflationInterval, "    \
@@ -802,7 +802,7 @@ const int ObjectAlignmentInBytes = 8;
   /* 8K is well beyond the reasonable HW cache line size, even with       */\
   /* aggressive prefetching, while still leaving the room for segregating */\
   /* among the distinct pages.                                            */\
-  product(intx, ContendedPaddingWidth, 128,                                 \
+  product(int, ContendedPaddingWidth, 128,                                  \
           "How many bytes to pad the fields/classes marked @Contended with")\
           range(0, 8192)                                                    \
           constraint(ContendedPaddingWidthConstraintFunc,AfterErgo)         \
@@ -918,7 +918,7 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   /* notice: the max range value here is max_jint, not max_intx  */         \
   /* because of overflow issue                                   */         \
-  product(intx, CICompilerCount, CI_COMPILER_COUNT,                         \
+  product(int, CICompilerCount, CI_COMPILER_COUNT,                          \
           "Number of compiler threads to run")                              \
           range(0, max_jint)                                                \
           constraint(CICompilerCountConstraintFunc, AfterErgo)              \
@@ -1315,7 +1315,7 @@ const int ObjectAlignmentInBytes = 8;
           "max number of compiled code units to print in error log")        \
           range(0, VMError::max_error_log_print_code)                       \
                                                                             \
-  notproduct(intx, MaxElementPrintSize, 256,                                \
+  notproduct(int, MaxElementPrintSize, 256,                                 \
           "maximum number of elements to print")                            \
                                                                             \
   notproduct(intx, MaxSubklassPrintSize, 4,                                 \
@@ -1355,7 +1355,7 @@ const int ObjectAlignmentInBytes = 8;
           "-XX:MallocLimit=2g:oom"                                          \
           "-XX:MallocLimit=compiler:200m:oom,code:100m")                    \
                                                                             \
-  product(intx, TypeProfileWidth, 2,                                        \
+  product(int, TypeProfileWidth, 2,                                         \
           "Number of receiver types to record in call/cast profile")        \
           range(0, 8)                                                       \
                                                                             \

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -227,7 +227,7 @@ static BufferBlob* initialize_stubs(StubCodeGenerator::StubsKind kind,
   ResourceMark rm;
   TraceTime timer(timer_msg, TRACETIME_LOG(Info, startuptime));
   // Add extra space for large CodeEntryAlignment
-  int size = code_size + CodeEntryAlignment * max_aligned_stubs;
+  int size = code_size + (int)CodeEntryAlignment * max_aligned_stubs;
   BufferBlob* stubs_code = BufferBlob::create(buffer_name, size);
   if (stubs_code == nullptr) {
     vm_exit_out_of_memory(code_size, OOM_MALLOC_ERROR, "CodeCache: no room for %s", buffer_name);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1169,7 +1169,7 @@ static bool monitors_used_above_threshold(MonitorList* list) {
   }
   if (NoAsyncDeflationProgressMax != 0 &&
       _no_progress_cnt >= NoAsyncDeflationProgressMax) {
-    float remainder = (100.0 - MonitorUsedDeflationThreshold) / 100.0;
+    float remainder = (100.0F - (float)MonitorUsedDeflationThreshold) / 100.0F;
     size_t new_ceiling = ceiling + (ceiling * remainder) + 1;
     ObjectSynchronizer::set_in_use_list_ceiling(new_ceiling);
     log_info(monitorinflation)("Too many deflations without progress; "
@@ -1183,7 +1183,7 @@ static bool monitors_used_above_threshold(MonitorList* list) {
   size_t monitor_usage = (monitors_used * 100LL) / ceiling;
   if (int(monitor_usage) > MonitorUsedDeflationThreshold) {
     log_info(monitorinflation)("monitors_used=" SIZE_FORMAT ", ceiling=" SIZE_FORMAT
-                               ", monitor_usage=" SIZE_FORMAT ", threshold=" INTX_FORMAT,
+                               ", monitor_usage=" SIZE_FORMAT ", threshold=" INT32_FORMAT,
                                monitors_used, ceiling, monitor_usage, MonitorUsedDeflationThreshold);
     return true;
   }


### PR DESCRIPTION
All the JVM options in `globals.hpp` are free of `-Wconversion` warnings.

###Tests
local: tier1 on linux-x64
mach5: tiers 1-4, linux-x64, linux-x64-debug, windows-x64-debug