### PR TITLE
8314743: Use of uninitialized local in SR_initialize after JDK-8314114

### DIFF
--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -1733,8 +1733,8 @@ int SR_initialize() {
         sig < NSIG) {                   // Must be legal signal and fit into sigflags[].
       PosixSignals::SR_signum = sig;
     } else {
-      warning("You set _JAVA_SR_SIGNUM=%d. It must be in range [%d, %d]. Using %d instead.",
-              sig, MAX2(SIGSEGV, SIGBUS)+1, NSIG-1, PosixSignals::SR_signum);
+      warning("You set _JAVA_SR_SIGNUM=%s. It must be a number in range [%d, %d]. Using %d instead.",
+              s, MAX2(SIGSEGV, SIGBUS)+1, NSIG-1, PosixSignals::SR_signum);
     }
   }
 


### PR DESCRIPTION
After [JDK-8314114](https://bugs.openjdk.org/browse/JDK-8314114), SonarCloud reports the use on uninitialized `sig` variable in the `warning` line here:
 
```
int SR_initialize() {
...
    int sig;
    bool result = parse_integer(s, &sig);
    if (result && sig > MAX2(SIGSEGV, SIGBUS) && // See 4355769.
        sig < NSIG) { // Must be legal signal and fit into sigflags[].
      PosixSignals::SR_signum = sig;
    } else {
      warning("You set _JAVA_SR_SIGNUM=%d. It must be in range [%d, %d]. Using %d instead.",
              sig, MAX2(SIGSEGV, SIGBUS)+1, NSIG-1, PosixSignals::SR_signum);
    }
```

I think the proper fix is to print out the actual string value.

```
# Before the fix
% _JAVA_SR_SIGNUM=asdfiasodj1 build/macosx-aarch64-server-fastdebug/images/jdk/bin/java Alloc.java
OpenJDK 64-Bit Server VM warning: You set _JAVA_SR_SIGNUM=0. It must be in range [12, 31]. Using 31 instead.

# After the fix
% _JAVA_SR_SIGNUM=asdfiasodj1 build/macosx-aarch64-server-fastdebug/images/jdk/bin/java Alloc.java
OpenJDK 64-Bit Server VM warning: You set _JAVA_SR_SIGNUM=asdfiasodj1. It must be a number in range [12, 31]. Using 31 instead.
```

Attn @coleenp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314743](https://bugs.openjdk.org/browse/JDK-8314743): Use of uninitialized local in SR_initialize after JDK-8314114 (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15381/head:pull/15381` \
`$ git checkout pull/15381`

Update a local copy of the PR: \
`$ git checkout pull/15381` \
`$ git pull https://git.openjdk.org/jdk.git pull/15381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15381`

View PR using the GUI difftool: \
`$ git pr show -t 15381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15381.diff">https://git.openjdk.org/jdk/pull/15381.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15381#issuecomment-1687711009)