### PR TITLE
 8311179: Generational ZGC: gc/z/TestSmallHeap.java failed with OutOfMemoryError

### DIFF
--- a/test/hotspot/jtreg/gc/z/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/z/TestSmallHeap.java
@@ -28,7 +28,7 @@ package gc.z;
  * @requires vm.gc.ZGenerational
  * @summary Test ZGC with small heaps
  * @library / /test/lib
- * @run driver gc.z.TestSmallHeap 8M 16M 32M 64M 128M 256M 512M 1024M
+ * @run driver gc.z.TestSmallHeap 16M 32M 64M 128M 256M 512M 1024M
  */
 
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
I propose that we remove the 8M config to get rid of some OOME failures under certain conditions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311179](https://bugs.openjdk.org/browse/JDK-8311179): Generational ZGC: gc/z/TestSmallHeap.java failed with OutOfMemoryError (**Bug** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15184/head:pull/15184` \
`$ git checkout pull/15184`

Update a local copy of the PR: \
`$ git checkout pull/15184` \
`$ git pull https://git.openjdk.org/jdk.git pull/15184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15184`

View PR using the GUI difftool: \
`$ git pr show -t 15184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15184.diff">https://git.openjdk.org/jdk/pull/15184.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15184#issuecomment-1669151045)