### PR TITLE
8314610: hotspot can't compile with the latest of gtest because of <iomanip>

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
+++ b/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 #include "utilities/vmassert_uninstall.hpp"
+#include <iomanip>
 #include <string.h>
 #include <sstream>
 #include "utilities/vmassert_reinstall.hpp"


### PR DESCRIPTION
This patch fixed a compilation error when we use the latest gtest. Because gtest has removed 
<iomanip> from its header files([link](https://github.com/google/googletest/commit/9ef5e8226919b56d6760b48258e706d819409994)),  we should include it by ourselves, or we can't find the definition of std::setw.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314610](https://bugs.openjdk.org/browse/JDK-8314610): hotspot can't compile with the latest of gtest because of &lt;iomanip&gt; (**Enhancement** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15352/head:pull/15352` \
`$ git checkout pull/15352`

Update a local copy of the PR: \
`$ git checkout pull/15352` \
`$ git pull https://git.openjdk.org/jdk.git pull/15352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15352`

View PR using the GUI difftool: \
`$ git pr show -t 15352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15352.diff">https://git.openjdk.org/jdk/pull/15352.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15352#issuecomment-1684542504)