### PR TITLE
8314020: Print instruction blocks in byte units

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -463,7 +463,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::Posix::ucontext_get_pc(uc);
-  print_instructions(st, pc, /*instrsize=*/4);
+  print_instructions(st, pc);
   st->cr();
 
   // Try to decode the instructions.

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -477,7 +477,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::Posix::ucontext_get_pc(uc);
-  print_instructions(st, pc, 4/*native instruction size*/);
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
+++ b/src/hotspot/os_cpu/bsd_x86/os_bsd_x86.cpp
@@ -854,7 +854,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::Posix::ucontext_get_pc(uc);
-  print_instructions(st, pc, sizeof(char));
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.cpp
@@ -355,7 +355,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::fetch_frame_from_context(uc).pc();
-  print_instructions(st, pc, 4/*native instruction size*/);
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
+++ b/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp
@@ -483,7 +483,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::Posix::ucontext_get_pc(uc);
-  print_instructions(st, pc, Assembler::InstructionSize);
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/os_linux_ppc.cpp
@@ -477,7 +477,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::Posix::ucontext_get_pc(uc);
-  print_instructions(st, pc, /*instrsize=*/4);
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -367,7 +367,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::fetch_frame_from_context(uc).pc();
-  print_instructions(st, pc, UseRVC ? sizeof(char) : (int)NativeInstruction::instruction_size);
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
+++ b/src/hotspot/os_cpu/linux_s390/os_linux_s390.cpp
@@ -456,7 +456,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::Posix::ucontext_get_pc(uc);
-  print_instructions(st, pc, /*intrsize=*/4);
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -571,7 +571,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::fetch_frame_from_context(uc).pc();
-  print_instructions(st, pc, sizeof(char));
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -409,7 +409,7 @@ void os::print_tos_pc(outputStream *st, const void* ucVoid) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::Posix::ucontext_get_pc(uc);
-  print_instructions(st, pc, sizeof(char));
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -469,7 +469,7 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   // point to garbage if entry point in an nmethod is corrupted. Leave
   // this at the end, and hope for the best.
   address pc = os::fetch_frame_from_context(uc).pc();
-  print_instructions(st, pc, sizeof(char));
+  print_instructions(st, pc);
   st->cr();
 }
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -772,7 +772,7 @@ class os: AllStatic {
   static void print_context(outputStream* st, const void* context);
   static void print_tos_pc(outputStream* st, const void* context);
   static void print_tos(outputStream* st, address sp);
-  static void print_instructions(outputStream* st, address pc, int unitsize);
+  static void print_instructions(outputStream* st, address pc, int unitsize = 1);
   static void print_register_info(outputStream* st, const void* context, int& continuation);
   static void print_register_info(outputStream* st, const void* context);
   static bool signal_sent_by_kill(const void* siginfo);


### PR DESCRIPTION
When following up on JVM crashes in the field, we frequently want to disassemble the "Instructions:" block in hs_err. Unfortunately, some architectures print out the instructions in N-byte chunks, which is affected by platform endianness. The simple scripts would then fail to parse the instruction stream, because they have no assumptions about the endianness, and would require additional re-assembling (pun intended).

See more details in the bug.

I understand it is natural to print the full instructions on architectures with fixed-size instructions like AArch64, RISC-V, PPC, ARM. But I'd argue we should simplify the mechanical parsing of those instruction dumps. What do you think, @theRealAph, @RealFYang, @TheRealMDoerr, @tstuefe?

After this fix, the following scripts work well with `Instruction:` block from artificial AArch64 crash:

```
% head asm.txt 
0x000000010763c8c4:   e0 a3 00 91 e1 03 13 aa fd 0d c9 97 e0 83 00 91
0x000000010763c8d4:   47 9e da 97 68 ce 40 f9 08 05 40 f9 09 31 40 b9
0x000000010763c8e4:   29 05 00 11 09 31 00 b9 25 16 f2 97 e0 23 00 91
0x000000010763c8f4:   e1 03 13 aa e2 03 16 aa e3 03 15 aa f2 3d 00 94
0x000000010763c904:   f6 83 40 a9 28 00 80 52 c8 42 13 39 e0 1f 00 f9
0x000000010763c914:   a8 2c 00 b0 1f 20 03 d5 08 8d 41 f9 1f 01 00 f1
0x000000010763c924:   04 18 40 fa 40 00 00 54 00 01 3f d6 78 2c 00 b0
0x000000010763c934:   18 1b 3f 91 08 03 40 39 68 00 00 34 e0 e3 00 91
0x000000010763c944:   90 e2 f1 97 e1 0f 40 f9 e0 e3 00 91 ef 3c 00 94
0x000000010763c954:   f5 03 00 aa 08 03 40 39 48 03 00 34 e0 e3 00 91

% cat asm.txt | cut -d: -f2 | sed -e 's/  \+/ /g' -e 's/ / 0x/g' | xxd -r -p > asm.bin; objdump -D -m aarch64 -b binary asm.bin | head -n 20

asm.bin:     file format binary


Disassembly of section .data:

0000000000000000 <.data>:
   0:	9100a3e0 	add	x0, sp, #0x28
   4:	aa1303e1 	mov	x1, x19
   8:	97c90dfd 	bl	0xffffffffff2437fc
   c:	910083e0 	add	x0, sp, #0x20
  10:	97da9e47 	bl	0xffffffffff6a792c
  14:	f940ce68 	ldr	x8, [x19, #408]
  18:	f9400508 	ldr	x8, [x8, #8]
  1c:	b9403109 	ldr	w9, [x8, #48]
  20:	11000529 	add	w9, w9, #0x1

% cat asm.txt | cut -d: -f2 | sed -e 's/  \+/ /g' -e 's/ / 0x/g' | llvm-mc --disassemble --show-encoding | head -n 20
	.text
	add	x0, sp, #40                     // encoding: [0xe0,0xa3,0x00,0x91]
                                        // =40
	mov	x1, x19                         // encoding: [0xe1,0x03,0x13,0xaa]
	bl	#-14403596                      // encoding: [0xfd,0x0d,0xc9,0x97]
	add	x0, sp, #32                     // encoding: [0xe0,0x83,0x00,0x91]
                                        // =32
	bl	#-9799396                       // encoding: [0x47,0x9e,0xda,0x97]
	ldr	x8, [x19, #408]                 // encoding: [0x68,0xce,0x40,0xf9]
	ldr	x8, [x8, #8]                    // encoding: [0x08,0x05,0x40,0xf9]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314020](https://bugs.openjdk.org/browse/JDK-8314020): Print instruction blocks in byte units (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15211/head:pull/15211` \
`$ git checkout pull/15211`

Update a local copy of the PR: \
`$ git checkout pull/15211` \
`$ git pull https://git.openjdk.org/jdk.git pull/15211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15211`

View PR using the GUI difftool: \
`$ git pr show -t 15211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15211.diff">https://git.openjdk.org/jdk/pull/15211.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15211#issuecomment-1671909704)