### PR TITLE
8314244: Incorrect file headers in new tests from JDK-8312597

### DIFF
--- a/test/hotspot/jtreg/compiler/arguments/TestLogJIT.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestLogJIT.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation. Amazon designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -17,6 +15,10 @@
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 /*
@@ -33,4 +35,3 @@ public class TestLogJIT {
         System.out.println("Passed");
     }
 }
-

--- a/test/hotspot/jtreg/compiler/arguments/TestTraceTypeProfile.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestTraceTypeProfile.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation. Amazon designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -17,6 +15,10 @@
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
 
 /*
@@ -34,4 +36,3 @@ public class TestTraceTypeProfile {
         System.out.println("Passed");
     }
 }
-


### PR DESCRIPTION
Trivial fix:

- Test files don't need/use the Classpath Exception.
- The Oracle contact details were missing.

These headers now match other Amazon-only copyrighted test files.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314244](https://bugs.openjdk.org/browse/JDK-8314244): Incorrect file headers in new tests from JDK-8312597 (**Bug** - P2)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15282/head:pull/15282` \
`$ git checkout pull/15282`

Update a local copy of the PR: \
`$ git checkout pull/15282` \
`$ git pull https://git.openjdk.org/jdk.git pull/15282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15282`

View PR using the GUI difftool: \
`$ git pr show -t 15282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15282.diff">https://git.openjdk.org/jdk/pull/15282.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15282#issuecomment-1678278207)