### PR TITLE
8313718: make container at requires command configurable

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -535,7 +535,7 @@ public class VMProps implements Callable<Map<String, String>> {
     protected String dockerSupport() {
         log("Entering dockerSupport()");
 
-        boolean isSupported = false;
+        boolean isSupported = true;
         if (Platform.isLinux()) {
            // currently docker testing is only supported for Linux,
            // on certain platforms
@@ -612,8 +612,10 @@ public class VMProps implements Callable<Map<String, String>> {
         if (Container.CONTAINER_REQUIRES_COMMAND.isEmpty()) {
             return true;
         }
+        String unescaped = Container.CONTAINER_REQUIRES_COMMAND.replace("\\u0020", " ");
+        log("checkContainerSupport(): unescaped = " + unescaped);
 
-        List<String> args = Arrays.asList(Container.CONTAINER_REQUIRES_COMMAND.split(" "));
+        List<String> args = Arrays.asList(unescaped.split(" "));
         ProcessBuilder pb = new ProcessBuilder(args);
         Map<String, String> logFileNames = redirectOutputToLogFile("checkContainerSupport(): <container command> ",
                                                       pb, "container-command");

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -535,7 +535,7 @@ public class VMProps implements Callable<Map<String, String>> {
     protected String containerSupport() {
         log("Entering containerSupport()");
 
-        boolean isSupported = true;
+        boolean isSupported = false;
         if (Platform.isLinux()) {
            // currently container testing is only supported for Linux,
            // on certain platforms

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -130,7 +130,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.libgraal.enabled", this::isLibgraalEnabled);
         map.put("vm.compiler1.enabled", this::isCompiler1Enabled);
         map.put("vm.compiler2.enabled", this::isCompiler2Enabled);
-        map.put("docker.support", this::dockerSupport);
+        map.put("docker.support", this::containerSupport);
         map.put("vm.musl", this::isMusl);
         map.put("release.implementor", this::implementor);
         map.put("jdk.containerized", this::jdkContainerized);
@@ -528,16 +528,16 @@ public class VMProps implements Callable<Map<String, String>> {
     }
 
     /**
-     * A simple check for docker support
+     * A simple check for container support
      *
-     * @return true if docker is supported in a given environment
+     * @return true if container subsystem is supported in a given environment
      */
-    protected String dockerSupport() {
-        log("Entering dockerSupport()");
+    protected String containerSupport() {
+        log("Entering containerSupport()");
 
         boolean isSupported = true;
         if (Platform.isLinux()) {
-           // currently docker testing is only supported for Linux,
+           // currently container testing is only supported for Linux,
            // on certain platforms
 
            String arch = System.getProperty("os.arch");
@@ -553,7 +553,7 @@ public class VMProps implements Callable<Map<String, String>> {
            }
         }
 
-        log("dockerSupport(): platform check: isSupported = " + isSupported);
+        log("containerSupport(): platform check: isSupported = " + isSupported);
 
         if (isSupported) {
            try {
@@ -563,7 +563,7 @@ public class VMProps implements Callable<Map<String, String>> {
            }
          }
 
-        log("dockerSupport(): returning isSupported = " + isSupported);
+        log("containerSupport(): returning isSupported = " + isSupported);
         return "" + isSupported;
     }
 

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -605,7 +605,7 @@ public class VMProps implements Callable<Map<String, String>> {
         log("checkContainerSupport(): entering");
 
         // Consult CONTAINER_REQUIRES_COMMAND first.
-        // See open/test/lib/jdk/test/lib/Container.java
+        // See test/lib/jdk/test/lib/Container.java
         log("checkContainerSupport(): CONTAINER_REQUIRES_COMMAND = "
             + Container.CONTAINER_REQUIRES_COMMAND);
         // If not defined or empty no check is needed; OK to run container tests.
@@ -613,13 +613,14 @@ public class VMProps implements Callable<Map<String, String>> {
             return true;
         }
         String unescaped = Container.CONTAINER_REQUIRES_COMMAND.replace("\\u0020", " ");
-        log("checkContainerSupport(): unescaped = " + unescaped);
+        log("checkContainerSupport(): unescaped = <" + unescaped + ">");
 
         List<String> args = Arrays.asList(unescaped.split(" "));
         ProcessBuilder pb = new ProcessBuilder(args);
         Map<String, String> logFileNames = redirectOutputToLogFile("checkContainerSupport(): <container command> ",
                                                       pb, "container-command");
         Process p = pb.start();
+        log("checkContainerSupport(): started: " + p.info().commandLine());
         p.waitFor(10, TimeUnit.SECONDS);
         int exitValue = p.exitValue();
 

--- a/test/lib/jdk/test/lib/Container.java
+++ b/test/lib/jdk/test/lib/Container.java
@@ -35,6 +35,7 @@ public class Container {
     // Use this property to specify command used to detect the ability to run
     // container testing on a given system. The command will be used by jtreg
     // "at requires" extention.
+    // Use unicode "\\u0020" to escape spaces between parameters.
     // If not specified or empty then container testing will proceed w/o any checks.
     // Default value is "<ENGINE_COMMAND> ps" as in "docker ps".
     public static final String CONTAINER_REQUIRES_COMMAND =

--- a/test/lib/jdk/test/lib/Container.java
+++ b/test/lib/jdk/test/lib/Container.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Red Hat Inc.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +24,19 @@
 package jdk.test.lib;
 
 public class Container {
-    // Use this property to specify docker location on your system.
-    // E.g.: "/usr/local/bin/docker". We define this constant here so
+    // Use this property to specify container command on your system.
+    // You may specify either short command or full path.
+    // E.g.: "/usr/local/bin/docker", "podman".  We define this constant here so
     // that it can be used in VMProps as well which checks docker support
     // via this command
     public static final String ENGINE_COMMAND =
         System.getProperty("jdk.test.container.command", "docker");
+
+    // Use this property to specify command used to detect the ability to run
+    // container testing on a given system. The command will be used by jtreg
+    // "at requires" extention.
+    // If not specified or empty then container testing will proceed w/o any checks.
+    // Default value is "<ENGINE_COMMAND> ps" as in "docker ps".
+    public static final String CONTAINER_REQUIRES_COMMAND =
+        System.getProperty("jdk.test.container.requires.command", ENGINE_COMMAND + " ps");
 }


### PR DESCRIPTION
Container ecosystem is growing. It would be beneficial to define custom command to figure out whether a specific test host or environment allows for container testing. This enhancement seeks to make the command used by jtreg "requires" extension configurable, specifically test/jtreg-ext/requires/VMProps.java checkContainerSupport().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313718](https://bugs.openjdk.org/browse/JDK-8313718): make container at requires command configurable (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15475/head:pull/15475` \
`$ git checkout pull/15475`

Update a local copy of the PR: \
`$ git checkout pull/15475` \
`$ git pull https://git.openjdk.org/jdk.git pull/15475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15475`

View PR using the GUI difftool: \
`$ git pr show -t 15475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15475.diff">https://git.openjdk.org/jdk/pull/15475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15475#issuecomment-1698210670)