### PR TITLE
8313798: [aarch64] sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java sometimes times out on aarch64

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package sun.jvm.hotspot.runtime;
 import java.io.*;
 import sun.jvm.hotspot.code.*;
 import sun.jvm.hotspot.utilities.*;
+import sun.jvm.hotspot.debugger.Address;
 
 public class VFrame {
   protected Frame       fr;
@@ -145,7 +146,16 @@ public class VFrame {
       if (f.isJavaFrame()) {
         return (JavaVFrame) f;
       }
+      Address oldSP = f.getFrame().getSP();
       f = f.sender(imprecise);
+      if (f != null) {
+          // Make sure the sender frame is above the current frame, not below
+          Address newSP = f.getFrame().getSP();
+          if (oldSP.greaterThanOrEqual(newSP)) {
+              String errString = "newSP(" + newSP + ") is not above oldSP(" + oldSP + ")";
+              throw new RuntimeException(errString);
+          }
+      }
     }
     return null;
   }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -734,7 +734,6 @@ sun/tools/jstat/jstatLineCounts3.sh                             8268211 linux-aa
 sun/tools/jstat/jstatLineCounts4.sh                             8268211 linux-aarch64
 
 sun/tools/jhsdb/JStackStressTest.java                           8276210 linux-aarch64
-sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java              8313798 generic-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
Make sure when walking the stack that the "sender" frame is not at a lower or the same address as the current frame, which can result in an infinite loop.

Tested with tier1 and stress testing sun/tools/jhsdb and hotspot/jtreg/serviceability/sa tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313798](https://bugs.openjdk.org/browse/JDK-8313798): [aarch64] sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java sometimes times out on aarch64 (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15183/head:pull/15183` \
`$ git checkout pull/15183`

Update a local copy of the PR: \
`$ git checkout pull/15183` \
`$ git pull https://git.openjdk.org/jdk.git pull/15183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15183`

View PR using the GUI difftool: \
`$ git pr show -t 15183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15183.diff">https://git.openjdk.org/jdk/pull/15183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15183#issuecomment-1668523617)