### PR TITLE
8311532: Option to disable Krb5LoginModule::login method

### DIFF
--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/Krb5LoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/Krb5LoginModule.java
@@ -379,7 +379,7 @@ public class Krb5LoginModule implements LoginModule {
     @SuppressWarnings("removal")
     private static final boolean skipLogin = AccessController.doPrivileged(
             (PrivilegedAction<Boolean>)
-                () -> Boolean.getBoolean("sun.security.auth.skipLogin"));
+                () -> Boolean.getBoolean("sun.security.auth.krb5.doNotLogin"));
 
     // initial state
     private Subject subject;


### PR DESCRIPTION
JGSS is implemented in the JVM in 2 levels: the standard Java security provider for Kerberos in sun.security.jgss.krb5.Krb5MechFactory and the JAAS login module for Kerberos in com.sun.security.auth.module.Krb5LoginModule. The problem is that in this hierarchy, the login module doesn't go through the provider, but tries to read the credential cache (which is blocked by the credential guard in Win platform). This is not an issue if Kerberos is used via the JGSS API because it automatically does the JAAS login as needed, and won't do it at all if a native implementation is used. However many libraries (even some built-in ones in the JVM) still needlessly call login() before using JGSS.

This patch represents the configuration option ( `“doNotLogin”` ) to allow skipping the login, with a system property (`“sun.security.auth.skipLogin”`) to set the default value if this option is not provided. This way it would not break the regular Java Kerberos provider and allow users to both individually (via JAAS configs) and globally (via the property) set the expected behavior

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 22 to be approved (needs to be created)

### Issue
 * [JDK-8311532](https://bugs.openjdk.org/browse/JDK-8311532): Option to disable Krb5LoginModule::login method (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15254/head:pull/15254` \
`$ git checkout pull/15254`

Update a local copy of the PR: \
`$ git checkout pull/15254` \
`$ git pull https://git.openjdk.org/jdk.git pull/15254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15254`

View PR using the GUI difftool: \
`$ git pr show -t 15254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15254.diff">https://git.openjdk.org/jdk/pull/15254.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15254#issuecomment-1675523642)