### PR TITLE
8313239: InetAddress.getCanonicalHostName may return ip address if reverse lookup fails

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -802,8 +802,9 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      *
      * @return  the fully qualified domain name for this IP address. 
      *          If either the operation is not allowed by the security check
-     *          or the system-wide resolver wasn't able to determine the fully qualified domain
-     *          name for the IP address, the textual representation of the IP address is returned instead.
+     *          or the system-wide resolver wasn't able to determine the
+     *          fully qualified domain name for the IP address, the textual
+     *          representation of the IP address is returned instead.
      *
      * @see SecurityManager#checkConnect
      *
@@ -830,10 +831,11 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      *
      * @param check make security check if true
      *
-     * @return  the fully qualified domain name for this IP address, or the textual representation
-     *          of the IP address if either the operation is not allowed by the security check
-     *          or the system-wide resolver wasn't able to determine the fully qualified domain
-     *          name for the IP address.
+     * @return  the fully qualified domain name for this IP address.
+     *          If either the operation is not allowed by the security check
+     *          or the system-wide resolver wasn't able to determine the
+     *          fully qualified domain name for the IP address, the textual
+     *          representation of the IP address is returned instead.
      *
      * @see SecurityManager#checkConnect
      */

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -822,19 +822,19 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
     }
 
     /**
-     * Returns the fully qualified domain name for this address.
+     * Returns the fully qualified domain name for the given address.
      *
      * <p>If there is a security manager, this method first
      * calls its {@code checkConnect} method
      * with the hostname and {@code -1}
      * as its arguments to see if the calling code is allowed to know
-     * the hostname for this IP address, i.e., to connect to the host.
+     * the hostname for the given IP address, i.e., to connect to the host.
      * If the operation is not allowed, it will return
      * the textual representation of the IP address.
      *
      * @param check make security check if true
      *
-     * @return  the fully qualified domain name for this IP address.
+     * @return  the fully qualified domain name for the given IP address.
      *          If either the operation is not allowed by the security check
      *          or the system-wide resolver wasn't able to determine the
      *          fully qualified domain name for the IP address, the textual

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -822,7 +822,7 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
     }
 
     /**
-     * Returns the fully qualified domain for this address.
+     * Returns the fully qualified domain name for this address.
      *
      * <p>If there is a security manager, this method first
      * calls its {@code checkConnect} method

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -790,8 +790,8 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * {@linkplain InetAddressResolver resolver}.
      *
      * <p>The system-wide resolver will be used to do a reverse name lookup of the IP address.
-     * The lookup may fail for reasons such as the host not being registered with the name
-     * service. In such cases, where the resolver isn't able to determine the fully qualified
+     * The lookup can fail for many reasons that include the host not being registered with the name
+     * service. If the resolver is unable to determine the fully qualified
      * domain name, this method returns the {@linkplain #getHostAddress() textual representation}
      * of the IP address.
      *

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -731,8 +731,8 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * <p>If this InetAddress was created with a host name,
      * this host name will be remembered and returned;
      * otherwise, a reverse name lookup will be performed
-     * and the result will be returned based on the system
-     * configured resolver. If a lookup of the name service
+     * and the result will be returned based on the system-wide
+     * resolver. If a lookup of the name service
      * is required, call
      * {@link #getCanonicalHostName() getCanonicalHostName}.
      *
@@ -1580,7 +1580,7 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
 
     /**
      * Given the name of a host, returns an array of its IP addresses,
-     * based on the configured system {@linkplain InetAddressResolver resolver}.
+     * based on the system-wide {@linkplain InetAddressResolver resolver}.
      *
      * <p> The host name can either be a machine name, such as
      * "{@code www.example.com}", or a textual representation of its IP

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -800,10 +800,10 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * If the operation is not allowed, it will return
      * the textual representation of the IP address.
      *
-     * @return  the fully qualified domain name for this IP address, or the textual representation
-     *          of the IP address if either the operation is not allowed by the security check
+     * @return  the fully qualified domain name for this IP address. 
+     *          If either the operation is not allowed by the security check
      *          or the system-wide resolver wasn't able to determine the fully qualified domain
-     *          name for the IP address.
+     *          name for the IP address, the textual representation of the IP address is returned instead.
      *
      * @see SecurityManager#checkConnect
      *

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -785,9 +785,12 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
     }
 
     /**
-     * Gets the fully qualified domain name for this IP address.
-     * Best effort method, meaning we may not be able to return
-     * the FQDN depending on the underlying system configuration.
+     * Gets the fully qualified domain name for this
+     * {@linkplain InetAddress#getAddress() IP address} using the system-wide
+     * {@linkplain InetAddressResolver resolver}. This is a best effort method,
+     * meaning we may not be able to return the fully qualified domain name; in
+     * which case this method returns the
+     * {@linkplain #getHostAddress() textual representation} of the IP address.
      *
      * <p>If there is a security manager, this method first
      * calls its {@code checkConnect} method
@@ -797,9 +800,10 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * If the operation is not allowed, it will return
      * the textual representation of the IP address.
      *
-     * @return  the fully qualified domain name for this IP address,
-     *    or if the operation is not allowed by the security check,
-     *    the textual representation of the IP address.
+     * @return  the fully qualified domain name for this IP address, or the textual representation
+     *          of the IP address if either the operation is not allowed by the security check
+     *          or the system-wide resolver wasn't able to determine the fully qualified domain
+     *          name for the IP address.
      *
      * @see SecurityManager#checkConnect
      *
@@ -814,7 +818,7 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
     }
 
     /**
-     * Returns the hostname for this address.
+     * Returns the fully qualified domain for this address.
      *
      * <p>If there is a security manager, this method first
      * calls its {@code checkConnect} method
@@ -824,11 +828,12 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * If the operation is not allowed, it will return
      * the textual representation of the IP address.
      *
-     * @return  the host name for this IP address, or if the operation
-     *    is not allowed by the security check, the textual
-     *    representation of the IP address.
-     *
      * @param check make security check if true
+     *
+     * @return  the fully qualified domain name for this IP address, or the textual representation
+     *          of the IP address if either the operation is not allowed by the security check
+     *          or the system-wide resolver wasn't able to determine the fully qualified domain
+     *          name for the IP address.
      *
      * @see SecurityManager#checkConnect
      */

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -787,10 +787,13 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
     /**
      * Gets the fully qualified domain name for this
      * {@linkplain InetAddress#getAddress() IP address} using the system-wide
-     * {@linkplain InetAddressResolver resolver}. This is a best effort method,
-     * meaning it may not be able to return the fully qualified domain name; in
-     * which case it returns the
-     * {@linkplain #getHostAddress() textual representation} of the IP address.
+     * {@linkplain InetAddressResolver resolver}.
+     *
+     * <p>The system-wide resolver will be used to do a reverse name lookup of the IP address.
+     * The lookup may fail for reasons such as the host not being registered with the name
+     * service. In such cases, where the resolver isn't able to determine the fully qualified
+     * domain name, this method returns the {@linkplain #getHostAddress() textual representation}
+     * of the IP address.
      *
      * <p>If there is a security manager, this method first
      * calls its {@code checkConnect} method

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -800,7 +800,7 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * If the operation is not allowed, it will return
      * the textual representation of the IP address.
      *
-     * @return  the fully qualified domain name for this IP address. 
+     * @return  the fully qualified domain name for this IP address.
      *          If either the operation is not allowed by the security check
      *          or the system-wide resolver wasn't able to determine the
      *          fully qualified domain name for the IP address, the textual

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -788,8 +788,8 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * Gets the fully qualified domain name for this
      * {@linkplain InetAddress#getAddress() IP address} using the system-wide
      * {@linkplain InetAddressResolver resolver}. This is a best effort method,
-     * meaning we may not be able to return the fully qualified domain name; in
-     * which case this method returns the
+     * meaning it may not be able to return the fully qualified domain name; in
+     * which case it returns the
      * {@linkplain #getHostAddress() textual representation} of the IP address.
      *
      * <p>If there is a security manager, this method first


### PR DESCRIPTION
Can I please get a review of this change which updates the javadoc of `java.net.InetAddress.getCanonicalHostName()` method to clarify its semantics? This addresses https://bugs.openjdk.org/browse/JDK-8313239.

This a javadoc only change and the documentation is updated to match the current implementation. A CSR will be drafted for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8313677](https://bugs.openjdk.org/browse/JDK-8313677) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8313239](https://bugs.openjdk.org/browse/JDK-8313239): InetAddress.getCanonicalHostName may return ip address if reverse lookup fails (**Bug** - P3)
 * [JDK-8313677](https://bugs.openjdk.org/browse/JDK-8313677): InetAddress.getCanonicalHostName may return ip address if reverse lookup fails (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [9ff86180](https://git.openjdk.org/jdk/pull/15134/files/9ff86180ca4763757e629ae427919f0870724014)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**) ⚠️ Review applies to [c9c3ba8b](https://git.openjdk.org/jdk/pull/15134/files/c9c3ba8b34d3dd3f769f04601c47ed8594412ba1)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [06fef8d8](https://git.openjdk.org/jdk/pull/15134/files/06fef8d83ed7b9900d410ff529eadcd364d2cc1f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15134/head:pull/15134` \
`$ git checkout pull/15134`

Update a local copy of the PR: \
`$ git checkout pull/15134` \
`$ git pull https://git.openjdk.org/jdk.git pull/15134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15134`

View PR using the GUI difftool: \
`$ git pr show -t 15134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15134.diff">https://git.openjdk.org/jdk/pull/15134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15134#issuecomment-1663454246)