### PR TITLE
8313785: Fix -Wconversion warnings in prims code

### DIFF
--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -710,11 +710,12 @@ bool Forte::is_enabled() {
 
 void Forte::register_stub(const char* name, address start, address end) {
 #if !defined(_WINDOWS)
-  assert(pointer_delta(end, start, sizeof(jbyte)) < INT_MAX,
+  size_t code_size = pointer_delta(end, start, sizeof(jbyte));
+  assert(code_size < INT_MAX,
          "Code size exceeds maximum range");
 
   collector_func_load((char*)name, nullptr, nullptr, start,
-    pointer_delta(end, start, sizeof(jbyte)), 0, nullptr);
+                      checked_cast<int>(code_size), 0, nullptr);
 #endif // !_WINDOWS
 }
 

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -188,7 +188,7 @@ extern LONG WINAPI topLevelExceptionFilter(_EXCEPTION_POINTERS* );
 bool jfieldIDWorkaround::is_valid_jfieldID(Klass* k, jfieldID id) {
   if (jfieldIDWorkaround::is_instance_jfieldID(k, id)) {
     uintptr_t as_uint = (uintptr_t) id;
-    intptr_t offset = raw_instance_offset(id);
+    int offset = raw_instance_offset(id);
     if (is_checked_jfieldID(id)) {
       if (!klass_hash_ok(k, id)) {
         return false;
@@ -208,12 +208,13 @@ bool jfieldIDWorkaround::is_valid_jfieldID(Klass* k, jfieldID id) {
 
 intptr_t jfieldIDWorkaround::encode_klass_hash(Klass* k, intptr_t offset) {
   if (offset <= small_offset_mask) {
+    int small_offset = checked_cast<int>(offset);
     Klass* field_klass = k;
     Klass* super_klass = field_klass->super();
     // With compressed oops the most super class with nonstatic fields would
     // be the owner of fields embedded in the header.
     while (InstanceKlass::cast(super_klass)->has_nonstatic_fields() &&
-           InstanceKlass::cast(super_klass)->contains_field_offset(offset)) {
+           InstanceKlass::cast(super_klass)->contains_field_offset(small_offset)) {
       field_klass = super_klass;   // super contains the field also
       super_klass = field_klass->super();
     }
@@ -249,7 +250,7 @@ bool jfieldIDWorkaround::klass_hash_ok(Klass* k, jfieldID id) {
 void jfieldIDWorkaround::verify_instance_jfieldID(Klass* k, jfieldID id) {
   guarantee(jfieldIDWorkaround::is_instance_jfieldID(k, id), "must be an instance field" );
   uintptr_t as_uint = (uintptr_t) id;
-  intptr_t offset = raw_instance_offset(id);
+  int offset = raw_instance_offset(id);
   if (VerifyJNIFields) {
     if (is_checked_jfieldID(id)) {
       guarantee(klass_hash_ok(k, id),
@@ -413,7 +414,7 @@ JNI_ENTRY(jfieldID, jni_FromReflectedField(JNIEnv *env, jobject field))
 
   // First check if this is a static field
   if (modifiers & JVM_ACC_STATIC) {
-    intptr_t offset = InstanceKlass::cast(k1)->field_offset( slot );
+    int offset = InstanceKlass::cast(k1)->field_offset( slot );
     JNIid* id = InstanceKlass::cast(k1)->jni_id_for(offset);
     assert(id != nullptr, "corrupt Field object");
     debug_only(id->set_is_static_field_id();)
@@ -425,7 +426,7 @@ JNI_ENTRY(jfieldID, jni_FromReflectedField(JNIEnv *env, jobject field))
   // The slot is the index of the field description in the field-array
   // The jfieldID is the offset of the field within the object
   // It may also have hash bits for k, if VerifyJNIFields is turned on.
-  intptr_t offset = InstanceKlass::cast(k1)->field_offset( slot );
+  int offset = InstanceKlass::cast(k1)->field_offset( slot );
   assert(InstanceKlass::cast(k1)->contains_field_offset(offset), "stay within object");
   ret = jfieldIDWorkaround::to_instance_jfieldID(k1, offset);
   return ret;
@@ -1884,6 +1885,7 @@ JNI_ENTRY_NO_PRESERVE(void, jni_SetObjectField(JNIEnv *env, jobject obj, jfieldI
   HOTSPOT_JNI_SETOBJECTFIELD_RETURN();
 JNI_END
 
+// TODO: make this a template
 
 #define DEFINE_SETFIELD(Argument,Fieldname,Result,SigType,unionType \
                         , EntryProbe, ReturnProbe) \
@@ -1901,7 +1903,7 @@ JNI_ENTRY_NO_PRESERVE(void, jni_Set##Result##Field(JNIEnv *env, jobject obj, jfi
     field_value.unionType = value; \
     o = JvmtiExport::jni_SetField_probe(thread, obj, o, k, fieldID, false, SigType, (jvalue *)&field_value); \
   } \
-  if (SigType == JVM_SIGNATURE_BOOLEAN) { value = ((jboolean)value) & 1; } \
+  if (SigType == JVM_SIGNATURE_BOOLEAN) { value = (Argument)(((jboolean)value) & 1); } \
   o->Fieldname##_field_put(offset, value); \
   ReturnProbe; \
 JNI_END
@@ -2094,7 +2096,7 @@ JNI_ENTRY(void, jni_SetStatic##Result##Field(JNIEnv *env, jclass clazz, jfieldID
     field_value.unionType = value; \
     JvmtiExport::jni_SetField_probe(thread, nullptr, nullptr, id->holder(), fieldID, true, SigType, (jvalue *)&field_value); \
   } \
-  if (SigType == JVM_SIGNATURE_BOOLEAN) { value = ((jboolean)value) & 1; } \
+  if (SigType == JVM_SIGNATURE_BOOLEAN) { value = (Argument)(((jboolean)value) & 1); } \
   id->holder()->java_mirror()-> Fieldname##_field_put (id->offset(), value); \
   ReturnProbe;\
 JNI_END

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -608,7 +608,8 @@ JVM_END
 
 JVM_ENTRY(jint, JVM_IHashCode(JNIEnv* env, jobject handle))
   // as implemented in the classic virtual machine; return 0 if object is null
-  return handle == nullptr ? 0 : ObjectSynchronizer::FastHashCode (THREAD, JNIHandles::resolve_non_null(handle)) ;
+  return handle == nullptr ? 0 :
+         checked_cast<jint>(ObjectSynchronizer::FastHashCode (THREAD, JNIHandles::resolve_non_null(handle)));
 JVM_END
 
 
@@ -1592,7 +1593,7 @@ static bool jvm_get_field_common(jobject field, fieldDescriptor& fd) {
   int modifiers = java_lang_reflect_Field::modifiers(reflected);
 
   InstanceKlass* ik = InstanceKlass::cast(k);
-  intptr_t offset = ik->field_offset(slot);
+  int offset = ik->field_offset(slot);
 
   if (modifiers & JVM_ACC_STATIC) {
     // for static fields we only look in the current class

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -616,7 +616,7 @@ JvmtiEnvBase::get_field_descriptor(Klass* k, jfieldID field, fieldDescriptor* fd
     found = id->find_local_field(fd);
   } else {
     // Non-static field. The fieldID is really the offset of the field within the object.
-    int offset = checked_cast<int>(jfieldIDWorkaround::from_instance_jfieldID(k, field));
+    int offset = jfieldIDWorkaround::from_instance_jfieldID(k, field);
     found = InstanceKlass::cast(k)->find_field_from_offset(offset, false, fd);
   }
   return found;

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -693,7 +693,7 @@ Handle MethodHandles::resolve_MemberName(Handle mname, Klass* caller, int lookup
 
   if (java_lang_invoke_MemberName::vmtarget(mname()) != nullptr) {
     // Already resolved.
-    DEBUG_ONLY(int vmindex = java_lang_invoke_MemberName::vmindex(mname()));
+    DEBUG_ONLY(intptr_t vmindex = java_lang_invoke_MemberName::vmindex(mname()));
     assert(vmindex >= Method::nonvirtual_vtable_index, "");
     return mname;
   }
@@ -707,7 +707,7 @@ Handle MethodHandles::resolve_MemberName(Handle mname, Klass* caller, int lookup
     THROW_MSG_(vmSymbols::java_lang_InternalError(), "obsolete MemberName format", empty);
   }
 
-  DEBUG_ONLY(int old_vmindex);
+  DEBUG_ONLY(intptr_t old_vmindex);
   assert((old_vmindex = java_lang_invoke_MemberName::vmindex(mname())) == 0, "clean input");
 
   if (defc_oop.is_null() || name_str.is_null() || type_str.is_null()) {
@@ -907,10 +907,10 @@ void MethodHandles::expand_MemberName(Handle mname, int suppress, TRAPS) {
       }
       InstanceKlass* defc = InstanceKlass::cast(java_lang_Class::as_Klass(clazz));
       DEBUG_ONLY(clazz = nullptr);  // safety
-      int vmindex  = java_lang_invoke_MemberName::vmindex(mname());
+      intptr_t vmindex  = java_lang_invoke_MemberName::vmindex(mname());
       bool is_static = ((flags & JVM_ACC_STATIC) != 0);
       fieldDescriptor fd; // find_field initializes fd if found
-      if (!defc->find_field_from_offset(vmindex, is_static, &fd))
+      if (!defc->find_field_from_offset(checked_cast<int>(vmindex), is_static, &fd))
         break;                  // cannot expand
       if (!have_name) {
         //not java_lang_String::create_from_symbol; let's intern member names
@@ -1161,7 +1161,7 @@ static jlong find_member_field_offset(oop mname, bool must_be_static, TRAPS) {
         (must_be_static
          ? (flags & JVM_ACC_STATIC) != 0
          : (flags & JVM_ACC_STATIC) == 0)) {
-      int vmindex = java_lang_invoke_MemberName::vmindex(mname);
+      intptr_t vmindex = java_lang_invoke_MemberName::vmindex(mname);
       return (jlong) vmindex;
     }
   }

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -80,7 +80,7 @@ void BaseFrameStream::set_continuation(Handle cont) {
   _continuation.replace(cont());
 }
 
-JavaFrameStream::JavaFrameStream(JavaThread* thread, int mode, Handle cont_scope, Handle cont)
+JavaFrameStream::JavaFrameStream(JavaThread* thread, jlong mode, Handle cont_scope, Handle cont)
   : BaseFrameStream(thread, cont),
    _vfst(cont.is_null()
       ? vframeStream(thread, cont_scope)

--- a/src/hotspot/share/prims/stackwalk.hpp
+++ b/src/hotspot/share/prims/stackwalk.hpp
@@ -90,7 +90,7 @@ private:
   bool                  _need_method_info;
 
 public:
-  JavaFrameStream(JavaThread* thread, int mode, Handle cont_scope, Handle cont);
+  JavaFrameStream(JavaThread* thread, jlong mode, Handle cont_scope, Handle cont);
 
   const RegisterMap* reg_map() override { return _vfst.reg_map(); };
 
@@ -147,21 +147,21 @@ private:
                             objArrayHandle frames_array,
                             int& end_index, TRAPS);
 
-  static inline bool get_caller_class(int mode) {
+  static inline bool get_caller_class(jlong mode) {
     return (mode & JVM_STACKWALK_GET_CALLER_CLASS) != 0;
   }
-  static inline bool skip_hidden_frames(int mode) {
+  static inline bool skip_hidden_frames(jlong mode) {
     return (mode & JVM_STACKWALK_SHOW_HIDDEN_FRAMES) == 0;
   }
-  static inline bool live_frame_info(int mode) {
+  static inline bool live_frame_info(jlong mode) {
     return (mode & JVM_STACKWALK_FILL_LIVE_STACK_FRAMES) != 0;
   }
 
 public:
-  static inline bool need_method_info(int mode) {
+  static inline bool need_method_info(jlong mode) {
     return (mode & JVM_STACKWALK_FILL_CLASS_REFS_ONLY) == 0;
   }
-  static inline bool use_frames_array(int mode) {
+  static inline bool use_frames_array(jlong mode) {
     return (mode & JVM_STACKWALK_FILL_CLASS_REFS_ONLY) == 0;
   }
   static oop walk(Handle stackStream, jlong mode, int skip_frames, Handle cont_scope, Handle cont,

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -108,7 +108,7 @@ static inline jlong field_offset_to_byte_offset(jlong field_offset) {
   return field_offset;
 }
 
-static inline jlong field_offset_from_byte_offset(jlong byte_offset) {
+static inline int field_offset_from_byte_offset(int byte_offset) {
   return byte_offset;
 }
 

--- a/src/hotspot/share/prims/wbtestmethods/parserTests.cpp
+++ b/src/hotspot/share/prims/wbtestmethods/parserTests.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,7 +141,7 @@ WB_ENTRY(jobjectArray, WB_ParseCommandLine(JNIEnv* env, jobject o, jstring j_cmd
   DCmdParser parser;
 
   const char* c_cmdline = java_lang_String::as_utf8_string(JNIHandles::resolve(j_cmdline));
-  const char c_delim = j_delim & 0xff;
+  const char c_delim = (char)(j_delim & 0xff);
   objArrayOop argumentArray = objArrayOop(JNIHandles::resolve_non_null(arguments));
   objArrayHandle argumentArray_ah(THREAD, argumentArray);
 

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1382,12 +1382,12 @@ WB_ENTRY(void, WB_SetBooleanVMFlag(JNIEnv* env, jobject o, jstring name, jboolea
 WB_END
 
 WB_ENTRY(void, WB_SetIntVMFlag(JNIEnv* env, jobject o, jstring name, jlong value))
-  int result = value;
+  int result = checked_cast<int>(value);
   SetVMFlag <JVM_FLAG_TYPE(int)> (thread, env, name, &result);
 WB_END
 
 WB_ENTRY(void, WB_SetUintVMFlag(JNIEnv* env, jobject o, jstring name, jlong value))
-  uint result = value;
+  uint result = checked_cast<uint>(value);
   SetVMFlag <JVM_FLAG_TYPE(uint)> (thread, env, name, &result);
 WB_END
 

--- a/src/hotspot/share/runtime/jfieldIDWorkaround.hpp
+++ b/src/hotspot/share/runtime/jfieldIDWorkaround.hpp
@@ -84,12 +84,14 @@ class jfieldIDWorkaround: AllStatic {
     uintptr_t as_uint = (uintptr_t) id;
     return ((as_uint & checked_mask_in_place) != 0);
   }
-  static intptr_t raw_instance_offset(jfieldID id) {
+  static int raw_instance_offset(jfieldID id) {
     uintptr_t result = (uintptr_t) id >> address_shift;
     if (VerifyJNIFields && is_checked_jfieldID(id)) {
       result &= small_offset_mask;  // cut off the hash bits
     }
-    return result;
+    // This gets back the InstanceKlass field offset that
+    // the jfieldID is created with.
+    return checked_cast<int>(result);
   }
   static intptr_t encode_klass_hash(Klass* k, intptr_t offset);
   static bool             klass_hash_ok(Klass* k, jfieldID id);
@@ -124,7 +126,7 @@ class jfieldIDWorkaround: AllStatic {
     return result;
   }
 
-  static intptr_t from_instance_jfieldID(Klass* k, jfieldID id) {
+  static int from_instance_jfieldID(Klass* k, jfieldID id) {
 #ifndef ASSERT
     // always verify in debug mode; switchable in anything else
     if (VerifyJNIFields)


### PR DESCRIPTION
This patch fixes Wconversion in code in the src/hotspot/share/prims directory.  Most of the changes correct the types.  jfieldID's are created with the int offset returned by InstanceKlass::field_offset().
     int     field_offset      (int index) const { return field(index).offset(); }

So when we get the field offset back, it's an int.

Also stackwalker passes jlong, so made that consistent.

Tested with tier1 on Oracle supported platforms.