### PR TITLE
8219567: Name of first parameter of RandomAccessFile(String,String) is inconsistent

### DIFF
--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -192,8 +192,8 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * called with the pathname of the {@code file} argument as its
      * argument to see if read access to the file is allowed.  If the mode
      * allows writing, the security manager's {@code checkWrite} method is
-     * also called with the path argument to see if write access to the file is
-     * allowed.
+     * also called with the pathname of the {@code file} argument to see if
+     * write access to the file is allowed.
      *
      * @param      file   the file object
      * @param      mode   the access mode, as described

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -92,7 +92,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
 
     /**
      * Creates a random access file stream to read from, and optionally
-     * to write to, a file with the specified name. A new
+     * to write to, a file with the specified pathname. A new
      * {@link FileDescriptor} object is created to represent the
      * connection to the file.
      *
@@ -103,25 +103,25 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      *
      * <p>
      * If there is a security manager, its {@code checkRead} method
-     * is called with the {@code name} argument
+     * is called with the {@code pathname} argument
      * as its argument to see if read access to the file is allowed.
      * If the mode allows writing, the security manager's
      * {@code checkWrite} method
-     * is also called with the {@code name} argument
+     * is also called with the {@code pathname} argument
      * as its argument to see if write access to the file is allowed.
      *
-     * @param      name   the system-dependent filename
-     * @param      mode   the access <a href="#mode">mode</a>
+     * @param      pathname   the system-dependent pathname string
+     * @param      mode       the access <a href="#mode">mode</a>
      * @throws     IllegalArgumentException  if the mode argument is not equal
      *             to one of {@code "r"}, {@code "rw"}, {@code "rws"}, or
      *             {@code "rwd"}
      * @throws     FileNotFoundException
-     *             if the mode is {@code "r"} but the given string does not
+     *             if the mode is {@code "r"} but the given pathname string does not
      *             denote an existing regular file, or if the mode begins with
-     *             {@code "rw"} but the given string does not denote an
+     *             {@code "rw"} but the given pathname string does not denote an
      *             existing, writable regular file and a new regular file of
-     *             that name cannot be created, or if some other error occurs
-     *             while opening or creating the file
+     *             that pathname cannot be created, or if some other error
+     *             occurs while opening or creating the file
      * @throws     SecurityException   if a security manager exists and its
      *             {@code checkRead} method denies read access to the file
      *             or the mode is {@code "rw"} and the security manager's
@@ -131,10 +131,10 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @see        java.lang.SecurityManager#checkWrite(java.lang.String)
      * @revised 1.4
      */
-    public RandomAccessFile(String name, String mode)
+    public RandomAccessFile(String pathname, String mode)
         throws FileNotFoundException
     {
-        this(name != null ? new File(name) : null, mode);
+        this(pathname != null ? new File(pathname) : null, mode);
     }
 
     /**
@@ -206,8 +206,8 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      *             not denote an existing regular file, or if the mode begins
      *             with {@code "rw"} but the given file object does not denote
      *             an existing, writable regular file and a new regular file of
-     *             that name cannot be created, or if some other error occurs
-     *             while opening or creating the file
+     *             that pathname cannot be created, or if some other error
+     *             occurs while opening or creating the file
      * @throws      SecurityException  if a security manager exists and its
      *             {@code checkRead} method denies read access to the file
      *             or the mode is {@code "rw"} and the security manager's


### PR DESCRIPTION
Revise some verbiage about the `RandomAccessFile(String,String)` constructor so that the string name of a file is referred to as _pathname string_ for consistency with `java.io.File`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8314669](https://bugs.openjdk.org/browse/JDK-8314669) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8219567](https://bugs.openjdk.org/browse/JDK-8219567): Name of first parameter of RandomAccessFile(String,String) is inconsistent (**Enhancement** - P5)
 * [JDK-8314669](https://bugs.openjdk.org/browse/JDK-8314669): Name of first parameter of RandomAccessFile(String,String) is inconsistent (**CSR**)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [d8e43b53](https://git.openjdk.org/jdk/pull/15351/files/d8e43b532e35b4cdb90c590087626f6e1c5ea598)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [d8e43b53](https://git.openjdk.org/jdk/pull/15351/files/d8e43b532e35b4cdb90c590087626f6e1c5ea598)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15351/head:pull/15351` \
`$ git checkout pull/15351`

Update a local copy of the PR: \
`$ git checkout pull/15351` \
`$ git pull https://git.openjdk.org/jdk.git pull/15351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15351`

View PR using the GUI difftool: \
`$ git pr show -t 15351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15351.diff">https://git.openjdk.org/jdk/pull/15351.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15351#issuecomment-1684542094)