### PR TITLE
8314555: Build with mawk fails on Windows

### DIFF
--- a/make/hotspot/lib/JvmMapfile.gmk
+++ b/make/hotspot/lib/JvmMapfile.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/hotspot/lib/JvmMapfile.gmk
+++ b/make/hotspot/lib/JvmMapfile.gmk
@@ -118,7 +118,7 @@ else ifeq ($(call isTargetOs, windows), true)
 
   FILTER_SYMBOLS_AWK_SCRIPT := \
       '{ \
-        if ($$7 ~ /??_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print $$7; \
+        if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print $$7; \
       }'
 
 else


### PR DESCRIPTION
Building JDK with mawk on windows fails due to regular expression. I use WSL Debian. Debian has mawk as the default awk implementation.
```
$ awk
Usage: mawk [Options] [Program] [file ...]

$ make images
Building target 'images' in configuration 'windows-x86_64-server-fastdebug'
...
nawk: line 1: regular expression compile failed (missing operand)
??_7.*@@6B@
```
The meta character '?' is not escaped, so the error occurs. I added an escape sequence prefix to it. Incidentally, this doesn't happen if we use gawk instead of mawk. Gawk works fine with or without the prefix.

### Check
I've built JDK with both awk and they are successful. Additionally, I checked the result of both awk executions. I saved each result to a file during the build.
```
$(JVM_OUTPUTDIR)/symbols-objects: $(BUILD_LIBJVM_ALL_OBJS)
	$(call LogInfo, Generating symbol list from object files)
	$(CD) $(JVM_OUTPUTDIR)/objs && \
	  $(DUMP_SYMBOLS_CMD) | $(AWK) $(FILTER_SYMBOLS_AWK_SCRIPT) | $(SORT) -u > [FILE]
```
The file from gawk before applying this PR, the file from mawk after applying this PR and the file from gawk after applying this PR were the same.

### Note

Only the windows build uses this regular expression. I also tried to look for non-escaped meta characters in the make directory, but there were none.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314555](https://bugs.openjdk.org/browse/JDK-8314555): Build with mawk fails on Windows (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15357/head:pull/15357` \
`$ git checkout pull/15357`

Update a local copy of the PR: \
`$ git checkout pull/15357` \
`$ git pull https://git.openjdk.org/jdk.git pull/15357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15357`

View PR using the GUI difftool: \
`$ git pr show -t 15357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15357.diff">https://git.openjdk.org/jdk/pull/15357.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15357#issuecomment-1689227287)