### PR TITLE
8314501: Shenandoah: sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java fails

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
@@ -86,11 +86,7 @@ public class HeapSummary extends Tool {
       printValMB("MetaspaceSize            = ", getFlagValue("MetaspaceSize", flagMap));
       printValMB("CompressedClassSpaceSize = ", getFlagValue("CompressedClassSpaceSize", flagMap));
       printValMB("MaxMetaspaceSize         = ", getFlagValue("MaxMetaspaceSize", flagMap));
-      if (heap instanceof ShenandoahHeap) {
-         printValMB("ShenandoahRegionSize     = ", ShenandoahHeapRegion.regionSizeBytes());
-      } else {
-         printValMB("G1HeapRegionSize         = ", HeapRegion.grainBytes());
-      }
+      printValMB("G1HeapRegionSize         = ", HeapRegion.grainBytes());
 
       System.out.println();
       System.out.println("Heap Usage:");
@@ -138,6 +134,7 @@ public class HeapSummary extends Tool {
          long num_regions = sh.numOfRegions();
          System.out.println("Shenandoah Heap:");
          System.out.println("   regions   = " + num_regions);
+         printValMB("region size = ", ShenandoahHeapRegion.regionSizeBytes());
          printValMB("capacity  = ", num_regions * ShenandoahHeapRegion.regionSizeBytes());
          printValMB("used      = ", sh.used());
          printValMB("committed = ", sh.committed());

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
@@ -86,7 +86,9 @@ public class HeapSummary extends Tool {
       printValMB("MetaspaceSize            = ", getFlagValue("MetaspaceSize", flagMap));
       printValMB("CompressedClassSpaceSize = ", getFlagValue("CompressedClassSpaceSize", flagMap));
       printValMB("MaxMetaspaceSize         = ", getFlagValue("MaxMetaspaceSize", flagMap));
-      printValMB("G1HeapRegionSize         = ", HeapRegion.grainBytes());
+      if (heap instanceof G1CollectedHeap) {
+        printValMB("G1HeapRegionSize         = ", HeapRegion.grainBytes());
+      }
 
       System.out.println();
       System.out.println("Heap Usage:");

--- a/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
+++ b/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
@@ -57,8 +57,7 @@ public class JMapHeapConfigTest {
         "NewRatio",
         "SurvivorRatio",
         "MetaspaceSize",
-        "CompressedClassSpaceSize",
-        "G1HeapRegionSize"};
+        "CompressedClassSpaceSize"};
 
     // Test can't deal with negative jlongs:
     //  ignoring MaxMetaspaceSize


### PR DESCRIPTION
Current test expects `G1HeapRegionSize` flag to be printed out from jmap. But that one is not printed when Shenandoah is enabled. I opted for the minimally intrusive fix: move the additional Shenandoah printout to the Shenandoah-specific block.

Additional testing:
 - [x] Affected test now passes with Shenandoah, continues to pass with G1, Serial, Parallel
 - [x] `sun/tools/jhsdb` passes with {Serial, Parallel, G1, Shenandoah}
 - [x] `serviceability/sa` passes with {Serial, Parallel, G1, Shenandoah}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314501](https://bugs.openjdk.org/browse/JDK-8314501): Shenandoah: sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java fails (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15328/head:pull/15328` \
`$ git checkout pull/15328`

Update a local copy of the PR: \
`$ git checkout pull/15328` \
`$ git pull https://git.openjdk.org/jdk.git pull/15328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15328`

View PR using the GUI difftool: \
`$ git pr show -t 15328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15328.diff">https://git.openjdk.org/jdk/pull/15328.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15328#issuecomment-1682025507)