### PR TITLE
8313796: AsyncGetCallTrace crash on unreadable interpreter method pointer

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -509,9 +509,12 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   // first the method
   Method** m_addr = interpreter_frame_method_addr();
   if (m_addr == nullptr) {
-    return false;
+      return false;
   }
-  Method* m = *m_addr;
+  Method* m = SafeFetchN(m_addr, nullptr);
+  if (m == nullptr) {
+      return false;
+  }
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -37,6 +37,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"

--- a/src/hotspot/cpu/aarch64/frame_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.cpp
@@ -507,8 +507,11 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   // do some validation of frame elements
 
   // first the method
-
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (m_addr == nullptr) {
+    return false;
+  }
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -425,7 +425,10 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   if (m_addr == nullptr) {
     return false;
   }
-  Method* m = *m_addr;
+  Method* m = SafeFetchN(m_addr, nullptr);
+  if (m == nullptr) {
+    return false;
+  }
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -36,6 +36,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/stubRoutines.hpp"

--- a/src/hotspot/cpu/arm/frame_arm.cpp
+++ b/src/hotspot/cpu/arm/frame_arm.cpp
@@ -421,7 +421,11 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (m_addr == nullptr) {
+    return false;
+  }
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -324,7 +324,11 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (m_addr == nullptr) {
+    return false;
+  }
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -328,7 +328,10 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   if (m_addr == nullptr) {
     return false;
   }
-  Method* m = *m_addr;
+  Method* m = SafeFetchN(m_addr, nullptr);
+  if (m == nullptr) {
+    return false;
+  }
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -37,6 +37,7 @@
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/monitorChunk.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -38,6 +38,7 @@
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
 #include "runtime/os.inline.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -478,7 +478,11 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   // do some validation of frame elements
 
   // first the method
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (m_addr == nullptr) {
+    return false;
+  }
+  Method* m = *m_addr;
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) {
     return false;

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -482,7 +482,10 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   if (m_addr == nullptr) {
     return false;
   }
-  Method* m = *m_addr;
+  Method* m = SafeFetchN(m_addr, nullptr);
+  if (m == nullptr) {
+    return false;
+  }
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) {
     return false;

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -36,6 +36,7 @@
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaCalls.hpp"
 #include "runtime/monitorChunk.hpp"
+#include "runtime/safefetch.hpp"
 #include "runtime/signature.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "runtime/stubCodeGenerator.hpp"

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -496,7 +496,11 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   // do some validation of frame elements
   // first the method
 
-  Method* m = *interpreter_frame_method_addr();
+  Method** m_addr = interpreter_frame_method_addr();
+  if (m_addr == nullptr) {
+    return false;
+  }
+  Method* m = *m_addr;
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;

--- a/src/hotspot/cpu/x86/frame_x86.cpp
+++ b/src/hotspot/cpu/x86/frame_x86.cpp
@@ -500,7 +500,10 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
   if (m_addr == nullptr) {
     return false;
   }
-  Method* m = *m_addr;
+  Method* m = SafeFetchN(m_addr, nullptr);
+  if (m == nullptr) {
+    return false;
+  }
 
   // validate the method we'd find in this potential sender
   if (!Method::is_valid_method(m)) return false;


### PR DESCRIPTION
We have observed invalid pointers to the interpreted method at Datadog. The fix is based on a discussion with and a code snippet from @parttimenerd.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313796](https://bugs.openjdk.org/browse/JDK-8313796): AsyncGetCallTrace crash on unreadable interpreter method pointer (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15178/head:pull/15178` \
`$ git checkout pull/15178`

Update a local copy of the PR: \
`$ git checkout pull/15178` \
`$ git pull https://git.openjdk.org/jdk.git pull/15178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15178`

View PR using the GUI difftool: \
`$ git pr show -t 15178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15178.diff">https://git.openjdk.org/jdk/pull/15178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15178#issuecomment-1668269741)