### PR TITLE
8314810: (fs) java/nio/file/Files/CopyInterference.java should use TestUtil::supportsLinks

### DIFF
--- a/test/jdk/java/nio/file/Files/CopyInterference.java
+++ b/test/jdk/java/nio/file/Files/CopyInterference.java
@@ -24,6 +24,8 @@
 /* @test
  * @bug 8114830
  * @summary Verify FileAlreadyExistsException is not thrown for REPLACE_EXISTING
+ * @library ..
+ * @build CopyInterference
  * @run junit CopyInterference
  */
 import java.io.InputStream;
@@ -112,17 +114,22 @@ public class CopyInterference {
                             new CopyOption[] {REPLACE_EXISTING});
         list.add(args);
 
-        // symblic link, followed
-        Path link = dir.resolve("link");
-        Files.createSymbolicLink(link, sourceFile);
-        args = Arguments.of(link, dir.resolve("linkFollowed"),
-                            new CopyOption[] {REPLACE_EXISTING});
-        list.add(args);
+        if (TestUtil.supportsLinks(dir)) {
+            // symbolic link, followed
+            Path link = dir.resolve("link");
+            Files.createSymbolicLink(link, sourceFile);
+            args = Arguments.of(link, dir.resolve("linkFollowed"),
+                                new CopyOption[] {REPLACE_EXISTING});
+            list.add(args);
 
-        // symblic link, not followed
-        args = Arguments.of(link, dir.resolve("linkNotFollowed"),
-                            new CopyOption[] {REPLACE_EXISTING, NOFOLLOW_LINKS});
-        list.add(args);
+            // symblic link, not followed
+            args = Arguments.of(link, dir.resolve("linkNotFollowed"),
+                                new CopyOption[] {REPLACE_EXISTING,
+                                                  NOFOLLOW_LINKS});
+            list.add(args);
+        } else {
+            System.out.println("Links not supported: not testing links");
+        }
 
         return list.stream();
     }

--- a/test/jdk/java/nio/file/Files/CopyInterference.java
+++ b/test/jdk/java/nio/file/Files/CopyInterference.java
@@ -122,7 +122,7 @@ public class CopyInterference {
                                 new CopyOption[] {REPLACE_EXISTING});
             list.add(args);
 
-            // symblic link, not followed
+            // symbolic link, not followed
             args = Arguments.of(link, dir.resolve("linkNotFollowed"),
                                 new CopyOption[] {REPLACE_EXISTING,
                                                   NOFOLLOW_LINKS});


### PR DESCRIPTION
Use TestUtil::supportsLinks to suppress testing links, e.g., when running on Windows without elevated privileges.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314810](https://bugs.openjdk.org/browse/JDK-8314810): (fs) java/nio/file/Files/CopyInterference.java should use TestUtil::supportsLinks (**Bug** - P4)


### Reviewers
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15391/head:pull/15391` \
`$ git checkout pull/15391`

Update a local copy of the PR: \
`$ git checkout pull/15391` \
`$ git pull https://git.openjdk.org/jdk.git pull/15391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15391`

View PR using the GUI difftool: \
`$ git pr show -t 15391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15391.diff">https://git.openjdk.org/jdk/pull/15391.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15391#issuecomment-1688734255)