### PR TITLE
8062795: (fs) Files.setPermissions requires read access when NOFOLLOW_LINKS specified

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -282,6 +282,7 @@ class UnixFileAttributeViews {
                 fd = open(file, O_RDONLY, O_NOFOLLOW);
             } catch (UnixException e1) {
                 if (e1.errno() == EACCES) {
+                    // retry with write access if there is no read permission
                     try {
                         fd = open(file, O_WRONLY, O_NOFOLLOW);
                     } catch (UnixException e2) {

--- a/test/jdk/java/nio/file/attribute/PosixFileAttributeView/Basic.java
+++ b/test/jdk/java/nio/file/attribute/PosixFileAttributeView/Basic.java
@@ -186,9 +186,8 @@ public class Basic {
                 Files.delete(link);
             }
 
-            // test that setting permissions on a link-free path with
-            // the NOFOLLOW_LINKS option succeeds when the path does
-            // not have read permission but fails on a path with links
+            // test that setting permissions on paths with and without
+            // links succeeds when the NOFOLLOW_LINKS option is set
 
             // ensure there are no links in the path to test
             Path realDir = dir.toRealPath();
@@ -225,12 +224,7 @@ public class Basic {
                                            PosixFileAttributeView.class,
                                            LinkOption.NOFOLLOW_LINKS);
             withView.setPermissions(Set.of(PosixFilePermission.OWNER_WRITE));
-            try {
-                withView.setPermissions(Set.of(PosixFilePermission.OWNER_WRITE));
-                throw new RuntimeException("AccessDeniedException not thrown");
-            } catch (AccessDeniedException expected) {
-                System.err.println("Ignored expected AccessDeniedException");
-            }
+            withView.setPermissions(Set.of(PosixFilePermission.OWNER_WRITE));
         }
 
         System.out.println("OKAY");

--- a/test/jdk/java/nio/file/attribute/PosixFileAttributeView/Basic.java
+++ b/test/jdk/java/nio/file/attribute/PosixFileAttributeView/Basic.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333
+ * @bug 4313887 6838333 8062795
  * @summary Unit test for java.nio.file.attribute.PosixFileAttributeView
  * @library ../..
  */


### PR DESCRIPTION
If setting POSIX permissions while not following links fails with `AccessDeniedException` but the path does not contain any symbolic links, then retry the operation as if the `NOFOLLOW_LINKS` option had not been specified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8062795](https://bugs.openjdk.org/browse/JDK-8062795): (fs) Files.setPermissions requires read access when NOFOLLOW_LINKS specified (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15214/head:pull/15214` \
`$ git checkout pull/15214`

Update a local copy of the PR: \
`$ git checkout pull/15214` \
`$ git pull https://git.openjdk.org/jdk.git pull/15214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15214`

View PR using the GUI difftool: \
`$ git pr show -t 15214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15214.diff">https://git.openjdk.org/jdk/pull/15214.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15214#issuecomment-1672304101)