### PR TITLE
8313816: Accessing jmethodID might lead to spurious crashes

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2828,6 +2828,10 @@ void InstanceKlass::release_C_heap_structures(bool release_sub_metadata) {
   jmethodID* jmeths = methods_jmethod_ids_acquire();
   if (jmeths != (jmethodID*)nullptr) {
     release_set_methods_jmethod_ids(nullptr);
+    size_t count = (size_t)jmeths[0];
+    for (size_t i = 1; i <= count; i++) {
+      *((Method**)jmeths[i]) = nullptr;
+    }
     FreeHeap(jmeths);
   }
 


### PR DESCRIPTION
This is a best effort attempt to harmonize the handling of jmethodIDs when the instanceKlass internal structures are being deallocated (eg. due to `ClassLoaderData::free_deallocate_list`).
In all other instances, the jmethodID is NULLed (or set to `_free_method`) before the references Method structures are deallocated. This actually makes possible to query such jmethodIDs without crashing JVM even if the corresponding classes/methods were unloaded.

While it is understandable why JVM can not keep the method metadata around forever it really should be possible to at least assert the validity of a jmethodID without crashing JVM. If nothing else, this makes using the JVMTI functions `GetAllStackTraces` or `GetStackTrace` a risk to use in JVMTI agents - the jmethodids can become invalid the very next moment after the stacktrace is obtained.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313816](https://bugs.openjdk.org/browse/JDK-8313816): Accessing jmethodID might lead to spurious crashes (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15171/head:pull/15171` \
`$ git checkout pull/15171`

Update a local copy of the PR: \
`$ git checkout pull/15171` \
`$ git pull https://git.openjdk.org/jdk.git pull/15171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15171`

View PR using the GUI difftool: \
`$ git pr show -t 15171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15171.diff">https://git.openjdk.org/jdk/pull/15171.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15171#issuecomment-1668732295)