### PR TITLE
8258970: Disabled JPasswordField foreground color is wrong with GTK LAF

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -2400,16 +2400,16 @@ static gint gtk3_get_color_for_state(JNIEnv *env, WidgetType widget_type,
     init_containers();
 
     if (gtk3_version_3_20) {
-        if ((widget_type == TEXT_FIELD || widget_type == PASSWORD_FIELD || widget_type == SPINNER_TEXT_FIELD ||
-            widget_type == FORMATTED_TEXT_FIELD) && state_type == GTK_STATE_SELECTED && color_type == TEXT_BACKGROUND) {
-            widget_type = TEXT_AREA;
+        if (widget_type == TEXT_FIELD || widget_type == PASSWORD_FIELD || widget_type == SPINNER_TEXT_FIELD ||
+            widget_type == FORMATTED_TEXT_FIELD) {
+                if (state_type == GTK_STATE_SELECTED && color_type == TEXT_BACKGROUND) {
+                    widget_type = TEXT_AREA;
+                } else if (state_type == GTK_STATE_INSENSITIVE && color_type == TEXT_FOREGROUND) {
+                    widget_type = TEXT_AREA;
+                }
         } else if (widget_type == MENU_BAR && state_type == GTK_STATE_INSENSITIVE
             && color_type == FOREGROUND) {
             widget_type = MENU;
-        } else if ((widget_type == TEXT_FIELD || widget_type == PASSWORD_FIELD
-            || widget_type == SPINNER_TEXT_FIELD || widget_type == FORMATTED_TEXT_FIELD)
-            && state_type == GTK_STATE_INSENSITIVE && color_type == TEXT_FOREGROUND) {
-            widget_type = TEXT_AREA;
         }
     }
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -2400,11 +2400,10 @@ static gint gtk3_get_color_for_state(JNIEnv *env, WidgetType widget_type,
     init_containers();
 
     if (gtk3_version_3_20) {
-        if (widget_type == TEXT_FIELD || widget_type == PASSWORD_FIELD || widget_type == SPINNER_TEXT_FIELD ||
-            widget_type == FORMATTED_TEXT_FIELD) {
-                if (state_type == GTK_STATE_SELECTED && color_type == TEXT_BACKGROUND) {
-                    widget_type = TEXT_AREA;
-                } else if (state_type == GTK_STATE_INSENSITIVE && color_type == TEXT_FOREGROUND) {
+        if (widget_type == TEXT_FIELD || widget_type == PASSWORD_FIELD
+            || widget_type == SPINNER_TEXT_FIELD || widget_type == FORMATTED_TEXT_FIELD) {
+                if ((state_type == GTK_STATE_SELECTED && color_type == TEXT_BACKGROUND)
+                    || (state_type == GTK_STATE_INSENSITIVE && color_type == TEXT_FOREGROUND)) {
                     widget_type = TEXT_AREA;
                 }
         } else if (widget_type == MENU_BAR && state_type == GTK_STATE_INSENSITIVE

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -2406,8 +2406,9 @@ static gint gtk3_get_color_for_state(JNIEnv *env, WidgetType widget_type,
         } else if (widget_type == MENU_BAR && state_type == GTK_STATE_INSENSITIVE
             && color_type == FOREGROUND) {
             widget_type = MENU;
-        } else if (widget_type == PASSWORD_FIELD && state_type == GTK_STATE_INSENSITIVE
-            && color_type == TEXT_FOREGROUND) {
+        } else if ((widget_type == TEXT_FIELD || widget_type == PASSWORD_FIELD
+            || widget_type == SPINNER_TEXT_FIELD || widget_type == FORMATTED_TEXT_FIELD)
+            && state_type == GTK_STATE_INSENSITIVE && color_type == TEXT_FOREGROUND) {
             widget_type = TEXT_AREA;
         }
     }

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -2406,6 +2406,9 @@ static gint gtk3_get_color_for_state(JNIEnv *env, WidgetType widget_type,
         } else if (widget_type == MENU_BAR && state_type == GTK_STATE_INSENSITIVE
             && color_type == FOREGROUND) {
             widget_type = MENU;
+        } else if (widget_type == PASSWORD_FIELD && state_type == GTK_STATE_INSENSITIVE
+            && color_type == TEXT_FOREGROUND) {
+            widget_type = TEXT_AREA;
         }
     }
 

--- a/test/jdk/javax/swing/JPasswordField/TestDisabledPasswordFieldForegroundColor.java
+++ b/test/jdk/javax/swing/JPasswordField/TestDisabledPasswordFieldForegroundColor.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8258970
+ * @key headful
+ * @requires (os.family == "linux")
+ * @summary Verifies if disabled password field foreground color grayed out
+ * @run main TestDisabledPasswordFieldForegroundColor
+ */
+
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.JPasswordField;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import java.lang.Math;
+
+public class TestDisabledPasswordFieldForegroundColor {
+
+    private static JFrame frame;
+    private static JPasswordField passwordField;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        Robot robot = new Robot();
+        robot.setAutoDelay(1000);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                createAndShowUI();
+            });
+
+            robot.waitForIdle();
+            robot.delay(500);
+            Point pt = passwordField.getLocationOnScreen();
+            BufferedImage enabledImg =
+                    robot.createScreenCapture(new Rectangle(pt.x, pt.y,
+                            passwordField.getWidth(), passwordField.getHeight()));
+            passwordField.setEnabled(false);
+            robot.waitForIdle();
+            robot.delay(500);
+            BufferedImage disabledImg =
+                    robot.createScreenCapture(new Rectangle(pt.x, pt.y,
+                            passwordField.getWidth(), passwordField.getHeight()));
+            boolean passed = compareImage(enabledImg,disabledImg);
+
+            if (!passed) {
+                ImageIO.write(enabledImg, "png", new File("JPasswordFieldEnabledImg.png"));
+                ImageIO.write(disabledImg, "png", new File("JPasswordFieldDisabledImg.png"));
+                throw new RuntimeException("Disabled JPasswordField foreground color not grayed out");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new JFrame("Test Disabled Password Field Foreground Color");
+        passwordField = new JPasswordField("passwordpassword");
+        passwordField.setEnabled(true);
+        frame.add(passwordField);
+        frame.pack();
+        frame.setSize(150, 100);
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+    }
+
+    /*
+    * Compare JPasswordField enabled and disabled state image and if both images
+    * width and height are equal but pixel's RGB values are not equal,
+    * method returns true; false otherwise.
+    */
+
+    private static boolean compareImage(BufferedImage img1, BufferedImage img2) {
+        int tolerance = 5;
+        if (img1.getWidth() == img2.getWidth()
+                && img1.getHeight() == img2.getHeight()) {
+            for (int x = 10; x < img1.getWidth()/2; ++x) {
+                for (int y = 10; y < img1.getHeight()-10; ++y) {
+                    Color c1 = new Color(img1.getRGB(x, y));
+                    Color c2 = new Color(img2.getRGB(x, y));
+
+                    if (Math.abs(c1.getRed() - c2.getRed()) > tolerance ||
+                            Math.abs(c1.getRed() - c2.getRed()) > tolerance ||
+                            Math.abs(c1.getRed() - c2.getRed()) > tolerance) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } else {
+            return false;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JPasswordField/TestDisabledPasswordFieldForegroundColor.java
+++ b/test/jdk/javax/swing/JPasswordField/TestDisabledPasswordFieldForegroundColor.java
@@ -64,7 +64,7 @@ public class TestDisabledPasswordFieldForegroundColor {
         UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
         boolean testFail = false;
         robot = new Robot();
-        robot.setAutoDelay(1000);
+        robot.setAutoDelay(100);
         try {
             SwingUtilities.invokeAndWait(
                     TestDisabledPasswordFieldForegroundColor::createAndShowUI);


### PR DESCRIPTION
Disabled JPasswordField foreground color was not grayed out in GTK LAF.

The foreground color in disabled state was close to black color (RGB 0,0,0) for password field which is not differentiable from enabled state foreground color.

To fix for this problem, the widget type is changed to `TEXT_AREA `for disable password field which returns the foreground color as gray. Checked with Oracle linux as well and fix worked fine.

An automated test case has been added and checked in CI, link is added in JBS. Test mentioned in JBS also works fine with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258970](https://bugs.openjdk.org/browse/JDK-8258970): Disabled JPasswordField foreground color is wrong with GTK LAF (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) ⚠️ Review applies to [cbe5816a](https://git.openjdk.org/jdk/pull/15263/files/cbe5816ac7c7c2ce317c7a6fd8c8691c9fc37386)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15263/head:pull/15263` \
`$ git checkout pull/15263`

Update a local copy of the PR: \
`$ git checkout pull/15263` \
`$ git pull https://git.openjdk.org/jdk.git pull/15263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15263`

View PR using the GUI difftool: \
`$ git pr show -t 15263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15263.diff">https://git.openjdk.org/jdk/pull/15263.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15263#issuecomment-1676630605)