### PR TITLE
8315051: jdk/jfr/jvm/TestGetEventWriter.java fails with non-JVMCI GCs

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestGetEventWriter.java
+++ b/test/jdk/jdk/jfr/jvm/TestGetEventWriter.java
@@ -38,7 +38,7 @@ import jdk.vm.ci.meta.ConstantPool;
 import jdk.vm.ci.runtime.JVMCI;
 
 /**
- * @test TestGetEventWriter
+ * @test id=default
  * @key jfr
  * @requires vm.hasJFR
  * @library /test/lib
@@ -57,9 +57,6 @@ import jdk.vm.ci.runtime.JVMCI;
  *
  * @run main/othervm jdk.jfr.jvm.TestGetEventWriter
  *
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -Dtest.jvmci=true --add-exports=jdk.jfr/jdk.jfr.internal.event=ALL-UNNAMED
- *      jdk.jfr.jvm.TestGetEventWriter
- *
  * @run main/othervm/timeout=300 -Xint -XX:+UseInterpreter -Dinterpreted=true
  *      jdk.jfr.jvm.TestGetEventWriter
  *
@@ -72,6 +69,30 @@ import jdk.vm.ci.runtime.JVMCI;
  * @run main/othervm/timeout=300 -Xcomp -XX:TieredStopAtLevel=4 -XX:-TieredCompilation -XX:-UseInterpreter -Dinterpreted=false
  *      jdk.jfr.jvm.TestGetEventWriter
  */
+
+/**
+ * @test id=jvmci
+ * @key jfr
+ * @requires vm.hasJFR
+ * @requires vm.jvmci
+ * @library /test/lib
+ * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
+ *          jdk.internal.vm.ci/jdk.vm.ci.runtime
+ *
+ * @compile PlaceholderEventWriter.java
+ * @compile PlaceholderEventWriterFactory.java
+ * @compile E.java
+ * @compile NonEvent.java
+ * @compile RegisteredTrueEvent.java
+ * @compile RegisteredFalseEvent.java
+ * @compile MyCommitRegisteredTrueEvent.java
+ * @compile MyCommitRegisteredFalseEvent.java
+ * @compile StaticCommitEvent.java
+ *
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:+EnableJVMCI -Dtest.jvmci=true --add-exports=jdk.jfr/jdk.jfr.internal.event=ALL-UNNAMED
+ *      jdk.jfr.jvm.TestGetEventWriter
+ */
+
 public class TestGetEventWriter {
 
     static class InitializationEvent extends Event {


### PR DESCRIPTION
See the bug for example test failure. There are two ways to fix it: bring in `Whitebox` and sense the JVMCI support from there, or use the `@requires` to sense this and other conditions for JVMCI enablement then. `@requires` seems safer, so I did that one.

Additional testing:
 - [x] Affected test with `-XX:+UseShenandoahGC` (now passes)
 - [x] Affected test with `-XX:+UseParallelGC` (still passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315051](https://bugs.openjdk.org/browse/JDK-8315051): jdk/jfr/jvm/TestGetEventWriter.java fails with non-JVMCI GCs (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15446/head:pull/15446` \
`$ git checkout pull/15446`

Update a local copy of the PR: \
`$ git checkout pull/15446` \
`$ git pull https://git.openjdk.org/jdk.git pull/15446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15446`

View PR using the GUI difftool: \
`$ git pr show -t 15446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15446.diff">https://git.openjdk.org/jdk/pull/15446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15446#issuecomment-1695694871)