### PR TITLE
8114830: (fs) Files.copy fails due to interference from something else changing the file system

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -669,7 +669,7 @@ abstract class UnixFileSystem
                            attrs.mode());
             } catch (UnixException x) {
                 if (x.errno() == EEXIST && flags.replaceExisting)
-                    throw new FileSystemException(toString());
+                    throw new FileSystemException(target.toString());
                 x.rethrowAsIOException(target);
             }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -32,6 +32,7 @@ import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
 import java.nio.file.LinkOption;
 import java.nio.file.LinkPermission;
 import java.nio.file.Path;
@@ -665,6 +666,9 @@ abstract class UnixFileSystem
                             O_EXCL),
                            attrs.mode());
             } catch (UnixException x) {
+                if (x.errno() == EEXIST)
+                    throw new FileSystemException(target.toString(), null,
+                        "File exists");
                 x.rethrowAsIOException(target);
             }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -520,6 +520,9 @@ abstract class UnixFileSystem
         try {
             mkdir(target, attrs.mode());
         } catch (UnixException x) {
+            if (x.errno() == EEXIST)
+                throw new FileSystemException(target.toString(), null,
+                    "Directory exists");
             x.rethrowAsIOException(target);
         }
 
@@ -787,6 +790,9 @@ abstract class UnixFileSystem
                 }
             }
         } catch (UnixException x) {
+            if (x.errno() == EEXIST)
+                throw new FileSystemException(target.toString(), null,
+                    "Link exists");
             x.rethrowAsIOException(target);
         }
     }
@@ -801,6 +807,9 @@ abstract class UnixFileSystem
         try {
             mknod(target, attrs.mode(), attrs.rdev());
         } catch (UnixException x) {
+            if (x.errno() == EEXIST)
+                throw new FileSystemException(target.toString(), null,
+                    "Special file exists");
             x.rethrowAsIOException(target);
         }
         boolean done = false;

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -521,8 +521,7 @@ abstract class UnixFileSystem
             mkdir(target, attrs.mode());
         } catch (UnixException x) {
             if (x.errno() == EEXIST)
-                throw new FileSystemException(target.toString(), null,
-                    "Directory exists");
+                throw new FileSystemException(target.toString());
             x.rethrowAsIOException(target);
         }
 
@@ -670,8 +669,7 @@ abstract class UnixFileSystem
                            attrs.mode());
             } catch (UnixException x) {
                 if (x.errno() == EEXIST)
-                    throw new FileSystemException(target.toString(), null,
-                        "File exists");
+                    throw new FileSystemException(toString());
                 x.rethrowAsIOException(target);
             }
 
@@ -791,8 +789,7 @@ abstract class UnixFileSystem
             }
         } catch (UnixException x) {
             if (x.errno() == EEXIST)
-                throw new FileSystemException(target.toString(), null,
-                    "Link exists");
+                throw new FileSystemException(target.toString());
             x.rethrowAsIOException(target);
         }
     }
@@ -808,8 +805,7 @@ abstract class UnixFileSystem
             mknod(target, attrs.mode(), attrs.rdev());
         } catch (UnixException x) {
             if (x.errno() == EEXIST)
-                throw new FileSystemException(target.toString(), null,
-                    "Special file exists");
+                throw new FileSystemException(target.toString());
             x.rethrowAsIOException(target);
         }
         boolean done = false;

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -520,7 +520,7 @@ abstract class UnixFileSystem
         try {
             mkdir(target, attrs.mode());
         } catch (UnixException x) {
-            if (x.errno() == EEXIST)
+            if (x.errno() == EEXIST && flags.replaceExisting)
                 throw new FileSystemException(target.toString());
             x.rethrowAsIOException(target);
         }
@@ -668,7 +668,7 @@ abstract class UnixFileSystem
                             O_EXCL),
                            attrs.mode());
             } catch (UnixException x) {
-                if (x.errno() == EEXIST)
+                if (x.errno() == EEXIST && flags.replaceExisting)
                     throw new FileSystemException(toString());
                 x.rethrowAsIOException(target);
             }
@@ -788,7 +788,7 @@ abstract class UnixFileSystem
                 }
             }
         } catch (UnixException x) {
-            if (x.errno() == EEXIST)
+            if (x.errno() == EEXIST && flags.replaceExisting)
                 throw new FileSystemException(target.toString());
             x.rethrowAsIOException(target);
         }
@@ -804,7 +804,7 @@ abstract class UnixFileSystem
         try {
             mknod(target, attrs.mode(), attrs.rdev());
         } catch (UnixException x) {
-            if (x.errno() == EEXIST)
+            if (x.errno() == EEXIST && flags.replaceExisting)
                 throw new FileSystemException(target.toString());
             x.rethrowAsIOException(target);
         }

--- a/test/jdk/java/nio/file/Files/CopyInterference.java
+++ b/test/jdk/java/nio/file/Files/CopyInterference.java
@@ -90,7 +90,6 @@ public class CopyInterference {
         throws IOException {
         Path parent = Path.of(System.getProperty("test.dir", "."));
         Path dir = Files.createTempDirectory(parent, "foobargus");
-        dir.toFile().deleteOnExit();
 
         List<Arguments> list = new ArrayList<Arguments>();
 

--- a/test/jdk/java/nio/file/Files/CopyInterference.java
+++ b/test/jdk/java/nio/file/Files/CopyInterference.java
@@ -134,13 +134,12 @@ public class CopyInterference {
     void copy(Path source, Path target, CopyOption[] options)
         throws InterruptedException, IOException {
 
-        ExecutorService es = Executors.newFixedThreadPool(N_THREADS);
-        CopyTask copyTask = new CopyTask(source, target, options);
         Future<?>[] results = new Future<?>[N_THREADS];
-        for (int i = 0; i < N_THREADS; i++)
-            results[i] = es.submit(copyTask);
-
-        es.close();
+        try (ExecutorService es = Executors.newFixedThreadPool(N_THREADS)) {
+            CopyTask copyTask = new CopyTask(source, target, options);
+            for (int i = 0; i < N_THREADS; i++)
+                results[i] = es.submit(copyTask);
+        }
 
         for (Future<?> res : results) {
             try {

--- a/test/jdk/java/nio/file/Files/CopyInterference.java
+++ b/test/jdk/java/nio/file/Files/CopyInterference.java
@@ -1,0 +1,113 @@
+
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8114830
+ * @summary Verify FileAlreadyExistsException is not thrown for REPLACE_EXISTING
+ */
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.FileSystemException;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CopyInterference {
+
+    private static final int N_THREADS = 2;
+
+    private static final Path SOURCE;
+    private static final Path TARGET;
+
+    private static final AtomicBoolean running = new AtomicBoolean(true);
+
+    static {
+        try {
+            Path dir = Path.of(System.getProperty("test.dir", "."));
+            SOURCE = Files.createTempFile(dir, "foo", "baz");
+            Files.delete(SOURCE);
+            TARGET = Files.createTempFile(dir, "fu", "bar");
+            Files.delete(TARGET);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static final Runnable copyTask = new Runnable() {
+        @Override
+        public void run() {
+            try {
+                while (running.get()) {
+                    Files.copy(SOURCE, TARGET,
+                               StandardCopyOption.REPLACE_EXISTING);
+                }
+            } catch (FileAlreadyExistsException e) {
+                running.set(false);
+                throw new RuntimeException("Unexpected exception", e);
+            } catch (FileSystemException e) {
+                System.out.printf("Expected FileSystemException: \"%s\"%n",
+                                  e.getMessage());
+            } catch (IOException e) {
+                running.set(false);
+                throw new RuntimeException("Unexpected exception", e);
+            }
+            running.set(false);
+        }
+    };
+
+    public static void main(String[] args) throws Exception {
+        Class c = CopyInterference.class;
+        String name = "CopyInterference.class";
+
+        try (InputStream in = c.getResourceAsStream(name)) {
+            Files.copy(in, SOURCE, StandardCopyOption.REPLACE_EXISTING);
+            Files.deleteIfExists(TARGET);
+
+            ExecutorService es = Executors.newFixedThreadPool(N_THREADS);
+            Future<?>[] results = new Future<?>[N_THREADS];
+            for (int i = 0; i < N_THREADS; i++)
+                results[i] = es.submit(copyTask);
+
+            es.shutdown();
+            es.awaitTermination(5, TimeUnit.SECONDS);
+
+            // Check results
+            for (Future<?> res : results) {
+                try {
+                    res.get();
+                } catch (ExecutionException e) {
+                    throw new RuntimeException(res.exceptionNow());
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/java/nio/file/Files/CopyInterference.java
+++ b/test/jdk/java/nio/file/Files/CopyInterference.java
@@ -57,9 +57,9 @@ public class CopyInterference {
     private static final AtomicBoolean running = new AtomicBoolean(true);
 
     private static class CopyTask implements Runnable {
-        Path source;
-        Path target;
-        CopyOption[] options;
+        final Path source;
+        final Path target;
+        final CopyOption[] options;
 
         CopyTask(Path source, Path target, CopyOption[] options) {
             this.source = source;
@@ -82,8 +82,9 @@ public class CopyInterference {
             } catch (IOException e) {
                 running.set(false);
                 throw new RuntimeException("Unexpected exception", e);
+            } finally {
+                running.set(false);
             }
-            running.set(false);
         }
     }
 

--- a/test/jdk/java/nio/file/Files/CopyInterference.java
+++ b/test/jdk/java/nio/file/Files/CopyInterference.java
@@ -74,13 +74,11 @@ public class CopyInterference {
                     Files.copy(source, target, options);
                 }
             } catch (FileAlreadyExistsException e) {
-                running.set(false);
                 throw new RuntimeException("Unexpected exception", e);
             } catch (FileSystemException e) {
                 System.out.printf("Expected FileSystemException: \"%s\"%n",
                                   e.getMessage());
             } catch (IOException e) {
-                running.set(false);
                 throw new RuntimeException("Unexpected exception", e);
             } finally {
                 running.set(false);


### PR DESCRIPTION
Throw a `FileSystemException` if attempting to create the target file with `O_EXCL` fails with `EEXIST`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8114830](https://bugs.openjdk.org/browse/JDK-8114830): (fs) Files.copy fails due to interference from something else changing the file system (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15141/head:pull/15141` \
`$ git checkout pull/15141`

Update a local copy of the PR: \
`$ git checkout pull/15141` \
`$ git pull https://git.openjdk.org/jdk.git pull/15141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15141`

View PR using the GUI difftool: \
`$ git pr show -t 15141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15141.diff">https://git.openjdk.org/jdk/pull/15141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15141#issuecomment-1664285001)