### PR TITLE
8314169: Combine related RoundingMode logic in j.text.DigitList

### DIFF
--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -513,15 +513,9 @@ final class DigitList implements Cloneable {
             case DOWN:
                 break;
             case CEILING:
+                return nonZeroAfterIndex(maximumDigits) && !isNegative;
             case FLOOR:
-                if (nonZeroAfterIndex(maximumDigits)) {
-                    if (roundingMode == RoundingMode.FLOOR) {
-                        return isNegative;
-                    } else {
-                        return !isNegative;
-                    }
-                }
-                break;
+                return nonZeroAfterIndex(maximumDigits) && isNegative;
             case HALF_UP:
             case HALF_DOWN:
             case HALF_EVEN:


### PR DESCRIPTION
Please review this PR which is a broad clean up of the DigitList class (used by Format classes in j.text).

This PR is intended to be a portion of a bigger change (split up to make reviewing easier). 

The main change simplifying related Rounding Mode logic in `shouldRoundUp()` - (_CEILING/FLOOR_, _HALF_UP/DOWN/EVEN_)

Other changes include
- Certain for loops can be replaced with cleaner syntax (E.g. for(;;), empty for loops)
- Introduce `roundInt(int)` - For use by Integer representations of DigitList
- Introduce `nonZeroAfterIndex(int)` - To reduce code duplication

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314169](https://bugs.openjdk.org/browse/JDK-8314169): Combine related RoundingMode logic in j.text.DigitList (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15252/head:pull/15252` \
`$ git checkout pull/15252`

Update a local copy of the PR: \
`$ git checkout pull/15252` \
`$ git pull https://git.openjdk.org/jdk.git pull/15252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15252`

View PR using the GUI difftool: \
`$ git pr show -t 15252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15252.diff">https://git.openjdk.org/jdk/pull/15252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15252#issuecomment-1675227630)