### PR TITLE
8314280: StructuredTaskScope.shutdown should document that the state of completing subtasks is not defined

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -756,6 +756,12 @@ public class StructuredTaskScope<T> implements AutoCloseable {
      * {@code join} or {@code joinUntil} will return immediately.
      * </ul>
      *
+     * <p> The {@linkplain Subtask.State state} of unfinished subtasks that complete at
+     * around the time that the task scope is shutdown is not defined. A subtask that
+     * completes successfully with a result, or fails with an exception, at around
+     * the time that the task scope is shutdown may or may not <i>transition</i> to a
+     * terminal state.
+     *
      * <p> This method may only be invoked by the task scope owner or threads contained
      * in the task scope.
      *


### PR DESCRIPTION
This is a docs only change. The specification for StructuredTaskScope.shutdown should make it clear that the state of subtasks that are completing (with a result or exception) at around the time of shutdown is not defined. The state of a completing subtask may transition to a terminal state, it may not, as it is racing with the shutdown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8314416](https://bugs.openjdk.org/browse/JDK-8314416) to be approved

### Issues
 * [JDK-8314280](https://bugs.openjdk.org/browse/JDK-8314280): StructuredTaskScope.shutdown should document that the state of completing subtasks is not defined (**Enhancement** - P4)
 * [JDK-8314416](https://bugs.openjdk.org/browse/JDK-8314416): StructuredTaskScope.shutdown should document that the state of completing subtasks is not defined (**CSR**)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15293/head:pull/15293` \
`$ git checkout pull/15293`

Update a local copy of the PR: \
`$ git checkout pull/15293` \
`$ git pull https://git.openjdk.org/jdk.git pull/15293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15293`

View PR using the GUI difftool: \
`$ git pr show -t 15293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15293.diff">https://git.openjdk.org/jdk/pull/15293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15293#issuecomment-1680060254)