### PR TITLE
8314247: JVMCI: expected int64_t but JavaThread::_held_monitor_count is of type intx

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfigAccess.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfigAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -296,6 +296,13 @@ public class HotSpotVMConfigAccess {
         return type.cast(convertValue(name, type, entry.value, inCppType));
     }
 
+    private boolean typeEquals(String t1, String t2) {
+        if (t1.equals("int64_t") && t2.equals("intx")) {
+            return true;
+        }
+        return t1.equals(t2);
+    }
+
     /**
      * Gets a C++ field.
      *
@@ -315,7 +322,7 @@ public class HotSpotVMConfigAccess {
         }
 
         // Make sure the native type is still the type we expect.
-        if (cppType != null && !cppType.equals(entry.type)) {
+        if (cppType != null && !typeEquals(cppType, entry.type)) {
             throw new JVMCIError("expected type " + cppType + " but VM field " + name + " is of type " + entry.type);
         }
         return entry;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/TestHotSpotVMConfig.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/TestHotSpotVMConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,9 @@ public class TestHotSpotVMConfig extends HotSpotVMConfigAccess {
 
     public final int maxOopMapStackOffset = getFieldValue("CompilerToVM::Data::_max_oop_map_stack_offset", Integer.class, "int");
     public final int heapWordSize = getConstant("HeapWordSize", Integer.class);
+
+    // Check field with intx declaration is the same as int64_t.
+    public final int heldMonitorCountOffset = getFieldOffset("JavaThread::_held_monitor_count", Integer.class, "int64_t");
 
     public final boolean ropProtection;
 }


### PR DESCRIPTION
Fix graal error with @iklam's fix of making intx and int64_t synonyms.  Tested with new test in jvmci tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314247](https://bugs.openjdk.org/browse/JDK-8314247): JVMCI: expected int64_t but JavaThread::_held_monitor_count is of type intx (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15295/head:pull/15295` \
`$ git checkout pull/15295`

Update a local copy of the PR: \
`$ git checkout pull/15295` \
`$ git pull https://git.openjdk.org/jdk.git pull/15295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15295`

View PR using the GUI difftool: \
`$ git pr show -t 15295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15295.diff">https://git.openjdk.org/jdk/pull/15295.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15295#issuecomment-1679369447)