### PR TITLE
8313795: Fix for JDK-8313564 breaks ppc and s390x builds

### DIFF
--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -497,7 +497,7 @@ void VM_Version::print_features() {
   if (Verbose) {
     if (ContendedPaddingWidth > 0) {
       tty->cr();
-      tty->print_cr("ContendedPaddingWidth " INTX_FORMAT, ContendedPaddingWidth);
+      tty->print_cr("ContendedPaddingWidth %d", ContendedPaddingWidth);
     }
   }
 }

--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -707,7 +707,7 @@ void VM_Version::print_features_internal(const char* text, bool print_anyway) {
     }
     if (ContendedPaddingWidth > 0) {
       tty->cr();
-      tty->print_cr("ContendedPaddingWidth " INTX_FORMAT, ContendedPaddingWidth);
+      tty->print_cr("ContendedPaddingWidth %d", ContendedPaddingWidth);
     }
   }
 }


### PR DESCRIPTION
The fix for JDK-8313564 breaks the ppc and s390x builds. This should repair it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313795](https://bugs.openjdk.org/browse/JDK-8313795): Fix for JDK-8313564 breaks ppc and s390x builds (**Bug** - P1)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15165/head:pull/15165` \
`$ git checkout pull/15165`

Update a local copy of the PR: \
`$ git checkout pull/15165` \
`$ git pull https://git.openjdk.org/jdk.git pull/15165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15165`

View PR using the GUI difftool: \
`$ git pr show -t 15165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15165.diff">https://git.openjdk.org/jdk/pull/15165.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15165#issuecomment-1666061661)