### PR TITLE
8282712

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/VMConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -544,16 +544,18 @@ class VMConnection {
         } catch (IOException ioe) {
             ioe.printStackTrace();
             MessageOutput.fatalError("Unable to launch target VM.");
+            throw new RuntimeException(ioe);
         } catch (IllegalConnectorArgumentsException icae) {
             icae.printStackTrace();
             MessageOutput.fatalError("Internal debugger error.");
+            throw new RuntimeException(icae);
         } catch (VMStartException vmse) {
             MessageOutput.println("vmstartexception", vmse.getMessage());
             MessageOutput.println();
             dumpFailedLaunchInfo(vmse.process());
             MessageOutput.fatalError("Target VM failed to initialize.");
+            throw new RuntimeException(vmse);
         }
-        return null; // Shuts up the compiler
     }
 
     /* attach to running target vm */
@@ -564,11 +566,12 @@ class VMConnection {
         } catch (IOException ioe) {
             ioe.printStackTrace();
             MessageOutput.fatalError("Unable to attach to target VM.");
+            throw new RuntimeException(ioe);
         } catch (IllegalConnectorArgumentsException icae) {
             icae.printStackTrace();
             MessageOutput.fatalError("Internal debugger error.");
+            throw new RuntimeException(icae);
         }
-        return null; // Shuts up the compiler
     }
 
     /* listen for connection from target vm */
@@ -583,10 +586,11 @@ class VMConnection {
         } catch (IOException ioe) {
             ioe.printStackTrace();
             MessageOutput.fatalError("Unable to attach to target VM.");
+            throw new RuntimeException(ioe);
         } catch (IllegalConnectorArgumentsException icae) {
             icae.printStackTrace();
             MessageOutput.fatalError("Internal debugger error.");
+            throw new RuntimeException(icae);
         }
-        return null; // Shuts up the compiler
     }
 }

--- a/test/jdk/com/sun/jdi/VMConnection.java
+++ b/test/jdk/com/sun/jdi/VMConnection.java
@@ -322,15 +322,17 @@ class VMConnection {
         } catch (IOException ioe) {
             ioe.printStackTrace();
             System.err.println("\n Unable to launch target VM.");
+            throw new RuntimeException(ioe);
         } catch (IllegalConnectorArgumentsException icae) {
             icae.printStackTrace();
             System.err.println("\n Internal debugger error.");
+            throw new RuntimeException(icae);
         } catch (VMStartException vmse) {
             System.err.println(vmse.getMessage() + "\n");
             dumpFailedLaunchInfo(vmse.process());
             System.err.println("\n Target VM failed to initialize.");
+            throw new RuntimeException(vmse);
         }
-        return null; // Shuts up the compiler
     }
 
     /* attach to running target vm */
@@ -341,11 +343,12 @@ class VMConnection {
         } catch (IOException ioe) {
             ioe.printStackTrace();
             System.err.println("\n Unable to attach to target VM.");
+            throw new RuntimeException(ioe);
         } catch (IllegalConnectorArgumentsException icae) {
             icae.printStackTrace();
             System.err.println("\n Internal debugger error.");
+            throw new RuntimeException(icae);
         }
-        return null; // Shuts up the compiler
     }
 
     /* listen for connection from target vm */
@@ -360,10 +363,11 @@ class VMConnection {
         } catch (IOException ioe) {
             ioe.printStackTrace();
             System.err.println("\n Unable to attach to target VM.");
+            throw new RuntimeException(ioe);
         } catch (IllegalConnectorArgumentsException icae) {
             icae.printStackTrace();
             System.err.println("\n Internal debugger error.");
+            throw new RuntimeException(icae);
         }
-        return null; // Shuts up the compiler
     }
 }


### PR DESCRIPTION
VMConnection.open() expects launchTarget(), attachTarget(), and listentTarget() to either throw an exception or return a valid VirtualMachine instance. Instead they were catching certain exceptions and returning null, which resulted in an NPE in VMConnection.open(). I've fixed it so these APIs now rethrow any caught exception and never return null.

Tested with tier1 and also running the following 10x each on linux-x64, macosx-aarch64, and windows-x64:

test/hotspot/jtreg/vmTestbase/nsk/jdwp/
test/hotspot/jtreg/vmTestbase/nsk/jdb/
test/hotspot/jtreg/vmTestbase/nsk/jdi
test/jdk/com/sun/jdi 
