### PR TITLE
8314161: G1: Fix -Wconversion warnings in G1CardSetConfiguration::_bitmap_hash_mask

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.cpp
@@ -110,7 +110,7 @@ G1CardSetConfiguration::G1CardSetConfiguration(uint inline_ptr_bits_per_card,
   _max_cards_in_howl_bitmap(G1CardSetHowl::bitmap_size(_max_cards_in_card_set, _num_buckets_in_howl)),
   _cards_in_howl_bitmap_threshold(_max_cards_in_howl_bitmap * cards_in_bitmap_threshold_percent),
   _log2_max_cards_in_howl_bitmap(log2i_exact(_max_cards_in_howl_bitmap)),
-  _bitmap_hash_mask(~(~(0) << _log2_max_cards_in_howl_bitmap)),
+  _bitmap_hash_mask((1U << _log2_max_cards_in_howl_bitmap) - 1),
   _log2_card_regions_per_heap_region(log2_card_regions_per_heap_region),
   _log2_cards_per_card_region(log2i_exact(_max_cards_in_card_set)) {
 

--- a/src/hotspot/share/gc/g1/g1CardSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSet.hpp
@@ -55,7 +55,7 @@ class G1CardSetConfiguration {
   uint _max_cards_in_howl_bitmap;
   uint _cards_in_howl_bitmap_threshold;
   uint _log2_max_cards_in_howl_bitmap;
-  size_t _bitmap_hash_mask;
+  uint _bitmap_hash_mask;
   uint _log2_card_regions_per_heap_region;
   uint _log2_cards_per_card_region;
 


### PR DESCRIPTION
Simple type change and updating to use more common mask-initialization.

Test: hotspot_gc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314161](https://bugs.openjdk.org/browse/JDK-8314161): G1: Fix -Wconversion warnings in G1CardSetConfiguration::_bitmap_hash_mask (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15247/head:pull/15247` \
`$ git checkout pull/15247`

Update a local copy of the PR: \
`$ git checkout pull/15247` \
`$ git pull https://git.openjdk.org/jdk.git pull/15247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15247`

View PR using the GUI difftool: \
`$ git pr show -t 15247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15247.diff">https://git.openjdk.org/jdk/pull/15247.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15247#issuecomment-1674722316)