### PR TITLE
6333341: [BI] Doc: java.text.BreakIterator class specification is unclear

### DIFF
--- a/src/java.base/share/classes/java/text/BreakIterator.java
+++ b/src/java.base/share/classes/java/text/BreakIterator.java
@@ -108,7 +108,8 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * <p>
  * The default implementations of {@code BreakIterator} will use a {@code
  * StringCharacterIterator} constructed with an empty string if the text hasn't
- * been set yet by either {@link #setText(String)} or {@link #setText(CharacterIterator)}.
+ * been set by either {@link #setText(String)} or {@link #setText(CharacterIterator)}
+ * and a boundary searching operation is called by the {@code BreakIterator} instance.
  * The {@code BreakIterator} instances returned by the factory methods
  * of this class are intended for use with natural languages only, not for
  * programming language text. It is however possible to define subclasses

--- a/src/java.base/share/classes/java/text/BreakIterator.java
+++ b/src/java.base/share/classes/java/text/BreakIterator.java
@@ -105,8 +105,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * <a href="https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries">
  * Grapheme Cluster Boundaries</a> section in the Unicode Standard Annex #29.
  *
- * <p>
- * The default implementations of {@code BreakIterator} will perform the equivalent
+ * @implNote The default implementations of {@code BreakIterator} will perform the equivalent
  * of calling {@code setText("")} if the text hasn't been set by either
  * {@link #setText(String)} or {@link #setText(CharacterIterator)}
  * and a boundary searching operation is called by the {@code BreakIterator} instance.

--- a/src/java.base/share/classes/java/text/BreakIterator.java
+++ b/src/java.base/share/classes/java/text/BreakIterator.java
@@ -106,6 +106,9 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * Grapheme Cluster Boundaries</a> section in the Unicode Standard Annex #29.
  *
  * <p>
+ * The default implementations of {@code BreakIterator} will use a {@code
+ * StringCharacterIterator} constructed with an empty string if the text hasn't
+ * been set yet by either {@link #setText(String)} or {@link #setText(CharacterIterator)}.
  * The {@code BreakIterator} instances returned by the factory methods
  * of this class are intended for use with natural languages only, not for
  * programming language text. It is however possible to define subclasses

--- a/src/java.base/share/classes/java/text/BreakIterator.java
+++ b/src/java.base/share/classes/java/text/BreakIterator.java
@@ -106,9 +106,9 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * Grapheme Cluster Boundaries</a> section in the Unicode Standard Annex #29.
  *
  * <p>
- * The default implementations of {@code BreakIterator} will use a {@code
- * StringCharacterIterator} constructed with an empty string if the text hasn't
- * been set by either {@link #setText(String)} or {@link #setText(CharacterIterator)}
+ * The default implementations of {@code BreakIterator} will perform the equivalent
+ * of calling {@code setText("")} if the text hasn't been set by either
+ * {@link #setText(String)} or {@link #setText(CharacterIterator)}
  * and a boundary searching operation is called by the {@code BreakIterator} instance.
  * The {@code BreakIterator} instances returned by the factory methods
  * of this class are intended for use with natural languages only, not for


### PR DESCRIPTION
Please review this PR and [CSR ](https://bugs.openjdk.org/browse/JDK-8314974)which clarifies behavior for BreakIterator instances when text has not been set.

For example,  calling `BreakIterator.getWordInstance().next();` has an ambiguous result.
A boundary searching operation was called but no text was supplied. Is the result an exception, 0, -1 (BreakIterator.DONE), or something else? In reality, the operation will be performed on any empty string.


This change makes it apparent that failing to set the text will cause the BreakIterator instance to default to a `StringCharacterIterator` with an empty string (equivalent to calling setText("")).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8314974](https://bugs.openjdk.org/browse/JDK-8314974) to be approved

### Issues
 * [JDK-6333341](https://bugs.openjdk.org/browse/JDK-6333341): [BI] Doc: java.text.BreakIterator class specification is unclear (**Bug** - P4)
 * [JDK-8314974](https://bugs.openjdk.org/browse/JDK-8314974): [BI] Doc: java.text.BreakIterator class specification is unclear (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15422/head:pull/15422` \
`$ git checkout pull/15422`

Update a local copy of the PR: \
`$ git checkout pull/15422` \
`$ git pull https://git.openjdk.org/jdk.git pull/15422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15422`

View PR using the GUI difftool: \
`$ git pr show -t 15422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15422.diff">https://git.openjdk.org/jdk/pull/15422.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15422#issuecomment-1692457216)