### PR TITLE
8311922: [macOS] right-Option key fails to generate release event

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -309,7 +309,6 @@ const nsKeyToJavaModifierTable[] =
     {0, 0, 0, 0, 0, 0}
 };
 
-static BOOL leftAltKeyPressed;
 
 /*
  * Almost all unicode characters just go from NS to Java with no translation.
@@ -540,12 +539,10 @@ NsKeyModifiersToJavaKeyInfo(NSUInteger nsFlags, unsigned short eventKeyCode,
             //    *javaKeyLocation = java_awt_event_KeyEvent_KEY_LOCATION_RIGHT;
             //}
             if (eventKeyCode == cur->leftKeyCode) {
-                leftAltKeyPressed = YES;
                 *javaKeyLocation = java_awt_event_KeyEvent_KEY_LOCATION_LEFT;
             } else if (eventKeyCode == cur->rightKeyCode) {
                 *javaKeyLocation = java_awt_event_KeyEvent_KEY_LOCATION_RIGHT;
             } else if (cur->nsMask == NSAlternateKeyMask) {
-                leftAltKeyPressed = NO;
                 continue;
             }
             *javaKeyType = (cur->nsMask & nsFlags) ?
@@ -570,9 +567,6 @@ jint NsKeyModifiersToJavaModifiers(NSUInteger nsFlags, BOOL isExtMods)
             //right alt, but that should be ok, since right alt contains left alt
             //mask value.
             javaModifiers |= isExtMods ? cur->javaExtMask : cur->javaMask;
-            if (cur->nsMask == NSAlternateKeyMask && leftAltKeyPressed) {
-                    break; //since right alt key struct is defined last, break out of the loop                }
-            }
         }
     }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -291,18 +291,10 @@ const nsKeyToJavaModifierTable[] =
         //kCGSFlagsMaskAppleLeftAlternateKey,
         //kCGSFlagsMaskAppleRightAlternateKey,
         58,
-        0,
+        61,
         java_awt_event_InputEvent_ALT_DOWN_MASK,
         java_awt_event_InputEvent_ALT_MASK,
         java_awt_event_KeyEvent_VK_ALT
-    },
-    {
-        NSAlternateKeyMask,
-        0,
-        61,
-        java_awt_event_InputEvent_ALT_DOWN_MASK | java_awt_event_InputEvent_ALT_GRAPH_DOWN_MASK,
-        java_awt_event_InputEvent_ALT_MASK | java_awt_event_InputEvent_ALT_GRAPH_MASK,
-        java_awt_event_KeyEvent_VK_ALT | java_awt_event_KeyEvent_VK_ALT_GRAPH
     },
     // NSNumericPadKeyMask
     {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTEvent.m
@@ -296,6 +296,14 @@ const nsKeyToJavaModifierTable[] =
         java_awt_event_InputEvent_ALT_MASK,
         java_awt_event_KeyEvent_VK_ALT
     },
+    {
+        NSAlternateKeyMask,
+        0,
+        61,
+        java_awt_event_InputEvent_ALT_DOWN_MASK | java_awt_event_InputEvent_ALT_GRAPH_DOWN_MASK,
+        java_awt_event_InputEvent_ALT_MASK | java_awt_event_InputEvent_ALT_GRAPH_MASK,
+        java_awt_event_KeyEvent_VK_ALT | java_awt_event_KeyEvent_VK_ALT_GRAPH
+    },
     // NSNumericPadKeyMask
     {
         NSHelpKeyMask,
@@ -309,6 +317,7 @@ const nsKeyToJavaModifierTable[] =
     {0, 0, 0, 0, 0, 0}
 };
 
+static BOOL leftAltKeyPressed;
 
 /*
  * Almost all unicode characters just go from NS to Java with no translation.
@@ -539,10 +548,12 @@ NsKeyModifiersToJavaKeyInfo(NSUInteger nsFlags, unsigned short eventKeyCode,
             //    *javaKeyLocation = java_awt_event_KeyEvent_KEY_LOCATION_RIGHT;
             //}
             if (eventKeyCode == cur->leftKeyCode) {
+                leftAltKeyPressed = YES;
                 *javaKeyLocation = java_awt_event_KeyEvent_KEY_LOCATION_LEFT;
             } else if (eventKeyCode == cur->rightKeyCode) {
                 *javaKeyLocation = java_awt_event_KeyEvent_KEY_LOCATION_RIGHT;
             } else if (cur->nsMask == NSAlternateKeyMask) {
+                leftAltKeyPressed = NO;
                 continue;
             }
             *javaKeyType = (cur->nsMask & nsFlags) ?
@@ -567,6 +578,9 @@ jint NsKeyModifiersToJavaModifiers(NSUInteger nsFlags, BOOL isExtMods)
             //right alt, but that should be ok, since right alt contains left alt
             //mask value.
             javaModifiers |= isExtMods ? cur->javaExtMask : cur->javaMask;
+            if (cur->nsMask == NSAlternateKeyMask && leftAltKeyPressed) {
+                    break; //since right alt key struct is defined last, break out of the loop                }
+            }
         }
     }
 

--- a/test/jdk/java/awt/event/KeyEvent/OptionKeyEventTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/OptionKeyEventTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8311922
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary To test both option key press and release event on Mac OS
+ * @run main/manual OptionKeyEventTest
+ * @requires (os.family == "mac")
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+
+public class OptionKeyEventTest extends JFrame
+        implements KeyListener, ActionListener
+{
+    private static JTextArea displayArea;
+    private static JTextField typingArea;
+    private static final String newline = System.getProperty("line.separator");
+    private static final String INSTRUCTIONS =
+            "This test checks if the key events for the left and right\n" +
+            "option keys are correct. To complete the test, click on the \n" +
+            "OptionKeyEventTest window's typing area at the top to focus it.\n" +
+            "Press and release the left option key. Then press and release\n" +
+            "the right option key. Confirm in the display area and pass the\n" +
+            "test if these are correct, otherwise this test fails: \n\n" +
+            "1. 'KEY PRESSED' appears first, followed by a 'KEY RELEASED'\n" +
+            "for each option button\n" +
+            "2. 'key location' shows 'left' or 'right' accordingly, not\n" +
+            "'standard' or 'unknown'";
+
+    public static void main(String[] args)
+            throws InterruptedException, InvocationTargetException {
+        PassFailJFrame passFailJFrame = new PassFailJFrame("OptionKeyEventTest",
+                INSTRUCTIONS, 5, 15, 35);
+        createAndShowGUI();
+        passFailJFrame.awaitAndCheck();
+    }
+
+    private static void createAndShowGUI()
+            throws InterruptedException, InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            OptionKeyEventTest frame =
+                    new OptionKeyEventTest("OptionKeyEventTest");
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.addComponentsToPane();
+            frame.pack();
+            frame.setVisible(true);
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+        });
+    }
+
+    private void addComponentsToPane() {
+        JButton button = new JButton("Clear");
+        button.addActionListener(this);
+
+        typingArea = new JTextField(20);
+        typingArea.addKeyListener(this);
+
+        displayArea = new JTextArea();
+        displayArea.setEditable(false);
+        JScrollPane scrollPane = new JScrollPane(displayArea);
+        scrollPane.setPreferredSize(new Dimension(375, 125));
+
+        getContentPane().add(typingArea, BorderLayout.PAGE_START);
+        getContentPane().add(scrollPane, BorderLayout.CENTER);
+        getContentPane().add(button, BorderLayout.PAGE_END);
+    }
+
+    public OptionKeyEventTest(String name) {
+        super(name);
+    }
+
+    public void keyTyped(KeyEvent e) {
+        displayInfo(e, "KEY TYPED: ");
+    }
+
+    public void keyPressed(KeyEvent e) {
+        displayInfo(e, "KEY PRESSED: ");
+    }
+
+    public void keyReleased(KeyEvent e) {
+        displayInfo(e, "KEY RELEASED: ");
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        //Clear the text components.
+        displayArea.setText("");
+        typingArea.setText("");
+
+        typingArea.requestFocusInWindow();
+    }
+
+    private void displayInfo(KeyEvent e, String keyStatus) {
+        int id = e.getID();
+        String keyString;
+        if (id == KeyEvent.KEY_TYPED) {
+            char c = e.getKeyChar();
+            keyString = "key character = '" + c + "'";
+        } else {
+            int keyCode = e.getKeyCode();
+            keyString = "key code = " + keyCode
+                    + " ("
+                    + KeyEvent.getKeyText(keyCode)
+                    + ")";
+        }
+
+        int modifiersEx = e.getModifiersEx();
+        String modString = "extended modifiers = " + modifiersEx;
+        String tmpString = KeyEvent.getModifiersExText(modifiersEx);
+        if (tmpString.length() > 0) {
+            modString += " (" + tmpString + ")";
+        } else {
+            modString += " (no extended modifiers)";
+        }
+
+        String actionString = "action key? ";
+        if (e.isActionKey()) {
+            actionString += "YES";
+        } else {
+            actionString += "NO";
+        }
+
+        String locationString = "key location: ";
+        int location = e.getKeyLocation();
+        if (location == KeyEvent.KEY_LOCATION_STANDARD) {
+            locationString += "standard";
+        } else if (location == KeyEvent.KEY_LOCATION_LEFT) {
+            locationString += "left";
+        } else if (location == KeyEvent.KEY_LOCATION_RIGHT) {
+            locationString += "right";
+        } else if (location == KeyEvent.KEY_LOCATION_NUMPAD) {
+            locationString += "numpad";
+        } else { // (location == KeyEvent.KEY_LOCATION_UNKNOWN)
+            locationString += "unknown";
+        }
+
+        displayArea.append(keyStatus + newline
+                + " " + keyString + newline
+                + " " + modString + newline
+                + " " + actionString + newline
+                + " " + locationString + newline);
+        displayArea.setCaretPosition(displayArea.getDocument().getLength());
+    }
+}

--- a/test/jdk/java/awt/event/KeyEvent/OptionKeyEventTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/OptionKeyEventTest.java
@@ -48,8 +48,7 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
 public class OptionKeyEventTest extends JFrame
-        implements KeyListener, ActionListener
-{
+        implements KeyListener, ActionListener {
     private static JTextArea displayArea;
     private static JTextField typingArea;
     private static final String newline = System.getProperty("line.separator");

--- a/test/jdk/java/awt/event/KeyEvent/OptionKeyEventTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/OptionKeyEventTest.java
@@ -54,8 +54,8 @@ public class OptionKeyEventTest extends JFrame
     private static final String newline = System.getProperty("line.separator");
     private static final String INSTRUCTIONS =
             "This test checks if the key events for the left and right\n" +
-            "option keys are correct. To complete the test, click on the \n" +
-            "OptionKeyEventTest window's typing area at the top to focus it.\n" +
+            "option keys are correct. To complete the test, ensure the\n" +
+            "OptionKeyEventTest window's typing area is focused.\n" +
             "Press and release the left option key. Then press and release\n" +
             "the right option key. Confirm in the display area and pass the\n" +
             "test if these are correct, otherwise this test fails: \n\n" +
@@ -84,6 +84,7 @@ public class OptionKeyEventTest extends JFrame
             PassFailJFrame.addTestWindow(frame);
             PassFailJFrame.positionTestWindow(frame,
                     PassFailJFrame.Position.HORIZONTAL);
+            typingArea.requestFocus();
         });
     }
 
@@ -96,6 +97,7 @@ public class OptionKeyEventTest extends JFrame
 
         displayArea = new JTextArea();
         displayArea.setEditable(false);
+        displayArea.setFocusable(false);
         JScrollPane scrollPane = new JScrollPane(displayArea);
         scrollPane.setPreferredSize(new Dimension(375, 125));
 


### PR DESCRIPTION
Previously, a new key combination involving the option key was added to Aqua LAF for JTextAreas. In doing so, some code was removed that created this regression. The regression caused the right option key on Mac OS to incorrectly show another KeyPressed event instead of a KeyReleased event when pressing and releasing the key. Additionally, the location of the key was 'standard' instead of 'right'. Adding back the key mask and its following code resolves the issue and doesn't cause any other CI tests to fail.

The headful test included displays the key events as they're pressed. After the changes, the test correctly shows the right option key's KeyPressed and KeyReleased events and shows the location as 'right'.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311922](https://bugs.openjdk.org/browse/JDK-8311922): [macOS] right-Option key fails to generate release event (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [d1b3ae5e](https://git.openjdk.org/jdk/pull/15432/files/d1b3ae5e5b95bceb99c2c114fb55de8feecf4300)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15432/head:pull/15432` \
`$ git checkout pull/15432`

Update a local copy of the PR: \
`$ git checkout pull/15432` \
`$ git pull https://git.openjdk.org/jdk.git pull/15432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15432`

View PR using the GUI difftool: \
`$ git pr show -t 15432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15432.diff">https://git.openjdk.org/jdk/pull/15432.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15432#issuecomment-1693743240)