### PR TITLE
8293850: need a largest_committed  metric for each category of NMT's output

### DIFF
--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -55,7 +55,7 @@ void MemReporterBase::print_total(size_t reserved, size_t committed, size_t peak
   output()->print("reserved=" SIZE_FORMAT "%s, committed=" SIZE_FORMAT "%s",
     amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale);
   if (peak != 0) {
-    output()->print(", largets_committed=" SIZE_FORMAT "%s", amount_in_current_scale(peak), scale);
+    output()->print(", largest_committed=" SIZE_FORMAT "%s", amount_in_current_scale(peak), scale);
   }
 }
 

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -50,10 +50,13 @@ size_t MemReporterBase::committed_total(const MallocMemory* malloc, const Virtua
   return malloc->malloc_size() + malloc->arena_size() + vm->committed();
 }
 
-void MemReporterBase::print_total(size_t reserved, size_t committed) const {
+void MemReporterBase::print_total(size_t reserved, size_t committed, size_t peak) const {
   const char* scale = current_scale();
   output()->print("reserved=" SIZE_FORMAT "%s, committed=" SIZE_FORMAT "%s",
     amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale);
+  if (peak != 0) {
+    output()->print(", largets_committed=" SIZE_FORMAT "%s", amount_in_current_scale(peak), scale);
+  }
 }
 
 void MemReporterBase::print_malloc(const MemoryCounter* c, MEMFLAGS flag) const {
@@ -89,10 +92,10 @@ void MemReporterBase::print_malloc(const MemoryCounter* c, MEMFLAGS flag) const 
   }
 }
 
-void MemReporterBase::print_virtual_memory(size_t reserved, size_t committed) const {
+void MemReporterBase::print_virtual_memory(size_t reserved, size_t committed, size_t peak) const {
   const char* scale = current_scale();
-  output()->print("(mmap: reserved=" SIZE_FORMAT "%s, committed=" SIZE_FORMAT "%s)",
-    amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale);
+  output()->print("(mmap: reserved=" SIZE_FORMAT "%s, committed=" SIZE_FORMAT "%s, largest_committed=" SIZE_FORMAT "%s)",
+    amount_in_current_scale(reserved), scale, amount_in_current_scale(committed), scale, amount_in_current_scale(peak), scale);
 }
 
 void MemReporterBase::print_malloc_line(const MemoryCounter* c) const {
@@ -101,9 +104,9 @@ void MemReporterBase::print_malloc_line(const MemoryCounter* c) const {
   output()->print_cr(" ");
 }
 
-void MemReporterBase::print_virtual_memory_line(size_t reserved, size_t committed) const {
+void MemReporterBase::print_virtual_memory_line(size_t reserved, size_t committed, size_t peak) const {
   output()->print("%28s", " ");
-  print_virtual_memory(reserved, committed);
+  print_virtual_memory(reserved, committed, peak);
   output()->print_cr(" ");
 }
 
@@ -228,7 +231,7 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
         // report thread count
         out->print_cr("%27s (thread #" SIZE_FORMAT ")", " ", ThreadStackTracker::thread_count());
         out->print("%27s (stack: ", " ");
-        print_total(thread_stack_usage->reserved(), thread_stack_usage->committed());
+        print_total(thread_stack_usage->reserved(), thread_stack_usage->committed(), thread_stack_usage->peak_size());
       } else {
         MallocMemory* thread_stack_memory = _malloc_snapshot->by_type(mtThreadStack);
         const char* scale = current_scale();
@@ -247,8 +250,9 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
       print_malloc_line(malloc_memory->malloc_counter());
     }
 
-    if (amount_in_current_scale(virtual_memory->reserved()) > 0) {
-      print_virtual_memory_line(virtual_memory->reserved(), virtual_memory->committed());
+    if (amount_in_current_scale(virtual_memory->reserved()) > 0
+        DEBUG_ONLY(|| amount_in_current_scale(virtual_memory->peak_size()) > 0)) {
+      print_virtual_memory_line(virtual_memory->reserved(), virtual_memory->committed(), virtual_memory->peak_size());
     }
 
     if (amount_in_current_scale(malloc_memory->arena_size()) > 0

--- a/src/hotspot/share/services/memReporter.hpp
+++ b/src/hotspot/share/services/memReporter.hpp
@@ -107,12 +107,12 @@ class MemReporterBase : public StackObj {
   }
 
   // Print summary total, malloc and virtual memory
-  void print_total(size_t reserved, size_t committed) const;
+  void print_total(size_t reserved, size_t committed, size_t peak = 0) const;
   void print_malloc(const MemoryCounter* c, MEMFLAGS flag = mtNone) const;
-  void print_virtual_memory(size_t reserved, size_t committed) const;
+  void print_virtual_memory(size_t reserved, size_t committed, size_t peak) const;
 
   void print_malloc_line(const MemoryCounter* c) const;
-  void print_virtual_memory_line(size_t reserved, size_t committed) const;
+  void print_virtual_memory_line(size_t reserved, size_t committed, size_t peak) const;
   void print_arena_line(const MemoryCounter* c) const;
 
   void print_virtual_memory_region(const char* type, address base, size_t size) const;

--- a/src/hotspot/share/services/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.cpp
@@ -34,6 +34,20 @@
 
 size_t VirtualMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(VirtualMemorySnapshot, size_t)];
 
+#ifdef ASSERT
+void VirtualMemory::update_peak(size_t size) {
+  size_t peak_sz = peak_size();
+  while (peak_sz < size) {
+    size_t old_sz = Atomic::cmpxchg(&_peak_size, peak_sz, size, memory_order_relaxed);
+    if (old_sz == peak_sz) {
+      break;
+    } else {
+      peak_sz = old_sz;
+    }
+  }
+}
+#endif // ASSERT
+
 void VirtualMemorySummary::initialize() {
   assert(sizeof(_snapshot) >= sizeof(VirtualMemorySnapshot), "Sanity Check");
   // Use placement operator new to initialize static data area.

--- a/src/hotspot/share/services/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/services/virtualMemoryTracker.hpp
@@ -43,12 +43,20 @@ class VirtualMemory {
   size_t     _reserved;
   size_t     _committed;
 
+#ifdef ASSERT
+  volatile size_t _peak_size;
+  void update_peak(size_t size);
+#endif // ASSERT
+
  public:
-  VirtualMemory() : _reserved(0), _committed(0) { }
+  VirtualMemory() : _reserved(0), _committed(0) {
+    DEBUG_ONLY(_peak_size  = 0;)
+  }
 
   inline void reserve_memory(size_t sz) { _reserved += sz; }
   inline void commit_memory (size_t sz) {
     _committed += sz;
+    DEBUG_ONLY(update_peak(sz);)
     assert(_committed <= _reserved, "Sanity check");
   }
 
@@ -64,6 +72,9 @@ class VirtualMemory {
 
   inline size_t reserved()  const { return _reserved;  }
   inline size_t committed() const { return _committed; }
+  inline size_t peak_size() const {
+    return DEBUG_ONLY(Atomic::load(&_peak_size)) NOT_DEBUG(0);
+  }
 };
 
 // Virtual memory allocation site, keeps track where the virtual memory is reserved.


### PR DESCRIPTION
The `peak` amount of allocation is kept for Virtual Memory allocations.
Whenever `reserved` and `committed` amounts are printed, the `largest_committed` also is printed.

tiers 1-7 passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293850](https://bugs.openjdk.org/browse/JDK-8293850): need a largest_committed  metric for each category of NMT's output (**Enhancement** - P4)


### Reviewers
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer) ⚠️ Review applies to [1fb0a284](https://git.openjdk.org/jdk/pull/15305/files/1fb0a28404605f42e3e6e63d27010d6a3deefb88)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [1fb0a284](https://git.openjdk.org/jdk/pull/15305/files/1fb0a28404605f42e3e6e63d27010d6a3deefb88)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15305/head:pull/15305` \
`$ git checkout pull/15305`

Update a local copy of the PR: \
`$ git checkout pull/15305` \
`$ git pull https://git.openjdk.org/jdk.git pull/15305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15305`

View PR using the GUI difftool: \
`$ git pr show -t 15305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15305.diff">https://git.openjdk.org/jdk/pull/15305.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15305#issuecomment-1687776354)