### PR TITLE
8315134: javac inference seems to be capturing types incorrectly

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1012,7 +1012,11 @@ public class Types {
      * Is t an unchecked subtype of s?
      */
     public boolean isSubtypeUnchecked(Type t, Type s, Warner warn) {
-        boolean result = isSubtypeUncheckedInternal(t, s, true, warn);
+        return isSubtypeUnchecked(t, s, true, warn);
+    }
+
+    public boolean isSubtypeUnchecked(Type t, Type s, boolean capture, Warner warn) {
+        boolean result = isSubtypeUncheckedInternal(t, s, capture, warn);
         if (result) {
             checkUnsafeVarargsConversion(t, s, warn);
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -1208,7 +1208,7 @@ public class Infer {
         IS_SUBTYPE() {
             @Override
             boolean apply(Type op1, Type op2, Warner warn, Types types) {
-                return types.isSubtypeUnchecked(op1, op2, warn);
+                return types.isSubtypeUnchecked(op1, op2, false, warn);
             }
         },
         IS_SAME_TYPE() {

--- a/test/langtools/tools/javac/generics/inference/7177306/T7177306e.out
+++ b/test/langtools/tools/javac/generics/inference/7177306/T7177306e.out
@@ -1,2 +1,2 @@
-T7177306e.java:16:8: compiler.err.cant.apply.symbol: kindname.method, m, java.util.List<U>, java.util.List<java.util.List<?>>, kindname.class, T7177306e, (compiler.misc.inferred.do.not.conform.to.eq.bounds: java.lang.Object, compiler.misc.type.captureof: 1, ?)
+T7177306e.java:16:8: compiler.err.cant.apply.symbol: kindname.method, m, java.util.List<U>, java.util.List<java.util.List<?>>, kindname.class, T7177306e, (compiler.misc.incompatible.bounds: U, (compiler.misc.eq.bounds: java.util.List<?>), (compiler.misc.upper.bounds: java.util.List<Z>))
 1 error

--- a/test/langtools/tools/javac/generics/inference/DontCaptureBeforeSubtypeCheckTest.java
+++ b/test/langtools/tools/javac/generics/inference/DontCaptureBeforeSubtypeCheckTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8315134
+ * @summary javac inference seems to be capturing types incorrectly
+ * @compile DontCaptureBeforeSubtypeCheckTest.java
+ */
+
+import java.util.*;
+
+public class DontCaptureBeforeSubtypeCheckTest {
+    private static <T> void arrayMethod(List<? super T>[] args) {
+        listMethod(Arrays.asList(args));
+    }
+
+    private static <T> void listMethod(List<List<? super T>> list) {}
+}


### PR DESCRIPTION
this code:

```
import java.util.*;

public class Test {
    private static <T> void arrayMethod(List<? super T>[] args) {
        listMethod(Arrays.asList(args));
    }

    private static <T> void listMethod(List<List<? super T>> list) {}
}
```

is being rejected by the compiler. This code should be accepted according to the spec. The compiler is doing a capture conversion that is not mentioned in the spec while reducing subtyping constraints during type inference. This fix is syncing the compiler with the spec.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315134](https://bugs.openjdk.org/browse/JDK-8315134): javac inference seems to be capturing types incorrectly (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15463/head:pull/15463` \
`$ git checkout pull/15463`

Update a local copy of the PR: \
`$ git checkout pull/15463` \
`$ git pull https://git.openjdk.org/jdk.git pull/15463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15463`

View PR using the GUI difftool: \
`$ git pr show -t 15463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15463.diff">https://git.openjdk.org/jdk/pull/15463.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15463#issuecomment-1696713230)