### PR TITLE
JDK-8315214: Do not run sun/tools/jhsdb tests concurrently

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -31,7 +31,7 @@ exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
-com/sun/net/httpserver/simpleserver
+com/sun/net/httpserver/simpleserver sun/tools/jhsdb
 
 # Group definitions
 groups=TEST.groups


### PR DESCRIPTION
The sun/tools/jhsdb tests have issues when we run them concurrently .
So add a related config to TEST.root.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315214](https://bugs.openjdk.org/browse/JDK-8315214): Do not run sun/tools/jhsdb tests concurrently (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15469/head:pull/15469` \
`$ git checkout pull/15469`

Update a local copy of the PR: \
`$ git checkout pull/15469` \
`$ git pull https://git.openjdk.org/jdk.git pull/15469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15469`

View PR using the GUI difftool: \
`$ git pr show -t 15469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15469.diff">https://git.openjdk.org/jdk/pull/15469.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15469#issuecomment-1697489004)