### PR TITLE
8214248: (fs) Files:mismatch spec clarifications

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1531,7 +1531,8 @@ public final class Files {
      * @throws  SecurityException
      *          In the case of the default provider, and a security manager is
      *          installed, the {@link SecurityManager#checkRead(String) checkRead}
-     *          method is invoked to check read access to both files.
+     *          method is invoked to check read access to both files when the
+     *          two paths are not equal
      *
      * @see java.nio.file.attribute.BasicFileAttributes#fileKey
      */
@@ -1569,8 +1570,8 @@ public final class Files {
      * {@code mismatch(f,f)} returns {@code -1L}). If the file system and files
      * remain static, then this method is <i>symmetric</i> (for two {@code Paths f}
      * and {@code g}, {@code mismatch(f,g)} will return the same value as
-     * {@code mismatch(g,f)}). If both paths locate the same file, the file
-     * system is not accessed.
+     * {@code mismatch(g,f)}). The only case where there is no file system
+     * access is when the paths are equal.
      *
      * @param   path
      *          the path to the first file
@@ -1584,8 +1585,8 @@ public final class Files {
      * @throws  SecurityException
      *          In the case of the default provider, and a security manager is
      *          installed, the {@link SecurityManager#checkRead(String) checkRead}
-     *          method is invoked to check read access to both files unless both
-     *          paths locate the same file
+     *          method is invoked to check read access to both files when the
+     *          two paths are not equal
      *
      * @since 12
      */

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1570,8 +1570,10 @@ public final class Files {
      * {@code mismatch(f,f)} returns {@code -1L}). If the file system and files
      * remain static, then this method is <i>symmetric</i> (for two {@code Paths f}
      * and {@code g}, {@code mismatch(f,g)} will return the same value as
-     * {@code mismatch(g,f)}). The only case where there is no file system
-     * access is when the paths are equal.
+     * {@code mismatch(g,f)}).
+     *
+     * <p> If both {@code Path} objects are equal, then this method returns
+     * {@code true} without checking if the file exists.
      *
      * @param   path
      *          the path to the first file

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1569,7 +1569,8 @@ public final class Files {
      * {@code mismatch(f,f)} returns {@code -1L}). If the file system and files
      * remain static, then this method is <i>symmetric</i> (for two {@code Paths f}
      * and {@code g}, {@code mismatch(f,g)} will return the same value as
-     * {@code mismatch(g,f)}).
+     * {@code mismatch(g,f)}). If both paths locate the same file, the file
+     * system is not accessed.
      *
      * @param   path
      *          the path to the first file
@@ -1583,7 +1584,8 @@ public final class Files {
      * @throws  SecurityException
      *          In the case of the default provider, and a security manager is
      *          installed, the {@link SecurityManager#checkRead(String) checkRead}
-     *          method is invoked to check read access to both files.
+     *          method is invoked to check read access to both files unless both
+     *          paths locate the same file
      *
      * @since 12
      */

--- a/src/java.base/share/classes/java/nio/file/package-info.java
+++ b/src/java.base/share/classes/java/nio/file/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,12 @@
  * is made. Whether this guarantee is possible with other {@link
  * java.nio.file.spi.FileSystemProvider provider} implementations is provider
  * specific. </p>
+ *
+ * <h2><a id="directories">Operations on Directories</a></h2>
+ * <p> Many operations which can be performed on regular files can also be
+ * performed on directories. It is highly implementation specific, however, as
+ * to whether such operations will succeed. These operations will either work
+ * or throw an {@code IOException}. </p>
  *
  * <h2>General Exceptions</h2>
  * <p> Unless otherwise noted, passing a {@code null} argument to a constructor

--- a/src/java.base/share/classes/java/nio/file/package-info.java
+++ b/src/java.base/share/classes/java/nio/file/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,12 +81,6 @@
  * is made. Whether this guarantee is possible with other {@link
  * java.nio.file.spi.FileSystemProvider provider} implementations is provider
  * specific. </p>
- *
- * <h2><a id="directories">Operations on Directories</a></h2>
- * <p> Many operations which can be performed on regular files can also be
- * performed on directories. It is highly implementation specific, however, as
- * to whether such operations will succeed. These operations will either work
- * or throw an {@code IOException}. </p>
  *
  * <h2>General Exceptions</h2>
  * <p> Unless otherwise noted, passing a {@code null} argument to a constructor


### PR DESCRIPTION
Clarify that `Files::mismatch` does not access the file system if both paths locate the same file. Add package documentation about file operations on directories being implementation specific.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8314682](https://bugs.openjdk.org/browse/JDK-8314682) to be approved

### Issues
 * [JDK-8214248](https://bugs.openjdk.org/browse/JDK-8214248): (fs) Files:mismatch spec clarifications (**Enhancement** - P3)
 * [JDK-8314682](https://bugs.openjdk.org/browse/JDK-8314682): (fs) Files:mismatch spec clarifications (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15350/head:pull/15350` \
`$ git checkout pull/15350`

Update a local copy of the PR: \
`$ git checkout pull/15350` \
`$ git pull https://git.openjdk.org/jdk.git pull/15350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15350`

View PR using the GUI difftool: \
`$ git pr show -t 15350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15350.diff">https://git.openjdk.org/jdk/pull/15350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15350#issuecomment-1684537947)