### PR TITLE
8314834: serviceability/jdwp/AllModulesCommandTest.java ignores VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import java.util.StringTokenizer;
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.JDWP;
 import static jdk.test.lib.Asserts.assertFalse;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * Launches the debuggee with the necessary JDWP options and handles the output
@@ -54,8 +55,9 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
     }
 
     private int jdwpPort = -1;
-    private static final String CLS_DIR = System.getProperty("test.classes", "").trim();
     private static final String DEBUGGEE = "AllModulesCommandTestDebuggee";
+    private static final String JDWP_OPT = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0";
+
     private Process p;
     private final Listener listener;
     private StreamHandler inputHandler;
@@ -76,28 +78,12 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
      */
     public void launchDebuggee() throws Throwable {
 
-        ProcessBuilder pb = new ProcessBuilder(getCommand());
+        ProcessBuilder pb = ProcessTools.createTestJvm(JDWP_OPT, DEBUGGEE);
         p = pb.start();
         inputHandler = new StreamHandler(p.getInputStream(), this);
         errorHandler = new StreamHandler(p.getErrorStream(), this);
         inputHandler.start();
         errorHandler.start();
-    }
-
-    /**
-     * Command to start the debuggee with the JDWP options and using the JDK
-     * under test
-     *
-     * @return the command
-     */
-    private String[] getCommand() {
-        return new String[]{
-            JDKToolFinder.getTestJDKTool("java"),
-            getJdwpOptions(),
-            "-cp",
-            CLS_DIR,
-            DEBUGGEE
-        };
     }
 
     /**
@@ -107,15 +93,6 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
         if (p.isAlive()) {
             p.destroyForcibly();
         }
-    }
-
-    /**
-     * Debuggee JDWP options
-     *
-     * @return the JDWP options to start the debuggee with
-     */
-    private static String getJdwpOptions() {
-        return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0";
     }
 
     /**


### PR DESCRIPTION
The test is fixed to start debuggee with tested VM options.
Verified with tier1, running svc tests with different vm flags and virtual thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314834](https://bugs.openjdk.org/browse/JDK-8314834): serviceability/jdwp/AllModulesCommandTest.java ignores VM flags (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15457/head:pull/15457` \
`$ git checkout pull/15457`

Update a local copy of the PR: \
`$ git checkout pull/15457` \
`$ git pull https://git.openjdk.org/jdk.git pull/15457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15457`

View PR using the GUI difftool: \
`$ git pr show -t 15457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15457.diff">https://git.openjdk.org/jdk/pull/15457.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15457#issuecomment-1696354807)