### PR TITLE
8309335: Get rid of use of reflection to call Thread.isVirtual() in nsk/jdi/EventRequestManager/stepRequests/stepreq001t.java

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/stepRequests/stepreq001t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/stepRequests/stepreq001t.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class stepreq001t {
             for (int i=1; i<stepreq001.THRDS_NUM; i++) {
                 thrs[i] = JDIThreadFactory.newThread(new stepreq001a(readyObj, lockObj,
                     stepreq001.DEBUGGEE_THRDS[i]));
-                if (!isVirtual(thrs[i])) {
+                if (!thrs[i].isVirtual()) {
                     thrs[i].setDaemon(stepreq001.DAEMON_THRDS[i]);
                 }
                 if (argHandler.verbose())
@@ -110,15 +110,6 @@ public class stepreq001t {
         }
         return stepreq001.JCK_STATUS_BASE +
             stepreq001.PASSED;
-    }
-
-    private static boolean isVirtual(Thread thread) {
-        try {
-            Method isVirtual = Thread.class.getMethod("isVirtual");
-            return (boolean) isVirtual.invoke(thread);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     class stepreq001a extends NamedTask {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/stepRequests/stepreq001t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/stepRequests/stepreq001t.java
@@ -23,7 +23,6 @@
 
 package nsk.jdi.EventRequestManager.stepRequests;
 
-import java.lang.reflect.Method;
 import nsk.share.jpda.*;
 import nsk.share.jdi.*;
 


### PR DESCRIPTION
No need to use reflection to call Thread.isVirtual().

Tested by running Tier5 CI (filtered to run just svc tests). This resulted in running this test with and without JTREG_TEST_THREAD_FACTORY=Virtual and also with a variety of GCs and platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309335](https://bugs.openjdk.org/browse/JDK-8309335): Get rid of use of reflection to call Thread.isVirtual() in nsk/jdi/EventRequestManager/stepRequests/stepreq001t.java (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [56f7cf6e](https://git.openjdk.org/jdk/pull/15275/files/56f7cf6e8e83d1d0dd6b90eb9286cdebb3747d15)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15275/head:pull/15275` \
`$ git checkout pull/15275`

Update a local copy of the PR: \
`$ git checkout pull/15275` \
`$ git pull https://git.openjdk.org/jdk.git pull/15275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15275`

View PR using the GUI difftool: \
`$ git pr show -t 15275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15275.diff">https://git.openjdk.org/jdk/pull/15275.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15275#issuecomment-1677816316)