### PR TITLE
8314949: linux PPC64 Big Endian: Implementation of Foreign Function & Memory API

### DIFF
--- a/src/hotspot/cpu/ppc/foreignGlobals_ppc.cpp
+++ b/src/hotspot/cpu/ppc/foreignGlobals_ppc.cpp
@@ -47,7 +47,7 @@ bool ABIDescriptor::is_volatile_reg(FloatRegister reg) const {
 }
 
 bool ForeignGlobals::is_foreign_linker_supported() {
-#ifdef ABI_ELFv2
+#ifdef LINUX
   return true;
 #else
   return false;

--- a/src/java.base/share/classes/jdk/internal/foreign/CABI.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/CABI.java
@@ -39,6 +39,7 @@ public enum CABI {
     LINUX_AARCH_64,
     MAC_OS_AARCH_64,
     WIN_AARCH_64,
+    LINUX_PPC_64,
     LINUX_PPC_64_LE,
     LINUX_RISCV_64,
     LINUX_S390,
@@ -73,6 +74,10 @@ public enum CABI {
                 } else {
                     // The Linux ABI follows the standard AAPCS ABI
                     return LINUX_AARCH_64;
+                }
+            } else if (arch.equals("ppc64")) {
+                if (OperatingSystem.isLinux()) {
+                    return LINUX_PPC_64;
                 }
             } else if (arch.equals("ppc64le")) {
                 if (OperatingSystem.isLinux()) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -30,6 +30,7 @@ import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.windows.WindowsAArch64Linker;
 import jdk.internal.foreign.abi.fallback.FallbackLinker;
+import jdk.internal.foreign.abi.ppc64.linux.LinuxPPC64Linker;
 import jdk.internal.foreign.abi.ppc64.linux.LinuxPPC64leLinker;
 import jdk.internal.foreign.abi.riscv64.linux.LinuxRISCV64Linker;
 import jdk.internal.foreign.abi.s390.linux.LinuxS390Linker;
@@ -60,7 +61,8 @@ import java.util.Set;
 
 public abstract sealed class AbstractLinker implements Linker permits LinuxAArch64Linker, MacOsAArch64Linker,
                                                                       SysVx64Linker, WindowsAArch64Linker,
-                                                                      Windowsx64Linker, LinuxPPC64leLinker,
+                                                                      Windowsx64Linker,
+                                                                      LinuxPPC64Linker, LinuxPPC64leLinker,
                                                                       LinuxRISCV64Linker, LinuxS390Linker,
                                                                       FallbackLinker {
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -419,17 +419,19 @@ public sealed interface Binding {
             return this;
         }
 
+        // Converts to long if needed then shifts left by the given number of Bytes.
         public Binding.Builder shiftLeft(int shiftAmount, Class<?> type) {
-            if (type == int.class || isSubIntType(type)) {
+            if (type != long.class) {
                 bindings.add(Binding.cast(type, long.class));
             }
             bindings.add(Binding.shiftLeft(shiftAmount));
             return this;
         }
 
+        // Shifts right by the given number of Bytes then converts from long if needed.
         public Binding.Builder shiftRight(int shiftAmount, Class<?> type) {
             bindings.add(Binding.shiftRight(shiftAmount));
-            if (type == int.class || isSubIntType(type)) {
+            if (type != long.class) {
                 bindings.add(Binding.cast(long.class, type));
             }
             return this;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/Binding.java
@@ -422,7 +422,6 @@ public sealed interface Binding {
         public Binding.Builder shiftLeft(int shiftAmount, Class<?> type) {
             if (type == int.class || isSubIntType(type)) {
                 bindings.add(Binding.cast(type, long.class));
-                type = long.class;
             }
             bindings.add(Binding.shiftLeft(shiftAmount));
             return this;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -730,23 +730,17 @@ public class BindingSpecializer {
     }
 
     private void emitShiftLeft(ShiftLeft shiftLeft) {
-        if (shiftLeft.type() != long.class) {
-            cb.i2l();
-            popType(int.class);
-            pushType(long.class);
-        }
+        popType(long.class);
         cb.constantInstruction(shiftLeft.shiftAmount() * Byte.SIZE);
         cb.lshl();
+        pushType(long.class);
     }
 
     private void emitShiftRight(ShiftRight shiftRight) {
+        popType(long.class);
         cb.constantInstruction(shiftRight.shiftAmount() * Byte.SIZE);
         cb.lushr();
-        if (shiftRight.type() != long.class) {
-            cb.l2i();
-            popType(long.class);
-            pushType(int.class);
-        }
+        pushType(long.class);
     }
 
     private void emitCast(Cast cast) {
@@ -768,6 +762,11 @@ public class BindingSpecializer {
             case INT_TO_BYTE -> cb.i2b();
             case INT_TO_CHAR -> cb.i2c();
             case INT_TO_SHORT -> cb.i2s();
+            case BYTE_TO_LONG, CHAR_TO_LONG, SHORT_TO_LONG, INT_TO_LONG -> cb.i2l();
+            case LONG_TO_BYTE -> { cb.l2i(); cb.i2b(); }
+            case LONG_TO_SHORT -> { cb.l2i(); cb.i2s(); }
+            case LONG_TO_CHAR -> { cb.l2i(); cb.i2c(); }
+            case LONG_TO_INT -> cb.l2i();
             case BOOLEAN_TO_INT, BYTE_TO_INT, CHAR_TO_INT, SHORT_TO_INT -> {
                 // no-op in bytecode
             }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -32,6 +32,7 @@ import jdk.internal.foreign.abi.Binding.BufferStore;
 import jdk.internal.foreign.abi.Binding.Cast;
 import jdk.internal.foreign.abi.Binding.Copy;
 import jdk.internal.foreign.abi.Binding.Dup;
+import jdk.internal.foreign.abi.Binding.ShiftLeft;
 import jdk.internal.foreign.abi.Binding.UnboxAddress;
 import jdk.internal.foreign.abi.Binding.VMLoad;
 import jdk.internal.foreign.abi.Binding.VMStore;
@@ -220,6 +221,7 @@ public class CallingSequenceBuilder {
             case Copy         unused -> true;
             case UnboxAddress unused -> true;
             case Dup          unused -> true;
+            case ShiftLeft    unused -> true;
             case Cast         unused -> true;
 
             case VMLoad       unused -> false;
@@ -254,6 +256,7 @@ public class CallingSequenceBuilder {
             case Allocate     unused -> true;
             case BoxAddress   unused -> true;
             case Dup          unused -> true;
+            case ShiftLeft    unused -> true;
             case Cast         unused -> true;
 
             case VMStore      unused -> false;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/CallingSequenceBuilder.java
@@ -33,6 +33,7 @@ import jdk.internal.foreign.abi.Binding.Cast;
 import jdk.internal.foreign.abi.Binding.Copy;
 import jdk.internal.foreign.abi.Binding.Dup;
 import jdk.internal.foreign.abi.Binding.ShiftLeft;
+import jdk.internal.foreign.abi.Binding.ShiftRight;
 import jdk.internal.foreign.abi.Binding.UnboxAddress;
 import jdk.internal.foreign.abi.Binding.VMLoad;
 import jdk.internal.foreign.abi.Binding.VMStore;
@@ -222,6 +223,7 @@ public class CallingSequenceBuilder {
             case UnboxAddress unused -> true;
             case Dup          unused -> true;
             case ShiftLeft    unused -> true;
+            case ShiftRight   unused -> true;
             case Cast         unused -> true;
 
             case VMLoad       unused -> false;
@@ -257,6 +259,7 @@ public class CallingSequenceBuilder {
             case BoxAddress   unused -> true;
             case Dup          unused -> true;
             case ShiftLeft    unused -> true;
+            case ShiftRight   unused -> true;
             case Cast         unused -> true;
 
             case VMStore      unused -> false;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -33,6 +33,7 @@ import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.windows.WindowsAArch64Linker;
 import jdk.internal.foreign.abi.fallback.FallbackLinker;
+import jdk.internal.foreign.abi.ppc64.linux.LinuxPPC64Linker;
 import jdk.internal.foreign.abi.ppc64.linux.LinuxPPC64leLinker;
 import jdk.internal.foreign.abi.riscv64.linux.LinuxRISCV64Linker;
 import jdk.internal.foreign.abi.s390.linux.LinuxS390Linker;
@@ -241,6 +242,7 @@ public final class SharedUtils {
             case LINUX_AARCH_64 -> LinuxAArch64Linker.getInstance();
             case MAC_OS_AARCH_64 -> MacOsAArch64Linker.getInstance();
             case WIN_AARCH_64 -> WindowsAArch64Linker.getInstance();
+            case LINUX_PPC_64 -> LinuxPPC64Linker.getInstance();
             case LINUX_PPC_64_LE -> LinuxPPC64leLinker.getInstance();
             case LINUX_RISCV_64 -> LinuxRISCV64Linker.getInstance();
             case LINUX_S390 -> LinuxS390Linker.getInstance();

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv1CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv1CallArranger.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.foreign.abi.ppc64;
+
+import jdk.internal.foreign.abi.ppc64.CallArranger;
+
+/**
+ * PPC64 CallArranger specialized for ABI v1.
+ */
+public class ABIv1CallArranger extends CallArranger {
+  // Currently no specific content, but CallArranger detects usage of ABIv1 for this class.
+}

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv1CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv1CallArranger.java
@@ -25,8 +25,6 @@
  */
 package jdk.internal.foreign.abi.ppc64;
 
-import jdk.internal.foreign.abi.ppc64.CallArranger;
-
 /**
  * PPC64 CallArranger specialized for ABI v1.
  */

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv1CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv1CallArranger.java
@@ -31,5 +31,9 @@ import jdk.internal.foreign.abi.ppc64.CallArranger;
  * PPC64 CallArranger specialized for ABI v1.
  */
 public class ABIv1CallArranger extends CallArranger {
-  // Currently no specific content, but CallArranger detects usage of ABIv1 for this class.
+
+    @Override
+    protected boolean useABIv2() {
+        return false;
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv2CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv2CallArranger.java
@@ -25,8 +25,6 @@
  */
 package jdk.internal.foreign.abi.ppc64;
 
-import jdk.internal.foreign.abi.ppc64.CallArranger;
-
 /**
  * PPC64 CallArranger specialized for ABI v2.
  */

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv2CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/ABIv2CallArranger.java
@@ -31,5 +31,9 @@ import jdk.internal.foreign.abi.ppc64.CallArranger;
  * PPC64 CallArranger specialized for ABI v2.
  */
 public class ABIv2CallArranger extends CallArranger {
-    // Currently no specific content, but CallArranger detects usage of ABIv2 for this class.
+
+    @Override
+    protected boolean useABIv2() {
+        return true;
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/CallArranger.java
@@ -62,7 +62,7 @@ import static jdk.internal.foreign.abi.ppc64.PPC64Architecture.Regs.*;
  * public constants CallArranger.ABIv1/2.
  */
 public abstract class CallArranger {
-    final boolean useABIv2 = (this instanceof ABIv2CallArranger);
+    final boolean useABIv2 = useABIv2();
 
     private static final int STACK_SLOT_SIZE = 8;
     private static final int MAX_COPY_SIZE = 8;
@@ -92,6 +92,11 @@ public abstract class CallArranger {
 
     public static final CallArranger ABIv1 = new ABIv1CallArranger();
     public static final CallArranger ABIv2 = new ABIv2CallArranger();
+
+    /**
+     * Select ABI version
+     */
+    protected abstract boolean useABIv2();
 
     public Bindings getBindings(MethodType mt, FunctionDescriptor cDesc, boolean forUpcall) {
         return getBindings(mt, cDesc, forUpcall, LinkerOptions.empty());

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/CallArranger.java
@@ -35,7 +35,6 @@ import jdk.internal.foreign.abi.DowncallLinker;
 import jdk.internal.foreign.abi.LinkerOptions;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.VMStorage;
-import jdk.internal.foreign.abi.ppc64.ABIv2CallArranger;
 
 import java.lang.foreign.AddressLayout;
 import java.lang.foreign.FunctionDescriptor;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/CallArranger.java
@@ -436,7 +436,7 @@ public abstract class CallArranger {
                         bindings.dup();
                         if (shiftAmount != 0) {
                             bindings.vmLoad(storage, long.class)
-                                    .shiftLeft(-shiftAmount, type);
+                                    .shiftRight(shiftAmount, type);
                         } else {
                             bindings.vmLoad(storage, type);
                         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/linux/LinuxPPC64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/linux/LinuxPPC64Linker.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.foreign.abi.ppc64.linux;
+
+import jdk.internal.foreign.abi.AbstractLinker;
+import jdk.internal.foreign.abi.LinkerOptions;
+import jdk.internal.foreign.abi.ppc64.CallArranger;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.nio.ByteOrder;
+
+public final class LinuxPPC64Linker extends AbstractLinker {
+
+    public static LinuxPPC64Linker getInstance() {
+        final class Holder {
+            private static final LinuxPPC64Linker INSTANCE = new LinuxPPC64Linker();
+        }
+
+        return Holder.INSTANCE;
+    }
+
+    private LinuxPPC64Linker() {
+        // Ensure there is only one instance
+    }
+
+    @Override
+    protected MethodHandle arrangeDowncall(MethodType inferredMethodType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.ABIv1.arrangeDowncall(inferredMethodType, function, options);
+    }
+
+    @Override
+    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.ABIv1.arrangeUpcall(targetType, function, options);
+    }
+
+    @Override
+    protected ByteOrder linkerByteOrder() {
+        return ByteOrder.BIG_ENDIAN;
+    }
+}


### PR DESCRIPTION
I've found a way to solve the remaining FFI problem on linux PPC64 Big Endian. Large structs (>8 Bytes) which are passed in registers or on stack require shifting the Bytes in the last slot if the size is not a multiple of 8. This PR adds the required functionality to the Java code.

Please review and provide feedback. There may be better ways to implement it. I just found one which works and makes the tests pass:
```
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/java/foreign                          88    88     0     0   
```

Note: This PR should be considered as preparation work for AIX which also uses ABIv1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314949](https://bugs.openjdk.org/browse/JDK-8314949): linux PPC64 Big Endian: Implementation of Foreign Function &amp; Memory API (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15417/head:pull/15417` \
`$ git checkout pull/15417`

Update a local copy of the PR: \
`$ git checkout pull/15417` \
`$ git pull https://git.openjdk.org/jdk.git pull/15417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15417`

View PR using the GUI difftool: \
`$ git pr show -t 15417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15417.diff">https://git.openjdk.org/jdk/pull/15417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15417#issuecomment-1691750537)