### PR TITLE
8020199: (fs) Files.move() throws DirectoryNotEmptyException pointing to wrong directory (win)

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1408,8 +1408,9 @@ public final class Files {
      * @throws  DirectoryNotEmptyException
      *          the {@code REPLACE_EXISTING} option is specified but the file
      *          cannot be replaced because it is a non-empty directory, or the
-     *          source is a non-empty directory containing entries that would
-     *          be required to be moved <i>(optional specific exceptions)</i>
+     *          source is a non-empty directory containing entries that would be
+     *          required to be moved and the target location is on a different
+     *          {@code FileStore} <i>(optional specific exceptions)</i>
      * @throws  AtomicMoveNotSupportedException
      *          if the options array contains the {@code ATOMIC_MOVE} option but
      *          the file cannot be moved as an atomic file system operation.


### PR DESCRIPTION
Amend description of when `DirectoryNotEmptyException` is thrown by `Files::move`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8020199](https://bugs.openjdk.org/browse/JDK-8020199): (fs) Files.move() throws DirectoryNotEmptyException pointing to wrong directory (win) (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15199/head:pull/15199` \
`$ git checkout pull/15199`

Update a local copy of the PR: \
`$ git checkout pull/15199` \
`$ git pull https://git.openjdk.org/jdk.git pull/15199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15199`

View PR using the GUI difftool: \
`$ git pr show -t 15199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15199.diff">https://git.openjdk.org/jdk/pull/15199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15199#issuecomment-1670315924)