### PR TITLE
8314476: TestJstatdPortAndServer.java failed with "java.rmi.NoSuchObjectException: no such object in table"

### DIFF
--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -65,6 +65,8 @@ public final class JstatdTest {
     private static final int JSTAT_GCUTIL_INTERVAL_MS = 250;
     private static final String JPS_OUTPUT_REGEX = "^\\d+\\s*.*";
 
+    private static final int MAX_JSTATD_TRIES = 10;
+
     private boolean useDefaultPort = true;
     private boolean useDefaultRmiPort = true;
     private String port;
@@ -324,7 +326,7 @@ public final class JstatdTest {
         ProcessThread jstatdThread = null;
         int tries = 0;
         try {
-            while (jstatdThread == null && ++tries <= 10) {
+            while (jstatdThread == null && ++tries <= MAX_JSTATD_TRIES) {
                 if (!useDefaultPort) {
                     port = String.valueOf(Utils.getFreePort());
                 }

--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -343,7 +343,7 @@ public final class JstatdTest {
                 jstatdThread = tryToSetupJstatdProcess();
             }
             if (jstatdThread == null) {
-                throw new RuntimeException("Cannot start jstatd.  No free port found.");
+                throw new RuntimeException("Cannot start jstatd.");
             }
             runToolsAndVerify();
         } finally {


### PR DESCRIPTION
Several tests from test/jdk/sun/tools/jstatd are intermittent.

Port clashes when run at the same time on the same machine have been a problem.
The RMI error "no such object in table" can mean a reference on the RMI server has been GC'd.
Either way, jstatd fails to startup and and the test fails.

These both have jstatd reporting "Could not bind" which should be recognised and retried, as we already do for (some) port in use problems. i.e. JstatdTest.java: the isJstadReady() method (will correct that typo also) checks for "Port already in use", which can be printed by TCPTransport.java.

Should update its test to check for "Could not bind".
Should limit the retries also.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314476](https://bugs.openjdk.org/browse/JDK-8314476): TestJstatdPortAndServer.java failed with "java.rmi.NoSuchObjectException: no such object in table" (**Bug** - P4)


### Reviewers
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15414/head:pull/15414` \
`$ git checkout pull/15414`

Update a local copy of the PR: \
`$ git checkout pull/15414` \
`$ git pull https://git.openjdk.org/jdk.git pull/15414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15414`

View PR using the GUI difftool: \
`$ git pr show -t 15414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15414.diff">https://git.openjdk.org/jdk/pull/15414.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15414#issuecomment-1691519115)