### PR TITLE
 8314242: Update applications/scimark/Scimark.java to accept VM flags

### DIFF
--- a/test/hotspot/jtreg/applications/scimark/Scimark.java
+++ b/test/hotspot/jtreg/applications/scimark/Scimark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 /*
  * @test
  * @library /test/lib
- * @requires vm.flagless
  * @run driver Scimark
  */
 
@@ -47,7 +46,9 @@ public class Scimark {
                             + Scimark.class.getName(), e);
         }
 
-        OutputAnalyzer output = new OutputAnalyzer(ProcessTools.createJavaProcessBuilder(
+        System.setProperty("test.noclasspath", "true");
+
+        OutputAnalyzer output = new OutputAnalyzer(ProcessTools.createTestJvm(
             "-cp", artifacts.get("gov.nist.math.scimark-2.0").toString(),
             "jnt.scimark2.commandline", "-large")
             .start());


### PR DESCRIPTION
Test applications/scimark/Scimark.java is a small stress test which currently ignores VM flags and is vm.flagless.
This fix update it to accept all flags.

Tested by running tier1 and this test with additional VM flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314242](https://bugs.openjdk.org/browse/JDK-8314242): Update applications/scimark/Scimark.java to accept VM flags (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15280/head:pull/15280` \
`$ git checkout pull/15280`

Update a local copy of the PR: \
`$ git checkout pull/15280` \
`$ git pull https://git.openjdk.org/jdk.git pull/15280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15280`

View PR using the GUI difftool: \
`$ git pr show -t 15280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15280.diff">https://git.openjdk.org/jdk/pull/15280.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15280#issuecomment-1678164240)