### PR TITLE
JDK-8313616: support loading library members on AIX in os::dll_load

### DIFF
--- a/src/hotspot/os/aix/libodm_aix.cpp
+++ b/src/hotspot/os/aix/libodm_aix.cpp
@@ -29,13 +29,16 @@
 #include <dlfcn.h>
 #include <string.h>
 #include "runtime/arguments.hpp"
+#include "runtime/os.hpp"
 
 
 dynamicOdm::dynamicOdm() {
-  const char *libodmname = "/usr/lib/libodm.a(shr_64.o)";
-  _libhandle = dlopen(libodmname, RTLD_MEMBER | RTLD_NOW);
+  const char* libodmname = "/usr/lib/libodm.a(shr_64.o)";
+  char ebuf[512];
+  void* _libhandle = os::dll_load(libodmname, ebuf, sizeof(ebuf));
+
   if (!_libhandle) {
-    trcVerbose("Couldn't open %s", libodmname);
+    trcVerbose("Cannot load %s (error %s)", libodmname, ebuf);
     return;
   }
   _odm_initialize  = (fun_odm_initialize )dlsym(_libhandle, "odm_initialize" );

--- a/src/hotspot/os/aix/libperfstat_aix.cpp
+++ b/src/hotspot/os/aix/libperfstat_aix.cpp
@@ -26,6 +26,7 @@
 
 #include "libperfstat_aix.hpp"
 #include "misc_aix.hpp"
+#include "runtime/os.hpp"
 
 #include <dlfcn.h>
 
@@ -71,11 +72,11 @@ static fun_perfstat_reset_t           g_fun_perfstat_reset           = nullptr;
 static fun_wpar_getcid_t              g_fun_wpar_getcid              = nullptr;
 
 bool libperfstat::init() {
-
-  // Dynamically load the libperfstat porting library.
-  g_libhandle = dlopen("/usr/lib/libperfstat.a(shr_64.o)", RTLD_MEMBER | RTLD_NOW);
+  const char* libperfstat = "/usr/lib/libperfstat.a(shr_64.o)";
+  char ebuf[512];
+  g_libhandle = os::dll_load(libperfstat, ebuf, sizeof(ebuf));
   if (!g_libhandle) {
-    trcVerbose("Cannot load libperfstat.a (dlerror: %s)", dlerror());
+    trcVerbose("Cannot load %s (error: %s)", libperfstat, ebuf);
     return false;
   }
 

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1127,7 +1127,7 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   // a MEMBER module that is a member of an archive.
   int flen = strlen(filename);
   if (flen > 0 && filename[flen - 1] == ')') {
-    dflags = RTLD_LAZY | RTLD_MEMBER;
+    dflags |= RTLD_MEMBER;
   }
 
   void * result= ::dlopen(filename, dflags);

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1101,8 +1101,6 @@ bool os::dll_address_to_library_name(address addr, char* buf,
   return true;
 }
 
-// Loads .dll/.so and in case of error it checks if .dll/.so was built
-// for the same architecture as Hotspot is running on.
 void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
 
   log_info(os)("attempting shared library load of %s", filename);
@@ -1122,8 +1120,17 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   event.set_name(filename);
 #endif
 
-  // RTLD_LAZY is currently not implemented. The dl is loaded immediately with all its dependants.
-  void * result= ::dlopen(filename, RTLD_LAZY);
+  // RTLD_LAZY has currently the same behavior as RTLD_NOW
+  // The dl is loaded immediately with all its dependants.
+  int dflags = RTLD_LAZY;
+  // check for filename ending with ')', it indicates we want to load
+  // a MEMBER module that is a member of an archive.
+  int flen = strlen(filename);
+  if (flen > 0 && filename[flen - 1] == ')') {
+    dflags = RTLD_LAZY | RTLD_MEMBER;
+  }
+
+  void * result= ::dlopen(filename, dflags);
   if (result != nullptr) {
     Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
     // Reload dll cache. Don't do this in signal handling.


### PR DESCRIPTION
AIX dlopen allows loading members of a lib; the syntax for members is libname(member-object) . However this needs an additional flag RTLD_MEMBER passed to dlopen.
Example from our OpenJDK codebase : dlopen("/usr/lib/libperfstat.a(shr_64.o)", RTLD_MEMBER | RTLD_NOW);

However, currently we do not support this in os::dll_load, so member loading would fail because of the missing RTLD_MEMBER flag.
See https://www.ibm.com/docs/en/aix/7.1?topic=d-dlopen-subroutine part about RTLD_MEMBER

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313616](https://bugs.openjdk.org/browse/JDK-8313616): support loading library members on AIX in os::dll_load (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * @JoKern65 (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15204/head:pull/15204` \
`$ git checkout pull/15204`

Update a local copy of the PR: \
`$ git checkout pull/15204` \
`$ git pull https://git.openjdk.org/jdk.git pull/15204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15204`

View PR using the GUI difftool: \
`$ git pr show -t 15204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15204.diff">https://git.openjdk.org/jdk/pull/15204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15204#issuecomment-1670892247)