### PR TITLE
8314571: GrowableArray should move its old data and not copy it

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -503,7 +503,7 @@ void GrowableArrayWithAllocator<E, Derived>::expand_to(int new_capacity) {
   this->_capacity = new_capacity;
   E* newData = static_cast<Derived*>(this)->allocate();
   int i = 0;
-  for (     ; i < this->_len; i++) ::new ((void*)&newData[i]) E(this->_data[i]);
+  for (     ; i < this->_len; i++) ::new ((void*)&newData[i]) E(static_cast<E&&>(this->_data[i]));
   for (     ; i < this->_capacity; i++) ::new ((void*)&newData[i]) E();
   for (i = 0; i < old_capacity; i++) this->_data[i].~E();
   if (this->_data != nullptr) {
@@ -542,7 +542,7 @@ void GrowableArrayWithAllocator<E, Derived>::shrink_to_fit() {
   this->_capacity = len;        // Must preceed allocate().
   if (len > 0) {
     new_data = static_cast<Derived*>(this)->allocate();
-    for (int i = 0; i < len; ++i) ::new (&new_data[i]) E(old_data[i]);
+    for (int i = 0; i < len; ++i) ::new (&new_data[i]) E(static_cast<E&&>(old_data[i]));
   }
   // Destroy contents of old data, and deallocate it.
   for (int i = 0; i < old_capacity; ++i) old_data[i].~E();

--- a/test/hotspot/gtest/utilities/test_growableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_growableArray.cpp
@@ -601,3 +601,18 @@ TEST(GrowableArrayCHeap, sanity) {
     delete a;
   }
 }
+
+struct NoncopyableStruct {
+  int some;
+  int data;
+  NONCOPYABLE(NoncopyableStruct);
+  NoncopyableStruct() : some(0), data(0) {
+  }
+  NoncopyableStruct(NoncopyableStruct&&) = default;
+};
+
+TEST(GrowableArray, ShouldMoveAndNotCopy) {
+  // This should cause a compilation error if GrowableArrayCHeap cannot handle a movable but noncopyable type.
+  GrowableArrayCHeap<NoncopyableStruct, mtTest> my_array;
+  my_array.reserve(256);
+}


### PR DESCRIPTION
Given some `GrowableArray<E>` where `E` is non-copyable with a move constructor then currently this will fail to compile. This is because `GrowableArray`'s expand and shrink calls the copy constructor. We cast the values to rvalues (akin to `std::move`) to instead call the move constructor if available.