### PR TITLE
8314573: G1: Heap resizing at Remark does not take existing eden regions into account

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.cpp
@@ -217,7 +217,14 @@ size_t G1HeapSizingPolicy::full_collection_resize_amount(bool& expand) {
   // Capacity, free and used after the GC counted as full regions to
   // include the waste in the following calculations.
   const size_t capacity_after_gc = _g1h->capacity();
-  const size_t used_after_gc = capacity_after_gc - _g1h->unused_committed_regions_in_bytes();
+  const size_t used_after_gc = capacity_after_gc -
+                               _g1h->unused_committed_regions_in_bytes() -
+                               // Discount space used by current Eden to establish a
+                               // situation during Remark similar to at the end of full
+                               // GC where eden is empty. During Remark there can be an
+                               // arbitrary number of eden regions which would skew the
+                               // results.
+                               _g1h->eden_regions_count() * HeapRegion::GrainBytes;
 
   size_t minimum_desired_capacity = target_heap_capacity(used_after_gc, MinHeapFreeRatio);
   size_t maximum_desired_capacity = target_heap_capacity(used_after_gc, MaxHeapFreeRatio);


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that tries to make the heap resizing policy at Remark more similar to the one after full GC?

The problem is that when calculating the amount of free regions to apply the Min/MaxHeapFreeRatio during Remark g1 does not consider that at Remark we might have already allocated lots of eden regions.
Which means that the heap appears fuller than it would be during full gc, which means that Remark sometimes expands very aggressively due to MinHeapFreeRatio setting. I.e. if at the time of remark pause free regions 

There should be no impact wrt to shrinking: MaxHeapFreeRatio is by default (70%) larger than the maximum eden/young gen size (G1MaxNewSizePercent = 60%), so there should be no additional shrinking (that would only lead to additional heap expansion later).

I am aware that fiddling with the values (MaxHeapFreeRatio/G1MaxNewSizePercent) may create a situation where g1 would immediately increase the heap afterwards due to young gen being able to be larger than MaxHeapFreeRatio (if G1MaxNewSizePercent > MaxHeapFreeRatio and G1 would use that large young gen). However this is no different to the current situation after full gc, so I would like to keep it as is. Also for the sake of not complicating this (imo) straightforward change.

A more comprehensive improvement to the problem would be [JDK-8238687](https://bugs.openjdk.org/browse/JDK-8238687), where we do the resizing when eden is empty after young gc, but I think this is out of scope here: this fix improves the situation recently reported to me where g1 suddenly started to expand a lot during Remark after upgrades, and should also fix the issue reported in https://bugs.openjdk.org/browse/JDK-6490394 in the last comment (which has been reported around 1 year after the push, which means likely it got overlooked).

Testing: tier1-3, internal perf testing with no changes

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314573](https://bugs.openjdk.org/browse/JDK-8314573): G1: Heap resizing at Remark does not take existing eden regions into account (**Bug** - P3)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15400/head:pull/15400` \
`$ git checkout pull/15400`

Update a local copy of the PR: \
`$ git checkout pull/15400` \
`$ git pull https://git.openjdk.org/jdk.git pull/15400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15400`

View PR using the GUI difftool: \
`$ git pr show -t 15400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15400.diff">https://git.openjdk.org/jdk/pull/15400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15400#issuecomment-1689667898)