### PR TITLE
8312428: PKCS11 tests fail with NSS 3.91

### DIFF
--- a/test/jdk/sun/security/pkcs11/MessageDigest/TestCloning.java
+++ b/test/jdk/sun/security/pkcs11/MessageDigest/TestCloning.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6414899 8242332
+ * @bug 6414899 8242332 8312428
  * @summary Ensure the cloning functionality works.
  * @author Valerie Peng
  * @library /test/lib ..
@@ -58,9 +58,16 @@ public class TestCloning extends PKCS11Test {
         r.nextBytes(data2);
         System.out.println("Testing against provider " + p.getName());
         for (String alg : ALGS) {
-            System.out.println("Testing " + alg);
+            System.out.println("Digest algo: " + alg);
             MessageDigest md = MessageDigest.getInstance(alg, p);
-            md = testCloning(md, p);
+            try {
+                md = testCloning(md, p);;
+            } catch (CloneNotSupportedException cnse) {
+                // skip test if clone isn't supported
+                System.out.println("=> Clone not supported; skip!");
+                continue;
+            }
+
             // repeat the test again after generating digest once
             for (int j = 0; j < 10; j++) {
                 md = testCloning(md, p);
@@ -125,4 +132,3 @@ public class TestCloning extends PKCS11Test {
         }
     }
 }
-

--- a/test/jdk/sun/security/pkcs11/MessageDigest/TestCloning.java
+++ b/test/jdk/sun/security/pkcs11/MessageDigest/TestCloning.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6414899 8242332 8312428
+ * @bug 6414899 8242332
  * @summary Ensure the cloning functionality works.
  * @author Valerie Peng
  * @library /test/lib ..
@@ -38,6 +38,8 @@ import java.security.Provider;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.List;
+
+import jtreg.SkippedException;
 
 public class TestCloning extends PKCS11Test {
 
@@ -57,6 +59,9 @@ public class TestCloning extends PKCS11Test {
         r.nextBytes(data1);
         r.nextBytes(data2);
         System.out.println("Testing against provider " + p.getName());
+
+        boolean skipTest = true;
+
         for (String alg : ALGS) {
             System.out.println("Digest algo: " + alg);
             MessageDigest md = MessageDigest.getInstance(alg, p);
@@ -68,10 +73,16 @@ public class TestCloning extends PKCS11Test {
                 continue;
             }
 
+            // start testing below
+            skipTest = false;
+
             // repeat the test again after generating digest once
             for (int j = 0; j < 10; j++) {
                 md = testCloning(md, p);
             }
+        }
+        if (skipTest) {
+            throw new SkippedException("Test Skipped!");
         }
     }
 

--- a/test/jdk/sun/security/pkcs11/PSSUtil.java
+++ b/test/jdk/sun/security/pkcs11/PSSUtil.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.security.*;
+import java.security.interfaces.*;
+import java.security.spec.*;
+
+public class PSSUtil {
+
+    /**
+     * ALGORITHM name, fixed as RSA for PKCS11
+     */
+    private static final String KEYALG = "RSA";
+    private static final String SIGALG = "RSASSA-PSS";
+    private static final String[] DIGESTS = {
+           "SHA-224", "SHA-256", "SHA-384" , "SHA-512",
+           "SHA3-224", "SHA3-256", "SHA3-384" , "SHA3-512",
+    };
+
+    public static enum AlgoSupport {
+        NO, MAYBE, YES
+    };
+
+    public static boolean isSignatureSupported(Provider p) {
+        try {
+            Signature.getInstance("RSASSA-PSS", p);
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            System.out.println("Skip testing RSASSA-PSS" +
+                " due to no support");
+            return false;
+        }
+    }
+
+    public static AlgoSupport isHashSupported(Provider p, String... hashAlgs) {
+
+        AlgoSupport status = AlgoSupport.YES;
+        for (String h : hashAlgs) {
+            String sigAlg = (h.startsWith("SHA3-")?
+                    h : h.replace("-","")) + "withRSASSA-PSS";
+            try {
+                Signature.getInstance(sigAlg, p);
+                // Yes, proceed to check next hash algorithm
+                continue;
+            } catch (NoSuchAlgorithmException e) {
+                // continue trying other checks
+            }
+            try {
+                MessageDigest.getInstance(h, p);
+                status = AlgoSupport.MAYBE;
+            } catch (NoSuchAlgorithmException e) {
+                // if not supported as a standalone digest algo, chance of it
+                // being supported by PSS is very very low
+                return AlgoSupport.NO;
+            }
+        }
+        return status;
+    }
+
+    public static KeyPair generateKeys(Provider p, int size)
+            throws NoSuchAlgorithmException {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(KEYALG, p);
+        kpg.initialize(size);
+        return kpg.generateKeyPair();
+    }
+}

--- a/test/jdk/sun/security/pkcs11/PSSUtil.java
+++ b/test/jdk/sun/security/pkcs11/PSSUtil.java
@@ -42,10 +42,10 @@ public class PSSUtil {
 
     public static boolean isSignatureSupported(Provider p) {
         try {
-            Signature.getInstance("RSASSA-PSS", p);
+            Signature.getInstance(SIGALG, p);
             return true;
         } catch (NoSuchAlgorithmException e) {
-            System.out.println("Skip testing RSASSA-PSS" +
+            System.out.println("Skip testing " + SIGALG +
                 " due to no support");
             return false;
         }
@@ -56,7 +56,7 @@ public class PSSUtil {
         AlgoSupport status = AlgoSupport.YES;
         for (String h : hashAlgs) {
             String sigAlg = (h.startsWith("SHA3-")?
-                    h : h.replace("-","")) + "withRSASSA-PSS";
+                    h : h.replace("-","")) + "with" + SIGALG;
             try {
                 Signature.getInstance(sigAlg, p);
                 // Yes, proceed to check next hash algorithm

--- a/test/jdk/sun/security/pkcs11/PSSUtil.java
+++ b/test/jdk/sun/security/pkcs11/PSSUtil.java
@@ -20,9 +20,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.security.*;
-import java.security.interfaces.*;
-import java.security.spec.*;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Signature;
 
 public class PSSUtil {
 
@@ -31,10 +34,6 @@ public class PSSUtil {
      */
     private static final String KEYALG = "RSA";
     private static final String SIGALG = "RSASSA-PSS";
-    private static final String[] DIGESTS = {
-           "SHA-224", "SHA-256", "SHA-384" , "SHA-512",
-           "SHA3-224", "SHA3-256", "SHA3-384" , "SHA3-512",
-    };
 
     public static enum AlgoSupport {
         NO, MAYBE, YES
@@ -55,8 +54,8 @@ public class PSSUtil {
 
         AlgoSupport status = AlgoSupport.YES;
         for (String h : hashAlgs) {
-            String sigAlg = (h.startsWith("SHA3-")?
-                    h : h.replace("-","")) + "with" + SIGALG;
+            String sigAlg = (h.startsWith("SHA3-") ?
+                    h : h.replace("-", "")) + "with" + SIGALG;
             try {
                 Signature.getInstance(sigAlg, p);
                 // Yes, proceed to check next hash algorithm

--- a/test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
@@ -114,6 +114,8 @@ public class KeyAndParamCheckForPSS extends PKCS11Test {
                 // confirmed to be unsupported; skip the rest of the test
                 System.out.println("=> Skip; no PSS support");
                 return;
+            } else {
+                throw new RuntimeException("Unexpected Exception", ex);
             }
         }
 

--- a/test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ import java.security.spec.*;
 
 /**
  * @test
- * @bug 8080462 8226651 8242332
+ * @bug 8080462 8226651 8242332 8312428
  * @summary Ensure that PSS key and params check are implemented properly
  *         regardless of call sequence
  * @library /test/lib ..
@@ -47,10 +47,7 @@ public class KeyAndParamCheckForPSS extends PKCS11Test {
 
     @Override
     public void main(Provider p) throws Exception {
-        Signature sig;
-        try {
-            sig = Signature.getInstance(SIGALG, p);
-        } catch (NoSuchAlgorithmException e) {
+        if (!PSSUtil.isSignatureSupported(p)) {
             System.out.println("Skip testing RSASSA-PSS" +
                 " due to no support");
             return;
@@ -78,25 +75,20 @@ public class KeyAndParamCheckForPSS extends PKCS11Test {
         runTest(p, 1040, "SHA3-512", "SHA3-512");
     }
 
-    private void runTest(Provider p, int keySize, String hashAlg,
+    private static void runTest(Provider p, int keySize, String hashAlg,
             String mgfHashAlg) throws Exception {
 
-        // skip further test if this provider does not support hashAlg or
-        // mgfHashAlg
-        try {
-            MessageDigest.getInstance(hashAlg, p);
-            MessageDigest.getInstance(mgfHashAlg, p);
-        } catch (NoSuchAlgorithmException nsae) {
-            System.out.println("No support for " + hashAlg + ", skip");
+        System.out.println("Testing " + hashAlg + " and MGF1" + mgfHashAlg);
+        PSSUtil.AlgoSupport s = PSSUtil.isHashSupported(p, hashAlg, mgfHashAlg);
+        if (s == PSSUtil.AlgoSupport.NO) {
+            System.out.println("=> Skip; no support");
             return;
         }
 
-        System.out.println("Testing [" + keySize + " " + hashAlg + "]");
+        Signature sig = Signature.getInstance(SIGALG, p);
 
         // create a key pair with the supplied size
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(KEYALG, p);
-        kpg.initialize(keySize);
-        KeyPair kp = kpg.generateKeyPair();
+        KeyPair kp = PSSUtil.generateKeys(p, keySize);
 
         int bigSaltLen = keySize/8 - 14;
         AlgorithmParameterSpec paramsBad = new PSSParameterSpec(hashAlg,
@@ -108,58 +100,71 @@ public class KeyAndParamCheckForPSS extends PKCS11Test {
         PublicKey pub = kp.getPublic();
 
         // test#1 - setParameter then initSign
-        Signature sig = Signature.getInstance("RSASSA-PSS", p);
-        sig.setParameter(paramsBad);
+        sig = Signature.getInstance(SIGALG, p);
         try {
+            sig.setParameter(paramsGood);
+            sig.initSign(priv);
+            System.out.println("test#1: good params pass");
+        } catch (Exception ex) {
+            if (s == PSSUtil.AlgoSupport.MAYBE) {
+                // confirmed to be unsupported; skip the rest of the test
+                System.out.println("=> Skip; no PSS support");
+                return;
+            }
+        }
+
+        sig = Signature.getInstance(SIGALG, p);
+        try {
+            sig.setParameter(paramsBad);
             sig.initSign(priv);
             throw new RuntimeException("Expected IKE not thrown");
         } catch (InvalidKeyException ike) {
             System.out.println("test#1: got expected IKE");
         }
 
-        sig.setParameter(paramsGood);
-        sig.initSign(priv);
-        System.out.println("test#1: pass");
-
         // test#2 - setParameter then initVerify
-        sig = Signature.getInstance("RSASSA-PSS", p);
-        sig.setParameter(paramsBad);
+        sig = Signature.getInstance(SIGALG, p);
+        sig.setParameter(paramsGood);
+        sig.initVerify(pub);
+        System.out.println("test#2: good params pass");
+
+        sig = Signature.getInstance(SIGALG, p);
         try {
+            sig.setParameter(paramsBad);
             sig.initVerify(pub);
             throw new RuntimeException("Expected IKE not thrown");
         } catch (InvalidKeyException ike) {
             System.out.println("test#2: got expected IKE");
         }
 
-        sig.setParameter(paramsGood);
-        sig.initVerify(pub);
-
-        System.out.println("test#2: pass");
-
         // test#3 - initSign, then setParameter
-        sig = Signature.getInstance("RSASSA-PSS", p);
+        sig = Signature.getInstance(SIGALG, p);
         sig.initSign(priv);
+        sig.setParameter(paramsGood);
+        System.out.println("test#3: good params pass");
+
+        sig = Signature.getInstance(SIGALG, p);
         try {
+            sig.initSign(priv);
             sig.setParameter(paramsBad);
             throw new RuntimeException("Expected IAPE not thrown");
         } catch (InvalidAlgorithmParameterException iape) {
             System.out.println("test#3: got expected IAPE");
         }
 
-        sig.setParameter(paramsGood);
-        System.out.println("test#3: pass");
-
         // test#4 - initVerify, then setParameter
-        sig = Signature.getInstance("RSASSA-PSS", p);
+        sig = Signature.getInstance(SIGALG, p);
+        sig.setParameter(paramsGood);
         sig.initVerify(pub);
+        System.out.println("test#4: good params pass");
+
+        sig = Signature.getInstance(SIGALG, p);
         try {
+            sig.initVerify(pub);
             sig.setParameter(paramsBad);
             throw new RuntimeException("Expected IAPE not thrown");
         } catch (InvalidAlgorithmParameterException iape) {
             System.out.println("test#4: got expected IAPE");
         }
-
-        sig.setParameter(paramsGood);
-        System.out.println("test#4: pass");
     }
 }

--- a/test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java
@@ -35,10 +35,6 @@ import java.security.spec.*;
  */
 public class KeyAndParamCheckForPSS extends PKCS11Test {
 
-    /**
-     * ALGORITHM name, fixed as RSA for PKCS11
-     */
-    private static final String KEYALG = "RSA";
     private static final String SIGALG = "RSASSA-PSS";
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
@@ -24,10 +24,11 @@ import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
 import java.util.stream.IntStream;
+import jtreg.SkippedException;
 
 /**
  * @test
- * @bug 8080462 8226651 8242332 8312428
+ * @bug 8080462 8226651 8242332
  * @summary Generate a RSASSA-PSS signature and verify it using PKCS11 provider
  * @library /test/lib ..
  * @modules jdk.crypto.cryptoki
@@ -54,6 +55,8 @@ public class SignatureTestPSS extends PKCS11Test {
      */
     private static final int UPDATE_TIMES_HUNDRED = 100;
 
+    private static boolean skipTest = true;
+
     public static void main(String[] args) throws Exception {
         main(new SignatureTestPSS(), args);
     }
@@ -61,8 +64,7 @@ public class SignatureTestPSS extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (!PSSUtil.isSignatureSupported(p)) {
-            System.out.println("Skip testing " + SIGALG + " due to no support");
-            return;
+            throw new SkippedException("Skip due to no support for " + SIGALG);
         }
 
         for (int kSize : KEYSIZES) {
@@ -83,6 +85,11 @@ public class SignatureTestPSS extends PKCS11Test {
                     checkSignature(p, DATA, pubKey, privKey, hash, mgfHash, s);
                 }
             };
+        }
+
+        // start testing below
+        if (skipTest) {
+            throw new SkippedException("Test Skipped");
         }
     }
 
@@ -109,6 +116,8 @@ public class SignatureTestPSS extends PKCS11Test {
                 return;
             }
         }
+        // start testing below
+        skipTest = false;
 
         for (int i = 0; i < UPDATE_TIMES_HUNDRED; i++) {
             sig.update(data);

--- a/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
@@ -35,8 +35,6 @@ import java.util.stream.IntStream;
  */
 public class SignatureTestPSS extends PKCS11Test {
 
-    // PKCS11 does not support RSASSA-PSS keys yet
-    private static final String KEYALG = "RSA";
     private static final String SIGALG = "RSASSA-PSS";
 
     private static final int[] KEYSIZES = { 2048, 3072 };
@@ -63,8 +61,7 @@ public class SignatureTestPSS extends PKCS11Test {
     @Override
     public void main(Provider p) throws Exception {
         if (!PSSUtil.isSignatureSupported(p)) {
-            System.out.println("Skip testing RSASSA-PSS" +
-                " due to no support");
+            System.out.println("Skip testing " + SIGALG + " due to no support");
             return;
         }
 

--- a/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
+++ b/test/jdk/sun/security/pkcs11/Signature/SignatureTestPSS.java
@@ -114,6 +114,8 @@ public class SignatureTestPSS extends PKCS11Test {
                 // confirmed to be unsupported; skip the rest of the test
                 System.out.println("    => Skip; no PSS support");
                 return;
+            } else {
+                throw new RuntimeException("Unexpected Exception", iape);
             }
         }
         // start testing below


### PR DESCRIPTION
Starting NSS v3.91, SHA-3 support is added for MessageDigest but not for PSS Signature. This breaks existing test assumptions made by PSS regression tests. In addition, the NSS SHA-3 message digests do not support cloning which causes the failure of TestCloning.java.

This PR adds a PSSUtil.java class which provides utility method for detecting/guessing whether a digest algorithm is valid for PSS signature or not.

The changes are verified with NSS v3.46, v3.57 and v3.91 (on local Linux machine).

Thanks in advance for review~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312428](https://bugs.openjdk.org/browse/JDK-8312428): PKCS11 tests fail with NSS 3.91 (**Bug** - P3)


### Reviewers
 * [Sibabrata Sahoo](https://openjdk.org/census#ssahoo) (@sisahoo - Committer) ⚠️ Review applies to [ca1a3b92](https://git.openjdk.org/jdk/pull/15217/files/ca1a3b9203f5147b35449dedb9d7b1ff39d3fad9)
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15217/head:pull/15217` \
`$ git checkout pull/15217`

Update a local copy of the PR: \
`$ git checkout pull/15217` \
`$ git pull https://git.openjdk.org/jdk.git pull/15217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15217`

View PR using the GUI difftool: \
`$ git pr show -t 15217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15217.diff">https://git.openjdk.org/jdk/pull/15217.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15217#issuecomment-1672393474)