### PR TITLE
8009550: PlatformPCSC should load versioned so

### DIFF
--- a/src/java.base/share/classes/sun/security/util/Debug.java
+++ b/src/java.base/share/classes/sun/security/util/Debug.java
@@ -81,6 +81,7 @@ public class Debug {
         System.err.println("logincontext  login context results");
         System.err.println("jca           JCA engine class debugging");
         System.err.println("keystore      KeyStore debugging");
+        System.err.println("pcsc          Smartcard library debugging");
         System.err.println("policy        loading and granting");
         System.err.println("provider      security provider debugging");
         System.err.println("pkcs11        PKCS11 session manager debugging");

--- a/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
+++ b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
@@ -47,12 +47,13 @@ class PlatformPCSC {
 
     private static final String PROP_NAME = "sun.security.smartcardio.library";
 
+    // The architecture templates are for Debian-based systems: https://wiki.debian.org/Multiarch/Tuples
+    // 32-bit arm differs from the pattern of the rest and has to be specified explicitly
     private static final String[] LIB_TEMPLATES = { "/usr/$LIBISA/libpcsclite.so",
                                                     "/usr/local/$LIBISA/libpcsclite.so",
                                                     "/usr/lib/$ARCH-linux-gnu/libpcsclite.so",
                                                     "/usr/lib/arm-linux-gnueabi/libpcsclite.so",
-                                                    "/usr/lib/arm-linux-gnueabihf/libpcsclite.so",
-                                                    "/usr/lib/$ARCH-kfreebsd-gnu/libpcsclite.so" };
+                                                    "/usr/lib/arm-linux-gnueabihf/libpcsclite.so" };
     private static final String[] LIB_SUFFIXES = { ".1", ".0", "" };
     private static final String PCSC_FRAMEWORK = "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC";
 

--- a/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
+++ b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +47,13 @@ class PlatformPCSC {
 
     private static final String PROP_NAME = "sun.security.smartcardio.library";
 
-    private static final String LIB1 = "/usr/$LIBISA/libpcsclite.so";
-    private static final String LIB2 = "/usr/local/$LIBISA/libpcsclite.so";
+    private static final String[] LIB_TEMPLATES = { "/usr/$LIBISA/libpcsclite.so",
+                                                    "/usr/local/$LIBISA/libpcsclite.so",
+                                                    "/usr/lib/$ARCH-linux-gnu/libpcsclite.so",
+                                                    "/usr/lib/arm-linux-gnueabi/libpcsclite.so",
+                                                    "/usr/lib/arm-linux-gnueabihf/libpcsclite.so",
+                                                    "/usr/lib/$ARCH-kfreebsd-gnu/libpcsclite.so" };
+    private static final String[] LIB_SUFFIXES = { ".1", ".0", "" };
     private static final String PCSC_FRAMEWORK = "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC";
 
     PlatformPCSC() {
@@ -73,23 +79,38 @@ class PlatformPCSC {
     });
 
     // expand $LIBISA to the system specific directory name for libraries
+    // expand $ARCH to the Debian system architecture in use
     private static String expand(String lib) {
         int k = lib.indexOf("$LIBISA");
-        if (k == -1) {
-            return lib;
+        if (k != -1) {
+            String libDir;
+            if ("64".equals(System.getProperty("sun.arch.data.model"))) {
+                // assume Linux convention
+                libDir = "lib64";
+            } else {
+                // must be 32-bit
+                libDir = "lib";
+            }
+            lib = lib.replace("$LIBISA", libDir);
         }
-        String s1 = lib.substring(0, k);
-        String s2 = lib.substring(k + 7);
-        String libDir;
-        if ("64".equals(System.getProperty("sun.arch.data.model"))) {
-            // assume Linux convention
-            libDir = "lib64";
-        } else {
-            // must be 32-bit
-            libDir = "lib";
+
+        k = lib.indexOf("$ARCH");
+        if (k != -1) {
+            String arch = System.getProperty("os.arch");
+            lib = lib.replace("$ARCH", getDebianArchitecture(arch));
         }
-        String s = s1 + libDir + s2;
-        return s;
+
+        return lib;
+    }
+
+    private static String getDebianArchitecture(String jdkArch) {
+        return switch (jdkArch) {
+            case "amd64" -> "x86_64";
+            case "ppc" -> "powerpc";
+            case "ppc64" -> "powerpc64";
+            case "ppc64le" -> "powerpc64le";
+            default -> jdkArch;
+        };
     }
 
     private static String getLibraryName() throws IOException {
@@ -98,15 +119,18 @@ class PlatformPCSC {
         if (lib.length() != 0) {
             return lib;
         }
-        lib = expand(LIB1);
-        if (new File(lib).isFile()) {
-            // if LIB1 exists, use that
-            return lib;
-        }
-        lib = expand(LIB2);
-        if (new File(lib).isFile()) {
-            // if LIB2 exists, use that
-            return lib;
+
+        for (String template : LIB_TEMPLATES) {
+            for (String suffix : LIB_SUFFIXES) {
+                lib = expand(template) + suffix;
+                if (debug != null) {
+                    debug.println("Looking for " + lib);
+                }
+                if (new File(lib).isFile()) {
+                    // if library exists, use that
+                    return lib;
+                }
+            }
         }
 
         // As of macos 11, framework libraries have been removed from the file


### PR DESCRIPTION
There is a long standing limitation in the UNIX smartcardio implementation which means it will only look for the `pcsclite` library in two locations; `/usr/lib` and `/usr/local/lib`. It also only searches for an unversioned library.

On systems that separate libraries from development headers in separate subpackages, the unversioned library is only installed by the `-devel` package, which rarely happens unless the user wants to write their own application using the libpcsclite headers or build someone else's code themselves. An example of this is the [pcsc-lite-libs package on Fedora](https://koji.fedoraproject.org/koji/rpminfo?rpmID=35258843)

On Debian-based systems, there is also the issue that libraries are now placed inside a subdirectory using a [tuple](https://wiki.debian.org/Multiarch/Tuples) consisting of the instruction set, syscall ABI and libc e.g. `x86_64-linux-gnu`.  So it will not only fail to find the library when only the versioned library is installed (e.g. [libpcsclite1](https://packages.ubuntu.com/kinetic/amd64/libpcsclite1/filelist)) but also when the dev package is also installed (e.g. [libpcsclite-dev](https://packages.ubuntu.com/kinetic/amd64/libpcsclite-dev/filelist)), because the file is in e.g. `/usr/lib/x86_64-linux-gnu/libpcsclite.so`

This patch makes both cases work. It prefers versioned libraries, as potentially a `libpcsclite.so.2` could become available with a different ABI that the JDK can not work with.  All cases that worked before with just `libpcsclite.so` will still work, but it should also now pick up the library on many additional systems.

A much simpler patch (search for the versioned symlink instead of unversioned) has been [in the Fedora and RHEL packages for nearly a decade](https://bugzilla.redhat.com/show_bug.cgi?id=910107), and an earlier version of this patch with Debian support has been used in IcedTea builds since 2015. It would be nice to finally fix this upstream.

Testing:

Test case:
~~~
import java.lang.reflect.Method;

public class TestPlatformPCSC {
    public static void main(String[] args)
    throws Exception {
        Class<?> cls = Class.forName("sun.security.smartcardio.PlatformPCSC");
        Method m = cls.getDeclaredMethod("getLibraryName");
        m.setAccessible(true);
        System.err.println(m.invoke(null));
    }
}
~~~

1. With `libpcsclite.so.1` available:
~~~
$ ~/builder/trunk/images/jdk/bin/java --add-opens java.smartcardio/sun.security.smartcardio=ALL-UNNAMED -Djava.security.debug=pcsc TestPlatformPCSC
pcsc: Looking for /usr/lib64/libpcsclite.so.1
pcsc: Using PC/SC library: /usr/lib64/libpcsclite.so.1
pcsc: Looking for /usr/lib64/libpcsclite.so.1
/usr/lib64/libpcsclite.so.1
~~~

2. With just `libpcsclite.so` available:
~~~
$ ~/builder/trunk/images/jdk/bin/java --add-opens java.smartcardio/sun.security.smartcardio=ALL-UNNAMED -Djava.security.debug=pcsc TestPlatformPCSC
pcsc: Looking for /usr/lib64/libpcsclite.so.1
pcsc: Looking for /usr/lib64/libpcsclite.so.0
pcsc: Looking for /usr/lib64/libpcsclite.so
pcsc: Using PC/SC library: /usr/lib64/libpcsclite.so
~~~

4. With `libpcsclite.so.1` in the Debian-style structure:
~~~
$ ~/builder/trunk/images/jdk/bin/java --add-opens java.smartcardio/sun.security.smartcardio=ALL-UNNAMED -Djava.security.debug=pcsc TestPlatformPCSC
pcsc: Looking for /usr/lib64/libpcsclite.so.1
pcsc: Looking for /usr/lib64/libpcsclite.so.0
pcsc: Looking for /usr/lib64/libpcsclite.so
pcsc: Looking for /usr/local/lib64/libpcsclite.so.1
pcsc: Looking for /usr/local/lib64/libpcsclite.so.0
pcsc: Looking for /usr/local/lib64/libpcsclite.so
pcsc: Looking for /usr/lib/x86_64-linux-gnu/libpcsclite.so.1
pcsc: Using PC/SC library: /usr/lib/x86_64-linux-gnu/libpcsclite.so.1
~~~

5. Without the library installed
~~~
$ ~/builder/trunk/images/jdk/bin/java --add-opens java.smartcardio/sun.security.smartcardio=ALL-UNNAMED -Djava.security.debug=pcsc TestPlatformPCSC
pcsc: Looking for /usr/lib64/libpcsclite.so.1
pcsc: Looking for /usr/lib64/libpcsclite.so.0
pcsc: Looking for /usr/lib64/libpcsclite.so
pcsc: Looking for /usr/local/lib64/libpcsclite.so.1
pcsc: Looking for /usr/local/lib64/libpcsclite.so.0
pcsc: Looking for /usr/local/lib64/libpcsclite.so
pcsc: Looking for /usr/lib/x86_64-linux-gnu/libpcsclite.so.1
pcsc: Looking for /usr/lib/x86_64-linux-gnu/libpcsclite.so.0
pcsc: Looking for /usr/lib/x86_64-linux-gnu/libpcsclite.so
pcsc: Looking for /usr/lib/arm-linux-gnueabi/libpcsclite.so.1
pcsc: Looking for /usr/lib/arm-linux-gnueabi/libpcsclite.so.0
pcsc: Looking for /usr/lib/arm-linux-gnueabi/libpcsclite.so
pcsc: Looking for /usr/lib/arm-linux-gnueabihf/libpcsclite.so.1
pcsc: Looking for /usr/lib/arm-linux-gnueabihf/libpcsclite.so.0
pcsc: Looking for /usr/lib/arm-linux-gnueabihf/libpcsclite.so
pcsc: Looking for /usr/lib/x86_64-kfreebsd-gnu/libpcsclite.so.1
pcsc: Looking for /usr/lib/x86_64-kfreebsd-gnu/libpcsclite.so.0
pcsc: Looking for /usr/lib/x86_64-kfreebsd-gnu/libpcsclite.so
pcsc: Looking for /usr/lib64/libpcsclite.so.1
pcsc: Looking for /usr/lib64/libpcsclite.so.0
pcsc: Looking for /usr/lib64/libpcsclite.so
pcsc: Looking for /usr/local/lib64/libpcsclite.so.1
pcsc: Looking for /usr/local/lib64/libpcsclite.so.0
pcsc: Looking for /usr/local/lib64/libpcsclite.so
pcsc: Looking for /usr/lib/x86_64-linux-gnu/libpcsclite.so.1
pcsc: Looking for /usr/lib/x86_64-linux-gnu/libpcsclite.so.0
pcsc: Looking for /usr/lib/x86_64-linux-gnu/libpcsclite.so
pcsc: Looking for /usr/lib/arm-linux-gnueabi/libpcsclite.so.1
pcsc: Looking for /usr/lib/arm-linux-gnueabi/libpcsclite.so.0
pcsc: Looking for /usr/lib/arm-linux-gnueabi/libpcsclite.so
pcsc: Looking for /usr/lib/arm-linux-gnueabihf/libpcsclite.so.1
pcsc: Looking for /usr/lib/arm-linux-gnueabihf/libpcsclite.so.0
pcsc: Looking for /usr/lib/arm-linux-gnueabihf/libpcsclite.so
pcsc: Looking for /usr/lib/x86_64-kfreebsd-gnu/libpcsclite.so.1
pcsc: Looking for /usr/lib/x86_64-kfreebsd-gnu/libpcsclite.so.0
pcsc: Looking for /usr/lib/x86_64-kfreebsd-gnu/libpcsclite.so
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:118)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at TestPlatformPCSC.main(TestPlatformPCSC.java:9)
Caused by: java.io.IOException: No PC/SC library found on this system
~~~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8009550](https://bugs.openjdk.org/browse/JDK-8009550): PlatformPCSC should load versioned so (**Bug** - P3)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to [d0523302](https://git.openjdk.org/jdk/pull/15409/files/d0523302416bc6507696f20d1068f16427bcf6b8)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [d0523302](https://git.openjdk.org/jdk/pull/15409/files/d0523302416bc6507696f20d1068f16427bcf6b8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15409/head:pull/15409` \
`$ git checkout pull/15409`

Update a local copy of the PR: \
`$ git checkout pull/15409` \
`$ git pull https://git.openjdk.org/jdk.git pull/15409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15409`

View PR using the GUI difftool: \
`$ git pr show -t 15409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15409.diff">https://git.openjdk.org/jdk/pull/15409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15409#issuecomment-1690832191)