### PR TITLE
8314828: Mark 3 jcmd command-line options test as vm.flagless

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @test
  * @summary Test of diagnostic command help (tests all DCMD executors)
  * @library /test/lib
- *          /vmTestbase
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * @test
  * @summary Test of invalid diagnostic command (tests all DCMD executors)
  * @library /test/lib
- *          /vmTestbase
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler
  *          java.management

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
@@ -27,7 +27,6 @@ import jdk.test.lib.dcmd.PidJcmdExecutor;
 import jdk.test.lib.dcmd.MainClassJcmdExecutor;
 import jdk.test.lib.dcmd.FileJcmdExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
-import nsk.share.jdi.ArgumentHandler;
 
 import org.testng.annotations.Test;
 
@@ -44,7 +43,7 @@ import org.testng.annotations.Test;
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @library /test/lib
- *          /vmTestbase
+ * @requires vm.flagless
  * @run testng/othervm -XX:+UsePerfData VMVersionTest
  */
 public class VMVersionTest {


### PR DESCRIPTION
Mark 3 tests as flagless to don't run them if not needed. Also, small clean up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314828](https://bugs.openjdk.org/browse/JDK-8314828): Mark 3 jcmd command-line options test as vm.flagless (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15407/head:pull/15407` \
`$ git checkout pull/15407`

Update a local copy of the PR: \
`$ git checkout pull/15407` \
`$ git pull https://git.openjdk.org/jdk.git pull/15407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15407`

View PR using the GUI difftool: \
`$ git pr show -t 15407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15407.diff">https://git.openjdk.org/jdk/pull/15407.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15407#issuecomment-1690755584)