### PR TITLE
8314618: RISC-V: -XX:MaxVectorSize does not work as expected

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -880,7 +880,7 @@ instruct vmla(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (AddVI dst_src1 (MulVI src2 src3)));
   match(Set dst_src1 (AddVL dst_src1 (MulVL src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vmla $dst_src1, $dst_src1, src2, src3" %}
+  format %{ "vmla $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
@@ -916,7 +916,7 @@ instruct vmls(vReg dst_src1, vReg src2, vReg src3) %{
   match(Set dst_src1 (SubVI dst_src1 (MulVI src2 src3)));
   match(Set dst_src1 (SubVL dst_src1 (MulVL src2 src3)));
   ins_cost(VEC_COST);
-  format %{ "vmls $dst_src1, $dst_src1, src2, src3" %}
+  format %{ "vmls $dst_src1, $dst_src1, $src2, $src3" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -267,8 +267,8 @@ void VM_Version::c2_initialize() {
       if (MaxVectorSize > _initial_vector_length) {
         warning("Current system only supports max RVV vector length %d. Set MaxVectorSize to %d",
                 _initial_vector_length, _initial_vector_length);
+        MaxVectorSize = _initial_vector_length;
       }
-      MaxVectorSize = _initial_vector_length;
     } else {
       vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
     }


### PR DESCRIPTION
Hi all,  we found that when the specified -XX:MaxVectorSize=16 no bigger than the detected _initial_vector_length=32, it causes the MaxVectorSize to be set incorrectly. 

MaxVectorSize is updated in src/hotspot/cpu/riscv/vm_version_riscv.cpp#VM_Version::c2_initialize().

```
  if (UseRVV) {
    if (FLAG_IS_DEFAULT(MaxVectorSize)) {
      MaxVectorSize = _initial_vector_length;
    } else if (MaxVectorSize < 16) {
      warning("RVV does not support vector length less than 16 bytes. Disabling RVV.");
      UseRVV = false;
    } else if (is_power_of_2(MaxVectorSize)) {
      if (MaxVectorSize > _initial_vector_length) {
        warning("Current system only supports max RVV vector length %d. Set MaxVectorSize to %d",
                _initial_vector_length, _initial_vector_length);
      }
      MaxVectorSize = _initial_vector_length;
    } else {
      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
    }
  }
```

It's that RISC-V only supports max-width vectorization at first, so it's unconditionally set to hardware max-width here. However, after https://github.com/openjdk/jdk/commit/43c71ddf923d442499449948f4bf8a7c79249af0, vectors with small widths are supported, so here it needs to be adjusted accordingly. The correct should be If MaxVectorSize is less than _initial_vector_length, then MaxVectorSize should be used as the final value.

This issue affects C2 autovectorization and some specific Vector API interfaces such as VectorSupport.getMaxLaneCount.

We can verify the problem using the following test case:

```
import jdk.internal.vm.vector.VectorSupport;

public class GetMaxVectorSizeTest {
    public static void main(String[] args) {
        final int maxLaneCount = VectorSupport.getMaxLaneCount(byte.class);
        System.out.println("maxLaneCount:" + maxLaneCount);
    }
}
```

The compile command is as follows:

```
javac --add-exports java.base/jdk.internal.vm.vector=ALL-UNNAMED GetMaxVectorSizeTest.java
```

RISC-V without the -XX:MaxVectorSize=16 has the following execution results(risc-v rvv vector length is set 256 bit):
```
zifeihan@plct-c8:~/jdk-rvv/build/linux-riscv64-server-fastdebug/jdk/bin$ ./java -XX:+UnlockExperimentalVMOptions -XX:+UseRVV --add-exports java.base/jdk.internal.vm.vector=ALL-UNNAMED  GetMaxVectorSizeTest
maxLaneCount:32
```

RISC-V using the -XX:MaxVectorSize=16 results in the following(risc-v rvv vector length is set 256 bit):

```
zifeihan@plct-c8:~/jdk-rvv/build/linux-riscv64-server-fastdebug/jdk/bin$ ./java -XX:MaxVectorSize=16 -XX:+UnlockExperimentalVMOptions -XX:+UseRVV --add-exports java.base/jdk.internal.vm.vector=ALL-UNNAMED  GetMaxVectorSizeTest
maxLaneCount:32
```


AArch64 without the -XX:MaxVectorSize=16 has the following execution results(aarch64 sve vector length is set 256 bit):
```
zifeihan@d915263bc793:~/jdk/build/linux-aarch64-server-fastdebug/jdk/bin$ ./java --add-exports java.base/jdk.internal.vm.vector=ALL-UNNAMED  GetMaxVectorSizeTest
maxLaneCount:32
```

AArch64 using the -XX:MaxVectorSize=16 results in the following(aarch64 sve vector length is set 256 bit):
```
zifeihan@d915263bc793:~/jdk/build/linux-aarch64-server-fastdebug/jdk/bin$ ./java  -XX:MaxVectorSize=16  --add-exports java.base/jdk.internal.vm.vector=ALL-UNNAMED  GetMaxVectorSizeTest
maxLaneCount:16
```

X86 without the -XX:MaxVectorSize=16 has the following execution results(x86 avx512, vector length is set 512 bit):

```
zifeihan@plct-c8:~/jdk/build/linux-riscv64-server-fastdebug/jdk/bin$ java --add-exports java.base/jdk.internal.vm.vector=ALL-UNNAMED  GetMaxVectorSizeTest
maxLaneCount:64
```

X86 using the -XX:MaxVectorSize=16 results in the following(x86 avx512, vector length is set 512 bit):

```
zifeihan@plct-c8:~/jdk/build/linux-riscv64-server-fastdebug/jdk/bin$ java  -XX:MaxVectorSize=16  --add-exports java.base/jdk.internal.vm.vector=ALL-UNNAMED  GetMaxVectorSizeTest
maxLaneCount:16
```
Testing:
qemu with UseRVV:

- [x] Tier1 tests (release)
- [ ] Tier2 tests (release)
- [ ] Tier3 tests (release)
- [x] test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314618](https://bugs.openjdk.org/browse/JDK-8314618): RISC-V: -XX:MaxVectorSize does not work as expected (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15356/head:pull/15356` \
`$ git checkout pull/15356`

Update a local copy of the PR: \
`$ git checkout pull/15356` \
`$ git pull https://git.openjdk.org/jdk.git pull/15356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15356`

View PR using the GUI difftool: \
`$ git pr show -t 15356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15356.diff">https://git.openjdk.org/jdk/pull/15356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15356#issuecomment-1685510928)