### PR TITLE
8315973: Remove unused fields from ThreadLocalRandom

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -39,14 +39,10 @@
 package java.util.concurrent;
 
 import java.io.ObjectStreamField;
-import java.math.BigInteger;
 import java.security.AccessControlContext;
-import java.util.Map;
 import java.util.Random;
-import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.random.RandomGenerator;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -367,11 +363,6 @@ public final class ThreadLocalRandom extends Random {
      * The increment of seeder per new instance.
      */
     private static final long SEEDER_INCREMENT = 0xbb67ae8584caa73bL;
-
-    // IllegalArgumentException messages
-    static final String BAD_BOUND = "bound must be positive";
-    static final String BAD_RANGE = "bound must be greater than origin";
-    static final String BAD_SIZE  = "size must be non-negative";
 
     // Unsafe mechanics
     private static final Unsafe U = Unsafe.getUnsafe();


### PR DESCRIPTION
These messages were used before [JDK-8248862](https://bugs.openjdk.org/browse/JDK-8248862)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315973](https://bugs.openjdk.org/browse/JDK-8315973): Remove unused fields from ThreadLocalRandom (**Enhancement** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15363/head:pull/15363` \
`$ git checkout pull/15363`

Update a local copy of the PR: \
`$ git checkout pull/15363` \
`$ git pull https://git.openjdk.org/jdk.git pull/15363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15363`

View PR using the GUI difftool: \
`$ git pr show -t 15363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15363.diff">https://git.openjdk.org/jdk/pull/15363.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15363#issuecomment-1713247117)