### PR TITLE
JDK-8313689 : C2: compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java fails intermittently with -XX:-TieredCompilation

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
@@ -43,6 +43,9 @@ public class AllocationMergesTests {
                                    "-XX:+ReduceAllocationMerges",
                                    "-XX:+TraceReduceAllocationMerges",
                                    "-XX:+DeoptimizeALot",
+                                   "-XX:CompileCommand=inline,*::charAt*",
+                                   "-XX:CompileCommand=inline,*PicturePositions::*",
+                                   "-XX:CompileCommand=inline,*Point::*",
                                    "-XX:CompileCommand=exclude,*::dummy*");
     }
 
@@ -92,9 +95,11 @@ public class AllocationMergesTests {
                  "testString_two_C2"
                 })
     public void runner(RunInfo info) {
+        invocations++;
+
         Random random = info.getRandom();
-        boolean cond1 = random.nextBoolean();
-        boolean cond2 = random.nextBoolean();
+        boolean cond1 = invocations % 2 == 0;
+        boolean cond2 = !cond1;
 
         int l = random.nextInt();
         int w = random.nextInt();
@@ -551,9 +556,10 @@ public class AllocationMergesTests {
             new F();
         }
 
+        int res = s.a;
         dummy();
 
-        return s.a;
+        return res;
     }
 
     @Test
@@ -1196,12 +1202,13 @@ public class AllocationMergesTests {
             global_escape = p;
         }
 
+        int res = p.x;
         if (is_c2) {
             // This will show up to C2 as a trap.
             dummy_defaults();
         }
 
-        return p.y;
+        return res;
     }
 
     @Test


### PR DESCRIPTION
Please see the JBS work item for more context.

These adjustments are necessary to make the IR graph shape more stable across executions of the tests. Also, tries to force inline of some important methods.

Tested locally on Linux x64 and Mac AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313689](https://bugs.openjdk.org/browse/JDK-8313689): C2: compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java fails intermittently with -XX:-TieredCompilation (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15367/head:pull/15367` \
`$ git checkout pull/15367`

Update a local copy of the PR: \
`$ git checkout pull/15367` \
`$ git pull https://git.openjdk.org/jdk.git pull/15367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15367`

View PR using the GUI difftool: \
`$ git pr show -t 15367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15367.diff">https://git.openjdk.org/jdk/pull/15367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15367#issuecomment-1686823894)