### PR TITLE
8313654: Test WaitNotifySuspendedVThreadTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  *
- * @summary Test verifies that raw jvmti monitor wait/notify works for
+ * @summary Test verifies that JVMTI raw monitor wait/notify works for
  * suspended virtual thread.
  *
  * @requires vm.continuations

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
@@ -24,20 +24,8 @@
 /*
  * @test
  *
- * @summary Test verifies set/get TLS data and verifies it's consistency.
- * Test set TLS with thread name which it belongs to and verify this information when getting test.
- *  -- cbThreadStart
- *  -- by AgentThread
- *
- * Test doesn't verify that TLS is not NULL because for some threads TLS is not initialized initially.
- * TODO:
- *  -- verify that TLS is not NULL (not possible to do with jvmti, ThreadStart might be called too late)
- *  -- add more events where TLS is set *first time*, it is needed to test lazily jvmtThreadState init
- *  -- set/get TLS from other JavaThreads (not from agent and current thread)
- *  -- set/get for suspened (blocked?) threads
- *  -- split test to "sanity" and "stress" version
- *  -- update properties to run jvmti stress tests non-concurrently?
- *
+ * @summary Test verifies that raw jvmti monitor wait/notify works for
+ * suspended virtual thread.
  *
  * @requires vm.continuations
  * @library /test/lib
@@ -64,8 +52,6 @@ public class WaitNotifySuspendedVThreadTest {
         WaitNotifySuspendedVThreadTask.setBreakpoint();
         WaitNotifySuspendedVThreadTask task = new WaitNotifySuspendedVThreadTask();
         Thread t = Thread.ofVirtual().start(task);
-
-        Thread.sleep(1000);
         WaitNotifySuspendedVThreadTask.notifyRawMonitors(t);
         t.join();
     }


### PR DESCRIPTION
Test might times out if it suspend thread before it starts breakpoint event handler.
The fix is to replace sleep with better synchronization and suspend virtual thread only when it runs native code.

Also, the completed monitor is acquired earlier to avoid racing when completing test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313654](https://bugs.openjdk.org/browse/JDK-8313654): Test WaitNotifySuspendedVThreadTest.java timed out (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [53bb6235](https://git.openjdk.org/jdk/pull/15196/files/53bb623547aee8a35130bf4b0472c0862d4b8789)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15196/head:pull/15196` \
`$ git checkout pull/15196`

Update a local copy of the PR: \
`$ git checkout pull/15196` \
`$ git pull https://git.openjdk.org/jdk.git pull/15196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15196`

View PR using the GUI difftool: \
`$ git pr show -t 15196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15196.diff">https://git.openjdk.org/jdk/pull/15196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15196#issuecomment-1670142128)