### PR TITLE
8314274: G1: Fix -Wconversion warnings around G1CardSetArray::_data

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -144,7 +144,8 @@ inline G1CardSetArray::G1CardSetArray(uint card_in_region, EntryCountType num_ca
   _num_entries(1) {
   assert(_size > 0, "CardSetArray of size 0 not supported.");
   assert(_size < LockBitMask, "Only support CardSetArray of size %u or smaller.", LockBitMask - 1);
-  _data[0] = card_in_region;
+  assert(card_in_region < (1u << sizeof(_data[0]) * BitsPerByte), "in-range");
+  _data[0] = static_cast<EntryDataType>(card_in_region);
 }
 
 inline G1CardSetArray::G1CardSetArrayLocker::G1CardSetArrayLocker(EntryCountType volatile* num_entries_addr) :
@@ -195,7 +196,7 @@ inline G1AddCardResult G1CardSetArray::add(uint card_idx) {
     return Overflow;
   }
 
-  _data[num_entries] = card_idx;
+  _data[num_entries] = static_cast<EntryDataType>(card_idx);
 
   x.inc_num_entries();
 

--- a/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.inline.hpp
@@ -144,8 +144,7 @@ inline G1CardSetArray::G1CardSetArray(uint card_in_region, EntryCountType num_ca
   _num_entries(1) {
   assert(_size > 0, "CardSetArray of size 0 not supported.");
   assert(_size < LockBitMask, "Only support CardSetArray of size %u or smaller.", LockBitMask - 1);
-  assert(card_in_region < (1u << sizeof(_data[0]) * BitsPerByte), "in-range");
-  _data[0] = static_cast<EntryDataType>(card_in_region);
+  _data[0] = checked_cast<EntryDataType>(card_in_region);
 }
 
 inline G1CardSetArray::G1CardSetArrayLocker::G1CardSetArrayLocker(EntryCountType volatile* num_entries_addr) :
@@ -196,7 +195,7 @@ inline G1AddCardResult G1CardSetArray::add(uint card_idx) {
     return Overflow;
   }
 
-  _data[num_entries] = static_cast<EntryDataType>(card_idx);
+  _data[num_entries] = checked_cast<EntryDataType>(card_idx);
 
   x.inc_num_entries();
 


### PR DESCRIPTION
Add value-range check and explicit type conversion. The second write has its check at the beginning of the method, so doesn't require an assertion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314274](https://bugs.openjdk.org/browse/JDK-8314274): G1: Fix -Wconversion warnings around G1CardSetArray::_data (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15289/head:pull/15289` \
`$ git checkout pull/15289`

Update a local copy of the PR: \
`$ git checkout pull/15289` \
`$ git pull https://git.openjdk.org/jdk.git pull/15289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15289`

View PR using the GUI difftool: \
`$ git pr show -t 15289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15289.diff">https://git.openjdk.org/jdk/pull/15289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15289#issuecomment-1678944128)