### PR TITLE
8314321: Remove unused field jdk.internal.util.xml.impl.Attrs.mAttrIdx

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/Attrs.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/Attrs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,16 +41,12 @@ public class Attrs implements Attributes {
      * Number of attributes in the attributes string array.
      */
     private char mLength;
-    /**
-     * current index
-     */
-    private char mAttrIdx = 0;
 
     /**
      * Constructor.
      */
     public Attrs() {
-        //              The default number of attributies capacity is 8.
+        //              The default number of attributes capacity is 8.
         mItems = new String[(8 << 3)];
     }
 
@@ -136,7 +132,7 @@ public class Attrs implements Attributes {
      *
      * <p>If the parser has not read a declaration for the attribute, or if the
      * parser does not report attribute types, then it must return the value
-     * "CDATA" as stated in the XML 1.0 Recommentation (clause 3.3.3,
+     * "CDATA" as stated in the XML 1.0 Recommendation (clause 3.3.3,
      * "Attribute-Value Normalization").</p>
      *
      * <p>For an enumerated attribute that is not a notation, the parser will


### PR DESCRIPTION
A field `char mAttrIdx` in the `jdk.internal.util.xml.impl.Attrs` class is unused and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314321](https://bugs.openjdk.org/browse/JDK-8314321): Remove unused field jdk.internal.util.xml.impl.Attrs.mAttrIdx (**Enhancement** - P5)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15298/head:pull/15298` \
`$ git checkout pull/15298`

Update a local copy of the PR: \
`$ git checkout pull/15298` \
`$ git pull https://git.openjdk.org/jdk.git pull/15298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15298`

View PR using the GUI difftool: \
`$ git pr show -t 15298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15298.diff">https://git.openjdk.org/jdk/pull/15298.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15298#issuecomment-1679554920)