### PR TITLE
JDK-8314272: Improve java.util.prefs.BackingStoreException: Couldn't get file lock.

### DIFF
--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -702,9 +702,12 @@ class FileSystemPreferences extends AbstractPreferences {
         return new FileSystemPreferences(this, name);
     }
 
+    @SuppressWarnings("removal")
+    private static final String osName = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("os.name"));
+
     private static String getErrorString(int errCode) {
-        String os = System.getProperty("os.name");
-        if (errCode == 35 && (os.contains("Mac") || os.contains("Darwin"))) return "EAGAIN";
+        if (errCode == 35 && (osName.contains("Mac") || osName.contains("Darwin"))) return "EAGAIN";
         switch (errCode) {
             case 13: return "EACCES";
             case 11: return "EAGAIN"; // macOS has for this 35

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -728,8 +728,8 @@ class FileSystemPreferences extends AbstractPreferences {
             int errCode = lockFile(false);
             if (errCode != 0) {
                 String errStr = getErrorString(errCode);
-                if (! errStr.equals("")) errStr = " (" + errStr + ")";
-                throw(new BackingStoreException("Couldn't get file lock. errno is " + errCode + errStr));
+                if (!errStr.equals("")) errStr = " (" + errStr + ")";
+                throw new BackingStoreException("Couldn't get file lock. errno is " + errCode + errStr);
             }
             try {
                 super.removeNode();
@@ -795,8 +795,8 @@ class FileSystemPreferences extends AbstractPreferences {
                String sharingMode = "shared";
                if (!shared) sharingMode = "nonshared";
                String errStr = getErrorString(errCode);
-               if (! errStr.equals("")) errStr = " (" + errStr + ")";
-               throw(new BackingStoreException("Couldn't get file lock. errno is " + errCode + errStr + " mode is " + sharingMode));
+               if (!errStr.equals("")) errStr = " (" + errStr + ")";
+               throw new BackingStoreException("Couldn't get file lock. errno is " + errCode + errStr + " mode is " + sharingMode);
            }
            final Long newModTime =
                 AccessController.doPrivileged(

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -33,7 +33,6 @@ import java.security.PrivilegedExceptionAction;
 import java.security.PrivilegedActionException;
 import sun.util.logging.PlatformLogger;
 
-
 /**
  * Preferences implementation for Unix.  Preferences are stored in the file
  * system, with one directory per preferences node.  All of the preferences


### PR DESCRIPTION
We run into some BackingStoreException: Couldn't get file lock. e.g. here :

[JShell] Exception in thread "main" java.lang.IllegalStateException: java.util.prefs.BackingStoreException: Couldn't get file lock.
[JShell] at jdk.jshell/jdk.internal.jshell.tool.JShellToolBuilder$PreferencesStorage.flush(JShellToolBuilder.java:313)
[JShell] at jdk.jshell/jdk.internal.jshell.tool.JShellTool$ReplayableHistory.storeHistory(JShellTool.java:692)
[JShell] at jdk.jshell/jdk.internal.jshell.tool.JShellTool.start(JShellTool.java:1008)
[JShell] at jdk.jshell/jdk.internal.jshell.tool.JShellToolBuilder.start(JShellToolBuilder.java:261)
[JShell] at jdk.jshell/jdk.internal.jshell.tool.JShellToolProvider.main(JShellToolProvider.java:120)
[JShell] Caused by: java.util.prefs.BackingStoreException: Couldn't get file lock.
[JShell] at java.prefs/java.util.prefs.FileSystemPreferences.sync(FileSystemPreferences.java:769)
[JShell] at java.prefs/java.util.prefs.FileSystemPreferences.flush(FileSystemPreferences.java:864)
[JShell] at jdk.jshell/jdk.internal.jshell.tool.JShellToolBuilder$PreferencesStorage.flush(JShellToolBuilder.java:311)
[JShell] ... 4 more

The BackingStoreException should be enhanced e.g. by adding the errno/errorCode that is already available in the coding

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314272](https://bugs.openjdk.org/browse/JDK-8314272): Improve java.util.prefs.BackingStoreException: Couldn't get file lock. (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [9230e1e3](https://git.openjdk.org/jdk/pull/15308/files/9230e1e350b4837bb4960f24c6091e411c7fafdd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15308/head:pull/15308` \
`$ git checkout pull/15308`

Update a local copy of the PR: \
`$ git checkout pull/15308` \
`$ git pull https://git.openjdk.org/jdk.git pull/15308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15308`

View PR using the GUI difftool: \
`$ git pr show -t 15308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15308.diff">https://git.openjdk.org/jdk/pull/15308.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15308#issuecomment-1680636602)