### PR TITLE
8314262: GHA: Cut down cross-compilation sysroots deeper

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -153,7 +153,8 @@ jobs:
           sudo chown ${USER} -R sysroot
           rm -rf sysroot/{dev,proc,run,sys,var}
           rm -rf sysroot/usr/{sbin,bin,share}
-          rm -rf sysroot/usr/lib/{apt,udev,systemd}
+          rm -rf sysroot/usr/lib/{apt,gcc,udev,systemd}
+          rm -rf sysroot/usr/libexec/{gcc}
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Configure'

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -154,7 +154,7 @@ jobs:
           rm -rf sysroot/{dev,proc,run,sys,var}
           rm -rf sysroot/usr/{sbin,bin,share}
           rm -rf sysroot/usr/lib/{apt,gcc,udev,systemd}
-          rm -rf sysroot/usr/libexec/{gcc}
+          rm -rf sysroot/usr/libexec/gcc
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Configure'


### PR DESCRIPTION
[JDK-8294941](https://bugs.openjdk.org/browse/JDK-8294941) cut out some unused files in GHA sysroots. But I notice that even after that, we still have quite a bit of fluff there, especially in RISC-V sysroot. We can cut a bit deeper. Notably, we don't need runnable gcc in the sysroot, because we use the cross-compilation toolchain from the host.

This further saves bandwidth, cache size, etc. for actively developed projects.

Seeing the following improvements in sysroot sizes:

```
ARM:      64 MB ->  37 MB
AArch64:  80 MB ->  46 MB
S390X:    69 MB ->  41 MB
PPC64:    84 MB ->  51 MB
RISC-V:  287 MB ->  53 MB

Total:   584 MB -> 228 MB (-61%)
```

Additional testing:
 - [x] GHA (cross-builds still work fine)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314262](https://bugs.openjdk.org/browse/JDK-8314262): GHA: Cut down cross-compilation sysroots deeper (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15287/head:pull/15287` \
`$ git checkout pull/15287`

Update a local copy of the PR: \
`$ git checkout pull/15287` \
`$ git pull https://git.openjdk.org/jdk.git pull/15287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15287`

View PR using the GUI difftool: \
`$ git pr show -t 15287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15287.diff">https://git.openjdk.org/jdk/pull/15287.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15287#issuecomment-1678870611)