### PR TITLE
8314024: SIGSEGV in PhaseIdealLoop::build_loop_late_post_work due to bad immediate dominator info

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2962,6 +2962,8 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
         continue;  // Don't rce this check but continue looking for other candidates.
       }
 
+      assert(is_dominator(compute_early_ctrl(limit, limit_c), pre_end), "node pinned on loop exit test?");
+
       // Check for scaled induction variable plus an offset
       Node *offset = nullptr;
 
@@ -2980,6 +2982,8 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
       if (is_dominator(ctrl, offset_c)) {
         continue; // Don't rce this check but continue looking for other candidates.
       }
+
+      assert(is_dominator(compute_early_ctrl(offset, offset_c), pre_end), "node pinned on loop exit test?");
 #ifdef ASSERT
       if (TraceRangeLimitCheck) {
         tty->print_cr("RC bool node%s", flip ? " flipped:" : ":");

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1799,6 +1799,11 @@ bool PhaseIdealLoop::ctrl_of_use_out_of_loop(const Node* n, Node* n_ctrl, IdealL
   if (n_loop->is_member(u_loop)) {
     return false; // Found use in inner loop
   }
+  if (n_loop->_head->is_CountedLoop() && n_loop->_head->as_CountedLoop()->is_pre_loop() &&
+      u_loop->_head->is_CountedLoop() && u_loop->_head->as_CountedLoop()->is_main_loop() &&
+      n_loop->_next == get_loop(u_loop->_head->as_CountedLoop()->skip_strip_mined())) {
+    return false;
+  }
   return true;
 }
 

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1799,6 +1799,9 @@ bool PhaseIdealLoop::ctrl_of_use_out_of_loop(const Node* n, Node* n_ctrl, IdealL
   if (n_loop->is_member(u_loop)) {
     return false; // Found use in inner loop
   }
+  // Sinking a node from a pre loop to its main loop pins the node between the pre and main loops. If that node is input
+  // to a check that's eliminated by range check elimination, it becomes input to an expression that feeds into the exit
+  // test of the pre loop above the point in the graph where it's pinned.
   if (n_loop->_head->is_CountedLoop() && n_loop->_head->as_CountedLoop()->is_pre_loop() &&
       u_loop->_head->is_CountedLoop() && u_loop->_head->as_CountedLoop()->is_main_loop() &&
       n_loop->_next == get_loop(u_loop->_head->as_CountedLoop()->skip_strip_mined())) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestNodeSunkFromPreLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestNodeSunkFromPreLoop.java
@@ -41,16 +41,21 @@ public class TestNodeSunkFromPreLoop {
 
     private static int test(A object, int stop, int inv) {
         int res = 0;
+        // pre/main/post loops created for this loop
         for (int i = 0; i < stop; i++) {
+            // Optimized out. Delay transformation of loop above.
             for (int j = 0; j < 10; j++) {
                 for (int k = 0; k < 10; k++) {
                 }
             }
+            // null check in pre loop so field load also in pre loop
             int v = object.field;
             int v2 = (v + inv);
             if (i > 1000) {
+                // never taken. v + inv has a use out of loop at an unc.
                 unusedField = v2;
             }
+            // transformed in the main loop to i + (v + inv)
             int v3 = (v + (i + inv));
             if (v3 > 1000) {
                 break;

--- a/test/hotspot/jtreg/compiler/loopopts/TestNodeSunkFromPreLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestNodeSunkFromPreLoop.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8314024
+ * @requires vm.compiler2.enabled
  * @summary Node used in check in main loop sunk from pre loop before RC elimination
  * @run main/othervm -XX:-BackgroundCompilation -XX:-UseLoopPredicate TestNodeSunkFromPreLoop
  *

--- a/test/hotspot/jtreg/compiler/loopopts/TestNodeSunkFromPreLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestNodeSunkFromPreLoop.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8314024
+ * @summary Node used in check in main loop sunk from pre loop before RC elimination
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseLoopPredicate TestNodeSunkFromPreLoop
+ *
+ */
+
+public class TestNodeSunkFromPreLoop {
+    private static int unusedField;
+
+    public static void main(String[] args) {
+        A object = new A();
+        for (int i = 0; i < 20_000; i++) {
+            test(object, 1000, 0);
+        }
+    }
+
+    private static int test(A object, int stop, int inv) {
+        int res = 0;
+        for (int i = 0; i < stop; i++) {
+            for (int j = 0; j < 10; j++) {
+                for (int k = 0; k < 10; k++) {
+                }
+            }
+            int v = object.field;
+            int v2 = (v + inv);
+            if (i > 1000) {
+                unusedField = v2;
+            }
+            int v3 = (v + (i + inv));
+            if (v3 > 1000) {
+                break;
+            }
+        }
+        return res;
+    }
+
+    private static class A {
+        public int field;
+    }
+}


### PR DESCRIPTION
A node is sunk from the pre loop into the main loop. That node, in the
main loop, feeds into a test. When the node is sunk it is pinned
between the main and pre loop. The test it feeds into is then
eliminated by range check elimination: the sunk node becomes input to
an expression that computes the new bound of the pre loop. The
resulting graph is broken because the sunk node is pinned below the
pre loop but used by the exit test of the pre loop.

The fix I propose is in `PhaseIdealLoop::try_sink_out_of_loop()`, to
skip nodes in pre loops that have a use in the companion main loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314024](https://bugs.openjdk.org/browse/JDK-8314024): SIGSEGV in PhaseIdealLoop::build_loop_late_post_work due to bad immediate dominator info (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15399/head:pull/15399` \
`$ git checkout pull/15399`

Update a local copy of the PR: \
`$ git checkout pull/15399` \
`$ git pull https://git.openjdk.org/jdk.git pull/15399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15399`

View PR using the GUI difftool: \
`$ git pr show -t 15399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15399.diff">https://git.openjdk.org/jdk/pull/15399.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15399#issuecomment-1689612840)