### PR TITLE
8314513: [IR Framework] Some internal IR Framework tests are failing after JDK-8310308 on PPC and Cascade Lake

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawFailOnConstraint.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawFailOnConstraint.java
@@ -25,12 +25,12 @@ package compiler.lib.ir_framework.driver.irmatching.irrule.constraint.raw;
 
 import compiler.lib.ir_framework.CompilePhase;
 import compiler.lib.ir_framework.IR;
-import compiler.lib.ir_framework.IRNode;
 import compiler.lib.ir_framework.TestFramework;
-import compiler.lib.ir_framework.shared.Comparison;
+import compiler.lib.ir_framework.driver.SuccessOnlyConstraintException;
 import compiler.lib.ir_framework.driver.irmatching.irrule.checkattribute.parsing.RawIRNode;
 import compiler.lib.ir_framework.driver.irmatching.irrule.constraint.Constraint;
 import compiler.lib.ir_framework.driver.irmatching.parser.VMInfo;
+import compiler.lib.ir_framework.shared.Comparison;
 
 /**
  * This class represents a raw constraint of a {@link IR#failOn()} attribute.
@@ -54,7 +54,11 @@ public class RawFailOnConstraint implements RawConstraint {
     @Override
     public Constraint parse(CompilePhase compilePhase, String compilationOutput, VMInfo vmInfo) {
         TestFramework.check(compilePhase != CompilePhase.DEFAULT, "must not be default");
-        return Constraint.createFailOn(rawIRNode.regex(compilePhase, vmInfo, Comparison.Bound.UPPER), constraintIndex, compilationOutput);
+        try {
+            return Constraint.createFailOn(rawIRNode.regex(compilePhase, vmInfo, Comparison.Bound.UPPER), constraintIndex, compilationOutput);
+        } catch (SuccessOnlyConstraintException e) {
+            return Constraint.createSuccess();
+        }
     }
 }
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -1055,28 +1055,17 @@ class BadIRAnnotationsAfterTestVM {
 
     @Test
     @FailCount(8)
-    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_MAX, "> 0"}, // valid
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, "> 0"}, // valid
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "xxx", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min()", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type)", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,max_int", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,-3", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, xxx)", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, min(max_for_type, max_for_type))", "> 0"},
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_MAX, "> 0"}) // valid
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, "> 0"}) // valid
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "xxx", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min()", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type)", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,max_int", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "2,4,8,16,32,64,-3", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, xxx)", "> 0"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "min(max_for_type, min(max_for_type, max_for_type))", "> 0"})
     public int[] badVectorNodeSize() {
         int[] a = new int[1024*8];
         for (int i = 0; i < a.length; i++) {


### PR DESCRIPTION
This patch fixes some internal IR framework failures after [JDK-8310308](https://bugs.openjdk.org/browse/JDK-8310308):
- `testlibrary_tests/ir_framework/tests/TestBadFormat.java` on Linux ppc64le:
  - `applyIfCPUFeature` clauses are false and the rule is not run. We will therefore not hit the format violations which the test expects to find. The fix here is to remove the `applyIfCPUFeature` constraints as the test is only interested in properly reporting format violations.
- `testlibrary_tests/ir_framework/examples/IRExample.java` on Cascade Lake x86_64:
  - On Cascade Lake, `failOn` constraints need the same "always true" handling as `counts` constraints. This was missed in JDK-8310308. I've added the same `try-catch` handling as in `RawCountsConstraint::parse()`:
https://github.com/openjdk/jdk/blob/97b94cb1cdeba00f4bba7326a300c0336950f3ec/test/hotspot/jtreg/compiler/lib/ir_framework/driver/irmatching/irrule/constraint/raw/RawCountsConstraint.java#L97-L104

Thanks to @MBaesken and @TheRealMDoerr for reporting this and helping with some pre-PR testing. Would you like to rerun your testing on PPC and Cascade Lake again?

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314513](https://bugs.openjdk.org/browse/JDK-8314513): [IR Framework] Some internal IR Framework tests are failing after JDK-8310308 on PPC and Cascade Lake (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15415/head:pull/15415` \
`$ git checkout pull/15415`

Update a local copy of the PR: \
`$ git checkout pull/15415` \
`$ git pull https://git.openjdk.org/jdk.git pull/15415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15415`

View PR using the GUI difftool: \
`$ git pr show -t 15415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15415.diff">https://git.openjdk.org/jdk/pull/15415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15415#issuecomment-1691541206)