### PR TITLE
JDK-8314426: runtime/os/TestTrimNative.java is failing on slow machines

### DIFF
--- a/test/hotspot/jtreg/runtime/os/TestTrimNative.java
+++ b/test/hotspot/jtreg/runtime/os/TestTrimNative.java
@@ -301,8 +301,7 @@ public class TestTrimNative {
                         new String[] { TestTrimNative.Tester.class.getName(), "0" }
                 );
                 long ms2 = System.currentTimeMillis();
-                long runtime_ms = ms2 - ms1;
-                long maxTrimsExpected = runtime_ms;
+                int maxTrimsExpected = (int)(ms2 - ms1); // 1ms trim interval
                 checkExpectedLogMessages(output, true, 1);
                 parseOutputAndLookForNegativeTrim(output, 1, (int)maxTrimsExpected, strictTesting);
             } break;

--- a/test/hotspot/jtreg/runtime/os/TestTrimNative.java
+++ b/test/hotspot/jtreg/runtime/os/TestTrimNative.java
@@ -170,7 +170,6 @@ public class TestTrimNative {
         if (expectEnabled) {
             output.shouldContain("Periodic native trim enabled (interval: " + expectedInterval + " ms");
             output.shouldContain("Native heap trimmer start");
-            output.shouldContain("Native heap trimmer stop");
         } else {
             output.shouldNotContain("Periodic native trim enabled");
         }
@@ -251,7 +250,7 @@ public class TestTrimNative {
             System.gc();
 
             // give GC time to react
-            System.out.println("Sleeping...");
+            System.out.println("Sleeping for " + sleeptime + " ms...");
             Thread.sleep(sleeptime);
             System.out.println("Done.");
         }
@@ -296,12 +295,16 @@ public class TestTrimNative {
 
             case "trimNativeLowInterval":
             case "trimNativeLowIntervalStrict": {
+                long ms1 = System.currentTimeMillis();
                 OutputAnalyzer output = runTestWithOptions(
                         new String[] { "-XX:+UnlockExperimentalVMOptions", "-XX:TrimNativeHeapInterval=1" },
                         new String[] { TestTrimNative.Tester.class.getName(), "0" }
                 );
+                long ms2 = System.currentTimeMillis();
+                long runtime_ms = ms2 - ms1;
+                long maxTrimsExpected = runtime_ms;
                 checkExpectedLogMessages(output, true, 1);
-                parseOutputAndLookForNegativeTrim(output, 1, 3000, strictTesting);
+                parseOutputAndLookForNegativeTrim(output, 1, (int)maxTrimsExpected, strictTesting);
             } break;
 
             case "testOffOnNonCompliantPlatforms": {


### PR DESCRIPTION
SAP reported errors on slow machines. Patch hardens the test against that.

- remove the grep for "Native Trimmer Stop" message, since that message is raced by the VM death and may not appear on slow machines
- for the low-interval test, made the number of trims to happen dependent on the runtime of the test. On slow machines, we could run longer than 3 seconds and therefore see more trim messages

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314426](https://bugs.openjdk.org/browse/JDK-8314426): runtime/os/TestTrimNative.java is failing on slow machines (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [087687b4](https://git.openjdk.org/jdk/pull/15309/files/087687b46272c642d218b25b7cdefa98aa2a3e18)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [087687b4](https://git.openjdk.org/jdk/pull/15309/files/087687b46272c642d218b25b7cdefa98aa2a3e18)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [087687b4](https://git.openjdk.org/jdk/pull/15309/files/087687b46272c642d218b25b7cdefa98aa2a3e18)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15309/head:pull/15309` \
`$ git checkout pull/15309`

Update a local copy of the PR: \
`$ git checkout pull/15309` \
`$ git pull https://git.openjdk.org/jdk.git pull/15309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15309`

View PR using the GUI difftool: \
`$ git pr show -t 15309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15309.diff">https://git.openjdk.org/jdk/pull/15309.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15309#issuecomment-1687900363)