### PR TITLE
8315098: Improve URLEncodeDecode microbenchmark

### DIFF
--- a/test/micro/org/openjdk/bench/java/net/URLEncodeDecode.java
+++ b/test/micro/org/openjdk/bench/java/net/URLEncodeDecode.java
@@ -38,7 +38,6 @@ import org.openjdk.jmh.infra.Blackhole;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -77,7 +76,7 @@ public class URLEncodeDecode {
     @Setup
     public void setupStrings() {
         char[] encodeTokens = new char[] { '[', '(', ' ', '\u00E4', '\u00E5', '\u00F6', ')', '='};
-        char[] tokens = new char[((int) 'Z' - (int) 'A' + 1) + ((int) 'z' - (int) 'a' + 1) + ((int) '9' - (int) '0' + 1) + 4];
+        char[] tokens = new char[('Z' - 'A' + 1) + ('z' - 'a' + 1) + ('9' - '0' + 1) + 4];
         int n = 0;
         for (char c = '0'; c <= '9'; c++) {
             tokens[n++] = c;


### PR DESCRIPTION
The `URLEncodeDecode` microbenchmark accidentally generates strings with a lot of `'\u0000'` chars, heavily skewing towards strings that need to be encoded in a rather unrealistic what. To be more realistic the benchmark should test a mix of inputs.

This patch fixes these inadvertent cases, and sets up the benchmark for a healthier mix by default - adding controls to allow testing some mixed scenarios.

#15354 explore a few optimizations to `URLEncoder`, but due the nature of this microbenchmark a trivial fast-path scan for chars that need no encoding shows underwhelming results. With the modifications to this benchmark then a simple fast-path to `URLEncode.encode` shows a decent win when some or all the inputs remain unchanged:

```
Name                           (encodeChars) (maxLength) (unchanged) Cnt  Base   Error   Test   Error  Unit  Diff%
URLEncodeDecode.testDecodeUTF8             6        1024           0  15 3,307 ± 0,507  3,010 ± 0,048 ms/op   9,0% (p = 0,030 )
URLEncodeDecode.testDecodeUTF8             6        1024          75  15 2,296 ± 0,003  2,313 ± 0,017 ms/op  -0,7% (p = 0,001*)
URLEncodeDecode.testDecodeUTF8             6        1024         100  15 0,812 ± 0,010  0,819 ± 0,017 ms/op  -0,8% (p = 0,201 )
URLEncodeDecode.testDecodeUTF8            35        1024           0  15 6,909 ± 0,065  7,192 ± 0,415 ms/op  -4,1% (p = 0,014 )
URLEncodeDecode.testDecodeUTF8            35        1024          75  15 3,346 ± 0,206  3,320 ± 0,270 ms/op   0,8% (p = 0,753 )
URLEncodeDecode.testDecodeUTF8            35        1024         100  15 0,794 ± 0,034  0,818 ± 0,015 ms/op  -3,0% (p = 0,016 )
URLEncodeDecode.testEncodeUTF8             6        1024           0  15 2,434 ± 0,019  2,579 ± 0,120 ms/op  -6,0% (p = 0,000*)
URLEncodeDecode.testEncodeUTF8             6        1024          75  15 1,764 ± 0,014  0,937 ± 0,012 ms/op  46,9% (p = 0,000*)
URLEncodeDecode.testEncodeUTF8             6        1024         100  15 1,227 ± 0,008  0,401 ± 0,001 ms/op  67,4% (p = 0,000*)
URLEncodeDecode.testEncodeUTF8            35        1024           0  15 6,177 ± 0,062  6,057 ± 0,199 ms/op   1,9% (p = 0,029 )
URLEncodeDecode.testEncodeUTF8            35        1024          75  15 2,716 ± 0,023  1,876 ± 0,012 ms/op  30,9% (p = 0,000*)
URLEncodeDecode.testEncodeUTF8            35        1024         100  15 1,220 ± 0,003  0,401 ± 0,001 ms/op  67,2% (p = 0,000*)
```

A potential future improvement would be to extend test data with varying amounts of surrogate pairs, e.g. Chinese or emojis

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315098](https://bugs.openjdk.org/browse/JDK-8315098): Improve URLEncodeDecode microbenchmark (**Enhancement** - P4)


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer) ⚠️ Review applies to [0d28ef05](https://git.openjdk.org/jdk/pull/15448/files/0d28ef05f05e4056a19f493d1c14d9ac9a5fd5f3)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15448/head:pull/15448` \
`$ git checkout pull/15448`

Update a local copy of the PR: \
`$ git checkout pull/15448` \
`$ git pull https://git.openjdk.org/jdk.git pull/15448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15448`

View PR using the GUI difftool: \
`$ git pr show -t 15448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15448.diff">https://git.openjdk.org/jdk/pull/15448.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15448#issuecomment-1695725307)