### PR TITLE
8315242: G1: Fix -Wconversion warnings around GCDrainStackTargetSize

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2317,9 +2317,9 @@ void G1CMTask::drain_local_queue(bool partially) {
   // Decide what the target size is, depending whether we're going to
   // drain it partially (so that other tasks can steal if they run out
   // of things to do) or totally (at the very end).
-  size_t target_size;
+  uint target_size;
   if (partially) {
-    target_size = MIN2((size_t)_task_queue->max_elems()/3, GCDrainStackTargetSize);
+    target_size = MIN2(_task_queue->max_elems()/3, GCDrainStackTargetSize);
   } else {
     target_size = 0;
   }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2319,7 +2319,7 @@ void G1CMTask::drain_local_queue(bool partially) {
   // of things to do) or totally (at the very end).
   uint target_size;
   if (partially) {
-    target_size = MIN2(_task_queue->max_elems()/3, GCDrainStackTargetSize);
+    target_size = MIN2(_task_queue->max_elems() / 3, GCDrainStackTargetSize);
   } else {
     target_size = 0;
   }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -178,15 +178,13 @@ PSPromotionManager::PSPromotionManager() {
   // We set the old lab's start array.
   _old_lab.set_start_array(old_gen()->start_array());
 
-  uint queue_size;
-  queue_size = claimed_stack_depth()->max_elems();
+  uint queue_size = claimed_stack_depth()->max_elems();
 
   if (ParallelGCThreads == 1) {
     _target_stack_size = 0;
   } else {
     // don't let the target stack size to be more than 1/4 of the entries
-    _target_stack_size = (uint) MIN2((uint) GCDrainStackTargetSize,
-                                     (uint) (queue_size / 4));
+    _target_stack_size = MIN2(GCDrainStackTargetSize, (queue_size / 4));
   }
 
   _array_chunk_size = ParGCArrayScanChunk;

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -684,10 +684,10 @@
   develop(uintx, GCExpandToAllocateDelayMillis, 0,                          \
           "Delay between expansion and allocation (in milliseconds)")       \
                                                                             \
-  product(uint, GCDrainStackTargetSize, 64,                                \
+  product(uint, GCDrainStackTargetSize, 64,                                 \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, (max_juint-1)/2)                                               \
+          range(0, (UINT_MAX - 1) / 2)                                      \
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -684,10 +684,10 @@
   develop(uintx, GCExpandToAllocateDelayMillis, 0,                          \
           "Delay between expansion and allocation (in milliseconds)")       \
                                                                             \
-  product(uintx, GCDrainStackTargetSize, 64,                                \
+  product(uint, GCDrainStackTargetSize, 64,                                \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, max_juint)                                               \
+          range(0, (max_juint-1)/2)                                               \
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1044,7 +1044,7 @@ const int      badCodeHeapFreeVal = 0xDD;                   // value used to zap
 #define       badHeapWord       (::badHeapWordVal)
 
 // Default TaskQueue size is 16K (32-bit) or 128K (64-bit)
-const size_t TASKQUEUE_SIZE = (NOT_LP64(1<<14) LP64_ONLY(1<<17));
+const uint TASKQUEUE_SIZE = (NOT_LP64(1<<14) LP64_ONLY(1<<17));
 
 //----------------------------------------------------------------------------------------------------
 // Utility functions for bitfield manipulations


### PR DESCRIPTION
Use more precise type and range for `GCDrainStackTargetSize`.

The change to `TASKQUEUE_SIZE` is there, because they are used in the same `MIN2`. (All uses expect `TASKQUEUE_SIZE` to be `uint` as well.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315242](https://bugs.openjdk.org/browse/JDK-8315242): G1: Fix -Wconversion warnings around GCDrainStackTargetSize (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15472/head:pull/15472` \
`$ git checkout pull/15472`

Update a local copy of the PR: \
`$ git checkout pull/15472` \
`$ git pull https://git.openjdk.org/jdk.git pull/15472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15472`

View PR using the GUI difftool: \
`$ git pr show -t 15472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15472.diff">https://git.openjdk.org/jdk/pull/15472.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15472#issuecomment-1697772903)