### PR TITLE
JDK-8314115: DatagramSocket.receive may hang if underlying UDP RCVBUF of OS is too small

### DIFF
--- a/src/java.base/share/classes/java/net/DatagramSocket.java
+++ b/src/java.base/share/classes/java/net/DatagramSocket.java
@@ -694,6 +694,11 @@ public class DatagramSocket implements java.io.Closeable {
      * Datagrams that are not permitted by the security manager are silently
      * discarded.
      *
+     * <p>Note that the native implementation of receive can cause a hanging
+     * situation if the size of UDP RCVBUF is not big enough to hold the
+     * UDP datagram packet to receive. This buffer size needs to be set
+     * accordingly on OS level.</p>
+     *
      * @param      p   the {@code DatagramPacket} into which to place
      *                 the incoming data.
      * @throws     IOException  if an I/O error occurs.

--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -465,6 +465,11 @@ public abstract class DatagramChannel
      * first cause the socket to be bound to an address that is assigned
      * automatically, as if by invoking the {@link #bind bind} method with a
      * parameter of {@code null}. </p>
+     * 
+     * <p>Note that the native implementation of receive can cause a hanging 
+     * situation if the size of UDP RCVBUF is not big enough to hold the 
+     * UDP datagram packet to receive. This buffer size needs to be set 
+     * accordingly on OS level.</p>
      *
      * @param  src
      *         The buffer containing the datagram to be sent

--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -465,10 +465,10 @@ public abstract class DatagramChannel
      * first cause the socket to be bound to an address that is assigned
      * automatically, as if by invoking the {@link #bind bind} method with a
      * parameter of {@code null}. </p>
-     * 
-     * <p>Note that the native implementation of receive can cause a hanging 
-     * situation if the size of UDP RCVBUF is not big enough to hold the 
-     * UDP datagram packet to receive. This buffer size needs to be set 
+     *
+     * <p>Note that the native implementation of receive can cause a hanging
+     * situation if the size of UDP RCVBUF is not big enough to hold the
+     * UDP datagram packet to receive. This buffer size needs to be set
      * accordingly on OS level.</p>
      *
      * @param  src


### PR DESCRIPTION
docu update to explain that receive can hang because of bad configuration

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 22 to be approved (needs to be created)

### Issue
 * [JDK-8314115](https://bugs.openjdk.org/browse/JDK-8314115): DatagramSocket.receive may hang if underlying UDP RCVBUF of OS is too small (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15401/head:pull/15401` \
`$ git checkout pull/15401`

Update a local copy of the PR: \
`$ git checkout pull/15401` \
`$ git pull https://git.openjdk.org/jdk.git pull/15401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15401`

View PR using the GUI difftool: \
`$ git pr show -t 15401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15401.diff">https://git.openjdk.org/jdk/pull/15401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15401#issuecomment-1690085069)