### PR TITLE
8315239: Problemlist test/jdk/javax/rmi/ssl/SSLSocketParametersTest.java for Virtual Threads on Windows

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -37,20 +37,17 @@ sun/tools/jcmd/JcmdOutputEncodingTest.java 8308033 generic-all
 sun/tools/jstack/BasicJStackTest.java 8308033 generic-all
 
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8308035 windows-x64
-
 javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-x64
-
 javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x64
+javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x64
+javax/management/remote/mandatory/connection/ConnectionTest.java 8308352 windows-x64
+javax/rmi/ssl/SSLSocketParametersTest.java 8314695 windows-x64
 
 java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
 
 java/lang/ScopedValue/StressStackOverflow.java#default 8309646 generic-all
 java/lang/ScopedValue/StressStackOverflow.java#no-TieredCompilation 8309646 generic-all
 java/lang/ScopedValue/StressStackOverflow.java#TieredStopAtLevel1 8309646 generic-all
-
-javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x64
-
-javax/management/remote/mandatory/connection/ConnectionTest.java 8308352 windows-x64
 
 ##########
 ## Tests incompatible with virtual test thread factory.


### PR DESCRIPTION
SSLSocketParametersTest.java is occasionally observed to hang on Windows during a network call, when jtreg starts the test from a Virtual Thread.  Problemlist this test, as has been done to others with the same symptom.

Change the grouping of the management tests in the virtual problem list file, to collect these together which all appear to be the same problem:

javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8308035 windows-x64
javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-x64
javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x64
javax/management/remote/mandatory/connection/DeadLockTest.java 8309069 windows-x64
javax/management/remote/mandatory/connection/ConnectionTest.java 8308352 windows-x64
javax/rmi/ssl/SSLSocketParametersTest.java 8314695 windows-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315239](https://bugs.openjdk.org/browse/JDK-8315239): Problemlist test/jdk/javax/rmi/ssl/SSLSocketParametersTest.java for Virtual Threads on Windows (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15471/head:pull/15471` \
`$ git checkout pull/15471`

Update a local copy of the PR: \
`$ git checkout pull/15471` \
`$ git pull https://git.openjdk.org/jdk.git pull/15471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15471`

View PR using the GUI difftool: \
`$ git pr show -t 15471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15471.diff">https://git.openjdk.org/jdk/pull/15471.diff</a>

</details>
