### PR TITLE
8314734: Remove unused field TypeVariableImpl.EMPTY_ANNOTATION_ARRAY

### DIFF
--- a/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/TypeVariableImpl.java
+++ b/src/java.base/share/classes/sun/reflect/generics/reflectiveObjects/TypeVariableImpl.java
@@ -210,8 +210,6 @@ public class TypeVariableImpl<D extends GenericDeclaration>
                                                          typeVarIndex());
     }
 
-    private static final Annotation[] EMPTY_ANNOTATION_ARRAY = new Annotation[0];
-
     // Helpers for annotation methods
     private int typeVarIndex() {
         TypeVariable<?>[] tVars = getGenericDeclaration().getTypeParameters();


### PR DESCRIPTION
Field is unused since [JDK-8004698](https://bugs.openjdk.org/browse/JDK-8004698) - https://github.com/openjdk/jdk/commit/b29b4794613a2aca125c2a6e9f8ed1d0f01a4ce2#diff-2b6035b7134d61a89cfee1ad7bdc1bf21ce37421358375d6399de950c17c0c8e

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314734](https://bugs.openjdk.org/browse/JDK-8314734): Remove unused field TypeVariableImpl.EMPTY_ANNOTATION_ARRAY (**Enhancement** - P5)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15379/head:pull/15379` \
`$ git checkout pull/15379`

Update a local copy of the PR: \
`$ git checkout pull/15379` \
`$ git pull https://git.openjdk.org/jdk.git pull/15379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15379`

View PR using the GUI difftool: \
`$ git pr show -t 15379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15379.diff">https://git.openjdk.org/jdk/pull/15379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15379#issuecomment-1687606361)