### PR TITLE
8313678 - SymbolTable can leak Symbols during cleanup

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -229,7 +229,7 @@ public:
   uintx get_hash() const {
     return _name->identity_hash();
   }
-  bool equals(DictionaryEntry** value, bool* is_dead) {
+  bool equals(DictionaryEntry** value, bool* is_dead, bool is_used_after) {
     DictionaryEntry *entry = *value;
     *is_dead = false;
     return (entry->instance_klass()->name() == _name);

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -176,7 +176,7 @@ class StringTableLookupJchar : StackObj {
   uintx get_hash() const {
     return _hash;
   }
-  bool equals(WeakHandle* value, bool* is_dead) {
+  bool equals(WeakHandle* value, bool* is_dead, bool is_used_after) {
     oop val_oop = value->peek();
     if (val_oop == nullptr) {
       // dead oop, mark this hash dead for cleaning
@@ -208,7 +208,7 @@ class StringTableLookupOop : public StackObj {
     return _hash;
   }
 
-  bool equals(WeakHandle* value, bool* is_dead) {
+  bool equals(WeakHandle* value, bool* is_dead, bool is_used_after) {
     oop val_oop = value->peek();
     if (val_oop == nullptr) {
       // dead oop, mark this hash dead for cleaning

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -374,12 +374,14 @@ public:
   uintx get_hash() const {
     return _hash;
   }
-  bool equals(Symbol* value, bool* is_dead) {
+  bool equals(Symbol* value, bool* is_dead, bool is_used_after) {
     assert(value != nullptr, "expected valid value");
     Symbol *sym = value;
     if (sym->equals(_str, _len)) {
-      if (sym->try_increment_refcount()) {
+      if (is_used_after && sym->try_increment_refcount()) {
         // something is referencing this symbol now.
+        return true;
+      } else if (!is_used_after && sym->refcount() > 0) {
         return true;
       } else {
         assert(sym->refcount() == 0, "expected dead symbol");

--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -258,7 +258,7 @@ class G1CardSetHashTable : public CHeapObj<mtGCCardSet> {
 
     uintx get_hash() const { return G1CardSetHashTable::get_hash(_region_idx); }
 
-    bool equals(G1CardSetHashTableValue* value, bool* is_dead) {
+    bool equals(G1CardSetHashTableValue* value, bool* is_dead, bool is_used_after) {
       *is_dead = false;
       return value->_region_idx == _region_idx;
     }

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -126,7 +126,7 @@ class ResolvedMethodTableLookup : StackObj {
   uintx get_hash() const {
     return _hash;
   }
-  bool equals(WeakHandle* value, bool* is_dead) {
+  bool equals(WeakHandle* value, bool* is_dead, bool is_used_after) {
     oop val_oop = value->peek();
     if (val_oop == nullptr) {
       // dead oop, mark this hash dead for cleaning

--- a/src/hotspot/share/services/finalizerService.cpp
+++ b/src/hotspot/share/services/finalizerService.cpp
@@ -137,7 +137,7 @@ class FinalizerEntryLookup : StackObj {
  public:
   FinalizerEntryLookup(const InstanceKlass* ik) : _ik(ik) {}
   uintx get_hash() const { return hash_function(_ik); }
-  bool equals(FinalizerEntry** value, bool* is_dead) {
+  bool equals(FinalizerEntry** value, bool* is_dead, bool is_used_after) {
     assert(value != nullptr, "invariant");
     assert(*value != nullptr, "invariant");
     return (*value)->klass() == _ik;

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -187,7 +187,7 @@ public:
   uintx get_hash() const {
     return _hash;
   }
-  bool equals(ThreadIdTableEntry** value, bool* is_dead) {
+  bool equals(ThreadIdTableEntry** value, bool* is_dead, bool is_used_after) {
     bool equals = primitive_equals(_tid, (*value)->tid());
     if (!equals) {
       return false;

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -457,7 +457,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   Node* rem_n = bucket->first();
   bool have_dead = false;
   while (rem_n != nullptr) {
-    if (lookup_f.equals(rem_n->value(), &have_dead)) {
+    if (lookup_f.equals(rem_n->value(), &have_dead, false)) {
       bucket->release_assign_node_ptr(rem_n_prev, rem_n->next());
       break;
     } else {
@@ -547,7 +547,7 @@ inline void ConcurrentHashTable<CONFIG, F>::
   Node* rem_n = bucket->first();
   while (rem_n != nullptr) {
     bool is_dead = false;
-    lookup_f.equals(rem_n->value(), &is_dead);
+    lookup_f.equals(rem_n->value(), &is_dead, false);
     if (is_dead) {
       ndel[dels++] = rem_n;
       Node* next_node = rem_n->next();
@@ -628,7 +628,7 @@ ConcurrentHashTable<CONFIG, F>::
   while (node != nullptr) {
     bool is_dead = false;
     ++loop_count;
-    if (lookup_f.equals(node->value(), &is_dead)) {
+    if (lookup_f.equals(node->value(), &is_dead, true)) {
       break;
     }
     if (is_dead && !(*have_dead)) {

--- a/test/hotspot/gtest/classfile/test_symbolTable.cpp
+++ b/test/hotspot/gtest/classfile/test_symbolTable.cpp
@@ -125,3 +125,17 @@ TEST_VM_FATAL_ERROR_MSG(SymbolTable, test_symbol_underflow, ".*refcount has gone
   my_symbol->decrement_refcount();
   my_symbol->increment_refcount();  // Should crash even in PRODUCT mode
 }
+
+TEST_VM(SymbolTable, test_cleanup_leak) {
+  // Check that dead entry cleanup doesn't increment refcount of live entry in same bucket.
+
+  // Create symbol and release ref, marking it available for cleanup.
+  Symbol* entry1 = SymbolTable::new_symbol("hash_collision_123");
+  entry1->decrement_refcount();
+
+  // Create a new symbol in the same bucket, which will notice the dead entry and trigger cleanup.
+  // Note: relies on SymbolTable's use of String::hashCode which collides for these two values.
+  Symbol* entry2 = SymbolTable::new_symbol("hash_collision_397476851");
+
+  ASSERT_EQ(entry2->refcount(), 1) << "Symbol refcount just created is 1";
+}

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -107,7 +107,7 @@ struct SimpleTestLookup {
   uintx get_hash() {
     return Pointer::get_hash(_val, NULL);
   }
-  bool equals(const uintptr_t* value, bool* is_dead) {
+  bool equals(const uintptr_t* value, bool* is_dead, bool is_used_after) {
     return _val == *value;
   }
 };
@@ -561,7 +561,7 @@ struct TestLookup {
   uintx get_hash() {
     return TestInterface::get_hash(_val, NULL);
   }
-  bool equals(const uintptr_t* value, bool* is_dead) {
+  bool equals(const uintptr_t* value, bool* is_dead, bool is_used_after) {
     return _val == *value;
   }
 };


### PR DESCRIPTION
Fix leak in SymbolTable during cleanup.

1. symbol1 inserted in bucket, refcount 1
2. Decrement refcount for this symbol, refcount is now 0
3. symbol2 inserted in same bucket
4. during insertion, concurrentHashTable notices there is a dead entry in this bucket
 4a. This triggers delete_in_bucket, which triggers SymbolTableLookup.equals for symbol2
 4b. SymbolTableLookup.equals for symbol2 spuriously increments symbol2's refcount
5. symbol2 is newly inserted with a refcount of 2, thus can never be cleaned up -> leak

The cleanup routine of concurrentHashTable uses the lookup function for its secondary effect of checking whether any particular value is dead or not. It does not actually care about the main purpose of the lookup function, i.e. checking if a particular value is the desired value.

The lookup function for SymbolTable, however, has the side effect of incrementing the Symbol refcount when the lookup succeeds. This is presumably with the assumption that a successful lookup will result in a newly held reference. concurrentHashTable's delete_in_bucket can break this assumption by completing a successful lookup without retaining the result (nor ever decrementing the refcount).

Thus, with a particular sequence of events (as shown in the new test case), a newly inserted Symbol can have a refcount of 2 instead of 1. Even if all legitimate references to this Symbol are removed, it will remain live, thus leaking.

The fix allows the caller of .equals to specify if they intend to use the value after the lookup, or not, allowing SymbolTable to only increment the refcount when appropriate.

I'd be happy to hear if anyone has any alternative suggestions for the fix, it seems a bit awkward/dangerous in general that SymbolTableLookup's equals increments the refcount. Also, any suggestions for implementing the test case without relying on the String.hashCode implementation would be great.

Thanks @shipilev for help debugging and fixing this :)