### PR TITLE
Allow lossy conversions in test code.

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -186,12 +186,12 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
     gcc)
       DISABLE_WARNING_PREFIX="-Wno-"
       BUILD_CC_DISABLE_WARNING_PREFIX="-Wno-"
-      CFLAGS_WARNINGS_ARE_ERRORS="-Werror"
+      CFLAGS_WARNINGS_ARE_ERRORS=""
 
       # Additional warnings that are not activated by -Wall and -Wextra
       WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wsign-compare \
           -Wunused-function -Wundef -Wunused-value -Wreturn-type \
-          -Wtrampolines"
+          -Wtrampolines -Wconversion"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"

--- a/test/hotspot/jtreg/compiler/floatingpoint/libTestFloatJNIArgs.c
+++ b/test/hotspot/jtreg/compiler/floatingpoint/libTestFloatJNIArgs.c
@@ -50,7 +50,7 @@ JNIEXPORT jfloat JNICALL Java_compiler_floatingpoint_TestFloatJNIArgs_addFloatsI
    jfloat  f5, jfloat  f6, jfloat  f7, jfloat  f8,
    jfloat  f9, jfloat f10, jfloat f11, jfloat f12,
    jfloat f13, jfloat f14, jfloat f15, jint a16, jint a17) {
-  return f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8 + f9 + f10 + f11 + f12 + f13 + f14 + f15 + a16 + a17;
+  return f1 + f2 + f3 + f4 + f5 + f6 + f7 + f8 + f9 + f10 + f11 + f12 + f13 + f14 + f15 + (jfloat)a16 + (jfloat)a17;
 }
 
 JNIEXPORT jdouble JNICALL Java_compiler_floatingpoint_TestFloatJNIArgs_add15doubles

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/libNativeCallTest.c
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/libNativeCallTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ JNIEXPORT jfloat JNICALL Java_jdk_vm_ci_code_test_NativeCallTest__1FF(JNIEnv *en
 }
 
 jfloat JNICALL SDILDS(jfloat a, jdouble b, jint c, jlong d, jdouble e, jfloat f) {
-  return (jfloat)(a + b + c + d + e + f);
+  return (jfloat)(a + b + (jdouble)c + (jdouble)d + (jdouble)e + f);
 }
 
 JNIEXPORT jlong JNICALL Java_jdk_vm_ci_code_test_NativeCallTest_getSDILDS(JNIEnv *env, jclass clazz) {
@@ -64,7 +64,7 @@ jfloat JNICALL F32SDILDS(jfloat f00, jfloat f01, jfloat f02, jfloat f03, jfloat 
                   f08 + f09 + f0a + f0b + f0c + f0d + f0e + f0f +
                   f10 + f11 + f12 + f13 + f14 + f15 + f16 + f17 +
                   f18 + f19 + f1a + f1b + f1c + f1d + f1e + f1f +
-                  a +   b +   c +   d +   e + f);
+                  a + b + (jdouble)c + (jdouble)d + e + f);
 }
 
 JNIEXPORT jlong JNICALL Java_jdk_vm_ci_code_test_NativeCallTest_getF32SDILDS(JNIEnv *env, jclass clazz) {
@@ -98,7 +98,7 @@ jfloat JNICALL D32SDILDS(jdouble d00, jdouble d01, jdouble d02, jdouble d03, jdo
                   d08 + d09 + d0a + d0b + d0c + d0d + d0e + d0f +
                   d10 + d11 + d12 + d13 + d14 + d15 + d16 + d17 +
                   d18 + d19 + d1a + d1b + d1c + d1d + d1e + d1f +
-                  a +   b +   c +   d +   e + f);
+                  a + b + (jdouble)c + (jdouble)d + e + f);
 }
 
 JNIEXPORT jlong JNICALL Java_jdk_vm_ci_code_test_NativeCallTest_getD32SDILDS(JNIEnv *env, jclass clazz) {
@@ -131,8 +131,8 @@ jfloat JNICALL I32SDILDS(jint i00, jint i01, jint i02, jint i03, jint i04, jint 
   return (jfloat)(i00 + i01 + i02 + i03 + i04 + i05 + i06 + i07 +
                   i08 + i09 + i0a + i0b + i0c + i0d + i0e + i0f +
                   i10 + i11 + i12 + i13 + i14 + i15 + i16 + i17 +
-                  i18 + i19 + i1a + i1b + i1c + i1d + i1e + i1f +
-                  a +   b +   c +   d +   e + f);
+                  i18 + i19 + i1a + i1b + i1c + i1d + i1e + i1f) +
+                  (jfloat)(a + b + c + (jdouble)d + e + f);
 }
 
 JNIEXPORT jlong JNICALL Java_jdk_vm_ci_code_test_NativeCallTest_getI32SDILDS(JNIEnv *env, jclass clazz) {
@@ -165,7 +165,7 @@ jfloat JNICALL L32SDILDS(jlong l00, jlong l01, jlong l02, jlong l03, jlong l04, 
                   l08 + l09 + l0a + l0b + l0c + l0d + l0e + l0f +
                   l10 + l11 + l12 + l13 + l14 + l15 + l16 + l17 +
                   l18 + l19 + l1a + l1b + l1c + l1d + l1e + l1f +
-                  a +   b +   c +   d +   e + f);
+                  (jlong)a + (jlong)b + c + d + (jlong)e + (jlong)f);
 }
 
 JNIEXPORT jlong JNICALL Java_jdk_vm_ci_code_test_NativeCallTest_getL32SDILDS(JNIEnv *env, jclass clazz) {

--- a/test/hotspot/jtreg/gc/stress/gclocker/libTestGCLocker.c
+++ b/test/hotspot/jtreg/gc/stress/gclocker/libTestGCLocker.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ Java_gc_stress_gclocker_GCLockerStresser_fillWithRandomValues(JNIEnv* env, jclas
   jbyte* p = (*env)->GetPrimitiveArrayCritical(env, arr, NULL);
   jsize i;
   for (i = 0; i < size; i++) {
-    p[i] = i % 128;
+    p[i] = (jbyte)(i % 128);
   }
   (*env)->ReleasePrimitiveArrayCritical(env, arr, p, 0);
 }

--- a/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
+++ b/test/hotspot/jtreg/runtime/StackGuardPages/exeinvoke.c
@@ -114,7 +114,7 @@ size_t get_java_stacksize () {
     fprintf(stderr, "Test ERROR. Can't get a valid value for the default stacksize.\n");
     exit(7);
   }
-  return jdk_args.javaStackSize;
+  return (size_t)jdk_args.javaStackSize;
 }
 
 // Call DoOverflow::`method` on JVM
@@ -246,7 +246,7 @@ int main (int argc, const char** argv) {
   JavaVMInitArgs vm_args;
   JavaVMOption options[3];
   JNIEnv* env;
-  int optlen;
+  size_t optlen;
   char *javaclasspath = NULL;
   char javaclasspathopt[4096];
 

--- a/test/hotspot/jtreg/runtime/jni/FindClassUtf8/libFindClassUtf8.c
+++ b/test/hotspot/jtreg/runtime/jni/FindClassUtf8/libFindClassUtf8.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 JNIEXPORT void JNICALL Java_FindClassUtf8_nTest(JNIEnv* env, jclass jclazz)
 {
-    jbyte chars[] = {0x18, 0xf8, 0x20, 0x5d, 0x31, 0x32, 0x31, 0x5b, 0}; // f8 is invalid utf8
+    jbyte chars[] = {0x18, (jbyte)0xf8, 0x20, 0x5d, 0x31, 0x32, 0x31, 0x5b, 0}; // f8 is invalid utf8
 
     jclass badClass = (*env)->FindClass(env, (const char*)&chars);
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -436,7 +436,7 @@ static double event_storage_get_average_size(EventStorage* storage) {
   max_size = storage->live_object_count;
 
   for (i = 0; i < max_size; i++) {
-    accumulation += storage->live_objects[i]->size;
+    accumulation += (double)storage->live_objects[i]->size;
   }
 
   event_storage_unlock(storage);

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/NullAsCurrentThreadTest/libNullAsCurrentThreadTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/NullAsCurrentThreadTest/libNullAsCurrentThreadTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -374,7 +374,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
 
   memset(&callbacks, 0, sizeof(callbacks));
   memset(&caps, 0, sizeof(caps));
-  caps.can_support_virtual_threads = vt_support_enabled;
+  caps.can_support_virtual_threads = vt_support_enabled & 1;
   caps.can_get_owned_monitor_info = 1;
   caps.can_get_owned_monitor_stack_depth_info = 1;
   caps.can_get_current_contended_monitor = 1;

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jni/ExceptionCheckingJniEnv.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jni/ExceptionCheckingJniEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2019, Google and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,6 +27,7 @@
 #include <string.h>
 
 #include "ExceptionCheckingJniEnv.hpp"
+#include "jni_tools.h"
 #include "nsk_tools.h"
 
 namespace {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jni/jni_tools.h
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jni/jni_tools.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,9 @@
 #define LL "I64"
 #include <STDDEF.H>
 
+// Turn off -Wconversion warnings
+__pragma(warning(disable : 4244))
+
 #else // !_WIN32
 
 #include <stdint.h>
@@ -51,6 +54,9 @@
 #else
 #define LL "ll"
 #endif
+
+// Turn off -Wconversion warnings
+# pragma GCC diagnostic ignored "-Wconversion"
 
 #endif // !_WIN32
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnihelper.h
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/jni/jnihelper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,18 @@
  */
 
 #include <stdlib.h>
+
+#ifdef _WIN32
+
+// Turn off -Wconversion warnings
+__pragma(warning(disable : 4244))
+
+#else // !_WIN32
+
+// Turn off -Wconversion warnings
+# pragma GCC diagnostic ignored "-Wconversion"
+
+#endif // !_WIN32
 
 // checked malloc to trap OOM conditions
 static void* c_malloc(JNIEnv* env, size_t size) {


### PR DESCRIPTION
Fix nsk tests to allow lossy conversions when -Wconversion is turned on.  Fix some Wconversion errors in jtreg cpp files.

The NSK sources have thousands of warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15220/head:pull/15220` \
`$ git checkout pull/15220`

Update a local copy of the PR: \
`$ git checkout pull/15220` \
`$ git pull https://git.openjdk.org/jdk.git pull/15220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15220`

View PR using the GUI difftool: \
`$ git pr show -t 15220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15220.diff">https://git.openjdk.org/jdk/pull/15220.diff</a>

</details>
