### PR TITLE
6415065: Submenu is shown on wrong screen in multiple monitor environment

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JMenu.java
@@ -478,6 +478,23 @@ public class JMenu extends JMenuItem implements Accessible,MenuElement
                 y = 0 - yOffset - pmSize.height;   // Otherwise drop 'up'
             }
         }
+        // Note that the position may be later adjusted to fit the menu into the screen if possible.
+        // However, the code that does it (JPopupMenu.adjustPopupLocationToFitScreen) has no idea which screen
+        // to fit into, and determines it by the position calculated here, so we need to make sure it's on
+        // the correct screen, otherwise the menu may appear on the wrong screen (JDK-6415065).
+        // (Both x and y are relative to the JMenu position here, that's why we need these +-position.x/y here.)
+        if (position.y + y < screenBounds.y) { // Above the current screen?
+            y = screenBounds.y - position.y; // The top of the screen relative to this JMenu.
+        }
+        if (position.y + y >= screenBounds.y + screenBounds.height) { // Below the current screen?
+            y = screenBounds.y + screenBounds.height - 1 - position.y; // The bottom of the screen...
+        }
+        if (position.x + x < screenBounds.x) { // To the left of the current screen?
+            x = screenBounds.x - position.x; // The left edge of the screen...
+        }
+        if (position.x + x >= screenBounds.x + screenBounds.width) { // To the right of the current screen?
+            x = screenBounds.x + screenBounds.width - 1 - position.x; // The right edge of the screen...
+        }
         return new Point(x,y);
     }
 


### PR DESCRIPTION
Hello!

I'm a member of the UI team in JetBrains IntelliJ department, and we have this bug with popup menus being shown on the wrong monitor in multi-monitor environments:

https://youtrack.jetbrains.com/issue/JBR-5824/Dual-monitor-bug-on-the-context-menu

I managed to track it down to this JDK bug:

https://bugs.openjdk.org/browse/JDK-6415065

I've described the cause and the fix in the commit message, but in short, what happens here is that `JMenu.getPopupMenuOrigin` sometimes returns coordinates outside (usually above) of the current screen, and later `JPopupMenu.adjustPopupLocationToFitScreen` uses those coordinates to fit the entire popup menu into the screen, which goes wrong because at that point it's no longer known which screen the menu was initially invoked on.

I've fixed this by making sure the Y coordinate is still within the correct screen when it's returned from `JMenu.getPopupMenuOrigin`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6415065](https://bugs.openjdk.org/browse/JDK-6415065): Submenu is shown on wrong screen in multiple monitor environment (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15185/head:pull/15185` \
`$ git checkout pull/15185`

Update a local copy of the PR: \
`$ git checkout pull/15185` \
`$ git pull https://git.openjdk.org/jdk.git pull/15185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15185`

View PR using the GUI difftool: \
`$ git pr show -t 15185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15185.diff">https://git.openjdk.org/jdk/pull/15185.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15185#issuecomment-1680806368)