### PR TITLE
JDK-8314883: Java_java_util_prefs_FileSystemPreferences_lockFile0 write result errno in missing case

### DIFF
--- a/src/java.prefs/unix/native/libprefs/FileSystemPreferences.c
+++ b/src/java.prefs/unix/native/libprefs/FileSystemPreferences.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ Java_java_util_prefs_FileSystemPreferences_lockFile0(JNIEnv *env,
     jclass thisclass, jstring java_fname, jint permission, jboolean shared) {
     const char *fname = JNU_GetStringPlatformChars(env, java_fname, NULL);
     int fd, rc;
-    int result[2];
+    int result[2] = {0, 0};
     jintArray javaResult = NULL;
     int old_umask;
     FLOCK fl;
@@ -90,6 +90,7 @@ Java_java_util_prefs_FileSystemPreferences_lockFile0(JNIEnv *env,
 
     if (shared == JNI_TRUE) {
         fd = open(fname, O_RDONLY, 0);
+        result[1] = errno;
     } else {
         old_umask = umask(0);
         fd = open(fname, O_WRONLY|O_CREAT, permission);


### PR DESCRIPTION
There seems to be a codepath in Java_java_util_prefs_FileSystemPreferences_lockFile0 where the errno is not stored but potentially accessed in the calling Java code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314883](https://bugs.openjdk.org/browse/JDK-8314883): Java_java_util_prefs_FileSystemPreferences_lockFile0 write result errno in missing case (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15402/head:pull/15402` \
`$ git checkout pull/15402`

Update a local copy of the PR: \
`$ git checkout pull/15402` \
`$ git pull https://git.openjdk.org/jdk.git pull/15402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15402`

View PR using the GUI difftool: \
`$ git pr show -t 15402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15402.diff">https://git.openjdk.org/jdk/pull/15402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15402#issuecomment-1690008810)