### PR TITLE
JDK-8311113: Remove invalid pointer cast and clean up setLabel() in awt_MenuItem.cpp

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WMenuItemPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WMenuItemPeer.java
@@ -75,9 +75,9 @@ class WMenuItemPeer extends WObjectPeer implements MenuItemPeer {
     public void setLabel(String label) {
         //Fix for 6288578: PIT. Windows: Shortcuts displayed for the menuitems in a popup menu
         readShortcutLabel();
-        _setLabel(label);
+        _setLabel();
     }
-    public native void _setLabel(String label);
+    public native void _setLabel();
 
     // Toolkit & peer internals
 

--- a/src/java.desktop/windows/classes/sun/awt/windows/WMenuItemPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WMenuItemPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp
@@ -703,7 +703,7 @@ void AwtMenuItem::SetLabel()
     memset(&mii, 0, sizeof(MENUITEMINFO));
     mii.cbSize = sizeof(MENUITEMINFO);
     mii.fMask = MIIM_CHECKMARKS | MIIM_DATA | MIIM_ID
-              | MIIM_STATE | MIIM_SUBMENU | MIIM_TYPE;
+              | MIIM_STATE | MIIM_SUBMENU | MIIM_FTYPE;
 
     ::GetMenuItemInfo(hMenu, GetID(), FALSE, &mii);
 
@@ -795,10 +795,6 @@ ret:
         env->DeleteGlobalRef(self);
 
         delete sls;
-
-        if (badAlloc) {
-            throw std::bad_alloc();
-        }
     } else {
         AwtToolkit::GetInstance().InvokeFunction(AwtMenuItem::_SetLabel, param);
     }
@@ -980,7 +976,7 @@ Java_sun_awt_windows_WMenuItemPeer_initIDs(JNIEnv *env, jclass cls)
 /*
  * Class:     sun_awt_windows_WMenuItemPeer
  * Method:    _setLabel
- * Signature: (Ljava/lang/String;)V
+ * Signature: ()V
  */
 JNIEXPORT void JNICALL
 Java_sun_awt_windows_WMenuItemPeer__1setLabel(JNIEnv *env, jobject self)

--- a/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.h
@@ -133,7 +133,7 @@ public:
     virtual BOOL IsTopMenu();
     void DrawCheck(HDC hDC, RECT rect);
 
-    void SetLabel(LPCTSTR sb);
+    void SetLabel();
     virtual void Enable(BOOL isEnabled);
     virtual void UpdateContainerLayout();
     virtual void RedrawMenuBar();

--- a/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/MenuItem/SetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.imageio.ImageIO;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.io.File;
+import java.io.IOException;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4234266
+ * @summary To test setLabel functionality on Windows.
+ * @requires (os.family == "windows")
+ * @run main/othervm -Dsun.java2d.uiScale=1 SetLabelTest
+ */
+
+public class SetLabelTest implements ActionListener {
+    private static Robot robot;
+    private static Frame frame;
+    private static MenuBar mb;
+    private static Point frameLoc;
+    private static boolean passed = true;
+    private static final String[][] newLabels = {new String[]{"New Menu-1", "New MI-1"},
+                                                 new String[]{"New PM-1", "New PMI-1"}};
+
+    public static void main(String[] args) throws Exception {
+        SetLabelTest obj = new SetLabelTest();
+        obj.start();
+    }
+
+    public void start() throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+
+            EventQueue.invokeAndWait(this::createTestUI);
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> frameLoc = frame.getLocationOnScreen());
+
+            // First Menu
+            robot.mouseMove(frameLoc.x + 35, frameLoc.y + 35);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(300);
+            captureScreen("Img_1");
+            robot.mouseMove(frameLoc.x + 35, frameLoc.y + 90);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(500);
+            captureScreen("Img_2");
+
+            //Second Menu
+            robot.mouseMove(frameLoc.x + 130, frameLoc.y + 35);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(300);
+            captureScreen("Img_3");
+            robot.mouseMove(frameLoc.x + 130, frameLoc.y + 90);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(500);
+            captureScreen("Img_3");
+
+            if(!checkLabels()) {
+                captureScreen("Fail_Image");
+                throw new RuntimeException("Test Failed! setLabel does not work");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private void createTestUI() {
+        frame = new Frame("Menu & MenuItem SetLabel Test");
+        mb = new MenuBar();
+
+        //Menu 1
+        Menu menu1 = new Menu("Menu1");
+        MenuItem mi1 = new MenuItem("MI-1");
+        mi1.addActionListener(this);
+        menu1.add(mi1);
+        menu1.addSeparator();
+        MenuItem mi2 = new MenuItem("Change Menu1");
+        mi2.addActionListener(this);
+        menu1.add(mi2);
+        mb.add(menu1);
+
+        //Popup menu
+        PopupMenu pm = new PopupMenu("PopupMenu1");
+        MenuItem pm1 = new MenuItem("PMI-1");
+        pm1.addActionListener(this);
+        pm.add(pm1);
+        pm.addSeparator();
+        MenuItem pm2 = new MenuItem("Change Menu2");
+        pm2.addActionListener(this);
+        pm.add(pm2);
+        mb.add(pm);
+
+        frame.setMenuBar(mb);
+        frame.setSize(300, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void changeLabels(int menuIndex, String[] labels) {
+            Menu m1 = mb.getMenu(menuIndex);
+            m1.setLabel(labels[0]);
+            MenuItem mItem1 = m1.getItem(0);
+            mItem1.setLabel(labels[1]);
+    }
+    private static boolean checkLabels() {
+        for (int i = 0; i < 2; i++) {
+            Menu m1 = mb.getMenu(i);
+            String menuLabel = m1.getLabel();
+            String menuItemLabel = m1.getItem(0).getLabel();
+            if (!(menuLabel.equals(newLabels[i][0])
+                    && menuItemLabel.equals(newLabels[i][1]))) {
+                passed = false;
+                break;
+            }
+        }
+        return passed;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (e.getActionCommand().equals("Change Menu1")) {
+            changeLabels(0, newLabels[0]);
+        } else {
+            changeLabels(1, newLabels[1]);
+        }
+    }
+
+    private static void captureScreen(String filename) {
+        Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+        try {
+            ImageIO.write(
+                    robot.createScreenCapture(new Rectangle(0, 0, screenSize.width, screenSize.height)),
+                    "png",
+                    new File(filename + ".png")
+            );
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/test/jdk/java/awt/MenuItem/SetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelTest.java
@@ -56,8 +56,6 @@ public class SetLabelTest {
     public static void main(String[] args) throws Exception {
         try {
             robot = new Robot();
-            robot.setAutoWaitForIdle(true);
-            robot.setAutoDelay(50);
 
             EventQueue.invokeAndWait(() -> createTestUI());
             robot.delay(1000);
@@ -65,7 +63,7 @@ public class SetLabelTest {
 
             checkMenu();
             checkPopupMenu();
-
+            robot.delay(200);
             if (!errorLog.isEmpty()) {
                 throw new RuntimeException("Before & After screenshots are same." +
                         " Test fails for the following case(s):\n" + errorLog);
@@ -85,30 +83,32 @@ public class SetLabelTest {
         mb = new MenuBar();
 
         //Menu 1
-        Menu menu1 = new Menu("Menu1");
-        MenuItem mi1 = new MenuItem("MI-1");
+        Menu menu1 = new Menu("Menu");
+        MenuItem mi1 = new MenuItem("Item-1");
         menu1.add(mi1);
         menu1.addSeparator();
-        MenuItem mi2 = new MenuItem("MI-2");
+        MenuItem mi2 = new MenuItem("Item-2");
         menu1.add(mi2);
         mb.add(menu1);
 
         //Popup menu
-        pm = new PopupMenu();
-        MenuItem pm1 = new MenuItem("PMI-1");
+        pm = new PopupMenu("Popup");
+        MenuItem pm1 = new MenuItem("Item-1");
         pm.add(pm1);
+        pm.addSeparator();
+        MenuItem pm2 = new MenuItem("Item-2");
+        pm.add(pm2);
         frame.add(pm);
 
         frame.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
+                showPopup(e);
             }
 
             @Override
             public void mouseReleased(MouseEvent e) {
-                if (e.getButton() != InputEvent.BUTTON1_DOWN_MASK) {
-                    showPopup(e);
-                }
+                showPopup(e);
             }
 
             private void showPopup(MouseEvent e) {
@@ -124,39 +124,52 @@ public class SetLabelTest {
         frame.setVisible(true);
     }
 
-    private static void checkMenu() throws IOException {
+    private static void checkMenu() throws Exception {
+        robot.mouseMove(frameLoc.x + 8, frameLoc.y + 8);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(200);
         BufferedImage beforeImgMenu = robot.createScreenCapture(frame.getBounds());
+
+        //Change Menu & MenuItem label
         Menu m1 = mb.getMenu(0);
         m1.setLabel("New Menu");
-        MenuItem mItem1 = m1.getItem(0);
-        mItem1.setLabel("New Menu Item");
+        m1.getItem(0).setLabel("New Item-1");
+        m1.getItem(2).setLabel("New Item-2");
         robot.delay(200);
         BufferedImage afterImgMenu = robot.createScreenCapture(frame.getBounds());
 
         if (compareImages(beforeImgMenu, afterImgMenu)) {
+            errorLog.append("Menu case\n");
             ImageIO.write(beforeImgMenu, "png", new File("MenuBefore.png"));
             ImageIO.write(afterImgMenu, "png", new File("MenuAfter.png"));
-            errorLog.append("Menu case\n");
         }
     }
 
     private static void checkPopupMenu() throws IOException {
-        BufferedImage beforeImgPopup = robot.createScreenCapture(frame.getBounds());
         robot.mouseMove(frameLoc.x + (frame.getWidth() / 2),
                 frameLoc.y + (frame.getHeight() /2));
         robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
         robot.delay(200);
-        pm.getItem(0).setLabel("Changed Label");
+        BufferedImage beforeImgPopup = robot.createScreenCapture(frame.getBounds());
+
+        //Change popup menu label
+        pm.setLabel("Changed Popup");
+        pm.getItem(0).setLabel("New Item-1");
+        pm.getItem(2).setLabel("New Item-2");
+        robot.delay(200);
         BufferedImage afterImgPopup = robot.createScreenCapture(frame.getBounds());
-        robot.delay(300);
+        robot.mouseMove(frameLoc.x + (frame.getWidth() - 10),
+                frameLoc.y + (frame.getHeight() - 10));
+        robot.delay(100);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
 
         if (compareImages(beforeImgPopup, afterImgPopup)) {
+            errorLog.append("Popup case\n");
             ImageIO.write(beforeImgPopup, "png", new File("PopupBefore.png"));
             ImageIO.write(afterImgPopup, "png", new File("PopupAfter.png"));
-            errorLog.append("Popup case\n");
         }
     }
 

--- a/test/jdk/java/awt/MenuItem/SetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelTest.java
@@ -145,6 +145,7 @@ public class SetLabelTest implements ActionListener {
             MenuItem mItem1 = m1.getItem(0);
             mItem1.setLabel(labels[1]);
     }
+
     private static boolean checkLabels() {
         for (int i = 0; i < 2; i++) {
             Menu m1 = mb.getMenu(i);

--- a/test/jdk/java/awt/MenuItem/SetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelTest.java
@@ -51,7 +51,7 @@ public class SetLabelTest {
     private static MenuBar mb;
     private static PopupMenu pm;
     private static Point frameLoc;
-    private static StringBuffer errorLog = new StringBuffer();
+    private static final StringBuffer errorLog = new StringBuffer();
 
     public static void main(String[] args) throws Exception {
         try {
@@ -124,7 +124,7 @@ public class SetLabelTest {
         frame.setVisible(true);
     }
 
-    private static void checkMenu() throws Exception {
+    private static void checkMenu() throws IOException {
         robot.mouseMove(frameLoc.x + 8, frameLoc.y + 8);
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);

--- a/test/jdk/java/awt/MenuItem/SetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelTest.java
@@ -77,27 +77,25 @@ public class SetLabelTest implements ActionListener {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(300);
-            captureScreen("Img_1");
             robot.mouseMove(frameLoc.x + 35, frameLoc.y + 90);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(500);
-            captureScreen("Img_2");
+            captureScreen("Img_1");
 
             //Second Menu
             robot.mouseMove(frameLoc.x + 130, frameLoc.y + 35);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(300);
-            captureScreen("Img_3");
             robot.mouseMove(frameLoc.x + 130, frameLoc.y + 90);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(500);
-            captureScreen("Img_3");
+            captureScreen("Img_2");
 
             if(!checkLabels()) {
-                captureScreen("Fail_Image");
+                captureScreen("Img_Failed");
                 throw new RuntimeException("Test Failed! setLabel does not work");
             }
         } finally {

--- a/test/jdk/java/awt/MenuItem/SetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelTest.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import javax.imageio.ImageIO;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.Frame;
@@ -38,6 +37,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.io.File;
 import java.io.IOException;
+import javax.imageio.ImageIO;
 
 /*
  * @test


### PR DESCRIPTION
In awt_MenuItem.cpp (712,22): ` mii.dwTypeData = (LPTSTR)(*sb)`  produces invalid pointer cast warning when complied on clang and moreover this is a no-op.  

`mii.dwTypeData` is used only when **MIIM_STRING** flag is set in the fMask (as per [Docs](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-menuiteminfoa)), which is not the case in JDK [Ln#705](https://github.com/openjdk/jdk/blob/e56d3bc2dab3d32453b6eda66e8434953c436084/src/java.desktop/windows/native/libawt/windows/awt_MenuItem.cpp#L706). Hence the assignment ` mii.dwTypeData = (LPTSTR)(*sb)`  is not required and so is the label parameter. Additionally necessary cleanup is done at the following places -

- WMenuItemPeer.java - to the native function call
- awt_MenuItem.cpp -  `WMenuItemPeer__1setLabel() ,_SetLabel(), SetLabel()`
- awt_MenuItem.h

Added a test which checks setLabel() functionality on Menu, MenuItem and PopupMenu.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311113](https://bugs.openjdk.org/browse/JDK-8311113): Remove invalid pointer cast and clean up setLabel() in awt_MenuItem.cpp (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15276/head:pull/15276` \
`$ git checkout pull/15276`

Update a local copy of the PR: \
`$ git checkout pull/15276` \
`$ git pull https://git.openjdk.org/jdk.git pull/15276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15276`

View PR using the GUI difftool: \
`$ git pr show -t 15276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15276.diff">https://git.openjdk.org/jdk/pull/15276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15276#issuecomment-1677872294)