### PR TITLE
8311775: [TEST] duplicate verifyHeapDump in several tests

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpAllTest.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-import java.io.IOException;
-
 import jdk.test.lib.dcmd.CommandExecutor;
 
 /*
@@ -42,7 +40,7 @@ public class HeapDumpAllTest extends HeapDumpTest {
     }
 
     @Override
-    public void run(CommandExecutor executor, boolean overwrite) throws IOException {
+    public void run(CommandExecutor executor, boolean overwrite) throws Exception {
         // Trigger gc by hand, so the created heap dump isnt't too large and
         // takes too long to parse.
         System.gc();

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpCompressedTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpCompressedTest.java
@@ -143,31 +143,7 @@ public class HeapDumpCompressedTest {
         output = executor.execute("GC.heap_dump -gz=1 " + dump.getAbsolutePath());
         output.shouldContain("Unable to create ");
 
-        verifyHeapDump(dump);
+        HprofParser.parseAndVerify(dump);
         dump.delete();
-    }
-
-    private static void verifyHeapDump(File dump) throws Exception {
-
-        Asserts.assertTrue(dump.exists() && dump.isFile(),
-                           "Could not create dump file " + dump.getAbsolutePath());
-
-        try {
-            File out = HprofParser.parse(dump);
-
-            Asserts.assertTrue(out != null && out.exists() && out.isFile(),
-                               "Could not find hprof parser output file");
-            List<String> lines = Files.readAllLines(out.toPath());
-            Asserts.assertTrue(lines.size() > 0, "hprof parser output file is empty");
-            for (String line : lines) {
-                Asserts.assertFalse(line.matches(".*WARNING(?!.*Failed to resolve " +
-                                                 "object.*constantPoolOop.*).*"));
-            }
-
-            out.delete();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Asserts.fail("Could not parse dump file " + dump.getAbsolutePath());
-        }
     }
 }

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
@@ -47,7 +47,7 @@ import jdk.test.lib.hprof.HprofParser;
 
 public class HeapDumpParallelTest {
 
-    private static void checkAndVerify(OutputAnalyzer dcmdOut, LingeredApp app, File heapDumpFile, boolean expectSerial) throws IOException {
+    private static void checkAndVerify(OutputAnalyzer dcmdOut, LingeredApp app, File heapDumpFile, boolean expectSerial) throws Exception {
         dcmdOut.shouldHaveExitValue(0);
         dcmdOut.shouldContain("Heap dump file created");
         OutputAnalyzer appOut = new OutputAnalyzer(app.getProcessStdout());
@@ -64,7 +64,7 @@ public class HeapDumpParallelTest {
             appOut.shouldNotContain("Dump heap objects in parallel");
             appOut.shouldNotContain("Merge heap files complete");
         }
-        verifyHeapDump(heapDumpFile);
+        HprofParser.parseAndVerify(heapDumpFile);
         if (heapDumpFile.exists()) {
             heapDumpFile.delete();
         }
@@ -124,24 +124,5 @@ public class HeapDumpParallelTest {
         System.out.println("Testing pid " + lingeredAppPid);
         PidJcmdExecutor executor = new PidJcmdExecutor("" + lingeredAppPid);
         return executor.execute("GC.heap_dump " + arg + " " + heapDumpFile.getAbsolutePath());
-    }
-
-    private static void verifyHeapDump(File dump) {
-        Asserts.assertTrue(dump.exists() && dump.isFile(), "Could not create dump file " + dump.getAbsolutePath());
-        try {
-            File out = HprofParser.parse(dump);
-
-            Asserts.assertTrue(out != null && out.exists() && out.isFile(), "Could not find hprof parser output file");
-            List<String> lines = Files.readAllLines(out.toPath());
-            Asserts.assertTrue(lines.size() > 0, "hprof parser output file is empty");
-            for (String line : lines) {
-                Asserts.assertFalse(line.matches(".*WARNING(?!.*Failed to resolve object.*constantPoolOop.*).*"));
-            }
-
-            out.delete();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Asserts.fail("Could not parse dump file " + dump.getAbsolutePath());
-        }
     }
 }

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
@@ -26,7 +26,6 @@ import org.testng.Assert;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.io.IOException;
 import java.util.List;
 
 import jdk.test.lib.hprof.HprofParser;
@@ -50,7 +49,7 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 public class HeapDumpTest {
     protected String heapDumpArgs = "";
 
-    public void run(CommandExecutor executor, boolean overwrite) throws IOException {
+    public void run(CommandExecutor executor, boolean overwrite) throws Exception {
         File dump = new File("jcmd.gc.heap_dump." + System.currentTimeMillis() + ".hprof");
         if (!overwrite && dump.exists()) {
             dump.delete();
@@ -61,37 +60,18 @@ public class HeapDumpTest {
         String cmd = "GC.heap_dump " + (overwrite ? "-overwrite " : "") + heapDumpArgs + " " + dump.getAbsolutePath();
         executor.execute(cmd);
 
-        verifyHeapDump(dump);
+        HprofParser.parseAndVerify(dump);
         dump.delete();
-    }
-
-    private void verifyHeapDump(File dump) {
-        Assert.assertTrue(dump.exists() && dump.isFile(), "Could not create dump file " + dump.getAbsolutePath());
-        try {
-            File out = HprofParser.parse(dump);
-
-            Assert.assertTrue(out != null && out.exists() && out.isFile(), "Could not find hprof parser output file");
-            List<String> lines = Files.readAllLines(out.toPath());
-            Assert.assertTrue(lines.size() > 0, "hprof parser output file is empty");
-            for (String line : lines) {
-                Assert.assertFalse(line.matches(".*WARNING(?!.*Failed to resolve object.*constantPoolOop.*).*"));
-            }
-
-            out.delete();
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Could not parse dump file " + dump.getAbsolutePath());
-        }
     }
 
     /* GC.heap_dump is not available over JMX, running jcmd pid executor instead */
     @Test
-    public void pid() throws IOException {
+    public void pid() throws Exception {
         run(new PidJcmdExecutor(), false);
     }
 
     @Test
-    public void pidRewrite() throws IOException {
+    public void pidRewrite() throws Exception {
         run(new PidJcmdExecutor(), true);
     }
 }

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
@@ -78,7 +78,7 @@ public class TestHeapDumpForInvokeDynamic {
         SAOutput.shouldContain(heapDumpFileName);
         System.out.println(SAOutput.getOutput());
 
-        HprofParser.parseAndVerify(heapDumpFileName);
+        HprofParser.parseAndVerify(new File(heapDumpFileName));
     }
 
     public static void main (String... args) throws Exception {

--- a/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
@@ -37,6 +37,7 @@ import jdk.test.lib.SA.SATestUtils;
 import jdk.test.lib.Utils;
 import jdk.test.lib.hprof.parser.HprofReader;
 import jdk.test.lib.hprof.parser.PositionDataInputStream;
+import jdk.test.lib.hprof.HprofParser;
 import jdk.test.lib.hprof.model.Snapshot;
 
 /**
@@ -54,30 +55,6 @@ import jdk.test.lib.hprof.model.Snapshot;
 public class TestHeapDumpForInvokeDynamic {
 
     private static LingeredAppWithInvokeDynamic theApp = null;
-
-    private static void verifyHeapDump(String heapFile) {
-
-        File heapDumpFile = new File(heapFile);
-        Asserts.assertTrue(heapDumpFile.exists() && heapDumpFile.isFile(),
-                          "Could not create dump file " + heapDumpFile.getAbsolutePath());
-        try (PositionDataInputStream in = new PositionDataInputStream(
-                new BufferedInputStream(new FileInputStream(heapFile)))) {
-            int i = in.readInt();
-            if (HprofReader.verifyMagicNumber(i)) {
-                Snapshot sshot;
-                HprofReader r = new HprofReader(heapFile, in, 0,
-                                                false, 0);
-                sshot = r.read();
-            } else {
-                throw new IOException("Unrecognized magic number: " + i);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            Asserts.fail("Could not read dump file " + heapFile);
-        } finally {
-            heapDumpFile.delete();
-        }
-    }
 
     private static void attachDumpAndVerify(String heapDumpFileName,
                                             long lingeredAppPid) throws Exception {
@@ -101,7 +78,7 @@ public class TestHeapDumpForInvokeDynamic {
         SAOutput.shouldContain(heapDumpFileName);
         System.out.println(SAOutput.getOutput());
 
-        verifyHeapDump(heapDumpFileName);
+        HprofParser.parseAndVerify(heapDumpFileName);
     }
 
     public static void main (String... args) throws Exception {

--- a/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestHeapDumpForInvokeDynamic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,7 @@
  */
 
 import java.io.File;
-import java.io.IOException;
-import java.io.BufferedInputStream;
 import java.util.stream.Collectors;
-import java.io.FileInputStream;
-
 
 import jdk.test.lib.apps.LingeredApp;
 import jdk.test.lib.Asserts;
@@ -35,10 +31,7 @@ import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.SA.SATestUtils;
 import jdk.test.lib.Utils;
-import jdk.test.lib.hprof.parser.HprofReader;
-import jdk.test.lib.hprof.parser.PositionDataInputStream;
 import jdk.test.lib.hprof.HprofParser;
-import jdk.test.lib.hprof.model.Snapshot;
 
 /**
  * @test

--- a/test/jdk/sun/tools/jmap/BasicJMapTest.java
+++ b/test/jdk/sun/tools/jmap/BasicJMapTest.java
@@ -297,30 +297,9 @@ public class BasicJMapTest {
         output.shouldHaveExitValue(expExitValue);
         output.shouldContain(expOutput);
         if (expExitValue == 0) {
-            verifyDumpFile(file);
+            HprofParser.parseAndVerify(file);
         }
         file.delete();
-    }
-
-    private static void verifyDumpFile(File dump) {
-        assertTrue(dump.exists() && dump.isFile(), "Could not create dump file " + dump.getAbsolutePath());
-        try {
-            File out = HprofParser.parse(dump);
-
-            assertTrue(out != null && out.exists() && out.isFile(),
-                       "Could not find hprof parser output file");
-            List<String> lines = Files.readAllLines(out.toPath());
-            assertTrue(lines.size() > 0, "hprof parser output file is empty");
-            for (String line : lines) {
-                assertFalse(line.matches(".*WARNING(?!.*Failed to resolve " +
-                                         "object.*constantPoolOop.*).*"));
-            }
-
-            out.delete();
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("Could not parse dump file " + dump.getAbsolutePath());
-        }
     }
 
     private static OutputAnalyzer jmap(String... toolArgs) throws Exception {

--- a/test/jdk/sun/tools/jmap/BasicJMapTest.java
+++ b/test/jdk/sun/tools/jmap/BasicJMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,7 @@ import static jdk.test.lib.Asserts.assertFalse;
 import static jdk.test.lib.Asserts.fail;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.List;
 
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;

--- a/test/lib/jdk/test/lib/hprof/HprofParser.java
+++ b/test/lib/jdk/test/lib/hprof/HprofParser.java
@@ -26,8 +26,13 @@ package jdk.test.lib.hprof;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.hprof.model.Snapshot;
 import jdk.test.lib.hprof.parser.Reader;
 
@@ -48,17 +53,24 @@ public class HprofParser {
     }
 
     /**
-     * @see #parse(File, boolean, boolean, boolean)
+     * @see #parse(File, boolean, boolean, boolean, boolean)
      */
-    public static File parse(File dump) throws Exception {
-        return parse(dump, false, true, true);
+    public static File parseAndVerify(File dump) throws Exception {
+        return parse(dump, false, true, true, true);
     }
 
     /**
-     * @see #parse(File, boolean, boolean, boolean)
+     * @see #parse(File, boolean, boolean, boolean, boolean)
+     */
+    public static File parse(File dump) throws Exception {
+        return parse(dump, false, true, true, false);
+    }
+
+    /**
+     * @see #parse(File, boolean, boolean, boolean, boolean)
      */
     public static File parseWithDebugInfo(File dump) throws Exception {
-        return parse(dump, true, true, true);
+        return parse(dump, true, true, true, false);
     }
 
     /**
@@ -68,10 +80,12 @@ public class HprofParser {
      * @param debug Turn on/off debug file parsing
      * @param callStack Turn on/off tracking of object allocation call stack
      * @param calculateRefs Turn on/off tracking object allocation call stack
+     * @param verifyParse Verify output of parse process and fail if error occurred
      * @throws Exception
      * @return File containing output from the parser
      */
-    public static File parse(File dump, boolean debug, boolean callStack, boolean calculateRefs) throws Exception {
+    public static File parse(File dump, boolean debug, boolean callStack,
+                             boolean calculateRefs, boolean verifyParse) throws Exception {
         File out = new File("hprof." + System.currentTimeMillis() + ".out");
         if (out.exists()) {
             out.delete();
@@ -87,11 +101,21 @@ public class HprofParser {
                 snapshot.resolve(calculateRefs);
                 System.out.println("Snapshot resolved.");
             }
-       } finally {
-           System.setOut(psSystemOut);
-       }
-
+        } finally {
+            System.setOut(psSystemOut);
+        }
+        if (verifyParse) {
+            verifyParse(out);
+        }
         return out;
     }
 
+    private static void verifyParse(File out) throws IOException {
+        Asserts.assertTrue(out != null && out.exists() && out.isFile(), "Could not find hprof parser output file");
+        List<String> lines = Files.readAllLines(out.toPath());
+        Asserts.assertTrue(lines.size() > 0, "hprof parser output file is empty");
+        for (String line : lines) {
+            Asserts.assertFalse(line.matches(".*WARNING(?!.*Failed to resolve object.*constantPoolOop.*).*"));
+        }
+    }
 }

--- a/test/lib/jdk/test/lib/hprof/HprofParser.java
+++ b/test/lib/jdk/test/lib/hprof/HprofParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This is a follow-up patch of #13667. verifyHeapDump is duplicated in several tests, this patch tries to consolidate them into one method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311775](https://bugs.openjdk.org/browse/JDK-8311775): [TEST] duplicate verifyHeapDump in several tests (**Enhancement** - P5)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [ac581090](https://git.openjdk.org/jdk/pull/15202/files/ac581090a12f6c020525ebe14584799af48b7d4a)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15202/head:pull/15202` \
`$ git checkout pull/15202`

Update a local copy of the PR: \
`$ git checkout pull/15202` \
`$ git pull https://git.openjdk.org/jdk.git pull/15202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15202`

View PR using the GUI difftool: \
`$ git pr show -t 15202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15202.diff">https://git.openjdk.org/jdk/pull/15202.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15202#issuecomment-1670811618)