### PR TITLE
JDK-8314197: AttachListener::pd_find_operation always returning nullptr

### DIFF
--- a/src/hotspot/os/aix/attachListener_aix.cpp
+++ b/src/hotspot/os/aix/attachListener_aix.cpp
@@ -579,10 +579,6 @@ void AttachListener::pd_data_dump() {
   os::signal_notify(SIGQUIT);
 }
 
-AttachOperationFunctionInfo* AttachListener::pd_find_operation(const char* n) {
-  return nullptr;
-}
-
 jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
   out->print_cr("flag '%s' cannot be changed", op->arg(0));
   return JNI_ERR;

--- a/src/hotspot/os/bsd/attachListener_bsd.cpp
+++ b/src/hotspot/os/bsd/attachListener_bsd.cpp
@@ -542,10 +542,6 @@ void AttachListener::pd_data_dump() {
   os::signal_notify(SIGQUIT);
 }
 
-AttachOperationFunctionInfo* AttachListener::pd_find_operation(const char* n) {
-  return nullptr;
-}
-
 jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
   out->print_cr("flag '%s' cannot be changed", op->arg(0));
   return JNI_ERR;

--- a/src/hotspot/os/linux/attachListener_linux.cpp
+++ b/src/hotspot/os/linux/attachListener_linux.cpp
@@ -547,10 +547,6 @@ void AttachListener::pd_data_dump() {
   os::signal_notify(SIGQUIT);
 }
 
-AttachOperationFunctionInfo* AttachListener::pd_find_operation(const char* n) {
-  return nullptr;
-}
-
 jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
   out->print_cr("flag '%s' cannot be changed", op->arg(0));
   return JNI_ERR;

--- a/src/hotspot/os/windows/attachListener_windows.cpp
+++ b/src/hotspot/os/windows/attachListener_windows.cpp
@@ -391,10 +391,6 @@ void AttachListener::pd_data_dump() {
   os::signal_notify(SIGBREAK);
 }
 
-AttachOperationFunctionInfo* AttachListener::pd_find_operation(const char* n) {
-  return nullptr;
-}
-
 jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
   out->print_cr("flag '%s' cannot be changed", op->arg(0));
   return JNI_ERR;

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -411,11 +411,6 @@ void AttachListenerThread::thread_entry(JavaThread* thread, TRAPS) {
         }
       }
 
-      // check for platform dependent attach operation
-      if (info == nullptr) {
-        info = AttachListener::pd_find_operation(op->name());
-      }
-
       if (info != nullptr) {
         // dispatch to the function that implements this operation
         res = (info->func)(op, &st);

--- a/src/hotspot/share/services/attachListener.hpp
+++ b/src/hotspot/share/services/attachListener.hpp
@@ -121,9 +121,6 @@ class AttachListener: AllStatic {
   // platform specific initialization
   static int pd_init();
 
-  // platform specific operation
-  static AttachOperationFunctionInfo* pd_find_operation(const char* name);
-
   // platform specific flag change
   static jint pd_set_flag(AttachOperation* op, outputStream* out);
 


### PR DESCRIPTION
AttachListener::pd_find_operation always returns nullptr and seems to be obsolete, so we could probably remove it and clean up the coding a bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314197](https://bugs.openjdk.org/browse/JDK-8314197): AttachListener::pd_find_operation always returning nullptr (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15265/head:pull/15265` \
`$ git checkout pull/15265`

Update a local copy of the PR: \
`$ git checkout pull/15265` \
`$ git pull https://git.openjdk.org/jdk.git pull/15265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15265`

View PR using the GUI difftool: \
`$ git pr show -t 15265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15265.diff">https://git.openjdk.org/jdk/pull/15265.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15265#issuecomment-1677090184)