### PR TITLE
8314071: Test java/foreign/TestByteBuffer.java timed out

### DIFF
--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -25,7 +25,7 @@
  * @test
  * @enablePreview
  * @modules java.base/sun.nio.ch java.base/jdk.internal.foreign
- * @run testng/othervm --enable-native-access=ALL-UNNAMED TestByteBuffer
+ * @run testng/othervm/timeout=600 --enable-native-access=ALL-UNNAMED TestByteBuffer
  */
 
 import java.lang.foreign.*;
@@ -82,7 +82,7 @@ import static org.testng.Assert.*;
 
 public class TestByteBuffer {
 
-    static Path tempPath;
+    static final Path tempPath;
 
     static {
         try {
@@ -109,16 +109,16 @@ public class TestByteBuffer {
                     BB_FLOAT.withName("value")
             ));
 
-    static SequenceLayout bytes = MemoryLayout.sequenceLayout(100, JAVA_BYTE);
-    static SequenceLayout chars = MemoryLayout.sequenceLayout(100, BB_CHAR);
-    static SequenceLayout shorts = MemoryLayout.sequenceLayout(100, BB_SHORT);
-    static SequenceLayout ints = MemoryLayout.sequenceLayout(100, BB_INT);
-    static SequenceLayout floats = MemoryLayout.sequenceLayout(100, BB_FLOAT);
-    static SequenceLayout longs = MemoryLayout.sequenceLayout(100, BB_LONG);
-    static SequenceLayout doubles = MemoryLayout.sequenceLayout(100, BB_DOUBLE);
+    static final SequenceLayout bytes = MemoryLayout.sequenceLayout(100, JAVA_BYTE);
+    static final SequenceLayout chars = MemoryLayout.sequenceLayout(100, BB_CHAR);
+    static final SequenceLayout shorts = MemoryLayout.sequenceLayout(100, BB_SHORT);
+    static final SequenceLayout ints = MemoryLayout.sequenceLayout(100, BB_INT);
+    static final SequenceLayout floats = MemoryLayout.sequenceLayout(100, BB_FLOAT);
+    static final SequenceLayout longs = MemoryLayout.sequenceLayout(100, BB_LONG);
+    static final SequenceLayout doubles = MemoryLayout.sequenceLayout(100, BB_DOUBLE);
 
-    static VarHandle indexHandle = tuples.varHandle(PathElement.sequenceElement(), PathElement.groupElement("index"));
-    static VarHandle valueHandle = tuples.varHandle(PathElement.sequenceElement(), PathElement.groupElement("value"));
+    static final VarHandle indexHandle = tuples.varHandle(PathElement.sequenceElement(), PathElement.groupElement("index"));
+    static final VarHandle valueHandle = tuples.varHandle(PathElement.sequenceElement(), PathElement.groupElement("value"));
 
     static void initTuples(MemorySegment base, long count) {
         for (long i = 0; i < count ; i++) {
@@ -338,7 +338,7 @@ public class TestByteBuffer {
         }
     }
 
-    static final long LARGE_SIZE = 3L * 1024L * 1024L * 1024L; // 3GB
+    static final long LARGE_SIZE = (2L * 1024L + 512L) * 1024L * 1024L; // 2.5 GiB
 
     @Test
     public void testLargeMappedSegment() throws Throwable {


### PR DESCRIPTION
This PR proposes improving performance for two `VarHandle` objects and increasing the timeout for the tests. The size of a mapped file is also reduced from 3 GiB to 2.5 GiB. This still crosses the 2<sup> 31</sup> boundary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314071](https://bugs.openjdk.org/browse/JDK-8314071): Test java/foreign/TestByteBuffer.java timed out (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15326/head:pull/15326` \
`$ git checkout pull/15326`

Update a local copy of the PR: \
`$ git checkout pull/15326` \
`$ git pull https://git.openjdk.org/jdk.git pull/15326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15326`

View PR using the GUI difftool: \
`$ git pr show -t 15326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15326.diff">https://git.openjdk.org/jdk/pull/15326.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15326#issuecomment-1681966279)