### PR TITLE
8314233: C2: assert(assertion_predicate_has_loop_opaque_node(iff)) failed: unexpected

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2079,12 +2079,17 @@ void PhaseIdealLoop::initialize_assertion_predicates_for_peeled_loop(const Predi
   Node* control = outer_loop_head->in(LoopNode::EntryControl);
   Node* input_proj = control;
 
+  const Node* parse_predicate_uncommon_trap = predicate_block->parse_predicate()->uncommon_trap();
   Node* next_regular_predicate_proj = predicate_block->skip_parse_predicate();
   while (next_regular_predicate_proj->is_IfProj()) {
     IfNode* iff = next_regular_predicate_proj->in(0)->as_If();
+    ProjNode* uncommon_proj = iff->proj_out(1 - next_regular_predicate_proj->as_Proj()->_con);
+    if (uncommon_proj->unique_ctrl_out() != parse_predicate_uncommon_trap) {
+      // Does not belong to this Predicate Block anymore.
+      break;
+    }
     if (iff->in(1)->Opcode() == Op_Opaque4) {
       assert(assertion_predicate_has_loop_opaque_node(iff), "unexpected");
-      ProjNode* uncommon_proj = iff->proj_out(1 - next_regular_predicate_proj->as_Proj()->_con);
       input_proj = clone_assertion_predicate_and_initialize(iff, init, stride, next_regular_predicate_proj, uncommon_proj, control,
                                                             outer_loop, input_proj);
 

--- a/test/hotspot/jtreg/compiler/predicates/TestPeelingFindsUnrelatedOpaque4Node.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestPeelingFindsUnrelatedOpaque4Node.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8314233
+ * @requires vm.compiler2.enabled
+ * @summary Test that loop peeling does not treat unrelated Opaque4 node as Template Assertion Predicate.
+ * @run main/othervm -Xbatch -XX:LoopMaxUnroll=0
+ *                   -XX:CompileCommand=compileonly,compiler.predicates.TestPeelingFindsUnrelatedOpaque4Node::*
+ *                   -XX:CompileCommand=inline,*String::* compiler.predicates.TestPeelingFindsUnrelatedOpaque4Node
+ */
+
+package compiler.predicates;
+
+public class TestPeelingFindsUnrelatedOpaque4Node {
+    static int iFld;
+    static boolean flag;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 1000; i++) {
+            test();
+            flag = !flag;
+        }
+    }
+
+    static void test() {
+        String s = flag ? "34323653" : "343423";
+        s.contains("343");
+        // Inlined and will call StringLatin1.indexOf intrinsics which emits Opaque4 node which will be wrongly
+        // found as Template Assertion Predicate when trying to initialize them which triggers the assert.
+        s.contains("3442");
+
+        for (int i = 0; i < 100; i++) {
+            if (flag) { // Triggers peeling
+                return;
+            }
+            iFld = 34;
+        }
+    }
+}


### PR DESCRIPTION
In the testcase, we try to initialize Assertion Predicates from the templates which have an `Opaque4` node. However, the code finds an unrelated `Opaque4` node added by an intrinsic. This, obviously, will not guard any `OpaqueLoop*` nodes required for Template Assertion Predicates and we fail with the assertion.

While splitting some changes away from the main fix of [JDK-8288981](https://bugs.openjdk.org/browse/JDK-8288981) for [JDK-8305636](https://bugs.openjdk.org/browse/JDK-8305636), I wrongly removed the check in loop peeling if an `Opaque4` node belongs to an `If` that also shares the uncommon trap with the Parse Predicate (this is not required in the main fix anymore because Template Assertion Predicates will always only have `HaltNodes` - but optimizing this here is wrong/too early).

The fix re-establishes the check for the uncommon trap.

Thanks,
Christian