### PR TITLE
JDK-8314611: Provide more explicative error message parsing Currencies

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -684,7 +684,7 @@ public final class Currency implements Serializable {
     private static int getMainTableEntry(char char1, char char2) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
             throw new IllegalArgumentException("The country code is not a " +
-                    "supported ISO 4217 code");
+                    "supported ISO 3166 code");
         }
         return mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')];
     }
@@ -696,7 +696,7 @@ public final class Currency implements Serializable {
     private static void setMainTableEntry(char char1, char char2, int entry) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
             throw new IllegalArgumentException("The country code is not a " +
-                    "supported ISO 4217 code");
+                    "supported ISO 3166 code");
         }
         mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')] = entry;
     }

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -297,7 +297,8 @@ public final class Currency implements Serializable {
      * @return the {@code Currency} instance for the given currency code
      * @throws    NullPointerException if {@code currencyCode} is null
      * @throws    IllegalArgumentException if {@code currencyCode} is not
-     * a supported ISO 4217 code.
+     * a supported ISO 4217 code or the length of {@code currencyCode} is
+     * not equal to 3
      */
     public static Currency getInstance(String currencyCode) {
         return getInstance(currencyCode, Integer.MIN_VALUE, 0);
@@ -319,7 +320,8 @@ public final class Currency implements Serializable {
             // or in the list of other currencies.
             boolean found = false;
             if (currencyCode.length() != 3) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("The input currency code must " +
+                        "have a length of 3 characters");
             }
             char char1 = currencyCode.charAt(0);
             char char2 = currencyCode.charAt(1);
@@ -342,7 +344,8 @@ public final class Currency implements Serializable {
             if (!found) {
                 OtherCurrencyEntry ocEntry = OtherCurrencyEntry.findEntry(currencyCode);
                 if (ocEntry == null) {
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("The input currency code" +
+                            " is not a supported ISO 4217 code");
                 }
                 defaultFractionDigits = ocEntry.fraction;
                 numericCode = ocEntry.numericCode;
@@ -397,7 +400,8 @@ public final class Currency implements Serializable {
         String country = CalendarDataUtility.findRegionOverride(locale).getCountry();
 
         if (country == null || !country.matches("^[a-zA-Z]{2}$")) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("The country of the input locale" +
+                    " is not a supported ISO 3166 country code");
         }
 
         char char1 = country.charAt(0);
@@ -414,7 +418,8 @@ public final class Currency implements Serializable {
         } else {
             // special cases
             if (tableEntry == INVALID_COUNTRY_ENTRY) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("The country of the input locale" +
+                        " is not a supported ISO 3166 country code");
             }
             if (tableEntry == COUNTRY_WITHOUT_CURRENCY_ENTRY) {
                 return null;

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -344,7 +344,7 @@ public final class Currency implements Serializable {
                 OtherCurrencyEntry ocEntry = OtherCurrencyEntry.findEntry(currencyCode);
                 if (ocEntry == null) {
                     throw new IllegalArgumentException("The input currency code" +
-                            " is not a supported ISO 4217 code");
+                            " is not a valid ISO 4217 code");
                 }
                 defaultFractionDigits = ocEntry.fraction;
                 numericCode = ocEntry.numericCode;
@@ -400,7 +400,7 @@ public final class Currency implements Serializable {
 
         if (country == null || !country.matches("^[a-zA-Z]{2}$")) {
             throw new IllegalArgumentException("The country of the input locale" +
-                    " is not a supported ISO 3166 country code");
+                    " is not a valid ISO 3166 country code");
         }
 
         char char1 = country.charAt(0);
@@ -418,7 +418,7 @@ public final class Currency implements Serializable {
             // special cases
             if (tableEntry == INVALID_COUNTRY_ENTRY) {
                 throw new IllegalArgumentException("The country of the input locale" +
-                        " is not a supported ISO 3166 country code");
+                        " is not a valid ISO 3166 country code");
             }
             if (tableEntry == COUNTRY_WITHOUT_CURRENCY_ENTRY) {
                 return null;
@@ -684,7 +684,7 @@ public final class Currency implements Serializable {
     private static int getMainTableEntry(char char1, char char2) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
             throw new IllegalArgumentException("The country code is not a " +
-                    "supported ISO 3166 code");
+                    "valid ISO 3166 code");
         }
         return mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')];
     }
@@ -696,7 +696,7 @@ public final class Currency implements Serializable {
     private static void setMainTableEntry(char char1, char char2, int entry) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
             throw new IllegalArgumentException("The country code is not a " +
-                    "supported ISO 3166 code");
+                    "valid ISO 3166 code");
         }
         mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')] = entry;
     }

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -297,8 +297,7 @@ public final class Currency implements Serializable {
      * @return the {@code Currency} instance for the given currency code
      * @throws    NullPointerException if {@code currencyCode} is null
      * @throws    IllegalArgumentException if {@code currencyCode} is not
-     * a supported ISO 4217 code or the length of {@code currencyCode} is
-     * not equal to 3
+     * a supported ISO 4217 code.
      */
     public static Currency getInstance(String currencyCode) {
         return getInstance(currencyCode, Integer.MIN_VALUE, 0);

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -683,7 +683,8 @@ public final class Currency implements Serializable {
      */
     private static int getMainTableEntry(char char1, char char2) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("The country code is not a " +
+                    "supported ISO 4217 code");
         }
         return mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')];
     }
@@ -694,7 +695,8 @@ public final class Currency implements Serializable {
      */
     private static void setMainTableEntry(char char1, char char2, int entry) {
         if (char1 < 'A' || char1 > 'Z' || char2 < 'A' || char2 > 'Z') {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("The country code is not a " +
+                    "supported ISO 4217 code");
         }
         mainTable[(char1 - 'A') * A_TO_Z + (char2 - 'A')] = entry;
     }

--- a/test/jdk/java/util/Currency/CurrencyTest.java
+++ b/test/jdk/java/util/Currency/CurrencyTest.java
@@ -80,14 +80,29 @@ public class CurrencyTest {
 
         // Calling getInstance() with an invalid currency code should throw an IAE
         @ParameterizedTest
-        @MethodSource("invalidCurrencies")
+        @MethodSource("non4217Currencies")
         public void invalidCurrencyTest(String currencyCode) {
-            assertThrows(IllegalArgumentException.class, () ->
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
                     Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
+            assertEquals("The input currency code is not a supported ISO 4217 code", ex.getMessage());
         }
 
-        private static Stream<String> invalidCurrencies() {
-            return Stream.of("AQD", "US$", "\u20AC");
+        private static Stream<String> non4217Currencies() {
+            return Stream.of("AQD", "US$");
+        }
+
+        // Calling getInstance() with a currency code not 3 characters long should throw
+        // an IAE
+        @ParameterizedTest
+        @MethodSource("invalidLengthCurrencies")
+        public void invalidCurrencyLengthTest(String currencyCode) {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                    Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
+            assertEquals("The input currency code must have a length of 3 characters", ex.getMessage());
+        }
+
+        private static Stream<String> invalidLengthCurrencies() {
+            return Stream.of("\u20AC", "", "12345");
         }
     }
 
@@ -144,7 +159,8 @@ public class CurrencyTest {
                         ctryLength == 3 || // UN M.49 code
                         ctryCode.matches("AA|Q[M-Z]|X[A-JL-Z]|ZZ" + // user defined codes, excluding "XK" (Kosovo)
                                 "AC|CP|DG|EA|EU|FX|IC|SU|TA|UK")) { // exceptional reservation codes
-                    assertThrows(IllegalArgumentException.class, () -> Currency.getInstance(locale), "Did not throw IAE");
+                    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> Currency.getInstance(locale), "Did not throw IAE");
+                    assertEquals("The country of the input locale is not a supported ISO 3166 country code", ex.getMessage());
                 } else {
                     goodCountries++;
                     Currency currency = Currency.getInstance(locale);
@@ -163,8 +179,9 @@ public class CurrencyTest {
         // Check an invalid country code
         @Test
         public void invalidCountryTest() {
-            assertThrows(IllegalArgumentException.class, ()->
-                    Currency.getInstance(Locale.of("", "EU")), "Did not throw IAE");
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                    ()-> Currency.getInstance(Locale.of("", "EU")), "Did not throw IAE");
+            assertEquals("The country of the input locale is not a supported ISO 3166 country code", ex.getMessage());
         }
 
         // Ensure a selection of countries have the expected currency

--- a/test/jdk/java/util/Currency/CurrencyTest.java
+++ b/test/jdk/java/util/Currency/CurrencyTest.java
@@ -84,7 +84,8 @@ public class CurrencyTest {
         public void invalidCurrencyTest(String currencyCode) {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
                     Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
-            assertEquals("The input currency code is not a supported ISO 4217 code", ex.getMessage());
+            assertEquals("The input currency code is not a" +
+                    " supported ISO 4217 code", ex.getMessage());
         }
 
         private static Stream<String> non4217Currencies() {
@@ -98,7 +99,8 @@ public class CurrencyTest {
         public void invalidCurrencyLengthTest(String currencyCode) {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
                     Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
-            assertEquals("The input currency code must have a length of 3 characters", ex.getMessage());
+            assertEquals("The input currency code must have a length of 3" +
+                    " characters", ex.getMessage());
         }
 
         private static Stream<String> invalidLengthCurrencies() {
@@ -159,8 +161,10 @@ public class CurrencyTest {
                         ctryLength == 3 || // UN M.49 code
                         ctryCode.matches("AA|Q[M-Z]|X[A-JL-Z]|ZZ" + // user defined codes, excluding "XK" (Kosovo)
                                 "AC|CP|DG|EA|EU|FX|IC|SU|TA|UK")) { // exceptional reservation codes
-                    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> Currency.getInstance(locale), "Did not throw IAE");
-                    assertEquals("The country of the input locale is not a supported ISO 3166 country code", ex.getMessage());
+                    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                            () -> Currency.getInstance(locale), "Did not throw IAE");
+                    assertEquals("The country of the input locale is not a" +
+                            " supported ISO 3166 country code", ex.getMessage());
                 } else {
                     goodCountries++;
                     Currency currency = Currency.getInstance(locale);
@@ -181,7 +185,8 @@ public class CurrencyTest {
         public void invalidCountryTest() {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                     ()-> Currency.getInstance(Locale.of("", "EU")), "Did not throw IAE");
-            assertEquals("The country of the input locale is not a supported ISO 3166 country code", ex.getMessage());
+            assertEquals("The country of the input locale is not a supported" +
+                    " ISO 3166 country code", ex.getMessage());
         }
 
         // Ensure a selection of countries have the expected currency

--- a/test/jdk/java/util/Currency/CurrencyTest.java
+++ b/test/jdk/java/util/Currency/CurrencyTest.java
@@ -85,7 +85,7 @@ public class CurrencyTest {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
                     Currency.getInstance(currencyCode), "getInstance() did not throw IAE");
             assertEquals("The input currency code is not a" +
-                    " supported ISO 4217 code", ex.getMessage());
+                    " valid ISO 4217 code", ex.getMessage());
         }
 
         private static Stream<String> non4217Currencies() {
@@ -164,7 +164,7 @@ public class CurrencyTest {
                     IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                             () -> Currency.getInstance(locale), "Did not throw IAE");
                     assertEquals("The country of the input locale is not a" +
-                            " supported ISO 3166 country code", ex.getMessage());
+                            " valid ISO 3166 country code", ex.getMessage());
                 } else {
                     goodCountries++;
                     Currency currency = Currency.getInstance(locale);
@@ -185,7 +185,7 @@ public class CurrencyTest {
         public void invalidCountryTest() {
             IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                     ()-> Currency.getInstance(Locale.of("", "EU")), "Did not throw IAE");
-            assertEquals("The country of the input locale is not a supported" +
+            assertEquals("The country of the input locale is not a valid" +
                     " ISO 3166 country code", ex.getMessage());
         }
 


### PR DESCRIPTION
Please review this PR which updates some exceptions in j.util.Currency to have an explicit error message (as opposed to nothing).

The exceptions are thrown when the ISO 4217/3166 currency/country codes are in an invalid form, or do not exist.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314611](https://bugs.openjdk.org/browse/JDK-8314611): Provide more explicative error message parsing Currencies (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15458/head:pull/15458` \
`$ git checkout pull/15458`

Update a local copy of the PR: \
`$ git checkout pull/15458` \
`$ git pull https://git.openjdk.org/jdk.git pull/15458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15458`

View PR using the GUI difftool: \
`$ git pr show -t 15458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15458.diff">https://git.openjdk.org/jdk/pull/15458.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15458#issuecomment-1696431200)