### PR TITLE
8314116: C2: assert(false) failed: malformed control flow after JDK-8305636

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2073,7 +2073,7 @@ void PhaseIdealLoop::initialize_assertion_predicates_for_peeled_loop(const Predi
                                                                      Node* stride, IdealLoopTree* outer_loop,
                                                                      const uint idx_before_clone,
                                                                      const Node_List &old_new) {
-  if (!predicate_block->has_runtime_predicates()) {
+  if (!predicate_block->has_parse_predicate()) {
     return;
   }
   Node* control = outer_loop_head->in(LoopNode::EntryControl);

--- a/test/hotspot/jtreg/compiler/predicates/TestTemplateAssertionPredicateNotRemoved.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestTemplateAssertionPredicateNotRemoved.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8314116
+ * @summary We fail to remove a Template Assertion Predicate of a dying loop causing an assert. This will only be fixed
+ *          completely with JDK-8288981 and 8314116 just mitigates the problem.
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.predicates.TestTemplateAssertionPredicateNotRemoved::*
+ *                   compiler.predicates.TestTemplateAssertionPredicateNotRemoved
+ * @run main/othervm -Xbatch -XX:-TieredCompilation -XX:LoopMaxUnroll=0
+ *                   -XX:CompileCommand=compileonly,compiler.predicates.TestTemplateAssertionPredicateNotRemoved::*
+ *                   compiler.predicates.TestTemplateAssertionPredicateNotRemoved
+ */
+
+package compiler.predicates;
+
+public class TestTemplateAssertionPredicateNotRemoved {
+    static int[] iArrFld = new int[10];
+    static long x;
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            test(i);
+            test2(i);
+        }
+    }
+
+    static void test(int i1) {
+        int i5, i6 = 8;
+
+        for (int i3 = 100; i3 > 3; --i3) {
+            for (i5 = 1; i5 < 5; i5++) {
+                switch (i1) {
+                    case 1:
+                    case 4:
+                    case 47:
+                        i6 = 4;
+                }
+                iArrFld[i5] = 23;
+            }
+        }
+    }
+
+    static void test2(int i1) {
+        int i3, i4 = 70, i5, i6 = 8, iArr1[] = new int[10];
+        double d1 = 0.41007;
+        for (i3 = 100; i3 > 3; --i3) {
+            i4 += 3;
+            for (i5 = 1; i5 < 5; i5++) {
+                switch (i1) {
+                    case 1:
+                    case 4:
+                    case 47:
+                        i6 = 34;
+                }
+                x /= 34;
+                iArrFld[i5] = 23;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
In the test case, a Template Assertion Predicate is not removed when a loop is dying. After applying more loop opts, it ends up above a different loop. We then peel this loop and create an Initialized Assertion Predicate from the template which gets completely unrelated values from the already removed loop. This causes some nodes to die and we end up with a broken graph.

This problem of not removing Template Assertion Predicates of dying loops which end up at different loops was already known before JDK-8305636 (see [analysis in JDK-8305428](https://bugs.openjdk.org/browse/JDK-8305428?focusedCommentId=14571901&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14571901)). 

Apparently, with JDK-8305636, this became much more likely because I've accidentally already included a fix for Loop Peeling when moving some refactorings from the complete fix ([JDK-8288981](https://bugs.openjdk.org/browse/JDK-8288981)) to JDK-8305636. The included fix creates Initialized Assertion Predicates when peeling a loop even though Parse Predicates have already been removed. This needs to be done eventually but seems to trigger JDK-8305428 more often with a different manifestation.

I therefore suggest to revert Loop Peeling back to the old state:
https://github.com/openjdk/jdk/blob/a38fdaf18dfeeb23775516d1986c720190ba9fc2/src/hotspot/share/opto/loopTransform.cpp#L781-L789

https://github.com/openjdk/jdk/blob/a38fdaf18dfeeb23775516d1986c720190ba9fc2/src/hotspot/share/opto/loopTransform.cpp#L2068-L2075

where we only create Initialized Assertion Predicates if there are actually Parse Predicates available.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314116](https://bugs.openjdk.org/browse/JDK-8314116): C2: assert(false) failed: malformed control flow after JDK-8305636 (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15244/head:pull/15244` \
`$ git checkout pull/15244`

Update a local copy of the PR: \
`$ git checkout pull/15244` \
`$ git pull https://git.openjdk.org/jdk.git pull/15244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15244`

View PR using the GUI difftool: \
`$ git pr show -t 15244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15244.diff">https://git.openjdk.org/jdk/pull/15244.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15244#issuecomment-1674392484)