### PR TITLE
8314113: G1: Remove unused G1CardSetInlinePtr::card_at

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -84,12 +84,6 @@ class G1CardSetInlinePtr : public StackObj {
 
   static ContainerPtr merge(ContainerPtr orig_value, uint card_in_region, uint idx, uint bits_per_card);
 
-  static uint card_at(ContainerPtr value, uint const idx, uint const bits_per_card) {
-    uint8_t card_pos = card_pos_for(idx, bits_per_card);
-    uint result = ((uintptr_t)value >> card_pos) & (((uintptr_t)1 << bits_per_card) - 1);
-    return result;
-  }
-
   uint find(uint const card_idx, uint const bits_per_card, uint start_at, uint num_cards);
 
 public:


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314113](https://bugs.openjdk.org/browse/JDK-8314113): G1: Remove unused G1CardSetInlinePtr::card_at (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15223/head:pull/15223` \
`$ git checkout pull/15223`

Update a local copy of the PR: \
`$ git checkout pull/15223` \
`$ git pull https://git.openjdk.org/jdk.git pull/15223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15223`

View PR using the GUI difftool: \
`$ git pr show -t 15223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15223.diff">https://git.openjdk.org/jdk/pull/15223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15223#issuecomment-1673169598)