### PR TITLE
JDK-8314389: AttachListener::pd_set_flag obsolete

### DIFF
--- a/src/hotspot/os/aix/attachListener_aix.cpp
+++ b/src/hotspot/os/aix/attachListener_aix.cpp
@@ -579,11 +579,6 @@ void AttachListener::pd_data_dump() {
   os::signal_notify(SIGQUIT);
 }
 
-jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
-  out->print_cr("flag '%s' cannot be changed", op->arg(0));
-  return JNI_ERR;
-}
-
 void AttachListener::pd_detachall() {
   // Cleanup server socket to detach clients.
   listener_cleanup();

--- a/src/hotspot/os/bsd/attachListener_bsd.cpp
+++ b/src/hotspot/os/bsd/attachListener_bsd.cpp
@@ -542,11 +542,6 @@ void AttachListener::pd_data_dump() {
   os::signal_notify(SIGQUIT);
 }
 
-jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
-  out->print_cr("flag '%s' cannot be changed", op->arg(0));
-  return JNI_ERR;
-}
-
 void AttachListener::pd_detachall() {
   // do nothing for now
 }

--- a/src/hotspot/os/linux/attachListener_linux.cpp
+++ b/src/hotspot/os/linux/attachListener_linux.cpp
@@ -547,11 +547,6 @@ void AttachListener::pd_data_dump() {
   os::signal_notify(SIGQUIT);
 }
 
-jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
-  out->print_cr("flag '%s' cannot be changed", op->arg(0));
-  return JNI_ERR;
-}
-
 void AttachListener::pd_detachall() {
   // do nothing for now
 }

--- a/src/hotspot/os/windows/attachListener_windows.cpp
+++ b/src/hotspot/os/windows/attachListener_windows.cpp
@@ -391,11 +391,6 @@ void AttachListener::pd_data_dump() {
   os::signal_notify(SIGBREAK);
 }
 
-jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
-  out->print_cr("flag '%s' cannot be changed", op->arg(0));
-  return JNI_ERR;
-}
-
 void AttachListener::pd_detachall() {
   // do nothing for now
 }

--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -319,13 +319,10 @@ static jint set_flag(AttachOperation* op, outputStream* out) {
   int ret = WriteableFlags::set_flag(op->arg(0), op->arg(1), JVMFlagOrigin::ATTACH_ON_DEMAND, err_msg);
   if (ret != JVMFlag::SUCCESS) {
     if (ret == JVMFlag::NON_WRITABLE) {
-      // if the flag is not manageable try to change it through
-      // the platform dependent implementation
-      return AttachListener::pd_set_flag(op, out);
+      out->print_cr("flag '%s' cannot be changed", op->arg(0));
     } else {
       out->print_cr("%s", err_msg.buffer());
     }
-
     return JNI_ERR;
   }
   return JNI_OK;

--- a/src/hotspot/share/services/attachListener.hpp
+++ b/src/hotspot/share/services/attachListener.hpp
@@ -121,9 +121,6 @@ class AttachListener: AllStatic {
   // platform specific initialization
   static int pd_init();
 
-  // platform specific flag change
-  static jint pd_set_flag(AttachOperation* op, outputStream* out);
-
   // platform specific detachall
   static void pd_detachall();
 


### PR DESCRIPTION
AttachListener::pd_set_flag is the same across platforms (always returning JNI_ERR ). So it can be centralized or removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314389](https://bugs.openjdk.org/browse/JDK-8314389): AttachListener::pd_set_flag obsolete (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15304/head:pull/15304` \
`$ git checkout pull/15304`

Update a local copy of the PR: \
`$ git checkout pull/15304` \
`$ git pull https://git.openjdk.org/jdk.git pull/15304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15304`

View PR using the GUI difftool: \
`$ git pr show -t 15304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15304.diff">https://git.openjdk.org/jdk/pull/15304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15304#issuecomment-1680167634)