### PR TITLE
8314990: Generational ZGC: Strong OopStorage stats reported as weak roots

### DIFF
--- a/src/hotspot/share/gc/z/zRootsIterator.cpp
+++ b/src/hotspot/share/gc/z/zRootsIterator.cpp
@@ -101,7 +101,7 @@ void ZParallelApply<Iterator>::apply(ClosureType* cl) {
 }
 
 void ZOopStorageSetIteratorStrong::apply(OopClosure* cl) {
-  ZRootStatTimer timer(ZSubPhaseConcurrentWeakRootsOopStorageSet, _generation);
+  ZRootStatTimer timer(ZSubPhaseConcurrentRootsOopStorageSet, _generation);
   _iter.oops_do(cl);
 }
 


### PR DESCRIPTION
`ZOopStorageSetIteratorStrong::apply` has incorrect `ZRootStatTimer`event. Should record strong roots but are recording weak roots.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314990](https://bugs.openjdk.org/browse/JDK-8314990): Generational ZGC: Strong OopStorage stats reported as weak roots (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15420/head:pull/15420` \
`$ git checkout pull/15420`

Update a local copy of the PR: \
`$ git checkout pull/15420` \
`$ git pull https://git.openjdk.org/jdk.git pull/15420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15420`

View PR using the GUI difftool: \
`$ git pr show -t 15420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15420.diff">https://git.openjdk.org/jdk/pull/15420.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15420#issuecomment-1692856259)