### PR TITLE
8313708: NMT: cleanup _mst_marker

### DIFF
--- a/src/hotspot/share/services/mallocHeader.cpp
+++ b/src/hotspot/share/services/mallocHeader.cpp
@@ -62,5 +62,5 @@ void MallocHeader::print_block_on_error(outputStream* st, address bad_address) c
 }
 
 bool MallocHeader::get_stack(NativeCallStack& stack) const {
-  return MallocSiteTable::access_stack(stack, _mst_marker);
+  return MallocSiteTable::access_stack(stack, _bucket_idx, _bucket_pos);
 }

--- a/src/hotspot/share/services/mallocHeader.cpp
+++ b/src/hotspot/share/services/mallocHeader.cpp
@@ -62,5 +62,5 @@ void MallocHeader::print_block_on_error(outputStream* st, address bad_address) c
 }
 
 bool MallocHeader::get_stack(NativeCallStack& stack) const {
-  return MallocSiteTable::access_stack(stack, _bucket_idx, _bucket_pos);
+  return MallocSiteTable::access_stack(stack, _bucket);
 }

--- a/src/hotspot/share/services/mallocHeader.hpp
+++ b/src/hotspot/share/services/mallocHeader.hpp
@@ -54,7 +54,7 @@ class outputStream;
  * on both 64-bit/32-bit to be enough for that. So the malloc header is 16 bytes long on both
  * 32-bit and 64-bit.
  *
- 
+
  * Layout on 64-bit:
  *
  *           0        1        2        3        4        5        6        7
@@ -77,7 +77,7 @@ class outputStream;
  *  ...  |     canary      |
  *       +--------+--------+
  *
- 
+
  * Layout on 32-bit:
  *
  *           0        1        2        3        4        5        6        7
@@ -100,7 +100,7 @@ class outputStream;
  *  ...  |     canary      |
  *       +--------+--------+
  *
- 
+
  * Notes:
  * - We have a canary in the two bytes directly preceding the user payload. That allows us to
  *   catch negative buffer overflows.

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -34,8 +34,8 @@
 #include "utilities/macros.hpp"
 #include "utilities/nativeCallStack.hpp"
 
-inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint32_t mst_marker)
-  : _size(size), _mst_marker(mst_marker), _flags(flags),
+inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint16_t mst_index, uint16_t bucket_pos)
+  : _size(size), _bucket_idx(mst_index), _bucket_pos(bucket_pos), _flags(flags),
     _unused(0), _canary(_header_canary_live_mark)
 {
   assert(size < max_reasonable_malloc_size, "Too large allocation size?");

--- a/src/hotspot/share/services/mallocHeader.inline.hpp
+++ b/src/hotspot/share/services/mallocHeader.inline.hpp
@@ -34,8 +34,8 @@
 #include "utilities/macros.hpp"
 #include "utilities/nativeCallStack.hpp"
 
-inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, uint16_t mst_index, uint16_t bucket_pos)
-  : _size(size), _bucket_idx(mst_index), _bucket_pos(bucket_pos), _flags(flags),
+inline MallocHeader::MallocHeader(size_t size, MEMFLAGS flags, BucketInfo bucket)
+  : _size(size), _bucket(bucket), _flags(flags),
     _unused(0), _canary(_header_canary_live_mark)
 {
   assert(size < max_reasonable_malloc_size, "Too large allocation size?");

--- a/src/hotspot/share/services/mallocSiteTable.cpp
+++ b/src/hotspot/share/services/mallocSiteTable.cpp
@@ -172,11 +172,11 @@ MallocSite* MallocSiteTable::lookup_or_add(const NativeCallStack& key, uint16_t*
 }
 
 // Access malloc site
-MallocSite* MallocSiteTable::malloc_site(uint16_t bucket_idx, uint16_t bucket_pos) {
-  assert(bucket_idx < table_size, "Invalid bucket index");
-  MallocSiteHashtableEntry* head = _table[bucket_idx];
+MallocSite* MallocSiteTable::malloc_site(MallocHeader::BucketInfo bucket) {
+  assert(bucket.index < table_size, "Invalid bucket index");
+  MallocSiteHashtableEntry* head = _table[bucket.index];
   for (size_t index = 0;
-       index < bucket_pos && head != nullptr;
+       index < bucket.position && head != nullptr;
        index++, head = (MallocSiteHashtableEntry*)head->next()) {}
   assert(head != nullptr, "Invalid position index");
   return head->data();

--- a/src/hotspot/share/services/mallocSiteTable.hpp
+++ b/src/hotspot/share/services/mallocSiteTable.hpp
@@ -109,9 +109,9 @@ class MallocSiteTable : AllStatic {
   static const int table_size = 4099;
 
   // Table cannot be wider than a 16bit bucket idx can hold
-#define MAX_MALLOCSITE_TABLE_SIZE (USHRT_MAX - 1)
+#define MAX_MALLOCSITE_TABLE_SIZE           (USHRT_MAX - 1)
   // Each bucket chain cannot be longer than what a 16 bit pos idx can hold (hopefully way shorter)
-#define MAX_BUCKET_LENGTH         (USHRT_MAX - 1)
+#define MAX_MALLOCSITE_TABLE_BUCKET_LENGTH  (USHRT_MAX - 1)
 
   STATIC_ASSERT(table_size <= MAX_MALLOCSITE_TABLE_SIZE);
 

--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -147,13 +147,14 @@ void* MallocTracker::record_malloc(void* malloc_base, size_t size, MEMFLAGS flag
   assert(malloc_base != nullptr, "precondition");
 
   MallocMemorySummary::record_malloc(size, flags);
-  uint32_t mst_marker = 0;
+  uint16_t bucket_idx = 0;
+  uint16_t bucket_pos = 0;
   if (MemTracker::tracking_level() == NMT_detail) {
-    MallocSiteTable::allocation_at(stack, size, &mst_marker, flags);
+    MallocSiteTable::allocation_at(stack, size, &bucket_idx, &bucket_pos, flags);
   }
 
   // Uses placement global new operator to initialize malloc header
-  MallocHeader* const header = ::new (malloc_base)MallocHeader(size, flags, mst_marker);
+  MallocHeader* const header = ::new (malloc_base)MallocHeader(size, flags, bucket_idx, bucket_pos);
   void* const memblock = (void*)((char*)malloc_base + sizeof(MallocHeader));
 
   // The alignment check: 8 bytes alignment for 32 bit systems.
@@ -188,7 +189,7 @@ void* MallocTracker::record_free_block(void* memblock) {
 void MallocTracker::deaccount(MallocHeader::FreeInfo free_info) {
   MallocMemorySummary::record_free(free_info.size, free_info.flags);
   if (MemTracker::tracking_level() == NMT_detail) {
-    MallocSiteTable::deallocation_at(free_info.size, free_info.mst_marker);
+    MallocSiteTable::deallocation_at(free_info.size, free_info.bucket_idx, free_info.bucket_pos);
   }
 }
 


### PR DESCRIPTION
While learning the NMT code I came across _mst_marker and I don't really like how it combines 16bit index and 16bit position into single 32bit mst_marker using bit sizzling.

Consequently, right now we need the following 3 APIs: build_marker(), bucket_idx_from_marker(), pos_idx_from_marker() to support this. They are really not adding any value, in my opinion, and in fact obfuscate the code.

I'd like to propose that we simplify the code and pass a struct value (as suggested by Thomas) which hides away the 2 individual fields that are implementation detail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313708](https://bugs.openjdk.org/browse/JDK-8313708): NMT: cleanup _mst_marker (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Afshin Zafari](https://openjdk.org/census#azafari) (@afshin-zafari - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15145/head:pull/15145` \
`$ git checkout pull/15145`

Update a local copy of the PR: \
`$ git checkout pull/15145` \
`$ git pull https://git.openjdk.org/jdk.git pull/15145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15145`

View PR using the GUI difftool: \
`$ git pr show -t 15145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15145.diff">https://git.openjdk.org/jdk/pull/15145.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15145#issuecomment-1674088135)