### PR TITLE
8314483: Optionally override copyright header in generated source

### DIFF
--- a/make/ToolsJdk.gmk
+++ b/make/ToolsJdk.gmk
@@ -137,4 +137,7 @@ PANDOC_HTML_MANPAGE_FILTER := $(BUILDTOOLS_OUTPUTDIR)/manpages/pandoc-html-manpa
 
 ##########################################################################################
 
+# Hook to include the corresponding custom post file, if present.
+$(eval $(call IncludeCustomExtension, ToolsJdk-post.gmk))
+
 endif # _TOOLS_GMK

--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -29,6 +29,7 @@ import build.tools.cldrconverter.BundleGenerator.BundleType;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.text.MessageFormat;
 import java.time.*;
@@ -114,6 +115,7 @@ public class CLDRConverter {
 
     private static Set<String> AVAILABLE_TZIDS;
     static int copyrightYear;
+    static String jdkHeaderTemplate;
     private static String zoneNameTempFile;
     private static String tzDataDir;
     private static final Map<String, String> canonicalTZMap = new HashMap<>();
@@ -229,6 +231,12 @@ public class CLDRConverter {
                         tzDataDir = args[++i];
                         break;
 
+                    case "-jdk-header-template":
+                        jdkHeaderTemplate = new String(
+                            Files.readAllBytes(Paths.get(args[++i])),
+                            StandardCharsets.UTF_8);
+                        break;
+
                     case "-help":
                         usage();
                         System.exit(0);
@@ -304,7 +312,9 @@ public class CLDRConverter {
                 + "\t-year year     copyright year in output%n"
                 + "\t-zntempfile    template file for java.time.format.ZoneName.java%n"
                 + "\t-tzdatadir     tzdata directory for java.time.format.ZoneName.java%n"
-                + "\t-utf8          use UTF-8 rather than \\uxxxx (for debug)%n");
+                + "\t-utf8          use UTF-8 rather than \\uxxxx (for debug)%n"
+                + "\t-jdk-header-template <file>%n"
+                + "\t\t       override default GPL header with contents of file%n");
     }
 
     static void info(String fmt, Object... args) {

--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -29,7 +29,6 @@ import build.tools.cldrconverter.BundleGenerator.BundleType;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.text.MessageFormat;
 import java.time.*;
@@ -232,9 +231,7 @@ public class CLDRConverter {
                         break;
 
                     case "-jdk-header-template":
-                        jdkHeaderTemplate = new String(
-                            Files.readAllBytes(Paths.get(args[++i])),
-                            StandardCharsets.UTF_8);
+                        jdkHeaderTemplate = Files.readString(Paths.get(args[++i]));
                         break;
 
                     case "-help":

--- a/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/ResourceBundleGenerator.java
@@ -174,7 +174,7 @@ class ResourceBundleGenerator implements BundleGenerator {
 
         try (PrintWriter out = new PrintWriter(file, encoding)) {
             // Output copyright headers
-            out.println(CopyrightHeaders.getOpenJDKCopyright(CLDRConverter.copyrightYear));
+            out.println(getOpenJDKCopyright());
             out.println(CopyrightHeaders.getUnicodeCopyright());
 
             if (useJava) {
@@ -294,7 +294,7 @@ class ResourceBundleGenerator implements BundleGenerator {
         CLDRConverter.info("Generating file " + file);
 
         try (PrintWriter out = new PrintWriter(file, "us-ascii")) {
-            out.printf(CopyrightHeaders.getOpenJDKCopyright(CLDRConverter.copyrightYear));
+            out.printf(getOpenJDKCopyright());
 
             out.printf("""
                 package sun.util.%s;
@@ -447,5 +447,13 @@ class ResourceBundleGenerator implements BundleGenerator {
             }
         });
         return tags;
+    }
+
+    private static String getOpenJDKCopyright() {
+        if (CLDRConverter.jdkHeaderTemplate != null) {
+            return String.format(CLDRConverter.jdkHeaderTemplate, CLDRConverter.copyrightYear);
+        } else {
+            return CopyrightHeaders.getOpenJDKCopyright(CLDRConverter.copyrightYear);
+        }
     }
 }

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -27,7 +27,6 @@ package build.tools.generatelsrequivmaps;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -60,8 +59,7 @@ public class EquivMapsGenerator {
             valid = false;
         } else if (args.length == 5) {
             if ("-jdk-header-template".equals(args[i])) {
-                jdkHeaderTemplate = new String(Files.readAllBytes(Paths.get(args[++i])),
-                                               StandardCharsets.UTF_8);
+                jdkHeaderTemplate = Files.readString(Paths.get(args[++i]));
                 i++;
             } else {
                 valid = false;

--- a/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/make/jdk/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -55,11 +55,19 @@ public class EquivMapsGenerator {
 
     public static void main(String[] args) throws Exception {
         int i = 0;
-        if (args.length == 5 && "-jdk-header-template".equals(args[i])) {
-            jdkHeaderTemplate = new String(Files.readAllBytes(Paths.get(args[++i])),
-                    StandardCharsets.UTF_8);
-            i++;
-        } else if (args.length != 3) {
+        boolean valid = true;
+        if (args.length != 5 && args.length !=3) {
+            valid = false;
+        } else if (args.length == 5) {
+            if ("-jdk-header-template".equals(args[i])) {
+                jdkHeaderTemplate = new String(Files.readAllBytes(Paths.get(args[++i])),
+                                               StandardCharsets.UTF_8);
+                i++;
+            } else {
+                valid = false;
+            }
+        }
+        if (!valid) {
             System.err.println("Usage: java EquivMapsGenerator"
                     + " [-jdk-header-template <file>]"
                     + " language-subtag-registry.txt LocaleEquivalentMaps.java copyrightYear");


### PR DESCRIPTION
In the JDK build we have various build tools that generate source code from data files. For most of these tools, the source files are based on template files, which already have copyright headers, but for some, the complete source file is generated by the tool, which is providing the copyright header programatically. For the latter, we would like to implement an override mechanism in each tool so that we can change the copyright header from a custom makefile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314483](https://bugs.openjdk.org/browse/JDK-8314483): Optionally override copyright header in generated source (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [a53cf2f2](https://git.openjdk.org/jdk/pull/15346/files/a53cf2f2c4618788cd122f36155cfd65e7160dcf)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [a53cf2f2](https://git.openjdk.org/jdk/pull/15346/files/a53cf2f2c4618788cd122f36155cfd65e7160dcf)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15346/head:pull/15346` \
`$ git checkout pull/15346`

Update a local copy of the PR: \
`$ git checkout pull/15346` \
`$ git pull https://git.openjdk.org/jdk.git pull/15346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15346`

View PR using the GUI difftool: \
`$ git pr show -t 15346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15346.diff">https://git.openjdk.org/jdk/pull/15346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15346#issuecomment-1684006772)