### PR TITLE
JDK-8368907: Fix WindowsException allow ERROR_PRIVILEGE_NOT_HELD(1314) be converted to AccessDeniedException

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsException.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsException.java
@@ -85,7 +85,7 @@ class WindowsException extends Exception {
             return new NoSuchFileException(file, other, null);
         if (lastError() == ERROR_FILE_EXISTS || lastError() == ERROR_ALREADY_EXISTS)
             return new FileAlreadyExistsException(file, other, null);
-        if (lastError() == ERROR_ACCESS_DENIED)
+        if (lastError() == ERROR_ACCESS_DENIED || lastError() == ERROR_PRIVILEGE_NOT_HELD)
             return new AccessDeniedException(file, other, null);
 
         // fallback to the more general exception


### PR DESCRIPTION
Fix WindowsException allow ERROR_PRIVILEGE_NOT_HELD(1314) be converted to AccessDeniedException
JDK-8368907
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15221/head:pull/15221` \
`$ git checkout pull/15221`

Update a local copy of the PR: \
`$ git checkout pull/15221` \
`$ git pull https://git.openjdk.org/jdk.git pull/15221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15221`

View PR using the GUI difftool: \
`$ git pr show -t 15221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15221.diff">https://git.openjdk.org/jdk/pull/15221.diff</a>

</details>
