### PR TITLE
JDK-8314517: some tests fail in case ipv6 is disabled on the machine

### DIFF
--- a/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/CommandLinePositiveTest.java
@@ -25,6 +25,7 @@
  * @test
  * @summary Positive tests for java -m jdk.httpserver command
  * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
  * @modules jdk.httpserver
  * @run testng/othervm CommandLinePositiveTest
  */
@@ -35,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import jdk.test.lib.Platform;
+import jdk.test.lib.net.IPSupport;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.FileUtils;
@@ -154,10 +156,12 @@ public class CommandLinePositiveTest {
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
                 .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
-        simpleserver(JAVA, "-m", "jdk.httpserver", opt, "::0")
-                .shouldHaveExitValue(NORMAL_EXIT_CODE)
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
-                .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
+        if (IPSupport.hasIPv6()) {
+            simpleserver(JAVA, "-m", "jdk.httpserver", opt, "::0")
+                    .shouldHaveExitValue(NORMAL_EXIT_CODE)
+                    .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
+                    .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
+        }
     }
 
     @Test(dataProvider = "bindOptions")

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/CommandLinePositiveTest.java
@@ -25,6 +25,7 @@
  * @test
  * @summary Positive tests for the jwebserver command-line tool
  * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
  * @modules jdk.httpserver
  * @run testng/othervm CommandLinePositiveTest
  */
@@ -35,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import jdk.test.lib.Platform;
+import jdk.test.lib.net.IPSupport;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.FileUtils;
@@ -154,10 +156,12 @@ public class CommandLinePositiveTest {
                 .shouldHaveExitValue(NORMAL_EXIT_CODE)
                 .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
                 .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
-        simpleserver(JWEBSERVER, opt, "::0")
-                .shouldHaveExitValue(NORMAL_EXIT_CODE)
-                .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
-                .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
+        if (IPSupport.hasIPv6()) {
+            simpleserver(JWEBSERVER, opt, "::0")
+                    .shouldHaveExitValue(NORMAL_EXIT_CODE)
+                    .shouldContain("Serving " + TEST_DIR_STR + " and subdirectories on 0.0.0.0 (all interfaces) port")
+                    .shouldContain("URL http://" + InetAddress.getLocalHost().getHostAddress());
+        }
     }
 
     @Test(dataProvider = "bindOptions")

--- a/test/jdk/java/net/InetAddress/HostsFileOrderingTest.java
+++ b/test/jdk/java/net/InetAddress/HostsFileOrderingTest.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jdk.test.lib.net.IPSupport;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.Assert;
@@ -39,6 +41,8 @@ import org.testng.Assert;
 
 /* @test
  * @bug 8244958
+ * @library /test/lib
+ * @build jdk.test.lib.Platform jdk.test.lib.net.IPSupport
  * @summary Test that "jdk.net.hosts.file" NameService implementation returns addresses
  *          with respect to "java.net.preferIPv4Stack" and "java.net.preferIPv6Addresses" system
  *          property values
@@ -84,16 +88,18 @@ public class HostsFileOrderingTest {
      */
     @Test
     public void testOrdering() throws Exception {
-        String [] resolvedAddresses = Arrays.stream(InetAddress.getAllByName("hostname.test.com"))
-                .map(InetAddress::getHostAddress).toArray(String[]::new);
-        String [] expectedAddresses = getExpectedAddressesArray();
+        if (IPSupport.hasIPv6()) {
+            String [] resolvedAddresses = Arrays.stream(InetAddress.getAllByName("hostname.test.com"))
+                    .map(InetAddress::getHostAddress).toArray(String[]::new);
+            String [] expectedAddresses = getExpectedAddressesArray();
 
-        if (Arrays.deepEquals(resolvedAddresses, expectedAddresses)) {
-            System.err.println("Test passed: The expected list of IP addresses is returned");
-        } else {
-            System.err.printf("Expected addresses:%n%s%n", Arrays.deepToString(expectedAddresses));
-            System.err.printf("Resolved addresses:%n%s%n", Arrays.deepToString(resolvedAddresses));
-            Assert.fail("Wrong host resolution result is returned");
+            if (Arrays.deepEquals(resolvedAddresses, expectedAddresses)) {
+                System.err.println("Test passed: The expected list of IP addresses is returned");
+            } else {
+                System.err.printf("Expected addresses:%n%s%n", Arrays.deepToString(expectedAddresses));
+                System.err.printf("Resolved addresses:%n%s%n", Arrays.deepToString(resolvedAddresses));
+                Assert.fail("Wrong host resolution result is returned");
+            }
         }
     }
 

--- a/test/jdk/java/net/InetAddress/InternalNameServiceTest.java
+++ b/test/jdk/java/net/InetAddress/InternalNameServiceTest.java
@@ -27,6 +27,8 @@
  *          the system property jdk.net.hosts.file. This property specifies
  *          a file name that contains address host mappings, similar to those in
  *          /etc/hosts file.
+ * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
  * @run main/othervm -Djdk.net.hosts.file=TestHosts -Dsun.net.inetaddr.ttl=0
  *      InternalNameServiceTest
  */
@@ -37,6 +39,8 @@ import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+
+import jdk.test.lib.net.IPSupport;
 
 public class InternalNameServiceTest {
 
@@ -128,17 +132,16 @@ public class InternalNameServiceTest {
         }
 
         // IPV6 tests
-
-        // IPV6 tests
-        addMappingToHostsFile("host-ipv6.sample-domain", "::1", hostsFileName,
-                true);
-        testAddress = InetAddress.getByName("host-ipv6.sample-domain");
-        retrievedIpAddr = testAddress.getAddress();
-        if (!Arrays.equals(retrievedIpAddr, expectedIpAddrIpv6_1)) {
-            System.out.println("retrieved ipv6 addr == " + Arrays.toString(retrievedIpAddr));
-            System.out.println("expected ipv6 addr == " + Arrays.toString(expectedIpAddrIpv6_1));
-            throw new RuntimeException(
-                    "retrieved IPV6 Addr not equal to expected IPV6 Addr");
+        if (IPSupport.hasIPv6()) {
+            addMappingToHostsFile("host-ipv6.sample-domain", "::1", hostsFileName, true);
+            testAddress = InetAddress.getByName("host-ipv6.sample-domain");
+            retrievedIpAddr = testAddress.getAddress();
+            if (!Arrays.equals(retrievedIpAddr, expectedIpAddrIpv6_1)) {
+                System.out.println("retrieved ipv6 addr == " + Arrays.toString(retrievedIpAddr));
+                System.out.println("expected ipv6 addr == " + Arrays.toString(expectedIpAddrIpv6_1));
+                throw new RuntimeException(
+                        "retrieved IPV6 Addr not equal to expected IPV6 Addr");
+            }
         }
     }
 

--- a/test/jdk/java/net/InetAddress/InternalNameServiceWithHostsFileTest.java
+++ b/test/jdk/java/net/InetAddress/InternalNameServiceWithHostsFileTest.java
@@ -28,6 +28,8 @@
  *          a file name that contains address host mappings, similar to those in
  *          /etc/hosts file. TestHosts-III file  exist, with a set of ipv4 and ipv6
  *          mappings
+ * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
  * @run main/othervm -Djdk.net.hosts.file=${test.src}/TestHosts-III -Dsun.net.inetaddr.ttl=0
  *      InternalNameServiceWithHostsFileTest
  */
@@ -35,6 +37,8 @@
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+
+import jdk.test.lib.net.IPSupport;
 
 public class InternalNameServiceWithHostsFileTest {
     public static void main(String args[]) throws Exception {
@@ -52,26 +56,31 @@ public class InternalNameServiceWithHostsFileTest {
 
         // 10.2.3.4  testHost.testDomain
         testHostsMapping(expectedIpv4Address, "testHost.testDomain");
-        // ::1     ip6-localhost ip6-loopback
-        testHostsMapping(expectedIpv6LocalhostAddress, "ip6-localhost");
-        // fe00::0 ip6-localnet
-        testHostsMapping(expectedIpv6LocalAddress, "ip6-localnet");
-        // fe80::1 link-local-host
-        testHostsMapping(expectedIpv6Address, "link-local-host");
+
+        if (IPSupport.hasIPv6()) {
+            // ::1     ip6-localhost ip6-loopback
+            testHostsMapping(expectedIpv6LocalhostAddress, "ip6-localhost");
+            // fe00::0 ip6-localnet
+            testHostsMapping(expectedIpv6LocalAddress, "ip6-localnet");
+            // fe80::1 link-local-host
+            testHostsMapping(expectedIpv6Address, "link-local-host");
+        }
 
         testReverseLookup("10.2.3.4", "testHost.testDomain");
 
-        testReverseLookup("::1", "ip6-localhost");
-        testReverseLookup("0:0:0:0:0:0:0:1", "ip6-localhost");
-        testReverseLookup("0000:0000:0000:0000:0000:0000:0000:0001", "ip6-localhost");
+        if (IPSupport.hasIPv6()) {
+            testReverseLookup("::1", "ip6-localhost");
+            testReverseLookup("0:0:0:0:0:0:0:1", "ip6-localhost");
+            testReverseLookup("0000:0000:0000:0000:0000:0000:0000:0001", "ip6-localhost");
 
-        testReverseLookup("fe00::0", "ip6-localnet");
-        testReverseLookup("fe00:0:0:0:0:0:0:0", "ip6-localnet");
-        testReverseLookup("fe00:0000:0000:0000:0000:0000:0000:0000", "ip6-localnet");
+            testReverseLookup("fe00::0", "ip6-localnet");
+            testReverseLookup("fe00:0:0:0:0:0:0:0", "ip6-localnet");
+            testReverseLookup("fe00:0000:0000:0000:0000:0000:0000:0000", "ip6-localnet");
 
-        testReverseLookup("fe80::1", "link-local-host");
-        testReverseLookup("fe80:000:0:00:0:000:00:1", "link-local-host");
-        testReverseLookup("fe80:0000:0000:0000:0000:0000:0000:0001", "link-local-host");
+            testReverseLookup("fe80::1", "link-local-host");
+            testReverseLookup("fe80:000:0:00:0:000:00:1", "link-local-host");
+            testReverseLookup("fe80:0000:0000:0000:0000:0000:0000:0001", "link-local-host");
+        }
     }
 
     private static void testHostsMapping(byte[] expectedIpAddress, String hostName)

--- a/test/jdk/jdk/net/ExtendedSocketOption/DontFragmentTest.java
+++ b/test/jdk/jdk/net/ExtendedSocketOption/DontFragmentTest.java
@@ -26,7 +26,7 @@
  * @bug 8243099 8285671
  * @modules jdk.net
  * @library /test/lib
- * @build jdk.test.lib.Platform
+ * @build jdk.test.lib.Platform jdk.test.lib.net.IPSupport
  * @run main/othervm DontFragmentTest ipv4
  * @run main/othervm DontFragmentTest ipv6
  */
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.net.*;
 import java.nio.channels.*;
 import jdk.test.lib.Platform;
+import jdk.test.lib.net.IPSupport;
 import static java.net.StandardProtocolFamily.INET;
 import static java.net.StandardProtocolFamily.INET6;
 import static jdk.net.ExtendedSocketOptions.IP_DONTFRAGMENT;
@@ -45,19 +46,24 @@ public class DontFragmentTest {
 
     public static void main(String[] args) throws IOException {
         isMacos = Platform.isOSX();
-        testDatagramChannel();
-        StandardProtocolFamily fam = args[0].equals("ipv4") ? INET : INET6;
-        System.out.println("Family = " + fam);
-        testDatagramChannel(args, fam);
-        try (DatagramSocket c = new DatagramSocket()) {
-            testDatagramSocket(c);
-        }
-        try (DatagramChannel dc = DatagramChannel.open(fam)) {
-            var c = dc.socket();
-            testDatagramSocket(c);
-        }
-        try (MulticastSocket mc = new MulticastSocket()) {
-            testDatagramSocket(mc);
+        boolean ipv6 = args[0].equals("ipv6");
+        if (ipv6 && !IPSupport.hasIPv6()) {
+            System.out.println("No IPv6 support detected, skipping IPv6 test case");
+        } else {
+            testDatagramChannel();
+            StandardProtocolFamily fam = ipv6 ? INET6 : INET;
+            System.out.println("Family = " + fam);
+            testDatagramChannel(args, fam);
+            try (DatagramSocket c = new DatagramSocket()) {
+                testDatagramSocket(c);
+            }
+            try (DatagramChannel dc = DatagramChannel.open(fam)) {
+                var c = dc.socket();
+                testDatagramSocket(c);
+            }
+            try (MulticastSocket mc = new MulticastSocket()) {
+                testDatagramSocket(mc);
+            }
         }
     }
 


### PR DESCRIPTION
Some jtreg tests fail with ipv6 disabled on the machine, this should be improved in the tests (e.g. by using IPSupport.hasIPv6() ).