### PR TITLE
8314324: "8311557: [JVMCI] deadlock with JVMTI thread suspension" causes various failures

### DIFF
--- a/src/hotspot/share/compiler/abstractCompiler.hpp
+++ b/src/hotspot/share/compiler/abstractCompiler.hpp
@@ -150,7 +150,9 @@ class AbstractCompiler : public CHeapObj<mtCompiler> {
   bool is_c2() const                     { return _type == compiler_c2; }
   bool is_jvmci() const                  { return _type == compiler_jvmci; }
   CompilerType type() const              { return _type; }
-  virtual bool is_hidden_from_external_view() const { return false; }
+
+  // Compiler threads are hidden by default.
+  virtual bool is_hidden_from_external_view() const { return true; }
 
   // Customization
   virtual void initialize () = 0;


### PR DESCRIPTION
I accidentally reversed the default in my refactor.  Testing is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314324](https://bugs.openjdk.org/browse/JDK-8314324): "8311557: [JVMCI] deadlock with JVMTI thread suspension" causes various failures (**Bug** - P2)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15300/head:pull/15300` \
`$ git checkout pull/15300`

Update a local copy of the PR: \
`$ git checkout pull/15300` \
`$ git pull https://git.openjdk.org/jdk.git pull/15300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15300`

View PR using the GUI difftool: \
`$ git pr show -t 15300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15300.diff">https://git.openjdk.org/jdk/pull/15300.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15300#issuecomment-1679645064)