### PR TITLE
8310134: NMT: thread count in Thread section of VM.native_memory output confusing with virtual threads

### DIFF
--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -226,7 +226,7 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
         const VirtualMemory* thread_stack_usage =
          _vm_snapshot->by_type(mtThreadStack);
         // report thread count
-        out->print_cr("%27s (thread #" SIZE_FORMAT ")", " ", ThreadStackTracker::thread_count());
+        out->print_cr("%27s (threads #" SIZE_FORMAT ")", " ", ThreadStackTracker::thread_count());
         out->print("%27s (stack: ", " ");
         print_total(thread_stack_usage->reserved(), thread_stack_usage->committed());
       } else {
@@ -234,7 +234,7 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
         const char* scale = current_scale();
         // report thread count
         assert(ThreadStackTracker::thread_count() == 0, "Not used");
-        out->print_cr("%27s (thread #" SIZE_FORMAT ")", " ", thread_stack_memory->malloc_count());
+        out->print_cr("%27s (threads #" SIZE_FORMAT ")", " ", thread_stack_memory->malloc_count());
         out->print("%27s (Stack: " SIZE_FORMAT "%s", " ",
           amount_in_current_scale(thread_stack_memory->malloc_size()), scale);
       }
@@ -595,7 +595,7 @@ void MemSummaryDiffReporter::diff_summary_of_type(MEMFLAGS flag,
 
     } else if (flag == mtThread) {
       // report thread count
-      out->print("%27s (thread #" SIZE_FORMAT "", " ", _current_baseline.thread_count());
+      out->print("%27s (threads #" SIZE_FORMAT "", " ", _current_baseline.thread_count());
       const ssize_t thread_count_diff = counter_diff(_current_baseline.thread_count(), _early_baseline.thread_count());
       if (thread_count_diff != 0) {
         out->print(" " SSIZE_PLUS_FORMAT, thread_count_diff);


### PR DESCRIPTION
This is a very simple tweak that changes NMT memory monitor output from:

```
- Thread (reserved=19511KB, committed=19511KB) 
                            (thread #19) 
                            (stack: reserved=19456KB, committed=19456KB) 
                            (malloc=33KB #118) 
                            (arena=21KB #37) 
```

to

```
- Thread (reserved=19511KB, committed=19511KB) 
                            (threads #19) 
                            (stack: reserved=19456KB, committed=19456KB) 
                            (malloc=33KB #118) 
                            (arena=21KB #37) 
```

to signify that we are talking about "thread count of 19" and not "thread with id 19"

There are more opportunities to clean up the output, but that will be handled in a followup bug https://bugs.openjdk.org/browse/JDK-8314227

Tested locally with NMT gtests and jtreg and Mach5 tier1,2,3,4,5

`jtreg -nr -va -jdk:./build/xcode/build/jdk/ test/hotspot/jtreg/runtime/NMT`

`gtestLauncher -jdk ./build/xcode/build/jdk/ --gtest_output=xml:test_result.xml --gtest_catch_exceptions=0 --gtest_filter="NMT*:os*" -XX:NativeMemoryTracking=summary`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310134](https://bugs.openjdk.org/browse/JDK-8310134): NMT: thread count in Thread section of VM.native_memory output confusing with virtual threads (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15277/head:pull/15277` \
`$ git checkout pull/15277`

Update a local copy of the PR: \
`$ git checkout pull/15277` \
`$ git pull https://git.openjdk.org/jdk.git pull/15277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15277`

View PR using the GUI difftool: \
`$ git pr show -t 15277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15277.diff">https://git.openjdk.org/jdk/pull/15277.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15277#issuecomment-1678033002)