### PR TITLE
8314022: Problem-list tests failing with jtreg 7.3

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -770,6 +770,9 @@ java/foreign/TestByteBuffer.java 8309475 aix-ppc64
 ############################################################################
 # Client manual tests
 
+javax/swing/JFileChooser/FileSystemView/SystemIconTest.java 8313902 windows-all
+sanity/client/SwingSet/src/FileChooserDemoTest.java 8313903 windows-all
+
 javax/swing/JFileChooser/6698013/bug6698013.java 8024419 macosx-all
 javax/swing/JColorChooser/8065098/bug8065098.java 8065647 macosx-all
 javax/swing/JTabbedPane/4666224/bug4666224.html 8144124  macosx-all


### PR DESCRIPTION
Please review this addition to the `jdk` problem-list including two tests failing due to a regression introduced in jtreg 7.3.

Find details at https://bugs.openjdk.org/browse/CODETOOLS-7903515 - some standard enviroment variables are not set on Windows, for example: `windir`.
