### PR TITLE
8313752: InstanceKlassFlags::print_on doesn't print the flag names

### DIFF
--- a/src/hotspot/share/oops/constMethodFlags.cpp
+++ b/src/hotspot/share/oops/constMethodFlags.cpp
@@ -29,7 +29,7 @@
 
 void ConstMethodFlags::print_on(outputStream* st) const {
 #define CM_PRINT(name, ignore)          \
-  if (name()) st->print(" " #name " ");
+  if (name()) st->print(#name " ");
   CM_FLAGS_DO(CM_PRINT)
 #undef CM_PRINT
 }

--- a/src/hotspot/share/oops/instanceKlassFlags.cpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.cpp
@@ -32,7 +32,7 @@
 
 void InstanceKlassFlags::print_on(outputStream* st) const {
 #define IK_FLAGS_PRINT(name, ignore)          \
-  if (name()) st->print(" ##name ");
+  if (name()) st->print(" " #name " ");
   IK_FLAGS_DO(IK_FLAGS_PRINT)
   IK_STATUS_DO(IK_FLAGS_PRINT)
 #undef IK_FLAGS_PRINT

--- a/src/hotspot/share/oops/instanceKlassFlags.cpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.cpp
@@ -32,11 +32,10 @@
 
 void InstanceKlassFlags::print_on(outputStream* st) const {
 #define IK_FLAGS_PRINT(name, ignore)          \
-  if (name()) st->print(" " #name " ");
+  if (name()) st->print(#name " ");
   IK_FLAGS_DO(IK_FLAGS_PRINT)
   IK_STATUS_DO(IK_FLAGS_PRINT)
 #undef IK_FLAGS_PRINT
-  st->cr();
 }
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/oops/methodFlags.cpp
+++ b/src/hotspot/share/oops/methodFlags.cpp
@@ -28,7 +28,7 @@
 
 void MethodFlags::print_on(outputStream* st) const {
 #define M_PRINT(name, ignore)          \
-  if (name()) st->print(" " #name " ");
+  if (name()) st->print(#name " ");
   M_STATUS_DO(M_PRINT)
 #undef M_PRINT
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/PrintClasses.java
@@ -56,5 +56,8 @@ public class PrintClasses {
     output = new OutputAnalyzer(pb.start());
     output.shouldContain("instance size");
     output.shouldContain(PrintClasses.class.getSimpleName());
+
+    // Test for previous bug in misc flags printing
+    output.shouldNotContain("##name");
   }
 }


### PR DESCRIPTION
I've found that our misc flags printing is broken. This can be seen in our hs_err files:
```
RCX=0x00007f86bf0073c8 is a pointer to class: 
java.lang.Class {0x00007f86bf0073c8}
 - instance size:     22
 - klass size:        97
 - access:            public final synchronized 
 - flags:              ##name  ##name  ##name  ##name  ##name  ##name 
```

With this fix the flags are now printed as expected:
```
java.util.Hashtable {0x00007f5fff00e8c0}
 - instance size:     8
 - klass size:        123
 - access:            public synchronized 
 - flags:              rewritten  has_nonstatic_fields  has_nonstatic_concrete_methods  is_shared_boot_class  has_localvariable_table  has_final_method 
```

The indentation doesn't look that great, so if you want me to change it I can do so in this patch as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313752](https://bugs.openjdk.org/browse/JDK-8313752): InstanceKlassFlags::print_on doesn't print the flag names (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [beae18c2](https://git.openjdk.org/jdk/pull/15153/files/beae18c2e01f2d5603613cba8e90cb237cfa216a)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15153/head:pull/15153` \
`$ git checkout pull/15153`

Update a local copy of the PR: \
`$ git checkout pull/15153` \
`$ git pull https://git.openjdk.org/jdk.git pull/15153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15153`

View PR using the GUI difftool: \
`$ git pr show -t 15153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15153.diff">https://git.openjdk.org/jdk/pull/15153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15153#issuecomment-1665464700)