### PR TITLE
8303427: Fixpath confused if unix root contains "/jdk"

### DIFF
--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -326,7 +326,9 @@ function convert_path() {
     suffix="${BASH_REMATCH[6]}"
 
     # We only believe this is a path if the first part is an existing directory
-    if [[ -d "/$firstdir" ]];  then
+    # and the prefix is not a subdirectory in the current working directory. Remove
+    # any part leading up to a : or = in the prefix before checking.
+    if [[ -d "/$firstdir" && ! -d "${prefix##*:}" && ! -d "${prefix##*=}" ]];  then
       if [[ $ENVROOT == "" ]]; then
         if [[ $QUIET != true ]]; then
           echo fixpath: failure: Path "'"$pathmatch"'" cannot be converted to Windows path >&2


### PR DESCRIPTION
On Windows, when a directory exists in the "unix" root with the same name as a directory in the "test" dir, fixpath will corrupt test arguments to jtreg (and possibly other arguments as well). Fixpath sees a string like this:
```
test/jdk/foo
```
It looks for the first `/` and checks if the first element following that, until the next `/`, is an existing directory in the unix filesystem root. In this case, the reporter had a directory named "/jdk" which satisfies this heuristic check. This makes fixpath assume that the `/jdk/foo` part is an absolute unix path that needs to be rewritten to a Windows path.

My suggested fix is to look at the prefix part, "test" in this case, and see if that itself is a valid path in the current working directory, as that would indicate that the string is intended to be a relative path.

I think we also need to account for possible prefixes with `:` and `=` here to handle a string like:
```
jtreg:test/jdk/foo
```
In that case we need to remove anything up to the last `:` before we try to match it as a relative directory. (Same thing applies to `=`)

Changing the heuristics of fixpath is rather sensitive and risky. I would appreciate help from people using Windows with trying this patch with some of your regular workflows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303427](https://bugs.openjdk.org/browse/JDK-8303427): Fixpath confused if unix root contains "/jdk" (**Bug** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15461/head:pull/15461` \
`$ git checkout pull/15461`

Update a local copy of the PR: \
`$ git checkout pull/15461` \
`$ git pull https://git.openjdk.org/jdk.git pull/15461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15461`

View PR using the GUI difftool: \
`$ git pr show -t 15461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15461.diff">https://git.openjdk.org/jdk/pull/15461.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15461#issuecomment-1696598046)