### PR TITLE
8314330: java/foreign tests should respect vm flags when start new processes

### DIFF
--- a/test/jdk/java/foreign/UpcallTestHelper.java
+++ b/test/jdk/java/foreign/UpcallTestHelper.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Utils;
 
 import java.io.BufferedReader;
@@ -57,22 +58,15 @@ public class UpcallTestHelper extends NativeTestHelper {
         assert !target.isArray();
 
         List<String> command = new ArrayList<>(List.of(
-            Paths.get(Utils.TEST_JDK)
-                    .resolve("bin")
-                    .resolve("java")
-                    .toAbsolutePath()
-                    .toString(),
             "--enable-preview",
             "--enable-native-access=ALL-UNNAMED",
             "-Djava.library.path=" + System.getProperty("java.library.path"),
             "-Djdk.internal.foreign.UpcallLinker.USE_SPEC=" + useSpec,
-            "-cp", Utils.TEST_CLASS_PATH,
             target.getName()
         ));
         command.addAll(Arrays.asList(programArgs));
-        Process process = new ProcessBuilder()
-            .command(command)
-            .start();
+
+        Process process = ProcessTools.createTestJvm(command).start();
 
         int result = process.waitFor();
         assertNotEquals(result, 0);

--- a/test/jdk/java/foreign/UpcallTestHelper.java
+++ b/test/jdk/java/foreign/UpcallTestHelper.java
@@ -22,13 +22,11 @@
  */
 
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.Utils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
The test helper which spawn new jvms is updated to start them using VM flags for testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314330](https://bugs.openjdk.org/browse/JDK-8314330): java/foreign tests should respect vm flags when start new processes (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [27f5eb83](https://git.openjdk.org/jdk/pull/15302/files/27f5eb83cf320b2d4a93edd0e583bde64e1605b0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15302/head:pull/15302` \
`$ git checkout pull/15302`

Update a local copy of the PR: \
`$ git checkout pull/15302` \
`$ git pull https://git.openjdk.org/jdk.git pull/15302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15302`

View PR using the GUI difftool: \
`$ git pr show -t 15302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15302.diff">https://git.openjdk.org/jdk/pull/15302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15302#issuecomment-1679793289)