### PR TITLE
5066247: Refine the spec of equals() and hashCode() for j.text.Format classes

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -518,7 +518,7 @@ public class ChoiceFormat extends NumberFormat {
      * two formats would format any value the same.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code ChoiceFormat}

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -497,8 +497,8 @@ public class ChoiceFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code ChoiceFormat}}
      *
-     * The hash code value is based on the length of the {@code limits} and
-     * {@code formats} fields of this {@code ChoiceFormat}.
+     * The hash code value is based on the values returned by {@link #getLimits()} and
+     * {@link #getFormats()} of this {@code ChoiceFormat}.
      *
      * @see Object#hashCode()
      */
@@ -514,8 +514,8 @@ public class ChoiceFormat extends NumberFormat {
 
     /**
      * Compares the specified object with this {@code ChoiceFormat} for equality.
-     * Returns true if the object is also a ChoiceFormat and the {@code limits} and
-     * {@code formats} of the two {@code ChoiceFormat}s are equal. Obeys the
+     * Returns true if the object is also a ChoiceFormat and the values returned by {@link #getLimits()} and
+     * {@link #getFormats()} of the two {@code ChoiceFormat}s are equal. Obeys the
      * general contract of {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
      *
      * @param  obj object to be compared for equality

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -498,7 +498,7 @@ public class ChoiceFormat extends NumberFormat {
      * {@return the hash code for this {@code ChoiceFormat}}
      *
      * The hash code value is based on the values returned by {@link #getLimits()} and
-     * {@link #getFormats()} of this {@code ChoiceFormat}.
+     * {@link #getFormats()}.
      *
      * @see Object#hashCode()
      */
@@ -514,9 +514,9 @@ public class ChoiceFormat extends NumberFormat {
 
     /**
      * Compares the specified object with this {@code ChoiceFormat} for equality.
-     * Returns true if the object is also a ChoiceFormat and the values returned by {@link #getLimits()} and
-     * {@link #getFormats()} of the two {@code ChoiceFormat}s are equal. Obeys the
-     * general contract of {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     * Returns true if the object is also a {@code ChoiceFormat} and the values
+     * returned by {@link #getLimits()} and {@link #getFormats()} of the two
+     * {@code ChoiceFormat}s are equal.
      *
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code ChoiceFormat}

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -495,7 +495,12 @@ public class ChoiceFormat extends NumberFormat {
     }
 
     /**
-     * Generates a hash code for the message format object.
+     * {@return the hash code for this {@code ChoiceFormat}}
+     *
+     * The hash code value is based on the length of the {@code limits} and
+     * {@code formats} of this {@code ChoiceFormat}.
+     *
+     * @see Object#hashCode()
      */
     @Override
     public int hashCode() {
@@ -508,7 +513,14 @@ public class ChoiceFormat extends NumberFormat {
     }
 
     /**
-     * Equality comparison between two
+     * Compares the specified object with this {@code ChoiceFormat} for equality.
+     * Returns true if the object is also a ChoiceFormat and the {@code limits} and
+     * {@code formats} of the two {@code ChoiceFormat}s are equal. Obeys the
+     * general contract of {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     *
+     * @param  obj object to be compared for equality
+     * @return {@code true} if the specified object is equal to this {@code ChoiceFormat}
+     * @see Object#equals(Object)
      */
     @Override
     public boolean equals(Object obj) {

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -497,8 +497,8 @@ public class ChoiceFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code ChoiceFormat}}
      *
-     * The hash code value is based on the values returned by {@link #getLimits()} and
-     * {@link #getFormats()}.
+     * The hash code value is calculated using any number of fields from the
+     * formatting configuration of this {@code ChoiceFormat} object.
      *
      * @see Object#hashCode()
      */
@@ -514,10 +514,12 @@ public class ChoiceFormat extends NumberFormat {
 
     /**
      * Compares the specified object with this {@code ChoiceFormat} for equality.
-     * Returns true if the object is also a {@code ChoiceFormat} and the values
-     * returned by {@link #getLimits()} and {@link #getFormats()} of the two
-     * {@code ChoiceFormat}s are equal.
+     * Returns true if the object is also a {@code ChoiceFormat} and the
+     * two formats would format any value the same.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code ChoiceFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -498,7 +498,7 @@ public class ChoiceFormat extends NumberFormat {
      * {@return the hash code for this {@code ChoiceFormat}}
      *
      * The hash code value is based on the length of the {@code limits} and
-     * {@code formats} of this {@code ChoiceFormat}.
+     * {@code formats} fields of this {@code ChoiceFormat}.
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -517,9 +517,9 @@ public class ChoiceFormat extends NumberFormat {
      * Returns true if the object is also a {@code ChoiceFormat} and the
      * two formats would format any value the same.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code ChoiceFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -497,8 +497,8 @@ public class ChoiceFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code ChoiceFormat}}
      *
-     * The hash code value is calculated using any number of fields from the
-     * formatting configuration of this {@code ChoiceFormat} object.
+     * The hash code value is calculated using the values returned by
+     * {@link #getFormats()} and {@link #getLimits()}.
      *
      * @see Object#hashCode()
      */
@@ -518,7 +518,7 @@ public class ChoiceFormat extends NumberFormat {
      * two formats would format any value the same.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code ChoiceFormat}

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -497,9 +497,8 @@ public class ChoiceFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code ChoiceFormat}}
      *
-     * The hash code value is calculated using the values returned by
+     * @implSpec This method calculates the hash code value using the values returned by
      * {@link #getFormats()} and {@link #getLimits()}.
-     *
      * @see Object#hashCode()
      */
     @Override
@@ -517,9 +516,10 @@ public class ChoiceFormat extends NumberFormat {
      * Returns true if the object is also a {@code ChoiceFormat} and the
      * two formats would format any value the same.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code ChoiceFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -2348,7 +2348,7 @@ public final class CompactNumberFormat extends NumberFormat {
      * two formats would format any value the same.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param obj the object to compare with
      * @return true if this is equal to the other {@code CompactNumberFormat}

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -2343,13 +2343,13 @@ public final class CompactNumberFormat extends NumberFormat {
     }
 
     /**
-     * Checks if this {@code CompactNumberFormat} is equal to the
-     * specified {@code obj}. The objects of type {@code CompactNumberFormat}
-     * are compared, other types return false; obeys the general contract of
-     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     * Compares the specified object with this {@code CompactNumberFormat} for equality.
+     * Returns true if the object is also a {@code CompactNumberFormat} and the
+     * two formats represent the same formatting configuration.
      *
      * @param obj the object to compare with
      * @return true if this is equal to the other {@code CompactNumberFormat}
+     * @see Object#hashCode()
      */
     @Override
     public boolean equals(Object obj) {
@@ -2373,7 +2373,13 @@ public final class CompactNumberFormat extends NumberFormat {
     }
 
     /**
-     * {@return the hash code for this {@code CompactNumberFormat} instance}
+     * {@return the hash code for this {@code CompactNumberFormat}}
+     *
+     * The hash code value is based on the formatting configuration, which
+     * is represented by a number of fields from this {@code CompactNumberFormat}
+     * object.
+     *
+     * @see Object#hashCode()
      */
     @Override
     public int hashCode() {

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -2345,8 +2345,11 @@ public final class CompactNumberFormat extends NumberFormat {
     /**
      * Compares the specified object with this {@code CompactNumberFormat} for equality.
      * Returns true if the object is also a {@code CompactNumberFormat} and the
-     * two formats represent the same formatting configuration.
+     * two formats would format any value the same.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param obj the object to compare with
      * @return true if this is equal to the other {@code CompactNumberFormat}
      * @see Object#hashCode()
@@ -2375,9 +2378,8 @@ public final class CompactNumberFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code CompactNumberFormat}}
      *
-     * The hash code value is based on the formatting configuration, which
-     * is represented by a number of fields from this {@code CompactNumberFormat}
-     * object.
+     * The hash code value is calculated using any number of fields from the
+     * formatting configuration of this {@code CompactNumberFormat} object.
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -2347,9 +2347,9 @@ public final class CompactNumberFormat extends NumberFormat {
      * Returns true if the object is also a {@code CompactNumberFormat} and the
      * two formats would format any value the same.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param obj the object to compare with
      * @return true if this is equal to the other {@code CompactNumberFormat}
      * @see Object#hashCode()

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -2379,7 +2379,7 @@ public final class CompactNumberFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code CompactNumberFormat}}
      *
-     * Non-transient and non-static fields of this class are used to calculate
+     * Non-transient instance fields of this class are used to calculate
      * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
      *
      * @see Object#hashCode()

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -217,6 +217,8 @@ public final class CompactNumberFormat extends NumberFormat {
     @java.io.Serial
     private static final long serialVersionUID = 7128367218649234678L;
 
+    // Non-transient / non-static fields should be added to hashCode impl
+
     /**
      * The patterns for compact form of numbers for this
      * {@code CompactNumberFormat}. A possible example is
@@ -2348,7 +2350,7 @@ public final class CompactNumberFormat extends NumberFormat {
      * two formats would format any value the same.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param obj the object to compare with
      * @return true if this is equal to the other {@code CompactNumberFormat}
@@ -2378,8 +2380,8 @@ public final class CompactNumberFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code CompactNumberFormat}}
      *
-     * The hash code value is calculated using any number of fields from the
-     * formatting configuration of this {@code CompactNumberFormat} object.
+     * All fields of this class that are non-transient and non-static are used
+     * to calculate the hash code value.
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -217,7 +217,6 @@ public final class CompactNumberFormat extends NumberFormat {
     @java.io.Serial
     private static final long serialVersionUID = 7128367218649234678L;
 
-    // Non-transient / non-static fields should be added to hashCode impl
 
     /**
      * The patterns for compact form of numbers for this
@@ -2380,8 +2379,8 @@ public final class CompactNumberFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code CompactNumberFormat}}
      *
-     * All fields of this class that are non-transient and non-static are used
-     * to calculate the hash code value.
+     * Non-transient and non-static fields of this class are used to calculate
+     * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -217,7 +217,6 @@ public final class CompactNumberFormat extends NumberFormat {
     @java.io.Serial
     private static final long serialVersionUID = 7128367218649234678L;
 
-
     /**
      * The patterns for compact form of numbers for this
      * {@code CompactNumberFormat}. A possible example is
@@ -2348,9 +2347,10 @@ public final class CompactNumberFormat extends NumberFormat {
      * Returns true if the object is also a {@code CompactNumberFormat} and the
      * two formats would format any value the same.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param obj the object to compare with
      * @return true if this is equal to the other {@code CompactNumberFormat}
      * @see Object#hashCode()
@@ -2379,9 +2379,8 @@ public final class CompactNumberFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code CompactNumberFormat}}
      *
-     * Non-transient instance fields of this class are used to calculate
+     * @implSpec Non-transient instance fields of this class are used to calculate
      * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
-     *
      * @see Object#hashCode()
      */
     @Override

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -769,7 +769,8 @@ public abstract class DateFormat extends Format {
     /**
      * {@return the hash code for this {@code DateFormat}}
      *
-     * The hash code value is based on the value returned by {@link #getNumberFormat()}.
+     * The hash code value is calculated using any number of fields from the
+     * formatting configuration of this {@code DateFormat} object.
      *
      * @see Object#hashCode()
      */
@@ -780,9 +781,12 @@ public abstract class DateFormat extends Format {
 
     /**
      * Compares the specified object with this {@code DateFormat} for equality.
-     * Returns true if the object is also a {@code DateFormat} and the two formats
-     * represent the same formatting configuration.
+     * Returns true if the object is also a {@code DateFormat} and the
+     * two formats would format any value the same.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -772,7 +772,6 @@ public abstract class DateFormat extends Format {
      * The hash code value is based on the value returned by {@link #getNumberFormat()}.
      *
      * @see Object#hashCode()
-     * @see NumberFormat#hashCode()
      */
     public int hashCode() {
         return numberFormat.hashCode();

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -785,7 +785,7 @@ public abstract class DateFormat extends Format {
      * two formats would format any value the same.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormat}

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -767,7 +767,13 @@ public abstract class DateFormat extends Format {
     }
 
     /**
-     * Overrides hashCode
+     * {@return the hash code for this {@code DateFormat}}
+     *
+     * The hash code value is based on the {@code numberFormat} field that belongs
+     * to this {@code DateFormat}.
+     *
+     * @see Object#hashCode()
+     * @see NumberFormat#hashCode()
      */
     public int hashCode() {
         return numberFormat.hashCode();
@@ -775,7 +781,14 @@ public abstract class DateFormat extends Format {
     }
 
     /**
-     * Overrides equals
+     * Compares the specified object with this {@code DateFormat} for equality.
+     * Returns true if the object is also a {@code DateFormat} and the two Formats
+     * represent the same formatting configuration. Obeys the general contract of
+     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     *
+     * @param  obj object to be compared for equality
+     * @return {@code true} if the specified object is equal to this {@code DateFormat}
+     * @see Object#equals(Object)
      */
     public boolean equals(Object obj) {
         if (this == obj) return true;

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -769,8 +769,8 @@ public abstract class DateFormat extends Format {
     /**
      * {@return the hash code for this {@code DateFormat}}
      *
-     * The hash code value is based on the {@code numberFormat} field that belongs
-     * to this {@code DateFormat}.
+     * The hash code value is based on the value returned by {@link #getNumberFormat()}
+     * of this {@code DateFormat}.
      *
      * @see Object#hashCode()
      * @see NumberFormat#hashCode()

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -769,8 +769,7 @@ public abstract class DateFormat extends Format {
     /**
      * {@return the hash code for this {@code DateFormat}}
      *
-     * The hash code value is based on the value returned by {@link #getNumberFormat()}
-     * of this {@code DateFormat}.
+     * The hash code value is based on the value returned by {@link #getNumberFormat()}.
      *
      * @see Object#hashCode()
      * @see NumberFormat#hashCode()
@@ -782,9 +781,8 @@ public abstract class DateFormat extends Format {
 
     /**
      * Compares the specified object with this {@code DateFormat} for equality.
-     * Returns true if the object is also a {@code DateFormat} and the two Formats
-     * represent the same formatting configuration. Obeys the general contract of
-     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     * Returns true if the object is also a {@code DateFormat} and the two formats
+     * represent the same formatting configuration.
      *
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormat}

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -769,9 +769,8 @@ public abstract class DateFormat extends Format {
     /**
      * {@return the hash code for this {@code DateFormat}}
      *
-     * The hash code value is calculated using the value returned by
+     * @implSpec This method calculates the hash code value using the value returned by
      * {@link #getNumberFormat()}.
-     *
      * @see Object#hashCode()
      */
     public int hashCode() {
@@ -784,9 +783,10 @@ public abstract class DateFormat extends Format {
      * Returns true if the object is also a {@code DateFormat} and the
      * two formats would format any value the same.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -769,8 +769,8 @@ public abstract class DateFormat extends Format {
     /**
      * {@return the hash code for this {@code DateFormat}}
      *
-     * The hash code value is calculated using any number of fields from the
-     * formatting configuration of this {@code DateFormat} object.
+     * The hash code value is calculated using the value returned by
+     * {@link #getNumberFormat()}.
      *
      * @see Object#hashCode()
      */
@@ -785,7 +785,7 @@ public abstract class DateFormat extends Format {
      * two formats would format any value the same.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormat}

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -784,9 +784,9 @@ public abstract class DateFormat extends Format {
      * Returns true if the object is also a {@code DateFormat} and the
      * two formats would format any value the same.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -656,8 +656,12 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     }
 
     /**
-     * Override hashCode.
-     * Generates a hash code for the DateFormatSymbols object.
+     * {@return the hash code for this {@code DateFormatSymbols}}
+     *
+     * The hash code value is based on the date-time formatting data, which is
+     * composed by a number of fields from this {@code DateFormatSymbols}.
+     *
+     * @see Object#hashCode()
      */
     @Override
     public int hashCode() {
@@ -681,7 +685,15 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     }
 
     /**
-     * Override equals
+     * Compares the specified object with this {@code DateFormatSymbols} for equality.
+     * Returns true if the object is also a {@code DateFormatSymbols} and the two
+     * {@code DateFormatSymbols} objects represent the same date-time formatting data.
+     * Obeys the general contract of {@link java.lang.Object#equals(java.lang.Object)
+     * Object.equals}.
+     *
+     * @param  obj object to be compared for equality
+     * @return {@code true} if the specified object is equal to this {@code DateFormatSymbols}
+     * @see Object#equals(Object)
      */
     @Override
     public boolean equals(Object obj)

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -690,7 +690,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * {@code DateFormatSymbols} objects represent the same date-time formatting data.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormatSymbols}

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -659,7 +659,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * {@return the hash code for this {@code DateFormatSymbols}}
      *
      * The hash code value is based on the date-time formatting data, which is
-     * composed by a number of fields from this {@code DateFormatSymbols}.
+     * composed of a number of fields from this {@code DateFormatSymbols}.
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -659,7 +659,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * {@return the hash code for this {@code DateFormatSymbols}}
      *
      * The hash code value is based on the date-time formatting data, which is
-     * composed of a number of fields from this {@code DateFormatSymbols}.
+     * represented by a number of fields from this {@code DateFormatSymbols} object.
      *
      * @see Object#hashCode()
      */
@@ -688,8 +688,6 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * Compares the specified object with this {@code DateFormatSymbols} for equality.
      * Returns true if the object is also a {@code DateFormatSymbols} and the two
      * {@code DateFormatSymbols} objects represent the same date-time formatting data.
-     * Obeys the general contract of {@link java.lang.Object#equals(java.lang.Object)
-     * Object.equals}.
      *
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormatSymbols}

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -689,6 +689,9 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * Returns true if the object is also a {@code DateFormatSymbols} and the two
      * {@code DateFormatSymbols} objects represent the same date-time formatting data.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormatSymbols}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -157,8 +157,6 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     private DateFormatSymbols(boolean flag) {
     }
 
-    // Non-transient / non-static fields should be added to hashCode impl
-
     /**
      * Era strings. For example: "AD" and "BC".  An array of 2 strings,
      * indexed by {@code Calendar.BC} and {@code Calendar.AD}.
@@ -660,8 +658,8 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     /**
      * {@return the hash code for this {@code DateFormatSymbols}}
      *
-     * All fields of this class that are non-transient and non-static are used
-     * to calculate the hash code value.
+     * Non-transient and non-static fields of this class are used to calculate
+     * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -157,6 +157,8 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     private DateFormatSymbols(boolean flag) {
     }
 
+    // Non-transient / non-static fields should be added to hashCode impl
+
     /**
      * Era strings. For example: "AD" and "BC".  An array of 2 strings,
      * indexed by {@code Calendar.BC} and {@code Calendar.AD}.
@@ -658,8 +660,8 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     /**
      * {@return the hash code for this {@code DateFormatSymbols}}
      *
-     * The hash code value is based on the date-time formatting data, which is
-     * represented by a number of fields from this {@code DateFormatSymbols} object.
+     * All fields of this class that are non-transient and non-static are used
+     * to calculate the hash code value.
      *
      * @see Object#hashCode()
      */
@@ -690,7 +692,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * {@code DateFormatSymbols} objects represent the same date-time formatting data.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormatSymbols}

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -689,9 +689,9 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * Returns true if the object is also a {@code DateFormatSymbols} and the two
      * {@code DateFormatSymbols} objects represent the same date-time formatting data.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormatSymbols}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -658,7 +658,7 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     /**
      * {@return the hash code for this {@code DateFormatSymbols}}
      *
-     * Non-transient and non-static fields of this class are used to calculate
+     * Non-transient instance fields of this class are used to calculate
      * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
      *
      * @see Object#hashCode()

--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -658,9 +658,8 @@ public class DateFormatSymbols implements Serializable, Cloneable {
     /**
      * {@return the hash code for this {@code DateFormatSymbols}}
      *
-     * Non-transient instance fields of this class are used to calculate
-     * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
-     *
+     * @implSpec Non-transient instance fields of this class are used to calculate
+     * a hash code value which adheres to the contract defined in {@link Objects#hashCode}.
      * @see Object#hashCode()
      */
     @Override
@@ -689,9 +688,10 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * Returns true if the object is also a {@code DateFormatSymbols} and the two
      * {@code DateFormatSymbols} objects represent the same date-time formatting data.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DateFormatSymbols}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2965,10 +2965,10 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * {@return the hash code for this {@code DecimalFormat} instance}
+     * {@return the hash code for this {@code DecimalFormat}}
      *
-     * The hash code value is based on the {@code positivePrefix} field and
-     * parent {@link NumberFormat#hashCode()} value.
+     * The hash code value is based on the value returned by {@link #getPositivePrefix()}
+     * and {@link NumberFormat#hashCode()}.
      *
      * @see Object#hashCode()
      * @see NumberFormat#hashCode()

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2914,9 +2914,12 @@ public class DecimalFormat extends NumberFormat {
 
     /**
      * Compares the specified object with this {@code DecimalFormat} for equality.
-     * Returns true if the object is also a {@code DecimalFormat} and the two formats
-     * represent the same formatting configuration.
+     * Returns true if the object is also a {@code DecimalFormat} and the
+     * two formats would format any value the same.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormat}
      * @see Object#equals(Object)
@@ -2966,8 +2969,8 @@ public class DecimalFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code DecimalFormat}}
      *
-     * The hash code value is based on the value returned by {@link #getPositivePrefix()}
-     * and {@link NumberFormat#hashCode()}.
+     * The hash code value is calculated using any number of fields from the
+     * formatting configuration of this {@code DecimalFormat} object.
      *
      * @see Object#hashCode()
      * @see NumberFormat#hashCode()

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2914,9 +2914,8 @@ public class DecimalFormat extends NumberFormat {
 
     /**
      * Compares the specified object with this {@code DecimalFormat} for equality.
-     * Returns true if the object is also a DecimalFormat and the two Formats
-     * represent the same formatting configuration. Obeys the general contract of
-     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     * Returns true if the object is also a {@code DecimalFormat} and the two formats
+     * represent the same formatting configuration.
      *
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormat}

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2913,7 +2913,14 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Overrides equals
+     * Compares the specified object with this {@code DecimalFormat} for equality.
+     * Returns true if the object is also a DecimalFormat and the two Formats
+     * represent the same formatting configuration. Obeys the general contract of
+     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     *
+     * @param  obj object to be compared for equality
+     * @return {@code true} if the specified object is equal to this {@code DecimalFormat}
+     * @see Object#equals(Object)
      */
     @Override
     public boolean equals(Object obj)
@@ -2958,7 +2965,13 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Overrides hashCode
+     * {@return the hash code for this {@code DecimalFormat} instance}
+     *
+     * The hash code value is based on the {@code positivePrefix} field and
+     * parent {@link NumberFormat#hashCode()} value.
+     *
+     * @see Object#hashCode()
+     * @see NumberFormat#hashCode()
      */
     @Override
     public int hashCode() {

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2918,7 +2918,7 @@ public class DecimalFormat extends NumberFormat {
      * two formats would format any value the same.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormat}

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2917,9 +2917,9 @@ public class DecimalFormat extends NumberFormat {
      * Returns true if the object is also a {@code DecimalFormat} and the
      * two formats would format any value the same.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2918,7 +2918,7 @@ public class DecimalFormat extends NumberFormat {
      * two formats would format any value the same.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormat}
@@ -2969,8 +2969,8 @@ public class DecimalFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code DecimalFormat}}
      *
-     * The hash code value is calculated using any number of fields from the
-     * formatting configuration of this {@code DecimalFormat} object.
+     * The hash code value is calculated using the values returned from
+     * {@link #getPositivePrefix()} and {@link NumberFormat#hashCode()}.
      *
      * @see Object#hashCode()
      * @see NumberFormat#hashCode()

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2917,9 +2917,10 @@ public class DecimalFormat extends NumberFormat {
      * Returns true if the object is also a {@code DecimalFormat} and the
      * two formats would format any value the same.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormat}
      * @see Object#equals(Object)
@@ -2969,9 +2970,8 @@ public class DecimalFormat extends NumberFormat {
     /**
      * {@return the hash code for this {@code DecimalFormat}}
      *
-     * The hash code value is calculated using the values returned from
+     * @implSpec This method calculates the hash code value using the values returned from
      * {@link #getPositivePrefix()} and {@link NumberFormat#hashCode()}.
-     *
      * @see Object#hashCode()
      * @see NumberFormat#hashCode()
      */

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -741,6 +741,9 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * Returns true if the object is also a {@code DecimalFormatSymbols} and the two
      * {@code DecimalFormatSymbols} objects represent the same set of symbols.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormatSymbols}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -737,7 +737,15 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     }
 
     /**
-     * Override equals.
+     * Compares the specified object with this {@code DecimalFormatSymbols} for equality.
+     * Returns true if the object is also a {@code DecimalFormatSymbols} and the two
+     * {@code DecimalFormatSymbols} objects represent the same set of symbols.
+     * Obeys the general contract of {@link java.lang.Object#equals(java.lang.Object)
+     * Object.equals}.
+     *
+     * @param  obj object to be compared for equality
+     * @return {@code true} if the specified object is equal to this {@code DecimalFormatSymbols}
+     * @see Object#equals(Object)
      */
     @Override
     public boolean equals(Object obj) {
@@ -767,7 +775,12 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     }
 
     /**
-     * Override hashCode.
+     * {@return the hash code for this {@code DecimalFormatSymbols}}
+     *
+     * The hash code value is based on the set of symbols, which is
+     * composed by a number of fields from this {@code DecimalFormatSymbols}.
+     *
+     * @see Object#hashCode()
      */
     @Override
     public int hashCode() {

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -778,7 +778,7 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * {@return the hash code for this {@code DecimalFormatSymbols}}
      *
      * The hash code value is based on the set of symbols, which is
-     * composed by a number of fields from this {@code DecimalFormatSymbols}.
+     * composed of a number of fields from this {@code DecimalFormatSymbols}.
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -740,8 +740,6 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * Compares the specified object with this {@code DecimalFormatSymbols} for equality.
      * Returns true if the object is also a {@code DecimalFormatSymbols} and the two
      * {@code DecimalFormatSymbols} objects represent the same set of symbols.
-     * Obeys the general contract of {@link java.lang.Object#equals(java.lang.Object)
-     * Object.equals}.
      *
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormatSymbols}
@@ -777,8 +775,8 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     /**
      * {@return the hash code for this {@code DecimalFormatSymbols}}
      *
-     * The hash code value is based on the set of symbols, which is
-     * composed of a number of fields from this {@code DecimalFormatSymbols}.
+     * The hash code value is based on the set of symbols, which is represented
+     * by a number of fields from this {@code DecimalFormatSymbols} object.
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -742,7 +742,7 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * {@code DecimalFormatSymbols} objects represent the same set of symbols.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormatSymbols}

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -741,9 +741,10 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * Returns true if the object is also a {@code DecimalFormatSymbols} and the two
      * {@code DecimalFormatSymbols} objects represent the same set of symbols.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormatSymbols}
      * @see Object#equals(Object)
@@ -778,9 +779,8 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     /**
      * {@return the hash code for this {@code DecimalFormatSymbols}}
      *
-     * Non-transient instance fields of this class are used to calculate
-     * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
-     *
+     * @implSpec Non-transient instance fields of this class are used to calculate
+     * a hash code value which adheres to the contract defined in {@link Objects#hashCode}.
      * @see Object#hashCode()
      */
     @Override

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -741,9 +741,9 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * Returns true if the object is also a {@code DecimalFormatSymbols} and the two
      * {@code DecimalFormatSymbols} objects represent the same set of symbols.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormatSymbols}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -778,8 +778,8 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     /**
      * {@return the hash code for this {@code DecimalFormatSymbols}}
      *
-     * All fields of this class that are non-transient and non-static are used
-     * to calculate the hash code value.
+     * Non-transient and non-static fields of this class are used to calculate
+     * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
      *
      * @see Object#hashCode()
      */
@@ -992,8 +992,6 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
             currencyInitialized = true;
         }
     }
-
-    // Non-transient / non-static fields should be added to hashCode impl
 
     /**
      * Character used for zero.

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -742,7 +742,7 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * {@code DecimalFormatSymbols} objects represent the same set of symbols.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code DecimalFormatSymbols}
@@ -778,8 +778,8 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     /**
      * {@return the hash code for this {@code DecimalFormatSymbols}}
      *
-     * The hash code value is based on the set of symbols, which is represented
-     * by a number of fields from this {@code DecimalFormatSymbols} object.
+     * All fields of this class that are non-transient and non-static are used
+     * to calculate the hash code value.
      *
      * @see Object#hashCode()
      */
@@ -992,6 +992,8 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
             currencyInitialized = true;
         }
     }
+
+    // Non-transient / non-static fields should be added to hashCode impl
 
     /**
      * Character used for zero.

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -778,7 +778,7 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
     /**
      * {@return the hash code for this {@code DecimalFormatSymbols}}
      *
-     * Non-transient and non-static fields of this class are used to calculate
+     * Non-transient instance fields of this class are used to calculate
      * a hash code value which adheres to the contract defined in {@link Objects#hashCode}
      *
      * @see Object#hashCode()

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1142,9 +1142,12 @@ public class MessageFormat extends Format {
 
     /**
      * Compares the specified object with this {@code MessageFormat} for equality.
-     * Returns true if the object is also a {@code MessageFormat} and the two formats
-     * represent the same formatting configuration.
+     * Returns true if the object is also a {@code MessageFormat} and the
+     * two formats would format any value the same.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code MessageFormat}
      * @see Object#equals(Object)
@@ -1167,9 +1170,8 @@ public class MessageFormat extends Format {
     /**
      * {@return the hash code value for this {@code MessageFormat}}
      *
-     * The hash code value is based on the string pattern supplied to this
-     * {@code MessageFormat} either during construction or set by
-     * {@link #applyPattern(String)}.
+     * The hash code value is calculated using any number of fields from the
+     * formatting configuration of this {@code MessageFormat} object.
      *
      * @see Object#hashCode()
      */

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1142,9 +1142,8 @@ public class MessageFormat extends Format {
 
     /**
      * Compares the specified object with this {@code MessageFormat} for equality.
-     * Returns true if the object is also a {@code MessageFormat} and the two Formats
-     * represent the same formatting configuration. Obeys the general contract of
-     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     * Returns true if the object is also a {@code MessageFormat} and the two formats
+     * represent the same formatting configuration.
      *
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code MessageFormat}

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1146,7 +1146,7 @@ public class MessageFormat extends Format {
      * two formats would format any value the same.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code MessageFormat}

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1141,7 +1141,14 @@ public class MessageFormat extends Format {
     }
 
     /**
-     * Equality comparison between two message format objects
+     * Compares the specified object with this {@code MessageFormat} for equality.
+     * Returns true if the object is also a {@code MessageFormat} and the two Formats
+     * represent the same formatting configuration. Obeys the general contract of
+     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     *
+     * @param  obj object to be compared for equality with this {@code MessageFormat}
+     * @return {@code true} if the specified object is equal to this {@code MessageFormat}
+     * @see Object#equals(Object)
      */
     @Override
     public boolean equals(Object obj) {
@@ -1159,7 +1166,13 @@ public class MessageFormat extends Format {
     }
 
     /**
-     * Generates a hash code for the message format object.
+     * {@return the hash code value for this {@code MessageFormat}}
+     *
+     * The hash code value is based on the String pattern supplied to this
+     * {@code MessageFormat} either during construction or set by
+     * {@link #applyPattern(String)}.
+     *
+     * @see Object#hashCode()
      */
     @Override
     public int hashCode() {

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1146,7 +1146,7 @@ public class MessageFormat extends Format {
      * represent the same formatting configuration. Obeys the general contract of
      * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
      *
-     * @param  obj object to be compared for equality with this {@code MessageFormat}
+     * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code MessageFormat}
      * @see Object#equals(Object)
      */
@@ -1168,7 +1168,7 @@ public class MessageFormat extends Format {
     /**
      * {@return the hash code value for this {@code MessageFormat}}
      *
-     * The hash code value is based on the String pattern supplied to this
+     * The hash code value is based on the string pattern supplied to this
      * {@code MessageFormat} either during construction or set by
      * {@link #applyPattern(String)}.
      *

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1146,7 +1146,7 @@ public class MessageFormat extends Format {
      * two formats would format any value the same.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code MessageFormat}
@@ -1170,8 +1170,8 @@ public class MessageFormat extends Format {
     /**
      * {@return the hash code value for this {@code MessageFormat}}
      *
-     * The hash code value is calculated using any number of fields from the
-     * formatting configuration of this {@code MessageFormat} object.
+     * The hash code value is calculated using the value returned by
+     * {@link #toPattern()}.
      *
      * @see Object#hashCode()
      */
@@ -1235,6 +1235,8 @@ public class MessageFormat extends Format {
     }
 
     // ===========================privates============================
+
+    // Non-transient / non-static fields should be added to hashCode impl
 
     /**
      * The locale to use for formatting numbers and dates.

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1145,9 +1145,10 @@ public class MessageFormat extends Format {
      * Returns true if the object is also a {@code MessageFormat} and the
      * two formats would format any value the same.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code MessageFormat}
      * @see Object#equals(Object)
@@ -1170,9 +1171,8 @@ public class MessageFormat extends Format {
     /**
      * {@return the hash code value for this {@code MessageFormat}}
      *
-     * The hash code value is calculated using the value returned by
+     * @implSpec This method calculates the hash code value using the value returned by
      * {@link #toPattern()}.
-     *
      * @see Object#hashCode()
      */
     @Override

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1236,8 +1236,6 @@ public class MessageFormat extends Format {
 
     // ===========================privates============================
 
-    // Non-transient / non-static fields should be added to hashCode impl
-
     /**
      * The locale to use for formatting numbers and dates.
      * @serial

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1145,9 +1145,9 @@ public class MessageFormat extends Format {
      * Returns true if the object is also a {@code MessageFormat} and the
      * two formats would format any value the same.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code MessageFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -717,7 +717,7 @@ public abstract class NumberFormat extends Format  {
      * two formats would format any value the same.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code NumberFormat}

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -698,7 +698,12 @@ public abstract class NumberFormat extends Format  {
     }
 
     /**
-     * Overrides hashCode.
+     * {@return the hash code for this {@code NumberFormat}}
+     *
+     * The hash code value is based on the values returned by {@link #getMaximumIntegerDigits()}
+     * and {@link #getMaximumFractionDigits()} of this {@code NumberFormat}.
+     *
+     * @see Object#hashCode()
      */
     @Override
     public int hashCode() {
@@ -707,7 +712,14 @@ public abstract class NumberFormat extends Format  {
     }
 
     /**
-     * Overrides equals.
+     * Compares the specified object with this {@code NumberFormat} for equality.
+     * Returns true if the object is also a {@code NumberFormat} and the two Formats
+     * represent the same formatting configuration. Obeys the general contract of
+     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     *
+     * @param  obj object to be compared for equality
+     * @return {@code true} if the specified object is equal to this {@code NumberFormat}
+     * @see Object#equals(Object)
      */
     @Override
     public boolean equals(Object obj) {

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -700,8 +700,8 @@ public abstract class NumberFormat extends Format  {
     /**
      * {@return the hash code for this {@code NumberFormat}}
      *
-     * The hash code value is based on the values returned by {@link #getMaximumIntegerDigits()}
-     * and {@link #getMaximumFractionDigits()}.
+     * The hash code value is calculated using any number of fields from the
+     * formatting configuration of this {@code NumberFormat} object.
      *
      * @see Object#hashCode()
      */
@@ -713,9 +713,12 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Compares the specified object with this {@code NumberFormat} for equality.
-     * Returns true if the object is also a {@code NumberFormat} and the two formats
-     * represent the same formatting configuration.
+     * Returns true if the object is also a {@code NumberFormat} and the
+     * two formats would format any value the same.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code NumberFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -701,7 +701,7 @@ public abstract class NumberFormat extends Format  {
      * {@return the hash code for this {@code NumberFormat}}
      *
      * The hash code value is based on the values returned by {@link #getMaximumIntegerDigits()}
-     * and {@link #getMaximumFractionDigits()} of this {@code NumberFormat}.
+     * and {@link #getMaximumFractionDigits()}.
      *
      * @see Object#hashCode()
      */
@@ -713,9 +713,8 @@ public abstract class NumberFormat extends Format  {
 
     /**
      * Compares the specified object with this {@code NumberFormat} for equality.
-     * Returns true if the object is also a {@code NumberFormat} and the two Formats
-     * represent the same formatting configuration. Obeys the general contract of
-     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     * Returns true if the object is also a {@code NumberFormat} and the two formats
+     * represent the same formatting configuration.
      *
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code NumberFormat}

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -700,9 +700,8 @@ public abstract class NumberFormat extends Format  {
     /**
      * {@return the hash code for this {@code NumberFormat}}
      *
-     * The hash code value is calculated using the values returned by
+     * @implSpec This method calculates the hash code value using the values returned by
      * {@link #getMaximumIntegerDigits()} and {@link #getMaximumFractionDigits()}.
-     *
      * @see Object#hashCode()
      */
     @Override
@@ -716,9 +715,10 @@ public abstract class NumberFormat extends Format  {
      * Returns true if the object is also a {@code NumberFormat} and the
      * two formats would format any value the same.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code NumberFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -700,8 +700,8 @@ public abstract class NumberFormat extends Format  {
     /**
      * {@return the hash code for this {@code NumberFormat}}
      *
-     * The hash code value is calculated using any number of fields from the
-     * formatting configuration of this {@code NumberFormat} object.
+     * The hash code value is calculated using the values returned by
+     * {@link #getMaximumIntegerDigits()} and {@link #getMaximumFractionDigits()}.
      *
      * @see Object#hashCode()
      */
@@ -717,7 +717,7 @@ public abstract class NumberFormat extends Format  {
      * two formats would format any value the same.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code NumberFormat}

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -716,9 +716,9 @@ public abstract class NumberFormat extends Format  {
      * Returns true if the object is also a {@code NumberFormat} and the
      * two formats would format any value the same.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code NumberFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -2429,7 +2429,7 @@ public class SimpleDateFormat extends DateFormat {
      * two formats would format any value the same.
      *
      * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * equality check using {@code getClass} rather than {@code instanceof} when
      * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code SimpleDateFormat}

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -2411,8 +2411,7 @@ public class SimpleDateFormat extends DateFormat {
     /**
      * {@return the hash code value for this {@code SimpleDateFormat}}
      *
-     * The hash code value is based on the value returned by {@link #toPattern()}
-     * of this {@code SimpleDateFormat}.
+     * The hash code value is based on the value returned by {@link #toPattern()}.
      *
      * @see Object#hashCode()
      */
@@ -2427,8 +2426,7 @@ public class SimpleDateFormat extends DateFormat {
      * Compares the specified object with this {@code SimpleDateFormat} for equality.
      * Returns true if the object is also a {@code SimpleDateFormat} and the values
      * returned by {@link #toPattern()} and {@link #getDateFormatSymbols()} of the
-     * two {@code SimpleDateFormat}s are equal. Obeys the general contract of
-     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
+     * two {@code SimpleDateFormat}s are equal.
      *
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code SimpleDateFormat}

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -2409,7 +2409,12 @@ public class SimpleDateFormat extends DateFormat {
     }
 
     /**
-     * {@return the hash code value for this {@code SimpleDateFormat} object}
+     * {@return the hash code value for this {@code SimpleDateFormat}}
+     *
+     * The hash code value is based on the value returned by {@link #toPattern()}
+     * of this {@code SimpleDateFormat}.
+     *
+     * @see Object#hashCode()
      */
     @Override
     public int hashCode()
@@ -2419,11 +2424,15 @@ public class SimpleDateFormat extends DateFormat {
     }
 
     /**
-     * Compares the given object with this {@code SimpleDateFormat} for
-     * equality.
+     * Compares the specified object with this {@code SimpleDateFormat} for equality.
+     * Returns true if the object is also a {@code SimpleDateFormat} and the values
+     * returned by {@link #toPattern()} and {@link #getDateFormatSymbols()} of the
+     * two {@code SimpleDateFormat}s are equal. Obeys the general contract of
+     * {@link java.lang.Object#equals(java.lang.Object) Object.equals}.
      *
-     * @return true if the given object is equal to this
-     * {@code SimpleDateFormat}
+     * @param  obj object to be compared for equality
+     * @return {@code true} if the specified object is equal to this {@code SimpleDateFormat}
+     * @see Object#equals(Object)
      */
     @Override
     public boolean equals(Object obj)

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -2411,7 +2411,8 @@ public class SimpleDateFormat extends DateFormat {
     /**
      * {@return the hash code value for this {@code SimpleDateFormat}}
      *
-     * The hash code value is based on the value returned by {@link #toPattern()}.
+     * The hash code value is calculated using any number of fields from the
+     * formatting configuration of this {@code SimpleDateFormat} object.
      *
      * @see Object#hashCode()
      */
@@ -2424,10 +2425,12 @@ public class SimpleDateFormat extends DateFormat {
 
     /**
      * Compares the specified object with this {@code SimpleDateFormat} for equality.
-     * Returns true if the object is also a {@code SimpleDateFormat} and the values
-     * returned by {@link #toPattern()} and {@link #getDateFormatSymbols()} of the
-     * two {@code SimpleDateFormat}s are equal.
+     * Returns true if the object is also a {@code SimpleDateFormat} and the
+     * two formats would format any value the same.
      *
+     * @implNote Implementers should be aware that the default implementation does an
+     * equality check using {@code getClass} rather than {@code instanceOf} when
+     * deciding if they should override this method.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code SimpleDateFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -2411,9 +2411,8 @@ public class SimpleDateFormat extends DateFormat {
     /**
      * {@return the hash code value for this {@code SimpleDateFormat}}
      *
-     * The hash code value is calculated using the value returned by
+     * @implSpec This method calculates the hash code value using the value returned by
      * {@link #toPattern()}.
-     *
      * @see Object#hashCode()
      */
     @Override
@@ -2428,9 +2427,10 @@ public class SimpleDateFormat extends DateFormat {
      * Returns true if the object is also a {@code SimpleDateFormat} and the
      * two formats would format any value the same.
      *
-     * @implSpec The default implementation performs an equality check with a
-     * notion of class identity based on {@code getClass()}, not {@code instanceof};
-     * overriding methods should do so as well.
+     * @implSpec This method performs an equality check with a notion of class
+     * identity based on {@code getClass()}, rather than {@code instanceof}.
+     * Therefore, in the equals methods in subclasses, no instance of this class
+     * should compare as equal to an instance of a subclass.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code SimpleDateFormat}
      * @see Object#equals(Object)

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -2411,8 +2411,8 @@ public class SimpleDateFormat extends DateFormat {
     /**
      * {@return the hash code value for this {@code SimpleDateFormat}}
      *
-     * The hash code value is calculated using any number of fields from the
-     * formatting configuration of this {@code SimpleDateFormat} object.
+     * The hash code value is calculated using the value returned by
+     * {@link #toPattern()}.
      *
      * @see Object#hashCode()
      */
@@ -2429,7 +2429,7 @@ public class SimpleDateFormat extends DateFormat {
      * two formats would format any value the same.
      *
      * @implSpec The default implementation performs an equality check with a
-     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * notion of class identity based on {@code getClass()}, not {@code instanceof};
      * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code SimpleDateFormat}

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -2428,9 +2428,9 @@ public class SimpleDateFormat extends DateFormat {
      * Returns true if the object is also a {@code SimpleDateFormat} and the
      * two formats would format any value the same.
      *
-     * @implNote Implementers should be aware that the default implementation does an
-     * equality check using {@code getClass} rather than {@code instanceof} when
-     * deciding if they should override this method.
+     * @implSpec The default implementation performs an equality check with a
+     * class identity notion based on {@code getClass()}, not {@code instanceof};
+     * overriding methods should do so as well.
      * @param  obj object to be compared for equality
      * @return {@code true} if the specified object is equal to this {@code SimpleDateFormat}
      * @see Object#equals(Object)


### PR DESCRIPTION
Please review this PR and [CSR](https://bugs.openjdk.org/browse/JDK-8315720) which refines the spec of `equals()` and `hashCode()` in `java.text.Format` related classes.

The current spec for most of these methods is either  "_Overrides <method_name>_" or are incomplete/wrong (i.e. see `ChoiceFormat`).

This fix adjusts the spec to provide a consistent definition for the overridden methods and specify what is being compared/used to generate a hash code value.

For implementations that use at most a few fields, the values are stated, otherwise a more general term is used as a substitution (i.e. see `DecimalFormat`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8315720](https://bugs.openjdk.org/browse/JDK-8315720) to be approved

### Issues
 * [JDK-5066247](https://bugs.openjdk.org/browse/JDK-5066247): Refine the spec of equals() and hashCode() for j.text.Format classes (**Bug** - P4)
 * [JDK-8315720](https://bugs.openjdk.org/browse/JDK-8315720): Refine the spec of equals() and hashCode() for j.text.Format classes (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [e322412c](https://git.openjdk.org/jdk/pull/15459/files/e322412cc148551e1ebf163ddb48cf159dfa2e58)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15459/head:pull/15459` \
`$ git checkout pull/15459`

Update a local copy of the PR: \
`$ git checkout pull/15459` \
`$ git pull https://git.openjdk.org/jdk.git pull/15459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15459`

View PR using the GUI difftool: \
`$ git pr show -t 15459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15459.diff">https://git.openjdk.org/jdk/pull/15459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15459#issuecomment-1696443213)