### PR TITLE
8312521: Unused field LocaleProviderAdapter#defaultLocaleProviderAdapter could be removed

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleProviderAdapter.java
@@ -109,12 +109,6 @@ public abstract class LocaleProviderAdapter {
     private static final Map<Type, LocaleProviderAdapter> adapterInstances = new ConcurrentHashMap<>();
 
     /**
-     * Default fallback adapter type, which should return something meaningful in any case.
-     * This is either CLDR or FALLBACK.
-     */
-    static volatile LocaleProviderAdapter.Type defaultLocaleProviderAdapter;
-
-    /**
      * Adapter lookup cache.
      */
     private static final ConcurrentMap<Class<? extends LocaleServiceProvider>, ConcurrentMap<Locale, LocaleProviderAdapter>>
@@ -147,13 +141,11 @@ public abstract class LocaleProviderAdapter {
             }
         }
 
-        defaultLocaleProviderAdapter = Type.CLDR;
         if (!typeList.isEmpty()) {
             // bona fide preference exists
             if (!(typeList.contains(Type.CLDR) || typeList.contains(Type.JRE))) {
                 // Append FALLBACK as the last resort when no ResourceBundleBasedAdapter is available.
                 typeList.add(Type.FALLBACK);
-                defaultLocaleProviderAdapter = Type.FALLBACK;
             }
         } else {
             // Default preference list.
@@ -345,10 +337,10 @@ public abstract class LocaleProviderAdapter {
     public abstract BreakIteratorProvider getBreakIteratorProvider();
 
     /**
-     * Returns a ollatorProvider for this LocaleProviderAdapter, or null if no
-     * ollatorProvider is available.
+     * Returns a CollatorProvider for this LocaleProviderAdapter, or null if no
+     * CollatorProvider is available.
      *
-     * @return a ollatorProvider
+     * @return a collatorProvider
      */
     public abstract CollatorProvider getCollatorProvider();
 


### PR DESCRIPTION
After [JDK-8245241](https://bugs.openjdk.org/browse/JDK-8245241), the field `sun.util.locale.provider.LocaleProviderAdapter#defaultLocaleProviderAdapter` is only written in `<clinit>` and then is not used after.
We can remove it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312521](https://bugs.openjdk.org/browse/JDK-8312521): Unused field LocaleProviderAdapter#defaultLocaleProviderAdapter could be removed (**Enhancement** - P5)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15388/head:pull/15388` \
`$ git checkout pull/15388`

Update a local copy of the PR: \
`$ git checkout pull/15388` \
`$ git pull https://git.openjdk.org/jdk.git pull/15388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15388`

View PR using the GUI difftool: \
`$ git pr show -t 15388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15388.diff">https://git.openjdk.org/jdk/pull/15388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15388#issuecomment-1688094878)