### PR TITLE
8314550: [macosx-aarch64] serviceability/sa/TestJmapCore.java fails with "sun.jvm.hotspot.debugger.UnmappedAddressException: 801000800"

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1683,6 +1683,22 @@ void FileMapInfo::close() {
   }
 }
 
+/*
+ * Same as os::map_memory() but also pretouches if AlwaysPreTouch is enabled.
+ */
+char* map_memory(int fd, const char* file_name, size_t file_offset,
+                 char *addr, size_t bytes, bool read_only,
+                 bool allow_exec, MEMFLAGS flags = mtNone) {
+  if (AlwaysPreTouch) {
+    read_only = false;
+  }
+  char* mem = os::map_memory(fd, file_name, file_offset, addr, bytes,
+                             read_only, allow_exec, flags);
+  if (mem != nullptr && AlwaysPreTouch) {
+    os::pretouch_memory(mem, mem + bytes, os::vm_page_size());
+  }
+  return mem;
+}
 
 // JVM/TI RedefineClasses() support:
 // Remap the shared readonly space to shared readwrite, private.
@@ -1818,9 +1834,9 @@ MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_ba
     // Note that this may either be a "fresh" mapping into unreserved address
     // space (Windows, first mapping attempt), or a mapping into pre-reserved
     // space (Posix). See also comment in MetaspaceShared::map_archives().
-    char* base = os::map_memory(_fd, _full_path, r->file_offset(),
-                                requested_addr, size, r->read_only(),
-                                r->allow_exec(), mtClassShared);
+    char* base = map_memory(_fd, _full_path, r->file_offset(),
+                            requested_addr, size, r->read_only(),
+                            r->allow_exec(), mtClassShared);
     if (base != requested_addr) {
       log_info(cds)("Unable to map %s shared space at " INTPTR_FORMAT,
                     shared_region_name[i], p2i(requested_addr));
@@ -1846,8 +1862,8 @@ char* FileMapInfo::map_bitmap_region() {
   }
   bool read_only = true, allow_exec = false;
   char* requested_addr = nullptr; // allow OS to pick any location
-  char* bitmap_base = os::map_memory(_fd, _full_path, r->file_offset(),
-                                     requested_addr, r->used_aligned(), read_only, allow_exec, mtClassShared);
+  char* bitmap_base = map_memory(_fd, _full_path, r->file_offset(),
+                                 requested_addr, r->used_aligned(), read_only, allow_exec, mtClassShared);
   if (bitmap_base == nullptr) {
     log_info(cds)("failed to map relocation bitmap");
     return nullptr;
@@ -2127,9 +2143,9 @@ bool FileMapInfo::map_heap_region_impl() {
   // Map the archived heap data. No need to call MemTracker::record_virtual_memory_type()
   // for mapped region as it is part of the reserved java heap, which is already recorded.
   char* addr = (char*)_mapped_heap_memregion.start();
-  char* base = os::map_memory(_fd, _full_path, r->file_offset(),
-                              addr, _mapped_heap_memregion.byte_size(), r->read_only(),
-                              r->allow_exec());
+  char* base = map_memory(_fd, _full_path, r->file_offset(),
+                          addr, _mapped_heap_memregion.byte_size(), r->read_only(),
+                          r->allow_exec());
   if (base == nullptr || base != addr) {
     dealloc_heap_region();
     log_info(cds)("UseSharedSpaces: Unable to map at required address in java heap. "

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1689,13 +1689,11 @@ void FileMapInfo::close() {
 char* map_memory(int fd, const char* file_name, size_t file_offset,
                  char *addr, size_t bytes, bool read_only,
                  bool allow_exec, MEMFLAGS flags = mtNone) {
-  if (AlwaysPreTouch) {
-    read_only = false;
-  }
   char* mem = os::map_memory(fd, file_name, file_offset, addr, bytes,
-                             read_only, allow_exec, flags);
+                             AlwaysPreTouch ? false : read_only,
+                             allow_exec, flags);
   if (mem != nullptr && AlwaysPreTouch) {
-    os::pretouch_memory(mem, mem + bytes, os::vm_page_size());
+    os::pretouch_memory(mem, mem + bytes);
   }
   return mem;
 }


### PR DESCRIPTION
On some macosx-aarch64 systems, not all mapped pages are dumped to the core file. This first turned up with [JDK-8293563](https://bugs.openjdk.org/browse/JDK-8293563) where large parts of the ZGC heap would not be in the core file, leading to various SA address errors. For JDK-8293563 the issue was addressed by having the core file test always use `-XX:+AlwaysPreTouch` on macosx-aarch64. This seemed to force the ZGC pages to always end up in the core file.

A similar issue has been noticed with mapped in pages of the CDS archive. We are seeing cases where SA references to addresses that are clearly in the CDS archive (based on info in the hs_err file) are failing to be read from the core file by SA. This problem has turned up a number of times during CI testing, but I have yet to be able to reproduce it myself. This PR is an attempt to address this testing issue by having the CDS archive also pretouch all mapped in pages when `-XX:+AlwaysPreTouch` is used.

Tested with tier1 and tier3 and also ran the test about 5,000 times with and without the fix. It never reproduced for either. Hopefully the problem is gone with this fix, but it may take a few months of CI testing before we can be confident it is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314550](https://bugs.openjdk.org/browse/JDK-8314550): [macosx-aarch64] serviceability/sa/TestJmapCore.java fails with "sun.jvm.hotspot.debugger.UnmappedAddressException: 801000800" (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [72b6fbcd](https://git.openjdk.org/jdk/pull/15423/files/72b6fbcd45fb8ae2ac1241cb0979b58595f39e50)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [72b6fbcd](https://git.openjdk.org/jdk/pull/15423/files/72b6fbcd45fb8ae2ac1241cb0979b58595f39e50)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [72b6fbcd](https://git.openjdk.org/jdk/pull/15423/files/72b6fbcd45fb8ae2ac1241cb0979b58595f39e50)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15423/head:pull/15423` \
`$ git checkout pull/15423`

Update a local copy of the PR: \
`$ git checkout pull/15423` \
`$ git pull https://git.openjdk.org/jdk.git pull/15423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15423`

View PR using the GUI difftool: \
`$ git pr show -t 15423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15423.diff">https://git.openjdk.org/jdk/pull/15423.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15423#issuecomment-1692549641)