### PR TITLE
8314076: ICC_ColorSpace#minVal/maxVal have the opposite description

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -93,12 +93,12 @@ public class ICC_ColorSpace extends ColorSpace {
     private ICC_Profile thisProfile;
 
     /**
-     * The maximum normalized component values.
+     * The minimum normalized component values.
      */
     private float[] minVal;
 
     /**
-     * The minimum normalized component values.
+     * The maximum normalized component values.
      */
     private float[] maxVal;
 


### PR DESCRIPTION
Fixed a typo in the spec which changes the meaning of the ICC_ColorSpace#minVal/maxVal fields to the opposite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8314077](https://bugs.openjdk.org/browse/JDK-8314077) to be approved

### Issues
 * [JDK-8314076](https://bugs.openjdk.org/browse/JDK-8314076): ICC_ColorSpace#minVal/maxVal have the opposite description (**Bug** - P4)
 * [JDK-8314077](https://bugs.openjdk.org/browse/JDK-8314077): ICC_ColorSpace#minVal/maxVal have the opposite description (**CSR**)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15216/head:pull/15216` \
`$ git checkout pull/15216`

Update a local copy of the PR: \
`$ git checkout pull/15216` \
`$ git pull https://git.openjdk.org/jdk.git pull/15216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15216`

View PR using the GUI difftool: \
`$ git pr show -t 15216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15216.diff">https://git.openjdk.org/jdk/pull/15216.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15216#issuecomment-1672361848)