### PR TITLE
JDK-8313691: use close after failing os::fdopen in vmError and ciEnv

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1710,6 +1710,7 @@ void ciEnv::dump_replay_data(int compile_id) {
         tty->print_cr("# Compiler replay data is saved as: %s", buffer);
       } else {
         tty->print_cr("# Can't open file to dump replay data.");
+        close(fd);
       }
     }
   }
@@ -1734,6 +1735,7 @@ void ciEnv::dump_inline_data(int compile_id) {
         tty->print_cr("%s", buffer);
       } else {
         tty->print_cr("# Can't open file to dump inline data.");
+        close(fd);
       }
     }
   }

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1833,7 +1833,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
       if (fd != -1) {
         FILE* replay_data_file = os::fdopen(fd, "w");
         if (replay_data_file != nullptr) {
-          fileStream replay_data_stream(replay_data_file, /*fclose replay_data_file in destructor:*/ true);
+          fileStream replay_data_stream(replay_data_file, /*need_close=*/true);
           env->dump_replay_data_unsafe(&replay_data_stream);
           out.print_raw("#\n# Compiler replay data is saved as:\n# ");
           out.print_raw_cr(buffer);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1833,7 +1833,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
       if (fd != -1) {
         FILE* replay_data_file = os::fdopen(fd, "w");
         if (replay_data_file != nullptr) {
-          fileStream replay_data_stream(replay_data_file, /*need_close=*/true);
+          fileStream replay_data_stream(replay_data_file, /*fclose replay_data_file in destructor:*/ true);
           env->dump_replay_data_unsafe(&replay_data_stream);
           out.print_raw("#\n# Compiler replay data is saved as:\n# ");
           out.print_raw_cr(buffer);
@@ -1841,6 +1841,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
           int e = errno;
           out.print_raw("#\n# Can't open file to dump replay data. Error: ");
           out.print_raw_cr(os::strerror(e));
+          close(fd);
         }
       }
     }


### PR DESCRIPTION
In vmError.cpp we use os::fdopen and in case this is successful pass the returned file pointer to a fileStream constructor.
The fileStream object calls fclose on our file pointer  in destruction (and this closes also the underlying file descriptor fd).

However in case of failing os::fdopen we do not create (and later destruct)  a fileStream object so direct call to close might be needed. I also adjusted a comment to make it  even clearer that the fileStream object fcloses the file pointer on the destructor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313691](https://bugs.openjdk.org/browse/JDK-8313691): use close after failing os::fdopen in vmError and ciEnv (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15139/head:pull/15139` \
`$ git checkout pull/15139`

Update a local copy of the PR: \
`$ git checkout pull/15139` \
`$ git pull https://git.openjdk.org/jdk.git pull/15139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15139`

View PR using the GUI difftool: \
`$ git pr show -t 15139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15139.diff">https://git.openjdk.org/jdk/pull/15139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15139#issuecomment-1664055010)