### PR TITLE
JDK-8314211: Add NativeLibraryUnload event

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1276,12 +1276,10 @@ void  os::dll_unload(void *lib) {
     log_info(os)("Attempt to unload dll \"%s\" [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
 #if INCLUDE_JFR
     event.set_success(false);
-    if (tl != 0) {
-      event.set_errorMessage(buf);
-    } else {
+    if (tl == 0) {
       os::snprintf(buf, sizeof(buf), "Attempt to unload dll failed (error code %d)", (int) errcode);
-      event.set_errorMessage(buf);
     }
+    event.set_errorMessage(buf);
     event.commit();
 #endif
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1254,13 +1254,36 @@ void  os::dll_unload(void *lib) {
   if (::GetModuleFileName((HMODULE)lib, name, sizeof(name)) == 0) {
     snprintf(name, MAX_PATH, "<not available>");
   }
+
+#if INCLUDE_JFR
+  EventNativeLibraryUnload event;
+  event.set_name(name);
+#endif
+
   if (::FreeLibrary((HMODULE)lib)) {
     Events::log_dll_message(nullptr, "Unloaded dll \"%s\" [" INTPTR_FORMAT "]", name, p2i(lib));
     log_info(os)("Unloaded dll \"%s\" [" INTPTR_FORMAT "]", name, p2i(lib));
+#if INCLUDE_JFR
+    event.set_success(true);
+    event.set_errorMessage(nullptr);
+    event.commit();
+#endif
   } else {
     const DWORD errcode = ::GetLastError();
+    char buf[500];
+    size_t tl = os::lasterror(buf, sizeof(buf));
     Events::log_dll_message(nullptr, "Attempt to unload dll \"%s\" [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
     log_info(os)("Attempt to unload dll \"%s\" [" INTPTR_FORMAT "] failed (error code %d)", name, p2i(lib), errcode);
+#if INCLUDE_JFR
+    event.set_success(false);
+    if (tl != 0) {
+      event.set_errorMessage(buf);
+    } else {
+      os::snprintf(buf, sizeof(buf), "Attempt to unload dll failed (error code %d)", (int) errcode);
+      event.set_errorMessage(buf);
+    }
+    event.commit();
+#endif
   }
 }
 

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -946,6 +946,13 @@
     <Field type="string" name="errorMessage" label="Error Message" description="In case of a load error, error description" />
   </Event>
 
+  <Event name="NativeLibraryUnload" category="Java Virtual Machine, Runtime" label="Native Library Unload" thread="false" stackTrace="true" startTime="true"
+    description="Information about a dynamic library or other native image unload operation">
+    <Field type="string" name="name" label="Name" />
+    <Field type="boolean" name="success" label="Success" description="Success or failure of the unload operation" />
+    <Field type="string" name="errorMessage" label="Error Message" description="In case of an unload error, error description" />
+  </Event>
+
   <Event name="ModuleRequire" category="Java Virtual Machine, Runtime, Modules" label="Module Require" thread="false" period="everyChunk"
     description="A directed edge representing a dependency">
     <Field type="Module" name="source" label="Source Module" />

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -700,6 +700,12 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
+    <event name="jdk.NativeLibraryUnload">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
     <event name="jdk.ModuleRequire">
       <setting name="enabled">true</setting>
       <setting name="period">endChunk</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -700,6 +700,12 @@
       <setting name="threshold">0 ms</setting>
     </event>
 
+    <event name="jdk.NativeLibraryUnload">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
     <event name="jdk.ModuleRequire">
       <setting name="enabled">true</setting>
       <setting name="period">endChunk</setting>

--- a/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
+++ b/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class TestLookForUntestedEvents {
 
     private static final Set<String> hardToTestEvents = new HashSet<>(
         Arrays.asList(
-            "DataLoss", "IntFlag", "ReservedStackActivation",
+            "DataLoss", "IntFlag", "ReservedStackActivation", "NativeLibraryUnload",
             "DoubleFlag", "UnsignedLongFlagChanged", "IntFlagChanged",
             "UnsignedIntFlag", "UnsignedIntFlagChanged", "DoubleFlagChanged")
     );

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -184,6 +184,7 @@ public class EventNames {
     public static final String InitialEnvironmentVariable = PREFIX + "InitialEnvironmentVariable";
     public static final String NativeLibrary = PREFIX + "NativeLibrary";
     public static final String NativeLibraryLoad = PREFIX + "NativeLibraryLoad";
+    public static final String NativeLibraryUnload = PREFIX + "NativeLibraryUnload";
     public static final String PhysicalMemory = PREFIX + "PhysicalMemory";
     public static final String NetworkUtilization = PREFIX + "NetworkUtilization";
     public static final String ProcessStart = PREFIX + "ProcessStart";


### PR DESCRIPTION
[JDK-8313251](https://bugs.openjdk.org/browse/JDK-8313251) introduced a a NativeLibraryLoad event that provides us more detail about shared lib/dll loads.
There should be a similar event for unload operations of shared libs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314211](https://bugs.openjdk.org/browse/JDK-8314211): Add NativeLibraryUnload event (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [ce607b38](https://git.openjdk.org/jdk/pull/15272/files/ce607b3885c5d1d86f3441c687d7fee5aa2ce854)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15272/head:pull/15272` \
`$ git checkout pull/15272`

Update a local copy of the PR: \
`$ git checkout pull/15272` \
`$ git pull https://git.openjdk.org/jdk.git pull/15272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15272`

View PR using the GUI difftool: \
`$ git pr show -t 15272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15272.diff">https://git.openjdk.org/jdk/pull/15272.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15272#issuecomment-1677520397)