### PR TITLE
8237542: JMapHeapConfigTest.java doesn't work with negative jlong values

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
@@ -280,14 +280,10 @@ public class HeapSummary extends Tool {
       printValMB(System.out, title, value);
    }
 
-   private static final double FACTOR = 1024*1024;
    private void printValMB(PrintStream tty, String title, long value) {
-      if (value < 0) {
-        tty.println(alignment + title +   (value >>> 20)  + " MB");
-      } else {
-        double mb = value/FACTOR;
-        tty.println(alignment + title + value + " (" + mb + "MB)");
-      }
+       double valueMB = value >>> 20;  // unsigned divide by 1024*1024
+       String valueUnsigned = Long.toUnsignedString(value, 10);
+       tty.println(alignment + title + valueUnsigned + " (" + valueMB + "MB)");
    }
 
    private void printValue(String title, long value) {

--- a/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
+++ b/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
@@ -149,7 +149,7 @@ public class JMapHeapConfigTest {
         if (exitcode != 0) {
             throw new RuntimeException("Test FAILED jmap exits with non zero exit code " + exitcode);
         }
-        
+
         System.out.println("Jmap Output:");
         for (String line : tmt.getToolOutput()) {
             System.out.println(line);

--- a/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
+++ b/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,15 +53,13 @@ public class JMapHeapConfigTest {
         "MaxHeapFreeRatio",
         "MaxHeapSize",
         "NewSize",
+        "MaxNewSize",
         "OldSize",
         "NewRatio",
         "SurvivorRatio",
         "MetaspaceSize",
-        "CompressedClassSpaceSize"};
-
-    // Test can't deal with negative jlongs:
-    //  ignoring MaxMetaspaceSize
-    //  ignoring MaxNewSize
+        "CompressedClassSpaceSize",
+        "MaxMetaspaceSize"};
 
     static final String desiredMaxHeapSize = "-Xmx128m";
 
@@ -150,6 +148,11 @@ public class JMapHeapConfigTest {
         int exitcode = tmt.launch(cmd.toArray(new String[0]));
         if (exitcode != 0) {
             throw new RuntimeException("Test FAILED jmap exits with non zero exit code " + exitcode);
+        }
+        
+        System.out.println("Jmap Output:");
+        for (String line : tmt.getToolOutput()) {
+            System.out.println(line);
         }
 
         Map<String,String> parsedJmapOutput = parseJMapOutput(tmt.getToolOutput());


### PR DESCRIPTION
The test tries to match up various GC -XX:+PrintFlagsFinal values with the output of jhsdb -jmap --pid <pid> --heap. With ZGC, MaxNewSize set to (size_t)-1, but PrintFlagsFinal prints it as an unsigned long:

    size_t MaxNewSize = 18446744073709551615 {product} {default} 

jmap normally prints out both the raw size and the MB size. For example:

MaxHeapSize              = 805306368 (768.0MB)

But as part of the fix for [JDK-6718125](https://bugs.openjdk.org/browse/JDK-6718125), it stopped printing the raw value for negative values an only printed the MB value. So for MaxNewSize we had:

     MaxNewSize = 17592186044415 MB

Instead of:

    MaxNewSize = 18446744073709551615 (17592186044415 MB)

So the test fails to find 18446744073709551615 in the output. I fixed jmap to include the raw value as an unsigned long, even if negative as a signed long (to be consistent with PrintFlagsFinal output), so now the test passes even when MaxNewSize is included in the list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8237542](https://bugs.openjdk.org/browse/JDK-8237542): JMapHeapConfigTest.java doesn't work with negative jlong values (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15368/head:pull/15368` \
`$ git checkout pull/15368`

Update a local copy of the PR: \
`$ git checkout pull/15368` \
`$ git pull https://git.openjdk.org/jdk.git pull/15368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15368`

View PR using the GUI difftool: \
`$ git pr show -t 15368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15368.diff">https://git.openjdk.org/jdk/pull/15368.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15368#issuecomment-1686936892)