### PR TITLE
JDK-8313656: assert(!JvmtiExport::can_support_virtual_threads()) with -XX:-DoJVMTIVirtualThreadTransitions

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1009,7 +1009,7 @@ JvmtiEnv::SuspendThreadList(jint request_count, const jthread* request_list, jvm
 
 jvmtiError
 JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list) {
-  if (!JvmtiExport::can_support_virtual_threads()) {
+  if (get_capabilities()->can_support_virtual_threads == 0) {
     return JVMTI_ERROR_MUST_POSSESS_CAPABILITY;
   }
   JavaThread* current = JavaThread::current();
@@ -1127,7 +1127,7 @@ JvmtiEnv::ResumeThreadList(jint request_count, const jthread* request_list, jvmt
 
 jvmtiError
 JvmtiEnv::ResumeAllVirtualThreads(jint except_count, const jthread* except_list) {
-  if (!JvmtiExport::can_support_virtual_threads()) {
+  if (get_capabilities()->can_support_virtual_threads == 0) {
     return JVMTI_ERROR_MUST_POSSESS_CAPABILITY;
   }
   jvmtiError err = JvmtiEnvBase::check_thread_list(except_count, except_list);

--- a/src/hotspot/share/prims/jvmtiManageCapabilities.hpp
+++ b/src/hotspot/share/prims/jvmtiManageCapabilities.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,12 @@ private:
   // all capabilities ever acquired
   static jvmtiCapabilities acquired_capabilities;
 
+  // counter for the agents possess can_support_virtual_threads capability
+  static int _can_support_virtual_threads_count;
+
+  // lock to access the class data
+  static Mutex* _capabilities_lock;
+
   // basic intenal operations
   static jvmtiCapabilities *either(const jvmtiCapabilities *a, const jvmtiCapabilities *b, jvmtiCapabilities *result);
   static jvmtiCapabilities *both(const jvmtiCapabilities *a, const jvmtiCapabilities *b, jvmtiCapabilities *result);
@@ -60,6 +66,14 @@ private:
   static jvmtiCapabilities init_onload_capabilities();
   static jvmtiCapabilities init_always_solo_capabilities();
   static jvmtiCapabilities init_onload_solo_capabilities();
+
+  // returns nullptr in onload phase
+  static Mutex* lock();
+
+  // get_potential_capabilities without lock
+  static void get_potential_capabilities_nolock(const jvmtiCapabilities* current,
+                                                const jvmtiCapabilities* prohibited,
+                                                jvmtiCapabilities* result);
 
 public:
   static void initialize();


### PR DESCRIPTION
The change fixes several issues with capability management:
- handling can_support_virtual_threads capability. JvmtiExport::can_support_virtual_threads() should be set to true if we have one or more agent with can_support_virtual_threads capability;
- JvmtiManageCapabilities (used by GetPotentialCapabilities/AddCapabilities/RelinquishCapabilities/GetCapabilities) is not thread safe;
- SuspendAllVirtualThreads and ResumeAllVirtualThreads should check capability on the caller agent (and not JvmtiExport::can_support_virtual_threads()).

Testing: tier1..5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313656](https://bugs.openjdk.org/browse/JDK-8313656): assert(!JvmtiExport::can_support_virtual_threads()) with -XX:-DoJVMTIVirtualThreadTransitions (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15219/head:pull/15219` \
`$ git checkout pull/15219`

Update a local copy of the PR: \
`$ git checkout pull/15219` \
`$ git pull https://git.openjdk.org/jdk.git pull/15219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15219`

View PR using the GUI difftool: \
`$ git pr show -t 15219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15219.diff">https://git.openjdk.org/jdk/pull/15219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15219#issuecomment-1672429122)