### PR TITLE
8314688: VM build without C1 fails after JDK-8313372

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -22,7 +22,9 @@
  */
 
 // no precompiled headers
+#ifdef COMPILER1
 #include "c1/c1_Compiler.hpp"
+#endif
 #include "ci/ciUtilities.hpp"
 #include "compiler/compiler_globals.hpp"
 #include "compiler/oopMap.hpp"
@@ -43,7 +45,9 @@
 #include "memory/universe.hpp"
 #include "oops/compressedOops.hpp"
 #include "oops/klass.inline.hpp"
+#ifdef COMPILER2
 #include "opto/c2compiler.hpp"
+#endif
 #include "runtime/flags/jvmFlag.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -225,6 +225,22 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
 #undef SET_TRIGFUNC
 }
 
+static jboolean is_c1_supported(vmIntrinsics::ID id){
+    jboolean supported = false;
+#ifdef COMPILER1
+    supported = (jboolean) Compiler::is_intrinsic_supported(id);
+#endif
+    return supported;
+}
+
+static jboolean is_c2_supported(vmIntrinsics::ID id){
+    jboolean supported = false;
+#ifdef COMPILER2
+    supported = (jboolean) C2Compiler::is_intrinsic_supported(id);
+#endif
+    return supported;
+}
+
 JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
   int len = vmIntrinsics::number_of_intrinsics() - 1; // Exclude vmIntrinsics::_none, which is 0
   JVMCIObjectArray vmIntrinsics = JVMCIENV->new_VMIntrinsicMethod_array(len, JVMCI_CHECK_NULL);
@@ -243,8 +259,8 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
     JVMCIObject sig_str = VM_SYMBOL_TO_STRING(sig);                      \
     JVMCIObject vmIntrinsicMethod = JVMCIENV->new_VMIntrinsicMethod(kls_str, name_str, sig_str, (jint) vmIntrinsics::id, \
                                     (jboolean) vmIntrinsics::is_intrinsic_available(vmIntrinsics::id),                   \
-                                    (jboolean) Compiler::is_intrinsic_supported(vmIntrinsics::id),                       \
-                                    (jboolean) C2Compiler::is_intrinsic_supported(vmIntrinsics::id), JVMCI_CHECK_NULL);  \
+                                    is_c1_supported(vmIntrinsics::id),                       \
+                                    is_c2_supported(vmIntrinsics::id), JVMCI_CHECK_NULL);  \
     JVMCIENV->put_object_at(vmIntrinsics, index++, vmIntrinsicMethod);   \
   }
 

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -260,7 +260,7 @@ JVMCIObjectArray CompilerToVM::initialize_intrinsics(JVMCI_TRAPS) {
     JVMCIObject vmIntrinsicMethod = JVMCIENV->new_VMIntrinsicMethod(kls_str, name_str, sig_str, (jint) vmIntrinsics::id, \
                                     (jboolean) vmIntrinsics::is_intrinsic_available(vmIntrinsics::id),                   \
                                     is_c1_supported(vmIntrinsics::id),                       \
-                                    is_c2_supported(vmIntrinsics::id), JVMCI_CHECK_NULL);  \
+                                    is_c2_supported(vmIntrinsics::id), JVMCI_CHECK_NULL);    \
     JVMCIENV->put_object_at(vmIntrinsics, index++, vmIntrinsicMethod);   \
   }
 


### PR DESCRIPTION
[8314688: VM build without C1 fails after JDK-8313372]
```
./configure --with-jvm-features=-compiler1 --with-debug-level=release
make images JOBS=32
```
```
jvmciCompilerToVMInit.o:make/hotspot/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp:252: more undefined references to `Compiler::is_intrinsic_supported(vmIntrinsicID)' follow
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314688](https://bugs.openjdk.org/browse/JDK-8314688): VM build without C1 fails after JDK-8313372 (**Bug** - P2)


### Reviewers
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - no project role) ⚠️ Review applies to [6937badb](https://git.openjdk.org/jdk/pull/15376/files/6937badb7424dc5213ce6276f245f270ad8549a6)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15376/head:pull/15376` \
`$ git checkout pull/15376`

Update a local copy of the PR: \
`$ git checkout pull/15376` \
`$ git pull https://git.openjdk.org/jdk.git pull/15376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15376`

View PR using the GUI difftool: \
`$ git pr show -t 15376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15376.diff">https://git.openjdk.org/jdk/pull/15376.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15376#issuecomment-1687366851)