### PR TITLE
8314144

### DIFF
--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPErgo.java
@@ -30,6 +30,7 @@
  * @requires !vm.flightRecorder
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
  * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @requires !vm.compMode == "Xcomp"
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  * @modules java.management

--- a/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
+++ b/test/hotspot/jtreg/gc/g1/ihop/TestIHOPStatic.java
@@ -28,7 +28,8 @@
  * @requires vm.gc.G1
  * @requires !vm.flightRecorder
  * @requires vm.opt.ExplicitGCInvokesConcurrent != true
- * @requires !(vm.graal.enabled & vm.compMode == "Xcomp")
+ * @requires !vm.graal.enabled
+ * @requires !vm.compMode == "Xcomp"
  * @requires os.maxMemory > 1G
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Hi all,

  please review this change to disable running these tests with -Xcomp to avoid unnecessary failures due to e.g. code cache getting full.

In order to avoid the same issue with the IHOP ergo test, do the same there. Running these tests with -Xcomp is not expected to yield any significant additional failures anyway.

Testing: gha, failing test with/without this change

Thanks,
  Thomas