### PR TITLE
8315033: Problemlist java/lang/template/StringTemplateTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -478,6 +478,7 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
+java/lang/template/StringTemplateTest.java                      8315029 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
This changeset problem-lists `java/lang/template/StringTemplateTest.java`, which fails intermittently after the integration of [JDK-8312749](https://bugs.openjdk.org/browse/JDK-8312749), to reduce CI pipeline noise while [JDK-8315029](https://bugs.openjdk.org/browse/JDK-8315029) is investigated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315033](https://bugs.openjdk.org/browse/JDK-8315033): Problemlist java/lang/template/StringTemplateTest.java (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15430/head:pull/15430` \
`$ git checkout pull/15430`

Update a local copy of the PR: \
`$ git checkout pull/15430` \
`$ git pull https://git.openjdk.org/jdk.git pull/15430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15430`

View PR using the GUI difftool: \
`$ git pr show -t 15430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15430.diff">https://git.openjdk.org/jdk/pull/15430.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15430#issuecomment-1693518299)