### PR TITLE
8314268: Missing include in assembler_riscv.hpp

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -27,6 +27,7 @@
 #ifndef CPU_RISCV_ASSEMBLER_RISCV_HPP
 #define CPU_RISCV_ASSEMBLER_RISCV_HPP
 
+#include "asm/assembler.hpp"
 #include "asm/register.hpp"
 #include "code/codeCache.hpp"
 #include "metaprogramming/enableIf.hpp"


### PR DESCRIPTION
Hello, please consider.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314268](https://bugs.openjdk.org/browse/JDK-8314268): Missing include in assembler_riscv.hpp (**Bug** - P5)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15285/head:pull/15285` \
`$ git checkout pull/15285`

Update a local copy of the PR: \
`$ git checkout pull/15285` \
`$ git pull https://git.openjdk.org/jdk.git pull/15285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15285`

View PR using the GUI difftool: \
`$ git pr show -t 15285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15285.diff">https://git.openjdk.org/jdk/pull/15285.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15285#issuecomment-1678810189)