### PR TITLE
JDK-8313632: ciEnv::dump_replay_data use fclose

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1708,8 +1708,10 @@ void ciEnv::dump_replay_data(int compile_id) {
         fileStream replay_data_stream(replay_data_file, /*need_close=*/true);
         dump_replay_data(&replay_data_stream);
         tty->print_cr("# Compiler replay data is saved as: %s", buffer);
+        fclose(replay_data_file);
       } else {
         tty->print_cr("# Can't open file to dump replay data.");
+        close(fd);
       }
     }
   }
@@ -1732,8 +1734,10 @@ void ciEnv::dump_inline_data(int compile_id) {
         replay_data_stream.flush();
         tty->print("# Compiler inline data is saved as: ");
         tty->print_cr("%s", buffer);
+        fclose(inline_data_file);
       } else {
         tty->print_cr("# Can't open file to dump inline data.");
+        close(fd);
       }
     }
   }


### PR DESCRIPTION
Seems we miss to call fclose at the end of ciEnv::dump_replay_data .
This should better be done like it is documented here in the fdopen example :
https://www.ibm.com/docs/en/i/7.3?topic=functions-fdopen-associates-stream-file-descriptor

I also added close calls in case fdopen fails, should we use them too?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313632](https://bugs.openjdk.org/browse/JDK-8313632): ciEnv::dump_replay_data use fclose (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15135/head:pull/15135` \
`$ git checkout pull/15135`

Update a local copy of the PR: \
`$ git checkout pull/15135` \
`$ git pull https://git.openjdk.org/jdk.git pull/15135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15135`

View PR using the GUI difftool: \
`$ git pr show -t 15135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15135.diff">https://git.openjdk.org/jdk/pull/15135.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15135#issuecomment-1663560365)