### PR TITLE
8313701: GHA: RISC-V should use the official repository for bootstrap

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -86,8 +86,7 @@ jobs:
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
-            debian-repository: https://deb.debian.org/debian-ports
-            debian-keyring: /usr/share/keyrings/debian-ports-archive-keyring.gpg
+            debian-repository: https://httpredir.debian.org/debian/
             debian-version: sid
 
     steps:


### PR DESCRIPTION
RISC-V is now the [official Debian architecture](https://lists.debian.org/debian-riscv/2023/07/msg00053.html). This means that the official repository is slowly building up the package set, while the old debian-ports repo is [slowly rotting](https://lists.debian.org/debian-riscv/2023/08/msg00007.html). For futureproof-ness, we want to bootstrap from the official repo going forward.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313701](https://bugs.openjdk.org/browse/JDK-8313701): GHA: RISC-V should use the official repository for bootstrap (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15149/head:pull/15149` \
`$ git checkout pull/15149`

Update a local copy of the PR: \
`$ git checkout pull/15149` \
`$ git pull https://git.openjdk.org/jdk.git pull/15149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15149`

View PR using the GUI difftool: \
`$ git pr show -t 15149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15149.diff">https://git.openjdk.org/jdk/pull/15149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15149#issuecomment-1665308086)