### PR TITLE
8314679: SA fails to properly attach to JVM after having just detached from a different JVM

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/memory/FileMapInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,8 @@ public class FileMapInfo {
   }
 
   private static void initialize(TypeDataBase db) {
+    vTableTypeMap = null; // force vTableTypeMap to get re-initialized later
+
     Type FileMapInfo_type = db.lookupType("FileMapInfo");
     Type FileMapHeader_type = db.lookupType("FileMapHeader");
     Type CDSFileMapRegion_type = db.lookupType("CDSFileMapRegion");

--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -32,6 +32,7 @@
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8307393   generic-all
 serviceability/sa/CDSJMapClstats.java                         8307393   generic-all
 serviceability/sa/ClhsdbAttach.java                           8307393   generic-all
+serviceability/sa/ClhsdbAttachDifferentJVMs.java              8307393   generic-all
 serviceability/sa/ClhsdbCDSCore.java                          8307393   generic-all
 serviceability/sa/ClhsdbCDSJstackPrintAll.java                8307393   generic-all
 serviceability/sa/ClhsdbClasses.java                          8307393   generic-all

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbAttachDifferentJVMs.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbAttachDifferentJVMs.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
+
+/**
+ * @test
+ * @bug 8314679
+ * @summary Test clhsdb attach, detach, and then attach to different JVM
+ * @requires vm.hasSA
+ * @library /test/lib
+ * @run main/othervm ClhsdbAttachDifferentJVMs
+ */
+
+public class ClhsdbAttachDifferentJVMs {
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Starting ClhsdbAttach test");
+
+        LingeredApp theApp1 = null;
+        LingeredApp theApp2 = null;
+        try {
+            ClhsdbLauncher test = new ClhsdbLauncher();
+            theApp1 = LingeredApp.startApp();
+            System.out.println("Started LingeredApp with pid " + theApp1.getPid());
+            theApp2 = LingeredApp.startApp();
+            System.out.println("Started LingeredApp with pid " + theApp2.getPid());
+            String attach1 = "attach " + theApp1.getPid();
+            String attach2 = "attach " + theApp2.getPid();
+
+            List<String> cmds = List.of(
+                    "where",
+                    attach1,
+                    "threads",
+                    "detach",
+                    attach2,
+                    "jstack");
+
+            Map<String, List<String>> expStrMap = new HashMap<>();
+            expStrMap.put("where", List.of(
+                    "Command not valid until attached to a VM"));
+            expStrMap.put(attach1, List.of(
+                    "Attaching to process " + theApp1.getPid()));
+            expStrMap.put("threads", List.of(
+                    "Reference Handler"));
+            expStrMap.put(attach2, List.of(
+                    "Attaching to process " + theApp2.getPid()));
+            expStrMap.put("jstack", List.of(
+                    "Reference Handler"));
+
+            Map<String, List<String>> unexpStrMap = new HashMap<>();
+            unexpStrMap.put("jstack", List.of(
+                    "WARNING"));
+
+            test.run(-1, cmds, expStrMap, unexpStrMap);
+        } catch (SkippedException se) {
+            throw se;
+        } catch (Exception ex) {
+            throw new RuntimeException("Test ERROR " + ex, ex);
+        } finally {
+            LingeredApp.stopApp(theApp1);
+            LingeredApp.stopApp(theApp2);
+        }
+        System.out.println("Test PASSED");
+    }
+}


### PR DESCRIPTION
The CDS archive can change memory locations on different runs of the same JVM binary. This exposed a long standing bug in FileMapInfo.java. It was caching addresses that could be different for different JVM processes. As a result, doing an attach, detach, and then another attach to a different JVM process was resulting in various exceptions because the contents of CDS memory was not as expected.

Tested by running all serviceability/sa tests. Also tested with ZGC and generational ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314679](https://bugs.openjdk.org/browse/JDK-8314679): SA fails to properly attach to JVM after having just detached from a different JVM (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15395/head:pull/15395` \
`$ git checkout pull/15395`

Update a local copy of the PR: \
`$ git checkout pull/15395` \
`$ git pull https://git.openjdk.org/jdk.git pull/15395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15395`

View PR using the GUI difftool: \
`$ git pr show -t 15395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15395.diff">https://git.openjdk.org/jdk/pull/15395.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15395#issuecomment-1689064529)