### PR TITLE
8314117: RISC-V: Incorrect VMReg encoding in RISCV64Frame.java

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2019, Red Hat Inc.
- * Copyright (c) 2021, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2021, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
@@ -71,7 +71,7 @@ public class RISCV64Frame extends Frame {
   // Native frames
   private static final int NATIVE_FRAME_INITIAL_PARAM_OFFSET =  2;
 
-  private static VMReg fp = new VMReg(8);
+  private static VMReg fp = new VMReg(8 << 1);
 
   static {
     VM.registerVMInitializedObserver(new Observer() {


### PR DESCRIPTION
Hi, inspired by [JDK-8247351](https://bugs.openjdk.org/browse/JDK-8247351),  this patch fixes a VMReg encoding issue in `RISCV64Frame.java`. As the VMReg has two slots in a 64-bit VM, the encoding of `fp` should be `8 << 1` instead of `8`.

Testing:
- [x] tier1 with release build
- [x] tier2 with release build
- [x] tier3 with release build
- [x] hotspot:tier4 with release build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314117](https://bugs.openjdk.org/browse/JDK-8314117): RISC-V: Incorrect VMReg encoding in RISCV64Frame.java (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15226/head:pull/15226` \
`$ git checkout pull/15226`

Update a local copy of the PR: \
`$ git checkout pull/15226` \
`$ git pull https://git.openjdk.org/jdk.git pull/15226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15226`

View PR using the GUI difftool: \
`$ git pr show -t 15226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15226.diff">https://git.openjdk.org/jdk/pull/15226.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15226#issuecomment-1673325837)