### PR TITLE
8313430: [JVMCI] fatal error: Never compilable: in JVMCI shutdown

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2225,7 +2225,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
         }
       }
     }
-    if (!task->is_success()  && !JVMCI::in_shutdown()) {
+    if (!task->is_success() && !JVMCI::in_shutdown()) {
       handle_compile_error(thread, task, nullptr, compilable, failure_reason);
     }
     if (event.should_commit()) {

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2225,7 +2225,7 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
         }
       }
     }
-    if (!task->is_success()) {
+    if (!task->is_success()  && !JVMCI::in_shutdown()) {
       handle_compile_error(thread, task, nullptr, compilable, failure_reason);
     }
     if (event.should_commit()) {


### PR DESCRIPTION
VM shutdown involves calling Java code which can schedule further compilations by the CompileBroker. With `UseJVMCICompiler`, all compilations started once VM shutdown has begun are abandoned since they are unnecessary and can delay VM shutdown.

This PR makes `-XX:+AbortVMOnCompilationFailure` ignore such abandoned compilations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313430](https://bugs.openjdk.org/browse/JDK-8313430): [JVMCI] fatal error: Never compilable: in JVMCI shutdown (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [8900b1c0](https://git.openjdk.org/jdk/pull/15433/files/8900b1c0eac5d4f3afb4adb08039ffc701d1dd06)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [8900b1c0](https://git.openjdk.org/jdk/pull/15433/files/8900b1c0eac5d4f3afb4adb08039ffc701d1dd06)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [8900b1c0](https://git.openjdk.org/jdk/pull/15433/files/8900b1c0eac5d4f3afb4adb08039ffc701d1dd06)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15433/head:pull/15433` \
`$ git checkout pull/15433`

Update a local copy of the PR: \
`$ git checkout pull/15433` \
`$ git pull https://git.openjdk.org/jdk.git pull/15433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15433`

View PR using the GUI difftool: \
`$ git pr show -t 15433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15433.diff">https://git.openjdk.org/jdk/pull/15433.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15433#issuecomment-1693809254)