### PR TITLE
8313791: Fix just zPage.inline.hpp and xPage.inline.hpp

### DIFF
--- a/src/hotspot/share/gc/x/xPage.inline.hpp
+++ b/src/hotspot/share/gc/x/xPage.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,7 @@ inline XPhysicalMemory& XPage::physical_memory() {
 
 inline uint8_t XPage::numa_id() {
   if (_numa_id == (uint8_t)-1) {
-    _numa_id = XNUMA::memory_id(XAddress::good(start()));
+    _numa_id = checked_cast<uint8_t>(XNUMA::memory_id(XAddress::good(start())));
   }
 
   return _numa_id;
@@ -158,7 +158,7 @@ inline uint64_t XPage::last_used() const {
 }
 
 inline void XPage::set_last_used() {
-  _last_used = ceil(os::elapsedTime());
+  _last_used = (uint64_t)ceil(os::elapsedTime());
 }
 
 inline bool XPage::is_in(uintptr_t addr) const {

--- a/src/hotspot/share/gc/z/zPage.inline.hpp
+++ b/src/hotspot/share/gc/z/zPage.inline.hpp
@@ -180,7 +180,7 @@ inline ZPhysicalMemory& ZPage::physical_memory() {
 
 inline uint8_t ZPage::numa_id() {
   if (_numa_id == (uint8_t)-1) {
-    _numa_id = ZNUMA::memory_id(untype(ZOffset::address(start())));
+    _numa_id = checked_cast<uint8_t>(ZNUMA::memory_id(untype(ZOffset::address(start()))));
   }
 
   return _numa_id;
@@ -207,7 +207,7 @@ inline uint64_t ZPage::last_used() const {
 }
 
 inline void ZPage::set_last_used() {
-  _last_used = ceil(os::elapsedTime());
+  _last_used = (uint64_t)ceil(os::elapsedTime());
 }
 
 inline bool ZPage::is_in(zoffset offset) const {


### PR DESCRIPTION
Please review this trivial change to fix -Wconversion warnings for these two files, which are included almost everywhere so generate lots of warnings.
Tested with tier1 on Oracle supported platforms  linux/macos/windows x86/aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313791](https://bugs.openjdk.org/browse/JDK-8313791): Fix just zPage.inline.hpp and xPage.inline.hpp (**Sub-task** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15166/head:pull/15166` \
`$ git checkout pull/15166`

Update a local copy of the PR: \
`$ git checkout pull/15166` \
`$ git pull https://git.openjdk.org/jdk.git pull/15166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15166`

View PR using the GUI difftool: \
`$ git pr show -t 15166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15166.diff">https://git.openjdk.org/jdk/pull/15166.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15166#issuecomment-1666090091)