### PR TITLE
8314119: G1: Fix -Wconversion warnings in G1CardSetInlinePtr::card_pos_for

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -78,7 +78,7 @@ class G1CardSetInlinePtr : public StackObj {
 
   static const uintptr_t SizeFieldMask = (((uint)1 << SizeFieldLen) - 1) << SizeFieldPos;
 
-  static uint8_t card_pos_for(uint const idx, uint const bits_per_card) {
+  static uint card_pos_for(uint const idx, uint const bits_per_card) {
     return (idx * bits_per_card + HeaderSize);
   }
 

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -35,7 +35,7 @@ inline G1CardSetInlinePtr::ContainerPtr G1CardSetInlinePtr::merge(ContainerPtr o
   assert((idx & (SizeFieldMask >> SizeFieldPos)) == idx, "Index %u too large to fit into size field", idx);
   assert(card_in_region < ((uint)1 << bits_per_card), "Card %u too large to fit into card value field", card_in_region);
 
-  uint8_t card_pos = card_pos_for(idx, bits_per_card);
+  uint card_pos = card_pos_for(idx, bits_per_card);
   assert(card_pos + bits_per_card < BitsInValue, "Putting card at pos %u with %u bits would extend beyond pointer", card_pos, bits_per_card);
 
   // Check that we do not touch any fields we do not own.


### PR DESCRIPTION
Simple type change to avoid narrowing-conversion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314119](https://bugs.openjdk.org/browse/JDK-8314119): G1: Fix -Wconversion warnings in G1CardSetInlinePtr::card_pos_for (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15228/head:pull/15228` \
`$ git checkout pull/15228`

Update a local copy of the PR: \
`$ git checkout pull/15228` \
`$ git pull https://git.openjdk.org/jdk.git pull/15228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15228`

View PR using the GUI difftool: \
`$ git pr show -t 15228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15228.diff">https://git.openjdk.org/jdk/pull/15228.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15228#issuecomment-1673442661)