### PR TITLE
8293176: SSLEngine handshaker does not send an alert after a bad parameters

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLEngineImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLEngineImpl.java
@@ -1270,7 +1270,12 @@ final class SSLEngineImpl extends SSLEngine implements SSLTransport {
                     Map.Entry<Byte, ByteBuffer> me =
                             context.delegatedActions.poll();
                     if (me != null) {
-                        context.dispatch(me.getKey(), me.getValue());
+                        try {
+                            context.dispatch(me.getKey(), me.getValue());
+                        } catch (Exception e) {
+                            throw context.conContext.fatal(Alert.INTERNAL_ERROR,
+                                    "Unhandled exception", e);
+                        }
                     }
                 }
                 return null;

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java
@@ -73,8 +73,8 @@ public class SSLEngineDecodeBadPoint {
         try {
             eng.wrap(emptyBuf, alert);
             throw new RuntimeException("Expected wrap to throw");
-        } catch (Exception e) {
-            System.err.println("Received expected exception:");
+        } catch (SSLException e) {
+            System.err.println("Received expected SSLException:");
             e.printStackTrace();
         }
         if (alert.position() != 0) {

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
+import java.nio.ByteBuffer;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/*
+ * @test
+ * @bug 8293176
+ * @summary SSLEngine should close after bad key share
+ * @run main SSLEngineDecodeBadPoint
+ */
+public class SSLEngineDecodeBadPoint {
+    static final byte[] clientHello = HexFormat.of().parseHex(
+            "160303013a0100013603031570" +
+                    "151d6066940aa5dfcecc99f470bfdc175eec2c6f3273b079b2f80b49" +
+                    "75c820efe3d307201492a49fcee79fac5b2f05dca26c572b65b0d90d" +
+                    "81f51fd26b49b700021302010000eb000500050100000000000a0016" +
+                    "0014001d001700180019001e01000101010201030104000d00220020" +
+                    "040305030603080708080804080508060809080a080b040105010601" +
+                    "02030201002b0003020304002d000201010032002200200403050306" +
+                    "03080708080804080508060809080a080b0401050106010203020100" +
+                    "33006b0069001d00209a4d13131f83cc4c5be46520f0b4d7a6f1d3f6" +
+                    "ca7118e6dd115125090da6e044" +
+                    // ECDHE key share, 5th byte changed from 04 to (invalid) 05
+                    "0017004105d8c3734b9c729f6a9851" +
+                    "5049543ec5a9bb6c19b8c02ca0bdc3b20a77c44acdab226b6329b7c5" +
+                    "db9204421932c6fa1abe614c6892f5289edf9ff43cac534cad9e");
+
+    public static void main(String[] args) throws NoSuchAlgorithmException, SSLException {
+        SSLContext ctx = SSLContext.getDefault();
+        SSLEngine eng = ctx.createSSLEngine();
+        eng.setUseClientMode(false);
+        eng.beginHandshake();
+        ByteBuffer hello = ByteBuffer.wrap(clientHello);
+        ByteBuffer emptyBuf = ByteBuffer.allocate(0);
+        SSLEngineResult res = eng.unwrap(hello, emptyBuf);
+        System.out.println("status after unwrap: " + res);
+        eng.getDelegatedTask().run();
+
+        SSLEngineResult.HandshakeStatus status = eng.getHandshakeStatus();
+        System.out.println("status after task: " + status);
+        if (status != SSLEngineResult.HandshakeStatus.NEED_WRAP) {
+            throw new RuntimeException("Unexpected status after task: " + status);
+        }
+        ByteBuffer alert = ByteBuffer.allocate(eng.getSession().getPacketBufferSize());
+
+        try {
+            eng.wrap(emptyBuf, alert);
+            throw new RuntimeException("Expected wrap to throw");
+        } catch (Exception e) {
+            System.err.println("Received expected exception:");
+            e.printStackTrace();
+        }
+        if (alert.position() != 0) {
+            throw new RuntimeException("Expected no bytes written in first wrap call");
+        }
+        res = eng.wrap(emptyBuf, alert);
+        System.out.println("status after wrap: " + res);
+        if (res.getStatus() != SSLEngineResult.Status.CLOSED ||
+                res.getHandshakeStatus() != SSLEngineResult.HandshakeStatus.NOT_HANDSHAKING) {
+            throw new RuntimeException("Unexpected status after wrap: " + res);
+        }
+        if (!eng.isOutboundDone()) {
+            throw new RuntimeException("Expected outbound done");
+        }
+    }
+}

--- a/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java
+++ b/test/jdk/sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java
@@ -38,19 +38,19 @@ import java.util.HexFormat;
 public class SSLEngineDecodeBadPoint {
     static final byte[] clientHello = HexFormat.of().parseHex(
             "160303013a0100013603031570" +
-                    "151d6066940aa5dfcecc99f470bfdc175eec2c6f3273b079b2f80b49" +
-                    "75c820efe3d307201492a49fcee79fac5b2f05dca26c572b65b0d90d" +
-                    "81f51fd26b49b700021302010000eb000500050100000000000a0016" +
-                    "0014001d001700180019001e01000101010201030104000d00220020" +
-                    "040305030603080708080804080508060809080a080b040105010601" +
-                    "02030201002b0003020304002d000201010032002200200403050306" +
-                    "03080708080804080508060809080a080b0401050106010203020100" +
-                    "33006b0069001d00209a4d13131f83cc4c5be46520f0b4d7a6f1d3f6" +
-                    "ca7118e6dd115125090da6e044" +
-                    // ECDHE key share, 5th byte changed from 04 to (invalid) 05
-                    "0017004105d8c3734b9c729f6a9851" +
-                    "5049543ec5a9bb6c19b8c02ca0bdc3b20a77c44acdab226b6329b7c5" +
-                    "db9204421932c6fa1abe614c6892f5289edf9ff43cac534cad9e");
+            "151d6066940aa5dfcecc99f470bfdc175eec2c6f3273b079b2f80b49" +
+            "75c820efe3d307201492a49fcee79fac5b2f05dca26c572b65b0d90d" +
+            "81f51fd26b49b700021302010000eb000500050100000000000a0016" +
+            "0014001d001700180019001e01000101010201030104000d00220020" +
+            "040305030603080708080804080508060809080a080b040105010601" +
+            "02030201002b0003020304002d000201010032002200200403050306" +
+            "03080708080804080508060809080a080b0401050106010203020100" +
+            "33006b0069001d00209a4d13131f83cc4c5be46520f0b4d7a6f1d3f6" +
+            "ca7118e6dd115125090da6e044" +
+            // ECDHE key share, 5th byte changed from 04 to (invalid) 05
+            "0017004105d8c3734b9c729f6a9851" +
+            "5049543ec5a9bb6c19b8c02ca0bdc3b20a77c44acdab226b6329b7c5" +
+            "db9204421932c6fa1abe614c6892f5289edf9ff43cac534cad9e");
 
     public static void main(String[] args) throws NoSuchAlgorithmException, SSLException {
         SSLContext ctx = SSLContext.getDefault();


### PR DESCRIPTION
Please review this patch that ensures that all exceptions thrown by SSLEngine delegated tasks are translated to alerts.

All exceptions should already be translated to SSLExceptions and alerts by the time we exit from context.dispatch; these exceptions are rethrown by `conContext.fatal` without modification. With this patch the remaining exceptions are translated to `internal_error` alerts.

SSLSocket implements similar handling in SSLSocketImpl#startHandshake. SSLSocket rethrows `SocketException`s without modification, and translates other `IOException`s to `handshake_failure` alerts. SSLEngine does not need to handle `SocketException`s, and IMO `internal_error` is a better choice here.

Tier1-3 tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293176](https://bugs.openjdk.org/browse/JDK-8293176): SSLEngine handshaker does not send an alert after a bad parameters (**Bug** - P4)


### Reviewers
 * [Matthew Donovan](https://openjdk.org/census#mdonovan) (@mpdonova - Committer)
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15148/head:pull/15148` \
`$ git checkout pull/15148`

Update a local copy of the PR: \
`$ git checkout pull/15148` \
`$ git pull https://git.openjdk.org/jdk.git pull/15148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15148`

View PR using the GUI difftool: \
`$ git pr show -t 15148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15148.diff">https://git.openjdk.org/jdk/pull/15148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15148#issuecomment-1665237197)