### PR TITLE
8314672: ProblemList runtime/cds/appcds/customLoader/HelloCustom_JFR.java on linux-all and windows-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -45,5 +45,3 @@ vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-
 
 vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
 vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64
-
-runtime/cds/appcds/customLoader/HelloCustom_JFR.java          8241075 linux-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -103,6 +103,7 @@ runtime/CompressedOops/CompressedClassPointers.java 8305765 generic-all
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
+runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A trivial fix to ProblemList runtime/cds/appcds/customLoader/HelloCustom_JFR.java on linux-all and windows-x64.

This test was previously ProblemListed on linux-all with ZGC via: 

[JDK-8314533](https://bugs.openjdk.org/browse/JDK-8314533) ProblemList runtime/cds/appcds/customLoader/HelloCustom_JFR.java on linux-all with ZGC 

but we have had 7 new failures in different configs since then 
so the ProblemListing needs to be wider. I thought above using 
generic-all, but we haven't seen an macosx-x64 failure since 
mid-May 2020 and have yet to see a macosx-aarch64 failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314672](https://bugs.openjdk.org/browse/JDK-8314672): ProblemList runtime/cds/appcds/customLoader/HelloCustom_JFR.java on linux-all and windows-x64 (**Sub-task** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15366/head:pull/15366` \
`$ git checkout pull/15366`

Update a local copy of the PR: \
`$ git checkout pull/15366` \
`$ git pull https://git.openjdk.org/jdk.git pull/15366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15366`

View PR using the GUI difftool: \
`$ git pr show -t 15366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15366.diff">https://git.openjdk.org/jdk/pull/15366.diff</a>

</details>
