### PR TITLE
8312232: Remove sun.jvm.hotspot.runtime.VM.buildLongFromIntsPD()

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/StackValueCollection.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/StackValueCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/StackValueCollection.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/StackValueCollection.java
@@ -47,8 +47,6 @@ public class StackValueCollection {
   public char      charAt(int slot)      { return (char) get(slot).getInteger(); }
   public short     shortAt(int slot)     { return (short) get(slot).getInteger(); }
   public int       intAt(int slot)       { return (int) get(slot).getInteger(); }
-  public long      longAt(int slot)      { return VM.getVM().buildLongFromIntsPD((int) get(slot).getInteger(),
-                                                                                 (int) get(slot+1).getInteger()); }
 
   public OopHandle oopHandleAt(int slot) {
     StackValue sv = get(slot);
@@ -59,5 +57,4 @@ public class StackValueCollection {
   }
 
   public float     floatAt(int slot)     { return Float.intBitsToFloat(intAt(slot)); }
-  public double    doubleAt(int slot)    { return Double.longBitsToDouble(longAt(slot)); }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -407,6 +407,7 @@ public class VM {
   }
 
   private VM(TypeDataBase db, JVMDebugger debugger, boolean isBigEndian) {
+      System.out.println("VM()");
     this.db          = db;
     this.debugger    = debugger;
     this.isBigEndian = isBigEndian;
@@ -535,6 +536,7 @@ public class VM {
 
   /** This is used by the debugging system */
   public static void initialize(TypeDataBase db, JVMDebugger debugger) {
+      System.out.println("VM.initialize()");
     if (soleInstance != null) {
       // Using multiple SA Tool classes in the same process creates a call here.
       return;
@@ -552,6 +554,7 @@ public class VM {
 
   /** This is used by the debugging system */
   public static void shutdown() {
+      System.out.println("VM.shutdown()");
     soleInstance = null;
   }
 
@@ -725,16 +728,6 @@ public class VM {
       shorts */
   public int buildIntFromShorts(short low, short high) {
     return (((int) high) << 16) | (((int) low) & 0xFFFF);
-  }
-
-  /** Utility routine for building a long from two "unsigned" 32-bit
-      ints in <b>platform-dependent</b> order */
-  public long buildLongFromIntsPD(int oneHalf, int otherHalf) {
-    if (isBigEndian) {
-      return (((long) otherHalf) << 32) | (((long) oneHalf) & 0x00000000FFFFFFFFL);
-    } else{
-      return (((long) oneHalf) << 32) | (((long) otherHalf) & 0x00000000FFFFFFFFL);
-    }
   }
 
   public TypeDataBase getTypeDataBase() {
@@ -953,20 +946,20 @@ public class VM {
   }
 
   public boolean isCompressedOopsEnabled() {
-    if (compressedOopsEnabled == null) {
+      //if (compressedOopsEnabled == null) {
         Flag flag = getCommandLineFlag("UseCompressedOops");
         compressedOopsEnabled = (flag == null) ? Boolean.FALSE:
              (flag.getBool()? Boolean.TRUE: Boolean.FALSE);
-    }
+        //}
     return compressedOopsEnabled.booleanValue();
   }
 
   public boolean isCompressedKlassPointersEnabled() {
-    if (compressedKlassPointersEnabled == null) {
+      //if (compressedKlassPointersEnabled == null) {
         Flag flag = getCommandLineFlag("UseCompressedClassPointers");
         compressedKlassPointersEnabled = (flag == null) ? Boolean.FALSE:
              (flag.getBool()? Boolean.TRUE: Boolean.FALSE);
-    }
+        //}
     return compressedKlassPointersEnabled.booleanValue();
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -407,7 +407,6 @@ public class VM {
   }
 
   private VM(TypeDataBase db, JVMDebugger debugger, boolean isBigEndian) {
-      System.out.println("VM()");
     this.db          = db;
     this.debugger    = debugger;
     this.isBigEndian = isBigEndian;
@@ -536,7 +535,6 @@ public class VM {
 
   /** This is used by the debugging system */
   public static void initialize(TypeDataBase db, JVMDebugger debugger) {
-      System.out.println("VM.initialize()");
     if (soleInstance != null) {
       // Using multiple SA Tool classes in the same process creates a call here.
       return;
@@ -554,7 +552,6 @@ public class VM {
 
   /** This is used by the debugging system */
   public static void shutdown() {
-      System.out.println("VM.shutdown()");
     soleInstance = null;
   }
 
@@ -946,20 +943,20 @@ public class VM {
   }
 
   public boolean isCompressedOopsEnabled() {
-      //if (compressedOopsEnabled == null) {
+    if (compressedOopsEnabled == null) {
         Flag flag = getCommandLineFlag("UseCompressedOops");
         compressedOopsEnabled = (flag == null) ? Boolean.FALSE:
              (flag.getBool()? Boolean.TRUE: Boolean.FALSE);
-        //}
+    }
     return compressedOopsEnabled.booleanValue();
   }
 
   public boolean isCompressedKlassPointersEnabled() {
-      //if (compressedKlassPointersEnabled == null) {
+    if (compressedKlassPointersEnabled == null) {
         Flag flag = getCommandLineFlag("UseCompressedClassPointers");
         compressedKlassPointersEnabled = (flag == null) ? Boolean.FALSE:
              (flag.getBool()? Boolean.TRUE: Boolean.FALSE);
-        //}
+    }
     return compressedKlassPointersEnabled.booleanValue();
   }
 


### PR DESCRIPTION
VM.buildLongFromIntsPD() is not longer used. Remove it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312232](https://bugs.openjdk.org/browse/JDK-8312232): Remove sun.jvm.hotspot.runtime.VM.buildLongFromIntsPD() (**Bug** - P5)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [3dcca44a](https://git.openjdk.org/jdk/pull/15371/files/3dcca44a79331022a4a5a7b1f58bbf802b67f02e)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15371/head:pull/15371` \
`$ git checkout pull/15371`

Update a local copy of the PR: \
`$ git checkout pull/15371` \
`$ git pull https://git.openjdk.org/jdk.git pull/15371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15371`

View PR using the GUI difftool: \
`$ git pr show -t 15371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15371.diff">https://git.openjdk.org/jdk/pull/15371.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15371#issuecomment-1686996707)