### PR TITLE
JDK-8314477: Improve definition of "prototypical type"

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -88,7 +88,7 @@ import javax.lang.model.util.*;
 public interface TypeElement extends Element, Parameterizable, QualifiedNameable {
     /**
      * Returns the type defined by this class or interface element,
-     * returning the <i>prototypical</i> type for an element
+     * returning the <dfn>{@index "prototypical type"}</dfn> for an element
      * representing a generic type.
      *
      * <p>A generic element defines a family of types, not just one.
@@ -98,6 +98,12 @@ public interface TypeElement extends Element, Parameterizable, QualifiedNameable
      * For example,
      * for the generic class element {@code C<N extends Number>},
      * the parameterized type {@code C<N>} is returned.
+     * Otherwise, for a non-generic class or interface, the
+     * prototypical type mirror corresponds to a use of the type.
+     * None of the components of the prototypical type are annotated,
+     * including the prototypical type itself.
+     *
+     * @apiNote
      * The {@link Types} utility interface has more general methods
      * for obtaining the full range of types defined by an element.
      *

--- a/src/java.compiler/share/classes/javax/lang/model/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/package-info.java
@@ -114,12 +114,8 @@
  * javax.lang.model.element.Element#asType() mapped to} some type.
  * The elements for classes and interfaces get {@linkplain
  * javax.lang.model.element.TypeElement#asType() mapped to} a
- * prototypical type.  (If a class or interface is generic, its
- * prototypical type mirror is parameterized with type arguments
- * matching the type variables of the declaration, all
- * unannotated. Otherwise, for a non-generic class or interface, the
- * prototypical type mirror corresponds to an unannotated use of the
- * type.)  Conversely, in general, many types can map to the same
+ * {@linkplain javax.lang.model.element.TypeElement#asType() prototypical type}.
+ * Conversely, in general, many types can map to the same
  * {@linkplain javax.lang.model.element.TypeElement type element}. For
  * example, the type mirror for the raw type {@code java.util.Set},
  * the prototypical type {@code java.util.Set<E>}, and the type {@code


### PR DESCRIPTION
Use an index tag to make the definition of "prototypical type" more findable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314477](https://bugs.openjdk.org/browse/JDK-8314477): Improve definition of "prototypical type" (**Enhancement** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15320/head:pull/15320` \
`$ git checkout pull/15320`

Update a local copy of the PR: \
`$ git checkout pull/15320` \
`$ git pull https://git.openjdk.org/jdk.git pull/15320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15320`

View PR using the GUI difftool: \
`$ git pr show -t 15320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15320.diff">https://git.openjdk.org/jdk/pull/15320.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15320#issuecomment-1681460502)