### PR TITLE
8313712: [BACKOUT] 8313632: ciEnv::dump_replay_data use fclose

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1708,10 +1708,8 @@ void ciEnv::dump_replay_data(int compile_id) {
         fileStream replay_data_stream(replay_data_file, /*need_close=*/true);
         dump_replay_data(&replay_data_stream);
         tty->print_cr("# Compiler replay data is saved as: %s", buffer);
-        fclose(replay_data_file);
       } else {
         tty->print_cr("# Can't open file to dump replay data.");
-        close(fd);
       }
     }
   }
@@ -1734,10 +1732,8 @@ void ciEnv::dump_inline_data(int compile_id) {
         replay_data_stream.flush();
         tty->print("# Compiler inline data is saved as: ");
         tty->print_cr("%s", buffer);
-        fclose(inline_data_file);
       } else {
         tty->print_cr("# Can't open file to dump inline data.");
-        close(fd);
       }
     }
   }


### PR DESCRIPTION
Clean backout of [JDK-8313712](https://bugs.openjdk.org/browse/JDK-8313712).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313712](https://bugs.openjdk.org/browse/JDK-8313712): [BACKOUT] 8313632: ciEnv::dump_replay_data use fclose (**Bug** - P2)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15144/head:pull/15144` \
`$ git checkout pull/15144`

Update a local copy of the PR: \
`$ git checkout pull/15144` \
`$ git pull https://git.openjdk.org/jdk.git pull/15144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15144`

View PR using the GUI difftool: \
`$ git pr show -t 15144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15144.diff">https://git.openjdk.org/jdk/pull/15144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15144#issuecomment-1664409609)