### PR TITLE
8314209: Wrong @since tag for RandomGenerator::equiDoubles

### DIFF
--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -293,7 +293,7 @@ public interface RandomGenerator {
      *         or {@code right} is not finite, or if the specified interval
      *         is empty.
      *
-     * @since 21
+     * @since 22
      */
     default DoubleStream equiDoubles(double left, double right,
         boolean isLeftIncluded, boolean isRightIncluded) {


### PR DESCRIPTION
Please review this trivial typo.
TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314209](https://bugs.openjdk.org/browse/JDK-8314209): Wrong @since tag for RandomGenerator::equiDoubles (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15303/head:pull/15303` \
`$ git checkout pull/15303`

Update a local copy of the PR: \
`$ git checkout pull/15303` \
`$ git pull https://git.openjdk.org/jdk.git pull/15303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15303`

View PR using the GUI difftool: \
`$ git pr show -t 15303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15303.diff">https://git.openjdk.org/jdk/pull/15303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15303#issuecomment-1680163568)