### PR TITLE
JDK-8315213: java/lang/ProcessHandle/TreeTest.java test enhance output of children

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/TreeTest.java
+++ b/test/jdk/java/lang/ProcessHandle/TreeTest.java
@@ -456,9 +456,9 @@ public class TreeTest extends ProcessUtil {
             Assert.assertTrue(count >= totalChildren,
                     "expected at least " + totalChildren + ", actual: " + count);
 
-            subprocesses = getDescendants(p1Handle);
+            List<ProcessHandle> descSubprocesses = getDescendants(p1Handle);
             printf(" descendants:  %s%n",
-                    subprocesses.stream().map(p -> p.pid())
+                    descSubprocesses.stream().map(p -> p.pid())
                     .collect(Collectors.toList()));
 
             p1.getOutputStream().close();  // Close stdin for the controlling p1

--- a/test/jdk/java/lang/ProcessHandle/TreeTest.java
+++ b/test/jdk/java/lang/ProcessHandle/TreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -444,6 +444,11 @@ public class TreeTest extends ProcessUtil {
                 Assert.assertEquals(0, count, "Extra processes in descendants");
             }
 
+            List<ProcessHandle> subprocesses = getChildren(p1Handle);
+            printf(" children:  %s%n",
+                    subprocesses.stream().map(p -> p.pid())
+                    .collect(Collectors.toList()));
+
             Assert.assertEquals(getChildren(p1Handle).size(),
                     factor, "expected direct children");
             count = getDescendants(p1Handle).size();
@@ -451,7 +456,7 @@ public class TreeTest extends ProcessUtil {
             Assert.assertTrue(count >= totalChildren,
                     "expected at least " + totalChildren + ", actual: " + count);
 
-            List<ProcessHandle> subprocesses = getDescendants(p1Handle);
+            subprocesses = getDescendants(p1Handle);
             printf(" descendants:  %s%n",
                     subprocesses.stream().map(p -> p.pid())
                     .collect(Collectors.toList()));


### PR DESCRIPTION
We have some failures in TreeTest.java where the expected number of child processes is differing from what we really get. It would be good to have more output to analyze these cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315213](https://bugs.openjdk.org/browse/JDK-8315213): java/lang/ProcessHandle/TreeTest.java test enhance output of children (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15466/head:pull/15466` \
`$ git checkout pull/15466`

Update a local copy of the PR: \
`$ git checkout pull/15466` \
`$ git pull https://git.openjdk.org/jdk.git pull/15466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15466`

View PR using the GUI difftool: \
`$ git pr show -t 15466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15466.diff">https://git.openjdk.org/jdk/pull/15466.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15466#issuecomment-1696957728)