### PR TITLE
8314139: TEST_BUG: runtime/os/THPsInThreadStackPreventionTest.java could fail on machine with large number of cores

### DIFF
--- a/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
+++ b/test/hotspot/jtreg/runtime/os/THPsInThreadStackPreventionTest.java
@@ -71,7 +71,7 @@ public class THPsInThreadStackPreventionTest {
     //
     // We then observe RSS of that program. We expect it to stay below a reasonable maximum. The unpatched
     // version should show an RSS of ~2 GB (paying for the fully paged in thread stacks). The fixed variant should
-    // cost only ~200-400 MB.
+    // cost only ~200-400 MB. The RSS varies depending on the number of available cores.
 
     static final int numThreads = 1000;
     static final long threadStackSizeMB = 2; // must be 2M
@@ -170,6 +170,12 @@ public class THPsInThreadStackPreventionTest {
             "-XX:+DelayThreadStartALot"
         };
         ArrayList<String> finalargs = new ArrayList<>(Arrays.asList(defaultArgs));
+
+        // The RSS could exceed acceptableRSSLimitMB on machines with a large number of cores (e.g.
+        // 128 or more cores). Thus we cap ActiveProcessorCount to 64.
+        if (Runtime.getRuntime().availableProcessors() > 64) {
+          finalargs.add("-XX:ActiveProcessorCount=64");
+        }
 
         switch (args[0]) {
             case "PATCH-ENABLED": {


### PR DESCRIPTION
Hi all, @tstuefe 

Could anyone review this fix for a test failure that could happen on machines with many cores? This fix caps `-XX:ActiveProcessorCount` to 64, which limits the number of internal threads the JVM creates.

An alternative is to bump up the `acceptableRSSLimitMB` such as increasing `basicRSSOverheadMB`. However, this approach could be fragile for machines with even more number of cores (e.g. 256 or more).

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314139](https://bugs.openjdk.org/browse/JDK-8314139): TEST_BUG: runtime/os/THPsInThreadStackPreventionTest.java could fail on machine with large number of cores (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15241/head:pull/15241` \
`$ git checkout pull/15241`

Update a local copy of the PR: \
`$ git checkout pull/15241` \
`$ git pull https://git.openjdk.org/jdk.git pull/15241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15241`

View PR using the GUI difftool: \
`$ git pr show -t 15241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15241.diff">https://git.openjdk.org/jdk/pull/15241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15241#issuecomment-1674252183)