### PR TITLE
8314580: PhaseIdealLoop::transform_long_range_checks fails with assert "was tested before"

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -769,7 +769,7 @@ SafePointNode* PhaseIdealLoop::find_safepoint(Node* back_control, Node* x, Ideal
 //     // inner_incr := AddI(inner_phi, intcon(stride))
 //     inner_incr = inner_phi + stride;
 //     if (inner_incr < inner_iters_actual) {
-//       ... use phi=>(outer_phi+inner_phi) and incr=>(outer_phi+inner_incr) ...
+//       ... use phi=>(outer_phi+inner_phi) ...
 //       continue;
 //     }
 //     else break;
@@ -979,10 +979,6 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
   // loop iv phi
   Node* iv_add = loop_nest_replace_iv(phi, inner_phi, outer_phi, head, bt);
 
-  // Replace inner loop long iv incr with inner loop int incr + outer
-  // loop iv phi
-  loop_nest_replace_iv(incr, inner_incr, outer_phi, head, bt);
-
   set_subtree_ctrl(inner_iters_actual_int, body_populated);
 
   LoopNode* inner_head = create_inner_head(loop, head, exit_test);
@@ -1031,7 +1027,7 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
   //       back_control: fallthrough;
   //     else
   //       inner_exit_branch: break;  //exit_branch->clone()
-  //     ... use phi=>(outer_phi+inner_phi) and incr=>(outer_phi+inner_incr) ...
+  //     ... use phi=>(outer_phi+inner_phi) ...
   //     inner_phi = inner_phi + stride;  // inner_incr
   //   }
   //   outer_exit_test:  //exit_test->clone(), in(0):=inner_exit_branch

--- a/test/hotspot/jtreg/compiler/rangechecks/TestLongRCWithLoopIncr.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestLongRCWithLoopIncr.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8314580
+ * @summary PhaseIdealLoop::transform_long_range_checks fails with assert "was tested before"
+ * @run main/othervm -XX:-BackgroundCompilation TestLongRCWithLoopIncr
+ *
+ */
+
+import java.util.Objects;
+
+public class TestLongRCWithLoopIncr {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test(1001);
+        }
+    }
+
+    private static void test(long length) {
+        for (long i = 0; i < 1000; i++) {
+            Objects.checkIndex(i + 1, length);
+        }
+    }
+}


### PR DESCRIPTION
For long counted loops, `PhaseIdealLoop::create_loop_nest()` first
goes over the loop body to collect range checks, then transforms the
long counted loop into a loop nest and then goes over the list of
range checks it collected to transfrom them. For that last step,
`PhaseIdealLoop::transform_long_range_checks()` needs to extract the
parameters of the range check from the range check expression. It
should still recognize the range check expression even though the loop
was transformed in the meantime. That's what fails here. The reason is
that the range check expression uses the long loop increment as input
which, in the creation of the loop nest, is transformed to `outer
phi + inner incr`. That breaks pattern matching of the range check
expression. I propose removing the transformation:

```
incr=>(outer_phi+inner_incr)
```

entireley. After looking at this code again, I don't think it's
needed. The transformation:

```
phi=>(outer_phi+inner_phi)
```

should be all that's needed to correctly transform the loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314580](https://bugs.openjdk.org/browse/JDK-8314580): PhaseIdealLoop::transform_long_range_checks fails with assert "was tested before" (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15411/head:pull/15411` \
`$ git checkout pull/15411`

Update a local copy of the PR: \
`$ git checkout pull/15411` \
`$ git pull https://git.openjdk.org/jdk.git pull/15411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15411`

View PR using the GUI difftool: \
`$ git pr show -t 15411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15411.diff">https://git.openjdk.org/jdk/pull/15411.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15411#issuecomment-1691204502)