### PR TITLE
[PATCH]: Make fields final in 'com.sun.crypto.provider' package

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/AESParameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/AESParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import java.security.spec.InvalidParameterSpecException;
  */
 public final class AESParameters extends AlgorithmParametersSpi {
 
-    private BlockCipherParamsCore core;
+    private final BlockCipherParamsCore core;
 
     public AESParameters() {
         core = new BlockCipherParamsCore(AESConstants.AES_BLOCK_SIZE, 4, 8);

--- a/src/java.base/share/classes/com/sun/crypto/provider/BlockCipherParamsCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/BlockCipherParamsCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,10 +46,10 @@ import javax.crypto.spec.IvParameterSpec;
  *
  */
 final class BlockCipherParamsCore {
-    private int block_size = 0;
+    private final int block_size;
     private byte[] iv = null;
 
-    private int[] moreSizes = null;
+    private final int[] moreSizes;
 
     BlockCipherParamsCore(int blksize, int... moreSizes) {
         block_size = blksize;

--- a/src/java.base/share/classes/com/sun/crypto/provider/BlowfishCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/BlowfishCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,7 @@ import java.security.*;
 import java.security.spec.*;
 import java.util.Arrays;
 
-import sun.security.util.*;
 import javax.crypto.*;
-import javax.crypto.spec.*;
 import javax.crypto.BadPaddingException;
 
 /**
@@ -57,7 +55,7 @@ public final class BlowfishCipher extends CipherSpi {
     /*
      * internal CipherCore object which does the real work.
      */
-    private CipherCore core = null;
+    private final CipherCore core;
 
     /**
      * Creates an instance of Blowfish cipher with default ECB mode and

--- a/src/java.base/share/classes/com/sun/crypto/provider/BlowfishParameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/BlowfishParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import java.security.spec.InvalidParameterSpecException;
 
 public final class BlowfishParameters extends AlgorithmParametersSpi {
 
-    private BlockCipherParamsCore core;
+    private final BlockCipherParamsCore core;
 
     public BlowfishParameters() {
         core = new BlockCipherParamsCore

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherBlockChaining.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherBlockChaining.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package com.sun.crypto.provider;
 
 import java.security.InvalidKeyException;
 import java.security.ProviderException;
-import java.util.Objects;
 
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import sun.security.util.ArrayUtil;
@@ -55,7 +54,7 @@ class CipherBlockChaining extends FeedbackCipher  {
     /*
      * output buffer
      */
-    private byte[] k;
+    private final byte[] k;
 
     // variables for save/restore calls
     private byte[] rSave = null;

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,12 +57,12 @@ final class CipherCore {
     /*
      * internal buffer
      */
-    private byte[] buffer = null;
+    private final byte[] buffer;
 
     /*
      * block size of cipher in bytes
      */
-    private int blockSize = 0;
+    private final int blockSize;
 
     /*
      * unit size (number of input bytes that can be processed at a time)

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherFeedback.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherFeedback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ final class CipherFeedback extends FeedbackCipher {
      * number of bytes for each stream unit, defaults to the blocksize
      * of the embedded cipher
      */
-    private int numBytes;
+    private final int numBytes;
 
     // variables for save/restore calls
     private byte[] registerSave = null;

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.security.*;
 import java.security.spec.*;
 import java.util.Arrays;
 import javax.crypto.*;
-import javax.crypto.spec.*;
 import javax.crypto.BadPaddingException;
 
 /**
@@ -52,7 +51,7 @@ public final class DESCipher extends CipherSpi {
     /*
      * internal CipherCore object which does the real work.
      */
-    private CipherCore core = null;
+    private final CipherCore core;
 
     /**
      * Creates an instance of DES cipher with default ECB mode and

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESParameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import java.security.spec.InvalidParameterSpecException;
 
 public final class DESParameters extends AlgorithmParametersSpi {
 
-    private BlockCipherParamsCore core;
+    private final BlockCipherParamsCore core;
 
     public DESParameters() {
         core = new BlockCipherParamsCore(DESConstants.DES_BLOCK_SIZE);

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.security.*;
 import java.security.spec.*;
 import java.util.Arrays;
 import javax.crypto.*;
-import javax.crypto.spec.*;
 
 /**
  * This class implements the DESede algorithm (DES-EDE, tripleDES) in
@@ -50,7 +49,7 @@ public sealed class DESedeCipher extends CipherSpi
     /*
      * internal CipherCore object which does the real work.
      */
-    private CipherCore core = null;
+    private final CipherCore core;
 
     /**
      * Creates an instance of DESede cipher with default ECB mode and

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeCrypt.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeCrypt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,8 @@ final class DESedeCrypt extends DESCrypt implements DESConstants {
     private byte[] key1 = null;
     private byte[] key2 = null;
     private byte[] key3 = null;
-    private byte[] buf1, buf2;
+    private final byte[] buf1;
+    private final byte[] buf2;
 
     /*
      * constructor

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeParameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import java.security.spec.InvalidParameterSpecException;
  */
 public final class DESedeParameters extends AlgorithmParametersSpi {
 
-    private BlockCipherParamsCore core;
+    private final BlockCipherParamsCore core;
 
     public DESedeParameters() {
         core = new BlockCipherParamsCore(DESConstants.DES_BLOCK_SIZE);

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeWrapCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeWrapCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public final class DESedeWrapCipher extends CipherSpi {
     /*
      * internal cipher object which does the real work.
      */
-    private FeedbackCipher cipher;
+    private final FeedbackCipher cipher;
 
     /*
      * iv for (re-)initializing the internal cipher object.

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHPrivateKey.java
@@ -49,28 +49,28 @@ final class DHPrivateKey implements PrivateKey,
         javax.crypto.interfaces.DHPrivateKey, Serializable {
 
     @java.io.Serial
-    static final long serialVersionUID = 7565477590005668886L;
+    private static final long serialVersionUID = 7565477590005668886L;
 
     // only supported version of PKCS#8 PrivateKeyInfo
     private static final BigInteger PKCS8_VERSION = BigInteger.ZERO;
 
     // the private key
-    private BigInteger x;
+    private final BigInteger x;
 
     // the key bytes, without the algorithm information
-    private byte[] key;
+    private final byte[] key;
 
     // the encoded key
     private byte[] encodedKey;
 
     // the prime modulus
-    private BigInteger p;
+    private final BigInteger p;
 
     // the base generator
-    private BigInteger g;
+    private final BigInteger g;
 
     // the private-value length (optional)
-    private int l;
+    private final int l;
 
     /**
      * Make a DH private key out of a private value <code>x</code>, a prime
@@ -163,6 +163,8 @@ final class DHPrivateKey implements PrivateKey,
             // Private-value length is OPTIONAL
             if (params.data.available() != 0) {
                 this.l = params.data.getInteger();
+            } else {
+                this.l = 0;
             }
             if (params.data.available() != 0) {
                 throw new InvalidKeyException("Extra parameter data");
@@ -172,7 +174,7 @@ final class DHPrivateKey implements PrivateKey,
             // privateKey
             //
             this.key = val.data.getOctetString();
-            parseKeyBits();
+            this.x = parseKeyBits();
 
             this.encodedKey = encodedKey.clone();
         } catch (IOException | NumberFormatException e) {
@@ -273,10 +275,10 @@ final class DHPrivateKey implements PrivateKey,
         }
     }
 
-    private void parseKeyBits() throws InvalidKeyException {
+    private BigInteger parseKeyBits() throws InvalidKeyException {
         try {
             DerInputStream in = new DerInputStream(this.key);
-            this.x = in.getBigInteger();
+            return in.getBigInteger();
         } catch (IOException e) {
             throw new InvalidKeyException(
                 "Error parsing key encoding: " + e.getMessage(), e);

--- a/src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHPublicKey.java
@@ -48,28 +48,28 @@ final class DHPublicKey implements PublicKey,
 javax.crypto.interfaces.DHPublicKey, Serializable {
 
     @java.io.Serial
-    static final long serialVersionUID = 7647557958927458271L;
+    private static final long serialVersionUID = 7647557958927458271L;
 
     // the public key
-    private BigInteger y;
+    private final BigInteger y;
 
     // the key bytes, without the algorithm information
-    private byte[] key;
+    private final byte[] key;
 
     // the encoded key
     private byte[] encodedKey;
 
     // the prime modulus
-    private BigInteger p;
+    private final BigInteger p;
 
     // the base generator
-    private BigInteger g;
+    private final BigInteger g;
 
     // the private-value length (optional)
-    private int l;
+    private final int l;
 
     // Note: this OID is used by DHPrivateKey as well.
-    static ObjectIdentifier DH_OID =
+    static final ObjectIdentifier DH_OID =
             ObjectIdentifier.of(KnownOIDs.DiffieHellman);
 
     /**
@@ -155,6 +155,8 @@ javax.crypto.interfaces.DHPublicKey, Serializable {
             // Private-value length is OPTIONAL
             if (params.data.available() != 0) {
                 this.l = params.data.getInteger();
+            } else {
+                this.l = 0;
             }
             if (params.data.available() != 0) {
                 throw new InvalidKeyException("Extra parameter data");
@@ -164,7 +166,7 @@ javax.crypto.interfaces.DHPublicKey, Serializable {
              * Parse the key
              */
             this.key = derKeyVal.data.getBitString();
-            parseKeyBits();
+            this.y = parseKeyBits();
             if (derKeyVal.data.available() != 0) {
                 throw new InvalidKeyException("Excess key data");
             }
@@ -265,10 +267,10 @@ javax.crypto.interfaces.DHPublicKey, Serializable {
         return sb.toString();
     }
 
-    private void parseKeyBits() throws InvalidKeyException {
+    private BigInteger parseKeyBits() throws InvalidKeyException {
         try {
             DerInputStream in = new DerInputStream(this.key);
-            this.y = in.getBigInteger();
+            return in.getBigInteger();
         } catch (IOException e) {
             throw new InvalidKeyException(
                 "Error parsing key encoding: " + e.toString());

--- a/src/java.base/share/classes/com/sun/crypto/provider/EncryptedPrivateKeyInfo.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/EncryptedPrivateKeyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,10 +44,10 @@ import sun.security.util.*;
 final class EncryptedPrivateKeyInfo {
 
     // the "encryptionAlgorithm" field
-    private AlgorithmId algid;
+    private final AlgorithmId algid;
 
     // the "encryptedData" field
-    private byte[] encryptedData;
+    private final byte[] encryptedData;
 
     // the ASN.1 encoded contents of this class
     private byte[] encoded;

--- a/src/java.base/share/classes/com/sun/crypto/provider/GHASH.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GHASH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ final class GHASH implements Cloneable, GCM {
 
     // hashtable subkeyHtbl holds 2*9 powers of subkeyH computed using
     // carry-less multiplication
-    private long[] subkeyHtbl;
+    private final long[] subkeyHtbl;
 
     // buffer for storing hash
     private final long[] state;

--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,8 +74,8 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * @since 1.8
  */
 abstract class GaloisCounterMode extends CipherSpi {
-    static int DEFAULT_IV_LEN = 12; // in bytes
-    static int DEFAULT_TAG_LEN = 16; // in bytes
+    private static final int DEFAULT_IV_LEN = 12; // in bytes
+    private static final int DEFAULT_TAG_LEN = 16; // in bytes
     // In NIST SP 800-38D, GCM input size is limited to be no longer
     // than (2^36 - 32) bytes. Otherwise, the counter will wrap
     // around and lead to a leak of plaintext.
@@ -106,7 +106,7 @@ abstract class GaloisCounterMode extends CipherSpi {
     // Default value is 128bits, this is in bytes.
     int tagLenBytes = DEFAULT_TAG_LEN;
     // Key size if the value is passed, in bytes.
-    int keySize;
+    private final int keySize;
     // Prevent reuse of iv or key
     boolean reInit = false;
     byte[] lastKey = EMPTY_BUF;

--- a/src/java.base/share/classes/com/sun/crypto/provider/ISO10126Padding.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ISO10126Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import javax.crypto.ShortBufferException;
  */
 final class ISO10126Padding implements Padding {
 
-    private int blockSize;
+    private final int blockSize;
 
     ISO10126Padding(int blockSize) {
         this.blockSize = blockSize;

--- a/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ public final class JceKeyStore extends KeyStoreSpi {
      * Private keys and certificates are stored in a hashtable.
      * Hash entries are keyed by alias names.
      */
-    private Hashtable<String, Object> entries = new Hashtable<String, Object>();
+    private final Hashtable<String, Object> entries = new Hashtable<String, Object>();
 
     /**
      * Returns the key associated with the given alias, using the given

--- a/src/java.base/share/classes/com/sun/crypto/provider/KeyProtector.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/KeyProtector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ final class KeyProtector {
 
     // the password used for protecting/recovering keys passed through this
     // key protector
-    private char[] password;
+    private final char[] password;
 
     /**
      * {@systemProperty jdk.jceks.iterationCount} property indicating the

--- a/src/java.base/share/classes/com/sun/crypto/provider/OAEPParameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/OAEPParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,9 +56,9 @@ public final class OAEPParameters extends AlgorithmParametersSpi {
     private String mdName;
     private MGF1ParameterSpec mgfSpec;
     private byte[] p;
-    private static ObjectIdentifier OID_MGF1 =
+    private static final ObjectIdentifier OID_MGF1 =
             ObjectIdentifier.of(KnownOIDs.MGF1);
-    private static ObjectIdentifier OID_PSpecified =
+    private static final ObjectIdentifier OID_PSpecified =
             ObjectIdentifier.of(KnownOIDs.PSpecified);
 
     public OAEPParameters() {

--- a/src/java.base/share/classes/com/sun/crypto/provider/OutputFeedback.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/OutputFeedback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,18 +45,18 @@ final class OutputFeedback extends FeedbackCipher {
     /*
      * output buffer
      */
-    private byte[] k = null;
+    private final byte[] k;
 
     /*
      * register buffer
      */
-    private byte[] register = null;
+    private final byte[] register;
 
     /*
      * number of bytes for each stream unit, defaults to the blocksize
      * of the embedded cipher
      */
-    private int numBytes;
+    private final int numBytes;
 
     // variables for save/restore calls
     private byte[] registerSave = null;

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
@@ -45,11 +45,11 @@ import jdk.internal.ref.CleanerFactory;
 final class PBEKey implements SecretKey {
 
     @java.io.Serial
-    static final long serialVersionUID = -2234768909660948176L;
+    private static final long serialVersionUID = -2234768909660948176L;
 
     private byte[] key;
 
-    private String type;
+    private final String type;
 
     /**
      * Creates a PBE key from a given PBE key specification.

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,8 @@ import java.util.Locale;
  */
 abstract class PBEKeyFactory extends SecretKeyFactorySpi {
 
-    private String type;
-    private static HashSet<String> validTypes;
+    private final String type;
+    private static final HashSet<String> validTypes;
 
     /**
      * Simple constructor

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES1Core.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES1Core.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,10 +43,9 @@ import javax.crypto.spec.*;
 final class PBES1Core {
 
     // the encapsulated DES cipher
-    private CipherCore cipher;
-    private MessageDigest md;
-    private int blkSize;
-    private String algo = null;
+    private final CipherCore cipher;
+    private final MessageDigest md;
+    private final String algo;
     private byte[] salt = null;
     private int iCount = 10;
 

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBES2Parameters.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBES2Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,15 +92,15 @@ import sun.security.util.*;
  */
 abstract class PBES2Parameters extends AlgorithmParametersSpi {
 
-    private static ObjectIdentifier pkcs5PBKDF2_OID =
+    private static final ObjectIdentifier pkcs5PBKDF2_OID =
             ObjectIdentifier.of(KnownOIDs.PBKDF2WithHmacSHA1);
-    private static ObjectIdentifier pkcs5PBES2_OID =
+    private static final ObjectIdentifier pkcs5PBES2_OID =
             ObjectIdentifier.of(KnownOIDs.PBES2);
-    private static ObjectIdentifier aes128CBC_OID =
+    private static final ObjectIdentifier aes128CBC_OID =
             ObjectIdentifier.of(KnownOIDs.AES_128$CBC$NoPadding);
-    private static ObjectIdentifier aes192CBC_OID =
+    private static final ObjectIdentifier aes192CBC_OID =
             ObjectIdentifier.of(KnownOIDs.AES_192$CBC$NoPadding);
-    private static ObjectIdentifier aes256CBC_OID =
+    private static final ObjectIdentifier aes256CBC_OID =
             ObjectIdentifier.of(KnownOIDs.AES_256$CBC$NoPadding);
 
     // the PBES2 algorithm name

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEWithMD5AndDESCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEWithMD5AndDESCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import javax.crypto.*;
 public final class PBEWithMD5AndDESCipher extends CipherSpi {
 
     // the encapsulated DES cipher
-    private PBES1Core core;
+    private final PBES1Core core;
 
     /**
      * Creates an instance of this cipher, and initializes its mode (CBC) and

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEWithMD5AndTripleDESCipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEWithMD5AndTripleDESCipher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ import javax.crypto.*;
  */
 public final class PBEWithMD5AndTripleDESCipher extends CipherSpi {
 
-    private PBES1Core core;
+    private final PBES1Core core;
 
     /**
      * Creates an instance of this cipher, and initializes its mode (CBC) and

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -58,16 +58,16 @@ import jdk.internal.ref.CleanerFactory;
 final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
 
     @java.io.Serial
-    static final long serialVersionUID = -2234868909660948157L;
+    private static final long serialVersionUID = -2234868909660948157L;
 
-    private char[] passwd;
-    private byte[] salt;
-    private int iterCount;
-    private byte[] key;
+    private final char[] passwd;
+    private final byte[] salt;
+    private final int iterCount;
+    private final byte[] key;
 
     // The following fields are not Serializable. See writeReplace method.
-    private transient Mac prf;
-    private transient Cleaner.Cleanable cleaner;
+    private final transient Mac prf;
+    private final transient Cleaner.Cleanable cleaner;
 
     private static byte[] getPasswordBytes(char[] passwd) {
         CharBuffer cb = CharBuffer.wrap(passwd);
@@ -93,6 +93,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
         // Convert the password from char[] to byte[]
         byte[] passwdBytes = getPasswordBytes(this.passwd);
 
+        byte[] key = null;
         try {
             this.salt = keySpec.getSalt();
             if (salt == null) {
@@ -111,7 +112,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
                 throw new InvalidKeySpecException("Key length is negative");
             }
             this.prf = Mac.getInstance(prfAlgo, SunJCE.getInstance());
-            this.key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
+            key = deriveKey(prf, passwdBytes, salt, iterCount, keyLength);
         } catch (NoSuchAlgorithmException nsae) {
             // not gonna happen; re-throw just in case
             throw new InvalidKeySpecException(nsae);
@@ -122,7 +123,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
             }
         }
         // Use the cleaner to zero the key when no longer referenced
-        final byte[] k = this.key;
+        final byte[] k = this.key = key;
         final char[] p = this.passwd;
         cleaner = CleanerFactory.cleaner().register(this,
                 () -> {

--- a/src/java.base/share/classes/com/sun/crypto/provider/PKCS5Padding.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PKCS5Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import java.util.Arrays;
  */
 final class PKCS5Padding implements Padding {
 
-    private int blockSize;
+    private final int blockSize;
 
     PKCS5Padding(int blockSize) {
         this.blockSize = blockSize;

--- a/src/java.base/share/classes/com/sun/crypto/provider/PrivateKeyInfo.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PrivateKeyInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,10 +53,10 @@ final class PrivateKeyInfo {
     private static final BigInteger VERSION = BigInteger.ZERO;
 
     // the private-key algorithm
-    private AlgorithmId algid;
+    private final AlgorithmId algid;
 
     // the private-key value
-    private byte[] privkey;
+    private final byte[] privkey;
 
     /**
      * Constructs a PKCS#8 PrivateKeyInfo from its ASN.1 encoding.

--- a/src/java.base/share/classes/com/sun/crypto/provider/TlsMasterSecretGenerator.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/TlsMasterSecretGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,7 +162,7 @@ public final class TlsMasterSecretGenerator extends KeyGeneratorSpi {
         @java.io.Serial
         private static final long serialVersionUID = 1019571680375368880L;
 
-        private byte[] key;
+        private final byte[] key;
         private final int majorVersion, minorVersion;
 
         TlsMasterSecretKey(byte[] key, int majorVersion, int minorVersion) {


### PR DESCRIPTION
A few classes in `com.sun.crypto.provider` package have non-final fields which could easily be marked `final`.