### PR TITLE
JDK-8313782: Add user-facing warning if THPs are enabled but cannot be used

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3794,14 +3794,14 @@ void os::large_page_init() {
   }
 
   // 2) check if the OS supports THPs resp. static hugepages.
-  if (UseTransparentHugePages && HugePages::supports_thp() == false) {
+  if (UseTransparentHugePages && !HugePages::supports_thp()) {
     if (!FLAG_IS_DEFAULT(UseTransparentHugePages)) {
-      log_warning(pagesize)("TransparentHugePages is not supported by the operating system.");
+      log_warning(pagesize)("UseTransparentHugePages disabled, transparent huge pages are not supported by the operating system.");
     }
     UseLargePages = UseTransparentHugePages = UseHugeTLBFS = UseSHM = false;
     return;
   }
-  if (!UseTransparentHugePages && HugePages::supports_static_hugepages() == false) {
+  if (!UseTransparentHugePages && !HugePages::supports_static_hugepages()) {
     warn_no_large_pages_configured();
     UseLargePages = UseTransparentHugePages = UseHugeTLBFS = UseSHM = false;
     return;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3793,15 +3793,17 @@ void os::large_page_init() {
     return;
   }
 
-  // 2) check if large pages are configured
-  if ( ( UseTransparentHugePages && HugePages::supports_thp() == false) ||
-       (!UseTransparentHugePages && HugePages::supports_static_hugepages() == false) ) {
-    // No large pages configured, return.
+  // 2) check if the OS supports THPs resp. static hugepages.
+  if (UseTransparentHugePages && HugePages::supports_thp() == false) {
+    if (!FLAG_IS_DEFAULT(UseTransparentHugePages)) {
+      log_warning(pagesize)("TransparentHugePages is not supported by the operating system.");
+    }
+    UseLargePages = UseTransparentHugePages = UseHugeTLBFS = UseSHM = false;
+    return;
+  }
+  if (!UseTransparentHugePages && HugePages::supports_static_hugepages() == false) {
     warn_no_large_pages_configured();
-    UseLargePages = false;
-    UseTransparentHugePages = false;
-    UseHugeTLBFS = false;
-    UseSHM = false;
+    UseLargePages = UseTransparentHugePages = UseHugeTLBFS = UseSHM = false;
     return;
   }
 


### PR DESCRIPTION
We don't warn the user if `+UseTransparentHugePages ` were specified (and nothing else, but this implies `+UseLargePages`), but the system does not support THPs.

We used to have warnings in the code, but I checked and they never really worked (I tried older versions of the JDK). The reason is that THP detection had been broken. The broken detection always reported success even if THPs are disabled, so the user would never have seen this warning even when we had it. 

THP detection has since been fixed with  [JDK-8310233](https://bugs.openjdk.org/browse/JDK-8310233), but we still don't warn.

The patch re-introduces the warning, with the same text as it used to have, and using the warning level of UL with the "pagesize" tag - that's what we do for static hugepage warnings too.

Before:
```
thomas@starfish$ ./images/jdk/bin/java -XX:+UseTransparentHugePages -version
openjdk version "20-ea" 2023-03-21
OpenJDK Runtime Environment SapMachine (build 20-ea+32)
OpenJDK 64-Bit Server VM SapMachine (build 20-ea+32, mixed mode, sharing)
```

Now:
```
thomas@starfish$ ./images/jdk/bin/java -XX:+UseTransparentHugePages -version
[0.001s][warning][pagesize] TransparentHugePages is not supported by the operating system.
openjdk version "22-internal" 2024-03-19
OpenJDK Runtime Environment (fastdebug build 22-internal-adhoc.thomas.source)
OpenJDK 64-Bit Server VM (fastdebug build 22-internal-adhoc.thomas.source, mixed mode, sharing)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313782](https://bugs.openjdk.org/browse/JDK-8313782): Add user-facing warning if THPs are enabled but cannot be used (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [c4e4ded6](https://git.openjdk.org/jdk/pull/15158/files/c4e4ded66e2224cd57681755fa6270ea949c8370)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15158/head:pull/15158` \
`$ git checkout pull/15158`

Update a local copy of the PR: \
`$ git checkout pull/15158` \
`$ git pull https://git.openjdk.org/jdk.git pull/15158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15158`

View PR using the GUI difftool: \
`$ git pr show -t 15158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15158.diff">https://git.openjdk.org/jdk/pull/15158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15158#issuecomment-1666025047)