### PR TITLE
8315195: RISC-V: Update hwprobe query for new extensions

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -45,6 +45,10 @@
 #define RISCV_HWPROBE_KEY_IMA_EXT_0     4
 #define   RISCV_HWPROBE_IMA_FD                  (1 << 0)
 #define   RISCV_HWPROBE_IMA_C                   (1 << 1)
+#define   RISCV_HWPROBE_IMA_V                   (1 << 2)
+#define   RISCV_HWPROBE_EXT_ZBA                 (1 << 3)
+#define   RISCV_HWPROBE_EXT_ZBB                 (1 << 4)
+#define   RISCV_HWPROBE_EXT_ZBS                 (1 << 5)
 
 #define RISCV_HWPROBE_KEY_CPUPERF_0     5
 #define   RISCV_HWPROBE_MISALIGNED_UNKNOWN      (0 << 0)
@@ -128,6 +132,18 @@ void RiscvHwprobe::add_features_from_query_result() {
   }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_IMA_C)) {
     VM_Version::ext_C.enable_feature();
+  }
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_IMA_V)) {
+    VM_Version::ext_V.enable_feature();
+  }
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBA)) {
+    VM_Version::ext_Zba.enable_feature();
+  }
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBB)) {
+    VM_Version::ext_Zbb.enable_feature();
+  }
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBS)) {
+    VM_Version::ext_Zbs.enable_feature();
   }
   if (is_valid(RISCV_HWPROBE_KEY_CPUPERF_0)) {
     VM_Version::unaligned_access.enable_feature(

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -224,22 +224,9 @@ void VM_Version::vendor_features() {
 
 void VM_Version::rivos_features() {
   // Enable common features not dependent on marchid/mimpid.
-  ext_I.enable_feature();
-  ext_M.enable_feature();
-  ext_A.enable_feature();
-  ext_F.enable_feature();
-  ext_D.enable_feature();
-  ext_C.enable_feature();
-  ext_H.enable_feature();
-  ext_V.enable_feature();
-
   ext_Zicbom.enable_feature();
   ext_Zicboz.enable_feature();
   ext_Zicbop.enable_feature();
-
-  ext_Zba.enable_feature();
-  ext_Zbb.enable_feature();
-  ext_Zbs.enable_feature();
 
   ext_Zicsr.enable_feature();
   ext_Zifencei.enable_feature();

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -228,6 +228,11 @@ void VM_Version::rivos_features() {
   ext_Zicboz.enable_feature();
   ext_Zicbop.enable_feature();
 
+  // If we running on a pre-6.5 kernel
+  ext_Zba.enable_feature();
+  ext_Zbb.enable_feature();
+  ext_Zbs.enable_feature();
+
   ext_Zicsr.enable_feature();
   ext_Zifencei.enable_feature();
   ext_Zic64b.enable_feature();


### PR DESCRIPTION
Hi all, please consider.

Linux 6.5 added new extensions to hwprobe.
Manually tested with qemu patch: https://lists.nongnu.org/archive/html/qemu-devel/2023-08/msg04784.html
And https://bugs.openjdk.org/browse/JDK-8315206 applied.

Also cleanup vendor path, the goal is to only have vendor specific extension in vendor paths.
But since we also have older kernels we need to support them also.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315195](https://bugs.openjdk.org/browse/JDK-8315195): RISC-V: Update hwprobe query for new extensions (**Enhancement** - P3)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) - Committer ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15465/head:pull/15465` \
`$ git checkout pull/15465`

Update a local copy of the PR: \
`$ git checkout pull/15465` \
`$ git pull https://git.openjdk.org/jdk.git pull/15465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15465`

View PR using the GUI difftool: \
`$ git pr show -t 15465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15465.diff">https://git.openjdk.org/jdk/pull/15465.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15465#issuecomment-1696894946)