### PR TITLE
8311508: ZGC: RAII use of IntelJccErratumAlignment

### DIFF
--- a/src/hotspot/cpu/x86/c2_intelJccErratum_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_intelJccErratum_x86.cpp
@@ -146,5 +146,6 @@ IntelJccErratumAlignment::~IntelJccErratumAlignment() {
     return;
   }
 
+  assert(pc() - _start_pc > 0, "No instruction aligned");
   assert(!IntelJccErratum::is_crossing_or_ending_at_32_byte_boundary(_start_pc, pc()), "Invalid jcc_size estimate");
 }

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -356,7 +356,7 @@ static void emit_store_fast_path_check_c2(MacroAssembler* masm, Address ref_addr
   // This is a JCC erratum mitigation wrapper for calling the inner check
   int size = store_fast_path_check_size(masm, ref_addr, is_atomic, medium_path);
   // Emit JCC erratum mitigation nops with the right size
-  IntelJccErratumAlignment(*masm, size);
+  IntelJccErratumAlignment intel_alignment(*masm, size);
   // Emit the JCC erratum mitigation guarded code
   emit_store_fast_path_check(masm, ref_addr, is_atomic, medium_path);
 #endif

--- a/src/hotspot/cpu/x86/gc/z/z_x86_64.ad
+++ b/src/hotspot/cpu/x86/gc/z/z_x86_64.ad
@@ -74,8 +74,10 @@ static void z_load_barrier(MacroAssembler& _masm, const MachNode* node, Address 
     return;
   }
   ZLoadBarrierStubC2* const stub = ZLoadBarrierStubC2::create(node, ref_addr, ref);
-  IntelJccErratumAlignment(_masm, 6);
-  __ jcc(Assembler::above, *stub->entry());
+  {
+    IntelJccErratumAlignment intel_alignment(_masm, 6);
+    __ jcc(Assembler::above, *stub->entry());
+  }
   __ bind(*stub->continuation());
 }
 


### PR DESCRIPTION
Fixed the locations where unnamed IntelJccErratumAlignment circumvented the correctness asserts.
Also strengthened the asserts so that a IntelJccErratumAlignment RAII object scope must surround at least some instruction. 

Tested GHA and tier1,tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311508](https://bugs.openjdk.org/browse/JDK-8311508): ZGC: RAII use of IntelJccErratumAlignment (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15191/head:pull/15191` \
`$ git checkout pull/15191`

Update a local copy of the PR: \
`$ git checkout pull/15191` \
`$ git pull https://git.openjdk.org/jdk.git pull/15191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15191`

View PR using the GUI difftool: \
`$ git pr show -t 15191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15191.diff">https://git.openjdk.org/jdk/pull/15191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15191#issuecomment-1669669926)