### PR TITLE
8314749: Remove unimplemented _Copy_conjoint_oops_atomic

### DIFF
--- a/src/hotspot/share/utilities/copy.hpp
+++ b/src/hotspot/share/utilities/copy.hpp
@@ -41,7 +41,6 @@ extern "C" {
   void _Copy_conjoint_jshorts_atomic(const jshort* from, jshort* to, size_t count);
   void _Copy_conjoint_jints_atomic  (const jint*   from, jint*   to, size_t count);
   void _Copy_conjoint_jlongs_atomic (const jlong*  from, jlong*  to, size_t count);
-  void _Copy_conjoint_oops_atomic   (const oop*    from, oop*    to, size_t count);
 
   void _Copy_arrayof_conjoint_bytes  (const HeapWord* from, HeapWord* to, size_t count);
   void _Copy_arrayof_conjoint_jshorts(const HeapWord* from, HeapWord* to, size_t count);


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314749](https://bugs.openjdk.org/browse/JDK-8314749): Remove unimplemented _Copy_conjoint_oops_atomic (**Enhancement** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15383/head:pull/15383` \
`$ git checkout pull/15383`

Update a local copy of the PR: \
`$ git checkout pull/15383` \
`$ git pull https://git.openjdk.org/jdk.git pull/15383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15383`

View PR using the GUI difftool: \
`$ git pr show -t 15383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15383.diff">https://git.openjdk.org/jdk/pull/15383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15383#issuecomment-1687767786)