### PR TITLE
8288936: Wrong lock ordering writing G1HeapRegionTypeChange JFR event

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -292,8 +292,8 @@ void mutex_init() {
   }
 
 #if INCLUDE_JFR
-  MUTEX_DEFN(JfrBuffer_lock                  , PaddedMutex  , nosafepoint);
-  MUTEX_DEFN(JfrMsg_lock                     , PaddedMonitor, nosafepoint-3);
+  MUTEX_DEFN(JfrBuffer_lock                  , PaddedMutex  , event);
+  MUTEX_DEFN(JfrMsg_lock                     , PaddedMonitor, event);
   MUTEX_DEFN(JfrStacktrace_lock              , PaddedMutex  , stackwatermark-1);
   MUTEX_DEFN(JfrThreadSampler_lock           , PaddedMonitor, nosafepoint);
 #endif


### PR DESCRIPTION
Greetings,

Please help review this adjustment to two JFR locks to avoid lock-ordering problems.

Test: jdk_jfr, reproducers

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288936](https://bugs.openjdk.org/browse/JDK-8288936): Wrong lock ordering writing G1HeapRegionTypeChange JFR event (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15155/head:pull/15155` \
`$ git checkout pull/15155`

Update a local copy of the PR: \
`$ git checkout pull/15155` \
`$ git pull https://git.openjdk.org/jdk.git pull/15155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15155`

View PR using the GUI difftool: \
`$ git pr show -t 15155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15155.diff">https://git.openjdk.org/jdk/pull/15155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15155#issuecomment-1665524946)