### PR TITLE
8313954: Add gc logging to vmTestbase/vm/gc/containers/Combination05

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/gc/containers/Combination05/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/gc/containers/Combination05/TestDescription.java
@@ -33,9 +33,9 @@
  *          /test/lib
  * @run main/othervm
  *      -XX:-UseGCOverheadLimit
+ *      -Xlog:gc*:gc.log::filecount=0
  *      vm.gc.containers.ContainersTest
  *      -ms low
  *      -ct TreeSet(randomString)
  *      -ct LinkedHashSet(random(arrays))
  */
-


### PR DESCRIPTION
Add GC logging to the tests so that we can get more information about why the test sometimes times out.