### PR TITLE
8313768: Reduce interaction with volatile field in j.u.l.StreamHandler

### DIFF
--- a/src/java.logging/share/classes/java/util/logging/StreamHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/StreamHandler.java
@@ -231,6 +231,7 @@ public class StreamHandler extends Handler {
             }
         }
     }
+
     private void publish0(LogRecord record) {
         if (!isLoggable(record)) {
             return;
@@ -246,6 +247,7 @@ public class StreamHandler extends Handler {
         }
 
         try {
+            Writer writer = this.writer;
             if (!doneHeader) {
                 writer.write(getFormatter().getHead(this));
                 doneHeader = true;
@@ -295,7 +297,9 @@ public class StreamHandler extends Handler {
             }
         }
     }
+
     private void flush0() {
+        Writer writer = this.writer;
         if (writer != null) {
             try {
                 writer.flush();
@@ -309,6 +313,7 @@ public class StreamHandler extends Handler {
 
     private void flushAndClose() throws SecurityException {
         checkPermission();
+        Writer writer = this.writer;
         if (writer != null) {
             try {
                 if (!doneHeader) {
@@ -323,8 +328,8 @@ public class StreamHandler extends Handler {
                 // report the exception to any registered ErrorManager.
                 reportError(null, ex, ErrorManager.CLOSE_FAILURE);
             }
-            writer = null;
             output = null;
+            this.writer = null;
         }
     }
 


### PR DESCRIPTION
In `publish0()`, `flush0()` and `flushAndClose()`methods of `StreamHandler` we read multiple times from volatile writer. The access number can be reduced by reading the field into local variable once.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313768](https://bugs.openjdk.org/browse/JDK-8313768): Reduce interaction with volatile field in j.u.l.StreamHandler (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15161/head:pull/15161` \
`$ git checkout pull/15161`

Update a local copy of the PR: \
`$ git checkout pull/15161` \
`$ git pull https://git.openjdk.org/jdk.git pull/15161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15161`

View PR using the GUI difftool: \
`$ git pr show -t 15161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15161.diff">https://git.openjdk.org/jdk/pull/15161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15161#issuecomment-1665747511)