### PR TITLE
8314819: [JVMCI] HotSpotJVMCIRuntime.lookupType throws unexpected ClassNotFoundException

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -617,10 +617,7 @@ C2V_VMENTRY_NULL(jobject, lookupType, (JNIEnv* env, jobject, jstring jname, ARGU
   }
 
   if (resolve) {
-    resolved_klass = SystemDictionary::resolve_or_null(class_name, class_loader, protection_domain, CHECK_NULL);
-    if (resolved_klass == nullptr) {
-      JVMCI_THROW_MSG_NULL(NoClassDefFoundError, str);
-    }
+    resolved_klass = SystemDictionary::resolve_or_fail(class_name, class_loader, protection_domain, true, CHECK_NULL);
   } else {
     if (Signature::has_envelope(class_name)) {
       // This is a name from a signature.  Strip off the trimmings.

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -243,7 +243,7 @@ final class CompilerToVM {
      * @param accessingClass the class loader of this class is used for resolution. Must not be null.
      * @param resolve force resolution to a {@link ResolvedJavaType}. If true, this method will
      *            either return a {@link ResolvedJavaType} or throw an exception
-     * @return the type for {@code name} or 0 if resolution failed and {@code resolve == false}
+     * @return the type for {@code name} or {@code null} if resolution failed and {@code resolve == false}
      * @throws NoClassDefFoundError if {@code resolve == true} and the resolution failed
      */
     HotSpotResolvedJavaType lookupType(String name, HotSpotResolvedObjectTypeImpl accessingClass, boolean resolve) throws NoClassDefFoundError {

--- a/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
@@ -84,7 +84,7 @@ public class CompilerToVMHelper {
     }
 
     public static HotSpotResolvedObjectType lookupType(String name,
-            Class<?> accessClass, boolean resolve) throws ClassNotFoundException {
+            Class<?> accessClass, boolean resolve) throws NoClassDefFoundError {
         if (accessClass == null) {
             throw new NullPointerException();
         }
@@ -94,11 +94,7 @@ public class CompilerToVMHelper {
 
     public static HotSpotResolvedObjectType lookupTypeHelper(String name,
             Class<?> accessingClass, boolean resolve) {
-        try {
-            return lookupType(name, accessingClass, resolve);
-        } catch (ClassNotFoundException e) {
-            throw (NoClassDefFoundError) new NoClassDefFoundError().initCause(e);
-        }
+        return lookupType(name, accessingClass, resolve);
     }
 
     public static Object lookupConstantInPool(ConstantPool constantPool, int cpi, boolean resolve) {

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestHotSpotJVMCIRuntime.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.hotspot.test/src/jdk/vm/ci/hotspot/test/TestHotSpotJVMCIRuntime.java
@@ -183,4 +183,9 @@ public class TestHotSpotJVMCIRuntime {
             output.shouldNotHaveExitValue(0);
         }
     }
+
+    @Test
+    public void lookupTypeTest() throws Exception {
+        // This is tested by compiler/jvmci/compilerToVM/LookupTypeTest.java
+    }
 }


### PR DESCRIPTION
This PR restores the expected behavior prior to [JDK-8313421](https://bugs.openjdk.org/browse/JDK-8313421) whereby `HotSpotJVMCIRuntime.lookupType` throws `NoClassDefFoundError` instead of `ClassNotFoundException`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314819](https://bugs.openjdk.org/browse/JDK-8314819): [JVMCI] HotSpotJVMCIRuntime.lookupType throws unexpected ClassNotFoundException (**Bug** - P3)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [c62ba346](https://git.openjdk.org/jdk/pull/15393/files/c62ba346670c1aea0ca4c310a3cc9e2cb705221d)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15393/head:pull/15393` \
`$ git checkout pull/15393`

Update a local copy of the PR: \
`$ git checkout pull/15393` \
`$ git pull https://git.openjdk.org/jdk.git pull/15393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15393`

View PR using the GUI difftool: \
`$ git pr show -t 15393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15393.diff">https://git.openjdk.org/jdk/pull/15393.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15393#issuecomment-1688973664)