### PR TITLE
8313554: Fix -Wconversion warnings for ResolvedFieldEntry

### DIFF
--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -716,7 +716,9 @@ void InterpreterRuntime::resolve_get_put(JavaThread* current, Bytecodes::Code by
 
   ResolvedFieldEntry* entry = pool->resolved_field_entry_at(field_index);
   entry->set_flags(info.access_flags().is_final(), info.access_flags().is_volatile());
-  entry->fill_in(info.field_holder(), info.offset(), (u2)info.index(), (u1)state, (u1)get_code, (u1)put_code);
+  entry->fill_in(info.field_holder(), info.offset(),
+                 checked_cast<u2>(info.index()), checked_cast<u1>(state),
+                 static_cast<u1>(get_code), static_cast<u1>(put_code));
 }
 
 

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -185,11 +185,11 @@ void Rewriter::rewrite_field_reference(address bcp, int offset, bool reverse) {
   if (!reverse) {
     int cp_index = Bytes::get_Java_u2(p);
     int field_entry_index = _cp_map.at(cp_index);
-    Bytes::put_native_u2(p, (u2)field_entry_index);
+    Bytes::put_native_u2(p, checked_cast<u2>(field_entry_index));
   } else {
     int field_entry_index = Bytes::get_native_u2(p);
     int pool_index = _initialized_field_entries.at(field_entry_index).constant_pool_index();
-    Bytes::put_Java_u2(p, (u2)pool_index);
+    Bytes::put_Java_u2(p, checked_cast<u2>(pool_index));
   }
 }
 

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -185,11 +185,11 @@ void Rewriter::rewrite_field_reference(address bcp, int offset, bool reverse) {
   if (!reverse) {
     int cp_index = Bytes::get_Java_u2(p);
     int field_entry_index = _cp_map.at(cp_index);
-    Bytes::put_native_u2(p, field_entry_index);
+    Bytes::put_native_u2(p, (u2)field_entry_index);
   } else {
     int field_entry_index = Bytes::get_native_u2(p);
     int pool_index = _initialized_field_entries.at(field_entry_index).constant_pool_index();
-    Bytes::put_Java_u2(p, pool_index);
+    Bytes::put_Java_u2(p, (u2)pool_index);
   }
 }
 

--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -101,11 +101,11 @@ public:
   // Printing
   void print_on(outputStream* st) const;
 
-  void set_flags(bool is_final, bool is_volatile) {
-    int new_flags = (is_final << is_final_shift) | static_cast<int>(is_volatile);
+  void set_flags(bool is_final_flag, bool is_volatile_flag) {
+    int new_flags = (is_final_flag << is_final_shift) | static_cast<int>(is_volatile_flag);
     _flags = checked_cast<u1>(new_flags);
-    assert(is_final() == is_final, "Must be");
-    assert(is_volatile() == is_volatile, "Must be");
+    assert(is_final() == is_final_flag, "Must be");
+    assert(is_volatile() == is_volatile_flag, "Must be");
   }
 
   inline void set_bytecode(u1* code, u1 new_code) {

--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -104,6 +104,8 @@ public:
   void set_flags(bool is_final, bool is_volatile) {
     int new_flags = (is_final << is_final_shift) | static_cast<int>(is_volatile);
     _flags = checked_cast<u1>(new_flags);
+    assert(is_final() == is_final, "Must be");
+    assert(is_volatile() == is_volatile, "Must be");
   }
 
   inline void set_bytecode(u1* code, u1 new_code) {

--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -50,7 +50,7 @@ class ResolvedFieldEntry {
   int _field_offset;            // Field offset in bytes
   u2 _field_index;              // Index into field information in holder InstanceKlass
   u2 _cpool_index;              // Constant pool index
-  u1 _tos_state;                      // TOS state
+  u1 _tos_state;                // TOS state
   u1 _flags;                    // Flags: [0000|00|is_final|is_volatile]
   u1 _get_code, _put_code;      // Get and Put bytecodes of the field
 
@@ -102,8 +102,8 @@ public:
   void print_on(outputStream* st) const;
 
   void set_flags(bool is_final, bool is_volatile) {
-    u1 new_flags = (static_cast<u1>(is_final) << static_cast<u1>(is_final_shift)) | static_cast<u1>(is_volatile);
-    _flags = new_flags;
+    int new_flags = (is_final << is_final_shift) | static_cast<int>(is_volatile);
+    _flags = (u1)new_flags;
   }
 
   inline void set_bytecode(u1* code, u1 new_code) {
@@ -116,7 +116,7 @@ public:
   }
 
   // Populate the strucutre with resolution information
-  void fill_in(InstanceKlass* klass, intx offset, int index, int tos_state, u1 b1, u1 b2) {
+  void fill_in(InstanceKlass* klass, int offset, u2 index, u1 tos_state, u1 b1, u1 b2) {
     _field_holder = klass;
     _field_offset = offset;
     _field_index = index;

--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -103,7 +103,7 @@ public:
 
   void set_flags(bool is_final, bool is_volatile) {
     int new_flags = (is_final << is_final_shift) | static_cast<int>(is_volatile);
-    _flags = (u1)new_flags;
+    _flags = checked_cast<u1>(new_flags);
   }
 
   inline void set_bytecode(u1* code, u1 new_code) {


### PR DESCRIPTION
The recent change in [JDK-8301996](https://bugs.openjdk.org/browse/JDK-8301996) added more -Wconversion warnings that are addressed in this patch. The aforementioned change has overlooked inconsistencies with the types used by `ResolvedFieldEntry` and the method `fill_in()`. Verified with tier 1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313554](https://bugs.openjdk.org/browse/JDK-8313554): Fix -Wconversion warnings for ResolvedFieldEntry (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15126/head:pull/15126` \
`$ git checkout pull/15126`

Update a local copy of the PR: \
`$ git checkout pull/15126` \
`$ git pull https://git.openjdk.org/jdk.git pull/15126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15126`

View PR using the GUI difftool: \
`$ git pr show -t 15126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15126.diff">https://git.openjdk.org/jdk/pull/15126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15126#issuecomment-1662914240)