### PR TITLE
8313722: JFR: Avoid unnecessary calls to Events.from(Recording)

### DIFF
--- a/test/jdk/jdk/jfr/api/event/TestExtends.java
+++ b/test/jdk/jdk/jfr/api/event/TestExtends.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,8 @@
  */
 
 package jdk.jfr.api.event;
+
+import java.util.List;
 
 import jdk.jfr.Event;
 import jdk.jfr.EventType;
@@ -88,7 +90,8 @@ public class TestExtends {
         m.commit();
 
         r.stop();
-        for (RecordedEvent re : Events.fromRecording(r)) {
+        List<RecordedEvent> events = Events.fromRecording(r);
+        for (RecordedEvent re : events) {
             System.out.println(re);
         }
         // Grandpa
@@ -127,18 +130,18 @@ public class TestExtends {
         verifyField(meType, "hiddenField");
         verifyFieldCount(meType, 11);
 
-        for (RecordedEvent re : Events.fromRecording(r)) {
+        for (RecordedEvent re : events) {
             System.out.println(re);
         }
 
-        RecordedEvent grandpa = findEvent(r, GrandpaEvent.class.getName());
+        RecordedEvent grandpa = findEvent(events, GrandpaEvent.class.getName());
         Asserts.assertEquals(grandpa.getValue("gPublicField"), 4);
         Asserts.assertEquals(grandpa.getValue("gProtectedField"), 3);
         Asserts.assertEquals(grandpa.getValue("gPrivateField"), 2);
         Asserts.assertEquals(grandpa.getValue("gDefaultField"), 1);
         Asserts.assertEquals(grandpa.getValue("hiddenField"), 4711);
 
-        RecordedEvent parent = findEvent(r, ParentEvent.class.getName());
+        RecordedEvent parent = findEvent(events, ParentEvent.class.getName());
         Asserts.assertEquals(parent.getValue("gPublicField"), 4);
         Asserts.assertEquals(parent.getValue("gProtectedField"), 3);
         Asserts.assertEquals(parent.getValue("gDefaultField"), 1);
@@ -148,7 +151,7 @@ public class TestExtends {
         Asserts.assertEquals(parent.getValue("pDefaultField"), 10);
         Asserts.assertEquals(parent.getValue("hiddenField"), true);
 
-        RecordedEvent me = findEvent(r, MeEvent.class.getName());
+        RecordedEvent me = findEvent(events, MeEvent.class.getName());
         Asserts.assertEquals(me.getValue("gPublicField"), 4);
         Asserts.assertEquals(me.getValue("gProtectedField"), 3);
         Asserts.assertEquals(me.getValue("gDefaultField"), 1);
@@ -162,8 +165,8 @@ public class TestExtends {
         Asserts.assertEquals(me.getValue("hiddenField"), "Hidden");
     }
 
-    private static RecordedEvent findEvent(Recording r, String name) throws Exception {
-        for (RecordedEvent re : Events.fromRecording(r)) {
+    private static RecordedEvent findEvent(List<RecordedEvent> events, String name) throws Exception {
+        for (RecordedEvent re : events) {
             if (re.getEventType().getName().equals(name)) {
                 return re;
             }

--- a/test/jdk/jdk/jfr/api/event/TestExtends.java
+++ b/test/jdk/jdk/jfr/api/event/TestExtends.java
@@ -24,7 +24,6 @@
 package jdk.jfr.api.event;
 
 import java.util.List;
-
 import jdk.jfr.Event;
 import jdk.jfr.EventType;
 import jdk.jfr.Recording;

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class TestZAllocationStallEvent {
             List<RecordedEvent> events = Events.fromRecording(recording);
             System.out.println("Events: " + events.size());
             Events.hasEvents(events);
-            for (RecordedEvent event : Events.fromRecording(recording)) {
+            for (RecordedEvent event : events) {
                 Events.assertField(event, "size").atLeast(2L * 1024 * 1024);
             }
         }

--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class TestZPageAllocationEvent {
             List<RecordedEvent> events = Events.fromRecording(recording);
             System.out.println("Events: " + events.size());
             Events.hasEvents(events);
-            for (RecordedEvent event : Events.fromRecording(recording)) {
+            for (RecordedEvent event : events) {
                 Events.assertField(event, "size").atLeast(2L * 1024 * 1024);
             }
         }

--- a/test/jdk/jdk/jfr/event/gc/heapsummary/HeapSummaryEventAllGcs.java
+++ b/test/jdk/jdk/jfr/event/gc/heapsummary/HeapSummaryEventAllGcs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,10 +48,11 @@ public class HeapSummaryEventAllGcs {
         GCHelper.callSystemGc(5, true);
         recording.stop();
 
-        if (!checkCollectors(recording, expectedYoungCollector, expectedOldCollector)) {
+        List<RecordedEvent> allEvents = Events.fromRecording(recording);
+        if (!checkCollectors(allEvents, expectedYoungCollector, expectedOldCollector)) {
             return;
         }
-        List<RecordedEvent> events = GCHelper.removeFirstAndLastGC(Events.fromRecording(recording));
+        List<RecordedEvent> events = GCHelper.removeFirstAndLastGC(allEvents);
         for (RecordedEvent event : events) {
             System.out.println("Event:" + event);
         }
@@ -190,8 +191,8 @@ public class HeapSummaryEventAllGcs {
         Asserts.assertEquals(size, end - start, "Size mismatch");
     }
 
-    private static boolean checkCollectors(Recording recording, String expectedYoung, String expectedOld) throws Exception {
-        for (RecordedEvent event : Events.fromRecording(recording)) {
+    private static boolean checkCollectors(List<RecordedEvent> events, String expectedYoung, String expectedOld) throws Exception {
+        for (RecordedEvent event : events) {
             if (Events.isEventType(event, EventNames.GCConfiguration)) {
                 final String young = Events.assertField(event, "youngCollector").notEmpty().getValue();
                 final String old = Events.assertField(event, "oldCollector").notEmpty().getValue();

--- a/test/jdk/jdk/jfr/event/gc/objectcount/ObjectCountAfterGCEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/objectcount/ObjectCountAfterGCEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,11 +53,11 @@ public class ObjectCountAfterGCEvent {
         recording.stop();
 
         System.out.println("gcName=" + gcName);
-        for (RecordedEvent event : Events.fromRecording(recording)) {
+        List<RecordedEvent> events = Events.fromRecording(recording);
+        for (RecordedEvent event : events) {
             System.out.println("Event: " + event);
         }
 
-        List<RecordedEvent> events= Events.fromRecording(recording);
         Optional<RecordedEvent> gcEvent = events.stream()
                                 .filter(e -> isMySystemGc(e, gcName))
                                 .findFirst();

--- a/test/jdk/jdk/jfr/event/oldobject/TestMetadataRetention.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestMetadataRetention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,10 +100,10 @@ public final class TestMetadataRetention {
                 RecordedEvent chunkRotation = findChunkRotationEvent(events);
                 try {
                     // Sanity check that class was unloaded
-                    Events.hasEvent(recording, EventNames.ClassUnload);
+                    Events.hasEvent(events, EventNames.ClassUnload);
                     validateClassUnloadEvent(events);
                     // Validate that metadata for old object event has survived chunk rotation
-                    Events.hasEvent(recording, EventNames.OldObjectSample);
+                    Events.hasEvent(events, EventNames.OldObjectSample);
                     validateOldObjectEvent(events, chunkRotation.getStartTime());
                 } catch (Throwable t) {
                     t.printStackTrace();

--- a/test/jdk/jdk/jfr/event/runtime/TestSafepointEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestSafepointEvents.java
@@ -68,7 +68,7 @@ public class TestSafepointEvents {
 
         try {
             // Verify that each event type was seen at least once
-            List<RecordedEvent> events =  Events.fromRecording(recording);
+            List<RecordedEvent> events = Events.fromRecording(recording);
             for (String name : EVENT_NAMES) {
                 boolean found = false;
                 for (RecordedEvent event : events) {

--- a/test/jdk/jdk/jfr/event/runtime/TestSafepointEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestSafepointEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,9 +68,10 @@ public class TestSafepointEvents {
 
         try {
             // Verify that each event type was seen at least once
+            List<RecordedEvent> events =  Events.fromRecording(recording);
             for (String name : EVENT_NAMES) {
                 boolean found = false;
-                for (RecordedEvent event : Events.fromRecording(recording)) {
+                for (RecordedEvent event : events) {
                     found = event.getEventType().getName().equals(name);
                     if (found) {
                         break;
@@ -81,7 +82,7 @@ public class TestSafepointEvents {
 
             // Collect all events grouped by safepoint id
             SortedMap<Long, Set<String>> safepointIds = new TreeMap<>();
-            for (RecordedEvent event : Events.fromRecording(recording)) {
+            for (RecordedEvent event : events) {
                 Long safepointId = event.getValue("safepointId");
                 if (!safepointIds.containsKey(safepointId)) {
                     safepointIds.put(safepointId, new HashSet<>());

--- a/test/jdk/jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestSyncOnValueBasedClassEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class TestSyncOnValueBasedClassEvent {
         List<String> classesFound = new ArrayList<String>();
         List<RecordedEvent> events = Events.fromRecording(recording);
         Events.hasEvents(events);
-        for (RecordedEvent event : Events.fromRecording(recording)) {
+        for (RecordedEvent event : events) {
             String className = Events.assertField(event, "valueBasedClass.name").notEmpty().getValue();
             RecordedThread jt = event.getThread();
             if (Thread.currentThread().getName().equals(jt.getJavaName())) {

--- a/test/jdk/jdk/jfr/event/runtime/TestVMOperation.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestVMOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class TestVMOperation {
 
         List<RecordedEvent> events = Events.fromRecording(recording);
         Events.hasEvents(events);
-        for (RecordedEvent event : Events.fromRecording(recording)) {
+        for (RecordedEvent event : events) {
             String operation = Events.assertField(event, "operation").notEmpty().getValue();
             if (operation.equals(VM_OPERATION)) {
                 Events.assertField(event, "safepoint").equal(true);

--- a/test/jdk/jdk/jfr/startupargs/TestRetransform.java
+++ b/test/jdk/jdk/jfr/startupargs/TestRetransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,11 @@
 
 package jdk.jfr.startupargs;
 
+import java.util.List;
 import jdk.jfr.Event;
 import jdk.jfr.EventType;
 import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.Events;
 import jdk.test.lib.jfr.SimpleEvent;
@@ -58,8 +60,9 @@ public class TestRetransform {
         if (type.isEnabled()) {
             Asserts.fail("Expected event to be disabled after recording stopped");
         }
-        Events.hasEvent(r, SimpleEvent.class.getName());
-        Events.hasEvent(r, TestEvent.class.getName());
+        List<RecordedEvent> events = Events.fromRecording(r);
+        Events.hasEvent(events, SimpleEvent.class.getName());
+        Events.hasEvent(events, TestEvent.class.getName());
     }
 
     // Classes that are loaded during a recording

--- a/test/lib/jdk/test/lib/jfr/Events.java
+++ b/test/lib/jdk/test/lib/jfr/Events.java
@@ -276,7 +276,7 @@ public class Events {
     private static long lastId = -1;
     public static List<RecordedEvent> fromRecording(Recording recording) throws IOException {
         if (recording.getId() == lastId) {
-            throw new IOException("Recording with id " + lastId + " has already been dumped. Store the results in an List<RecoredEvent> instead of dumping again");
+            throw new IOException("Recording with id " + lastId + " has already been dumped. Store the results in a List<RecordedEvent> instead of dumping the recording again");
         }
         lastId = recording.getId();
         return RecordingFile.readAllEvents(makeCopy(recording));

--- a/test/lib/jdk/test/lib/jfr/Events.java
+++ b/test/lib/jdk/test/lib/jfr/Events.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -273,7 +273,12 @@ public class Events {
      * @throws IOException if an event set could not be created due to I/O
      *         errors.
      */
+    private static long lastId = -1;
     public static List<RecordedEvent> fromRecording(Recording recording) throws IOException {
+        if (recording.getId() == lastId) {
+            throw new IOException("Recording with id " + lastId + " has already been dumped. Store the results in an List<RecoredEvent> instead of dumping again");
+        }
+        lastId = recording.getId();
         return RecordingFile.readAllEvents(makeCopy(recording));
     }
 


### PR DESCRIPTION
Could I have a review of PR that removes unnecessary calls to Events.from(Recording). 

With each call a new dump file is created. A better approach is store the events in a List that can be reused,

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313722](https://bugs.openjdk.org/browse/JDK-8313722): JFR: Avoid unnecessary calls to Events.from(Recording) (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15147/head:pull/15147` \
`$ git checkout pull/15147`

Update a local copy of the PR: \
`$ git checkout pull/15147` \
`$ git pull https://git.openjdk.org/jdk.git pull/15147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15147`

View PR using the GUI difftool: \
`$ git pr show -t 15147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15147.diff">https://git.openjdk.org/jdk/pull/15147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15147#issuecomment-1664937043)