### PR TITLE
8314045: ArithmeticException in GaloisCounterMode

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -1572,6 +1572,13 @@ abstract class GaloisCounterMode extends CipherSpi {
                 len += buffer.remaining();
             }
 
+            // Check that input data is long enough to fit the expected tag.
+            if (len < 0) {
+                throw new AEADBadTagException("Input data too short to " +
+                    "contain an expected tag length of " + tagLenBytes +
+                    "bytes");
+            }
+
             checkDataLength(len);
 
             // Verify dst is large enough

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMShortInput.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMShortInput.java
@@ -28,8 +28,8 @@
  */
 
 import java.nio.ByteBuffer;
-import java.security.GeneralSecurityException;
 
+import javax.crypto.AEADBadTagException;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -50,8 +50,8 @@ public class GCMShortInput {
         cipher.init(Cipher.DECRYPT_MODE, keySpec, params);
         try {
             cipher.doFinal(ByteBuffer.allocate(0), ByteBuffer.allocate(0));
-            throw new AssertionError("GeneralSecurityException expected");
-        } catch (GeneralSecurityException e) {
+            throw new AssertionError("AEADBadTagException expected");
+        } catch (AEADBadTagException e) {
             // expected
         }
     }

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMShortInput.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMShortInput.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8314045
+ * @summary ArithmeticException in GaloisCounterMode
+ */
+
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class GCMShortInput {
+
+    public static void main(String args[]) throws Exception {
+        SecretKeySpec keySpec =
+                new SecretKeySpec(
+                        new byte[] {
+                            88, 26, 43, -100, -24, -29, -70, 10, 34, -85, 52, 101, 45, -68, -105,
+                            -123
+                        },
+                        "AES");
+        GCMParameterSpec params =
+                new GCMParameterSpec(8 * 16, new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, params);
+        try {
+            cipher.doFinal(ByteBuffer.allocate(0), ByteBuffer.allocate(0));
+            throw new AssertionError("GeneralSecurityException expected");
+        } catch (GeneralSecurityException e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
Please consider this fix for [JDK-8314045](https://bugs.openjdk.org/browse/JDK-8314045), which adds a missing size check to avoid an `ArithmeticException` in `GaloisCounterMode`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314045](https://bugs.openjdk.org/browse/JDK-8314045): ArithmeticException in GaloisCounterMode (**Bug** - P3)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Contributors
 * Ioana Nedelcu `<ioannanedelcu@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15212/head:pull/15212` \
`$ git checkout pull/15212`

Update a local copy of the PR: \
`$ git checkout pull/15212` \
`$ git pull https://git.openjdk.org/jdk.git pull/15212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15212`

View PR using the GUI difftool: \
`$ git pr show -t 15212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15212.diff">https://git.openjdk.org/jdk/pull/15212.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15212#issuecomment-1671926073)