### PR TITLE
8314644: Change "Rvalue references and move semantics" into an accepted feature

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -1093,6 +1093,8 @@ function name and the parameter list.</li>
 <h3 id="additional-permitted-features">Additional Permitted
 Features</h3>
 <ul>
+<li><p>Rvalue references and move semantics (<a
+href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1690.html">n1690</a>)</p></li>
 <li><p><code>alignof</code> (<a
 href="https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2341.pdf">n2341</a>)</p></li>
 <li><p><code>constexpr</code> (<a
@@ -1203,7 +1205,6 @@ href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2541.htm">n2541</
 href="https://isocpp.org/files/papers/N3651.pdf">n3651</a>)</p></li>
 <li><p>Member initializers and aggregates (<a
 href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html">n3653</a>)</p></li>
-<li><p>Rvalue references and move semantics</p></li>
 </ul>
 </body>
 </html>

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -1086,6 +1086,9 @@ The following attributes are expressly forbidden:
 
 ### Additional Permitted Features
 
+* Rvalue references and move semantics
+([n1690](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1690.html))
+
 * `alignof`
 ([n2341](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2341.pdf))
 
@@ -1209,8 +1212,6 @@ features that have not yet been discussed.
 
 * Member initializers and aggregates
 ([n3653](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3653.html))
-
-* Rvalue references and move semantics
 
 [ADL]: https://en.cppreference.com/w/cpp/language/adl
   "Argument Dependent Lookup"

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -1088,6 +1088,13 @@ The following attributes are expressly forbidden:
 
 * Rvalue references and move semantics
 ([n1690](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1690.html))
+Rvalue references and move semantics is an advanced C++ concept and should be
+treated as such. In HotSpot we prefer copy construction when possible.
+However, we do recognize that there are cases where move semantics permit significant
+ergonomic and performance advantages to the developer.
+For example, if you have a data structure T which is non-copyable but needs to
+be stored in a resizable container, then defining a move constructor may be preferable
+to changing the contained element type from T to T\*.
 
 * `alignof`
 ([n2341](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2341.pdf))

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -1088,6 +1088,7 @@ The following attributes are expressly forbidden:
 
 * Rvalue references and move semantics
 ([n1690](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2004/n1690.html))
+* Use `std::move` when moving an object.
 Rvalue references and move semantics is an advanced C++ concept and should be
 treated as such. In HotSpot we prefer copy construction when possible.
 However, we do recognize that there are cases where move semantics permit significant


### PR DESCRIPTION
Hi,

I'd like to propose that rvalue references and move semantics are now considered permitted in the style guide. This change would allow for move constructors to be written. This enables more performant code, if the move ctr is less expensive than the copy ctr, but also more correct code. For the latter part, look at "8314571: GrowableArray should move its old data and not copy it". Here we can avoid using copy assignment, instead using move constructors, which more accurately reflects what is happening: The old elements are in fact moved, and not copied.

Two useful std functions will become available to us with this change:

1. `std::move`, for explicitly moving a value. This is a slightly more powerful `static_cast<T&&>(T)`, in that it also handles `T&` corectly.
2. `std::forward`, which simplifies the usage of perfect forwarding. Perfect forwarding is a technique where in copying is minimized. To quote Scott Meyers ( https://cppandbeyond.com/2011/04/25/session-announcement-adventures-in-perfect-forwarding/ ):

> Perfecting forwarding is an important C++0x technique built atop rvalue references.  It allows move semantics to be automatically applied, even when the source and the destination of a move are separated by intervening function calls.  Common examples include constructors and setter functions that forward arguments they receive to the data members of the class they are initializing or setting, as well as standard library functions like make_shared, which “perfect-forwards” its arguments to the class constructor of whatever object the to-be-created shared_ptr is to point to. 

Looking forward to your feedback, thank you.
Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314644](https://bugs.openjdk.org/browse/JDK-8314644): Change "Rvalue references and move semantics" into an accepted feature (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15386/head:pull/15386` \
`$ git checkout pull/15386`

Update a local copy of the PR: \
`$ git checkout pull/15386` \
`$ git pull https://git.openjdk.org/jdk.git pull/15386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15386`

View PR using the GUI difftool: \
`$ git pr show -t 15386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15386.diff">https://git.openjdk.org/jdk/pull/15386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15386#issuecomment-1688083083)