### PR TITLE
8314406: Provide a shared doubly LinkedList implementation

### DIFF
--- a/src/hotspot/share/utilities/doublyLinkedList.hpp
+++ b/src/hotspot/share/utilities/doublyLinkedList.hpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef SHARE_UTILITIES_DOUBLYLINKEDLIST_HPP
+#define SHARE_UTILITIES_DOUBLYLINKEDLIST_HPP
+
+#include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+template<typename NodeTraits>
+class DoublyLinkedList;
+
+// Base element in a doubly linked list.
+class DoublyLinkedListNode {
+  template<typename T>
+  friend class DoublyLinkedList;
+
+  DoublyLinkedListNode* _next;
+  DoublyLinkedListNode* _prev;
+
+  NONCOPYABLE(DoublyLinkedListNode);
+
+  void verify_links() const;
+  void verify_links_linked() const;
+  void verify_links_unlinked() const;
+
+public:
+  DoublyLinkedListNode();
+  ~DoublyLinkedListNode();
+};
+
+template <typename T, size_t m_offset>
+struct ListNodeTraits {
+  using ValueType = T;
+
+  static DoublyLinkedListNode* to_node_ptr(ValueType* elem) {
+    return reinterpret_cast<DoublyLinkedListNode*>(
+              reinterpret_cast<char*>(elem) + m_offset);
+  }
+
+  static ValueType* to_value_ptr(DoublyLinkedListNode* node ) {
+    return reinterpret_cast<ValueType*>(
+              reinterpret_cast<char*>(node) - m_offset);
+  }
+};
+
+
+// The DoublyLinkedList template provides insertion, removal, and traversal of elements in a doubly
+// linked list structure. The DoublyLinkedList is configured using NodeTraits which contain
+// information on the Nodes in the list. NodeTraits must support the interface:
+//    typedef ValueType; - Type of elements in the list
+//    static ValueType* to_value_ptr(DoublyLinkedListNode* node ); - return the element that contains the list node.
+//    static DoublyLinkedListNode* to_node_ptr(ValueType* elem); - return the DoublyLinkedList node associated with the list.
+//
+// Note: The DoublyLinkedList does not perform memory allocation or deallocation for the elements.
+// Therefore, it is the responsibility of the class template users to manage the memory of the
+// elements added or removed from the list.
+//
+template<typename NodeTraits>
+class DoublyLinkedList {
+  using Node = DoublyLinkedListNode;
+  using T = typename NodeTraits::ValueType;
+
+  Node _head;
+  size_t _size;
+
+  NONCOPYABLE(DoublyLinkedList);
+
+  void verify_head() const;
+
+  void insert(Node* before, Node* node);
+
+  Node* cast_to_inner(T* elem) const;
+  T* cast_to_outer(Node* node) const;
+
+  Node* next(Node* elem) const;
+  Node* prev(Node* elem) const;
+
+public:
+  DoublyLinkedList();
+  ~DoublyLinkedList();
+
+  size_t size() const;
+  bool is_empty() const;
+
+  T* first() const;
+  T* last() const;
+
+  void insert_first(T* elem);
+  void insert_last(T* elem);
+  void insert_before(T* before, T* elem);
+  void insert_after(T* after, T* elem);
+
+  void remove(T* elem);
+  T* remove_first();
+  T* remove_last();
+
+  class Iterator;
+
+  class RemoveIterator;
+
+  Iterator begin();
+  Iterator end();
+};
+
+template <typename NodeTraits>
+class DoublyLinkedList<NodeTraits>::Iterator : public StackObj {
+  using T = typename NodeTraits::ValueType;
+  friend class DoublyLinkedList<NodeTraits>;
+
+  const DoublyLinkedList<NodeTraits>* const _list;
+  DoublyLinkedListNode* _cur_node;
+
+  Iterator(const DoublyLinkedList<NodeTraits>* list, DoublyLinkedListNode* start);
+
+public:
+  Iterator& operator++() {
+    _cur_node = _list->next(_cur_node);
+    return *this;
+  }
+
+  Iterator operator++(int) {
+    Iterator tmp = *this;
+    ++(*this);
+    return tmp;
+  }
+
+  Iterator& operator--() {
+    assert(_cur_node != nullptr, "Sanity");
+    _cur_node = _list->prev(_cur_node);
+    return *this;
+  }
+
+  Iterator operator--(int) {
+    Iterator tmp = *this;
+    --(*this);
+    return tmp;
+  }
+
+  T* operator*() { return _list->cast_to_outer(_cur_node); }
+
+  bool operator==(const Iterator& rhs) {
+    assert(_list == rhs._list, "iterator belongs to different List");
+    return _cur_node == rhs._cur_node;
+  }
+
+  bool operator!=(const Iterator& rhs) {
+    assert(_list == rhs._list, "iterator belongs to different List");
+    return _cur_node != rhs._cur_node;
+  }
+};
+
+template <typename NodeTraits>
+class DoublyLinkedList<NodeTraits>::RemoveIterator : public StackObj {
+  using T = typename NodeTraits::ValueType;
+private:
+  DoublyLinkedList<NodeTraits>* const _list;
+  const bool _forward;
+
+public:
+  explicit RemoveIterator(DoublyLinkedList<NodeTraits>* list, bool forward_iterate = true);
+
+  bool next(T** elem);
+};
+
+#endif // SHARE_UTILITIES_DOUBLYLINKEDLIST_HPP

--- a/src/hotspot/share/utilities/doublyLinkedList.inline.hpp
+++ b/src/hotspot/share/utilities/doublyLinkedList.inline.hpp
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifndef SHARE_UTILITIES_DOUBLYLINKEDLIST_INLINE_HPP
+#define SHARE_UTILITIES_DOUBLYLINKEDLIST_INLINE_HPP
+
+#include "utilities/doublyLinkedList.hpp"
+
+#include "utilities/debug.hpp"
+
+inline DoublyLinkedListNode::DoublyLinkedListNode()
+  : _next(this),
+    _prev(this) { }
+
+inline DoublyLinkedListNode::~DoublyLinkedListNode() {
+  verify_links_unlinked();
+}
+
+inline void DoublyLinkedListNode::verify_links() const {
+  assert(_next->_prev == this, "Corrupt list node");
+  assert(_prev->_next == this, "Corrupt list node");
+}
+
+inline void DoublyLinkedListNode::verify_links_linked() const {
+  assert(_next != this, "Should be in a list");
+  assert(_prev != this, "Should be in a list");
+  verify_links();
+}
+
+inline void DoublyLinkedListNode::verify_links_unlinked() const {
+  assert(_next == this, "Should not be in a list");
+  assert(_prev == this, "Should not be in a list");
+}
+
+template <typename NodeTraits>
+inline void DoublyLinkedList<NodeTraits>::verify_head() const {
+  _head.verify_links();
+}
+
+template <typename NodeTraits>
+inline DoublyLinkedList<NodeTraits>::~DoublyLinkedList() = default;
+
+template <typename NodeTraits>
+inline void DoublyLinkedList<NodeTraits>::insert(Node* before, Node* node) {
+  verify_head();
+  before->verify_links();
+  node->verify_links_unlinked();
+
+  node->_prev = before;
+  node->_next = before->_next;
+  before->_next = node;
+  node->_next->_prev = node;
+
+  before->verify_links_linked();
+  node->verify_links_linked();
+
+  _size++;
+}
+
+
+template <typename NodeTraits>
+inline DoublyLinkedListNode* DoublyLinkedList<NodeTraits>::cast_to_inner(T* elem) const {
+  return NodeTraits::to_node_ptr(elem);
+}
+
+template <typename NodeTraits>
+inline typename NodeTraits::ValueType* DoublyLinkedList<NodeTraits>::cast_to_outer(Node* node) const {
+  return NodeTraits::to_value_ptr(node);
+}
+
+template <typename NodeTraits>
+inline DoublyLinkedList<NodeTraits>::DoublyLinkedList()
+  : _head(),
+    _size(0) {
+  verify_head();
+}
+
+template <typename NodeTraits>
+inline size_t DoublyLinkedList<NodeTraits>::size() const {
+  verify_head();
+  return _size;
+}
+
+template <typename NodeTraits>
+inline bool DoublyLinkedList<NodeTraits>::is_empty() const {
+  return size() == 0;
+}
+
+template <typename NodeTraits>
+inline typename NodeTraits::ValueType* DoublyLinkedList<NodeTraits>::first() const {
+  return is_empty() ? nullptr : cast_to_outer(_head._next);
+}
+
+template <typename NodeTraits>
+inline typename NodeTraits::ValueType* DoublyLinkedList<NodeTraits>::last() const {
+  return is_empty() ? nullptr : cast_to_outer(_head._prev);
+}
+
+template <typename NodeTraits>
+inline DoublyLinkedListNode* DoublyLinkedList<NodeTraits>::next(Node* elem) const {
+  verify_head();
+
+  return elem->_next;
+}
+
+template <typename NodeTraits>
+inline DoublyLinkedListNode* DoublyLinkedList<NodeTraits>::prev(Node* elem) const {
+  verify_head();
+
+  return elem->_prev;
+}
+
+template <typename NodeTraits>
+inline void DoublyLinkedList<NodeTraits>::insert_first(T* elem) {
+  insert(&_head, cast_to_inner(elem));
+}
+
+template <typename NodeTraits>
+inline void DoublyLinkedList<NodeTraits>::insert_last(T* elem) {
+  insert(_head._prev, cast_to_inner(elem));
+}
+
+template <typename NodeTraits>
+inline void DoublyLinkedList<NodeTraits>::insert_before(T* before, T* elem) {
+  insert(cast_to_inner(before)->_prev, cast_to_inner(elem));
+}
+
+template <typename NodeTraits>
+inline void DoublyLinkedList<NodeTraits>::insert_after(T* after, T* elem) {
+  insert(cast_to_inner(after), cast_to_inner(elem));
+}
+
+template <typename NodeTraits>
+inline void DoublyLinkedList<NodeTraits>::remove(T* elem) {
+  verify_head();
+
+  Node* const node = cast_to_inner(elem);
+  node->verify_links_linked();
+
+  Node* const next = node->_next;
+  Node* const prev = node->_prev;
+  next->verify_links_linked();
+  prev->verify_links_linked();
+
+  node->_next = prev->_next;
+  node->_prev = next->_prev;
+  node->verify_links_unlinked();
+
+  next->_prev = prev;
+  prev->_next = next;
+  next->verify_links();
+  prev->verify_links();
+
+  assert(_size > 0, "Sanity check!");
+  _size--;
+}
+
+template <typename NodeTraits>
+inline typename NodeTraits::ValueType* DoublyLinkedList<NodeTraits>::remove_first() {
+  T* elem = first();
+  if (elem != nullptr) {
+    remove(elem);
+  }
+  return elem;
+}
+
+template <typename NodeTraits>
+inline typename NodeTraits::ValueType* DoublyLinkedList<NodeTraits>::remove_last() {
+  T* elem = last();
+  if (elem != nullptr) {
+    remove(elem);
+  }
+  return elem;
+}
+
+template <typename NodeTraits>
+inline typename DoublyLinkedList<NodeTraits>::Iterator DoublyLinkedList<NodeTraits>::begin() {
+ return Iterator(this, _head._next);
+}
+
+template <typename NodeTraits>
+inline typename DoublyLinkedList<NodeTraits>::Iterator DoublyLinkedList<NodeTraits>::end() {
+ return Iterator(this, &_head);
+}
+
+template <typename NodeTraits>
+inline DoublyLinkedList<NodeTraits>::Iterator::Iterator(const DoublyLinkedList<NodeTraits>* list, DoublyLinkedListNode* start)
+  : _list(list),
+    _cur_node(start) {}
+
+template <typename NodeTraits>
+inline DoublyLinkedList<NodeTraits>::RemoveIterator::RemoveIterator(DoublyLinkedList<NodeTraits>* list, bool forward_iterate)
+  : _list(list),
+    _forward(forward_iterate) {}
+
+
+template <typename NodeTraits>
+inline bool DoublyLinkedList<NodeTraits>::RemoveIterator::next(T** elem) {
+  *elem = _forward ? _list->remove_first() : _list->remove_last();
+  return *elem != nullptr;
+}
+
+#endif // SHARE_UTILITIES_DOUBLYLINKEDLIST_INLINE_HPP

--- a/test/hotspot/gtest/utilities/test_doublyLinkedList.cpp
+++ b/test/hotspot/gtest/utilities/test_doublyLinkedList.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+
+ */
+
+#include "precompiled.hpp"
+#include "unittest.hpp"
+#include "utilities/doublyLinkedList.inline.hpp"
+
+class ListTestElement : public StackObj {
+ private:
+  size_t _value;
+ public:
+  DoublyLinkedListNode _node;
+
+  ListTestElement(size_t i = 0)
+    : _value(i),
+      _node() { }
+
+  size_t value() const { return _value; }
+
+  void set_value(size_t value) { _value = value; }
+};
+
+struct ListTestElement2 : public StackObj {
+  size_t _value;
+  DoublyLinkedListNode _list1;
+  DoublyLinkedListNode _list2;
+
+  ListTestElement2(size_t i = 0)
+    : _value(i),
+      _list1(),
+      _list2() { }
+
+  size_t value() const { return _value; }
+  void set_value(size_t value) { _value = value; }
+};
+
+struct TestNodeTraits {
+  using ValueType = ListTestElement;
+  using NodeType = DoublyLinkedListNode;
+
+  static NodeType* to_node_ptr(ValueType* elem) {
+    return &elem->_node;
+  }
+
+  static ValueType* to_value_ptr(NodeType* node ) {
+    return (ValueType*)((uintptr_t)node - offset_of(ValueType, _node));
+  }
+};
+
+typedef DoublyLinkedList<TestNodeTraits> TestDoublyLinkedList;
+
+struct DoublyLinkedListTest : public ::testing::Test {
+  static const size_t num_elements = 10;
+  ListTestElement elements[num_elements];
+  TestDoublyLinkedList dlist;
+
+  DoublyLinkedListTest();
+  ~DoublyLinkedListTest();
+
+  void initialize();
+  void teardown();
+};
+
+const size_t DoublyLinkedListTest::num_elements;
+
+DoublyLinkedListTest::DoublyLinkedListTest() : dlist() {
+  initialize();
+}
+
+void DoublyLinkedListTest::initialize() {
+  ASSERT_TRUE(dlist.is_empty());
+  ASSERT_EQ(0u, dlist.size());
+  ASSERT_TRUE(dlist.first() == nullptr);
+  ASSERT_TRUE(dlist.last() == nullptr);
+  ASSERT_TRUE(dlist.remove_first() == nullptr);
+  ASSERT_TRUE(dlist.remove_last() == nullptr);
+
+  for (size_t i = 0; i < num_elements; ++i) {
+    elements[i].set_value(i);
+    ListTestElement* e = &elements[i];
+    dlist.insert_last(e);
+    ASSERT_FALSE(dlist.is_empty());
+    ASSERT_EQ(e, dlist.last());
+  }
+
+  ASSERT_TRUE(dlist.first() == &elements[0]);
+  ASSERT_EQ(num_elements, dlist.size());
+}
+
+void DoublyLinkedListTest::teardown() {
+  TestDoublyLinkedList::RemoveIterator rm_iter(&dlist);
+
+  ListTestElement* e = nullptr;
+  while (rm_iter.next(&e)) { }
+
+  ASSERT_TRUE(dlist.is_empty());
+  ASSERT_EQ(0u, dlist.size());
+}
+
+DoublyLinkedListTest::~DoublyLinkedListTest() {
+  teardown();
+}
+
+TEST(DoublyLinkedList, node_traits) {
+  ListTestElement2 e;
+  constexpr uintptr_t offset = offsetof(ListTestElement2, _list1);
+  DoublyLinkedListNode* list_node = ListNodeTraits<ListTestElement2, offset>::to_node_ptr(&e);
+  ASSERT_EQ(list_node, &e._list1);
+
+  ListTestElement e2;
+  DoublyLinkedListNode* list_node2 = TestNodeTraits::to_node_ptr(&e2);
+  ASSERT_EQ(list_node2, &e2._node);
+}
+
+TEST_F(DoublyLinkedListTest, insert_remove_last) {
+
+  for (size_t i = num_elements; i > 0; ) {
+    ASSERT_FALSE(dlist.is_empty());
+    ASSERT_EQ(i, dlist.size());
+    --i;
+    ListTestElement* e = dlist.remove_last();
+    ASSERT_TRUE(e != nullptr);
+    ASSERT_EQ(e, &elements[i]);
+  }
+
+  ASSERT_TRUE(dlist.is_empty());
+  ASSERT_EQ(0u, dlist.size());
+}
+
+TEST_F(DoublyLinkedListTest, insert_remove_first) {
+  teardown(); // First clear the list
+
+  ASSERT_TRUE(dlist.is_empty());
+  ASSERT_EQ(0u, dlist.size());
+  ASSERT_TRUE(dlist.first() == nullptr);
+  ASSERT_TRUE(dlist.last() == nullptr);
+  ASSERT_TRUE(dlist.remove_first() == nullptr);
+  ASSERT_TRUE(dlist.remove_last() == nullptr);
+
+  for (size_t i = 0; i < num_elements; ++i) {
+    elements[i].set_value(i);
+    ListTestElement* e = &elements[i];
+    dlist.insert_first(e);
+    ASSERT_FALSE(dlist.is_empty());
+    ASSERT_EQ(e, dlist.first());
+  }
+
+  ASSERT_EQ(num_elements, dlist.size());
+
+  for (size_t i = num_elements; i > 0; ) {
+    ASSERT_FALSE(dlist.is_empty());
+    ASSERT_EQ(i, dlist.size());
+    --i;
+    ListTestElement* e = dlist.remove_first();
+    ASSERT_TRUE(e != nullptr);
+    ASSERT_EQ(e, &elements[i]);
+  }
+
+  ASSERT_TRUE(dlist.is_empty());
+  ASSERT_EQ(0u, dlist.size());
+}
+
+TEST_F(DoublyLinkedListTest, insert_remove) {
+
+  ListTestElement* first = dlist.remove_first();
+  ListTestElement* last = dlist.last();
+
+  dlist.insert_after(last, first);
+  ASSERT_EQ(first, dlist.last());
+
+  first = dlist.remove_last();
+  dlist.insert_before(last, first);
+  ASSERT_EQ(last, dlist.last());
+}
+
+TEST_F(DoublyLinkedListTest, forward_iterate) {
+  size_t i = 0;
+  for (ListTestElement* e : dlist) {
+    ASSERT_FALSE(dlist.is_empty());
+    ASSERT_EQ(e, &elements[i++]);
+  }
+
+  TestDoublyLinkedList::Iterator iter = dlist.begin();
+  i = 0;
+  while (iter != dlist.end()) {
+    ListTestElement* e = *iter;
+    ASSERT_FALSE(dlist.is_empty());
+    ASSERT_EQ(e, &elements[i++]);
+    ++iter;
+  }
+}
+
+TEST_F(DoublyLinkedListTest, reverse_iterate) {
+  size_t i = num_elements;
+  TestDoublyLinkedList::Iterator iter = dlist.end();
+
+  while (iter-- != dlist.begin()) {
+    ListTestElement* e = *iter;
+    ASSERT_FALSE(dlist.is_empty());
+    ASSERT_EQ(e, &elements[--i]);
+  }
+}
+
+TEST_F(DoublyLinkedListTest, remove_iterate) {
+  size_t i = num_elements;
+  TestDoublyLinkedList::RemoveIterator rm_iter(&dlist, false /* forward_iterate */);
+
+  ListTestElement* e = nullptr;
+  while (rm_iter.next(&e)) {
+    ASSERT_EQ(e, &elements[--i]);
+  }
+
+  ASSERT_TRUE(dlist.is_empty());
+  ASSERT_EQ(0u, dlist.size());
+}
+
+TEST(DoublyLinkedList, two_lists) {
+  constexpr uintptr_t offset_list_1 = offsetof(ListTestElement2, _list1);
+  constexpr uintptr_t offset_list_2 = offsetof(ListTestElement2, _list2);
+
+  using TestListType_1 = DoublyLinkedList<ListNodeTraits<ListTestElement2, offset_list_1>>;
+  using TestListType_2 = DoublyLinkedList<ListNodeTraits<ListTestElement2, offset_list_2>>;
+
+  TestListType_1 dlist_1;
+  TestListType_2 dlist_2;
+
+  static const size_t num_elements = 10;
+  ListTestElement2 elements[num_elements];
+
+  ASSERT_TRUE(dlist_1.is_empty());
+  ASSERT_TRUE(dlist_2.is_empty());
+
+  for (size_t i = 0; i < num_elements; ++i) {
+    elements[i].set_value(i);
+    ListTestElement2* e = &elements[i];
+    dlist_1.insert_last(e);
+    ASSERT_FALSE(dlist_1.is_empty());
+    ASSERT_EQ(e, dlist_1.last());
+
+    dlist_2.insert_last(e);
+  }
+
+  ASSERT_EQ(num_elements, dlist_1.size());
+  ASSERT_EQ(num_elements, dlist_2.size());
+
+  TestListType_1::RemoveIterator rm_iter(&dlist_1, false /* forward_iterate */);
+
+  size_t i = num_elements;
+  ListTestElement2* e = nullptr;
+  while (rm_iter.next(&e)) {
+    ASSERT_EQ(e, &elements[--i]);
+  }
+
+  ASSERT_TRUE(dlist_1.is_empty());
+  ASSERT_EQ(0u, dlist_1.size());
+
+  ASSERT_EQ(num_elements, dlist_2.size());
+
+  TestListType_2::RemoveIterator rm_iter2(&dlist_2, true /* forward_iterate */);
+
+  i = 0;
+  while (rm_iter2.next(&e)) {
+    ASSERT_EQ(e, &elements[i++]);
+  }
+
+  ASSERT_TRUE(dlist_2.is_empty());
+}


### PR DESCRIPTION
Hi all,

Please review this refactoring change to move the ZGC ZList to utilities. Mainly code motion with addition of the necessary tests.

Another notable change is allowing the List elements to exist in multiple lists at the same time. 

Testing: 
     - Linux x86_64 fastdebug `gtest:all`.
     - Mach5 GTestWrapper

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314406](https://bugs.openjdk.org/browse/JDK-8314406): Provide a shared doubly LinkedList implementation (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15312/head:pull/15312` \
`$ git checkout pull/15312`

Update a local copy of the PR: \
`$ git checkout pull/15312` \
`$ git pull https://git.openjdk.org/jdk.git pull/15312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15312`

View PR using the GUI difftool: \
`$ git pr show -t 15312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15312.diff">https://git.openjdk.org/jdk/pull/15312.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15312#issuecomment-1680873971)