### PR TITLE
8313901: [TESTBUG] test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java fails with java.lang.VirtualMachineError

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -59,7 +59,7 @@ public class CodeCacheFullCountTest {
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         if (oa.getExitValue() != 0) {
             // Ignore adapter creation failures
-            if (!oa.getStdout().contains("Out of space in CodeCache for adapters")) {
+            if (!oa.getStderr().contains("Out of space in CodeCache for adapters")) {
                 throw new Exception("VM finished with exit code " + oa.getExitValue());
             }
         }

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -57,11 +57,9 @@ public class CodeCacheFullCountTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
-        if (oa.getExitValue() != 0) {
-            // Ignore adapter creation failures
-            if (!oa.getStderr().contains("Out of space in CodeCache for adapters")) {
-                throw new Exception("VM finished with exit code " + oa.getExitValue());
-            }
+        // Ignore adapter creation failures
+        if (oa.getExitValue() != 0 && !oa.getStderr().contains("Out of space in CodeCache for adapters")) {
+            throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
         }
         String stdout = oa.getStdout();
 

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ import java.net.URLClassLoader;
 import java.lang.reflect.Field;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -57,7 +58,7 @@ public class CodeCacheFullCountTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
-        oa.shouldHaveExitValue(0);
+        Asserts.assertEquals(oa.getExitValue(), 0, "Failed to create adapters");
         String stdout = oa.getStdout();
 
         Pattern pattern = Pattern.compile("full_count=(\\d)");

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -59,6 +59,7 @@ public class CodeCacheFullCountTest {
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         // Ignore adapter creation failures
         if (oa.getExitValue() != 0 && !oa.getStderr().contains("Out of space in CodeCache for adapters")) {
+            oa.reportDiagnosticSummary();
             throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
         }
         String stdout = oa.getStdout();

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -26,7 +26,6 @@ import java.net.URLClassLoader;
 import java.lang.reflect.Field;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -58,7 +57,12 @@ public class CodeCacheFullCountTest {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
-        Asserts.assertEquals(oa.getExitValue(), 0, "Failed to create adapters");
+        if (oa.getExitValue() != 0) {
+            // Ignore adapter creation failures
+            if (!oa.getStdout().contains("Out of space in CodeCache for adapters")) {
+                throw new Exception("VM finished with exit code " + oa.getExitValue());
+            }
+        }
         String stdout = oa.getStdout();
 
         Pattern pattern = Pattern.compile("full_count=(\\d)");


### PR DESCRIPTION
I would like to fix this issue because it is difficult for testers to understand why the test failed.
There is no risk as I just added an assertion message instead of exit code error.
I would appreciate it if someone could review the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313901](https://bugs.openjdk.org/browse/JDK-8313901): [TESTBUG] test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java fails with java.lang.VirtualMachineError (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15329/head:pull/15329` \
`$ git checkout pull/15329`

Update a local copy of the PR: \
`$ git checkout pull/15329` \
`$ git pull https://git.openjdk.org/jdk.git pull/15329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15329`

View PR using the GUI difftool: \
`$ git pr show -t 15329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15329.diff">https://git.openjdk.org/jdk/pull/15329.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15329#issuecomment-1682070093)