### PR TITLE
8313707: GHA: Bootstrap sysroots with --variant=minbase

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -140,6 +140,7 @@ jobs:
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype6-dev,libpng-dev
           --resolve-deps
+          --variant=minbase
           $(test -n "${{ matrix.debian-keyring }}" && echo "--keyring=${{ matrix.debian-keyring }}")
           ${{ matrix.debian-version }}
           sysroot


### PR DESCRIPTION
We don't need the fully bootable Debian installation to build against. Therefore, we can bootstrap with `--variant=minbase`. The sysroots are about 5..10% smaller then.

This would also make our builds more immune to issues like [JDK-8313701](https://bugs.openjdk.org/browse/JDK-8313701). Note how RISC-V GHAs are fixed with this PR by dodging the systemd dependency failure.

Additional testing:
 - [x] GHA cross-compilation builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313707](https://bugs.openjdk.org/browse/JDK-8313707): GHA: Bootstrap sysroots with --variant=minbase (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15140/head:pull/15140` \
`$ git checkout pull/15140`

Update a local copy of the PR: \
`$ git checkout pull/15140` \
`$ git pull https://git.openjdk.org/jdk.git pull/15140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15140`

View PR using the GUI difftool: \
`$ git pr show -t 15140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15140.diff">https://git.openjdk.org/jdk/pull/15140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15140#issuecomment-1664415053)