### PR TITLE
8284772: GHA: Use GCC Major Version Dependencies Only

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -31,12 +31,6 @@ on:
       gcc-major-version:
         required: true
         type: string
-      apt-gcc-version:
-        required: true
-        type: string
-      apt-gcc-cross-version:
-        required: true
-        type: string
       extra-conf-options:
         required: false
         type: string
@@ -113,10 +107,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
           sudo apt-get install \
-              gcc-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} \
-              g++-${{ inputs.gcc-major-version }}=${{ inputs.apt-gcc-version }} \
-              gcc-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-cross-version }} \
-              g++-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}}=${{ inputs.apt-gcc-cross-version }} \
+              gcc-${{ inputs.gcc-major-version }} \
+              g++-${{ inputs.gcc-major-version }} \
+              gcc-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}} \
+              g++-${{ inputs.gcc-major-version }}-${{ matrix.gnu-arch }}-linux-gnu${{ matrix.gnu-abi}} \
               libxrandr-dev libxtst-dev libcups2-dev libasound2-dev \
               debian-ports-archive-keyring
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -49,9 +49,6 @@ on:
         required: false
         type: string
         default: ''
-      apt-gcc-version:
-        required: true
-        type: string
       apt-architecture:
         required: false
         type: string
@@ -114,7 +111,7 @@ jobs:
           fi
           sudo apt-get update
           sudo apt-get install --only-upgrade apt
-          sudo apt-get install gcc-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }}=${{ inputs.apt-gcc-version }} g++-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }}=${{ inputs.apt-gcc-version }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
+          sudo apt-get install gcc-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }} g++-${{ inputs.gcc-major-version }}${{ inputs.gcc-package-suffix }} libxrandr-dev${{ steps.arch.outputs.suffix }} libxtst-dev${{ steps.arch.outputs.suffix }} libcups2-dev${{ steps.arch.outputs.suffix }} libasound2-dev${{ steps.arch.outputs.suffix }} ${{ inputs.apt-extra-packages }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ inputs.gcc-major-version }} 100 --slave /usr/bin/g++ g++ /usr/bin/g++-${{ inputs.gcc-major-version }}
 
       - name: 'Configure'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,6 @@ jobs:
     with:
       platform: linux-x64
       gcc-major-version: '10'
-      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     # The linux-x64 jdk bundle is used as buildjdk for the cross-compile job
@@ -144,7 +143,6 @@ jobs:
       platform: linux-x86
       gcc-major-version: '10'
       gcc-package-suffix: '-multilib'
-      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       apt-architecture: 'i386'
       # Some multilib libraries do not have proper inter-dependencies, so we have to
       # install their dependencies manually.
@@ -163,7 +161,6 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       extra-conf-options: '--disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -178,7 +175,6 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       extra-conf-options: '--with-jvm-variants=zero --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -193,7 +189,6 @@ jobs:
       make-target: 'hotspot'
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       extra-conf-options: '--with-jvm-variants=minimal --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -209,7 +204,6 @@ jobs:
       # Technically this is not the "debug" level, but we can't inject a new matrix state for just this job
       debug-levels: '[ "debug" ]'
       gcc-major-version: '10'
-      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       extra-conf-options: '--with-debug-level=optimized --disable-precompiled-headers'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
@@ -223,8 +217,6 @@ jobs:
     uses: ./.github/workflows/build-cross-compile.yml
     with:
       gcc-major-version: '10'
-      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
-      apt-gcc-cross-version: '10.5.0-1ubuntu1~22.04cross1'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-cross-compile == 'true'
@@ -290,7 +282,6 @@ jobs:
       # build JDK, and we do not need the additional testing of the graphs.
       extra-conf-options: '--disable-full-docs'
       gcc-major-version: '10'
-      apt-gcc-version: '10.5.0-1ubuntu1~22.04'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.docs == 'true'


### PR DESCRIPTION
GHA regularly breaks because we specify a very explicit GCC version, even down to the release versioning of the Ubuntu package.  In just this last week, it has caused issues with the testing of PRs on 11u (https://github.com/openjdk/jdk11u-dev/pull/2084) and 17u (https://github.com/openjdk/jdk17u-dev/pull/1672)

Rather than bumping this yet again like [JDK-8313428](https://bugs.openjdk.org/browse/JDK-8313428), this PR suggests dropping the specific version as we did some time ago in 8u and have now done in 11u (https://github.com/openjdk/jdk11u-dev/pull/2087). The requirement still specifies a specific major version of GCC. It just means the dependency isn't broken every time Ubuntu bumps to a new minor release or even just makes a minor change to the package alone.

Note that the current setup does not guarantee sticking with an exact version of GCC anyway, because - as seen by recent GHA breakage - older versions get removed from the package repository. All we get from this exact version requirement is sporadic breakage of testing and developer time wasted fixing & reviewing (and, in the case of backport trees, approving). If we truly want a static version of GCC, we need to provide our own - or maybe even a full devkit - as we do with the JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8284772](https://bugs.openjdk.org/browse/JDK-8284772): GHA: Use GCC Major Version Dependencies Only (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15374/head:pull/15374` \
`$ git checkout pull/15374`

Update a local copy of the PR: \
`$ git checkout pull/15374` \
`$ git pull https://git.openjdk.org/jdk.git pull/15374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15374`

View PR using the GUI difftool: \
`$ git pr show -t 15374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15374.diff">https://git.openjdk.org/jdk/pull/15374.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15374#issuecomment-1687315559)