### PR TITLE
8314940: Use of NIO in JDKs Metrics implementation causes issues in GraalVM

### DIFF
--- a/src/java.base/linux/classes/jdk/internal/platform/CgroupUtil.java
+++ b/src/java.base/linux/classes/jdk/internal/platform/CgroupUtil.java
@@ -26,30 +26,22 @@
 package jdk.internal.platform;
 
 import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 public final class CgroupUtil {
 
-    @SuppressWarnings("removal")
     public static Stream<String> readFilePrivileged(Path path) throws IOException {
-        try {
-            PrivilegedExceptionAction<Stream<String>> pea = () -> Files.lines(path);
-            return AccessController.doPrivileged(pea);
-        } catch (PrivilegedActionException e) {
-            unwrapIOExceptionAndRethrow(e);
-            throw new InternalError(e.getCause());
-        } catch (UncheckedIOException e) {
-            throw e.getCause();
-        }
+        return readAllLinesPrivileged(path).stream();
     }
 
     static void unwrapIOExceptionAndRethrow(PrivilegedActionException pae) throws IOException {
@@ -64,7 +56,7 @@ public final class CgroupUtil {
 
     static String readStringValue(CgroupSubsystemController controller, String param) throws IOException {
         PrivilegedExceptionAction<BufferedReader> pea = () ->
-                Files.newBufferedReader(Paths.get(controller.path(), param));
+                new BufferedReader(new FileReader(Paths.get(controller.path(), param).toString(), StandardCharsets.UTF_8));
         try (@SuppressWarnings("removal") BufferedReader bufferedReader =
                      AccessController.doPrivileged(pea)) {
             String line = bufferedReader.readLine();
@@ -72,21 +64,26 @@ public final class CgroupUtil {
         } catch (PrivilegedActionException e) {
             unwrapIOExceptionAndRethrow(e);
             throw new InternalError(e.getCause());
-        } catch (UncheckedIOException e) {
-            throw e.getCause();
         }
     }
 
     @SuppressWarnings("removal")
     public static List<String> readAllLinesPrivileged(Path path) throws IOException {
         try {
-            PrivilegedExceptionAction<List<String>> pea = () -> Files.readAllLines(path);
+            PrivilegedExceptionAction<List<String>> pea = () -> {
+                try (BufferedReader bufferedReader = new BufferedReader(new FileReader(path.toString(), StandardCharsets.UTF_8))) {
+                    String line;
+                    List<String> lines = new ArrayList<>();
+                    while ((line = bufferedReader.readLine()) != null) {
+                        lines.add(line);
+                    }
+                    return lines;
+                }
+            };
             return AccessController.doPrivileged(pea);
         } catch (PrivilegedActionException e) {
             unwrapIOExceptionAndRethrow(e);
             throw new InternalError(e.getCause());
-        } catch (UncheckedIOException e) {
-            throw e.getCause();
         }
     }
 }


### PR DESCRIPTION
Please review this rather trivial fix to not use `nio` in `CgroupUtil`, part of the
JDK's Metrics API. The primary motivating factor is that it allows one to use the
JDK's version of `Metrics` in GraalVM. See the bug for details as to why this is
needed.

Testing:
- [x] GraalVM builds with/without the fix and the reproducer (fails before/works after)
- [x] `jdk/internal/platform` jtreg tests on Linux x86_64 (cgv1).
- [x] GHA - passed (Failed GHA cross compile on RISCV is unrelated)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314940](https://bugs.openjdk.org/browse/JDK-8314940): Use of NIO in JDKs Metrics implementation causes issues in GraalVM (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Contributors
 * Aleksandar Pejovic `<apejovic@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15416/head:pull/15416` \
`$ git checkout pull/15416`

Update a local copy of the PR: \
`$ git checkout pull/15416` \
`$ git pull https://git.openjdk.org/jdk.git pull/15416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15416`

View PR using the GUI difftool: \
`$ git pr show -t 15416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15416.diff">https://git.openjdk.org/jdk/pull/15416.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15416#issuecomment-1691676764)