### PR TITLE
JDK-8313764: Offer JVM HS functionality to shared lib load operations done by the JDK codebase

### DIFF
--- a/make/data/hotspot-symbols/symbols-shared
+++ b/make/data/hotspot-symbols/symbols-shared
@@ -27,7 +27,6 @@ jio_printf
 jio_snprintf
 jio_vfprintf
 jio_vsnprintf
-dlopen_ext
 JNI_CreateJavaVM
 JNI_GetCreatedJavaVMs
 JNI_GetDefaultJavaVMInitArgs

--- a/make/data/hotspot-symbols/symbols-shared
+++ b/make/data/hotspot-symbols/symbols-shared
@@ -27,6 +27,7 @@ jio_printf
 jio_snprintf
 jio_vfprintf
 jio_vsnprintf
+dlopen_ext
 JNI_CreateJavaVM
 JNI_GetCreatedJavaVMs
 JNI_GetDefaultJavaVMInitArgs

--- a/make/data/hotspot-symbols/symbols-unix
+++ b/make/data/hotspot-symbols/symbols-unix
@@ -207,6 +207,7 @@ JVM_TotalMemory
 JVM_UnloadLibrary
 JVM_WaitForReferencePendingList
 JVM_Yield
+dlopen_ext
 
 # Module related API's
 JVM_AddModuleExports

--- a/src/java.base/share/native/libjava/macro_helper.h
+++ b/src/java.base/share/native/libjava/macro_helper.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef MACRO_HELPER_H
+#define MACRO_HELPER_H
+
+#include "jni.h"
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+
+#ifdef _WIN32
+
+/* unfortunately on Windows we use already macros for LoadLibrary, see libloaderapi.h */
+#if defined(LoadLibrary)
+#undef LoadLibrary
+#endif
+
+_JNI_IMPORT_OR_EXPORT_ HMODULE JNICALL LoadLibrary_ext(LPCSTR lpLibFileName);
+
+#define LoadLibrary(lpLibFileName)  LoadLibrary_ext(lpLibFileName)
+
+#else
+_JNI_IMPORT_OR_EXPORT_ void* JNICALL dlopen_ext(const char* file, int mode);
+
+#define dlopen(file,mode)  dlopen_ext(file,mode)
+
+#endif
+
+
+#endif

--- a/src/java.base/unix/native/libnet/DefaultProxySelector.c
+++ b/src/java.base/unix/native/libnet/DefaultProxySelector.c
@@ -37,6 +37,9 @@
 
 #include "sun_net_spi_DefaultProxySelector.h"
 
+/* for dlopen */
+#include <macro_helper.h>
+
 
 /**
  * These functions are used by the sun.net.spi.DefaultProxySelector class

--- a/src/java.desktop/unix/native/common/awt/fontpath.c
+++ b/src/java.desktop/unix/native/common/awt/fontpath.c
@@ -48,6 +48,9 @@
 #define AWT_UNLOCK()
 #endif /* !HEADLESS */
 
+/* for dlopen */
+#include <macro_helper.h>
+
 #ifndef HEADLESS
 extern Display *awt_display;
 #endif /* !HEADLESS */

--- a/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
+++ b/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
@@ -61,6 +61,10 @@ typedef struct _XRadialGradient {
 
 #include <dlfcn.h>
 
+/* for dlopen */
+#include <macro_helper.h>
+
+
 #define BUILD_TRANSFORM_MATRIX(TRANSFORM, M00, M01, M02, M10, M11, M12)                        \
     {                                                                                          \
       TRANSFORM.matrix[0][0] = M00;                                                            \

--- a/src/jdk.sctp/unix/native/libsctp/SctpNet.c
+++ b/src/jdk.sctp/unix/native/libsctp/SctpNet.c
@@ -36,6 +36,9 @@
 #include "sun_nio_ch_sctp_SctpNet.h"
 #include "sun_nio_ch_sctp_SctpStdSocketOption.h"
 
+/* for dlopen */
+#include <macro_helper.h>
+
 static jclass isaCls = 0;
 static jmethodID isaCtrID = 0;
 


### PR DESCRIPTION
Currently there is a number of functionality that would be interesting to have for shared lib load operations in the JDK C code.
Some examples :
Events::log_dll_message for hs-err files reporting
JFR event NativeLibraryLoad
There is the need to update the shared lib Cache on AIX ( see LoadedLibraries::reload() , see also https://bugs.openjdk.org/browse/JDK-8314152 ),
this is currently not fully in sync with libs loaded form jdk c-libs and sometimes reports outdated information

Offer an interface (e.g. jvm.cpp) to support this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313764](https://bugs.openjdk.org/browse/JDK-8313764): Offer JVM HS functionality to shared lib load operations done by the JDK codebase (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15264/head:pull/15264` \
`$ git checkout pull/15264`

Update a local copy of the PR: \
`$ git checkout pull/15264` \
`$ git pull https://git.openjdk.org/jdk.git pull/15264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15264`

View PR using the GUI difftool: \
`$ git pr show -t 15264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15264.diff">https://git.openjdk.org/jdk/pull/15264.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15264#issuecomment-1676881491)