### PR TITLE
8314213: DocLint should warn about unknown standard tags

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletManager.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletManager.java
@@ -358,7 +358,7 @@ public class TagletManager {
             if (!name.isEmpty() && name.charAt(0) == '@') {
                 name = name.substring(1);
             }
-            if (! (standardTags.contains(name) || allTaglets.containsKey(name))) {
+            if (! (standardTags.contains(name) || allTaglets.containsKey(name))) { // defunct, see 8314213
                 if (standardTagsLowercase.contains(Utils.toLowerCase(name))) {
                     messages.warning(ch.getDocTreePath(tag), "doclet.UnknownTagLowercase", ch.getTagName(tag));
                     continue;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -41,6 +41,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
@@ -1138,8 +1140,21 @@ public class Checker extends DocTreePathScanner<Void, Void> {
     }
 
     private void checkUnknownTag(DocTree tree, String tagName) {
+        // if it were a standard tag, this method wouldn't be called:
+        // a standard tag is never represented by Unknown{Block,Inline}TagTree
+        assert tree instanceof UnknownBlockTagTree
+                || tree instanceof UnknownInlineTagTree;
+        assert !getStandardTags().contains(tagName);
+        // report an unknown tag only if custom tags are set, see 8314213
         if (env.customTags != null && !env.customTags.contains(tagName))
             env.messages.error(SYNTAX, tree, "dc.tag.unknown", tagName);
+    }
+
+    private Set<String> getStandardTags() {
+        return Stream.of(DocTree.Kind.values())
+                .filter(k -> k.tagName != null) // not all DocTree represent tags
+                .map(k -> k.tagName)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override @DefinedBy(Api.COMPILER_TREE)


### PR DESCRIPTION
This PR is primarily informational: aside from adding a few code comments and `assert` statements, it acts as a place to record observations on unknown JavaDoc tag reporting mechanics. Because it's a PR, this text will be automatically sent to the javadoc-dev mailing list and archived for future reference.

---

DocLint can be run in three modes:

  * from javac (i.e. `javac -Xdoclint`)
  * from javadoc (i.e. `javadoc -Xdoclint`)
  * as a standalone test tool (i.e. `test/langtools/tools/doclint/DocLintTester.java`)

While the core of all these modes is the same, `jdk.javadoc.internal.doclint.DocLint`, and is capable of reporting on unknown tags, whether an unknown tag will be reported, depends on the core configuration, which differs significantly among these modes.

The latter mode is for testing only and can be configured flexibly, but it's of little interest to us. The former two modes are important as they face end user, but are limited in their configuration and, additionally, each has own peculiarities.

In javac mode, DocLint cannot be passed with a list of custom tags: the required wiring is missing. So, when a potentially unknown tag is detected, the error is not raised because `env.customTags == null`:

    private void checkUnknownTag(DocTree tree, String tagName) {
        if (env.customTags != null && !env.customTags.contains(tagName))
            ^^^^^^^^^^^^^^^^^^^^^^
            env.messages.error(SYNTAX, tree, "dc.tag.unknown", tagName);
    }

This is why we don't see errors for JDK-specific tags (e.g. `@implSpec`, `@implNote`, `@apiNote`, `@jls`) when `make images`, during which DocLint is run from javac.

In javadoc mode DocLint is passed with a list of custom tags, containing tags captured from `-tag` and `-taglet` options. Because `make docs` runs javadoc with such options for each of the JDK-specific tags, all tags are known, and no errors are reported.

Here's a twist though: javadoc has its own machinery for reporting unknown tags. So why don't we see doubling of diagnostics? There should be an error from DocLint and a warning [sic!] from javadoc, but there's only an error. Here's why:

    public void checkTags(Element element, Iterable<? extends DocTree> trees) {
        CommentHelper ch = utils.getCommentHelper(element);
        for (DocTree tag : trees) {
            String name = tag.getKind().tagName;
                              ^^^^^^^^^^^^^^^^^
            if (name == null) {
                continue;
            }
            if (!name.isEmpty() && name.charAt(0) == '@') {
                name = name.substring(1);
            }
            if (! (standardTags.contains(name) || allTaglets.containsKey(name))) {
                if (standardTagsLowercase.contains(Utils.toLowerCase(name))) {
                    messages.warning(ch.getDocTreePath(tag), "doclet.UnknownTagLowercase", ch.getTagName(tag));
                    continue;
                } else {
                    messages.warning(ch.getDocTreePath(tag), "doclet.UnknownTag", ch.getTagName(tag));
                    continue;
                }
            }

Unknown tags are modelled by two `DocTree` subinterfaces, `UnknownInlineTagTree` and `UnknownBlockTagTree`, each of which return the name of the captured tag from `getTagName()`, not from `getKind().tagName`, which (unsurprisingly) returns null for those two kinds. That means that the body of this `if` block is dead code (i.e. DocLint or not, it's never reached for an unknown tag):

            if (! (standardTags.contains(name) || allTaglets.containsKey(name))) {

Here's another twist: DocLint can be disabled for a javadoc run: `-Xdoclint:none`. When coupled with defunct javadoc reporting, disabled DocLint means that no unknown tags are reported.

I don't know which of the above is by mistake and which by design, but it's how it works today. We could address (some of) that in a later PR. Personally, I wouldn't provide missing wiring in javac, given that javac mode has been recently somewhat de-emphasized. That said, I think we should repair javadoc reporting and make sure that either DocLint or javadoc, but not both, report on unknown tags at all times (i.e. whatever the javadoc configuration might be).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314213](https://bugs.openjdk.org/browse/JDK-8314213): DocLint should warn about unknown standard tags (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15314/head:pull/15314` \
`$ git checkout pull/15314`

Update a local copy of the PR: \
`$ git checkout pull/15314` \
`$ git pull https://git.openjdk.org/jdk.git pull/15314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15314`

View PR using the GUI difftool: \
`$ git pr show -t 15314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15314.diff">https://git.openjdk.org/jdk/pull/15314.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15314#issuecomment-1680962817)