### PR TITLE
8315116: fix minor issue in copyright header introduced by JDK-8269957 that is breaking the build

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Utf8NameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Utf8NameTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The copyright header of new file: `src/jdk.compiler/share/classes/com/sun/tools/javac/util/Utf8NameTable.java` introduced by the fix for `JDK-8269957` is missing a `,` after the copyright year.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315116](https://bugs.openjdk.org/browse/JDK-8315116): fix minor issue in copyright header introduced by JDK-8269957 that is breaking the build (**Bug** - P1)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15450/head:pull/15450` \
`$ git checkout pull/15450`

Update a local copy of the PR: \
`$ git checkout pull/15450` \
`$ git pull https://git.openjdk.org/jdk.git pull/15450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15450`

View PR using the GUI difftool: \
`$ git pr show -t 15450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15450.diff">https://git.openjdk.org/jdk/pull/15450.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15450#issuecomment-1695911737)