### PR TITLE
8313779: RISC-V: use andn / orn in the MD5 instrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1654,6 +1654,28 @@ void MacroAssembler::xorrw(Register Rd, Register Rs1, Register Rs2) {
   sign_extend(Rd, Rd, 32);
 }
 
+// Rd = Rs1 & (~Rd2)
+void MacroAssembler::andnr(Register Rd, Register Rs1, Register Rs2) {
+  if (UseZbb) {
+    andn(Rd, Rs1, Rs2);
+    return;
+  }
+
+  notr(Rd, Rs2);
+  andr(Rd, Rs1, Rd);
+}
+
+// Rd = Rs1 | (~Rd2)
+void MacroAssembler::ornr(Register Rd, Register Rs1, Register Rs2) {
+  if (UseZbb) {
+    orn(Rd, Rs1, Rs2);
+    return;
+  }
+
+  notr(Rd, Rs2);
+  orr(Rd, Rs1, Rd);
+}
+
 // Note: load_unsigned_short used to be called load_unsigned_word.
 int MacroAssembler::load_unsigned_short(Register dst, Address src) {
   int off = offset();

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1655,9 +1655,9 @@ void MacroAssembler::xorrw(Register Rd, Register Rs1, Register Rs2) {
 }
 
 // Rd = Rs1 & (~Rd2)
-void MacroAssembler::andnr(Register Rd, Register Rs1, Register Rs2) {
+void MacroAssembler::andn(Register Rd, Register Rs1, Register Rs2) {
   if (UseZbb) {
-    andn(Rd, Rs1, Rs2);
+    Assembler::andn(Rd, Rs1, Rs2);
     return;
   }
 
@@ -1666,9 +1666,9 @@ void MacroAssembler::andnr(Register Rd, Register Rs1, Register Rs2) {
 }
 
 // Rd = Rs1 | (~Rd2)
-void MacroAssembler::ornr(Register Rd, Register Rs1, Register Rs2) {
+void MacroAssembler::orn(Register Rd, Register Rs1, Register Rs2) {
   if (UseZbb) {
-    orn(Rd, Rs1, Rs2);
+    Assembler::orn(Rd, Rs1, Rs2);
     return;
   }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -763,6 +763,10 @@ public:
   void orrw(Register Rd, Register Rs1, Register Rs2);
   void xorrw(Register Rd, Register Rs1, Register Rs2);
 
+  // logic with negate
+  void andnr(Register Rd, Register Rs1, Register Rs2);
+  void ornr(Register Rd, Register Rs1, Register Rs2);
+
   // revb
   void revb_h_h(Register Rd, Register Rs, Register tmp = t0);                           // reverse bytes in halfword in lower 16 bits, sign-extend
   void revb_w_w(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);      // reverse bytes in lower word, sign-extend

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -764,8 +764,8 @@ public:
   void xorrw(Register Rd, Register Rs1, Register Rs2);
 
   // logic with negate
-  void andnr(Register Rd, Register Rs1, Register Rs2);
-  void ornr(Register Rd, Register Rs1, Register Rs2);
+  void andn(Register Rd, Register Rs1, Register Rs2);
+  void orn(Register Rd, Register Rs1, Register Rs2);
 
   // revb
   void revb_h_h(Register Rd, Register Rs, Register tmp = t0);                           // reverse bytes in halfword in lower 16 bits, sign-extend

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3960,7 +3960,7 @@ class StubGenerator: public StubCodeGenerator {
     // rtmp1 = rtmp1 + x + ac
     reg_cache.get_u32(rtmp2, k, rmask32);
     __ addw(rtmp1, rtmp1, rtmp2);
-    __ li(rtmp2, t);
+    __ mv(rtmp2, t);
     __ addw(rtmp1, rtmp1, rtmp2);
 
     // a += rtmp1 + x + ac
@@ -4153,7 +4153,7 @@ class StubGenerator: public StubCodeGenerator {
       __ mv(ofs, ofs_arg);
       __ mv(limit, limit_arg);
     }
-    __ li(rmask32, MASK_32);
+    __ mv(rmask32, MASK_32);
 
     // to minimize the number of memory operations:
     // read the 4 state 4-byte values in pairs, with a single ld,

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3981,8 +3981,7 @@ class StubGenerator: public StubCodeGenerator {
     __ andr(rtmp1, b, c);
 
     // rtmp2 = (~b) & d
-    __ notr(rtmp2, b);
-    __ andr(rtmp2, rtmp2, d);
+    __ andnr(rtmp2, d, b);
 
     // rtmp1 = (b & c) | ((~b) & d)
     __ orr(rtmp1, rtmp1, rtmp2);
@@ -4000,9 +3999,8 @@ class StubGenerator: public StubCodeGenerator {
     // rtmp1 = b & d
     __ andr(rtmp1, b, d);
 
-    // rtmp2 = (c & (~d))
-    __ notr(rtmp2, d);
-    __ andr(rtmp2, rtmp2, c);
+    // rtmp2 = c & (~d)
+    __ andnr(rtmp2, c, d);
 
     // rtmp1 = (b & d) | (c & (~d))
     __ orr(rtmp1, rtmp1, rtmp2);
@@ -4032,9 +4030,8 @@ class StubGenerator: public StubCodeGenerator {
               int k, int s, int t,
               Register rtmp1, Register rtmp2, Register rmask32) {
     // rtmp1 = c ^ (b | (~d))
-    __ notr(rtmp2, d);
-    __ orr(rtmp1, b, rtmp2);
-    __ xorr(rtmp1, c, rtmp1);
+    __ ornr(rtmp2, b, d);
+    __ xorr(rtmp1, c, rtmp2);
 
     m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t,
                             rtmp1, rtmp2, rmask32);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3981,7 +3981,7 @@ class StubGenerator: public StubCodeGenerator {
     __ andr(rtmp1, b, c);
 
     // rtmp2 = (~b) & d
-    __ andnr(rtmp2, d, b);
+    __ andn(rtmp2, d, b);
 
     // rtmp1 = (b & c) | ((~b) & d)
     __ orr(rtmp1, rtmp1, rtmp2);
@@ -4000,7 +4000,7 @@ class StubGenerator: public StubCodeGenerator {
     __ andr(rtmp1, b, d);
 
     // rtmp2 = c & (~d)
-    __ andnr(rtmp2, c, d);
+    __ andn(rtmp2, c, d);
 
     // rtmp1 = (b & d) | (c & (~d))
     __ orr(rtmp1, rtmp1, rtmp2);
@@ -4030,8 +4030,8 @@ class StubGenerator: public StubCodeGenerator {
               int k, int s, int t,
               Register rtmp1, Register rtmp2, Register rmask32) {
     // rtmp1 = c ^ (b | (~d))
-    __ ornr(rtmp2, b, d);
-    __ xorr(rtmp1, c, rtmp2);
+    __ orn(rtmp1, b, d);
+    __ xorr(rtmp1, c, rtmp1);
 
     m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t,
                             rtmp1, rtmp2, rmask32);


### PR DESCRIPTION
Small improvement of the MD5 intrinsic when the Zbb extension is available. Performance comparison (with thanks again to @robehn for this!):

before:

```
MessageDigests.digest                   md5        64     DEFAULT  avgt    6    1835.246 ±  252.071  ns/op
MessageDigests.digest                   md5     16384     DEFAULT  avgt    6  145386.522 ±  444.446  ns/op
MessageDigests.getAndDigest             md5        64     DEFAULT  avgt    6    2555.515 ±  639.491  ns/op
MessageDigests.getAndDigest             md5     16384     DEFAULT  avgt    6  149045.631 ± 6658.545  ns/op
```

after:

```
MessageDigests.digest                   md5        64     DEFAULT  avgt    6    1779.637 ±  207.869  ns/op
MessageDigests.digest                   md5     16384     DEFAULT  avgt    6  137147.179 ±  706.396  ns/op
MessageDigests.getAndDigest             md5        64     DEFAULT  avgt    6    2645.354 ± 1245.318  ns/op
MessageDigests.getAndDigest             md5     16384     DEFAULT  avgt    6  141306.966 ± 7000.576  ns/op
```

(only line 3 is not an improvement, but it has higher variation)

It seems to save around 5% of executed instructions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313779](https://bugs.openjdk.org/browse/JDK-8313779): RISC-V: use andn / orn in the MD5 instrinsic (**Enhancement** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer) ⚠️ Review applies to [d7d1cfee](https://git.openjdk.org/jdk/pull/15156/files/d7d1cfeec3adabc91acaec16671d597294a691f1)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [d7d1cfee](https://git.openjdk.org/jdk/pull/15156/files/d7d1cfeec3adabc91acaec16671d597294a691f1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15156/head:pull/15156` \
`$ git checkout pull/15156`

Update a local copy of the PR: \
`$ git checkout pull/15156` \
`$ git pull https://git.openjdk.org/jdk.git pull/15156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15156`

View PR using the GUI difftool: \
`$ git pr show -t 15156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15156.diff">https://git.openjdk.org/jdk/pull/15156.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15156#issuecomment-1665595293)