### PR TITLE
JDK-8313670: Simplify shared lib name handling code in some tests

### DIFF
--- a/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
+++ b/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
+++ b/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
@@ -144,7 +144,6 @@ public class SigTestDriver {
     }
 
     private static Path libjsig() {
-        return Platform.jvmLibDir().resolve(Platform.sharedLibraryPrefix() + "jsig."
-                + Platform.sharedLibraryExt());
+        return Platform.jvmLibDir().resolve(Platform.buildSharedLibraryName("jsig"));
     }
 }

--- a/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
+++ b/test/hotspot/jtreg/runtime/signal/SigTestDriver.java
@@ -144,7 +144,7 @@ public class SigTestDriver {
     }
 
     private static Path libjsig() {
-        return Platform.jvmLibDir().resolve((Platform.isWindows() ? "" : "lib")
-                + "jsig." + Platform.sharedLibraryExt());
+        return Platform.jvmLibDir().resolve(Platform.sharedLibraryPrefix() + "jsig."
+                + Platform.sharedLibraryExt());
     }
 }

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachFailedTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachFailedTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachFailedTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachFailedTestBase.java
@@ -39,14 +39,7 @@ public abstract class AttachFailedTestBase {
      * Build path to shared object according to platform rules
      */
     public static String getSharedObjectPath(String name) {
-        String libname;
-        if (Platform.isWindows()) {
-            libname = name + ".dll";
-        } else if (Platform.isOSX()) {
-            libname = "lib" + name + ".dylib";
-        } else {
-            libname = "lib" + name + ".so";
-        }
+        String libname = Platform.sharedLibraryPrefix() + name + "." + Platform.sharedLibraryExt();
 
         return Paths.get(Utils.TEST_NATIVE_PATH, libname)
                     .toAbsolutePath()

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachFailedTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/AttachFailed/AttachFailedTestBase.java
@@ -39,7 +39,7 @@ public abstract class AttachFailedTestBase {
      * Build path to shared object according to platform rules
      */
     public static String getSharedObjectPath(String name) {
-        String libname = Platform.sharedLibraryPrefix() + name + "." + Platform.sharedLibraryExt();
+        String libname = Platform.buildSharedLibraryName(name);
 
         return Paths.get(Utils.TEST_NATIVE_PATH, libname)
                     .toAbsolutePath()

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
@@ -63,8 +63,7 @@ public class LoadAgentDcmdTest {
                       "'-Dtest.jdk=/path/to/jdk'.");
         }
 
-        Path libpath = Paths.get(jdkPath, jdkLibPath(),
-                                 Platform.sharedLibraryPrefix() + "instrument." + Platform.sharedLibraryExt());
+        Path libpath = Paths.get(jdkPath, jdkLibPath(), Platform.buildSharedLibraryName("instrument"));
 
         if (!libpath.toFile().exists()) {
             throw new FileNotFoundException(

--- a/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/jvmti/LoadAgentDcmdTest.java
@@ -63,7 +63,8 @@ public class LoadAgentDcmdTest {
                       "'-Dtest.jdk=/path/to/jdk'.");
         }
 
-        Path libpath = Paths.get(jdkPath, jdkLibPath(), sharedObjectName("instrument"));
+        Path libpath = Paths.get(jdkPath, jdkLibPath(),
+                                 Platform.sharedLibraryPrefix() + "instrument." + Platform.sharedLibraryExt());
 
         if (!libpath.toFile().exists()) {
             throw new FileNotFoundException(
@@ -155,19 +156,6 @@ public class LoadAgentDcmdTest {
             return "bin";
         }
         return "lib";
-    }
-
-    /**
-     * Build name of shared object according to platform rules
-     */
-    public static String sharedObjectName(String name) {
-        if (Platform.isWindows()) {
-            return name + ".dll";
-        }
-        if (Platform.isOSX()) {
-            return "lib" + name + ".dylib";
-        }
-        return "lib" + name + ".so";
     }
 
     @Test

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
@@ -44,12 +44,9 @@ public class DynLibsTest {
 
     public void run(CommandExecutor executor) {
         OutputAnalyzer output = executor.execute("VM.dynlibs");
-
-        String osDependentBaseString = Platform.sharedLibraryPrefix() + "%s." + Platform.sharedLibraryExt();
-
-        output.shouldContain(String.format(osDependentBaseString, "jvm"));
-        output.shouldContain(String.format(osDependentBaseString, "java"));
-        output.shouldContain(String.format(osDependentBaseString, "management"));
+        output.shouldContain(Platform.buildSharedLibraryName("jvm"));
+        output.shouldContain(Platform.buildSharedLibraryName("java"));
+        output.shouldContain(Platform.buildSharedLibraryName("management"));
     }
 
     @Test

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/DynLibsTest.java
@@ -45,20 +45,7 @@ public class DynLibsTest {
     public void run(CommandExecutor executor) {
         OutputAnalyzer output = executor.execute("VM.dynlibs");
 
-        String osDependentBaseString = null;
-        if (Platform.isAix()) {
-            osDependentBaseString = "lib%s.so";
-        } else if (Platform.isLinux()) {
-            osDependentBaseString = "lib%s.so";
-        } else if (Platform.isOSX()) {
-            osDependentBaseString = "lib%s.dylib";
-        } else if (Platform.isWindows()) {
-            osDependentBaseString = "%s.dll";
-        }
-
-        if (osDependentBaseString == null) {
-            Assert.fail("Unsupported OS");
-        }
+        String osDependentBaseString = Platform.sharedLibraryPrefix() + "%s." + Platform.sharedLibraryExt();
 
         output.shouldContain(String.format(osDependentBaseString, "jvm"));
         output.shouldContain(String.format(osDependentBaseString, "java"));

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeLibraryCopier.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeLibraryCopier.java
@@ -34,12 +34,12 @@ import java.nio.file.Paths;
 public class NativeLibraryCopier {
     public static void main(String[] args) {
         Path src = Paths.get(Utils.TEST_NATIVE_PATH)
-                        .resolve(libname(args[0]))
+                        .resolve(Platform.buildSharedLibraryName(args[0]))
                         .toAbsolutePath();
 
         Path dstDir = Paths.get(".");
         for (int i = 1; i < args.length; ++i) {
-            Path dst = dstDir.resolve(libname(args[i])).toAbsolutePath();
+            Path dst = dstDir.resolve(Platform.buildSharedLibraryName(args[i])).toAbsolutePath();
             System.out.println("copying " + src + " to " + dst);
             try {
                 Files.copy(src, dst);
@@ -47,9 +47,5 @@ public class NativeLibraryCopier {
                 throw new Error("can't copy " + src + " to " + dst, e);
             }
         }
-    }
-
-    private static String libname(String name) {
-        return Platform.sharedLibraryPrefix() + name + "." + Platform.sharedLibraryExt();
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeLibraryCopier.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeLibraryCopier.java
@@ -50,9 +50,6 @@ public class NativeLibraryCopier {
     }
 
     private static String libname(String name) {
-        return String.format("%s%s.%s",
-                Platform.isWindows() ? "" : "lib",
-                name,
-                Platform.sharedLibraryExt());
+        return Platform.sharedLibraryPrefix() + name + "." + Platform.sharedLibraryExt();
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeLibraryCopier.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/NativeLibraryCopier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
+++ b/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
@@ -79,9 +79,8 @@ class DynamicLoadWarningTest {
     @BeforeAll
     static void setup() throws Exception {
         // get absolute path to JVM TI agents
-        String prefix = Platform.isWindows() ? "" : "lib";
-        String libname1 = prefix + JVMTI_AGENT1_LIB + "." + Platform.sharedLibraryExt();
-        String libname2 = prefix + JVMTI_AGENT2_LIB + "." + Platform.sharedLibraryExt();
+        String libname1 = Platform.sharedLibraryPrefix() + JVMTI_AGENT1_LIB + "." + Platform.sharedLibraryExt();
+        String libname2 = Platform.sharedLibraryPrefix() + JVMTI_AGENT2_LIB + "." + Platform.sharedLibraryExt();
         jvmtiAgentPath1 = Path.of(Utils.TEST_NATIVE_PATH, libname1).toAbsolutePath().toString();
         jvmtiAgentPath2 = Path.of(Utils.TEST_NATIVE_PATH, libname2).toAbsolutePath().toString();
 

--- a/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
+++ b/test/jdk/com/sun/tools/attach/warnings/DynamicLoadWarningTest.java
@@ -79,8 +79,8 @@ class DynamicLoadWarningTest {
     @BeforeAll
     static void setup() throws Exception {
         // get absolute path to JVM TI agents
-        String libname1 = Platform.sharedLibraryPrefix() + JVMTI_AGENT1_LIB + "." + Platform.sharedLibraryExt();
-        String libname2 = Platform.sharedLibraryPrefix() + JVMTI_AGENT2_LIB + "." + Platform.sharedLibraryExt();
+        String libname1 = Platform.buildSharedLibraryName(JVMTI_AGENT1_LIB);
+        String libname2 = Platform.buildSharedLibraryName(JVMTI_AGENT2_LIB);
         jvmtiAgentPath1 = Path.of(Utils.TEST_NATIVE_PATH, libname1).toAbsolutePath().toString();
         jvmtiAgentPath2 = Path.of(Utils.TEST_NATIVE_PATH, libname2).toAbsolutePath().toString();
 

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeLibrariesEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeLibrariesEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeLibrariesEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeLibrariesEvent.java
@@ -70,12 +70,10 @@ public class TestNativeLibrariesEvent {
     }
 
     private static List<String> getExpectedLibs() throws Throwable {
-        String libTemplate = Platform.sharedLibraryPrefix() + "%s." + Platform.sharedLibraryExt();
-
         List<String> libs = new ArrayList<String>();
         String[] names = { "jvm", "java", "zip" };
         for (String name : names) {
-            libs.add(String.format(libTemplate, name));
+            libs.add(Platform.buildSharedLibraryName(name));
         }
         return libs;
     }

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeLibrariesEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeLibrariesEvent.java
@@ -70,20 +70,7 @@ public class TestNativeLibrariesEvent {
     }
 
     private static List<String> getExpectedLibs() throws Throwable {
-        String libTemplate = null;
-        if (Platform.isWindows()) {
-            libTemplate = "%s.dll";
-        } else if (Platform.isOSX()) {
-            libTemplate = "lib%s.dylib";
-        } else if (Platform.isLinux()) {
-            libTemplate = "lib%s.so";
-        } else if (Platform.isAix()) {
-            libTemplate = "lib%s.so";
-        }
-
-        if (libTemplate == null) {
-            throw new Exception("Unsupported OS");
-        }
+        String libTemplate = Platform.sharedLibraryPrefix() + "%s." + Platform.sharedLibraryExt();
 
         List<String> libs = new ArrayList<String>();
         String[] names = { "jvm", "java", "zip" };

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeLibraryLoadEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeLibraryLoadEvent.java
@@ -70,20 +70,7 @@ public class TestNativeLibraryLoadEvent {
     }
 
     private static List<String> getExpectedLibs() throws Throwable {
-        String libTemplate = null;
-        if (Platform.isWindows()) {
-            libTemplate = "%s.dll";
-        } else if (Platform.isOSX()) {
-            libTemplate = "lib%s.dylib";
-        } else if (Platform.isLinux()) {
-            libTemplate = "lib%s.so";
-        } else if (Platform.isAix()) {
-            libTemplate = "lib%s.so";
-        }
-
-        if (libTemplate == null) {
-            throw new Exception("Unsupported OS");
-        }
+        String libTemplate = Platform.sharedLibraryPrefix() + "%s." + Platform.sharedLibraryExt();
 
         List<String> libs = new ArrayList<String>();
         String[] names = { "instrument" };

--- a/test/jdk/jdk/jfr/event/runtime/TestNativeLibraryLoadEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestNativeLibraryLoadEvent.java
@@ -54,30 +54,17 @@ public class TestNativeLibraryLoadEvent {
             System.loadLibrary("instrument");
             recording.stop();
 
-            List<String> expectedLibs = getExpectedLibs();
+            String expectedLib = Platform.buildSharedLibraryName("instrument");
+            boolean expectedLibFound = false;
             for (RecordedEvent event : Events.fromRecording(recording)) {
                 System.out.println("Event:" + event);
                 String lib = Events.assertField(event, "name").notEmpty().getValue();
                 Events.assertField(event, "success");
-                for (String expectedLib : new ArrayList<>(expectedLibs)) {
-                    if (lib.contains(expectedLib)) {
-                        expectedLibs.remove(expectedLib);
-                    }
+                if (lib.contains(expectedLib)) {
+                    expectedLibFound = true;
                 }
             }
-            assertTrue(expectedLibs.isEmpty(), "Missing libraries:" + expectedLibs.stream().collect(Collectors.joining(", ")));
+            assertTrue(expectedLibFound, "Missing library " + expectedLib);
         }
     }
-
-    private static List<String> getExpectedLibs() throws Throwable {
-        String libTemplate = Platform.sharedLibraryPrefix() + "%s." + Platform.sharedLibraryExt();
-
-        List<String> libs = new ArrayList<String>();
-        String[] names = { "instrument" };
-        for (String name : names) {
-            libs.add(String.format(libTemplate, name));
-        }
-        return libs;
-    }
-
 }

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -362,6 +362,18 @@ public class Platform {
         }
     }
 
+    /**
+     * Returns the usual file prefix of a shared library, e.g. "lib" on linux, empty on windows.
+     * @return file name prefix
+     */
+    public static String sharedLibraryPrefix() {
+        if (isWindows()) {
+            return "";
+        } else {
+            return "lib";
+        }
+    }
+
     /*
      * Returns name of system variable containing paths to shared native libraries.
      */

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -374,6 +374,15 @@ public class Platform {
         }
     }
 
+    /**
+     * Returns the usual full shared lib name of a name without prefix and extension, e.g. for jsig
+     * "libjsig.so" on linux, "jsig.dll" on windows.
+     * @return the full shared lib name
+     */
+    public static String buildSharedLibraryName(String name) {
+        return sharedLibraryPrefix() + name + "." + sharedLibraryExt();
+    }
+
     /*
      * Returns name of system variable containing paths to shared native libraries.
      */


### PR DESCRIPTION
There is coding e.g. in
https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/jfr/event/runtime/TestNativeLibrariesEvent.java#L72
that deals with shared lib naming on different OS.
This code should be simplified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313670](https://bugs.openjdk.org/browse/JDK-8313670): Simplify shared lib name handling code in some tests (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [9f9c5b25](https://git.openjdk.org/jdk/pull/15151/files/9f9c5b259a2c789312abb94cc3ca385c501106e4)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [9f9c5b25](https://git.openjdk.org/jdk/pull/15151/files/9f9c5b259a2c789312abb94cc3ca385c501106e4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15151/head:pull/15151` \
`$ git checkout pull/15151`

Update a local copy of the PR: \
`$ git checkout pull/15151` \
`$ git pull https://git.openjdk.org/jdk.git pull/15151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15151`

View PR using the GUI difftool: \
`$ git pr show -t 15151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15151.diff">https://git.openjdk.org/jdk/pull/15151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15151#issuecomment-1665361602)