### PR TITLE
8311639: Replace currentTimeMillis() with nanoTime() in jtreg/gc

### DIFF
--- a/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
+++ b/test/hotspot/jtreg/gc/cslocker/TestCSLocker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,10 +44,8 @@ import static gc.testlibrary.Allocation.blackHole;
 
 public class TestCSLocker extends Thread
 {
-    static int timeout = 5000;
+    static int timeoutMillis = 5000;
     public static void main(String args[]) throws Exception {
-        long startTime = System.currentTimeMillis();
-
         // start garbage producer thread
         GarbageProducer garbageProducer = new GarbageProducer(1000000, 10);
         garbageProducer.start();
@@ -61,9 +59,7 @@ public class TestCSLocker extends Thread
         // code until unlock() is called below.
 
         // check timeout to success deadlocking
-        while (System.currentTimeMillis() < startTime + timeout) {
-            sleep(1000);
-        }
+        sleep(timeoutMillis);
 
         csLocker.unlock();
         garbageProducer.interrupt();

--- a/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsClearMarkBits.java
+++ b/test/hotspot/jtreg/gc/g1/TestEagerReclaimHumongousRegionsClearMarkBits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ class ObjectWithSomeRefs {
 }
 
 class TestEagerReclaimHumongousRegionsClearMarkBitsReclaimRegionFast {
-    public static final long MAX_MILLIS_FOR_RUN = 50 * 1000; // The maximum runtime for the actual test.
+    public static final long MAX_NANOS_FOR_RUN = 50L * 1_000_000_000L; // The maximum runtime for the actual test.
 
     public static final int M = 1024*1024;
 
@@ -93,11 +93,11 @@ class TestEagerReclaimHumongousRegionsClearMarkBitsReclaimRegionFast {
 
         Object ref_from_stack = large1;
 
-        long start_millis = System.currentTimeMillis();
+        long start_nanos = System.nanoTime();
 
         for (int i = 0; i < 20; i++) {
-            long current_millis = System.currentTimeMillis();
-            if ((current_millis - start_millis) > MAX_MILLIS_FOR_RUN) {
+            long current_nanos = System.nanoTime();
+            if ((current_nanos - start_nanos) > MAX_NANOS_FOR_RUN) {
               System.out.println("Finishing test because maximum runtime exceeded");
               break;
             }

--- a/test/hotspot/jtreg/gc/g1/TestPeriodicCollectionJNI.java
+++ b/test/hotspot/jtreg/gc/g1/TestPeriodicCollectionJNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,8 +57,7 @@ public class TestPeriodicCollectionJNI {
     }
 
     public static void main(String[] args) throws InterruptedException {
-        long timeout = 2000;
-        long startTime = System.currentTimeMillis();
+        long timeoutMillis = 2000;
 
         // Start thread doing JNI call
         BlockInNative blocker = new BlockInNative();
@@ -66,10 +65,7 @@ public class TestPeriodicCollectionJNI {
 
         try {
             // Wait for periodic GC timeout to trigger
-            while (System.currentTimeMillis() < startTime + timeout) {
-                System.out.println("Sleeping to let periodic GC trigger...");
-                Thread.sleep(200);
-            }
+            Thread.sleep(timeoutMillis);
         } finally {
             unblock();
         }

--- a/test/hotspot/jtreg/gc/g1/humongousObjects/TestNoAllocationsInHRegions.java
+++ b/test/hotspot/jtreg/gc/g1/humongousObjects/TestNoAllocationsInHRegions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -178,11 +178,11 @@ public class TestNoAllocationsInHRegions {
         }
 
         // test duration
-        long duration = Integer.parseInt(args[0]) * 1000L;
+        long durationNanos = Integer.parseInt(args[0]) * 1_000_000_000L;
         // part of heap preallocated with humongous objects (in percents)
         int percentOfAllocatedHeap = Integer.parseInt(args[1]);
 
-        long startTime = System.currentTimeMillis();
+        long startTimeNanos = System.nanoTime();
 
         long initialFreeRegionsCount = WB.g1NumFreeRegions();
         int regionsToAllocate = (int) ((double) initialFreeRegionsCount / 100.0 * percentOfAllocatedHeap);
@@ -219,7 +219,7 @@ public class TestNoAllocationsInHRegions {
 
         threads.stream().forEach(Thread::start);
 
-        while ((System.currentTimeMillis() - startTime < duration) && error == null) {
+        while ((System.nanoTime() - startTimeNanos < durationNanos) && error == null) {
             Thread.yield();
         }
 

--- a/test/hotspot/jtreg/gc/logging/TestUnifiedLoggingSwitchStress.java
+++ b/test/hotspot/jtreg/gc/logging/TestUnifiedLoggingSwitchStress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,9 +222,9 @@ public class TestUnifiedLoggingSwitchStress {
         if (args.length != 1) {
             throw new Error("Test Bug: Expected duration (in seconds) wasn't provided as command line argument");
         }
-        long duration = Integer.parseInt(args[0]) * 1000;
+        long durationNanos = Integer.parseInt(args[0]) * 1_000_000_000L;
 
-        long startTime = System.currentTimeMillis();
+        long startTimeNanos = System.nanoTime();
 
         List<Thread> threads = new LinkedList<>();
 
@@ -238,7 +238,7 @@ public class TestUnifiedLoggingSwitchStress {
 
         threads.stream().forEach(Thread::start);
 
-        while (System.currentTimeMillis() - startTime < duration) {
+        while (System.nanoTime() - startTimeNanos < durationNanos) {
             Thread.yield();
         }
 

--- a/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
+++ b/test/hotspot/jtreg/gc/shenandoah/TestStringDedupStress.java
@@ -113,7 +113,7 @@ public class TestStringDedupStress {
 
     private static final int TARGET_STRINGS = Integer.getInteger("targetStrings", 2_500_000);
     private static final long MAX_REWRITE_GC_CYCLES = 6;
-    private static final long MAX_REWRITE_TIME = 30*1000; // ms
+    private static final long MAX_REWRITE_TIME_NS = 30L * 1_000_000_000L; // 30s in ns
 
     private static final int UNIQUE_STRINGS = 20;
 
@@ -211,7 +211,7 @@ public class TestStringDedupStress {
         }
 
         long cycleBeforeRewrite = gcCycleMBean.getCollectionCount();
-        long timeBeforeRewrite = System.currentTimeMillis();
+        long timeBeforeRewriteNanos = System.nanoTime();
 
         long loop = 1;
         while (true) {
@@ -229,7 +229,7 @@ public class TestStringDedupStress {
                 }
 
                 // enough time is spent waiting for GC to happen
-                if (System.currentTimeMillis() - timeBeforeRewrite >= MAX_REWRITE_TIME) {
+                if (System.nanoTime() - timeBeforeRewriteNanos >= MAX_REWRITE_TIME_NS) {
                     break;
                 }
             }

--- a/test/hotspot/jtreg/gc/shenandoah/jni/TestJNIGlobalRefs.java
+++ b/test/hotspot/jtreg/gc/shenandoah/jni/TestJNIGlobalRefs.java
@@ -49,7 +49,7 @@ public class TestJNIGlobalRefs {
         System.loadLibrary("TestJNIGlobalRefs");
     }
 
-    private static final int TIME_MSEC = 120000;
+    private static final long TIME_NSEC = 120L * 1_000_000_000L;
     private static final int ARRAY_SIZE = 10000;
 
     private static native void makeGlobalRef(Object o);
@@ -60,13 +60,13 @@ public class TestJNIGlobalRefs {
     public static void main(String[] args) throws Throwable {
         seedGlobalRef();
         seedWeakGlobalRef();
-        long start = System.currentTimeMillis();
-        long current = start;
-        while (current - start < TIME_MSEC) {
+        long startNanos = System.nanoTime();
+        long currentNanos = startNanos;
+        while (currentNanos - startNanos < TIME_NSEC) {
             testGlobal();
             testWeakGlobal();
             Thread.sleep(1);
-            current = System.currentTimeMillis();
+            currentNanos = System.nanoTime();
         }
     }
 

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestChurnNotifications.java
@@ -129,7 +129,7 @@ public class TestChurnNotifications {
     static volatile Object sink;
 
     public static void main(String[] args) throws Exception {
-        final long startTime = System.currentTimeMillis();
+        final long startTimeNanos = System.nanoTime();
 
         final AtomicLong churnBytes = new AtomicLong();
 
@@ -176,8 +176,8 @@ public class TestChurnNotifications {
         // Look at test timeout to figure out how long we can wait without breaking into timeout.
         // Default to 1/4 of the remaining time in 1s steps.
         final long STEP_MS = 1000;
-        long spentTime = System.currentTimeMillis() - startTime;
-        long maxTries = (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) - spentTime) / STEP_MS / 4;
+        long spentTimeNanos = System.nanoTime() - startTimeNanos;
+        long maxTries = (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) - (spentTimeNanos / 1_000_000L)) / STEP_MS / 4;
 
         // Wait until enough notifications are accrued to match minimum boundary.
         long tries = 0;

--- a/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
+++ b/test/hotspot/jtreg/gc/shenandoah/mxbeans/TestPauseNotifications.java
@@ -122,7 +122,7 @@ public class TestPauseNotifications {
     }
 
     public static void main(String[] args) throws Exception {
-        final long startTime = System.currentTimeMillis();
+        final long startTimeNanos = System.nanoTime();
 
         final AtomicLong pausesDuration = new AtomicLong();
         final AtomicLong cyclesDuration = new AtomicLong();
@@ -173,8 +173,8 @@ public class TestPauseNotifications {
         // Look at test timeout to figure out how long we can wait without breaking into timeout.
         // Default to 1/4 of the remaining time in 1s steps.
         final long STEP_MS = 1000;
-        long spentTime = System.currentTimeMillis() - startTime;
-        long maxTries = (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) - spentTime) / STEP_MS / 4;
+        long spentTimeNanos = System.nanoTime() - startTimeNanos;
+        long maxTries = (Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) - (spentTimeNanos / 1_000_000L)) / STEP_MS / 4;
 
         long actualPauses = 0;
         long actualCycles = 0;

--- a/test/hotspot/jtreg/gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java
+++ b/test/hotspot/jtreg/gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java
@@ -137,14 +137,14 @@ public class TestJNIBlockFullGC {
         System.out.println("# Warmup Threads = " + warmupThreads);
 
         long warmupDurationNanos = 1_000_000L * Integer.parseInt(args[1]);
-        System.out.println("WarmUp Duration Nanos = " + warmupDurationNanos);
+        System.out.println("WarmUp Duration Millis = " + args[1]);
         int warmupIterations = Integer.parseInt(args[2]);
         System.out.println("# Warmup Iterations = "+ warmupIterations);
 
         int mainThreads = Integer.parseInt(args[3]);
         System.out.println("# Main Threads = " + mainThreads);
         long mainDurationNanos = 1_000_000L * Integer.parseInt(args[4]);
-        System.out.println("Main Duration Nanos = " + mainDurationNanos);
+        System.out.println("Main Duration Millis = " + args[4]);
         int mainIterations = Integer.parseInt(args[5]);
         System.out.println("# Main Iterations = " + mainIterations);
 

--- a/test/hotspot/jtreg/gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java
+++ b/test/hotspot/jtreg/gc/stress/TestJNIBlockFullGC/TestJNIBlockFullGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017 SAP SE and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -62,12 +62,12 @@ public class TestJNIBlockFullGC {
         }
     }
 
-    public static void warmUp(long warmupEndTime, int size, long seed) {
+    public static void warmUp(long warmupEndTimeNanos, int size, long seed) {
         Random r = new Random(seed);
         // First let the GC assume most of our objects will die.
         Node[] roots = new Node[size];
 
-        while (System.currentTimeMillis() < warmupEndTime) {
+        while (System.nanoTime() - warmupEndTimeNanos < 0) {
             int index = (int) (r.nextDouble() * roots.length);
             roots[index] = new Node(1);
         }
@@ -78,7 +78,7 @@ public class TestJNIBlockFullGC {
         }
     }
 
-    public static void runTest(long endTime, int size, double alive, long seed) {
+    public static void runTest(long endTimeNanos, int size, double alive, long seed) {
         Random r = new Random(seed);
         final int length = 10000;
         int[] array1 = new int[length];
@@ -91,7 +91,7 @@ public class TestJNIBlockFullGC {
             int index = 0;
             roots[0] = new Node(0);
 
-            while (!hadError && (System.currentTimeMillis() < endTime)) {
+            while (!hadError && (System.nanoTime() - endTimeNanos < 0)) {
                 int test_val1 = TestCriticalArray0(array1);
 
                 if (r.nextDouble() > alive) {
@@ -136,15 +136,15 @@ public class TestJNIBlockFullGC {
         int warmupThreads = Integer.parseInt(args[0]);
         System.out.println("# Warmup Threads = " + warmupThreads);
 
-        int warmupDuration = Integer.parseInt(args[1]);
-        System.out.println("WarmUp Duration = " + warmupDuration);
+        long warmupDurationNanos = 1_000_000L * Integer.parseInt(args[1]);
+        System.out.println("WarmUp Duration Nanos = " + warmupDurationNanos);
         int warmupIterations = Integer.parseInt(args[2]);
         System.out.println("# Warmup Iterations = "+ warmupIterations);
 
         int mainThreads = Integer.parseInt(args[3]);
         System.out.println("# Main Threads = " + mainThreads);
-        int mainDuration = Integer.parseInt(args[4]);
-        System.out.println("Main Duration = " + mainDuration);
+        long mainDurationNanos = 1_000_000L * Integer.parseInt(args[4]);
+        System.out.println("Main Duration Nanos = " + mainDurationNanos);
         int mainIterations = Integer.parseInt(args[5]);
         System.out.println("# Main Iterations = " + mainIterations);
 
@@ -154,12 +154,12 @@ public class TestJNIBlockFullGC {
         Thread threads[] = new Thread[Math.max(warmupThreads, mainThreads)];
 
         System.out.println("Start warm-up threads!");
-        long warmupStartTime = System.currentTimeMillis();
+        long warmupStartTimeNanos = System.nanoTime();
         for (int i = 0; i < warmupThreads; i++) {
             long seed = rng.nextLong();
             threads[i] = new Thread() {
                 public void run() {
-                    warmUp(warmupStartTime + warmupDuration, warmupIterations, seed);
+                    warmUp(warmupStartTimeNanos + warmupDurationNanos, warmupIterations, seed);
                 };
             };
             threads[i].start();
@@ -170,12 +170,12 @@ public class TestJNIBlockFullGC {
         System.gc();
         System.out.println("Keep alive a lot");
 
-        long startTime = System.currentTimeMillis();
+        long startTimeNanos = System.nanoTime();
         for (int i = 0; i < mainThreads; i++) {
             long seed = rng.nextLong();
             threads[i] = new Thread() {
                 public void run() {
-                    runTest(startTime + mainDuration, mainIterations, liveFrac, seed);
+                    runTest(startTimeNanos + mainDurationNanos, mainIterations, liveFrac, seed);
                 };
             };
             threads[i].start();

--- a/test/hotspot/jtreg/gc/stress/TestMultiThreadStressRSet.java
+++ b/test/hotspot/jtreg/gc/stress/TestMultiThreadStressRSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public class TestMultiThreadStressRSet {
         }
         long time = Long.parseLong(args[0]);
         int threads = Integer.parseInt(args[1]);
-        new TestMultiThreadStressRSet().test(time * 1000, threads);
+        new TestMultiThreadStressRSet().test(time * 1_000_000_000L, threads);
     }
 
     /**
@@ -147,23 +147,23 @@ public class TestMultiThreadStressRSet {
      * <li> stops the Shifter thread
      * </ul>
      *
-     * @param timeInMillis how long to stress
+     * @param timeInNanos how long to stress
      * @param maxThreads the maximum number of Worker thread working together.
      */
-    public void test(long timeInMillis, int maxThreads) {
-        if (timeInMillis <= 0 || maxThreads <= 0) {
+    public void test(long timeInNanos, int maxThreads) {
+        if (timeInNanos <= 0 || maxThreads <= 0) {
             throw new IllegalArgumentException("TEST BUG: be positive!");
         }
-        System.out.println("%% Time to work: " + timeInMillis / 1000 + "s");
+        System.out.println("%% Time to work: " + timeInNanos / 1_000_000_000L + "s");
         System.out.println("%% Number of threads: " + maxThreads);
-        long finish = System.currentTimeMillis() + timeInMillis;
+        long finishNanos = System.nanoTime() + timeInNanos;
         Shifter shift = new Shifter(this, 1000, (int) (windowSize * 0.9));
         shift.start();
         for (int i = 0; i < maxThreads; i++) {
             new Worker(this, 100).start();
         }
         try {
-            while (System.currentTimeMillis() < finish && errorMessage == null) {
+            while (System.nanoTime() - finishNanos < 0 && errorMessage == null) {
                 Thread.sleep(100);
             }
         } catch (Throwable t) {

--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,23 +139,23 @@ public class TestStressRSetCoarsening {
     /**
      * Initial time.
      */
-    public final long start;
+    public final long startNanos;
 
     /**
      * Time when the test should stop working.
      */
-    public final long finishAt;
+    public final long finishAtNanos;
 
     /**
      * Does pre-calculation and allocate necessary objects.
      *
      * @param objPerRegions how many objects per G1 heap region
      */
-    TestStressRSetCoarsening(int objPerRegions, int regsToRefresh, int timeout) {
+    TestStressRSetCoarsening(int objPerRegions, int regsToRefresh, int timeoutSec) {
         this.K = objPerRegions;
         this.regsToRefresh = regsToRefresh;
-        this.start = System.currentTimeMillis();
-        this.finishAt = start + timeout * 900; // 10% ahead of jtreg timeout
+        this.startNanos = System.nanoTime();
+        this.finishAtNanos = startNanos + (timeoutSec * 900_000_000L); // 10% ahead of jtreg timeout
 
         long regionSize = WB.g1RegionSize();
 
@@ -284,7 +284,7 @@ public class TestStressRSetCoarsening {
                         for (int rn = pre; rn != cur; rn += step) {
                             Object[] rnArray = storage.getArrayAt(getY(to, from, rn));
                             rnArray[getX(to, from, rn)] = celebrity;
-                            if (System.currentTimeMillis() > finishAt) {
+                            if (System.nanoTime() - finishAtNanos > 0) {
                                 throw new TimeoutException();
                             }
                         }
@@ -322,9 +322,9 @@ public class TestStressRSetCoarsening {
         } catch (TimeoutException e) {
             System.out.println("%% TIMEOUT!!!");
         }
-        long now = System.currentTimeMillis();
+        long nowNanos = System.nanoTime();
         System.out.println("%% Summary");
-        System.out.println("%%   Time spent          : " + ((now - start) / 1000) + " seconds");
+        System.out.println("%%   Time spent          : " + ((nowNanos - startNanos) / 1_000_000_000L) + " seconds");
         System.out.println("%%   Free memory left    : " + Runtime.getRuntime().freeMemory() / KB + "K");
         System.out.println("%% Test passed");
     }

--- a/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasher.java
+++ b/test/hotspot/jtreg/gc/stress/gcbasher/TestGCBasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,9 +57,9 @@ public class TestGCBasher {
             return;
         }
 
-        long durationMillis = Long.valueOf(args[0]);
-        long start = System.currentTimeMillis();
-        while (System.currentTimeMillis() - start < durationMillis) {
+        long durationNanos = Long.valueOf(args[0]) * 1_000_000L;
+        long startNanos = System.nanoTime();
+        while (System.nanoTime() - startNanos < durationNanos) {
             parseClassFiles();
         }
     }

--- a/test/hotspot/jtreg/gc/stress/gclocker/TestExcessGCLockerCollections.java
+++ b/test/hotspot/jtreg/gc/stress/gclocker/TestExcessGCLockerCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,18 +133,12 @@ class TestExcessGCLockerCollectionsAux {
             new Thread(new JNICriticalWorker()).start();
         }
 
-        long durationMS = (long) (1000 * durationSec);
-        long start = System.currentTimeMillis();
-        long now = start;
-        long soFar = now - start;
-        while (soFar < durationMS) {
-            try {
-                Thread.sleep(durationMS - soFar);
-            } catch (Exception e) {
-            }
-            now = System.currentTimeMillis();
-            soFar = now - start;
+        try {
+            Thread.sleep(durationSec * 1000L);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Test Failure, did not expect an InterruptedException", e);
         }
+
         println("Done.");
         keepRunning = false;
     }

--- a/test/hotspot/jtreg/gc/stress/gcold/TestGCOld.java
+++ b/test/hotspot/jtreg/gc/stress/gcold/TestGCOld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -369,14 +369,14 @@ public class TestGCOld {
 
     System.err.println("Initialization complete...");
 
-    long start = System.currentTimeMillis();
+    long startNanos = System.nanoTime();
 
     for (int step = 0; step < steps; step++) {
       doStep(MEG);
     }
 
-    long end = System.currentTimeMillis();
-    float secs = ((float)(end-start))/1000.0F;
+    long endNanos = System.nanoTime();
+    float secs = (endNanos - startNanos) / 1_000_000_000F;
 
 //  checkTrees();
 

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
@@ -77,7 +77,7 @@ class LongLivedAllocationTask extends Exitable implements Runnable {
     @Override
     public void run() {
         while (!shouldExit()) {
-            String prefix = "long" + (System.nanoTime() % 10000); // limit to 4 digits after changing from milliseconds to nanoseconds, else the key will use more memory
+            String prefix = "long" + System.currentTimeMillis();
             for (int i = 0; i < 10; i++) {
                 String key = prefix + " key = " + i;
                 String value = "the value is " + i;
@@ -192,7 +192,7 @@ public class TestSystemGC {
             throw new IllegalArgumentException("Must specify timeout in seconds as first argument");
         }
         long timeoutNanos = Integer.parseInt(args[0]) * 1_000_000_000L;
-        System.out.println("Running with timeout of " + timeoutNanos + "ns");
+        System.out.println("Running with timeout of " + (timeoutNanos / 1_000_000_000L) + " seconds");
         endTimeNanos = System.nanoTime() + timeoutNanos;
         // First allocate the long lived objects and then run all phases.
         populateLongLived();

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
@@ -192,7 +192,7 @@ public class TestSystemGC {
             throw new IllegalArgumentException("Must specify timeout in seconds as first argument");
         }
         long timeoutNanos = Integer.parseInt(args[0]) * 1_000_000_000L;
-        System.out.println("Running with timeout of " + (timeoutNanos / 1_000_000_000L) + " seconds");
+        System.out.println("Running with timeout of " + args[0] + " seconds");
         endTimeNanos = System.nanoTime() + timeoutNanos;
         // First allocate the long lived objects and then run all phases.
         populateLongLived();

--- a/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
+++ b/test/hotspot/jtreg/gc/stress/systemgc/TestSystemGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ class LongLivedAllocationTask extends Exitable implements Runnable {
     @Override
     public void run() {
         while (!shouldExit()) {
-            String prefix = "long" + System.currentTimeMillis();
+            String prefix = "long" + (System.nanoTime() % 10000); // limit to 4 digits after changing from milliseconds to nanoseconds, else the key will use more memory
             for (int i = 0; i < 10; i++) {
                 String key = prefix + " key = " + i;
                 String value = "the value is " + i;
@@ -104,7 +104,7 @@ class SystemGCTask extends Exitable implements Runnable {
 }
 
 public class TestSystemGC {
-    private static long endTime;
+    private static long endTimeNanos;
 
     private static final int numGroups = 7;
     private static final int numGCsPerGroup = 4;
@@ -137,7 +137,7 @@ public class TestSystemGC {
         for (int i = 0; i < numGroups; i++) {
             for (int j = 0; j < numGCsPerGroup; j++) {
                System.gc();
-               if (System.currentTimeMillis() >= endTime) {
+               if (System.nanoTime() - endTimeNanos >= 0) {
                    return;
                }
                ThreadUtils.sleep(getDelayMS(i));
@@ -165,7 +165,7 @@ public class TestSystemGC {
     }
 
     private static void runAllPhases() {
-        for (int i = 0; i < 4 && System.currentTimeMillis() < endTime; i++) {
+        for (int i = 0; i < 4 && System.nanoTime() - endTimeNanos < 0; i++) {
             SystemGCTask gcTask =
                 (i % 2 == 1) ? createSystemGCTask(numGroups / 3) : null;
             ShortLivedAllocationTask shortTask =
@@ -191,9 +191,9 @@ public class TestSystemGC {
         if (args.length == 0) {
             throw new IllegalArgumentException("Must specify timeout in seconds as first argument");
         }
-        int timeout = Integer.parseInt(args[0]) * 1000;
-        System.out.println("Running with timeout of " + timeout + "ms");
-        endTime = System.currentTimeMillis() + timeout;
+        long timeoutNanos = Integer.parseInt(args[0]) * 1_000_000_000L;
+        System.out.println("Running with timeout of " + timeoutNanos + "ns");
+        endTimeNanos = System.nanoTime() + timeoutNanos;
         // First allocate the long lived objects and then run all phases.
         populateLongLived();
         runAllPhases();


### PR DESCRIPTION
I have removed usage of `currentTimeMillis()` in jtreg/gc as `currentTimeMillis()` is not monotonic. It is mostly changing from milliseconds to nanoseconds. In certain places, I have changed the code from something like `(instant1 < instant2)` to `(instant1 - instant2 < 0)` It might look like I am removing instant2 from both sides of the inequality and the result ought to be the same, but due to overflow arithmetic, the change should be better if nanoseconds where to overflow. I have also removed some loops where the loop is doing nothing except sleeping. I somewhat shortened the string in the key of a hash map because the nanosecond value made the string too long for the heap size.

All tests within jtreg/gc passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311639](https://bugs.openjdk.org/browse/JDK-8311639): Replace currentTimeMillis() with nanoTime() in jtreg/gc (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15331/head:pull/15331` \
`$ git checkout pull/15331`

Update a local copy of the PR: \
`$ git checkout pull/15331` \
`$ git pull https://git.openjdk.org/jdk.git pull/15331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15331`

View PR using the GUI difftool: \
`$ git pr show -t 15331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15331.diff">https://git.openjdk.org/jdk/pull/15331.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15331#issuecomment-1682548865)