### PR TITLE
4799358: BufferedOutputStream.write() should immediately throw IOException on closed stream

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -159,6 +159,7 @@ public class BufferedOutputStream extends FilterOutputStream {
      */
     @Override
     public void write(int b) throws IOException {
+        ensureOpen();
         if (lock != null) {
             lock.lock();
             try {

--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -127,6 +127,12 @@ public class BufferedOutputStream extends FilterOutputStream {
         }
     }
 
+    /** Checks to make sure that the stream has not been closed */
+    private void ensureOpen() throws IOException {
+        if (out == null || !isOpen())
+            throw new IOException("Stream closed");
+    }
+
     /**
      * Grow buf to fit an additional len bytes if needed.
      * If possible, it grows by len+1 to avoid flushing when len bytes
@@ -194,6 +200,7 @@ public class BufferedOutputStream extends FilterOutputStream {
      */
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
+        ensureOpen();
         if (lock != null) {
             lock.lock();
             try {

--- a/src/java.base/share/classes/java/io/FilterOutputStream.java
+++ b/src/java.base/share/classes/java/io/FilterOutputStream.java
@@ -200,4 +200,13 @@ public class FilterOutputStream extends OutputStream {
             }
         }
     }
+
+    /**
+     * Tells whether or not this stream is open.
+     *
+     * @return {@code true} if, and only if, this stream is open
+     */
+    protected boolean isOpen(){
+        return !closed;
+    }
 }

--- a/src/java.base/share/classes/java/io/FilterOutputStream.java
+++ b/src/java.base/share/classes/java/io/FilterOutputStream.java
@@ -206,7 +206,7 @@ public class FilterOutputStream extends OutputStream {
      *
      * @return {@code true} if, and only if, this stream is open
      */
-    protected boolean isOpen(){
+    boolean isOpen(){
         return !closed;
     }
 }

--- a/test/jdk/java/io/BufferedOutputStream/WriteAfterClose.java
+++ b/test/jdk/java/io/BufferedOutputStream/WriteAfterClose.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 4799358
+ * @summary BufferOutputStream.write() should immediately throw IOException on
+ * closed stream
+ * @run main WriteAfterClose
+ *
+ */
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+
+public class WriteAfterClose {
+
+    static void testWrite(OutputStream os) throws IOException{
+        // close the stream first
+        os.close();
+        byte[] buf = {'a', 'b', 'c', 'd'};
+        try {
+            os.write(buf);
+            throw new RuntimeException("Should not allow write on a closed stream");
+        } catch (IOException e) {
+            System.out.println("Caught the IOException as expected: " + e.getMessage());
+        }
+    }
+
+    public static void main(String argv[]) throws IOException {
+        var file = new File(System.getProperty("test.dir", "."), "test.txt");
+        file.createNewFile();
+        file.deleteOnExit();
+        var bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(file));
+        testWrite(bufferedOutputStream);
+    }
+}

--- a/test/jdk/java/io/BufferedOutputStream/WriteAfterClose.java
+++ b/test/jdk/java/io/BufferedOutputStream/WriteAfterClose.java
@@ -37,13 +37,20 @@ import java.io.FileOutputStream;
 
 public class WriteAfterClose {
 
-    static void testWrite(OutputStream os) throws IOException{
+    static void testWrite(OutputStream os) throws IOException {
         // close the stream first
         os.close();
         byte[] buf = {'a', 'b', 'c', 'd'};
         try {
             os.write(buf);
-            throw new RuntimeException("Should not allow write on a closed stream");
+            throw new RuntimeException("Should not allow write(byte[]) on a closed stream");
+        } catch (IOException e) {
+            System.out.println("Caught the IOException as expected: " + e.getMessage());
+        }
+
+        try {
+            os.write(1);
+            throw new RuntimeException("Should not allow write(int) on a closed stream");
         } catch (IOException e) {
             System.out.println("Caught the IOException as expected: " + e.getMessage());
         }


### PR DESCRIPTION
With the current  implementation of BufferedOutputStream if you close the stream and try to write to the closed stream BufferedOutputStream does not throw an IOException until the internal buffer is full. To fix this issue i added a private  "ensureOpen" function to BufferedOutputStream which will check if the underline stream is open. If the underline stream is closed "ensureOpen" will throw the IOException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8314870](https://bugs.openjdk.org/browse/JDK-8314870) to be approved

### Issues
 * [JDK-4799358](https://bugs.openjdk.org/browse/JDK-4799358): BufferedOutputStream.write() should immediately throw IOException on closed stream (**Bug** - P4)
 * [JDK-8314870](https://bugs.openjdk.org/browse/JDK-8314870): BufferedOutputStream.write() should immediately throw IOException on closed stream (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15361/head:pull/15361` \
`$ git checkout pull/15361`

Update a local copy of the PR: \
`$ git checkout pull/15361` \
`$ git pull https://git.openjdk.org/jdk.git pull/15361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15361`

View PR using the GUI difftool: \
`$ git pr show -t 15361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15361.diff">https://git.openjdk.org/jdk/pull/15361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15361#issuecomment-1686451085)