### PR TITLE
8280743: HSDB "Monitor Cache Dump" command might throw NPE

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MonitorCacheDumpPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MonitorCacheDumpPanel.java
@@ -67,10 +67,10 @@ public class MonitorCacheDumpPanel extends JPanel {
     tty.println();
     tty.println("  _header: 0x" + Long.toHexString(mon.header().value()));
     OopHandle obj = mon.object();
-    Oop oop = heap.newOop(obj);
     if (obj == null) {
       tty.println("  _object: null");
     } else {
+      Oop oop = heap.newOop(obj);
       tty.println("  _object: " + obj + ", a " + oop.getKlass().getName().asString());
     }
     Address owner = mon.owner();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MonitorCacheDumpPanel.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/MonitorCacheDumpPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,11 @@ public class MonitorCacheDumpPanel extends JPanel {
     tty.println("  _header: 0x" + Long.toHexString(mon.header().value()));
     OopHandle obj = mon.object();
     Oop oop = heap.newOop(obj);
-    tty.println("  _object: " + obj + ", a " + oop.getKlass().getName().asString());
+    if (obj == null) {
+      tty.println("  _object: null");
+    } else {
+      tty.println("  _object: " + obj + ", a " + oop.getKlass().getName().asString());
+    }
     Address owner = mon.owner();
     tty.println("  _owner: " + owner);
     if (!raw && owner != null) {


### PR DESCRIPTION
ObjectMonitor.object() can be null so we need to defend against it. This bug was discovered by code inspection while working on [JDK-8280555](https://bugs.openjdk.org/browse/JDK-8280555).  We have no test for this, and I'm not sure how to reproduce this with HSDB like the [JDK-8280555](https://bugs.openjdk.org/browse/JDK-8280555) test did.  I did at least verify that the HSDB "Monitor Cache Dump" feature still works after this fix, although none of the monitors had a null object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280743](https://bugs.openjdk.org/browse/JDK-8280743): HSDB "Monitor Cache Dump" command might throw NPE (**Bug** - P5)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [a3f3f0e9](https://git.openjdk.org/jdk/pull/15369/files/a3f3f0e9d45afd2446c40f490270d2944cf43ebf)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15369/head:pull/15369` \
`$ git checkout pull/15369`

Update a local copy of the PR: \
`$ git checkout pull/15369` \
`$ git pull https://git.openjdk.org/jdk.git pull/15369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15369`

View PR using the GUI difftool: \
`$ git pr show -t 15369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15369.diff">https://git.openjdk.org/jdk/pull/15369.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15369#issuecomment-1686960822)