### PR TITLE
8313891: JFR: Incorrect exception message for RecordedObject::getInt

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -539,7 +539,7 @@ public sealed class RecordedObject
             case UnsignedValue(Integer i) -> i;
             case UnsignedValue(Short s) -> Short.toUnsignedInt(s);
             case UnsignedValue(Byte b) -> Byte.toUnsignedInt(b);
-            case null, default -> throw newIllegalArgumentException(name, "short");
+            case null, default -> throw newIllegalArgumentException(name, "int");
         };
     }
 


### PR DESCRIPTION
Could I have a review of PR that fixes an incorrect exception message.

Testing: test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313891](https://bugs.openjdk.org/browse/JDK-8313891): JFR: Incorrect exception message for RecordedObject::getInt (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15181/head:pull/15181` \
`$ git checkout pull/15181`

Update a local copy of the PR: \
`$ git checkout pull/15181` \
`$ git pull https://git.openjdk.org/jdk.git pull/15181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15181`

View PR using the GUI difftool: \
`$ git pr show -t 15181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15181.diff">https://git.openjdk.org/jdk/pull/15181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15181#issuecomment-1668266026)