### PR TITLE
8313661: [REDO] Relax prerequisites for java.base-jmod target

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -967,11 +967,15 @@ else
   jdk.compiler-gendata: $(GENSRC_MODULEINFO_TARGETS)
 
   # Declare dependencies between jmod targets.
-  # java.base jmod needs jrt-fs.jar and access to the other jmods to be built.
+  # java.base jmod needs jrt-fs.jar and access to the jmods for all non
+  # upgradeable modules and their transitive dependencies.
   # When creating the BUILDJDK, we don't need to add hashes to java.base, thus
   # we don't need to depend on all other jmods
   ifneq ($(CREATING_BUILDJDK), true)
-    java.base-jmod: jrtfs-jar $(filter-out java.base-jmod, $(JMOD_TARGETS))
+    java.base-jmod: jrtfs-jar $(addsuffix -jmod, $(filter-out java.base, $(sort \
+        $(foreach m, $(filter-out $(call FindAllUpgradeableModules), $(JMOD_MODULES)), \
+          $m $(call FindTransitiveDepsForModules, $m) \
+        ))))
   endif
 
   # If not already set, set the JVM target so that the JVM will be built.


### PR DESCRIPTION
This is a redo of [pull/14561](https://git.openjdk.org/jdk/pull/14561). The change relaxes the prerequisites for the top level java.base-jmod target to not include targets for jmods of upgradable modules. 

The problem with the previous fix was that jdk.jdeps, which is a non upgradable module, depends on java.compiler, which is an upgradable module. The jmod tool wants to resolve the complete module graph given to the `--hash-modules` option and this failed with:

Error: Resolution failed: Module java.compiler not found, required by jdk.jdeps

The fix is to modify the prerequisite list for the java.base-jmod target to include the jmod targets of the transitive deps of all the non upgradable modules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313661](https://bugs.openjdk.org/browse/JDK-8313661): [REDO] Relax prerequisites for java.base-jmod target (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15279/head:pull/15279` \
`$ git checkout pull/15279`

Update a local copy of the PR: \
`$ git checkout pull/15279` \
`$ git pull https://git.openjdk.org/jdk.git pull/15279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15279`

View PR using the GUI difftool: \
`$ git pr show -t 15279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15279.diff">https://git.openjdk.org/jdk/pull/15279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15279#issuecomment-1678165723)