### PR TITLE
JDK-8311792: java/net/httpclient/ResponsePublisher.java fails intermittently with AssertionError: Found some outstanding operations

### DIFF
--- a/test/jdk/java/net/httpclient/ResponsePublisher.java
+++ b/test/jdk/java/net/httpclient/ResponsePublisher.java
@@ -494,8 +494,8 @@ public class ResponsePublisher implements HttpServerAdapters {
 
     // Wait for the client to be garbage collected.
     // we use the ReferenceTracker API rather than HttpClient::close here,
-    // because these tests inject faults by throwing inside callbacks, which
-    // is more likely to get HttpClient::close wedged until jtreg times out.
+    // because we want to get some diagnosis if a client doesn't release
+    // its resources and terminates as expected
     // By using the ReferenceTracker, we will get some diagnosis about what
     // is keeping the client alive if it doesn't get GC'ed within the
     // expected time frame.

--- a/test/jdk/java/net/httpclient/ResponsePublisher.java
+++ b/test/jdk/java/net/httpclient/ResponsePublisher.java
@@ -36,6 +36,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsServer;
+import jdk.internal.net.http.common.OperationTrackers;
 import jdk.test.lib.net.SimpleSSLContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
@@ -99,6 +100,16 @@ public class ResponsePublisher implements HttpServerAdapters {
     static final int ITERATION_COUNT = 3;
     // a shared executor helps reduce the amount of threads created by the test
     static final Executor executor = Executors.newCachedThreadPool();
+
+    static final long start = System.nanoTime();
+
+    public static String now() {
+        long now = System.nanoTime() - start;
+        long secs = now / 1000_000_000;
+        long mill = (now % 1000_000_000) / 1000_000;
+        long nan = now % 1000_000;
+        return String.format("[%d s, %d ms, %d ns] ", secs, mill, nan);
+    }
 
     interface BHS extends Supplier<BodyHandler<Publisher<List<ByteBuffer>>>> {
         static BHS of(BHS impl, String name) {
@@ -216,6 +227,12 @@ public class ResponsePublisher implements HttpServerAdapters {
             // Get the final result and compare it with the expected body
             String body = ofString.getBody().toCompletableFuture().get();
             assertEquals(body, "");
+            // ensure client closes before next iteration
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                clientCleanup(tracker);
+            }
         }
     }
 
@@ -239,6 +256,12 @@ public class ResponsePublisher implements HttpServerAdapters {
             // Get the final result and compare it with the expected body
             String body = ofString.getBody().toCompletableFuture().get();
             assertEquals(body, "");
+            // ensure client closes before next iteration
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                clientCleanup(tracker);
+            }
         }
     }
 
@@ -265,6 +288,12 @@ public class ResponsePublisher implements HttpServerAdapters {
                             });
             // Get the final result and compare it with the expected body
             assertEquals(result.get(), "");
+            // ensure client closes before next iteration
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                clientCleanup(tracker);
+            }
         }
     }
 
@@ -288,6 +317,12 @@ public class ResponsePublisher implements HttpServerAdapters {
             // Get the final result and compare it with the expected body
             String body = ofString.getBody().toCompletableFuture().get();
             assertEquals(body, WITH_BODY);
+            // ensure client closes before next iteration
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                clientCleanup(tracker);
+            }
         }
     }
 
@@ -314,6 +349,12 @@ public class ResponsePublisher implements HttpServerAdapters {
             // Get the final result and compare it with the expected body
             String body = result.get();
             assertEquals(body, WITH_BODY);
+            // ensure client closes before next iteration
+            if (!sameClient) {
+                var tracker = TRACKER.getTracker(client);
+                client = null;
+                clientCleanup(tracker);
+            }
         }
     }
 
@@ -449,6 +490,23 @@ public class ResponsePublisher implements HttpServerAdapters {
                 throw fail;
             }
         }
+    }
+
+    // Wait for the client to be garbage collected.
+    // we use the ReferenceTracker API rather than HttpClient::close here,
+    // because these tests inject faults by throwing inside callbacks, which
+    // is more likely to get HttpClient::close wedged until jtreg times out.
+    // By using the ReferenceTracker, we will get some diagnosis about what
+    // is keeping the client alive if it doesn't get GC'ed within the
+    // expected time frame.
+    public void clientCleanup(OperationTrackers.Tracker tracker){
+        System.gc();
+        System.out.println(now() + "waiting for client to shutdown: " + tracker.getName());
+        System.err.println(now() + "waiting for client to shutdown: " + tracker.getName());
+        var error = TRACKER.check(tracker, 10000);
+        if (error != null) throw error;
+        System.out.println(now() + "client shutdown normally: " + tracker.getName());
+        System.err.println(now() + "client shutdown normally: " + tracker.getName());
     }
 
     static final String WITH_BODY = "Lorem ipsum dolor sit amet, consectetur" +


### PR DESCRIPTION
Currently `ResponsePublisher` occasionally fails due to unreleased resources.
Updated test based on [AbstractThrowingPushPromises](https://github.com/openjdk/jdk/blob/b80001de0c0aeedeb412430660a4727fc26be98b/test/jdk/java/net/httpclient/AbstractThrowingPushPromises.java#L343) to ensure that non-shared clients get closed before further iterations run, this should limit the max number of clients that remain alive during the test.

I ran tiers 1-3 and everything is passing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311792](https://bugs.openjdk.org/browse/JDK-8311792): java/net/httpclient/ResponsePublisher.java fails intermittently with AssertionError: Found some outstanding operations (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15307/head:pull/15307` \
`$ git checkout pull/15307`

Update a local copy of the PR: \
`$ git checkout pull/15307` \
`$ git pull https://git.openjdk.org/jdk.git pull/15307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15307`

View PR using the GUI difftool: \
`$ git pr show -t 15307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15307.diff">https://git.openjdk.org/jdk/pull/15307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15307#issuecomment-1680514783)