### PR TITLE
8313927: Examine if Arrays.mismatch can be simplified

### DIFF
--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -7640,12 +7640,16 @@ public final class Arrays {
      * @since 9
      */
     public static int mismatch(byte[] a, byte[] b) {
-        int length = Math.min(a.length, b.length); // Check null array refs
-        if (a == b)
-            return -1;
-
-        int i = ArraysSupport.mismatch(a, b, length);
-        return (i < 0 && a.length != b.length) ? length : i;
+        if (a.length == b.length) { // Check null array refs
+            if (a == b) {
+                return -1;
+            }
+            return ArraysSupport.mismatch(a, b, a.length);
+        } else {
+            int length = Math.min(a.length, b.length);
+            int i = ArraysSupport.mismatch(a, b, length);
+            return (i < 0) ? length : i;
+        }
     }
 
     /**

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -7771,12 +7771,16 @@ public final class Arrays {
      * @since 9
      */
     public static int mismatch(char[] a, char[] b) {
-        int length = Math.min(a.length, b.length); // Check null array refs
-        if (a == b)
-            return -1;
-
-        int i = ArraysSupport.mismatch(a, b, length);
-        return (i < 0 && a.length != b.length) ? length : i;
+        if (a.length == b.length) { // Check null array refs
+            if (a == b) {
+                return -1;
+            }
+            return ArraysSupport.mismatch(a, b, a.length);
+        } else {
+            int length = Math.min(a.length, b.length);
+            int i = ArraysSupport.mismatch(a, b, length);
+            return (i < 0) ? length : i;
+        }
     }
 
     /**
@@ -7898,12 +7902,16 @@ public final class Arrays {
      * @since 9
      */
     public static int mismatch(short[] a, short[] b) {
-        int length = Math.min(a.length, b.length); // Check null array refs
-        if (a == b)
-            return -1;
-
-        int i = ArraysSupport.mismatch(a, b, length);
-        return (i < 0 && a.length != b.length) ? length : i;
+        if (a.length == b.length) { // Check null array refs
+            if (a == b) {
+                return -1;
+            }
+            return ArraysSupport.mismatch(a, b, a.length);
+        } else {
+            int length = Math.min(a.length, b.length);
+            int i = ArraysSupport.mismatch(a, b, length);
+            return (i < 0) ? length : i;
+        }
     }
 
     /**
@@ -8025,12 +8033,16 @@ public final class Arrays {
      * @since 9
      */
     public static int mismatch(int[] a, int[] b) {
-        int length = Math.min(a.length, b.length); // Check null array refs
-        if (a == b)
-            return -1;
-
-        int i = ArraysSupport.mismatch(a, b, length);
-        return (i < 0 && a.length != b.length) ? length : i;
+        if (a.length == b.length) { // Check null array refs
+            if (a == b) {
+                return -1;
+            }
+            return ArraysSupport.mismatch(a, b, a.length);
+        } else {
+            int length = Math.min(a.length, b.length);
+            int i = ArraysSupport.mismatch(a, b, length);
+            return (i < 0) ? length : i;
+        }
     }
 
     /**
@@ -8152,12 +8164,16 @@ public final class Arrays {
      * @since 9
      */
     public static int mismatch(long[] a, long[] b) {
-        int length = Math.min(a.length, b.length); // Check null array refs
-        if (a == b)
-            return -1;
-
-        int i = ArraysSupport.mismatch(a, b, length);
-        return (i < 0 && a.length != b.length) ? length : i;
+        if (a.length == b.length) { // Check null array refs
+            if (a == b) {
+                return -1;
+            }
+            return ArraysSupport.mismatch(a, b, a.length);
+        } else {
+            int length = Math.min(a.length, b.length);
+            int i = ArraysSupport.mismatch(a, b, length);
+            return (i < 0) ? length : i;
+        }
     }
 
     /**
@@ -8279,12 +8295,16 @@ public final class Arrays {
      * @since 9
      */
     public static int mismatch(float[] a, float[] b) {
-        int length = Math.min(a.length, b.length); // Check null array refs
-        if (a == b)
-            return -1;
-
-        int i = ArraysSupport.mismatch(a, b, length);
-        return (i < 0 && a.length != b.length) ? length : i;
+        if (a.length == b.length) { // Check null array refs
+            if (a == b) {
+                return -1;
+            }
+            return ArraysSupport.mismatch(a, b, a.length);
+        } else {
+            int length = Math.min(a.length, b.length);
+            int i = ArraysSupport.mismatch(a, b, length);
+            return (i < 0) ? length : i;
+        }
     }
 
     /**
@@ -8406,12 +8426,16 @@ public final class Arrays {
      * @since 9
      */
     public static int mismatch(double[] a, double[] b) {
-        int length = Math.min(a.length, b.length); // Check null array refs
-        if (a == b)
-            return -1;
-
-        int i = ArraysSupport.mismatch(a, b, length);
-        return (i < 0 && a.length != b.length) ? length : i;
+        if (a.length == b.length) { // Check null array refs
+            if (a == b) {
+                return -1;
+            }
+            return ArraysSupport.mismatch(a, b, a.length);
+        } else {
+            int length = Math.min(a.length, b.length);
+            int i = ArraysSupport.mismatch(a, b, length);
+            return (i < 0) ? length : i;
+        }
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -335,11 +335,8 @@ public class ArraysSupport {
         // assert length <= a.length
         // assert length <= b.length
 
-        int i = 0;
-        if (length > 7) {
-            if (a[0] != b[0])
-                return 0;
-            i = vectorizedMismatch(
+        if (length > 0) {
+            int i = vectorizedMismatch(
                     a, Unsafe.ARRAY_BYTE_BASE_OFFSET,
                     b, Unsafe.ARRAY_BYTE_BASE_OFFSET,
                     length, LOG2_ARRAY_BYTE_INDEX_SCALE);
@@ -347,12 +344,12 @@ public class ArraysSupport {
                 return i;
             // Align to tail
             i = length - ~i;
-//            assert i >= 0 && i <= 7;
-        }
-        // Tail < 8 bytes
-        for (; i < length; i++) {
-            if (a[i] != b[i])
-                return i;
+            //            assert i >= 0 && i <= 7;
+            // Tail < 8 bytes
+            for (; i < length; i++) {
+                if (a[i] != b[i])
+                    return i;
+            }
         }
         return -1;
     }
@@ -383,24 +380,20 @@ public class ArraysSupport {
         // assert 0 <= bFromIndex < b.length
         // assert 0 <= bFromIndex + length <= b.length
         // assert length >= 0
-
-        int i = 0;
-        if (length > 7) {
-            if (a[aFromIndex] != b[bFromIndex])
-                return 0;
+        if (length > 0) {
             int aOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + aFromIndex;
             int bOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + bFromIndex;
-            i = vectorizedMismatch(
+            int i = vectorizedMismatch(
                     a, aOffset,
                     b, bOffset,
                     length, LOG2_ARRAY_BYTE_INDEX_SCALE);
             if (i >= 0)
                 return i;
             i = length - ~i;
-        }
-        for (; i < length; i++) {
-            if (a[aFromIndex + i] != b[bFromIndex + i])
-                return i;
+            for (; i < length; i++) {
+                if (a[aFromIndex + i] != b[bFromIndex + i])
+                    return i;
+            }
         }
         return -1;
     }

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -377,21 +377,20 @@ public class ArraysSupport {
         // assert 0 <= bFromIndex < b.length
         // assert 0 <= bFromIndex + length <= b.length
         // assert length >= 0
-        if (length == 0) {
-            return -1;
-        }
-        int aOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + aFromIndex;
-        int bOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + bFromIndex;
-        int i = vectorizedMismatch(
-                a, aOffset,
-                b, bOffset,
-                length, LOG2_ARRAY_BYTE_INDEX_SCALE);
-        if (i >= 0)
-            return i;
-        i = length - ~i;
-        for (; i < length; i++) {
-            if (a[aFromIndex + i] != b[bFromIndex + i])
+        if (length > 0) {
+            int aOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + aFromIndex;
+            int bOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + bFromIndex;
+            int i = vectorizedMismatch(
+                    a, aOffset,
+                    b, bOffset,
+                    length, LOG2_ARRAY_BYTE_INDEX_SCALE);
+            if (i >= 0)
                 return i;
+            i = length - ~i;
+            for (; i < length; i++) {
+                if (a[aFromIndex + i] != b[bFromIndex + i])
+                    return i;
+            }
         }
         return -1;
     }
@@ -402,19 +401,18 @@ public class ArraysSupport {
     public static int mismatch(char[] a,
                                char[] b,
                                int length) {
-        if (length == 0) {
-            return -1;
-        }
-        int i = vectorizedMismatch(
-                a, Unsafe.ARRAY_CHAR_BASE_OFFSET,
-                b, Unsafe.ARRAY_CHAR_BASE_OFFSET,
-                length, LOG2_ARRAY_CHAR_INDEX_SCALE);
-        if (i >= 0)
-            return i;
-        i = length - ~i;
-        for (; i < length; i++) {
-            if (a[i] != b[i])
+        if (length > 0) {
+            int i = vectorizedMismatch(
+                    a, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                    b, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                    length, LOG2_ARRAY_CHAR_INDEX_SCALE);
+            if (i >= 0)
                 return i;
+            i = length - ~i;
+            for (; i < length; i++) {
+                if (a[i] != b[i])
+                    return i;
+            }
         }
         return -1;
     }
@@ -422,21 +420,20 @@ public class ArraysSupport {
     public static int mismatch(char[] a, int aFromIndex,
                                char[] b, int bFromIndex,
                                int length) {
-        if (length == 0) {
-            return -1;
-        }
-        int aOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_CHAR_INDEX_SCALE);
-        int bOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_CHAR_INDEX_SCALE);
-        int i = vectorizedMismatch(
-                a, aOffset,
-                b, bOffset,
-                length, LOG2_ARRAY_CHAR_INDEX_SCALE);
-        if (i >= 0)
-            return i;
-        i = length - ~i;
-        for (; i < length; i++) {
-            if (a[aFromIndex + i] != b[bFromIndex + i])
+        if (length > 0) {
+            int aOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_CHAR_INDEX_SCALE);
+            int bOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_CHAR_INDEX_SCALE);
+            int i = vectorizedMismatch(
+                    a, aOffset,
+                    b, bOffset,
+                    length, LOG2_ARRAY_CHAR_INDEX_SCALE);
+            if (i >= 0)
                 return i;
+            i = length - ~i;
+            for (; i < length; i++) {
+                if (a[aFromIndex + i] != b[bFromIndex + i])
+                    return i;
+            }
         }
         return -1;
     }
@@ -447,19 +444,18 @@ public class ArraysSupport {
     public static int mismatch(short[] a,
                                short[] b,
                                int length) {
-        if (length == 0) {
-            return -1;
-        }
-        int i = vectorizedMismatch(
-                a, Unsafe.ARRAY_SHORT_BASE_OFFSET,
-                b, Unsafe.ARRAY_SHORT_BASE_OFFSET,
-                length, LOG2_ARRAY_SHORT_INDEX_SCALE);
-        if (i >= 0)
-            return i;
-        i = length - ~i;
-        for (; i < length; i++) {
-            if (a[i] != b[i])
+        if (length > 0) {
+            int i = vectorizedMismatch(
+                    a, Unsafe.ARRAY_SHORT_BASE_OFFSET,
+                    b, Unsafe.ARRAY_SHORT_BASE_OFFSET,
+                    length, LOG2_ARRAY_SHORT_INDEX_SCALE);
+            if (i >= 0)
                 return i;
+            i = length - ~i;
+            for (; i < length; i++) {
+                if (a[i] != b[i])
+                    return i;
+            }
         }
         return -1;
     }
@@ -467,22 +463,21 @@ public class ArraysSupport {
     public static int mismatch(short[] a, int aFromIndex,
                                short[] b, int bFromIndex,
                                int length) {
-        if (length == 0) {
-            return -1;
-        }
-        int aOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_SHORT_INDEX_SCALE);
-        int bOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_SHORT_INDEX_SCALE);
-        int i = vectorizedMismatch(
-                a, aOffset,
-                b, bOffset,
-                length, LOG2_ARRAY_SHORT_INDEX_SCALE);
-        if (i >= 0)
-            return i;
-        i = length - ~i;
-
-        for (; i < length; i++) {
-            if (a[aFromIndex + i] != b[bFromIndex + i])
+        if (length > 0) {
+            int aOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_SHORT_INDEX_SCALE);
+            int bOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_SHORT_INDEX_SCALE);
+            int i = vectorizedMismatch(
+                    a, aOffset,
+                    b, bOffset,
+                    length, LOG2_ARRAY_SHORT_INDEX_SCALE);
+            if (i >= 0)
                 return i;
+            i = length - ~i;
+
+            for (; i < length; i++) {
+                if (a[aFromIndex + i] != b[bFromIndex + i])
+                    return i;
+            }
         }
         return -1;
     }
@@ -493,19 +488,18 @@ public class ArraysSupport {
     public static int mismatch(int[] a,
                                int[] b,
                                int length) {
-        if (length == 0) {
-            return -1;
-        }
-        int i = vectorizedMismatch(
-                a, Unsafe.ARRAY_INT_BASE_OFFSET,
-                b, Unsafe.ARRAY_INT_BASE_OFFSET,
-                length, LOG2_ARRAY_INT_INDEX_SCALE);
-        if (i >= 0)
-            return i;
-        i = length - ~i;
-        for (; i < length; i++) {
-            if (a[i] != b[i])
+        if (length > 0) {
+            int i = vectorizedMismatch(
+                    a, Unsafe.ARRAY_INT_BASE_OFFSET,
+                    b, Unsafe.ARRAY_INT_BASE_OFFSET,
+                    length, LOG2_ARRAY_INT_INDEX_SCALE);
+            if (i >= 0)
                 return i;
+            i = length - ~i;
+            for (; i < length; i++) {
+                if (a[i] != b[i])
+                    return i;
+            }
         }
         return -1;
     }
@@ -513,21 +507,20 @@ public class ArraysSupport {
     public static int mismatch(int[] a, int aFromIndex,
                                int[] b, int bFromIndex,
                                int length) {
-        if (length == 0) {
-            return -1;
-        }
-        int aOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_INT_INDEX_SCALE);
-        int bOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_INT_INDEX_SCALE);
-        int i = vectorizedMismatch(
-                a, aOffset,
-                b, bOffset,
-                length, LOG2_ARRAY_INT_INDEX_SCALE);
-        if (i >= 0)
-            return i;
-        i = length - ~i;
-        for (; i < length; i++) {
-            if (a[aFromIndex + i] != b[bFromIndex + i])
+        if (length > 0) {
+            int aOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_INT_INDEX_SCALE);
+            int bOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_INT_INDEX_SCALE);
+            int i = vectorizedMismatch(
+                    a, aOffset,
+                    b, bOffset,
+                    length, LOG2_ARRAY_INT_INDEX_SCALE);
+            if (i >= 0)
                 return i;
+            i = length - ~i;
+            for (; i < length; i++) {
+                if (a[aFromIndex + i] != b[bFromIndex + i])
+                    return i;
+            }
         }
         return -1;
     }
@@ -585,29 +578,29 @@ public class ArraysSupport {
     public static int mismatch(long[] a,
                                long[] b,
                                int length) {
-        if (length == 0) {
-            return -1;
+        if (length > 0) {
+            int i = vectorizedMismatch(
+                    a, Unsafe.ARRAY_LONG_BASE_OFFSET,
+                    b, Unsafe.ARRAY_LONG_BASE_OFFSET,
+                    length, LOG2_ARRAY_LONG_INDEX_SCALE);
+            if (i >= 0) return i;
         }
-        int i = vectorizedMismatch(
-                a, Unsafe.ARRAY_LONG_BASE_OFFSET,
-                b, Unsafe.ARRAY_LONG_BASE_OFFSET,
-                length, LOG2_ARRAY_LONG_INDEX_SCALE);
-        return i >= 0 ? i : -1;
+        return -1;
     }
 
     public static int mismatch(long[] a, int aFromIndex,
                                long[] b, int bFromIndex,
                                int length) {
-        if (length == 0) {
-            return -1;
+        if (length > 0) {
+            int aOffset = Unsafe.ARRAY_LONG_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_LONG_INDEX_SCALE);
+            int bOffset = Unsafe.ARRAY_LONG_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_LONG_INDEX_SCALE);
+            int i = vectorizedMismatch(
+                    a, aOffset,
+                    b, bOffset,
+                    length, LOG2_ARRAY_LONG_INDEX_SCALE);
+            if (i >= 0) return i;
         }
-        int aOffset = Unsafe.ARRAY_LONG_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_LONG_INDEX_SCALE);
-        int bOffset = Unsafe.ARRAY_LONG_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_LONG_INDEX_SCALE);
-        int i = vectorizedMismatch(
-                a, aOffset,
-                b, bOffset,
-                length, LOG2_ARRAY_LONG_INDEX_SCALE);
-        return i >= 0 ? i : -1;
+        return -1;
     }
 
 
@@ -622,31 +615,30 @@ public class ArraysSupport {
     public static int mismatch(double[] a, int aFromIndex,
                                double[] b, int bFromIndex,
                                int length) {
-        if (length == 0) {
-            return -1;
-        }
-        int i = 0;
-        if (Double.doubleToRawLongBits(a[aFromIndex]) == Double.doubleToRawLongBits(b[bFromIndex])) {
-            int aOffset = Unsafe.ARRAY_DOUBLE_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_DOUBLE_INDEX_SCALE);
-            int bOffset = Unsafe.ARRAY_DOUBLE_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_DOUBLE_INDEX_SCALE);
-            i = vectorizedMismatch(
-                    a, aOffset,
-                    b, bOffset,
-                    length, LOG2_ARRAY_DOUBLE_INDEX_SCALE);
-        }
-        if (i >= 0) {
-            // Check if mismatch is not associated with two NaN values
-            if (!Double.isNaN(a[aFromIndex + i]) || !Double.isNaN(b[bFromIndex + i]))
-                return i;
-
-            // Mismatch on two different NaN values that are normalized to match
-            // Fall back to slow mechanism
-            // ISSUE: Consider looping over vectorizedMismatch adjusting ranges
-            // However, requires that returned value be relative to input ranges
-            i++;
-            for (; i < length; i++) {
-                if (Double.doubleToLongBits(a[aFromIndex + i]) != Double.doubleToLongBits(b[bFromIndex + i]))
+        if (length > 0) {
+            int i = 0;
+            if (Double.doubleToRawLongBits(a[aFromIndex]) == Double.doubleToRawLongBits(b[bFromIndex])) {
+                int aOffset = Unsafe.ARRAY_DOUBLE_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_DOUBLE_INDEX_SCALE);
+                int bOffset = Unsafe.ARRAY_DOUBLE_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_DOUBLE_INDEX_SCALE);
+                i = vectorizedMismatch(
+                        a, aOffset,
+                        b, bOffset,
+                        length, LOG2_ARRAY_DOUBLE_INDEX_SCALE);
+            }
+            if (i >= 0) {
+                // Check if mismatch is not associated with two NaN values
+                if (!Double.isNaN(a[aFromIndex + i]) || !Double.isNaN(b[bFromIndex + i]))
                     return i;
+
+                // Mismatch on two different NaN values that are normalized to match
+                // Fall back to slow mechanism
+                // ISSUE: Consider looping over vectorizedMismatch adjusting ranges
+                // However, requires that returned value be relative to input ranges
+                i++;
+                for (; i < length; i++) {
+                    if (Double.doubleToLongBits(a[aFromIndex + i]) != Double.doubleToLongBits(b[bFromIndex + i]))
+                        return i;
+                }
             }
         }
 

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -269,18 +269,16 @@ public class ArraysSupport {
     public static int mismatch(boolean[] a,
                                boolean[] b,
                                int length) {
-        int i = 0;
-        if (length > 7) {
-            if (a[0] != b[0])
-                return 0;
-            i = vectorizedMismatch(
-                    a, Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
-                    b, Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
-                    length, LOG2_ARRAY_BOOLEAN_INDEX_SCALE);
-            if (i >= 0)
-                return i;
-            i = length - ~i;
+        if (length == 0) {
+            return -1;
         }
+        int i = vectorizedMismatch(
+                a, Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
+                b, Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
+                length, LOG2_ARRAY_BOOLEAN_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
         for (; i < length; i++) {
             if (a[i] != b[i])
                 return i;
@@ -291,20 +289,18 @@ public class ArraysSupport {
     public static int mismatch(boolean[] a, int aFromIndex,
                                boolean[] b, int bFromIndex,
                                int length) {
-        int i = 0;
-        if (length > 7) {
-            if (a[aFromIndex] != b[bFromIndex])
-                return 0;
-            int aOffset = Unsafe.ARRAY_BOOLEAN_BASE_OFFSET + aFromIndex;
-            int bOffset = Unsafe.ARRAY_BOOLEAN_BASE_OFFSET + bFromIndex;
-            i = vectorizedMismatch(
-                    a, aOffset,
-                    b, bOffset,
-                    length, LOG2_ARRAY_BOOLEAN_INDEX_SCALE);
-            if (i >= 0)
-                return i;
-            i = length - ~i;
+        if (length == 0) {
+            return -1;
         }
+        int aOffset = Unsafe.ARRAY_BOOLEAN_BASE_OFFSET + aFromIndex;
+        int bOffset = Unsafe.ARRAY_BOOLEAN_BASE_OFFSET + bFromIndex;
+        int i = vectorizedMismatch(
+                a, aOffset,
+                b, bOffset,
+                length, LOG2_ARRAY_BOOLEAN_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
         for (; i < length; i++) {
             if (a[aFromIndex + i] != b[bFromIndex + i])
                 return i;
@@ -334,22 +330,23 @@ public class ArraysSupport {
         // ISSUE: defer to index receiving methods if performance is good
         // assert length <= a.length
         // assert length <= b.length
+        if (length == 0) {
+            return -1;
+        }
+        int i = vectorizedMismatch(
+                a, Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                b, Unsafe.ARRAY_BYTE_BASE_OFFSET,
+                length, LOG2_ARRAY_BYTE_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        // Align to tail
+        i = length - ~i;
+        // assert i >= 0 && i <= 7;
 
-        if (length > 0) {
-            int i = vectorizedMismatch(
-                    a, Unsafe.ARRAY_BYTE_BASE_OFFSET,
-                    b, Unsafe.ARRAY_BYTE_BASE_OFFSET,
-                    length, LOG2_ARRAY_BYTE_INDEX_SCALE);
-            if (i >= 0)
+        // Tail < 8 bytes
+        for (; i < length; i++) {
+            if (a[i] != b[i])
                 return i;
-            // Align to tail
-            i = length - ~i;
-            //            assert i >= 0 && i <= 7;
-            // Tail < 8 bytes
-            for (; i < length; i++) {
-                if (a[i] != b[i])
-                    return i;
-            }
         }
         return -1;
     }
@@ -380,20 +377,21 @@ public class ArraysSupport {
         // assert 0 <= bFromIndex < b.length
         // assert 0 <= bFromIndex + length <= b.length
         // assert length >= 0
-        if (length > 0) {
-            int aOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + aFromIndex;
-            int bOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + bFromIndex;
-            int i = vectorizedMismatch(
-                    a, aOffset,
-                    b, bOffset,
-                    length, LOG2_ARRAY_BYTE_INDEX_SCALE);
-            if (i >= 0)
+        if (length == 0) {
+            return -1;
+        }
+        int aOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + aFromIndex;
+        int bOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + bFromIndex;
+        int i = vectorizedMismatch(
+                a, aOffset,
+                b, bOffset,
+                length, LOG2_ARRAY_BYTE_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
+        for (; i < length; i++) {
+            if (a[aFromIndex + i] != b[bFromIndex + i])
                 return i;
-            i = length - ~i;
-            for (; i < length; i++) {
-                if (a[aFromIndex + i] != b[bFromIndex + i])
-                    return i;
-            }
         }
         return -1;
     }
@@ -404,18 +402,16 @@ public class ArraysSupport {
     public static int mismatch(char[] a,
                                char[] b,
                                int length) {
-        int i = 0;
-        if (length > 3) {
-            if (a[0] != b[0])
-                return 0;
-            i = vectorizedMismatch(
-                    a, Unsafe.ARRAY_CHAR_BASE_OFFSET,
-                    b, Unsafe.ARRAY_CHAR_BASE_OFFSET,
-                    length, LOG2_ARRAY_CHAR_INDEX_SCALE);
-            if (i >= 0)
-                return i;
-            i = length - ~i;
+        if (length == 0) {
+            return -1;
         }
+        int i = vectorizedMismatch(
+                a, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                b, Unsafe.ARRAY_CHAR_BASE_OFFSET,
+                length, LOG2_ARRAY_CHAR_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
         for (; i < length; i++) {
             if (a[i] != b[i])
                 return i;
@@ -426,20 +422,18 @@ public class ArraysSupport {
     public static int mismatch(char[] a, int aFromIndex,
                                char[] b, int bFromIndex,
                                int length) {
-        int i = 0;
-        if (length > 3) {
-            if (a[aFromIndex] != b[bFromIndex])
-                return 0;
-            int aOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_CHAR_INDEX_SCALE);
-            int bOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_CHAR_INDEX_SCALE);
-            i = vectorizedMismatch(
-                    a, aOffset,
-                    b, bOffset,
-                    length, LOG2_ARRAY_CHAR_INDEX_SCALE);
-            if (i >= 0)
-                return i;
-            i = length - ~i;
+        if (length == 0) {
+            return -1;
         }
+        int aOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_CHAR_INDEX_SCALE);
+        int bOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_CHAR_INDEX_SCALE);
+        int i = vectorizedMismatch(
+                a, aOffset,
+                b, bOffset,
+                length, LOG2_ARRAY_CHAR_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
         for (; i < length; i++) {
             if (a[aFromIndex + i] != b[bFromIndex + i])
                 return i;
@@ -453,18 +447,16 @@ public class ArraysSupport {
     public static int mismatch(short[] a,
                                short[] b,
                                int length) {
-        int i = 0;
-        if (length > 3) {
-            if (a[0] != b[0])
-                return 0;
-            i = vectorizedMismatch(
-                    a, Unsafe.ARRAY_SHORT_BASE_OFFSET,
-                    b, Unsafe.ARRAY_SHORT_BASE_OFFSET,
-                    length, LOG2_ARRAY_SHORT_INDEX_SCALE);
-            if (i >= 0)
-                return i;
-            i = length - ~i;
+        if (length == 0) {
+            return -1;
         }
+        int i = vectorizedMismatch(
+                a, Unsafe.ARRAY_SHORT_BASE_OFFSET,
+                b, Unsafe.ARRAY_SHORT_BASE_OFFSET,
+                length, LOG2_ARRAY_SHORT_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
         for (; i < length; i++) {
             if (a[i] != b[i])
                 return i;
@@ -475,20 +467,19 @@ public class ArraysSupport {
     public static int mismatch(short[] a, int aFromIndex,
                                short[] b, int bFromIndex,
                                int length) {
-        int i = 0;
-        if (length > 3) {
-            if (a[aFromIndex] != b[bFromIndex])
-                return 0;
-            int aOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_SHORT_INDEX_SCALE);
-            int bOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_SHORT_INDEX_SCALE);
-            i = vectorizedMismatch(
-                    a, aOffset,
-                    b, bOffset,
-                    length, LOG2_ARRAY_SHORT_INDEX_SCALE);
-            if (i >= 0)
-                return i;
-            i = length - ~i;
+        if (length == 0) {
+            return -1;
         }
+        int aOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_SHORT_INDEX_SCALE);
+        int bOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_SHORT_INDEX_SCALE);
+        int i = vectorizedMismatch(
+                a, aOffset,
+                b, bOffset,
+                length, LOG2_ARRAY_SHORT_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
+
         for (; i < length; i++) {
             if (a[aFromIndex + i] != b[bFromIndex + i])
                 return i;
@@ -502,18 +493,16 @@ public class ArraysSupport {
     public static int mismatch(int[] a,
                                int[] b,
                                int length) {
-        int i = 0;
-        if (length > 1) {
-            if (a[0] != b[0])
-                return 0;
-            i = vectorizedMismatch(
-                    a, Unsafe.ARRAY_INT_BASE_OFFSET,
-                    b, Unsafe.ARRAY_INT_BASE_OFFSET,
-                    length, LOG2_ARRAY_INT_INDEX_SCALE);
-            if (i >= 0)
-                return i;
-            i = length - ~i;
+        if (length == 0) {
+            return -1;
         }
+        int i = vectorizedMismatch(
+                a, Unsafe.ARRAY_INT_BASE_OFFSET,
+                b, Unsafe.ARRAY_INT_BASE_OFFSET,
+                length, LOG2_ARRAY_INT_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
         for (; i < length; i++) {
             if (a[i] != b[i])
                 return i;
@@ -524,20 +513,18 @@ public class ArraysSupport {
     public static int mismatch(int[] a, int aFromIndex,
                                int[] b, int bFromIndex,
                                int length) {
-        int i = 0;
-        if (length > 1) {
-            if (a[aFromIndex] != b[bFromIndex])
-                return 0;
-            int aOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_INT_INDEX_SCALE);
-            int bOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_INT_INDEX_SCALE);
-            i = vectorizedMismatch(
-                    a, aOffset,
-                    b, bOffset,
-                    length, LOG2_ARRAY_INT_INDEX_SCALE);
-            if (i >= 0)
-                return i;
-            i = length - ~i;
+        if (length == 0) {
+            return -1;
         }
+        int aOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_INT_INDEX_SCALE);
+        int bOffset = Unsafe.ARRAY_INT_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_INT_INDEX_SCALE);
+        int i = vectorizedMismatch(
+                a, aOffset,
+                b, bOffset,
+                length, LOG2_ARRAY_INT_INDEX_SCALE);
+        if (i >= 0)
+            return i;
+        i = length - ~i;
         for (; i < length; i++) {
             if (a[aFromIndex + i] != b[bFromIndex + i])
                 return i;
@@ -601,8 +588,6 @@ public class ArraysSupport {
         if (length == 0) {
             return -1;
         }
-        if (a[0] != b[0])
-            return 0;
         int i = vectorizedMismatch(
                 a, Unsafe.ARRAY_LONG_BASE_OFFSET,
                 b, Unsafe.ARRAY_LONG_BASE_OFFSET,
@@ -616,8 +601,6 @@ public class ArraysSupport {
         if (length == 0) {
             return -1;
         }
-        if (a[aFromIndex] != b[bFromIndex])
-            return 0;
         int aOffset = Unsafe.ARRAY_LONG_BASE_OFFSET + (aFromIndex << LOG2_ARRAY_LONG_INDEX_SCALE);
         int bOffset = Unsafe.ARRAY_LONG_BASE_OFFSET + (bFromIndex << LOG2_ARRAY_LONG_INDEX_SCALE);
         int i = vectorizedMismatch(

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
@@ -45,6 +45,7 @@ public class StringComparisons {
     public boolean utf16;
 
     public String string;
+    public String mismatchString;
     public String equalString;
     public String endsWithA;
     public String endsWithB;
@@ -54,6 +55,7 @@ public class StringComparisons {
     public void setup() {
         String c = utf16 ? "\uff11" : "c";
         string = c.repeat(size);
+        mismatchString = c.repeat(size + 1);
         equalString = c.repeat(size);
         endsWithA = c.repeat(size).concat("A");
         endsWithB = c.repeat(size).concat("B");
@@ -68,6 +70,15 @@ public class StringComparisons {
     @Benchmark
     public boolean endsWith() {
         return startsWithA.endsWith(string);
+    }
+    @Benchmark
+    public boolean startsWithMismatch() {
+        return endsWithA.startsWith(mismatchString);
+    }
+
+    @Benchmark
+    public boolean endsWithMismatch() {
+        return endsWithA.endsWith(string);
     }
 
     @Benchmark


### PR DESCRIPTION
On various microbenchmarks we've seen that Arrays.mismatch slightly underperform naive loops for small array inputs, both on x86 and aarch64. Since small arrays may be more common this hampers adoption in performance-sensitive locales that want to take more explicit advantage of mismatch vectorization.

One contributor appears to be some extra branchy logic outside of the intrinsified Arrays.vectorizedMismatch method. Simplifying the outside logic so that we always call the intrinsified code seem to be a win on x86 and aarch64 in C1 and C2 modes. There's a cost for such small inputs in the interpreter.

Benchmark results will be added in comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313927](https://bugs.openjdk.org/browse/JDK-8313927): Examine if Arrays.mismatch can be simplified (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15197/head:pull/15197` \
`$ git checkout pull/15197`

Update a local copy of the PR: \
`$ git checkout pull/15197` \
`$ git pull https://git.openjdk.org/jdk.git pull/15197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15197`

View PR using the GUI difftool: \
`$ git pr show -t 15197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15197.diff">https://git.openjdk.org/jdk/pull/15197.diff</a>

</details>
