### PR TITLE
8314551: More generic way to handshake GC threads with monitor deflation

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -24,7 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/vmSymbols.hpp"
-#include "gc/shared/suspendibleThreadSet.hpp"
+#include "gc/shared/collectedHeap.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
@@ -1641,8 +1641,8 @@ public:
   bool evaluate_at_safepoint() const override { return false; }
   VMOp_Type type() const override { return VMOp_RendezvousGCThreads; }
   void doit() override {
-    SuspendibleThreadSet::synchronize();
-    SuspendibleThreadSet::desynchronize();
+    Universe::heap()->safepoint_synchronize_begin();
+    Universe::heap()->safepoint_synchronize_end();
   };
 };
 


### PR DESCRIPTION
We currently handshake GC threads with monitor deflation by calling SuspendibleThreadSet::synchronize() and SuspendibleThreadSet::desynchronize(). This is somewhat problematic though, because GCs may use other mechanisms to sync their GC threads. In particular, ZGC uses ZRelocateQueue to do that.

Luckily, CollectedHeap comes with interfaces for exactly this purpose: CollectedHeap::safepoint_synchronize_begin() and CollectedHeap::safepoint_synchronize_end(). Those methods are implemented by ZGC to do the correct synchronization with ZRelocateQueue. All GCs which need that sort of synchronization are overriding these methods and delegate to STS methods, so we can replace the STS calls with the CollectedHeap calls.

Testing:
 - [x] hotspot_gc
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314551](https://bugs.openjdk.org/browse/JDK-8314551): More generic way to handshake GC threads with monitor deflation (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15336/head:pull/15336` \
`$ git checkout pull/15336`

Update a local copy of the PR: \
`$ git checkout pull/15336` \
`$ git pull https://git.openjdk.org/jdk.git pull/15336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15336`

View PR using the GUI difftool: \
`$ git pr show -t 15336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15336.diff">https://git.openjdk.org/jdk/pull/15336.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15336#issuecomment-1683038090)