### PR TITLE
8312306: Add more Reference.reachabilityFence() calls to the security classes using Cleaner

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
@@ -89,12 +89,12 @@ final class DESKey implements SecretKey {
     public byte[] getEncoded() {
         // Return a copy of the key, rather than a reference,
         // so that the key data cannot be modified from outside
-
-        // The key is zeroized by finalize()
-        // The reachability fence ensures finalize() isn't called early
-        byte[] result = key.clone();
-        Reference.reachabilityFence(this);
-        return result;
+        try {
+            return key.clone();
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
+        }
     }
 
     public String getAlgorithm() {
@@ -111,25 +111,35 @@ final class DESKey implements SecretKey {
      */
     @Override
     public int hashCode() {
-        return Arrays.hashCode(this.key) ^ "des".hashCode();
+        try {
+            return Arrays.hashCode(this.key) ^ "des".hashCode();
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
+        }
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
+        try {
+            if (this == obj)
+                return true;
 
-        if (!(obj instanceof SecretKey that))
-            return false;
+            if (!(obj instanceof SecretKey that))
+                return false;
 
-        String thatAlg = that.getAlgorithm();
-        if (!(thatAlg.equalsIgnoreCase("DES")))
-            return false;
+            String thatAlg = that.getAlgorithm();
+            if (!(thatAlg.equalsIgnoreCase("DES")))
+                return false;
 
-        byte[] thatKey = that.getEncoded();
-        boolean ret = MessageDigest.isEqual(this.key, thatKey);
-        java.util.Arrays.fill(thatKey, (byte)0x00);
-        return ret;
+            byte[] thatKey = that.getEncoded();
+            boolean ret = MessageDigest.isEqual(this.key, thatKey);
+            java.util.Arrays.fill(thatKey, (byte)0x00);
+            return ret;
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
+        }
     }
 
     /**
@@ -141,7 +151,13 @@ final class DESKey implements SecretKey {
          throws java.io.IOException, ClassNotFoundException
     {
         s.defaultReadObject();
-        key = key.clone();
+        byte[] temp = key;
+        key = temp.clone();
+        Arrays.fill(temp, (byte)0x00);
+        // Use the cleaner to zero the key when no longer referenced
+        final byte[] k = this.key;
+        CleanerFactory.cleaner().register(this,
+                () -> java.util.Arrays.fill(k, (byte)0x00));
     }
 
     /**
@@ -154,9 +170,14 @@ final class DESKey implements SecretKey {
      */
     @java.io.Serial
     private Object writeReplace() throws java.io.ObjectStreamException {
-        return new KeyRep(KeyRep.Type.SECRET,
+        try {
+            return new KeyRep(KeyRep.Type.SECRET,
                         getAlgorithm(),
                         getFormat(),
                         key);
+        } finally {
+            // prevent this from being cleaned for the above block
+            Reference.reachabilityFence(this);
+        }
     }
 }

--- a/src/java.base/share/classes/com/sun/crypto/provider/KeyProtector.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/KeyProtector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,7 +129,7 @@ final class KeyProtector {
         SecretKey sKey = null;
         PBEWithMD5AndTripleDESCipher cipher;
         try {
-            sKey = new PBEKey(pbeKeySpec, "PBEWithMD5AndTripleDES", false);
+            sKey = new PBEKey(pbeKeySpec, "PBEWithMD5AndTripleDES");
             // encrypt private key
             cipher = new PBEWithMD5AndTripleDESCipher();
             cipher.engineInit(Cipher.ENCRYPT_MODE, sKey, pbeSpec, null);
@@ -193,7 +193,7 @@ final class KeyProtector {
 
                 // create PBE key from password
                 PBEKeySpec pbeKeySpec = new PBEKeySpec(this.password);
-                sKey = new PBEKey(pbeKeySpec, "PBEWithMD5AndTripleDES", false);
+                sKey = new PBEKey(pbeKeySpec, "PBEWithMD5AndTripleDES");
                 pbeKeySpec.clearPassword();
 
                 // decrypt private key
@@ -339,7 +339,7 @@ final class KeyProtector {
         SecretKey sKey = null;
         Cipher cipher;
         try {
-            sKey = new PBEKey(pbeKeySpec, "PBEWithMD5AndTripleDES", false);
+            sKey = new PBEKey(pbeKeySpec, "PBEWithMD5AndTripleDES");
             pbeKeySpec.clearPassword();
 
             // seal key
@@ -366,8 +366,7 @@ final class KeyProtector {
         try {
             // create PBE key from password
             PBEKeySpec pbeKeySpec = new PBEKeySpec(this.password);
-            sKey = new PBEKey(pbeKeySpec,
-                    "PBEWithMD5AndTripleDES", false);
+            sKey = new PBEKey(pbeKeySpec, "PBEWithMD5AndTripleDES");
             pbeKeySpec.clearPassword();
 
             SealedObjectForKeyProtector soForKeyProtector = null;

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,7 +239,7 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
         if (!(keySpec instanceof PBEKeySpec)) {
             throw new InvalidKeySpecException("Invalid key spec");
         }
-        return new PBEKey((PBEKeySpec)keySpec, type, true);
+        return new PBEKey((PBEKeySpec)keySpec, type);
     }
 
     /**

--- a/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
+++ b/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8312306
+ * @summary Check the destroy()/isDestroyed() of the PBEKey impl from SunJCE
+ * @library /test/lib
+ * @run testng/othervm PBEKeyDestroyTest
+ */
+import javax.crypto.*;
+import javax.crypto.spec.*;
+import java.nio.charset.StandardCharsets;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PBEKeyDestroyTest {
+
+    @Test
+    public void test() throws Exception {
+        PBEKeySpec keySpec = new PBEKeySpec("12345678".toCharArray(),
+                "abcdefgh".getBytes(StandardCharsets.UTF_8), 100000, 128 >> 3);
+
+        SecretKeyFactory skf = SecretKeyFactory.getInstance
+                ("PBEWithHmacSHA1AndAES_128", "SunJCE");
+
+        SecretKey key1 = skf.generateSecret(keySpec);
+        SecretKey key2 = skf.generateSecret(keySpec);
+
+        Assert.assertFalse(key1.isDestroyed());
+        Assert.assertFalse(key2.isDestroyed());
+
+        // check key1 equals key2
+        Assert.assertTrue(key1.equals(key2));
+        Assert.assertTrue(key2.equals(key1));
+
+        key1.destroy();
+        Assert.assertTrue(key1.isDestroyed());
+
+        Assert.assertFalse(key1.equals(key2));
+        Assert.assertFalse(key2.equals(key1));
+
+        key2.destroy();
+        Assert.assertTrue(key2.isDestroyed());
+        Assert.assertFalse(key1.equals(key2));
+        Assert.assertFalse(key2.equals(key1));
+
+        // call destroy again to make sure no unexpected exceptions
+        key2.destroy();
+    }
+}

--- a/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
+++ b/test/jdk/com/sun/crypto/provider/KeyFactory/PBEKeyDestroyTest.java
@@ -47,19 +47,19 @@ public class PBEKeyDestroyTest {
         SecretKey key1 = skf.generateSecret(keySpec);
         SecretKey key2 = skf.generateSecret(keySpec);
 
+        // should be equal
         Assert.assertFalse(key1.isDestroyed());
         Assert.assertFalse(key2.isDestroyed());
-
-        // check key1 equals key2
         Assert.assertTrue(key1.equals(key2));
         Assert.assertTrue(key2.equals(key1));
 
+        // destroy key1
         key1.destroy();
         Assert.assertTrue(key1.isDestroyed());
-
         Assert.assertFalse(key1.equals(key2));
         Assert.assertFalse(key2.equals(key1));
 
+        // also destroy key2
         key2.destroy();
         Assert.assertTrue(key2.isDestroyed());
         Assert.assertFalse(key1.equals(key2));


### PR DESCRIPTION
This PR updates the various security classes using Cleaner with the try/finally pattern. Also noticed that SunJCE's PBEKey impl class overrides the destroy() method but not the isDestroyed() method, fixed this inconsistency as well.

Thanks in advance for the review!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312306](https://bugs.openjdk.org/browse/JDK-8312306): Add more Reference.reachabilityFence() calls to the security classes using Cleaner (**Enhancement** - P3)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15390/head:pull/15390` \
`$ git checkout pull/15390`

Update a local copy of the PR: \
`$ git checkout pull/15390` \
`$ git pull https://git.openjdk.org/jdk.git pull/15390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15390`

View PR using the GUI difftool: \
`$ git pr show -t 15390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15390.diff">https://git.openjdk.org/jdk/pull/15390.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15390#issuecomment-1688707475)