### PR TITLE
8314877: Make fields final in 'java.net' package

### DIFF
--- a/src/java.base/share/classes/java/net/HttpConnectSocketImpl.java
+++ b/src/java.base/share/classes/java/net/HttpConnectSocketImpl.java
@@ -53,7 +53,7 @@ import java.util.Set;
     private final String server;
     private final Socket socket;
     private InetSocketAddress external_address;
-    private HashMap<Integer, Object> optionsMap = new HashMap<>();
+    private final HashMap<Integer, Object> optionsMap = new HashMap<>();
 
     static  {
         try {

--- a/src/java.base/share/classes/java/net/HttpRetryException.java
+++ b/src/java.base/share/classes/java/net/HttpRetryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class HttpRetryException extends IOException {
     /**
      * The response code.
      */
-    private int responseCode;
+    private final int responseCode;
 
     /**
      * The URL to be redirected to.

--- a/src/java.base/share/classes/java/net/IDN.java
+++ b/src/java.base/share/classes/java/net/IDN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,9 +242,10 @@ public final class IDN {
     private static final int MAX_LABEL_LENGTH   = 63;
 
     // single instance of nameprep
-    private static StringPrep namePrep = null;
+    private static final StringPrep namePrep;
 
     static {
+        StringPrep stringPrep = null;
         try {
             final String IDN_PROFILE = "/sun/net/idn/uidna.spp";
             @SuppressWarnings("removal")
@@ -255,12 +256,13 @@ public final class IDN {
                             }})
                     : StringPrep.class.getResourceAsStream(IDN_PROFILE);
 
-            namePrep = new StringPrep(stream);
+            stringPrep = new StringPrep(stream);
             stream.close();
         } catch (IOException e) {
             // should never reach here
             assert false;
         }
+        namePrep = stringPrep;
     }
 
 

--- a/src/java.base/share/classes/java/net/PasswordAuthentication.java
+++ b/src/java.base/share/classes/java/net/PasswordAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,8 @@ package java.net;
 
 public final class PasswordAuthentication {
 
-    private String userName;
-    private char[] password;
+    private final String userName;
+    private final char[] password;
 
     /**
      * Creates a new {@code PasswordAuthentication} object from the given

--- a/src/java.base/share/classes/java/net/Proxy.java
+++ b/src/java.base/share/classes/java/net/Proxy.java
@@ -59,8 +59,8 @@ public class Proxy {
         SOCKS
     };
 
-    private Type type;
-    private SocketAddress sa;
+    private final Type type;
+    private final SocketAddress sa;
 
     /**
      * A proxy setting that represents a {@code DIRECT} connection,

--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -44,6 +44,7 @@ import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import sun.net.util.IPAddressUtil;
 import sun.net.PortConfig;
+import sun.security.action.GetBooleanAction;
 import sun.security.util.RegisteredDomain;
 import sun.security.util.SecurityConstants;
 import sun.security.util.Debug;
@@ -234,7 +235,7 @@ public final class SocketPermission extends Permission
     private transient boolean trusted;
 
     // true if the sun.net.trustNameService system property is set
-    private static boolean trustNameService;
+    private static final boolean trustNameService = GetBooleanAction.privilegedGetProperty("sun.net.trustNameService");
 
     private static Debug debug = null;
     private static boolean debugInit = false;
@@ -244,13 +245,6 @@ public final class SocketPermission extends Permission
         static final int low = initEphemeralPorts("low", DEF_EPH_LOW);
             static final int high = initEphemeralPorts("high", PORT_MAX);
     };
-
-    static {
-        @SuppressWarnings("removal")
-        Boolean tmp = java.security.AccessController.doPrivileged(
-                new sun.security.action.GetBooleanAction("sun.net.trustNameService"));
-        trustNameService = tmp.booleanValue();
-    }
 
     private static synchronized Debug getDebug() {
         if (!debugInit) {

--- a/src/java.base/share/classes/java/net/URI.java
+++ b/src/java.base/share/classes/java/net/URI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2977,7 +2977,7 @@ public final class URI
 
     private class Parser {
 
-        private String input;           // URI input string
+        private final String input;           // URI input string
         private boolean requireServerAuthority = false;
 
         Parser(String s) {

--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -1471,10 +1471,10 @@ public final class URL implements java.io.Serializable {
     private static Iterator<URLStreamHandlerProvider> providers() {
         return new Iterator<>() {
 
-            ClassLoader cl = ClassLoader.getSystemClassLoader();
-            ServiceLoader<URLStreamHandlerProvider> sl =
+            final ClassLoader cl = ClassLoader.getSystemClassLoader();
+            final ServiceLoader<URLStreamHandlerProvider> sl =
                     ServiceLoader.load(URLStreamHandlerProvider.class, cl);
-            Iterator<URLStreamHandlerProvider> i = sl.iterator();
+            final Iterator<URLStreamHandlerProvider> i = sl.iterator();
 
             URLStreamHandlerProvider next = null;
 
@@ -1589,7 +1589,7 @@ public final class URL implements java.io.Serializable {
     /**
      * A table of protocol handlers.
      */
-    static Hashtable<String,URLStreamHandler> handlers = new Hashtable<>();
+    static final Hashtable<String,URLStreamHandler> handlers = new Hashtable<>();
     private static final Object streamHandlerLock = new Object();
 
     /**

--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -1589,7 +1589,7 @@ public final class URL implements java.io.Serializable {
     /**
      * A table of protocol handlers.
      */
-    static final Hashtable<String,URLStreamHandler> handlers = new Hashtable<>();
+    private static final Hashtable<String, URLStreamHandler> handlers = new Hashtable<>();
     private static final Object streamHandlerLock = new Object();
 
     /**

--- a/src/java.base/share/classes/java/net/URLClassLoader.java
+++ b/src/java.base/share/classes/java/net/URLClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,7 +264,7 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
      * we have to keep a weak reference to each stream.
      */
 
-    private WeakHashMap<Closeable,Void>
+    private final WeakHashMap<Closeable,Void>
         closeables = new WeakHashMap<>();
 
     /**

--- a/src/java.base/share/classes/java/net/URLConnection.java
+++ b/src/java.base/share/classes/java/net/URLConnection.java
@@ -308,7 +308,7 @@ public abstract class URLConnection {
 
         if (map == null) {
             fileNameMap = map = new FileNameMap() {
-                private FileNameMap internalMap =
+                private final FileNameMap internalMap =
                     sun.net.www.MimeTable.loadTable();
 
                 public String getContentTypeFor(String fileName) {


### PR DESCRIPTION
A few classes in `java.net` package have non-final fields which could easily be marked `final`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314877](https://bugs.openjdk.org/browse/JDK-8314877): Make fields final in 'java.net' package (**Enhancement** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15358/head:pull/15358` \
`$ git checkout pull/15358`

Update a local copy of the PR: \
`$ git checkout pull/15358` \
`$ git pull https://git.openjdk.org/jdk.git pull/15358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15358`

View PR using the GUI difftool: \
`$ git pr show -t 15358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15358.diff">https://git.openjdk.org/jdk/pull/15358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15358#issuecomment-1689721965)