### PR TITLE
8313345: SuperWord fails due to CMove without matching Bool pack

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2081,6 +2081,18 @@ bool SuperWord::profitable(Node_List* p) {
       }
     }
   }
+  if (p0->is_CMove()) {
+    // Verify that CMove has a matching Bool pack
+    BoolNode* bol = p0->in(1)->as_Bool();
+    if (bol == nullptr || my_pack(bol) == nullptr) {
+      return false;
+    }
+    // Verify that Bool has a matching Cmp pack
+    CmpNode* cmp = bol->in(1)->as_Cmp();
+    if (cmp == nullptr || my_pack(cmp) == nullptr) {
+      return false;
+    }
+  }
   return true;
 }
 

--- a/test/hotspot/jtreg/compiler/vectorization/TestCMoveWithoutBoolPack.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestCMoveWithoutBoolPack.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8313345
+ * @summary TODO
+ * @requires vm.compiler2.enabled
+ * @library /test/lib /
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestCMoveWithoutBoolPack*::fill -Xbatch
+ *                   compiler.vectorization.TestCMoveWithoutBoolPack
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestCMoveWithoutBoolPack*::fill -Xbatch
+ *                   -XX:+UseCMoveUnconditionally
+ *                   compiler.vectorization.TestCMoveWithoutBoolPack
+ */
+
+package compiler.vectorization;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+
+public class TestCMoveWithoutBoolPack {
+
+    public static void main(String[] args) {
+        A a = new A();
+        B b = new B();
+        double[] c = new double[1000];
+        for (int i = 0; i < 1000; i++) {
+            a.fill(c);
+            b.fill(c);
+        }
+    }
+
+    public static class A {
+        void fill(double[] array) {
+            for (int i = 0; i < array.length; ++i) {
+                array[i] = this.transform(array[i]);
+            }
+        }
+
+        public double transform(double value) {
+            return value * value;
+        }
+    }
+
+    public static class B extends A {
+        public double transform(double value) {
+            return value;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorization/TestCMoveWithoutBoolPack.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestCMoveWithoutBoolPack.java
@@ -20,23 +20,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 /**
  * @test
  * @bug 8313345
- * @summary TODO
+ * @summary Test SuperWord with a CMove that does not have a matching bool pack.
  * @requires vm.compiler2.enabled
- * @library /test/lib /
- * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestCMoveWithoutBoolPack*::fill -Xbatch
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,*TestCMoveWithoutBoolPack*::fill -Xbatch
  *                   compiler.vectorization.TestCMoveWithoutBoolPack
- * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,TestCMoveWithoutBoolPack*::fill -Xbatch
+ * @run main/othervm -XX:-TieredCompilation -XX:CompileCommand=compileonly,*TestCMoveWithoutBoolPack*::fill -Xbatch
  *                   -XX:+UseCMoveUnconditionally
  *                   compiler.vectorization.TestCMoveWithoutBoolPack
  */
 
 package compiler.vectorization;
-
-import compiler.lib.ir_framework.*;
-import java.util.Random;
 
 public class TestCMoveWithoutBoolPack {
 


### PR DESCRIPTION
SuperWord fails after [JDK-8306302](https://bugs.openjdk.org/browse/JDK-8306302), when trying to convert `Bool + Cmp + CMove` packs into `VectorMaskCmp + VectorBlend` because it does not find the `Bool` (and `Cmp`) packs for a `CMoveD`:

```
After filter_packs
packset
Pack: 0
 align: 0 	 674  StoreD  === 691 695 678 675  [[ 669 672 ]]  @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=8;  Memory: @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull:exact+any *, idx=8; !orig=603,364,300 !jvms: Reproducer2$A::fill @ bci:17 (line 16)
 align: 8 	 669  StoreD  === 691 674 673 670  [[ 603 606 ]]  @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=8;  Memory: @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull:exact+any *, idx=8; !orig=364,300 !jvms: Reproducer2$A::fill @ bci:17 (line 16)
 align: 16 	 603  StoreD  === 691 669 607 604  [[ 367 364 ]]  @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=8;  Memory: @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull:exact+any *, idx=8; !orig=364,300 !jvms: Reproducer2$A::fill @ bci:17 (line 16)
 align: 24 	 364  StoreD  === 691 603 368 428  [[ 695 363 514 ]]  @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=8;  Memory: @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):NotNull:exact+any *, idx=8; !orig=300 !jvms: Reproducer2$A::fill @ bci:17 (line 16)
Pack: 1
 align: 0 	 677  LoadD  === 525 695 678  [[ 675 676 676 ]]  @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=8; #double !orig=606,367,193 !jvms: Reproducer2$A::fill @ bci:13 (line 16)
 align: 8 	 672  LoadD  === 525 674 673  [[ 670 671 671 ]]  @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=8; #double !orig=367,193 !jvms: Reproducer2$A::fill @ bci:13 (line 16)
 align: 16 	 606  LoadD  === 525 669 607  [[ 604 605 605 ]]  @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=8; #double !orig=367,193 !jvms: Reproducer2$A::fill @ bci:13 (line 16)
 align: 24 	 367  LoadD  === 525 603 368  [[ 366 366 428 ]]  @double[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=8; #double !orig=193 !jvms: Reproducer2$A::fill @ bci:13 (line 16)
Pack: 2
 align: 0 	 675  CMoveD  === _ 327 676 677  [[ 674 ]]  #double !orig=604,428,[393],278 !jvms: Reproducer2$A::fill @ bci:14 (line 16)
 align: 8 	 670  CMoveD  === _ 327 671 672  [[ 669 ]]  #double !orig=428,[393],278 !jvms: Reproducer2$A::fill @ bci:14 (line 16)
 align: 16 	 604  CMoveD  === _ 327 605 606  [[ 603 ]]  #double !orig=428,[393],278 !jvms: Reproducer2$A::fill @ bci:14 (line 16)
 align: 24 	 428  CMoveD  === _ 327 366 367  [[ 364 ]]  #double !orig=[393],278 !jvms: Reproducer2$A::fill @ bci:14 (line 16)
Pack: 3
 align: 0 	 676  MulD  === _ 677 677  [[ 675 ]]  !orig=605,366,273 !jvms: Reproducer2$A::transform @ bci:2 (line 21) Reproducer2$A::fill @ bci:14 (line 16)
 align: 8 	 671  MulD  === _ 672 672  [[ 670 ]]  !orig=366,273 !jvms: Reproducer2$A::transform @ bci:2 (line 21) Reproducer2$A::fill @ bci:14 (line 16)
 align: 16 	 605  MulD  === _ 606 606  [[ 604 ]]  !orig=366,273 !jvms: Reproducer2$A::transform @ bci:2 (line 21) Reproducer2$A::fill @ bci:14 (line 16)
 align: 24 	 366  MulD  === _ 367 367  [[ 428 ]]  !orig=273 !jvms: Reproducer2$A::transform @ bci:2 (line 21) Reproducer2$A::fill @ bci:14 (line 16)
```

In the failing case, both the `Cmp` and the `Bool` are outside of the loop. I propose to detect this case in `SuperWord::profitable` and simply bail out. This is obviously not a profitability check but the fix for [JDK-8306302](https://bugs.openjdk.org/browse/JDK-8306302) already added similar checks just above. This should be refactored at some point. @eme64, I think you had plans for that, right?

Looking at https://github.com/openjdk/jdk/pull/13493, I noticed the following statement:

> From what I understand, we currently never introduce a CMoveF/D, unless asked for by UseCMoveUnconditionally (C->use_c_move()). If the flag is set, we attribute no cost to the CMove, else we take Matcher::float_cmove_cost(), which seems to be ConditionalMoveLimit, and so the Phi is never converted into a CMove.

This is not true, because `Matcher::float_cmove_cost()` is `0` on AArch64 and RISCV:
https://github.com/openjdk/jdk/blob/055b4b426cbc56d97e82219f3dd3aba1ebf977e4/src/hotspot/cpu/aarch64/matcher_aarch64.hpp#L70-L73

It's true on the other platforms, where we would need to set `-XX:+UseCMoveUnconditionally` to avoid the bailout. I added runs for both cases to the test.

As also stated in https://github.com/openjdk/jdk/pull/13493, this only affects `CMoveF` and `CMoveD`. For other `CMove` nodes, we bail out during `filter_packs` with "Unimplemented" because `VectorNode::implemented` -> `VectorNode::opcode` only handles `Op_CMoveF` and `Op_CMoveD`:
https://github.com/openjdk/jdk/blob/055b4b426cbc56d97e82219f3dd3aba1ebf977e4/src/hotspot/share/opto/vectornode.cpp#L84-L87

I first tried to bail out in `SuperWord::output` but that does not work because the graph was already modified. We hit an assert in IGVN due to a vector vs. non-vector type mismatch. In general, I don't understand how the `do_reserve_copy` bailouts are supposed to work because we might have already replaced nodes by vector nodes and the `do_reserve_copy` logic does not undo these changes:
https://github.com/openjdk/jdk/blob/055b4b426cbc56d97e82219f3dd3aba1ebf977e4/src/hotspot/share/opto/superword.cpp#L2690-L2694

@eme64 I slightly remember that we talked about this before, did you observe a similar issue? Do we have a tracking bug for this broken bailout logic?

Big thanks to @SirYwell for the report and test case and to @eme64 for the initial investigation!

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313345](https://bugs.openjdk.org/browse/JDK-8313345): SuperWord fails due to CMove without matching Bool pack (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Hannes Greule](https://openjdk.org/census#hgreule) (@SirYwell - Author)


### Contributors
 * Emanuel Peter `<epeter@openjdk.org>`
 * Hannes Greule `<hannesgreule@outlook.de>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15189/head:pull/15189` \
`$ git checkout pull/15189`

Update a local copy of the PR: \
`$ git checkout pull/15189` \
`$ git pull https://git.openjdk.org/jdk.git pull/15189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15189`

View PR using the GUI difftool: \
`$ git pr show -t 15189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15189.diff">https://git.openjdk.org/jdk/pull/15189.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15189#issuecomment-1669398300)