### PR TITLE
8314283: Support for NSS tests on aarch64 platforms

### DIFF
--- a/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
+++ b/test/jdk/sun/security/pkcs11/KeyStore/ClientAuth.java
@@ -389,6 +389,10 @@ public class ClientAuth extends PKCS11Test {
                      * Our client thread just died.
                      */
                     System.err.println("Client died...");
+                    // if the exception is thrown before connecting to the
+                    // server, the test will time out and the exception will
+                    // be lost/hidden.
+                    e.printStackTrace(System.err);
                     clientException = e;
                 }
             });

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -79,6 +79,11 @@ public abstract class PKCS11Test {
     private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
     private static final SecureRandom srdm = new SecureRandom();
 
+    // Version of the NSS artifact. This coincides with the version of
+    // the NSS version
+    private static final String NSS_BUNDLE_VERSION = "3.91";
+    private static final String NSSLIB = "jpg.tests.jdk.nsslib";
+
     static double nss_version = -1;
     static ECCState nss_ecc_status = ECCState.Basic;
 
@@ -891,8 +896,14 @@ public abstract class PKCS11Test {
             case "MacOSX-x86_64-64":
                 return fetchNssLib(MACOSX_X64.class);
 
+            case "MacOSX-aarch64-64":
+                return fetchNssLib(MACOSX_AARCH64.class);
+
             case "Linux-amd64-64":
                 return fetchNssLib(LINUX_X64.class);
+
+            case "Linux-aarch64-64":
+                return fetchNssLib(LINUX_AARCH64.class);
 
             default:
                 return null;
@@ -903,8 +914,8 @@ public abstract class PKCS11Test {
         String path = null;
         try {
             path = ArtifactResolver.resolve(clazz).entrySet().stream()
-                    .findAny().get().getValue() + File.separator + "nsslib"
-                    + File.separator;
+                    .findAny().get().getValue() + File.separator + "nss"
+                    + File.separator + "lib" + File.separator;
         } catch (ArtifactResolverException e) {
             Throwable cause = e.getCause();
             if (cause == null) {
@@ -1000,9 +1011,9 @@ public abstract class PKCS11Test {
     public static enum ECCState {None, Basic, Extended}
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
             name = "nsslib-windows_x64",
-            revision = "3.46-VS2017",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class WINDOWS_X64 {
     }
@@ -1016,18 +1027,35 @@ public abstract class PKCS11Test {
     }
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
             name = "nsslib-macosx_x64",
-            revision = "3.46",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class MACOSX_X64 {
     }
 
     @Artifact(
-            organization = "jpg.tests.jdk.nsslib",
+            organization = NSSLIB,
+            name = "nsslib-macosx_aarch64",
+            revision = NSS_BUNDLE_VERSION,
+            extension = "zip")
+    private static class MACOSX_AARCH64 {
+    }
+
+    @Artifact(
+            organization = NSSLIB,
             name = "nsslib-linux_x64",
-            revision = "3.46",
+            revision = NSS_BUNDLE_VERSION,
             extension = "zip")
     private static class LINUX_X64 {
+    }
+
+    @Artifact(
+            organization = NSSLIB,
+            name = "nsslib-linux_aarch64",
+            revision = NSS_BUNDLE_VERSION,
+            extension = "zip"
+    )
+    private static class LINUX_AARCH64{
     }
 }


### PR DESCRIPTION
This PR updates the version of NSS to 3.91 and includes aarch64 platforms.

There is a related bug in PR (https://github.com/openjdk/jdk/pull/15217) so we may want to wait for that to merge before merging this one.