### PR TITLE
JDK-8315137: Add explicit override RecordComponentElement.asType()

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -68,6 +68,7 @@ public interface Element extends AnnotatedConstruct {
      * @see TypeElement#asType
      * @see TypeParameterElement#asType
      * @see VariableElement#asType
+     * @see RecordComponentElement#asType
      */
     TypeMirror asType();
 

--- a/src/java.compiler/share/classes/javax/lang/model/element/RecordComponentElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/RecordComponentElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,9 @@
 
 package javax.lang.model.element;
 
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeKind;
+
 /**
  * Represents a record component.
  *
@@ -32,6 +35,18 @@ package javax.lang.model.element;
  * @since 16
  */
 public interface RecordComponentElement extends Element {
+    /**
+     * {@return the type of this record component}
+     *
+     * Note that the types of variables range over {@linkplain
+     * TypeKind many kinds} of types, including primitive types,
+     * declared types, and array types.
+     *
+     * @see TypeKind
+     */
+    @Override
+    TypeMirror asType();
+
     /**
      * {@return the enclosing element of this record component}
      *

--- a/src/java.compiler/share/classes/javax/lang/model/element/RecordComponentElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/RecordComponentElement.java
@@ -38,7 +38,7 @@ public interface RecordComponentElement extends Element {
     /**
      * {@return the type of this record component}
      *
-     * Note that the types of variables range over {@linkplain
+     * Note that the types of record components range over {@linkplain
      * TypeKind many kinds} of types, including primitive types,
      * declared types, and array types.
      *


### PR DESCRIPTION
No change in semantics, just adding more explicit information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315137](https://bugs.openjdk.org/browse/JDK-8315137): Add explicit override RecordComponentElement.asType() (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15456/head:pull/15456` \
`$ git checkout pull/15456`

Update a local copy of the PR: \
`$ git checkout pull/15456` \
`$ git pull https://git.openjdk.org/jdk.git pull/15456/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15456`

View PR using the GUI difftool: \
`$ git pr show -t 15456`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15456.diff">https://git.openjdk.org/jdk/pull/15456.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15456#issuecomment-1696317610)