### PR TITLE
8315039: Parallel: Remove unimplemented PSYoungGen::oop_iterate

### DIFF
--- a/src/hotspot/share/gc/parallel/psYoungGen.hpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.hpp
@@ -134,7 +134,6 @@ class PSYoungGen : public CHeapObj<mtGC> {
   }
 
   // Iteration.
-  void oop_iterate(OopIterateClosure* cl);
   void object_iterate(ObjectClosure* cl);
 
   void reset_survivors_after_shrink();


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315039](https://bugs.openjdk.org/browse/JDK-8315039): Parallel: Remove unimplemented PSYoungGen::oop_iterate (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15431/head:pull/15431` \
`$ git checkout pull/15431`

Update a local copy of the PR: \
`$ git checkout pull/15431` \
`$ git pull https://git.openjdk.org/jdk.git pull/15431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15431`

View PR using the GUI difftool: \
`$ git pr show -t 15431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15431.diff">https://git.openjdk.org/jdk/pull/15431.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15431#issuecomment-1693590048)