### PR TITLE
8311006: missing @since info in jdk.xml.dom

### DIFF
--- a/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathEvaluator.java
+++ b/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathEvaluator.java
@@ -62,6 +62,8 @@ import org.w3c.dom.DOMException;
  * extension functions or variables as would be defined by other
  * specifications.
  * <p>See also the <a href='https://www.w3.org/TR/DOM-Level-3-XPath/'>Document Object Model (DOM) Level 3 XPath Specification</a>.
+ *
+ * @since 1.4, DOM Level 3
  */
 public interface XPathEvaluator {
     /**

--- a/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathException.java
+++ b/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathException.java
@@ -52,6 +52,8 @@ package org.w3c.dom.xpath;
  * Specification, Working Draft 20 August 2002 where the values of
  * {@link #INVALID_EXPRESSION_ERR} and {@link #TYPE_ERR}
  * are 1 and 2 respectively (instead of 51 and 52 as in the 2004 version).
+ *
+ * @since 1.4, DOM Level 3
  */
 public class XPathException extends RuntimeException {
     private static final long serialVersionUID = 3471034171575979943L;

--- a/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathExpression.java
+++ b/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathExpression.java
@@ -49,6 +49,8 @@ import org.w3c.dom.DOMException;
  * The <code>XPathExpression</code> interface represents a parsed and resolved
  * XPath expression.
  * <p>See also the <a href='https://www.w3.org/TR/DOM-Level-3-XPath/'>Document Object Model (DOM) Level 3 XPath Specification</a>.
+ *
+ * @since 1.4, DOM Level 3
  */
 public interface XPathExpression {
     /**

--- a/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathNSResolver.java
+++ b/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathNSResolver.java
@@ -49,6 +49,8 @@ package org.w3c.dom.xpath;
  * construct an implementation of <code>XPathNSResolver</code> from a node,
  * or the interface may be implemented by any application.
  * <p>See also the <a href='https://www.w3.org/TR/DOM-Level-3-XPath/'>Document Object Model (DOM) Level 3 XPath Specification</a>.
+ *
+ * @since 1.4, DOM Level 3
  */
 public interface XPathNSResolver {
     /**

--- a/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathNamespace.java
+++ b/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathNamespace.java
@@ -75,6 +75,8 @@ import org.w3c.dom.Node;
  * node may be changed incomatibly, in which case incompatible changes to
  * field values may be required to implement versions beyond XPath 1.0.
  * <p>See also the <a href='https://www.w3.org/TR/DOM-Level-3-XPath/'>Document Object Model (DOM) Level 3 XPath Specification</a>.
+ *
+ * @since 1.4, DOM Level 3
  */
 public interface XPathNamespace extends Node {
     // XPathNodeType

--- a/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathResult.java
+++ b/src/jdk.xml.dom/share/classes/org/w3c/dom/xpath/XPathResult.java
@@ -52,6 +52,8 @@ import org.w3c.dom.DOMException;
  * result types, this object makes it possible to discover and manipulate
  * the type and value of the result.
  * <p>See also the <a href='https://www.w3.org/TR/DOM-Level-3-XPath/'>Document Object Model (DOM) Level 3 XPath Specification</a>.
+ *
+ * @since 1.4, DOM Level 3
  */
 public interface XPathResult {
     // XPathResultType


### PR DESCRIPTION
Please review a patch that add `@since` tags following existing convention for XML APIs in java.xml and jdk.xml.dom modules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311006](https://bugs.openjdk.org/browse/JDK-8311006): missing @since info in jdk.xml.dom (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15129/head:pull/15129` \
`$ git checkout pull/15129`

Update a local copy of the PR: \
`$ git checkout pull/15129` \
`$ git pull https://git.openjdk.org/jdk.git pull/15129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15129`

View PR using the GUI difftool: \
`$ git pr show -t 15129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15129.diff">https://git.openjdk.org/jdk/pull/15129.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15129#issuecomment-1663057212)