### PR TITLE
8312597: Convert TraceTypeProfile to UL

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestLogJIT.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestLogJIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Amazon designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/*
+ * @test
+ * @summary Test running with log:jit*=debug enabled.
+ * @run main/othervm -Xlog:jit*=debug compiler.arguments.TestTraceTypeProfile
+ */
+
+package compiler.arguments;
+
+public class TestLogJIT {
+
+    static public void main(String[] args) {
+        System.out.println("Passed");
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/arguments/TestTraceTypeProfile.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestTraceTypeProfile.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Amazon designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/*
+ * @test
+ * @summary Test running TraceTypeProfile enabled.
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+TraceTypeProfile compiler.arguments.TestTraceTypeProfile
+ */
+
+package compiler.arguments;
+
+public class TestTraceTypeProfile {
+
+    static public void main(String[] args) {
+        System.out.println("Passed");
+    }
+}
+


### PR DESCRIPTION
This PR adds the output from `-XX:+TraceTypeProfile` to the `jit` and `inlining` tags in unified logging. It also adds minimal tests for `-XX:+TraceTypeProfile` and `-Xlog:jit*=debug`.

Change passes tier1 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8312597](https://bugs.openjdk.org/browse/JDK-8312597): Convert TraceTypeProfile to UL (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15167/head:pull/15167` \
`$ git checkout pull/15167`

Update a local copy of the PR: \
`$ git checkout pull/15167` \
`$ git pull https://git.openjdk.org/jdk.git pull/15167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15167`

View PR using the GUI difftool: \
`$ git pr show -t 15167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15167.diff">https://git.openjdk.org/jdk/pull/15167.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15167#issuecomment-1668521855)