### PR TITLE
8314085: Fixing scope from benchmark to thread for JMH tests having shared state

### DIFF
--- a/test/micro/org/openjdk/bench/java/io/DataInputStreamTest.java
+++ b/test/micro/org/openjdk/bench/java/io/DataInputStreamTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 4, warmups = 0)
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 2, time = 2)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class DataInputStreamTest {
     private final int size = 1024;
 

--- a/test/micro/org/openjdk/bench/java/lang/ArrayClone.java
+++ b/test/micro/org/openjdk/bench/java/lang/ArrayClone.java
@@ -46,7 +46,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Warmup(iterations = 2, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 15, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class ArrayClone {
 
     @Param({"0", "10", "100", "1000"})

--- a/test/micro/org/openjdk/bench/java/lang/StringCompareToDifferentLength.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringCompareToDifferentLength.java
@@ -51,7 +51,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Measurement(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Warmup(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/StringCompareToIgnoreCase.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringCompareToIgnoreCase.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringComparisons.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 3)

--- a/test/micro/org/openjdk/bench/java/lang/StringEquals.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringEquals.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 3)

--- a/test/micro/org/openjdk/bench/java/lang/StringFormat.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringFormat.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 3)

--- a/test/micro/org/openjdk/bench/java/lang/StringReplace.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringReplace.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 3)

--- a/test/micro/org/openjdk/bench/java/lang/StringSubstring.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringSubstring.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 3)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class StringSubstring {
 
     public String s = new String("An arbitrary string that happened to be of length 52");

--- a/test/micro/org/openjdk/bench/java/lang/StringTemplateFMT.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringTemplateFMT.java
@@ -42,7 +42,7 @@ import static java.util.FormatProcessor.FMT;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 3, jvmArgsAppend = "--enable-preview")

--- a/test/micro/org/openjdk/bench/java/lang/constant/MethodTypeDescFactories.java
+++ b/test/micro/org/openjdk/bench/java/lang/constant/MethodTypeDescFactories.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 3, time = 2)
 @Measurement(iterations = 6, time = 1)
 @Fork(1)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class MethodTypeDescFactories {
 
     private static final ClassDesc DUMMY_CD = ClassDesc.of("Dummy_invalid");

--- a/test/micro/org/openjdk/bench/java/lang/constant/ReferenceClassDescResolve.java
+++ b/test/micro/org/openjdk/bench/java/lang/constant/ReferenceClassDescResolve.java
@@ -47,7 +47,7 @@ import static java.lang.constant.ConstantDescs.*;
 @Warmup(iterations = 3, time = 2)
 @Measurement(iterations = 6, time = 1)
 @Fork(1)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class ReferenceClassDescResolve {
     private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
     private static final ClassDesc CLASS_OR_INTERFACE = CD_String;

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesConstant.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesIdentity.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesIdentity.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesThrowException.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodHandlesThrowException.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAppendParams.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeAppendParams.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeChangeParam.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeChangeParam.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeChangeReturn.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeChangeReturn.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeDropParams.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeDropParams.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeGenerify.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeGenerify.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeInsertParams.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/MethodTypeInsertParams.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(3)

--- a/test/micro/org/openjdk/bench/java/security/CipherSuiteBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CipherSuiteBench.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 
 @Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.ssl=ALL-UNNAMED", "--add-opens", "java.base/sun.security.ssl=ALL-UNNAMED"})
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 5, time = 1)

--- a/test/micro/org/openjdk/bench/java/time/GetYearBench.java
+++ b/test/micro/org/openjdk/bench/java/time/GetYearBench.java
@@ -58,7 +58,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(3)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class GetYearBench {
 
     private TimeZone UTC = TimeZone.getTimeZone("UTC");

--- a/test/micro/org/openjdk/bench/java/time/InstantBench.java
+++ b/test/micro/org/openjdk/bench/java/time/InstantBench.java
@@ -50,7 +50,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(3)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class InstantBench {
 
     private Instant[] INSTANTS;

--- a/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterWithPaddingBench.java
+++ b/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterWithPaddingBench.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(3)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class DateTimeFormatterWithPaddingBench {
 
     private static final DateTimeFormatter FORMATTER_WITH_PADDING = new DateTimeFormatterBuilder()

--- a/test/micro/org/openjdk/bench/java/util/ListArgs.java
+++ b/test/micro/org/openjdk/bench/java/util/ListArgs.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
  * initializers. Use parallel GC and set initial heap size to avoid
  * GC during runs.
  */
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(value = 3, jvmArgsAppend = { "-verbose:gc", "-XX:+UseParallelGC", "-Xms4g", "-Xmx4g", "-Xint" })
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)

--- a/test/micro/org/openjdk/bench/java/util/LocaleDefaults.java
+++ b/test/micro/org/openjdk/bench/java/util/LocaleDefaults.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 4, time = 2)
 @Measurement(iterations = 4, time = 2)
 @Fork(value = 3)

--- a/test/micro/org/openjdk/bench/java/util/TestAdler32.java
+++ b/test/micro/org/openjdk/bench/java/util/TestAdler32.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class TestAdler32 {
 
     private Adler32 adler32;

--- a/test/micro/org/openjdk/bench/java/util/TestCRC32.java
+++ b/test/micro/org/openjdk/bench/java/util/TestCRC32.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 4, time = 2)
 @Measurement(iterations = 4, time = 2)
 @Fork(value = 3)

--- a/test/micro/org/openjdk/bench/java/util/TestCRC32C.java
+++ b/test/micro/org/openjdk/bench/java/util/TestCRC32C.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 4, time = 2)
 @Measurement(iterations = 4, time = 2)
 @Fork(value = 3)

--- a/test/micro/org/openjdk/bench/java/util/regex/Exponential.java
+++ b/test/micro/org/openjdk/bench/java/util/regex/Exponential.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
 @Fork(2)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class Exponential {
     /** Run length of non-matching consecutive whitespace chars. */
     @Param({"16", "128", "1024"})

--- a/test/micro/org/openjdk/bench/java/util/regex/Primality.java
+++ b/test/micro/org/openjdk/bench/java/util/regex/Primality.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
 @Fork(1)
 @Warmup(iterations = 2, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 3, timeUnit = TimeUnit.SECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class Primality {
     /** Number to be primality tested. */
     @Param({"16", "17", /* "256", "257", */ "4096", "4099"})

--- a/test/micro/org/openjdk/bench/java/util/regex/Trim.java
+++ b/test/micro/org/openjdk/bench/java/util/regex/Trim.java
@@ -78,7 +78,7 @@ import java.util.regex.Pattern;
 @Fork(2)
 @Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class Trim {
     /** Run length of non-matching consecutive whitespace chars. */
     @Param({"16", "256", "4096"})

--- a/test/micro/org/openjdk/bench/javax/crypto/AESReinit.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/AESReinit.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 public class AESReinit {
 
     private Cipher cipher;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/LoadMaskedIOOBEBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/LoadMaskedIOOBEBenchmark.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})

--- a/test/micro/org/openjdk/bench/vm/compiler/Rotation.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/Rotation.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Fork(value = 3)
 @Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
@@ -28,7 +28,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Fork(value = 3, jvmArgsAppend = "-XX:-UseSuperWord")
 @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(time = 1, timeUnit = TimeUnit.SECONDS)

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/ConvertF2I.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/ConvertF2I.java
@@ -28,16 +28,16 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @Fork(value = 1, jvmArgsAppend = {"-XX:-UseSuperWord"})
 public class ConvertF2I {
     static final int LENGTH = 1000;
-    static final int[] INT_ARRAY = new int[LENGTH];
-    static final long[] LONG_ARRAY = new long[LENGTH];
-    static final float[] FLOAT_ARRAY = new float[LENGTH];
-    static final double[] DOUBLE_ARRAY = new double[LENGTH];
+    int[] intArray = new int[LENGTH];
+    long[] longArray = new long[LENGTH];
+    float[] floatArray = new float[LENGTH];
+    double[] doubleArray = new double[LENGTH];
     float f;
     double d;
 
@@ -64,28 +64,28 @@ public class ConvertF2I {
     @Benchmark
     public void f2iArray() {
         for (int i = 0; i < LENGTH; i++) {
-            INT_ARRAY[i] = (int)FLOAT_ARRAY[i];
+            intArray[i] = (int)floatArray[i];
         }
     }
 
     @Benchmark
     public void f2lArray() {
         for (int i = 0; i < LENGTH; i++) {
-            LONG_ARRAY[i] = (long)FLOAT_ARRAY[i];
+            longArray[i] = (long)floatArray[i];
         }
     }
 
     @Benchmark
     public void d2iArray() {
         for (int i = 0; i < LENGTH; i++) {
-            INT_ARRAY[i] = (int)DOUBLE_ARRAY[i];
+            intArray[i] = (int)doubleArray[i];
         }
     }
 
     @Benchmark
     public void d2lArray() {
         for (int i = 0; i < LENGTH; i++) {
-            LONG_ARRAY[i] = (long)DOUBLE_ARRAY[i];
+            longArray[i] = (long)doubleArray[i];
         }
     }
 }


### PR DESCRIPTION
In addition to the issue [JDK-8311178](https://bugs.openjdk.org/browse/JDK-8311178), logically fixing the scope from benchmark to thread for below benchmark files having shared state, also which fixes few of the benchmarks scalability problems.

org/openjdk/bench/java/io/DataInputStreamTest.java
org/openjdk/bench/java/lang/ArrayClone.java
org/openjdk/bench/java/lang/StringCompareToDifferentLength.java
org/openjdk/bench/java/lang/StringCompareToIgnoreCase.java
org/openjdk/bench/java/lang/StringComparisons.java
org/openjdk/bench/java/lang/StringEquals.java
org/openjdk/bench/java/lang/StringFormat.java
org/openjdk/bench/java/lang/StringReplace.java
org/openjdk/bench/java/lang/StringSubstring.java
org/openjdk/bench/java/lang/StringTemplateFMT.java
org/openjdk/bench/java/lang/constant/MethodTypeDescFactories.java
org/openjdk/bench/java/lang/constant/ReferenceClassDescResolve.java
org/openjdk/bench/java/lang/invoke/MethodHandlesConstant.java
org/openjdk/bench/java/lang/invoke/MethodHandlesIdentity.java
org/openjdk/bench/java/lang/invoke/MethodHandlesThrowException.java
org/openjdk/bench/java/lang/invoke/MethodTypeAppendParams.java
org/openjdk/bench/java/lang/invoke/MethodTypeChangeParam.java
org/openjdk/bench/java/lang/invoke/MethodTypeChangeReturn.java
org/openjdk/bench/java/lang/invoke/MethodTypeDropParams.java
org/openjdk/bench/java/lang/invoke/MethodTypeGenerify.java
org/openjdk/bench/java/lang/invoke/MethodTypeInsertParams.java
org/openjdk/bench/java/security/CipherSuiteBench.java
org/openjdk/bench/java/time/GetYearBench.java
org/openjdk/bench/java/time/InstantBench.java
org/openjdk/bench/java/time/format/DateTimeFormatterWithPaddingBench.java
org/openjdk/bench/java/util/ListArgs.java
org/openjdk/bench/java/util/LocaleDefaults.java
org/openjdk/bench/java/util/TestAdler32.java
org/openjdk/bench/java/util/TestCRC32.java
org/openjdk/bench/java/util/TestCRC32C.java
org/openjdk/bench/java/util/regex/Exponential.java
org/openjdk/bench/java/util/regex/Primality.java
org/openjdk/bench/java/util/regex/Trim.java
org/openjdk/bench/javax/crypto/AESReinit.java
org/openjdk/bench/jdk/incubator/vector/LoadMaskedIOOBEBenchmark.java
org/openjdk/bench/vm/compiler/Rotation.java
org/openjdk/bench/vm/compiler/x86/ConvertF2I.java
org/openjdk/bench/vm/compiler/x86/BasicRules.java

Please review and provide your feedback.

Thanks,
Swati

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314085](https://bugs.openjdk.org/browse/JDK-8314085): Fixing scope from benchmark to thread for JMH tests having shared state (**Enhancement** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer)


### Contributors
 * Vladimir Ivanov `<vaivanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15230/head:pull/15230` \
`$ git checkout pull/15230`

Update a local copy of the PR: \
`$ git checkout pull/15230` \
`$ git pull https://git.openjdk.org/jdk.git pull/15230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15230`

View PR using the GUI difftool: \
`$ git pr show -t 15230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15230.diff">https://git.openjdk.org/jdk/pull/15230.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15230#issuecomment-1673495957)