### PR TITLE
8313880: Incorrect copyright header in jdk/java/foreign/TestFree.java after JDK-8310643

### DIFF
--- a/test/jdk/java/foreign/TestFree.java
+++ b/test/jdk/java/foreign/TestFree.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @enablePreview
  * @bug 8248421
  * @summary SystemCLinker should have a way to free memory allocated outside Java
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestFree

--- a/test/jdk/java/foreign/TestFree.java
+++ b/test/jdk/java/foreign/TestFree.java
@@ -4,13 +4,13 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
  *
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
@@ -23,7 +23,6 @@
 
 /*
  * @test
- * @enablePreview
  * @bug 8248421
  * @summary SystemCLinker should have a way to free memory allocated outside Java
  * @run testng/othervm --enable-native-access=ALL-UNNAMED TestFree


### PR DESCRIPTION
This PR fixes a formatting error in a copyright header.