### PR TITLE
JDK-8314975: JavadocTester should set source path if not specified

### DIFF
--- a/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
+++ b/test/langtools/jdk/javadoc/lib/javadoc/tester/JavadocTester.java
@@ -424,12 +424,14 @@ public abstract class JavadocTester {
         String charsetArg = null;
         String docencodingArg = null;
         String encodingArg = null;
+        boolean haveSourcePath = false;
         for (int i = 0; i < args.length - 2; i++) {
             switch (args[i]) {
                 case "-d" -> outputDir = Path.of(args[++i]);
                 case "-charset" -> charsetArg = args[++i];
                 case "-docencoding" -> docencodingArg = args[++i];
                 case "-encoding" -> encodingArg = args[++i];
+                case "-sourcepath", "--source-path", "--module-source-path" -> haveSourcePath = true;
             }
         }
 
@@ -449,6 +451,16 @@ public abstract class JavadocTester {
             charset = Charset.forName(cs);
         } catch (UnsupportedCharsetException e) {
             charset = Charset.defaultCharset();
+        }
+
+        // explicitly set the source path if none specified
+        // to override the javadoc tool default to use the classpath
+        if (!haveSourcePath) {
+            var newArgs = new String[args.length + 2];
+            newArgs[0] = "-sourcepath";
+            newArgs[1] = testSrc;
+            System.arraycopy(args, 0, newArgs, 2, args.length);
+            args = newArgs;
         }
 
         out.println("args: " + Arrays.toString(args));


### PR DESCRIPTION
Please review a test-only fix, for `JavadocTester`, to set the source path to a sensible value if none specified explicitly, to override the tool default to use the class path.

The underlying issue is that TestNG is on the class path, and contains a file `Version.java` in the root directory -- i.e. the unnamed package. This can interfere with various tests that use classes in the unnamed package.

The fix is to set the source path to `testSrc`, so that `testng.jar` is never on the source path.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314975](https://bugs.openjdk.org/browse/JDK-8314975): JavadocTester should set source path if not specified (**Bug** - P3)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15424/head:pull/15424` \
`$ git checkout pull/15424`

Update a local copy of the PR: \
`$ git checkout pull/15424` \
`$ git pull https://git.openjdk.org/jdk.git pull/15424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15424`

View PR using the GUI difftool: \
`$ git pr show -t 15424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15424.diff">https://git.openjdk.org/jdk/pull/15424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15424#issuecomment-1692590139)