### PR TITLE
8313633: [macOS] java/awt/dnd/NextDropActionTest/NextDropActionTest.java fails with java.lang.RuntimeException: wrong next drop action!

### DIFF
--- a/test/jdk/java/awt/dnd/NextDropActionTest/NextDropActionTest.java
+++ b/test/jdk/java/awt/dnd/NextDropActionTest/NextDropActionTest.java
@@ -175,7 +175,7 @@ public class NextDropActionTest {
 
 class Util {
     public static int sign(int n) {
-        return n < 0 ? -1 : n == 0 ? 0 : 1;
+        return Integer.compare(n, 0);
     }
 
     public static void doDragDrop(Robot robot, Point startPoint, Point endPoint) {

--- a/test/jdk/java/awt/dnd/NextDropActionTest/NextDropActionTest.java
+++ b/test/jdk/java/awt/dnd/NextDropActionTest/NextDropActionTest.java
@@ -88,7 +88,7 @@ public class NextDropActionTest {
             final DragSourceListener dsl = new DragSourceAdapter() {
                 boolean firstCall = true;
                 public void dragDropEnd(DragSourceDropEvent e) {
-                    System.err.println("DragSourseListener.dragDropEnd(): " +
+                    System.err.println("DragSourceListener.dragDropEnd(): " +
                             " firstCall=" + firstCall +
                             " drop action=" + e.getDropAction());
                     if (firstCall) {
@@ -140,18 +140,22 @@ public class NextDropActionTest {
                 robot.keyRelease(KeyEvent.VK_CONTROL);
                 LOCK.wait(WAIT_TIMEOUT);
             }
+
             if (!firstEnd) {
-                System.err.println("DragSourseListener.dragDropEnd() " +
+                System.err.println("DragSourceListener.dragDropEnd() " +
                         "was not called, returning");
                 return;
             }
+
+            robot.delay(1000);
 
             synchronized (LOCK) {
                 Util.doDragDrop(robot, startPoint, endPoint);
                 LOCK.wait(WAIT_TIMEOUT);
             }
+
             if (!secondEnd) {
-                System.err.println("DragSourseListener.dragDropEnd() " +
+                System.err.println("DragSourceListener.dragDropEnd() " +
                         "was not called, returning");
                 return;
             }


### PR DESCRIPTION
Test fails intermittently on macosx-aarch64. Adding a delay between the first and second drag fixes the issue since there may be some timing issue between the two drag events. Tested the change twice, with 100 repeats per test on all OS's. All tests passed. Also corrected a spelling mistake and added logical newlines to read/debug cleaner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313633](https://bugs.openjdk.org/browse/JDK-8313633): [macOS] java/awt/dnd/NextDropActionTest/NextDropActionTest.java fails with java.lang.RuntimeException: wrong next drop action! (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [a8d94bf9](https://git.openjdk.org/jdk/pull/15213/files/a8d94bf91bc80677a4c550ecccd7af82136258a9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15213/head:pull/15213` \
`$ git checkout pull/15213`

Update a local copy of the PR: \
`$ git checkout pull/15213` \
`$ git pull https://git.openjdk.org/jdk.git pull/15213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15213`

View PR using the GUI difftool: \
`$ git pr show -t 15213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15213.diff">https://git.openjdk.org/jdk/pull/15213.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15213#issuecomment-1672240116)