### PR TITLE
JDK-8314752: Use google test string comparison macros

### DIFF
--- a/test/hotspot/gtest/logging/test_logConfiguration.cpp
+++ b/test/hotspot/gtest/logging/test_logConfiguration.cpp
@@ -36,6 +36,8 @@
 #include "unittest.hpp"
 #include "utilities/ostream.hpp"
 
+using testing::HasSubstr;
+
 class LogConfigurationTest : public LogTestFixture {
  protected:
   static char _all_decorators[256];
@@ -71,26 +73,26 @@ TEST_VM_F(LogConfigurationTest, describe) {
   const char* description = ss.as_string();
 
   // Verify that stdout and stderr are listed by default
-  EXPECT_PRED2(string_contains_substring, description, LogConfiguration::StdoutLog->name());
-  EXPECT_PRED2(string_contains_substring, description, LogConfiguration::StderrLog->name());
+  EXPECT_THAT(description, HasSubstr(LogConfiguration::StdoutLog->name()));
+  EXPECT_THAT(description, HasSubstr(LogConfiguration::StderrLog->name()));
 
   // Verify that each tag, level and decorator is listed
   for (size_t i = 0; i < LogTag::Count; i++) {
-    EXPECT_PRED2(string_contains_substring, description, LogTag::name(static_cast<LogTagType>(i)));
+    EXPECT_THAT(description, HasSubstr(LogTag::name(static_cast<LogTagType>(i))));
   }
   for (size_t i = 0; i < LogLevel::Count; i++) {
-    EXPECT_PRED2(string_contains_substring, description, LogLevel::name(static_cast<LogLevelType>(i)));
+    EXPECT_THAT(description, HasSubstr(LogLevel::name(static_cast<LogLevelType>(i))));
   }
   for (size_t i = 0; i < LogDecorators::Count; i++) {
-    EXPECT_PRED2(string_contains_substring, description, LogDecorators::name(static_cast<LogDecorators::Decorator>(i)));
+    EXPECT_THAT(description, HasSubstr(LogDecorators::name(static_cast<LogDecorators::Decorator>(i))));
   }
 
   // Verify that the default configuration is printed
   char expected_buf[256];
   int ret = jio_snprintf(expected_buf, sizeof(expected_buf), "=%s", LogLevel::name(LogLevel::Default));
   ASSERT_NE(-1, ret);
-  EXPECT_PRED2(string_contains_substring, description, expected_buf);
-  EXPECT_PRED2(string_contains_substring, description, "#1: stderr all=off");
+  EXPECT_THAT(description, HasSubstr(expected_buf));
+  EXPECT_THAT(description, HasSubstr("#1: stderr all=off"));
 
   // Verify default decorators are listed
   LogDecorators default_decorators;
@@ -107,7 +109,7 @@ TEST_VM_F(LogConfigurationTest, describe) {
       ASSERT_NE(-1, ret);
     }
   }
-  EXPECT_PRED2(string_contains_substring, description, expected_buf);
+  EXPECT_THAT(description, HasSubstr(expected_buf));
 
   // Add a new output and verify that it gets described after it has been added
   const char* what = "all=trace";
@@ -493,8 +495,8 @@ TEST_VM_F(LogConfigurationTest, parse_invalid_tagset) {
   bool success = LogConfiguration::parse_log_arguments("stdout", invalid_tagset, NULL, NULL, &ss);
   const char* msg = ss.as_string();
   EXPECT_TRUE(success) << "Should only cause a warning, not an error";
-  EXPECT_TRUE(string_contains_substring(msg, "No tag set matches selection:"));
-  EXPECT_TRUE(string_contains_substring(msg, invalid_tagset));
+  EXPECT_THAT(msg, HasSubstr("No tag set matches selection:"));
+  EXPECT_THAT(msg, HasSubstr(invalid_tagset));
 }
 
 TEST_VM_F(LogConfigurationTest, output_name_normalization) {
@@ -559,7 +561,7 @@ TEST_VM_F(LogConfigurationTest, suggest_similar_selection) {
 
   const char* suggestion = ss.as_string();
   SCOPED_TRACE(suggestion);
-  EXPECT_TRUE(string_contains_substring(ss.as_string(), "Did you mean any of the following?"));
+  EXPECT_THAT(suggestion, HasSubstr("Did you mean any of the following?"));
   EXPECT_TRUE(string_contains_substring(suggestion, "logging") ||
               string_contains_substring(suggestion, "start") ||
               string_contains_substring(suggestion, "exit") ||

--- a/test/hotspot/gtest/logging/test_logFileOutput.cpp
+++ b/test/hotspot/gtest/logging/test_logFileOutput.cpp
@@ -188,7 +188,7 @@ TEST_VM(LogFileOutput, invalid_file) {
   EXPECT_FALSE(bad_file.initialize("", &ss))
     << "file was initialized when there was an existing directory with the same name";
   char* logger_output = ss.as_string();
-  EXPECT_TRUE(string_contains_substring(logger_output, expected_output_substring))
+  EXPECT_THAT(logger_output, testing::HasSubstr(expected_output_substring))
     << "missing expected error message, received msg: %s" << logger_output;
   delete_empty_directory(path);
 }

--- a/test/hotspot/gtest/logging/test_logTagSetDescriptions.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSetDescriptions.cpp
@@ -42,7 +42,7 @@ TEST_VM(LogTagSetDescriptions, describe) {
     ResourceMark rm;
     stringStream stream;
     LogConfiguration::describe(&stream);
-    EXPECT_PRED2(string_contains_substring, stream.as_string(), expected)
+    EXPECT_THAT(stream.base(), testing::HasSubstr(expected))
       << "missing log tag set descriptions in LogConfiguration::describe";
   }
 }

--- a/test/hotspot/gtest/memory/test_guardedMemory.cpp
+++ b/test/hotspot/gtest/memory/test_guardedMemory.cpp
@@ -139,7 +139,7 @@ TEST(GuardedMemory, wrap) {
   if (HasFatalFailure()) {
     return;
   }
-  EXPECT_EQ(0, strcmp(str, str_copy)) << "Not identical copy";
+  EXPECT_STREQ(str, str_copy) << "Not identical copy";
   EXPECT_TRUE(GuardedMemory::free_copy(str_copy)) << "Free copy failed to verify";
 
   void* no_data = NULL;

--- a/test/hotspot/gtest/oops/test_cpCache_output.cpp
+++ b/test/hotspot/gtest/oops/test_cpCache_output.cpp
@@ -42,31 +42,21 @@ TEST_VM(ConstantPoolCache, print_on) {
   klass->constants()->cache()->print_on(&ss);
 
   const char* output = ss.freeze();
-  // method entry test
-  ASSERT_TRUE(strstr(output, "this") != NULL) << "must have \"this\"";
-  ASSERT_TRUE(strstr(output, "bytecode 1:") != NULL) << "must have \"bytecode 1\"";
-  ASSERT_TRUE(strstr(output, "bytecode 2:") != NULL) << "must have \"bytecode 2\"";
-  ASSERT_TRUE(strstr(output, "cp index:") != NULL) << "must have constant pool index";
-  ASSERT_TRUE(strstr(output, "F1:") != NULL) << "must have F1 value";
-  ASSERT_TRUE(strstr(output, "F2:") != NULL) << "must have F2 value";
-  ASSERT_TRUE(strstr(output, "method:") != NULL) << "must have a method";
-  ASSERT_TRUE(strstr(output, "flag values:") != NULL) << "must have a flag";
-  ASSERT_TRUE(strstr(output, "tos:") != NULL) << "must have result type";
-  ASSERT_TRUE(strstr(output, "local signature:") != NULL) << "must have local signature flag";
-  ASSERT_TRUE(strstr(output, "has appendix:") != NULL) << "must have appendix flag";
-  ASSERT_TRUE(strstr(output, "forced virtual:") != NULL) << "must have forced virtual flag";
-  ASSERT_TRUE(strstr(output, "final:") != NULL) << "must have final flag";
-  ASSERT_TRUE(strstr(output, "virtual final:") != NULL) << "must have virtual final flag";
-  ASSERT_TRUE(strstr(output, "resolution failed:") != NULL) << "must have resolution failed flag";
-  ASSERT_TRUE(strstr(output, "num parameters:") != NULL) << "must have number of parameters";
+  static const char* const expected_strings[] = {
+    // Method entry tests:
+    "this", "bytecode 1:", "bytecode 2:", "cp index:", "F1:", "F2:",
+    "method:", "flag values:", "tos:", "local signature:", "has appendix:",
+    "forced virtual:", "final:", "virtual final:", "resolution failed:",
+    "num parameters:",
 
-  // field entry test
-  ASSERT_TRUE(strstr(output, "Offset:") != NULL) << "must have field offset";
-  ASSERT_TRUE(strstr(output, "Field Index:") != NULL) << "must have field index";
-  ASSERT_TRUE(strstr(output, "CP Index:") != NULL) << "must have constant pool index";
-  ASSERT_TRUE(strstr(output, "TOS:") != NULL) << "must have type";
-  ASSERT_TRUE(strstr(output, "Is Final:") != NULL) << "must have final flag";
-  ASSERT_TRUE(strstr(output, "Is Volatile:") != NULL) << "must have volatile flag";
-  ASSERT_TRUE(strstr(output, "Put Bytecode:") != NULL) << "must have \"put code\"";
-  ASSERT_TRUE(strstr(output, "Get Bytecode:") != NULL) << "must have \"get code\"";
+    // field entry test
+    "Offset:", "Field Index:", "CP Index:", "TOS:", "Is Final:", "Is Volatile:",
+    "Put Bytecode:", "Get Bytecode:",
+    nullptr
+  };
+
+  for (int i = 0; expected_strings[i] != nullptr; i++) {
+    ASSERT_THAT(output, testing::HasSubstr(expected_strings[i]));
+  }
+
 }

--- a/test/hotspot/gtest/oops/test_instanceKlass.cpp
+++ b/test/hotspot/gtest/oops/test_instanceKlass.cpp
@@ -33,6 +33,8 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "unittest.hpp"
 
+using testing::HasSubstr;
+
 // Tests for InstanceKlass::is_class_loader_instance_klass() function
 TEST_VM(InstanceKlass, class_loader_class) {
   InstanceKlass* klass = vmClasses::ClassLoader_klass();
@@ -51,20 +53,20 @@ TEST_VM(InstanceKlass, class_loader_printer) {
   stringStream st;
   loader->print_on(&st);
   // See if injected loader_data field is printed in string
-  ASSERT_TRUE(strstr(st.as_string(), "injected 'loader_data'") != NULL) << "Must contain injected fields";
+  ASSERT_THAT(st.base(), HasSubstr("injected 'loader_data'")) << "Must contain injected fields";
   st.reset();
   // See if mirror injected fields are printed.
   oop mirror = vmClasses::ClassLoader_klass()->java_mirror();
   mirror->print_on(&st);
-  ASSERT_TRUE(strstr(st.as_string(), "injected 'protection_domain'") != NULL) << "Must contain injected fields";
+  ASSERT_THAT(st.base(), HasSubstr("injected 'protection_domain'")) << "Must contain injected fields";
   // We should test other printing functions too.
 #ifndef PRODUCT
   st.reset();
   // method printing is non-product
   Method* method = vmClasses::ClassLoader_klass()->methods()->at(0);  // we know there's a method here!
   method->print_on(&st);
-  ASSERT_TRUE(strstr(st.as_string(), "method holder:") != NULL) << "Must contain method_holder field";
-  ASSERT_TRUE(strstr(st.as_string(), "'java/lang/ClassLoader'") != NULL) << "Must be in ClassLoader";
+  ASSERT_THAT(st.base(), HasSubstr("method holder:")) << "Must contain method_holder field";
+  ASSERT_THAT(st.base(), HasSubstr("'java/lang/ClassLoader'")) << "Must be in ClassLoader";
 #endif
 }
 

--- a/test/hotspot/gtest/oops/test_markWord.cpp
+++ b/test/hotspot/gtest/oops/test_markWord.cpp
@@ -40,14 +40,11 @@
 
 // The test doesn't work for PRODUCT because it needs WizardMode
 #ifndef PRODUCT
-static bool test_pattern(stringStream* st, const char* pattern) {
-  return (strstr(st->as_string(), pattern) != NULL);
-}
 
 static void assert_test_pattern(Handle object, const char* pattern) {
   stringStream st;
   object->print_on(&st);
-  ASSERT_TRUE(test_pattern(&st, pattern)) << pattern << " not in " << st.as_string();
+  ASSERT_THAT(st.base(), testing::HasSubstr(pattern));
 }
 
 class LockerThread : public JavaTestThread {

--- a/test/hotspot/gtest/runtime/test_classPrinter.cpp
+++ b/test/hotspot/gtest/runtime/test_classPrinter.cpp
@@ -29,6 +29,8 @@
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
 
+using testing::HasSubstr;
+
 TEST_VM(ClassPrinter, print_classes) {
   JavaThread* THREAD = JavaThread::current();
   ThreadInVMfromNative invm(THREAD);
@@ -38,9 +40,9 @@ TEST_VM(ClassPrinter, print_classes) {
   ClassPrinter::print_classes("java/lang/Object", 0x03, &ss);
   const char* output = ss.freeze();
 
-  ASSERT_TRUE(strstr(output, "class java/lang/Object loader data:") != NULL) << "must find java/lang/Object";
-  ASSERT_TRUE(strstr(output, "method wait : (J)V") != NULL) << "must find java/lang/Object::wait";
-  ASSERT_TRUE(strstr(output, "method finalize : ()V\n   0 return") != NULL) << "must find java/lang/Object::finalize and disasm";
+  ASSERT_THAT(output, HasSubstr("class java/lang/Object loader data:")) << "must find java/lang/Object";
+  ASSERT_THAT(output, HasSubstr("method wait : (J)V")) << "must find java/lang/Object::wait";
+  ASSERT_THAT(output, HasSubstr("method finalize : ()V\n   0 return")) << "must find java/lang/Object::finalize and disasm";
 }
 
 TEST_VM(ClassPrinter, print_methods) {
@@ -51,16 +53,16 @@ TEST_VM(ClassPrinter, print_methods) {
   stringStream s1;
   ClassPrinter::print_methods("*ang/Object*", "wait", 0x1, &s1);
   const char* o1 = s1.freeze();
-  ASSERT_TRUE(strstr(o1, "class java/lang/Object loader data:") != NULL) << "must find java/lang/Object";
-  ASSERT_TRUE(strstr(o1, "method wait : (J)V")    != NULL) << "must find java/lang/Object::wait(long)";
-  ASSERT_TRUE(strstr(o1, "method wait : ()V")     != NULL) << "must find java/lang/Object::wait()";
-  ASSERT_TRUE(strstr(o1, "method finalize : ()V") == NULL) << "must not find java/lang/Object::finalize";
+  ASSERT_THAT(o1, HasSubstr("class java/lang/Object loader data:")) << "must find java/lang/Object";
+  ASSERT_THAT(o1, HasSubstr("method wait : (J)V")) << "must find java/lang/Object::wait(long)";
+  ASSERT_THAT(o1, HasSubstr("method wait : ()V")) << "must find java/lang/Object::wait()";
+  ASSERT_THAT(o1, Not(HasSubstr("method finalize : ()V"))) << "must not find java/lang/Object::finalize";
 
   stringStream s2;
   ClassPrinter::print_methods("j*ang/Object*", "wait:(*J*)V", 0x1, &s2);
   const char* o2 = s2.freeze();
-  ASSERT_TRUE(strstr(o2, "class java/lang/Object loader data:") != NULL) << "must find java/lang/Object";
-  ASSERT_TRUE(strstr(o2, "method wait : (J)V")  != NULL) << "must find java/lang/Object::wait(long)";
-  ASSERT_TRUE(strstr(o2, "method wait : (JI)V") != NULL) << "must find java/lang/Object::wait(long,int)";
-  ASSERT_TRUE(strstr(o2, "method wait : ()V")   == NULL) << "must not find java/lang/Object::wait()";
+  ASSERT_THAT(o2, HasSubstr("class java/lang/Object loader data:")) << "must find java/lang/Object";
+  ASSERT_THAT(o2, HasSubstr("method wait : (J)V")) << "must find java/lang/Object::wait(long)";
+  ASSERT_THAT(o2, HasSubstr("method wait : (JI)V")) << "must find java/lang/Object::wait(long,int)";
+  ASSERT_THAT(o2, Not(HasSubstr("method wait : ()V"))) << "must not find java/lang/Object::wait()";
 }

--- a/test/hotspot/gtest/runtime/test_globals.cpp
+++ b/test/hotspot/gtest/runtime/test_globals.cpp
@@ -77,11 +77,11 @@ TEST_VM(FlagGuard, ccstr_flag) {
 TEST_VM(FlagAccess, ccstr_flag) {
   FLAG_SET_CMDLINE(SharedArchiveConfigFile, "");
   ASSERT_EQ(FLAG_IS_CMDLINE(SharedArchiveConfigFile), true);
-  ASSERT_EQ(strcmp(SharedArchiveConfigFile, ""), 0);
+  EXPECT_STREQ(SharedArchiveConfigFile, "");
 
   FLAG_SET_ERGO(SharedArchiveConfigFile, "foobar");
   ASSERT_EQ(FLAG_IS_ERGO(SharedArchiveConfigFile), true);
-  ASSERT_EQ(strcmp(SharedArchiveConfigFile, "foobar") , 0);
+  EXPECT_STREQ(SharedArchiveConfigFile, "foobar");
 
   FLAG_SET_ERGO(SharedArchiveConfigFile, nullptr);
   ASSERT_EQ(FLAG_IS_ERGO(SharedArchiveConfigFile), true);
@@ -89,7 +89,7 @@ TEST_VM(FlagAccess, ccstr_flag) {
 
   FLAG_SET_ERGO(SharedArchiveConfigFile, "xyz");
   ASSERT_EQ(FLAG_IS_ERGO(SharedArchiveConfigFile), true);
-  ASSERT_EQ(strcmp(SharedArchiveConfigFile, "xyz"), 0);
+  EXPECT_STREQ(SharedArchiveConfigFile, "xyz");
 }
 
 template <typename T, int type_enum>

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -38,6 +38,8 @@
 #include "os_windows.hpp"
 #endif
 
+using testing::HasSubstr;
+
 static size_t small_page_size() {
   return os::vm_page_size();
 }
@@ -171,7 +173,7 @@ static void do_test_print_hex_dump(address addr, size_t len, int unitsize, const
   os::print_hex_dump(&ss, addr, addr + len, unitsize);
   // tty->print_cr("expected: %s", expected);
   // tty->print_cr("result: %s", buf);
-  EXPECT_THAT(buf, testing::HasSubstr(expected));
+  EXPECT_THAT(buf, HasSubstr(expected));
 }
 
 TEST_VM(os, test_print_hex_dump) {
@@ -768,7 +770,7 @@ TEST_VM(os, pagesizes_test_print) {
   char buffer[256];
   stringStream ss(buffer, sizeof(buffer));
   pss.print_on(&ss);
-  ASSERT_EQ(strcmp(expected, buffer), 0);
+  EXPECT_STREQ(expected, buffer);
 }
 
 TEST_VM(os, dll_address_to_function_and_library_name) {
@@ -777,9 +779,9 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
   stringStream st(output, sizeof(output));
 
 #define EXPECT_CONTAINS(haystack, needle) \
-  EXPECT_NE(::strstr(haystack, needle), (char*)NULL)
+  EXPECT_THAT(haystack, HasSubstr(needle));
 #define EXPECT_DOES_NOT_CONTAIN(haystack, needle) \
-  EXPECT_EQ(::strstr(haystack, needle), (char*)NULL)
+  EXPECT_THAT(haystack, Not(HasSubstr(needle)));
 // #define LOG(...) tty->print_cr(__VA_ARGS__); // enable if needed
 #define LOG(...)
 

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -433,7 +433,7 @@ TEST(os_linux, addr_to_function_valid) {
   int offset = -1;
   address valid_function_pointer = (address)JNI_CreateJavaVM;
   ASSERT_TRUE(os::dll_address_to_function_name(valid_function_pointer, buf, sizeof(buf), &offset, true));
-  ASSERT_TRUE(strstr(buf, "JNI_CreateJavaVM") != nullptr);
+  ASSERT_THAT(buf, testing::HasSubstr("JNI_CreateJavaVM"));
   ASSERT_TRUE(offset >= 0);
 }
 
@@ -444,7 +444,7 @@ TEST_VM(os_linux, decoder_get_source_info_valid) {
   int line = -1;
   address valid_function_pointer = (address)ReportJNIFatalError;
   ASSERT_TRUE(Decoder::get_source_info(valid_function_pointer, buf, sizeof(buf), &line));
-  ASSERT_TRUE(strcmp(buf, "jniCheck.hpp") == 0);
+  EXPECT_STREQ(buf, "jniCheck.hpp");
   ASSERT_TRUE(line > 0);
 }
 
@@ -471,7 +471,7 @@ TEST_VM(os_linux, decoder_get_source_info_valid_overflow) {
   int line = -1;
   address valid_function_pointer = (address)ReportJNIFatalError;
   ASSERT_TRUE(Decoder::get_source_info(valid_function_pointer, buf, 11, &line));
-  ASSERT_TRUE(strcmp(buf, "<OVERFLOW>") == 0);
+  EXPECT_STREQ(buf, "<OVERFLOW>");
   ASSERT_TRUE(line > 0);
 }
 
@@ -482,7 +482,7 @@ TEST_VM(os_linux, decoder_get_source_info_valid_overflow_minimal) {
   int line = -1;
   address valid_function_pointer = (address)ReportJNIFatalError;
   ASSERT_TRUE(Decoder::get_source_info(valid_function_pointer, buf, 2, &line));
-  ASSERT_TRUE(strcmp(buf, "L") == 0); // Overflow message does not fit, so we fall back to "L:line_number"
+  EXPECT_STREQ(buf, "L"); // Overflow message does not fit, so we fall back to "L:line_number"
   ASSERT_TRUE(line > 0); // Line should correctly be found and returned
 }
 #endif // clang

--- a/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
+++ b/test/hotspot/gtest/utilities/test_globalDefinitions.cpp
@@ -226,11 +226,9 @@ TEST(globalDefinitions, array_size) {
     stringStream out;                                          \
     out.print((format), (value));                              \
     const char* result = out.as_string();                      \
-    EXPECT_EQ(strcmp(result, (expected)), 0) << "Failed with"  \
+    EXPECT_STREQ((result), (expected)) << "Failed with"        \
         << " format '"   << (format)   << "'"                  \
-        << " value '"    << (value)    << "'"                  \
-        << " result '"   << result     << "'"                  \
-        << " expected '" << (expected) << "'";                 \
+        << " value '"    << (value);                           \
   } while (false)
 
 TEST(globalDefinitions, format_specifiers) {

--- a/test/hotspot/gtest/utilities/test_parse_memory_size.cpp
+++ b/test/hotspot/gtest/utilities/test_parse_memory_size.cpp
@@ -66,7 +66,7 @@ static void do_test_valid(T expected_value, const char* pattern) {
   ASSERT_TRUE(rc);
   ASSERT_EQ(value, expected_value);
   ASSERT_EQ(end, ss.base() + strlen(pattern));
-  ASSERT_EQ(strcmp(end, ":-)"), 0);
+  EXPECT_STREQ(end, ":-)");
 
   rc = parse_integer(ss.base(), &value);
   ASSERT_FALSE(rc);

--- a/test/hotspot/gtest/utilities/test_resourceHash.cpp
+++ b/test/hotspot/gtest/utilities/test_resourceHash.cpp
@@ -468,7 +468,7 @@ TEST_VM_F(ResourceHashtablePrintTest, print_test) {
   const char* strings[] = {
       "Number of buckets", "Number of entries", "300", "Number of literals", "Average bucket size", "Maximum bucket size" };
   for (const auto& str : strings) {
-    ASSERT_TRUE(strstr(st.as_string(), str) != nullptr) << "string not present " << str;
+    ASSERT_THAT(st.base(), testing::HasSubstr(str));
   }
   // Cleanup: need to delete pointers in entries
   TableDeleter deleter;


### PR DESCRIPTION
Small improvement to use google test's string comparison macros instead of raw C-functions.

This makes the code more readable and provides us with automatic error output in case of string mismatches (so we don't have to print the values via "<<").

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314752](https://bugs.openjdk.org/browse/JDK-8314752): Use google test string comparison macros (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15355/head:pull/15355` \
`$ git checkout pull/15355`

Update a local copy of the PR: \
`$ git checkout pull/15355` \
`$ git pull https://git.openjdk.org/jdk.git pull/15355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15355`

View PR using the GUI difftool: \
`$ git pr show -t 15355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15355.diff">https://git.openjdk.org/jdk/pull/15355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15355#issuecomment-1687802605)