### PR TITLE
8313889: Fix -Wconversion warnings in foreign benchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c
@@ -56,7 +56,7 @@ JNIEXPORT void JNICALL Java_org_openjdk_bench_java_lang_foreign_QSort_jni_1qsort
     jint* ints = (*env)->GetIntArrayElements(env, arr, NULL);
     jsize length = (*env)->GetArrayLength(env, arr);
 
-    qsort(ints, length, sizeof(jint), &comparator);
+    qsort(ints, (size_t) length, sizeof(jint), &comparator);
 
     (*env)->ReleaseIntArrayElements(env, arr, ints, 0);
 }
@@ -84,6 +84,6 @@ JNIEXPORT void JNICALL Java_org_openjdk_bench_java_lang_foreign_QSort_jni_1qsort
 
     jint* carr = (*env)->GetIntArrayElements(env, arr, 0);
     jsize length = (*env)->GetArrayLength(env, arr);
-    qsort(carr, length, sizeof(jint), java_cmp);
+    qsort(carr, (size_t) length, sizeof(jint), java_cmp);
     (*env)->ReleaseIntArrayElements(env, arr, carr, 0);
 }


### PR DESCRIPTION
Fix these -Wconversion warnings in the foreign benchmarks:

```
./test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c: In function ‘Java_org_openjdk_bench_java_lang_foreign_QSort_jni_1qsort_1optimized’:
./test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c:59:17: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘jsize’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
   59 |     qsort(ints, length, sizeof(jint), &comparator);
      |                 ^~~~~~
./test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c: In function ‘Java_org_openjdk_bench_java_lang_foreign_QSort_jni_1qsort_1naive’:
./test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c:87:17: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘jsize’ {aka ‘int’} may change the sign of the result [-Wsign-conversion]
   87 |     qsort(carr, length, sizeof(jint), java_cmp);
      |
```

In this case the issue is that we're converting from a signed type to an unsigned type. So, if the source value is negative, it will be positive after conversion.

Since the source value is a Java array length in both cases, the value can not be negative, so we simply fix this by casting to `size_t` explicitly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313889](https://bugs.openjdk.org/browse/JDK-8313889): Fix -Wconversion warnings in foreign benchmarks (**Enhancement** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15179/head:pull/15179` \
`$ git checkout pull/15179`

Update a local copy of the PR: \
`$ git checkout pull/15179` \
`$ git pull https://git.openjdk.org/jdk.git pull/15179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15179`

View PR using the GUI difftool: \
`$ git pr show -t 15179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15179.diff">https://git.openjdk.org/jdk/pull/15179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15179#issuecomment-1668064808)