### PR TITLE
8314481: JDWPTRANSPORT_ERROR_INTERNAL code in socketTransport.c can never be executed

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -740,11 +740,6 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
         listenAddr = &(addrInfo[0]);
     }
 
-    if (listenAddr == NULL) {
-        dbgsysFreeAddrInfo(addrInfo);
-        RETURN_ERROR(JDWPTRANSPORT_ERROR_INTERNAL, "listen failed: wrong address");
-    }
-
     // Binding to IN6ADDR_ANY allows to serve both IPv4 and IPv6 connections,
     // but binding to mapped INADDR_ANY (::ffff:0.0.0.0) allows to serve IPv4
     // connections only. Make sure that IN6ADDR_ANY is preferred over

--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -736,7 +736,7 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
     }
 
     if (listenAddr == NULL) {
-        // No address of preferred address family found, grab the fist one.
+        // No address of preferred address family found, grab the first one.
         listenAddr = &(addrInfo[0]);
     }
 


### PR DESCRIPTION
[JDK-8250630](https://bugs.openjdk.org/browse/JDK-8250630) introduced the following change:

```
     if (listenAddr == NULL) {
+        // No address of preferred addres family found, grab the fist one.
+        listenAddr = &(addrInfo[0]);
+    }
+
+    if (listenAddr == NULL) {
         dbgsysFreeAddrInfo(addrInfo);
         RETURN_ERROR(JDWPTRANSPORT_ERROR_INTERNAL, "listen failed: wrong address");
     }
```

After this change it is no longer possible for the RETURN_ERROR block to ever be executed because listenAddr can not ever still be NULL. The entire block should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314481](https://bugs.openjdk.org/browse/JDK-8314481): JDWPTRANSPORT_ERROR_INTERNAL code in socketTransport.c can never be executed (**Bug** - P5)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15330/head:pull/15330` \
`$ git checkout pull/15330`

Update a local copy of the PR: \
`$ git checkout pull/15330` \
`$ git pull https://git.openjdk.org/jdk.git pull/15330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15330`

View PR using the GUI difftool: \
`$ git pr show -t 15330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15330.diff">https://git.openjdk.org/jdk/pull/15330.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15330#issuecomment-1682462996)