### PR TITLE
8314118: Update JMH devkit to 1.37

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -26,8 +26,8 @@
 # Create a bundle in the build directory, containing what's needed to
 # build and run JMH microbenchmarks from the OpenJDK build.
 
-JMH_VERSION=1.36
-COMMONS_MATH3_VERSION=3.2
+JMH_VERSION=1.37
+COMMONS_MATH3_VERSION=3.6.1
 JOPT_SIMPLE_VERSION=5.0.4
 
 BUNDLE_NAME=jmh-$JMH_VERSION.tar.gz


### PR DESCRIPTION
Time to update JMH devkit to latest version.  This time, the dependency version of Commons Math 3 also changed.
https://github.com/openjdk/jmh/blob/362d6579e007f0241f05c1305f0b269fcc2cc27a/pom.xml#L284

Additional testing:
 - [x] Sample benchmark run with new devkit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314118](https://bugs.openjdk.org/browse/JDK-8314118): Update JMH devkit to 1.37 (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15227/head:pull/15227` \
`$ git checkout pull/15227`

Update a local copy of the PR: \
`$ git checkout pull/15227` \
`$ git pull https://git.openjdk.org/jdk.git pull/15227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15227`

View PR using the GUI difftool: \
`$ git pr show -t 15227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15227.diff">https://git.openjdk.org/jdk/pull/15227.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15227#issuecomment-1673383568)