### PR TITLE
8315073: Zero build on macOS fails after JDK-8303852

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -176,7 +176,7 @@ size_t os::Posix::default_stack_size(os::ThreadType thr_type) {
   return s;
 }
 
-void os::current_stack_base_and_size(address* base, size_t* size)
+void os::current_stack_base_and_size(address* base, size_t* size) {
   address bottom;
 
 #ifdef __APPLE__


### PR DESCRIPTION
It might be one copy-and-paste error in JDK-8303852. Adding the missing opening brace would fix this build failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315073](https://bugs.openjdk.org/browse/JDK-8315073): Zero build on macOS fails after JDK-8303852 (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15443/head:pull/15443` \
`$ git checkout pull/15443`

Update a local copy of the PR: \
`$ git checkout pull/15443` \
`$ git pull https://git.openjdk.org/jdk.git pull/15443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15443`

View PR using the GUI difftool: \
`$ git pr show -t 15443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15443.diff">https://git.openjdk.org/jdk/pull/15443.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15443#issuecomment-1695263529)