### PR TITLE
8189685: need PerfMemory class update and a volatile_static_field support in VMStructs

### DIFF
--- a/src/hotspot/share/gc/shared/vmStructs_gc.hpp
+++ b/src/hotspot/share/gc/shared/vmStructs_gc.hpp
@@ -54,6 +54,7 @@
 #endif
 
 #define VM_STRUCTS_GC(nonstatic_field,                                                                                               \
+                      volatile_static_field,                                                                                         \
                       volatile_nonstatic_field,                                                                                      \
                       static_field,                                                                                                  \
                       unchecked_nonstatic_field)                                                                                     \

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -51,9 +51,9 @@ char*                    PerfMemory::_start = nullptr;
 char*                    PerfMemory::_end = nullptr;
 char*                    PerfMemory::_top = nullptr;
 size_t                   PerfMemory::_capacity = 0;
-int                      PerfMemory::_initialized = false;
+volatile int             PerfMemory::_initialized = 0;
 PerfDataPrologue*        PerfMemory::_prologue = nullptr;
-bool                     PerfMemory::_destroyed = false;
+volatile int             PerfMemory::_destroyed = 0;
 
 void perfMemory_init() {
 
@@ -197,7 +197,7 @@ void PerfMemory::destroy() {
     delete_memory_region();
   }
 
-  _destroyed = true;
+  Atomic::release_store(&_destroyed, 1);
 }
 
 // allocate an aligned block of memory from the PerfData memory
@@ -271,3 +271,8 @@ char* PerfMemory::get_perfdata_file_path() {
 bool PerfMemory::is_initialized() {
   return Atomic::load_acquire(&_initialized) != 0;
 }
+
+bool PerfMemory::is_destroyed() {
+  return Atomic::load_acquire(&_destroyed) != 0;
+}
+

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -53,7 +53,7 @@ char*                    PerfMemory::_top = nullptr;
 size_t                   PerfMemory::_capacity = 0;
 volatile int             PerfMemory::_initialized = 0;
 PerfDataPrologue*        PerfMemory::_prologue = nullptr;
-volatile int             PerfMemory::_destroyed = 0;
+volatile bool            PerfMemory::_destroyed = false;
 
 void perfMemory_init() {
 
@@ -197,7 +197,7 @@ void PerfMemory::destroy() {
     delete_memory_region();
   }
 
-  _destroyed = 1;
+  _destroyed = true;
 }
 
 // allocate an aligned block of memory from the PerfData memory
@@ -270,8 +270,4 @@ char* PerfMemory::get_perfdata_file_path() {
 
 bool PerfMemory::is_initialized() {
   return Atomic::load_acquire(&_initialized) != 0;
-}
-
-bool PerfMemory::is_destroyed() {
-  return _destroyed != 0;
 }

--- a/src/hotspot/share/runtime/perfMemory.cpp
+++ b/src/hotspot/share/runtime/perfMemory.cpp
@@ -197,7 +197,7 @@ void PerfMemory::destroy() {
     delete_memory_region();
   }
 
-  Atomic::release_store(&_destroyed, 1);
+  _destroyed = 1;
 }
 
 // allocate an aligned block of memory from the PerfData memory
@@ -273,6 +273,5 @@ bool PerfMemory::is_initialized() {
 }
 
 bool PerfMemory::is_destroyed() {
-  return Atomic::load_acquire(&_destroyed) != 0;
+  return _destroyed != 0;
 }
-

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -121,8 +121,8 @@ class PerfMemory : AllStatic {
     static char*  _top;
     static size_t _capacity;
     static PerfDataPrologue*  _prologue;
-    static int    _initialized;
-    static bool   _destroyed;
+    static volatile int _initialized;
+    static volatile int _destroyed;
 
     static void create_memory_region(size_t sizep);
     static void delete_memory_region();
@@ -134,7 +134,7 @@ class PerfMemory : AllStatic {
     static size_t used() { return (size_t) (_top - _start); }
     static size_t capacity() { return _capacity; }
     static bool is_initialized();
-    static bool is_destroyed() { return _destroyed; }
+    static bool is_destroyed();
     static bool is_usable() { return is_initialized() && !is_destroyed(); }
     static bool contains(char* addr) {
       return ((_start != nullptr) && (addr >= _start) && (addr < _end));

--- a/src/hotspot/share/runtime/perfMemory.hpp
+++ b/src/hotspot/share/runtime/perfMemory.hpp
@@ -122,7 +122,7 @@ class PerfMemory : AllStatic {
     static size_t _capacity;
     static PerfDataPrologue*  _prologue;
     static volatile int _initialized;
-    static volatile int _destroyed;
+    static volatile bool _destroyed;
 
     static void create_memory_region(size_t sizep);
     static void delete_memory_region();
@@ -134,7 +134,7 @@ class PerfMemory : AllStatic {
     static size_t used() { return (size_t) (_top - _start); }
     static size_t capacity() { return _capacity; }
     static bool is_initialized();
-    static bool is_destroyed();
+    static bool is_destroyed() { return _destroyed; }
     static bool is_usable() { return is_initialized() && !is_destroyed(); }
     static bool contains(char* addr) {
       return ((_start != nullptr) && (addr >= _start) && (addr < _end));

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -180,7 +180,7 @@
 
 #define VM_STRUCTS(nonstatic_field,                                                                                                  \
                    static_field,                                                                                                     \
-                   static_ptr_volatile_field,                                                                                        \
+                   volatile_static_field,                                                                                            \
                    unchecked_nonstatic_field,                                                                                        \
                    volatile_nonstatic_field,                                                                                         \
                    nonproduct_nonstatic_field,                                                                                       \
@@ -194,6 +194,7 @@
   /*************/                                                                                                                    \
                                                                                                                                      \
   VM_STRUCTS_GC(nonstatic_field,                                                                                                     \
+                volatile_static_field,                                                                                               \
                 volatile_nonstatic_field,                                                                                            \
                 static_field,                                                                                                        \
                 unchecked_nonstatic_field)                                                                                           \
@@ -447,7 +448,7 @@
      static_field(PerfMemory,                  _top,                                          char*)                                 \
      static_field(PerfMemory,                  _capacity,                                     size_t)                                \
      static_field(PerfMemory,                  _prologue,                                     PerfDataPrologue*)                     \
-     static_field(PerfMemory,                  _initialized,                                  int)                                   \
+     volatile_static_field(PerfMemory,         _initialized,                                  int)                                   \
                                                                                                                                      \
   /********************/                                                                                                             \
   /* SystemDictionary */                                                                                                             \
@@ -477,7 +478,7 @@
   volatile_nonstatic_field(ClassLoaderData,    _klasses,                                      Klass*)                                \
   nonstatic_field(ClassLoaderData,             _has_class_mirror_holder,                      bool)                                  \
                                                                                                                                      \
-  static_ptr_volatile_field(ClassLoaderDataGraph, _head,                                      ClassLoaderData*)                      \
+  volatile_static_field(ClassLoaderDataGraph, _head,                                          ClassLoaderData*)                      \
                                                                                                                                      \
   /**********/                                                                                                                       \
   /* Arrays */                                                                                                                       \
@@ -638,7 +639,7 @@
   static_field(Threads,                     _number_of_non_daemon_threads,                    int)                                   \
   static_field(Threads,                     _return_code,                                     int)                                   \
                                                                                                                                      \
-  static_ptr_volatile_field(ThreadsSMRSupport, _java_thread_list,                             ThreadsList*)                          \
+  volatile_static_field(ThreadsSMRSupport, _java_thread_list,                                 ThreadsList*)                          \
   nonstatic_field(ThreadsList,                 _length,                                       const uint)                            \
   nonstatic_field(ThreadsList,                 _threads,                                      JavaThread *const *const)              \
                                                                                                                                      \
@@ -2685,7 +2686,7 @@ VMStructEntry VMStructs::localHotSpotVMStructs[] = {
 
   VM_STRUCTS(GENERATE_NONSTATIC_VM_STRUCT_ENTRY,
              GENERATE_STATIC_VM_STRUCT_ENTRY,
-             GENERATE_STATIC_PTR_VOLATILE_VM_STRUCT_ENTRY,
+             GENERATE_VOLATILE_STATIC_VM_STRUCT_ENTRY,
              GENERATE_UNCHECKED_NONSTATIC_VM_STRUCT_ENTRY,
              GENERATE_NONSTATIC_VM_STRUCT_ENTRY,
              GENERATE_NONPRODUCT_NONSTATIC_VM_STRUCT_ENTRY,
@@ -2887,7 +2888,7 @@ JNIEXPORT uint64_t gHotSpotVMLongConstantEntryArrayStride = STRIDE(gHotSpotVMLon
 void VMStructs::init() {
   VM_STRUCTS(CHECK_NONSTATIC_VM_STRUCT_ENTRY,
              CHECK_STATIC_VM_STRUCT_ENTRY,
-             CHECK_STATIC_PTR_VOLATILE_VM_STRUCT_ENTRY,
+             CHECK_VOLATILE_STATIC_VM_STRUCT_ENTRY,
              CHECK_NO_OP,
              CHECK_VOLATILE_NONSTATIC_VM_STRUCT_ENTRY,
              CHECK_NONPRODUCT_NONSTATIC_VM_STRUCT_ENTRY,

--- a/src/hotspot/share/runtime/vmStructs.hpp
+++ b/src/hotspot/share/runtime/vmStructs.hpp
@@ -165,8 +165,8 @@ private:
 
 // This macro generates a VMStructEntry line for a static pointer volatile field,
 // e.g.: "static ObjectMonitor * volatile g_block_list;"
-#define GENERATE_STATIC_PTR_VOLATILE_VM_STRUCT_ENTRY(typeName, fieldName, type)    \
- { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 1, 0, (void *)&typeName::fieldName },
+#define GENERATE_VOLATILE_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)    \
+  { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 1, 0, (type*)&typeName::fieldName },
 
 // This macro generates a VMStructEntry line for an unchecked
 // nonstatic field, in which the size of the type is also specified.
@@ -207,7 +207,7 @@ private:
 
 // This macro checks the type of a static pointer volatile VMStructEntry by comparing pointer types,
 // e.g.: "static ObjectMonitor * volatile g_block_list;"
-#define CHECK_STATIC_PTR_VOLATILE_VM_STRUCT_ENTRY(typeName, fieldName, type)       \
+#define CHECK_VOLATILE_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)       \
  {type volatile * dummy = &typeName::fieldName; }
 
 // This macro ensures the type of a field and its containing type are

--- a/src/hotspot/share/runtime/vmStructs.hpp
+++ b/src/hotspot/share/runtime/vmStructs.hpp
@@ -163,7 +163,7 @@ private:
 #define GENERATE_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)                 \
  { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 1, 0, &typeName::fieldName },
 
-// This macro generates a VMStructEntry line for a static pointer volatile field,
+// This macro generates a VMStructEntry line for a static volatile field,
 // e.g.: "static ObjectMonitor * volatile g_block_list;"
 #define GENERATE_VOLATILE_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)    \
   { QUOTE(typeName), QUOTE(fieldName), QUOTE(type), 1, 0, (type*)&typeName::fieldName },
@@ -205,7 +205,7 @@ private:
 #define CHECK_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)                    \
  {type* dummy = &typeName::fieldName; }
 
-// This macro checks the type of a static pointer volatile VMStructEntry by comparing pointer types,
+// This macro checks the type of a static volatile VMStructEntry by comparing pointer types,
 // e.g.: "static ObjectMonitor * volatile g_block_list;"
 #define CHECK_VOLATILE_STATIC_VM_STRUCT_ENTRY(typeName, fieldName, type)       \
  {type volatile * dummy = &typeName::fieldName; }


### PR DESCRIPTION
During [JDK-8151815](https://bugs.openjdk.org/browse/JDK-8151815) it was noted that the PerfMemory _initialized and _destroyed fields should be volatile, but VMStructs didn't have the needed support for doing that, so it was left as a future task. @YaSuenag provided a patch at the time to take care of the VMStructs support. I've integrated it, although it was far from clean due to some changes in VMStructs, and also moving OrderAccess::release_store to Atomic::release_store.

One other change I made to the patch had to do with consistency with using "volatile static" vs "static volatile". We already have volatile_nonstatic_field. The patch renamed static_ptr_volatile_field to static_volatile_field to make it more general purpose, but this was inconsistent with the name of volatile_nonstatic_field, so I chose the name volatile_static_field instead. This carried over into some other areas like the names of the GENERATE_VOLATILE_STATIC_VM_STRUCT_ENTRY and CHECK_VOLATILE_STATIC_VM_STRUCT_ENTRY macros.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8189685](https://bugs.openjdk.org/browse/JDK-8189685): need PerfMemory class update and a volatile_static_field support in VMStructs (**Bug** - P4)


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.org/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15373/head:pull/15373` \
`$ git checkout pull/15373`

Update a local copy of the PR: \
`$ git checkout pull/15373` \
`$ git pull https://git.openjdk.org/jdk.git pull/15373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15373`

View PR using the GUI difftool: \
`$ git pr show -t 15373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15373.diff">https://git.openjdk.org/jdk/pull/15373.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15373#issuecomment-1687095922)