### PR TITLE
8313997: The jdi/ListeningConnector/startListening/startlis001 may fail if the hosts file is modified

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ListeningConnector/startListening/startlis001.java
@@ -103,16 +103,13 @@ public class startlis001 {
          * matches the address which was set via connector's arguments.
          * Empty host address causes listening for local connections only (loopback interface).
          * */
-        String hostname = "localhost";
         List<String> validAddresses = new LinkedList<>();
-        validAddresses.add(hostname);
+        makeValidAddresses("localhost", validAddresses);
         try {
-            Arrays.stream(InetAddress.getAllByName(hostname))
-                    .forEach(address -> validAddresses.add(address.getHostAddress()));
+            makeValidAddresses(InetAddress.getLocalHost().getHostName(),
+                               validAddresses);
         } catch (UnknownHostException e) {
-            log.complain("FAILURE: caught UnknownHostException " +
-                    e.getMessage());
-            totalRes = false;
+            // cannot resolve the local host name, skip it
         }
 
         port = argHandler.getTransportPortIfNotDynamic();
@@ -204,6 +201,18 @@ public class startlis001 {
 
         if (totalRes) return PASSED;
         else return FAILED;
+    }
+
+    private void makeValidAddresses(String hostname, List<String> validAddresses) {
+        validAddresses.add(hostname);
+        try {
+            Arrays.stream(InetAddress.getAllByName(hostname))
+                    .forEach(address -> validAddresses.add(address.getHostAddress()));
+        } catch (UnknownHostException e) {
+            log.complain("FAILURE: caught UnknownHostException " +
+                    e.getMessage());
+            totalRes = false;
+        }
     }
 
     private VirtualMachine attachTarget() {


### PR DESCRIPTION
The test uses this code to create a list of valid addresses for the localhost:

        String hostname = "localhost";
        List<String> validAddresses = new LinkedList<>();
        validAddresses.add(hostname);
        Arrays.stream(InetAddress.getAllByName(hostname))
                    .forEach(address -> validAddresses.add(address.getHostAddress()));

It does not work properly if the custom name is set for the 127.0.01 via /etc/hosts file. In that case, the address returned by the "startListen()" will be "SomeCustomName:port", for example we can return it here:
https://github.com/openjdk/jdk/blob/360f65d7b15b327e2f160c42f318945cc6548bda/src/jdk.jdi/share/classes/com/sun/tools/jdi/SocketTransportService.java#L82

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8313997](https://bugs.openjdk.org/browse/JDK-8313997): The jdi/ListeningConnector/startListening/startlis001 may fail if the hosts file is modified (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15203/head:pull/15203` \
`$ git checkout pull/15203`

Update a local copy of the PR: \
`$ git checkout pull/15203` \
`$ git pull https://git.openjdk.org/jdk.git pull/15203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15203`

View PR using the GUI difftool: \
`$ git pr show -t 15203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15203.diff">https://git.openjdk.org/jdk/pull/15203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15203#issuecomment-1671753199)