### PR TITLE
JDK-8314163: os::print_hex_dump prints incorrectly for big endian platforms and unit sizes larger than 1

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -942,6 +942,7 @@ ATTRIBUTE_NO_ASAN static bool read_safely_from(intptr_t* p, intptr_t* result) {
 }
 
 static void print_hex_location(outputStream* st, address p, int unitsize) {
+  assert(is_aligned(p, unitsize), "Unaligned");
   address pa = align_down(p, sizeof(intptr_t));
 #ifndef _LP64
   // Special handling for printing qwords on 32-bit platforms
@@ -961,10 +962,14 @@ static void print_hex_location(outputStream* st, address p, int unitsize) {
 #endif // 32-bit, qwords
   intptr_t i = 0;
   if (read_safely_from((intptr_t*)pa, &i)) {
+    // bytes:   CA FE BA BE DE AD C0 DE
+    // bytoff:   0  1  2  3  4  5  6  7
+    // LE bits  0  8  16 24 32 40 48 56
+    // BE bits  56 48 40 32 24 16  8  0
     const int offset = (int)(p - (address)pa);
     const int bitoffset =
       LITTLE_ENDIAN_ONLY(offset * BitsPerByte)
-      BIG_ENDIAN_ONLY((int)(sizeof(intptr_t) - 1 - offset) * BitsPerByte);
+      BIG_ENDIAN_ONLY((int)((sizeof(intptr_t) - unitsize - offset) * BitsPerByte));
     const int bitfieldsize = unitsize * BitsPerByte;
     intptr_t value = bitfield(i, bitoffset, bitfieldsize);
     switch (unitsize) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -964,8 +964,8 @@ static void print_hex_location(outputStream* st, address p, int unitsize) {
   if (read_safely_from((intptr_t*)pa, &i)) {
     // bytes:   CA FE BA BE DE AD C0 DE
     // bytoff:   0  1  2  3  4  5  6  7
-    // LE bits  0  8  16 24 32 40 48 56
-    // BE bits  56 48 40 32 24 16  8  0
+    // LE bits:  0  8 16 24 32 40 48 56
+    // BE bits: 56 48 40 32 24 16  8  0
     const int offset = (int)(p - (address)pa);
     const int bitoffset =
       LITTLE_ENDIAN_ONLY(offset * BitsPerByte)

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -165,7 +165,7 @@ TEST_VM_ASSERT_MSG(os, page_size_for_region_with_zero_min_pages,
 #endif
 
 static void do_test_print_hex_dump(address addr, size_t len, int unitsize, const char* expected) {
-  alignas(sizeof(intptr_t)) char buf[256];
+  char buf[256];
   buf[0] = '\0';
   stringStream ss(buf, sizeof(buf));
   os::print_hex_dump(&ss, addr, addr + len, unitsize);

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -165,7 +165,7 @@ TEST_VM_ASSERT_MSG(os, page_size_for_region_with_zero_min_pages,
 #endif
 
 static void do_test_print_hex_dump(address addr, size_t len, int unitsize, const char* expected) {
-  char buf[256];
+  alignas(sizeof(intptr_t)) char buf[256];
   buf[0] = '\0';
   stringStream ss(buf, sizeof(buf));
   os::print_hex_dump(&ss, addr, addr + len, unitsize);


### PR DESCRIPTION
See comment. Seen on AIX. Big-endian is a pain.

Thanks to @MBaesken for testing the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314163](https://bugs.openjdk.org/browse/JDK-8314163): os::print_hex_dump prints incorrectly for big endian platforms and unit sizes larger than 1 (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [fc2fc204](https://git.openjdk.org/jdk/pull/15256/files/fc2fc204c795c935d6f59e870e7f2a423b6bf115)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15256/head:pull/15256` \
`$ git checkout pull/15256`

Update a local copy of the PR: \
`$ git checkout pull/15256` \
`$ git pull https://git.openjdk.org/jdk.git pull/15256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15256`

View PR using the GUI difftool: \
`$ git pr show -t 15256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15256.diff">https://git.openjdk.org/jdk/pull/15256.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15256#issuecomment-1678591378)