### PR TITLE
8313810: BoxLayout uses <blockquote> instead of list for layout options

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/BoxLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/BoxLayout.java
@@ -51,13 +51,14 @@ import java.io.PrintStream;
  * <p> The BoxLayout manager is constructed with an axis parameter that
  * specifies the type of layout that will be done. There are four choices:
  *
- * <blockquote><b>{@code X_AXIS}</b> - Components are laid out horizontally
- * from left to right.</blockquote>
+ * <ul>
+ * <li><b>{@code X_AXIS}</b> - Components are laid out horizontally
+ * from left to right.</li>
  *
- * <blockquote><b>{@code Y_AXIS}</b> - Components are laid out vertically
- * from top to bottom.</blockquote>
+ * <li><b>{@code Y_AXIS}</b> - Components are laid out vertically
+ * from top to bottom.</li>
  *
- * <blockquote><b>{@code LINE_AXIS}</b> - Components are laid out the way
+ * <li><b>{@code LINE_AXIS}</b> - Components are laid out the way
  * words are laid out in a line, based on the container's
  * {@code ComponentOrientation} property. If the container's
  * {@code ComponentOrientation} is horizontal then components are laid out
@@ -65,9 +66,9 @@ import java.io.PrintStream;
  * orientations, if the container's {@code ComponentOrientation} is left to
  * right then components are laid out left to right, otherwise they are laid
  * out right to left. For vertical orientations components are always laid out
- * from top to bottom.</blockquote>
+ * from top to bottom.</li>
  *
- * <blockquote><b>{@code PAGE_AXIS}</b> - Components are laid out the way
+ * <li><b>{@code PAGE_AXIS}</b> - Components are laid out the way
  * text lines are laid out on a page, based on the container's
  * {@code ComponentOrientation} property. If the container's
  * {@code ComponentOrientation} is horizontal then components are laid out
@@ -75,7 +76,9 @@ import java.io.PrintStream;
  * orientations, if the container's {@code ComponentOrientation} is left to
  * right then components are laid out left to right, otherwise they are laid
  * out right to left.&nbsp; For vertical orientations components are always
- * laid out from top to bottom.</blockquote>
+ * laid out from top to bottom.</li>
+ * </ul>
+ *
  * <p>
  * For all directions, components are arranged in the same order as they were
  * added to the container.

--- a/src/java.desktop/share/classes/javax/swing/BoxLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/BoxLayout.java
@@ -84,8 +84,9 @@ import java.io.PrintStream;
  * added to the container.
  * <p>
  * BoxLayout attempts to arrange components
- * at their preferred widths (for horizontal layout)
- * or heights (for vertical layout).
+ * at their preferred widths (for a horizontal layout)
+ * or heights (for a vertical layout).
+ * <p>
  * For a horizontal layout,
  * if not all the components are the same height,
  * BoxLayout attempts to make all the components
@@ -106,7 +107,7 @@ import java.io.PrintStream;
  * horizontal alignment is done based on the leading edge of the component.
  * In other words, an X alignment value of 0.0 means the left edge of a
  * component if the container's {@code ComponentOrientation} is left to
- * right and it means the right edge of the component otherwise.
+ * right, and it means the right edge of the component otherwise.
  * <p>
  * Instead of using BoxLayout directly, many programs use the Box class.
  * The Box class is a lightweight container that uses a BoxLayout.

--- a/src/java.desktop/share/classes/javax/swing/BoxLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/BoxLayout.java
@@ -26,10 +26,16 @@
 
 package javax.swing;
 
-import java.awt.*;
+import java.awt.AWTError;
+import java.awt.Component;
+import java.awt.ComponentOrientation;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Insets;
+import java.awt.LayoutManager2;
 import java.beans.ConstructorProperties;
-import java.io.Serializable;
 import java.io.PrintStream;
+import java.io.Serializable;
 
 /**
  * A layout manager that allows multiple components to be laid out either

--- a/src/java.desktop/share/classes/javax/swing/BoxLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/BoxLayout.java
@@ -50,11 +50,12 @@ import java.io.Serializable;
  * </div>
  * <p>
  * Nesting multiple panels with different combinations of horizontal and
- * vertical gives an effect similar to GridBagLayout, without the
+ * vertical gives an effect similar to
+ * {@link java.awt.GridBagLayout GridBagLayout}, without the
  * complexity. The diagram shows two panels arranged horizontally, each
  * of which contains 3 components arranged vertically.
  *
- * <p> The BoxLayout manager is constructed with an axis parameter that
+ * <p> The {@code BoxLayout} manager is constructed with an axis parameter that
  * specifies the type of layout that will be done. There are four choices:
  *
  * <ul>
@@ -98,7 +99,7 @@ import java.io.Serializable;
  * BoxLayout attempts to make all the components
  * as high as the highest component.
  * If that's not possible for a particular component,
- * then BoxLayout aligns that component vertically,
+ * then {@code BoxLayout} aligns that component vertically,
  * according to the component's Y alignment.
  * By default, a component has a Y alignment of 0.5,
  * which means that the vertical center of the component
@@ -106,7 +107,7 @@ import java.io.Serializable;
  * the vertical centers of other components with 0.5 Y alignment.
  * <p>
  * Similarly, for a vertical layout,
- * BoxLayout attempts to make all components in the column
+ * {@code BoxLayout} attempts to make all components in the column
  * as wide as the widest component.
  * If that fails, it aligns them horizontally
  * according to their X alignments.  For {@code PAGE_AXIS} layout,
@@ -115,9 +116,11 @@ import java.io.Serializable;
  * component if the container's {@code ComponentOrientation} is left to
  * right, and it means the right edge of the component otherwise.
  * <p>
- * Instead of using BoxLayout directly, many programs use the Box class.
- * The Box class is a lightweight container that uses a BoxLayout.
- * It also provides handy methods to help you use BoxLayout well.
+ * Instead of using {@code BoxLayout} directly,
+ * many programs use the {@link Box} class.
+ * The {@code Box} class is a lightweight container that uses
+ * the {@code BoxLayout} layout manager.
+ * It also provides handy methods to help you use {@code BoxLayout} well.
  * Adding components to multiple nested boxes is a powerful way to get
  * the arrangement you want.
  * <p>


### PR DESCRIPTION
A clean-up of documentation for [`BoxLayout`](https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/javax/swing/BoxLayout.html#class-description):

1. Use the `<ul>` element instead of `<blockquote>` to list layout options or axes.
2. Add links to `GridBagLayout` and `Box` classes.
3. Markup references to classes, mostly `BoxLayout` itself, with `{@code}`.
4. Separate the introduction to layout description from the description of horizontal layout. They're now in different paragraphs for easier scanning.
5. Add the missing ‘a’ articles.
6. Organise imports, including expanding the wildcard import.

The updated version: [**`BoxLayout.html`**](https://cr.openjdk.org/~aivanov/8313810/api/java.desktop/javax/swing/BoxLayout.html#class-description) (without the CSS).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8313810](https://bugs.openjdk.org/browse/JDK-8313810): BoxLayout uses &lt;blockquote&gt; instead of list for layout options (**Bug** - P4)
 * [JDK-8313811](https://bugs.openjdk.org/browse/JDK-8313811): Improve description of how BoxLayout lays out components (**Bug** - P5)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15182/head:pull/15182` \
`$ git checkout pull/15182`

Update a local copy of the PR: \
`$ git checkout pull/15182` \
`$ git pull https://git.openjdk.org/jdk.git pull/15182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15182`

View PR using the GUI difftool: \
`$ git pr show -t 15182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15182.diff">https://git.openjdk.org/jdk/pull/15182.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15182#issuecomment-1668482573)