### PR TITLE
JDK-8303815: Improve Metaspace test speed

### DIFF
--- a/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
@@ -194,7 +194,7 @@ class ChunkManagerRandomChunkAllocTest {
 
     IntRange rand(100);
 
-    for (int j = 0; j < 1000; j++) {
+    for (int j = 0; j < 750; j++) {
 
       bool force_alloc = false;
       bool force_free = true;
@@ -249,7 +249,7 @@ public:
   // {}
 
   void do_tests() {
-    const int num_runs = 5;
+    const int num_runs = 3;
     for (int n = 0; n < num_runs; n++) {
       one_test();
     }

--- a/test/hotspot/gtest/metaspace/test_freeblocks.cpp
+++ b/test/hotspot/gtest/metaspace/test_freeblocks.cpp
@@ -130,7 +130,7 @@ class FreeBlocksTest {
     bool forcefeed = false;
     bool draining = false;
     bool stop = false;
-    int iter = 100000; // safety stop
+    int iter = 25000; // safety stop
     while (!stop && iter > 0) {
       iter --;
       int surprise = (int)os::random() % 10;

--- a/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
@@ -383,7 +383,7 @@ public:
     // - (rarely) deallocate (simulates metaspace deallocation, e.g. class redefinitions)
     // - delete a test bed (simulates collection of a loader and subsequent return of metaspace to freelists)
 
-    const int iterations = 10000;
+    const int iterations = 2500;
 
     // Lets have a ceiling on number of words allocated (this is independent from the commit limit)
     const size_t max_allocation_size = 8 * M;

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -355,7 +355,7 @@ public:
     TestMap testmap(c->word_size());
     assert(testmap.get_num_set() == 0, "Sanity");
 
-    for (int run = 0; run < 1000; run++) {
+    for (int run = 0; run < 750; run++) {
 
       const size_t committed_words_before = testmap.get_num_set();
       ASSERT_EQ(_commit_limiter.committed_words(), committed_words_before);
@@ -425,7 +425,7 @@ public:
 
     assert(_commit_limit >= _vs_word_size, "No commit limit here pls");
 
-    // Allocate a root chunk and commit a random part of it. Then repeatedly split
+    // Allocate a root chunk and commit a part of it. Then repeatedly split
     // it and merge it back together; observe the committed regions of the split chunks.
 
     Metachunk* c = alloc_root_chunk();
@@ -562,15 +562,10 @@ TEST_VM(metaspace, virtual_space_node_test_2) {
 }
 
 TEST_VM(metaspace, virtual_space_node_test_3) {
-  double d = os::elapsedTime();
   // Test committing uncommitting arbitrary ranges
-  for (int run = 0; run < 100; run++) {
-    VirtualSpaceNodeTest test(metaspace::chunklevel::MAX_CHUNK_WORD_SIZE,
-        metaspace::chunklevel::MAX_CHUNK_WORD_SIZE);
-    test.test_split_and_merge_chunks();
-  }
-  double d2 = os::elapsedTime();
-  LOG("%f", (d2-d));
+  VirtualSpaceNodeTest test(metaspace::chunklevel::MAX_CHUNK_WORD_SIZE,
+      metaspace::chunklevel::MAX_CHUNK_WORD_SIZE);
+  test.test_split_and_merge_chunks();
 }
 
 TEST_VM(metaspace, virtual_space_node_test_4) {

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT1.java
@@ -54,7 +54,24 @@
  * @run main/othervm/timeout=400
  *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      -XX:VerifyMetaspaceInterval=10
- *      TestMetaspaceAllocationMT1
+ *      TestMetaspaceAllocationMT1 3
+ */
+
+/*
+ * @test id=debug-default-strict
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build jdk.test.whitebox.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == true)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/manual
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      TestMetaspaceAllocationMT1 10
  */
 
 /*
@@ -72,7 +89,7 @@
  *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      -XX:VerifyMetaspaceInterval=10
  *      -XX:+MetaspaceGuardAllocations
- *      TestMetaspaceAllocationMT1
+ *      TestMetaspaceAllocationMT1 3
  */
 
 /*
@@ -88,7 +105,7 @@
  *
  * @run main/othervm/timeout=400
  *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *      TestMetaspaceAllocationMT1
+ *      TestMetaspaceAllocationMT1 3
  */
 
 public class TestMetaspaceAllocationMT1 {
@@ -97,7 +114,7 @@ public class TestMetaspaceAllocationMT1 {
 
         final long testAllocationCeiling = 1024 * 1024 * 8; // 8m words = 64M on 64bit
         final int numThreads = 4;
-        final int seconds = 10;
+        final int seconds = Integer.parseInt(args[0]);
 
         for (int i = 0; i < 3; i ++) {
 

--- a/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/elastic/TestMetaspaceAllocationMT2.java
@@ -54,7 +54,24 @@
  * @run main/othervm/timeout=400
  *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      -XX:VerifyMetaspaceInterval=10
- *      TestMetaspaceAllocationMT2
+ *      TestMetaspaceAllocationMT2 3
+ */
+
+/*
+ * @test id=debug-default-strict
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build jdk.test.whitebox.WhiteBox
+ * @key randomness
+ * @requires (vm.debug == true)
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/manual
+ *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      -XX:VerifyMetaspaceInterval=10
+ *      TestMetaspaceAllocationMT2 10
  */
 
 /*
@@ -72,7 +89,7 @@
  *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *      -XX:VerifyMetaspaceInterval=10
  *      -XX:+MetaspaceGuardAllocations
- *      TestMetaspaceAllocationMT2
+ *      TestMetaspaceAllocationMT2 3
  */
 
 /*
@@ -88,7 +105,7 @@
  *
  * @run main/othervm/timeout=400
  *      -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
- *      TestMetaspaceAllocationMT2
+ *      TestMetaspaceAllocationMT2 3
  */
 
 public class TestMetaspaceAllocationMT2 {
@@ -97,7 +114,7 @@ public class TestMetaspaceAllocationMT2 {
 
         final long testAllocationCeiling = 1024 * 1024 * 6; // 8m words = 64M on 64bit
         final int numThreads = 4;
-        final int seconds = 10;
+        final int seconds = Integer.parseInt(args[0]);
 
         for (int i = 0; i < 3; i ++) {
 


### PR DESCRIPTION
Small adjustments that cut down time needed for Metaspace tests:

gtests: 22 seconds -> 6 seconds
elastic metaspace jtreg tests: 36 seconds -> 15 seconds

For the jtreg tests, I preserve the option to execute them full time as manual tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303815](https://bugs.openjdk.org/browse/JDK-8303815): Improve Metaspace test speed (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15324/head:pull/15324` \
`$ git checkout pull/15324`

Update a local copy of the PR: \
`$ git checkout pull/15324` \
`$ git pull https://git.openjdk.org/jdk.git pull/15324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15324`

View PR using the GUI difftool: \
`$ git pr show -t 15324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15324.diff">https://git.openjdk.org/jdk/pull/15324.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15324#issuecomment-1682106742)