### PR TITLE
8274122: java/io/File/createTempFile/SpecialTempFile.java fails in Windows 11

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -491,7 +491,6 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 # jdk_io
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
-java/io/File/createTempFile/SpecialTempFile.java                8274122 windows11
 
 ############################################################################
 

--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,12 +99,15 @@ public class SpecialTempFile {
         test("SlashedName", slashPre, slashSuf, true);
 
         // Windows tests
-        if (!System.getProperty("os.name").startsWith("Windows"))
+        String osName = System.getProperty("os.name");
+        if (!osName.startsWith("Windows"))
             return;
 
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        test("ReservedName", resvPre, resvSuf, true);
+        // Windows 11 does not reserve the names "COM" and "LPT1"
+        boolean exceptionExpected = !osName.endsWith("11");
+        test("ReservedName", resvPre, resvSuf, exceptionExpected);
     }
 }

--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -32,10 +32,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class SpecialTempFile {
-
     private static void test(String name, String[] prefix, String[] suffix,
                              boolean exceptionExpected) throws IOException
     {
@@ -48,7 +46,7 @@ public class SpecialTempFile {
         final String exceptionMsg = "Unable to create temporary file";
         String[] dirs = { null, "." };
 
-        Path testPath = Paths.get(System.getProperty("test.dir", "."));
+        Path testPath = Path.of(System.getProperty("test.dir", "."));
         for (int i = 0; i < prefix.length; i++) {
             boolean exceptionThrown = false;
             File f = null;
@@ -106,8 +104,8 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        // Windows 11 does not reserve the names "COM" and "LPT1"
-        boolean exceptionExpected = !osName.endsWith("11");
+        double osVersion = Double.valueOf(System.getProperty("os.version"));
+        boolean exceptionExpected = !(osName.endsWith("11") || osVersion > 10.0);
         test("ReservedName", resvPre, resvSuf, exceptionExpected);
     }
 }

--- a/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
+++ b/test/jdk/java/io/File/createTempFile/SpecialTempFile.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8013827 8011950 8017212 8025128
+ * @modules java.base/jdk.internal.util
  * @summary Check whether File.createTempFile can handle special parameters
  * @author Dan Xu
  */
@@ -32,6 +33,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import jdk.internal.util.OperatingSystem;
+import jdk.internal.util.OSVersion;
 
 public class SpecialTempFile {
     private static void test(String name, String[] prefix, String[] suffix,
@@ -97,15 +101,15 @@ public class SpecialTempFile {
         test("SlashedName", slashPre, slashSuf, true);
 
         // Windows tests
-        String osName = System.getProperty("os.name");
-        if (!osName.startsWith("Windows"))
+        if (!OperatingSystem.isWindows())
             return;
 
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        double osVersion = Double.valueOf(System.getProperty("os.version"));
-        boolean exceptionExpected = !(osName.endsWith("11") || osVersion > 10.0);
+        boolean exceptionExpected =
+            !(System.getProperty("os.name").endsWith("11") ||
+              new OSVersion(10, 0).compareTo(OSVersion.current()) > 0);
         test("ReservedName", resvPre, resvSuf, exceptionExpected);
     }
 }


### PR DESCRIPTION
Windows 11 does not reserve as many names as prior versions of Windows so do not expect exceptions for COM7 and LPT1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8274122](https://bugs.openjdk.org/browse/JDK-8274122): java/io/File/createTempFile/SpecialTempFile.java fails in Windows 11 (**Bug** - P3)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [1d18442c](https://git.openjdk.org/jdk/pull/15460/files/1d18442c40c3b843b14087d99adbe3af468ca9e8)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15460/head:pull/15460` \
`$ git checkout pull/15460`

Update a local copy of the PR: \
`$ git checkout pull/15460` \
`$ git pull https://git.openjdk.org/jdk.git pull/15460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15460`

View PR using the GUI difftool: \
`$ git pr show -t 15460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15460.diff">https://git.openjdk.org/jdk/pull/15460.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15460#issuecomment-1696582206)