### PR TITLE
8313657 : com.sun.jndi.ldap.Connection.cleanup does not close connections on SocketTimeoutErrors

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -657,8 +657,6 @@ public final class Connection implements Runnable {
                             if (debug) {
                                 if (sock.isClosed()) {
                                     System.err.println("Connection::cleanup - socket closed.");
-                                } else {
-                                    System.err.println("Connection::cleanup - socket not closed.");
                                 }
                             }
                         } catch (IOException ioe) {

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -644,9 +644,9 @@ public final class Connection implements Runnable {
                     }
                 } finally {
 
-                    flushCloseOutputStream();
+                    flushAndCloseOutputStream();
                     // 8313657 socket is not closed until GC is run
-                    closeConnectionSocket();
+                    closeOpenedSocket();
                     tryUnpauseReader();
 
                     if (!notifyParent) {
@@ -683,7 +683,7 @@ public final class Connection implements Runnable {
     }
 
     // flush and close output stream
-    private void flushCloseOutputStream() {
+    private void flushAndCloseOutputStream() {
         try {
             outStream.flush();
         } catch (IOException ioEx) {
@@ -699,7 +699,7 @@ public final class Connection implements Runnable {
     }
 
     // close socket
-    private void closeConnectionSocket() {
+    private void closeOpenedSocket() {
         try {
             sock.close();
         } catch (IOException ioEx) {

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -703,8 +703,10 @@ public final class Connection implements Runnable {
         try {
             sock.close();
         } catch (IOException ioEx) {
-            if (debug)
-                System.err.println("Connection.closeConnectionSocket: Socket closing problem " + ioEx);
+            if (debug) {
+                System.err.println("Connection.closeConnectionSocket: Socket close problem: " + ioEx);
+                System.err.println("Socket isClosed: " + sock.isClosed());
+            }
         }
     }
 

--- a/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -650,6 +650,21 @@ public final class Connection implements Runnable {
                     } catch (IOException ie) {
                         if (debug)
                             System.err.println("Connection: problem closing socket: " + ie);
+                        //bug 8313657, socket not closed util GC running
+                        try {
+                            sock.close();
+                            unpauseReader();
+                            if (debug) {
+                                if (sock.isClosed()) {
+                                    System.err.println("Connection::cleanup - socket closed.");
+                                } else {
+                                    System.err.println("Connection::cleanup - socket not closed.");
+                                }
+                            }
+                        } catch (IOException ioe) {
+                            if (debug)
+                                System.err.println("Connection::cleanup problem: " + ioe);
+                        }
                     }
                     if (!notifyParent) {
                         LdapRequest ldr = pendingRequests;

--- a/test/jdk/com/sun/jndi/ldap/SocketCloseTest.java
+++ b/test/jdk/com/sun/jndi/ldap/SocketCloseTest.java
@@ -43,6 +43,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary make sure socket is closed when the error happens for OutputStream flushing
  * The value of provider url can be random, not necessary to be the one in the code
  * @library /test/lib
+ * @run main/othervm SocketCloseTest
  */
 
 public class SocketCloseTest {
@@ -54,6 +55,11 @@ public class SocketCloseTest {
     };
 
     public static void main(String[] args) throws Exception {
+        SocketCloseTest scTest = new SocketCloseTest();
+        scTest.runCloseSocketScenario();
+    }
+
+    public void runCloseSocketScenario() throws Exception {
         Hashtable<String, Object> props = new Hashtable<>();
 
         props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
@@ -66,13 +72,9 @@ public class SocketCloseTest {
                 System.out.println(SOCKET_CLOSED_MSG);
             } else {
                 System.out.println(SOCKET_NOT_CLOSED_MSG);
+                throw e;
             }
         }
-
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm("SocketCloseTest");
-        outputAnalyzer.stdoutShouldContain(SOCKET_CLOSED_MSG);
-        outputAnalyzer.stdoutShouldNotContain(SOCKET_NOT_CLOSED_MSG);
-        outputAnalyzer.stdoutShouldContain(BAD_FLUSH);
     }
 
     public static class CustomSocketFactory extends SocketFactory {

--- a/test/jdk/com/sun/jndi/ldap/SocketCloseTest.java
+++ b/test/jdk/com/sun/jndi/ldap/SocketCloseTest.java
@@ -25,10 +25,13 @@ import javax.naming.Context;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.net.SocketFactory;
-import java.io.*;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Hashtable;
 
 import jdk.test.lib.process.OutputAnalyzer;
@@ -38,6 +41,7 @@ import jdk.test.lib.process.ProcessTools;
  * @test
  * @bug 8313657
  * @summary make sure socket is closed when the error happens for OutputStream flushing
+ * The value of provider url can be random, not necessary to be the one in the code
  * @library /test/lib
  */
 
@@ -45,23 +49,8 @@ public class SocketCloseTest {
     public static String SOCKET_CLOSED_MSG = "The socket has been closed.";
     public static String SOCKET_NOT_CLOSED_MSG = "The socket was not closed.";
     public static String BAD_FLUSH = "Bad flush!";
-    private static final int BIND_SIZE = 14;
     private static final byte[] BIND_RESPONSE = new byte[]{
             48, 12, 2, 1, 1, 97, 7, 10, 1, 0, 4, 0, 4, 0
-    };
-    private static final int SEARCH_SIZE = 87;
-    private static final byte[] SEARCH_RESPONSE = new byte[]{
-            48, -127, -71, 2, 1, 2, 100, -127, -77, 4, 19, 111, 61, 101, 120, 97, 109, 112, 108,
-            101, 44, 111, 61, 101, 120, 97, 109, 112, 108, 101, 48, -127, -101, 48, 34, 4, 11,
-            111, 98, 106, 101, 99, 116, 99, 108, 97, 115, 115, 49, 19, 4, 12, 111, 114, 103, 97,
-            110, 105, 122, 97, 116, 105, 111, 110, 4, 3, 116, 111, 112, 48, 34, 4, 13, 106, 97,
-            118, 97, 67, 108, 97, 115, 115, 78, 97, 109, 101, 49, 17, 4, 15, 69, 118, 105, 108,
-            67, 108, 97, 115, 115, 76, 111, 97, 100, 101, 114, 48, 65, 4, 18, 106, 97, 118, 97,
-            83, 101, 114, 105, 97, 108, 105, 122, 101, 100, 68, 97, 116, 97, 49, 43, 4, 41, -84,
-            -19, 0, 5, 115, 114, 0, 20, 77, 97, 105, 110, 36, 69, 118, 105, 108, 67, 108, 97, 115,
-            115, 76, 111, 97, 100, 101, 114, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 120, 112, 48, 14,
-            4, 1, 111, 49, 9, 4, 7, 101, 120, 97, 109, 112, 108, 101, 48, 12, 2, 1, 2, 101, 7, 10,
-            1, 0, 4, 0, 4, 0
     };
 
     public static void main(String[] args) throws Exception {
@@ -122,7 +111,6 @@ public class SocketCloseTest {
     }
 
     public static class LdapInputStream extends InputStream {
-
         private LdapOutputStream los;
         private ByteArrayInputStream bos;
         int pos = 0;
@@ -156,7 +144,6 @@ public class SocketCloseTest {
     public static class CustomSocket extends Socket {
         private int closeMethodCalled = 0;
         private LdapOutputStream output = new LdapOutputStream();
-
         private LdapInputStream input = new LdapInputStream(output);
 
         public void connect(SocketAddress address, int timeout) {

--- a/test/jdk/com/sun/jndi/ldap/SocketCloseTest.java
+++ b/test/jdk/com/sun/jndi/ldap/SocketCloseTest.java
@@ -113,11 +113,9 @@ public class SocketCloseTest {
     }
 
     private static class LdapInputStream extends InputStream {
-        private LdapOutputStream los;
         private ByteArrayInputStream bos;
 
-        public LdapInputStream(LdapOutputStream los) {
-            this.los = los;
+        public LdapInputStream() {
         }
 
         @Override
@@ -144,7 +142,7 @@ public class SocketCloseTest {
     private static class CustomSocket extends Socket {
         private int closeMethodCalled = 0;
         private LdapOutputStream output = new LdapOutputStream();
-        private LdapInputStream input = new LdapInputStream(output);
+        private LdapInputStream input = new LdapInputStream();
 
         public void connect(SocketAddress address, int timeout) {
         }

--- a/test/jdk/com/sun/jndi/ldap/SocketCloseTest.java
+++ b/test/jdk/com/sun/jndi/ldap/SocketCloseTest.java
@@ -112,10 +112,9 @@ public class SocketCloseTest {
         }
     }
 
-    public static class LdapInputStream extends InputStream {
+    private static class LdapInputStream extends InputStream {
         private LdapOutputStream los;
         private ByteArrayInputStream bos;
-        int pos = 0;
 
         public LdapInputStream(LdapOutputStream los) {
             this.los = los;
@@ -124,12 +123,11 @@ public class SocketCloseTest {
         @Override
         public int read() throws IOException {
             bos = new ByteArrayInputStream(BIND_RESPONSE);
-            int next = bos.read();
-            return next;
+            return bos.read();
         }
     }
 
-    public static class LdapOutputStream extends OutputStream {
+    private static class LdapOutputStream extends OutputStream {
 
         @Override
         public void write(int b) throws IOException {
@@ -143,7 +141,7 @@ public class SocketCloseTest {
         }
     }
 
-    public static class CustomSocket extends Socket {
+    private static class CustomSocket extends Socket {
         private int closeMethodCalled = 0;
         private LdapOutputStream output = new LdapOutputStream();
         private LdapInputStream input = new LdapInputStream(output);

--- a/test/jdk/javax/naming/InitialContext/SocketCloseTest.java
+++ b/test/jdk/javax/naming/InitialContext/SocketCloseTest.java
@@ -42,141 +42,142 @@ import jdk.test.lib.process.ProcessTools;
  */
 
 public class SocketCloseTest {
-	public static String SOCKET_CLOSED_MSG = "The socket has been closed.";
-	public static String SOCKET_NOT_CLOSED_MSG = "The socket was not closed.";
-	public static String BAD_FLUSH = "Bad flush!";
-	private static final int BIND_SIZE = 14;
-	private static final byte[] BIND_RESPONSE = new byte[]{
-			48, 12, 2, 1, 1, 97, 7, 10, 1, 0, 4, 0, 4, 0
-	};
-	private static final int SEARCH_SIZE = 87;
-	private static final byte[] SEARCH_RESPONSE = new byte[]{
-			48, -127, -71, 2, 1, 2, 100, -127, -77, 4, 19, 111, 61, 101, 120, 97, 109, 112, 108,
-			101, 44, 111, 61, 101, 120, 97, 109, 112, 108, 101, 48, -127, -101, 48, 34, 4, 11,
-			111, 98, 106, 101, 99, 116, 99, 108, 97, 115, 115, 49, 19, 4, 12, 111, 114, 103, 97,
-			110, 105, 122, 97, 116, 105, 111, 110, 4, 3, 116, 111, 112, 48, 34, 4, 13, 106, 97,
-			118, 97, 67, 108, 97, 115, 115, 78, 97, 109, 101, 49, 17, 4, 15, 69, 118, 105, 108,
-			67, 108, 97, 115, 115, 76, 111, 97, 100, 101, 114, 48, 65, 4, 18, 106, 97, 118, 97,
-			83, 101, 114, 105, 97, 108, 105, 122, 101, 100, 68, 97, 116, 97, 49, 43, 4, 41, -84,
-			-19, 0, 5, 115, 114, 0, 20, 77, 97, 105, 110, 36, 69, 118, 105, 108, 67, 108, 97, 115,
-			115, 76, 111, 97, 100, 101, 114, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 120, 112, 48, 14,
-			4, 1, 111, 49, 9, 4, 7, 101, 120, 97, 109, 112, 108, 101, 48, 12, 2, 1, 2, 101, 7, 10,
-			1, 0, 4, 0, 4, 0
-	};
+    public static String SOCKET_CLOSED_MSG = "The socket has been closed.";
+    public static String SOCKET_NOT_CLOSED_MSG = "The socket was not closed.";
+    public static String BAD_FLUSH = "Bad flush!";
+    private static final int BIND_SIZE = 14;
+    private static final byte[] BIND_RESPONSE = new byte[]{
+            48, 12, 2, 1, 1, 97, 7, 10, 1, 0, 4, 0, 4, 0
+    };
+    private static final int SEARCH_SIZE = 87;
+    private static final byte[] SEARCH_RESPONSE = new byte[]{
+            48, -127, -71, 2, 1, 2, 100, -127, -77, 4, 19, 111, 61, 101, 120, 97, 109, 112, 108,
+            101, 44, 111, 61, 101, 120, 97, 109, 112, 108, 101, 48, -127, -101, 48, 34, 4, 11,
+            111, 98, 106, 101, 99, 116, 99, 108, 97, 115, 115, 49, 19, 4, 12, 111, 114, 103, 97,
+            110, 105, 122, 97, 116, 105, 111, 110, 4, 3, 116, 111, 112, 48, 34, 4, 13, 106, 97,
+            118, 97, 67, 108, 97, 115, 115, 78, 97, 109, 101, 49, 17, 4, 15, 69, 118, 105, 108,
+            67, 108, 97, 115, 115, 76, 111, 97, 100, 101, 114, 48, 65, 4, 18, 106, 97, 118, 97,
+            83, 101, 114, 105, 97, 108, 105, 122, 101, 100, 68, 97, 116, 97, 49, 43, 4, 41, -84,
+            -19, 0, 5, 115, 114, 0, 20, 77, 97, 105, 110, 36, 69, 118, 105, 108, 67, 108, 97, 115,
+            115, 76, 111, 97, 100, 101, 114, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 120, 112, 48, 14,
+            4, 1, 111, 49, 9, 4, 7, 101, 120, 97, 109, 112, 108, 101, 48, 12, 2, 1, 2, 101, 7, 10,
+            1, 0, 4, 0, 4, 0
+    };
 
-	public static void main(String[] args) throws Exception {
-		Hashtable<String, Object> props = new Hashtable<>();
+    public static void main(String[] args) throws Exception {
+        Hashtable<String, Object> props = new Hashtable<>();
 
-		props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-		props.put(Context.PROVIDER_URL, "ldap://localhost:1389/o=example");
-		props.put("java.naming.ldap.factory.socket", CustomSocketFactory.class.getName());
-		try {
-			final DirContext ctx = new InitialDirContext(props);
-		} catch (Exception e) {
-			if (CustomSocketFactory.customSocket.closeMethodCalledCount() > 0) {
-				System.out.println(SOCKET_CLOSED_MSG);
-			} else {
-				System.out.println(SOCKET_NOT_CLOSED_MSG);
-			}
-		}
+        props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        props.put(Context.PROVIDER_URL, "ldap://localhost:1389/o=example");
+        props.put("java.naming.ldap.factory.socket", CustomSocketFactory.class.getName());
+        try {
+            final DirContext ctx = new InitialDirContext(props);
+        } catch (Exception e) {
+            if (CustomSocketFactory.customSocket.closeMethodCalledCount() > 0) {
+                System.out.println(SOCKET_CLOSED_MSG);
+            } else {
+                System.out.println(SOCKET_NOT_CLOSED_MSG);
+            }
+        }
 
-		OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm("SocketCloseTest");
-		outputAnalyzer.stdoutShouldContain(SOCKET_CLOSED_MSG);
-		outputAnalyzer.stdoutShouldNotContain(SOCKET_NOT_CLOSED_MSG);
-		outputAnalyzer.stdoutShouldContain(BAD_FLUSH);
-	}
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm("SocketCloseTest");
+        outputAnalyzer.stdoutShouldContain(SOCKET_CLOSED_MSG);
+        outputAnalyzer.stdoutShouldNotContain(SOCKET_NOT_CLOSED_MSG);
+        outputAnalyzer.stdoutShouldContain(BAD_FLUSH);
+    }
 
-	public static class CustomSocketFactory extends SocketFactory {
-		public static CustomSocket customSocket = new CustomSocket();
+    public static class CustomSocketFactory extends SocketFactory {
+        public static CustomSocket customSocket = new CustomSocket();
 
-		public static CustomSocketFactory getDefault() {
-			return new CustomSocketFactory();
-		}
+        public static CustomSocketFactory getDefault() {
+            return new CustomSocketFactory();
+        }
 
-		@Override
-		public Socket createSocket() {
-			return customSocket;
-		}
+        @Override
+        public Socket createSocket() {
+            return customSocket;
+        }
 
-		@Override
-		public Socket createSocket(String s, int timeout) {
-			return customSocket;
-		}
-		@Override
-		public Socket createSocket(String host, int port, InetAddress localHost,
-		                           int localPort) {
-			return customSocket;
-		}
+        @Override
+        public Socket createSocket(String s, int timeout) {
+            return customSocket;
+        }
 
-		@Override
-		public Socket createSocket(InetAddress host, int port) {
-			return customSocket;
-		}
+        @Override
+        public Socket createSocket(String host, int port, InetAddress localHost,
+                                   int localPort) {
+            return customSocket;
+        }
 
-		@Override
-		public Socket createSocket(InetAddress address, int port,
-		                           InetAddress localAddress, int localPort) {
-			return customSocket;
-		}
-	}
+        @Override
+        public Socket createSocket(InetAddress host, int port) {
+            return customSocket;
+        }
 
-	public static class LdapInputStream extends InputStream {
+        @Override
+        public Socket createSocket(InetAddress address, int port,
+                                   InetAddress localAddress, int localPort) {
+            return customSocket;
+        }
+    }
 
-		private LdapOutputStream los;
-		private ByteArrayInputStream bos;
-		int pos = 0;
+    public static class LdapInputStream extends InputStream {
 
-		public LdapInputStream(LdapOutputStream los) {
-			this.los = los;
-		}
+        private LdapOutputStream los;
+        private ByteArrayInputStream bos;
+        int pos = 0;
 
-		@Override
-		public int read() throws IOException {
-			bos = new ByteArrayInputStream(BIND_RESPONSE);
-			int next = bos.read();
-			return next;
-		}
-	}
+        public LdapInputStream(LdapOutputStream los) {
+            this.los = los;
+        }
 
-	public static class LdapOutputStream extends OutputStream {
+        @Override
+        public int read() throws IOException {
+            bos = new ByteArrayInputStream(BIND_RESPONSE);
+            int next = bos.read();
+            return next;
+        }
+    }
 
-		@Override
-		public void write(int b) throws IOException {
-			System.out.println("output stream writing");
-		}
+    public static class LdapOutputStream extends OutputStream {
 
-		@Override
-		public void flush() throws IOException {
-			System.out.println(BAD_FLUSH);
-			throw new IOException(BAD_FLUSH);
-		}
-	}
+        @Override
+        public void write(int b) throws IOException {
+            System.out.println("output stream writing");
+        }
 
-	public static class CustomSocket extends Socket {
-		private int closeMethodCalled = 0;
-		private LdapOutputStream output = new LdapOutputStream();
+        @Override
+        public void flush() throws IOException {
+            System.out.println(BAD_FLUSH);
+            throw new IOException(BAD_FLUSH);
+        }
+    }
 
-		private LdapInputStream input = new LdapInputStream(output);
+    public static class CustomSocket extends Socket {
+        private int closeMethodCalled = 0;
+        private LdapOutputStream output = new LdapOutputStream();
 
-		public void connect(SocketAddress address, int timeout) {
-		}
+        private LdapInputStream input = new LdapInputStream(output);
 
-		public InputStream getInputStream() {
-			return input;
-		}
+        public void connect(SocketAddress address, int timeout) {
+        }
 
-		public OutputStream getOutputStream() {
-			return output;
-		}
+        public InputStream getInputStream() {
+            return input;
+        }
 
-		public int closeMethodCalledCount() {
-			return closeMethodCalled;
-		}
+        public OutputStream getOutputStream() {
+            return output;
+        }
 
-		@Override
-		public void close() throws IOException {
-			closeMethodCalled++;
-			super.close();
-		}
-	}
+        public int closeMethodCalledCount() {
+            return closeMethodCalled;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeMethodCalled++;
+            super.close();
+        }
+    }
 }

--- a/test/jdk/javax/naming/InitialContext/SocketCloseTest.java
+++ b/test/jdk/javax/naming/InitialContext/SocketCloseTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.naming.Context;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import javax.net.SocketFactory;
+import java.io.*;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.Hashtable;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+/*
+ * @test
+ * @bug 8313657
+ * @summary make sure socket is closed when the error happens for OutputStream flushing
+ * @library /test/lib
+ */
+
+public class SocketCloseTest {
+	public static String SOCKET_CLOSED_MSG = "The socket has been closed.";
+	public static String SOCKET_NOT_CLOSED_MSG = "The socket was not closed.";
+	public static String BAD_FLUSH = "Bad flush!";
+	private static final int BIND_SIZE = 14;
+	private static final byte[] BIND_RESPONSE = new byte[]{
+			48, 12, 2, 1, 1, 97, 7, 10, 1, 0, 4, 0, 4, 0
+	};
+	private static final int SEARCH_SIZE = 87;
+	private static final byte[] SEARCH_RESPONSE = new byte[]{
+			48, -127, -71, 2, 1, 2, 100, -127, -77, 4, 19, 111, 61, 101, 120, 97, 109, 112, 108,
+			101, 44, 111, 61, 101, 120, 97, 109, 112, 108, 101, 48, -127, -101, 48, 34, 4, 11,
+			111, 98, 106, 101, 99, 116, 99, 108, 97, 115, 115, 49, 19, 4, 12, 111, 114, 103, 97,
+			110, 105, 122, 97, 116, 105, 111, 110, 4, 3, 116, 111, 112, 48, 34, 4, 13, 106, 97,
+			118, 97, 67, 108, 97, 115, 115, 78, 97, 109, 101, 49, 17, 4, 15, 69, 118, 105, 108,
+			67, 108, 97, 115, 115, 76, 111, 97, 100, 101, 114, 48, 65, 4, 18, 106, 97, 118, 97,
+			83, 101, 114, 105, 97, 108, 105, 122, 101, 100, 68, 97, 116, 97, 49, 43, 4, 41, -84,
+			-19, 0, 5, 115, 114, 0, 20, 77, 97, 105, 110, 36, 69, 118, 105, 108, 67, 108, 97, 115,
+			115, 76, 111, 97, 100, 101, 114, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 120, 112, 48, 14,
+			4, 1, 111, 49, 9, 4, 7, 101, 120, 97, 109, 112, 108, 101, 48, 12, 2, 1, 2, 101, 7, 10,
+			1, 0, 4, 0, 4, 0
+	};
+
+	public static void main(String[] args) throws Exception {
+
+		Hashtable<String, Object> props = new Hashtable<>();
+
+		props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+		props.put(Context.PROVIDER_URL, "ldap://localhost:1389/o=example");
+		props.put("java.naming.ldap.factory.socket", CustomSocketFactory.class.getName());
+
+		try {
+			final DirContext ctx = new InitialDirContext(props);
+		} catch (Exception e) {
+			if (CustomSocketFactory.customSocket.closeMethodCalledCount() > 0) {
+				System.out.println(SOCKET_CLOSED_MSG);
+			} else {
+				System.out.println(SOCKET_NOT_CLOSED_MSG);
+			}
+		}
+
+		OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm("SocketCloseTest");
+		outputAnalyzer.stdoutShouldContain(SOCKET_CLOSED_MSG);
+		outputAnalyzer.stdoutShouldNotContain(SOCKET_NOT_CLOSED_MSG);
+		outputAnalyzer.stdoutShouldContain(BAD_FLUSH);
+	}
+
+	public static class CustomSocketFactory extends SocketFactory {
+		public static CustomSocket customSocket = new CustomSocket();
+
+		public static CustomSocketFactory getDefault() {
+			return new CustomSocketFactory();
+		}
+
+		@Override
+		public Socket createSocket() {
+			return customSocket;
+		}
+
+		@Override
+		public Socket createSocket(String s, int timeout) {
+			return customSocket;
+		}
+
+		@Override
+		public Socket createSocket(String host, int port, InetAddress localHost,
+		                           int localPort) {
+			return customSocket;
+		}
+
+		@Override
+		public Socket createSocket(InetAddress host, int port) {
+			return customSocket;
+		}
+
+		@Override
+		public Socket createSocket(InetAddress address, int port,
+		                           InetAddress localAddress, int localPort) {
+			return customSocket;
+		}
+	}
+
+	public static class LdapInputStream extends InputStream {
+
+		private LdapOutputStream los;
+		private ByteArrayInputStream bos;
+		int pos = 0;
+
+		public LdapInputStream(LdapOutputStream los) {
+			this.los = los;
+		}
+
+		@Override
+		public int read() throws IOException {
+			bos = new ByteArrayInputStream(BIND_RESPONSE);
+			int next = bos.read();
+			return next;
+		}
+	}
+
+	public static class LdapOutputStream extends OutputStream {
+
+		@Override
+		public void write(int b) throws IOException {
+			System.out.println("output stream writing");
+		}
+
+		@Override
+		public void flush() throws IOException {
+			System.out.println(BAD_FLUSH);
+			throw new IOException(BAD_FLUSH);
+		}
+	}
+
+	public static class CustomSocket extends Socket {
+		private int closeMethodCalled = 0;
+		private LdapOutputStream output = new LdapOutputStream();
+
+		private LdapInputStream input = new LdapInputStream(output);
+
+		public void connect(SocketAddress address, int timeout) {
+		}
+
+		public InputStream getInputStream() {
+			return input;
+		}
+
+		public OutputStream getOutputStream() {
+			return output;
+		}
+
+		public int closeMethodCalledCount() {
+			return closeMethodCalled;
+		}
+
+		@Override
+		public void close() throws IOException {
+			closeMethodCalled++;
+			super.close();
+		}
+	}
+}

--- a/test/jdk/javax/naming/InitialContext/SocketCloseTest.java
+++ b/test/jdk/javax/naming/InitialContext/SocketCloseTest.java
@@ -65,13 +65,11 @@ public class SocketCloseTest {
 	};
 
 	public static void main(String[] args) throws Exception {
-
 		Hashtable<String, Object> props = new Hashtable<>();
 
 		props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
 		props.put(Context.PROVIDER_URL, "ldap://localhost:1389/o=example");
 		props.put("java.naming.ldap.factory.socket", CustomSocketFactory.class.getName());
-
 		try {
 			final DirContext ctx = new InitialDirContext(props);
 		} catch (Exception e) {
@@ -104,7 +102,6 @@ public class SocketCloseTest {
 		public Socket createSocket(String s, int timeout) {
 			return customSocket;
 		}
-
 		@Override
 		public Socket createSocket(String host, int port, InetAddress localHost,
 		                           int localPort) {


### PR DESCRIPTION
com.sun.jndi.ldap.Connection::leanup does not close the underlying socket if the is an IOException generation when the output stream was flushing the buffer.

Please refer to the bug https://bugs.openjdk.org/browse/JDK-8313657.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313657](https://bugs.openjdk.org/browse/JDK-8313657): com.sun.jndi.ldap.Connection.cleanup does not close connections on SocketTimeoutErrors (**Bug** - P3)


### Reviewers
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [e3e98226](https://git.openjdk.org/jdk/pull/15143/files/e3e98226a9771f2054eb203cd7ef1db322be1d7a)
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15143/head:pull/15143` \
`$ git checkout pull/15143`

Update a local copy of the PR: \
`$ git checkout pull/15143` \
`$ git pull https://git.openjdk.org/jdk.git pull/15143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15143`

View PR using the GUI difftool: \
`$ git pr show -t 15143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15143.diff">https://git.openjdk.org/jdk/pull/15143.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15143#issuecomment-1665581450)