### PR TITLE
8311222: strace004 can fail due to unexpected stack length after JDK-8309408

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
@@ -150,6 +150,7 @@ public class strace001 {
                 "java.lang.Thread.currentThread",
                 "java.util.concurrent.TimeUnit.toNanos",
                 "jdk.internal.event.ThreadSleepEvent.<clinit>",
+                "jdk.internal.event.ThreadSleepEvent.<init>",
                 "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
                 "jdk.internal.event.ThreadSleepEvent.isEnabled"
         };
@@ -210,7 +211,7 @@ public class strace001 {
         // recursionNative() methods must not be greater than depth,
         // also one run() and one waitForSign(), plus whatever can be
         // reached from Thread.yield or Thread.sleep.
-        int expectedLength = depth + 6;
+        int expectedLength = depth + 7;
         boolean result = true;
 
         // Check the length of the trace


### PR DESCRIPTION
The [JDK-8309408](https://bugs.openjdk.org/browse/JDK-8309408) introduced sleepNanos and the tests expected stack is updated.
The "jdk.internal.event.ThreadSleepEvent.<init>" was added just because I hit this issue while testing fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311222](https://bugs.openjdk.org/browse/JDK-8311222): strace004 can fail due to unexpected stack length after JDK-8309408 (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15332/head:pull/15332` \
`$ git checkout pull/15332`

Update a local copy of the PR: \
`$ git checkout pull/15332` \
`$ git pull https://git.openjdk.org/jdk.git pull/15332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15332`

View PR using the GUI difftool: \
`$ git pr show -t 15332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15332.diff">https://git.openjdk.org/jdk/pull/15332.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15332#issuecomment-1682605520)