### PR TITLE
8314091: Set native thread name for Java main thread

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -536,7 +536,13 @@ bool Thread::set_as_starting_thread() {
          "_starting_thread=" INTPTR_FORMAT, p2i(_starting_thread));
   // NOTE: this must be called inside the main thread.
   DEBUG_ONLY(_starting_thread = this;)
-  return os::create_main_thread(JavaThread::cast(this));
+  JavaThread* main_java_thread = JavaThread::cast(this);
+  bool created = os::create_main_thread(main_java_thread);
+  if (!created) {
+    return false;
+  }
+  main_java_thread->set_native_thread_name("main");
+  return true;
 }
 
 // Ad-hoc mutual exclusion primitives: SpinLock


### PR DESCRIPTION
`cat /proc/<java_process>/task/<main thread>/comm` shows "java"

User wants it to be "main", just like any other JVM threads, which can be achieved by explicitly calling pthread_setname_np when spawning main thread at VM startup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314091](https://bugs.openjdk.org/browse/JDK-8314091): Set native thread name for Java main thread (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15224/head:pull/15224` \
`$ git checkout pull/15224`

Update a local copy of the PR: \
`$ git checkout pull/15224` \
`$ git pull https://git.openjdk.org/jdk.git pull/15224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15224`

View PR using the GUI difftool: \
`$ git pr show -t 15224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15224.diff">https://git.openjdk.org/jdk/pull/15224.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15224#issuecomment-1673191809)