### PR TITLE
8313809: String template fails with java.lang.StringIndexOutOfBoundsException if last fragment is UTF16

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1107,10 +1107,8 @@ public final class StringConcatFactory {
         MethodHandle mh = MethodHandles.dropArguments(newString(), 2, ttypes);
 
         long initialLengthCoder = INITIAL_CODER;
-        String lastFragment = "";
         pos = 0;
         for (String fragment : fragments) {
-            lastFragment = fragment;
             initialLengthCoder = JLA.stringConcatMix(initialLengthCoder, fragment);
 
             if (ttypes.length <= pos) {
@@ -1119,13 +1117,14 @@ public final class StringConcatFactory {
 
             Class<?> ttype = ttypes[pos];
             // (long,byte[],ttype) -> long
-            MethodHandle prepender = prepender(lastFragment.isEmpty() ? null : fragment, ttype);
+            MethodHandle prepender = prepender(fragment.isEmpty() ? null : fragment, ttype);
             // (byte[],long,ttypes...) -> String (unchanged)
             mh = MethodHandles.filterArgumentsWithCombiner(mh, 1, prepender,1, 0, 2 + pos);
 
             pos++;
         }
 
+        String lastFragment = fragments.getLast();
         initialLengthCoder -= lastFragment.length();
         MethodHandle newArrayCombinator = lastFragment.isEmpty() ? newArray() :
                 newArrayWithSuffix(lastFragment);

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1111,6 +1111,7 @@ public final class StringConcatFactory {
         pos = 0;
         for (String fragment : fragments) {
             lastFragment = fragment;
+            initialLengthCoder = JLA.stringConcatMix(initialLengthCoder, fragment);
 
             if (ttypes.length <= pos) {
                 break;
@@ -1119,13 +1120,13 @@ public final class StringConcatFactory {
             Class<?> ttype = ttypes[pos];
             // (long,byte[],ttype) -> long
             MethodHandle prepender = prepender(lastFragment.isEmpty() ? null : fragment, ttype);
-            initialLengthCoder = JLA.stringConcatMix(initialLengthCoder, fragment);
             // (byte[],long,ttypes...) -> String (unchanged)
             mh = MethodHandles.filterArgumentsWithCombiner(mh, 1, prepender,1, 0, 2 + pos);
 
             pos++;
         }
 
+        initialLengthCoder -= lastFragment.length();
         MethodHandle newArrayCombinator = lastFragment.isEmpty() ? newArray() :
                 newArrayWithSuffix(lastFragment);
         // (long,ttypes...) -> String

--- a/test/jdk/java/lang/template/T8313809.java
+++ b/test/jdk/java/lang/template/T8313809.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8313809
- * @summary String template fails with java.lang.StringIndexOutOfBoundsException if the string contains euro symbol.
+ * @summary String template fails with java.lang.StringIndexOutOfBoundsException if last fragment is UTF16
+.
  * @enablePreview true
  */
 

--- a/test/jdk/java/lang/template/T8313809.java
+++ b/test/jdk/java/lang/template/T8313809.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8313809
+ * @summary String template fails with java.lang.StringIndexOutOfBoundsException if the string contains euro symbol.
+ * @enablePreview true
+ */
+
+import static java.util.FormatProcessor.FMT;
+
+public class T8313809 {
+    public static void main(final String[] args) throws Exception {
+        double sum = 12.34;
+        final String message = FMT."The sum is : %f\{sum} €"; // this fails
+        if (!message.equals("The sum is : 12.340000 €")) {
+            throw new RuntimeException("Incorrect result");
+        }
+    }
+}
+


### PR DESCRIPTION
The last fragment of a string template does not get it's coder added to the mix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313809](https://bugs.openjdk.org/browse/JDK-8313809): String template fails with java.lang.StringIndexOutOfBoundsException if last fragment is UTF16 (**Bug** - P2)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15195/head:pull/15195` \
`$ git checkout pull/15195`

Update a local copy of the PR: \
`$ git checkout pull/15195` \
`$ git pull https://git.openjdk.org/jdk.git pull/15195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15195`

View PR using the GUI difftool: \
`$ git pr show -t 15195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15195.diff">https://git.openjdk.org/jdk/pull/15195.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15195#issuecomment-1670113605)