### PR TITLE
8313905: Checked_cast assert in CDS compare_by_loader

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -597,9 +597,9 @@ public:
     ClassLoaderData* loader_b = b[0]->class_loader_data();
 
     if (loader_a != loader_b) {
-      return checked_cast<int>(intptr_t(loader_a) - intptr_t(loader_b));
+      return primitive_compare(loader_a, loader_b);
     } else {
-      return checked_cast<int>(intptr_t(a[0]) - intptr_t(b[0]));
+      return primitive_compare(a[0], b[0]);
     }
   }
 

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1334,6 +1334,11 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
   return k0 == k1;
 }
 
+template<typename K> int primitive_compare(const K& k0, const K& k1) {
+  return (((uintptr_t)k0 < (uintptr_t)k1) ? -1
+       : ((uintptr_t)k0 == (uintptr_t)k1) ? 0 : 1);
+}
+
 //----------------------------------------------------------------------------------------------------
 
 // Allow use of C++ thread_local when approved - see JDK-8282469.


### PR DESCRIPTION
Fix a checked_cast<> assert caused by changes to CDS code, but not using address calculations for comparison operators for class loaders or InstanceKlass pointers.
Tested with tier1-4 on linux-x64-debug and windows-x64-debug.