### PR TITLE
8314748: 1-10% regressions on Crypto micros

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
@@ -365,7 +365,7 @@ class StubGenerator: public StubCodeGenerator {
   // Utility routine for increase 128bit counter (iv in CTR mode)
   void inc_counter(Register reg, XMMRegister xmmdst, int inc_delta, Label& next_block);
   void ev_add128(XMMRegister xmmdst, XMMRegister xmmsrc1, XMMRegister xmmsrc2,
-                 int vector_len, KRegister ktmp, XMMRegister ones, Register rscratch = noreg);
+                 int vector_len, KRegister ktmp, XMMRegister ones);
   void generate_aes_stubs();
 
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
@@ -365,7 +365,7 @@ class StubGenerator: public StubCodeGenerator {
   // Utility routine for increase 128bit counter (iv in CTR mode)
   void inc_counter(Register reg, XMMRegister xmmdst, int inc_delta, Label& next_block);
   void ev_add128(XMMRegister xmmdst, XMMRegister xmmsrc1, XMMRegister xmmsrc2,
-                 int vector_len, KRegister ktmp, Register rscratch = noreg);
+                 int vector_len, KRegister ktmp, XMMRegister ones, Register rscratch = noreg);
   void generate_aes_stubs();
 
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
@@ -1637,12 +1637,12 @@ void StubGenerator::ev_load_key(XMMRegister xmmdst, Register key, int offset, Re
 // Clobber ktmp and rscratch.
 // Used by aesctr_encrypt.
 void StubGenerator::ev_add128(XMMRegister xmmdst, XMMRegister xmmsrc1, XMMRegister xmmsrc2,
-                            int vector_len, KRegister ktmp, Register rscratch) {
+                              int vector_len, KRegister ktmp, XMMRegister ones, Register rscratch) {
   __ vpaddq(xmmdst, xmmsrc1, xmmsrc2, vector_len);
-  __ evpcmpuq(ktmp, xmmdst, xmmsrc2, __ lt, vector_len);
-  __ kshiftlbl(ktmp, ktmp, 1);
-  __ evpaddq(xmmdst, ktmp, xmmdst, ExternalAddress(counter_mask_ones_addr()), /*merge*/true,
-             vector_len, rscratch);
+  __ evpcmpuq(ktmp, xmmdst, xmmsrc2, __ lt, vector_len); // set mask[0/1] bit if addq to dst[0/1] wraps
+  __ kshiftlbl(ktmp, ktmp, 1);                        // mask[1] <- mask[0], mask[0] <- 0, etc
+
+  __ evpaddq(xmmdst, ktmp, xmmdst, ones, /*merge*/true, vector_len); // dst[1]++ if mask[1] set
 }
 
 // AES-ECB Encrypt Operation
@@ -2125,16 +2125,20 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   // each zmm register has 4 counter values as its MSB
   // the counters are incremented in parallel
 
+  const XMMRegister ones = xmm17;
+  // Vector value to propagate carries
+  __ evmovdquq(ones, ExternalAddress(counter_mask_ones_addr()), Assembler::AVX_512bit, r15);
+
   __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc0_addr()), Assembler::AVX_512bit, r15 /*rscratch*/);
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc4_addr()), Assembler::AVX_512bit, r15 /*rscratch*/);
-  ev_add128(xmm9,  xmm8,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
-  ev_add128(xmm10, xmm9,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
-  ev_add128(xmm11, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
-  ev_add128(xmm12, xmm11, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
-  ev_add128(xmm13, xmm12, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
-  ev_add128(xmm14, xmm13, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
-  ev_add128(xmm15, xmm14, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm9,  xmm8,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm10, xmm9,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm11, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm12, xmm11, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm13, xmm12, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm14, xmm13, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm15, xmm14, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
 
   // load linc32 mask in zmm register.linc32 increments counter by 32
   __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc32_addr()), Assembler::AVX_512bit, r15 /*rscratch*/);
@@ -2182,21 +2186,21 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   // This is followed by incrementing counter values in zmm8-zmm15.
   // Since we will be processing 32 blocks at a time, the counter is incremented by 32.
   roundEnc(xmm21, 7);
-  ev_add128(xmm8,   xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm8,   xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   roundEnc(xmm22, 7);
-  ev_add128(xmm9,   xmm9, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm9,   xmm9, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   roundEnc(xmm23, 7);
-  ev_add128(xmm10, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm10, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   roundEnc(xmm24, 7);
-  ev_add128(xmm11, xmm11, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm11, xmm11, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   roundEnc(xmm25, 7);
-  ev_add128(xmm12, xmm12, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm12, xmm12, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   roundEnc(xmm26, 7);
-  ev_add128(xmm13, xmm13, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm13, xmm13, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   roundEnc(xmm27, 7);
-  ev_add128(xmm14, xmm14, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm14, xmm14, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   roundEnc(xmm28, 7);
-  ev_add128(xmm15, xmm15, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm15, xmm15, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   roundEnc(xmm29, 7);
 
   __ cmpl(rounds, 52);
@@ -2274,8 +2278,8 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ vpshufb(xmm3, xmm11, xmm16, Assembler::AVX_512bit);
   __ evpxorq(xmm3, xmm3, xmm20, Assembler::AVX_512bit);
   // Increment counter values by 16
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
-  ev_add128(xmm9, xmm9, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm9, xmm9, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   // AES encode rounds
   roundEnc(xmm21, 3);
   roundEnc(xmm22, 3);
@@ -2342,7 +2346,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ vpshufb(xmm1, xmm9, xmm16, Assembler::AVX_512bit);
   __ evpxorq(xmm1, xmm1, xmm20, Assembler::AVX_512bit);
   // increment counter by 8
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   // AES encode
   roundEnc(xmm21, 1);
   roundEnc(xmm22, 1);
@@ -2401,7 +2405,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ evpxorq(xmm0, xmm0, xmm20, Assembler::AVX_512bit);
 
   // Increment counter
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   __ vaesenc(xmm0, xmm0, xmm21, Assembler::AVX_512bit);
   __ vaesenc(xmm0, xmm0, xmm22, Assembler::AVX_512bit);
   __ vaesenc(xmm0, xmm0, xmm23, Assembler::AVX_512bit);
@@ -2451,7 +2455,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ evpxorq(xmm0, xmm0, xmm20, Assembler::AVX_128bit);
   __ vaesenc(xmm0, xmm0, xmm21, Assembler::AVX_128bit);
   // Increment counter by 1
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_128bit, /*ktmp*/k1, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_128bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
   __ vaesenc(xmm0, xmm0, xmm22, Assembler::AVX_128bit);
   __ vaesenc(xmm0, xmm0, xmm23, Assembler::AVX_128bit);
   __ vaesenc(xmm0, xmm0, xmm24, Assembler::AVX_128bit);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
@@ -1637,7 +1637,7 @@ void StubGenerator::ev_load_key(XMMRegister xmmdst, Register key, int offset, Re
 // Clobber ktmp and rscratch.
 // Used by aesctr_encrypt.
 void StubGenerator::ev_add128(XMMRegister xmmdst, XMMRegister xmmsrc1, XMMRegister xmmsrc2,
-                              int vector_len, KRegister ktmp, XMMRegister ones, Register rscratch) {
+                              int vector_len, KRegister ktmp, XMMRegister ones) {
   __ vpaddq(xmmdst, xmmsrc1, xmmsrc2, vector_len);
   __ evpcmpuq(ktmp, xmmdst, xmmsrc2, __ lt, vector_len); // set mask[0/1] bit if addq to dst[0/1] wraps
   __ kshiftlbl(ktmp, ktmp, 1);                        // mask[1] <- mask[0], mask[0] <- 0, etc
@@ -2130,15 +2130,15 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ evmovdquq(ones, ExternalAddress(counter_mask_ones_addr()), Assembler::AVX_512bit, r15);
 
   __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc0_addr()), Assembler::AVX_512bit, r15 /*rscratch*/);
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
-  __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc4_addr()), Assembler::AVX_512bit, r15 /*rscratch*/);
-  ev_add128(xmm9,  xmm8,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
-  ev_add128(xmm10, xmm9,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
-  ev_add128(xmm11, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
-  ev_add128(xmm12, xmm11, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
-  ev_add128(xmm13, xmm12, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
-  ev_add128(xmm14, xmm13, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
-  ev_add128(xmm15, xmm14, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
+  __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc4_addr()), Assembler::AVX_512bit);
+  ev_add128(xmm9,  xmm8,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
+  ev_add128(xmm10, xmm9,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
+  ev_add128(xmm11, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
+  ev_add128(xmm12, xmm11, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
+  ev_add128(xmm13, xmm12, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
+  ev_add128(xmm14, xmm13, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
+  ev_add128(xmm15, xmm14, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
 
   // load linc32 mask in zmm register.linc32 increments counter by 32
   __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc32_addr()), Assembler::AVX_512bit, r15 /*rscratch*/);
@@ -2186,21 +2186,21 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   // This is followed by incrementing counter values in zmm8-zmm15.
   // Since we will be processing 32 blocks at a time, the counter is incremented by 32.
   roundEnc(xmm21, 7);
-  ev_add128(xmm8,   xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm8,   xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   roundEnc(xmm22, 7);
-  ev_add128(xmm9,   xmm9, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm9,   xmm9, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   roundEnc(xmm23, 7);
-  ev_add128(xmm10, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm10, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   roundEnc(xmm24, 7);
-  ev_add128(xmm11, xmm11, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm11, xmm11, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   roundEnc(xmm25, 7);
-  ev_add128(xmm12, xmm12, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm12, xmm12, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   roundEnc(xmm26, 7);
-  ev_add128(xmm13, xmm13, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm13, xmm13, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   roundEnc(xmm27, 7);
-  ev_add128(xmm14, xmm14, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm14, xmm14, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   roundEnc(xmm28, 7);
-  ev_add128(xmm15, xmm15, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm15, xmm15, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   roundEnc(xmm29, 7);
 
   __ cmpl(rounds, 52);
@@ -2278,8 +2278,8 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ vpshufb(xmm3, xmm11, xmm16, Assembler::AVX_512bit);
   __ evpxorq(xmm3, xmm3, xmm20, Assembler::AVX_512bit);
   // Increment counter values by 16
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
-  ev_add128(xmm9, xmm9, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
+  ev_add128(xmm9, xmm9, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   // AES encode rounds
   roundEnc(xmm21, 3);
   roundEnc(xmm22, 3);
@@ -2346,7 +2346,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ vpshufb(xmm1, xmm9, xmm16, Assembler::AVX_512bit);
   __ evpxorq(xmm1, xmm1, xmm20, Assembler::AVX_512bit);
   // increment counter by 8
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   // AES encode
   roundEnc(xmm21, 1);
   roundEnc(xmm22, 1);
@@ -2405,7 +2405,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ evpxorq(xmm0, xmm0, xmm20, Assembler::AVX_512bit);
 
   // Increment counter
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   __ vaesenc(xmm0, xmm0, xmm21, Assembler::AVX_512bit);
   __ vaesenc(xmm0, xmm0, xmm22, Assembler::AVX_512bit);
   __ vaesenc(xmm0, xmm0, xmm23, Assembler::AVX_512bit);
@@ -2455,7 +2455,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   __ evpxorq(xmm0, xmm0, xmm20, Assembler::AVX_128bit);
   __ vaesenc(xmm0, xmm0, xmm21, Assembler::AVX_128bit);
   // Increment counter by 1
-  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_128bit, /*ktmp*/k1, ones, r15 /*rscratch*/);
+  ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_128bit, /*ktmp*/k1, ones);
   __ vaesenc(xmm0, xmm0, xmm22, Assembler::AVX_128bit);
   __ vaesenc(xmm0, xmm0, xmm23, Assembler::AVX_128bit);
   __ vaesenc(xmm0, xmm0, xmm24, Assembler::AVX_128bit);


### PR DESCRIPTION
Performance improvement. This also reduces the delta between mainline head and the backportts in 11u and 8u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314748](https://bugs.openjdk.org/browse/JDK-8314748): 1-10% regressions on Crypto micros (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15427/head:pull/15427` \
`$ git checkout pull/15427`

Update a local copy of the PR: \
`$ git checkout pull/15427` \
`$ git pull https://git.openjdk.org/jdk.git pull/15427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15427`

View PR using the GUI difftool: \
`$ git pr show -t 15427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15427.diff">https://git.openjdk.org/jdk/pull/15427.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15427#issuecomment-1698832710)