### PR TITLE
8314951: VM build without C2 still fails after JDK-8313530

### DIFF
--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -130,6 +130,9 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   CHECK_NOT_SET(JVMCILibDumpJNIConfig,               EnableJVMCI)
 
 #ifndef COMPILER2
+  JVMCI_FLAG_CHECKED(EnableVectorAggressiveReboxing)
+  JVMCI_FLAG_CHECKED(EnableVectorReboxing)
+  JVMCI_FLAG_CHECKED(EnableVectorSupport)
   JVMCI_FLAG_CHECKED(MaxVectorSize)
   JVMCI_FLAG_CHECKED(ReduceInitialCardMarks)
   JVMCI_FLAG_CHECKED(UseMultiplyToLenIntrinsic)
@@ -137,6 +140,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   JVMCI_FLAG_CHECKED(UseMulAddIntrinsic)
   JVMCI_FLAG_CHECKED(UseMontgomeryMultiplyIntrinsic)
   JVMCI_FLAG_CHECKED(UseMontgomerySquareIntrinsic)
+  JVMCI_FLAG_CHECKED(UseVectorStubs)
 #endif // !COMPILER2
 
 #ifndef PRODUCT


### PR DESCRIPTION
JDK-8313530 fixed the release VM build but the debug VM build would still fail.
This patch fix the debug VM build failure.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314951](https://bugs.openjdk.org/browse/JDK-8314951): VM build without C2 still fails after JDK-8313530 (**Bug** - P2)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15419/head:pull/15419` \
`$ git checkout pull/15419`

Update a local copy of the PR: \
`$ git checkout pull/15419` \
`$ git pull https://git.openjdk.org/jdk.git pull/15419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15419`

View PR using the GUI difftool: \
`$ git pr show -t 15419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15419.diff">https://git.openjdk.org/jdk/pull/15419.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15419#issuecomment-1691786155)