### PR TITLE
8307408: Some jdk/sun/tools/jhsdb tests don't pass test JVM args to the debuggee JVM

### DIFF
--- a/test/jdk/ProblemList-zgc.txt
+++ b/test/jdk/ProblemList-zgc.txt
@@ -28,3 +28,6 @@
 #############################################################################
 
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8309218 generic-all
+
+sun/tools/jhsdb/JShellHeapDumpTest.java            8276539 generic-all
+sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8276539 generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -734,6 +734,7 @@ sun/tools/jstat/jstatLineCounts3.sh                             8268211 linux-aa
 sun/tools/jstat/jstatLineCounts4.sh                             8268211 linux-aarch64
 
 sun/tools/jhsdb/JStackStressTest.java                           8276210 linux-aarch64
+sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java              8313798 generic-aarch64
 
 ############################################################################
 

--- a/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
+++ b/test/jdk/sun/tools/jhsdb/JShellHeapDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,7 +150,14 @@ public class JShellHeapDumpTest {
         System.out.println("Starting Jshell");
         long startTime = System.currentTimeMillis();
         try {
-            ProcessBuilder pb = new ProcessBuilder(JDKToolFinder.getTestJDKTool("jshell"));
+            JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jshell");
+            if (doSleep) {
+                launcher.addVMArgs(Utils.getTestJavaOpts());
+            } else {
+                // Don't allow use of SerialGC. See JDK-8313655.
+                launcher.addVMArgs(Utils.getFilteredTestJavaOpts("-XX:\\+UseSerialGC"));
+            }
+            ProcessBuilder pb = new ProcessBuilder(launcher.getCommand());
             jShellProcess = ProcessTools.startProcess("JShell", pb,
                                                       s -> {  // warm-up predicate
                                                           return s.contains("Welcome to JShell");

--- a/test/jdk/sun/tools/jhsdb/JStackStressTest.java
+++ b/test/jdk/sun/tools/jhsdb/JStackStressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,9 @@ public class JStackStressTest {
         System.out.println("Starting Jshell");
         long startTime = System.currentTimeMillis();
         try {
-            ProcessBuilder pb = new ProcessBuilder(JDKToolFinder.getTestJDKTool("jshell"));
+            JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jshell");
+            launcher.addVMArgs(Utils.getTestJavaOpts());
+            ProcessBuilder pb = new ProcessBuilder(launcher.getCommand());
             jShellProcess = ProcessTools.startProcess("JShell", pb);
         } catch (Exception ex) {
             throw new RuntimeException("Test ERROR " + ex, ex);


### PR DESCRIPTION
Normally we want the test args passed to the SA debuggee. In fact for proper SA test coverage, it is more important for the test args to be passed to the debuggee than to be passed to the test or the the SA tool that the test launches. For a couple of jhsdb tests that launch jshell as the debuggee, this wasn't happening, and jshell was always launched with no extra args.

Fixing this was very simple. Dealing with the unexpected fallout wasn't.  I filed a number of bugs that turned up (or where otherwise exposed) once I fixed this CR. The main ones were:

[JDK-8313798](https://bugs.openjdk.org/browse/JDK-8313798) [aarch64] sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java sometimes times out on aarch64
[JDK-8313655](https://bugs.openjdk.org/browse/JDK-8313655) sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java frequently fails with SerialGC

For the first one I'm problem listing the test for now, but have a fix and will get it out for review shortly. For the second one I'm just having the test avoid the issue by not allowing jshell to be launched with SerialGC.

Note also that this change caused some failures with ZGC due to an already filed CR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307408](https://bugs.openjdk.org/browse/JDK-8307408): Some jdk/sun/tools/jhsdb tests don't pass test JVM args to the debuggee JVM (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15168/head:pull/15168` \
`$ git checkout pull/15168`

Update a local copy of the PR: \
`$ git checkout pull/15168` \
`$ git pull https://git.openjdk.org/jdk.git pull/15168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15168`

View PR using the GUI difftool: \
`$ git pr show -t 15168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15168.diff">https://git.openjdk.org/jdk/pull/15168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15168#issuecomment-1666251057)