### PR TITLE
8314106: C2: assert(is_valid()) failed: must be valid after JDK-8305636

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -445,9 +445,8 @@ void PhaseIdealLoop::clone_loop_predication_predicates_to_unswitched_loop(IdealL
                                                                           Deoptimization::DeoptReason reason,
                                                                           IfProjNode*& iffast_pred,
                                                                           IfProjNode*& ifslow_pred) {
-  if (predicate_block->is_non_empty()) {
+  if (predicate_block->has_parse_predicate()) {
     clone_parse_predicate_to_unswitched_loops(predicate_block, reason, iffast_pred, ifslow_pred);
-
     clone_assertion_predicates_to_unswitched_loop(loop, old_new, reason, predicate_block->parse_predicate_success_proj(),
                                                   iffast_pred, ifslow_pred);
   }
@@ -456,6 +455,7 @@ void PhaseIdealLoop::clone_loop_predication_predicates_to_unswitched_loop(IdealL
 void PhaseIdealLoop::clone_parse_predicate_to_unswitched_loops(const PredicateBlock* predicate_block,
                                                                Deoptimization::DeoptReason reason,
                                                                IfProjNode*& iffast_pred, IfProjNode*& ifslow_pred) {
+  assert(predicate_block->has_parse_predicate(), "must have parse predicate");
   ParsePredicateSuccessProj* parse_predicate_proj = predicate_block->parse_predicate_success_proj();
   iffast_pred = clone_parse_predicate_to_unswitched_loop(parse_predicate_proj, iffast_pred, reason, false);
   check_cloned_parse_predicate_for_unswitching(iffast_pred, true);

--- a/test/hotspot/jtreg/compiler/predicates/TestLoopUnswitchingWithoutParsePredicates.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestLoopUnswitchingWithoutParsePredicates.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8314106
+ * @summary Test that we do not try to copy a Parse Predicate to an unswitched loop if they do not exist anymore.
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.predicates.TestLoopUnswitchingWithoutParsePredicates::*
+ *                   compiler.predicates.TestLoopUnswitchingWithoutParsePredicates
+ */
+
+package compiler.predicates;
+
+public class TestLoopUnswitchingWithoutParsePredicates {
+    static byte byFld;
+    static byte byArrFld[] = new byte[400];
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 1000;i++) {
+            test(i);
+        }
+    }
+
+    static void test(int i2) {
+        int i10, i11 = 0, i12, i13, i14;
+        double dArr[] = new double[400];
+        for (i10 = 7; i10 < 307; i10++) {
+            byArrFld[i10] = 58;
+            for (i12 = 1; i12 < 3; i12++) {
+                for (i14 = 1; i14 < 2; i14++) {
+                    byFld &= i14;
+                    switch (i2) {
+                        case 4:
+                            dArr[1] = i14;
+                        case 2:
+                            i13 = i11;
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
In the failing test case, we are unswitching a loop for which we've already removed Parse Predicates with `Compile::cleanup_parse_predicates()`. We are wrongly checking if a predicate block is non-empty (i.e. find the Parse **or** Runtime Predicates) instead of only checking if we find the Parse Predicate:
https://github.com/openjdk/jdk/blob/23fe2ece586d3ed750e905e1b71a2cd1da91f335/src/hotspot/share/opto/loopPredicate.cpp#L448-L453

In the test case, we have a predicate block that contains Runtime Predicates from Loop Predication but no Parse Predicate anymore. Therefore, when trying to clone the non-existing Parse Predicate, we fail with the assertion because we do not have a valid Parse Predicate.

The fix is to only clone a Parse Predicate and the Assertion Predicates for a predicate block if the Parse Predicate is actually there. This is not entirely correct because we would also need to clone Assertion Predicates in the absence of Parse Predicates. But this was already wrong before JDK-8305636:
https://github.com/openjdk/jdk/blob/a38fdaf18dfeeb23775516d1986c720190ba9fc2/src/hotspot/share/opto/loopPredicate.cpp#L598-L612

This will only be fixed with the complete fix ([JDK-8288981](https://bugs.openjdk.org/browse/JDK-8288981)). The proposed fix here just reverts back to the old behavior before JDK-8305636.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314106](https://bugs.openjdk.org/browse/JDK-8314106): C2: assert(is_valid()) failed: must be valid after JDK-8305636 (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15225/head:pull/15225` \
`$ git checkout pull/15225`

Update a local copy of the PR: \
`$ git checkout pull/15225` \
`$ git pull https://git.openjdk.org/jdk.git pull/15225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15225`

View PR using the GUI difftool: \
`$ git pr show -t 15225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15225.diff">https://git.openjdk.org/jdk/pull/15225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15225#issuecomment-1673273981)