### PR TITLE
8313277: Resolve multiple definition of 'normalize' when statically linking JDK native libraries with user code

### DIFF
--- a/src/java.instrument/share/native/libinstrument/FileSystemSupport.h
+++ b/src/java.instrument/share/native/libinstrument/FileSystemSupport.h
@@ -31,26 +31,26 @@
  * still has slash separators; code in the File class will translate them
  * after this method returns.
  */
-char* FFS_fromURIPath(const char* path);
+char* fromURIPath(const char* path);
 
 /**
  * Return the basen path of the given pathname. If the string is already
  * the base path then it is simply returned.
  */
-char* FFS_basePath(const char* path);
+char* basePath(const char* path);
 
 /**
  * Convert the given pathname string to normal form.  If the string is
  * already in normal form then it is simply returned.
  */
-char* FFS_normalize(const char* path);
+char* normalize_path(const char* path);
 
 /**
  * Tell whether or not the given abstract pathname is absolute.
  */
-int FFS_isAbsolute(const char * path);
+int isAbsolute(const char * path);
 
 /**
  * Resolve the child pathname string against the parent.
  */
-char* FFS_resolve(const char* parent, const char* child);
+char* resolve(const char* parent, const char* child);

--- a/src/java.instrument/share/native/libinstrument/FileSystemSupport.h
+++ b/src/java.instrument/share/native/libinstrument/FileSystemSupport.h
@@ -31,26 +31,26 @@
  * still has slash separators; code in the File class will translate them
  * after this method returns.
  */
-char* fromURIPath(const char* path);
+char* FFS_fromURIPath(const char* path);
 
 /**
  * Return the basen path of the given pathname. If the string is already
  * the base path then it is simply returned.
  */
-char* basePath(const char* path);
+char* FFS_basePath(const char* path);
 
 /**
  * Convert the given pathname string to normal form.  If the string is
  * already in normal form then it is simply returned.
  */
-char* normalize(const char* path);
+char* FFS_normalize(const char* path);
 
 /**
  * Tell whether or not the given abstract pathname is absolute.
  */
-int isAbsolute(const char * path);
+int FFS_isAbsolute(const char * path);
 
 /**
  * Resolve the child pathname string against the parent.
  */
-char* resolve(const char* parent, const char* child);
+char* FFS_resolve(const char* parent, const char* child);

--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -918,13 +918,13 @@ appendBootClassPath( JPLISAgent* agent,
          * Post-process the URI path - needed on Windows to transform
          * /c:/foo to c:/foo.
          */
-        TRANSFORM(path, fromURIPath(path));
+        TRANSFORM(path, FFS_fromURIPath(path));
 
         /*
          * Normalize the path - no duplicate slashes (except UNCs on Windows), trailing
          * slash removed.
          */
-        TRANSFORM(path, normalize(path));
+        TRANSFORM(path, FFS_normalize(path));
 
         /*
          * If the path is an absolute path then add to the bootclassloader
@@ -936,7 +936,7 @@ appendBootClassPath( JPLISAgent* agent,
          * In 1.5.0 the AddToBootstrapClassLoaderSearch takes a platform string
          * - see 5049313.
          */
-        if (isAbsolute(path)) {
+        if (FFS_isAbsolute(path)) {
             jvmtierr = (*jvmtienv)->AddToBootstrapClassLoaderSearch(jvmtienv, path);
         } else {
             char* resolved;
@@ -947,12 +947,12 @@ appendBootClassPath( JPLISAgent* agent,
                     free(path);
                     continue;
                 }
-                parent = basePath(canonicalPath);
+                parent = FFS_basePath(canonicalPath);
                 jplis_assert(parent != (char*)NULL);
                 haveBasePath = 1;
             }
 
-            resolved = resolve(parent, path);
+            resolved = FFS_resolve(parent, path);
             jvmtierr = (*jvmtienv)->AddToBootstrapClassLoaderSearch(jvmtienv, resolved);
             free(resolved);
         }

--- a/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
+++ b/src/java.instrument/share/native/libinstrument/InvocationAdapter.c
@@ -918,13 +918,13 @@ appendBootClassPath( JPLISAgent* agent,
          * Post-process the URI path - needed on Windows to transform
          * /c:/foo to c:/foo.
          */
-        TRANSFORM(path, FFS_fromURIPath(path));
+        TRANSFORM(path, fromURIPath(path));
 
         /*
          * Normalize the path - no duplicate slashes (except UNCs on Windows), trailing
          * slash removed.
          */
-        TRANSFORM(path, FFS_normalize(path));
+        TRANSFORM(path, normalize_path(path));
 
         /*
          * If the path is an absolute path then add to the bootclassloader
@@ -936,7 +936,7 @@ appendBootClassPath( JPLISAgent* agent,
          * In 1.5.0 the AddToBootstrapClassLoaderSearch takes a platform string
          * - see 5049313.
          */
-        if (FFS_isAbsolute(path)) {
+        if (isAbsolute(path)) {
             jvmtierr = (*jvmtienv)->AddToBootstrapClassLoaderSearch(jvmtienv, path);
         } else {
             char* resolved;
@@ -947,12 +947,12 @@ appendBootClassPath( JPLISAgent* agent,
                     free(path);
                     continue;
                 }
-                parent = FFS_basePath(canonicalPath);
+                parent = basePath(canonicalPath);
                 jplis_assert(parent != (char*)NULL);
                 haveBasePath = 1;
             }
 
-            resolved = FFS_resolve(parent, path);
+            resolved = resolve(parent, path);
             jvmtierr = (*jvmtienv)->AddToBootstrapClassLoaderSearch(jvmtienv, resolved);
             free(resolved);
         }

--- a/src/java.instrument/unix/native/libinstrument/FileSystemSupport_md.c
+++ b/src/java.instrument/unix/native/libinstrument/FileSystemSupport_md.c
@@ -35,7 +35,7 @@
 
 #define slash           '/'
 
-char* FFS_basePath(const char* path) {
+char* basePath(const char* path) {
     char* last = strrchr(path, slash);
     if (last == NULL) {
         return (char*)path;
@@ -54,7 +54,7 @@ char* FFS_basePath(const char* path) {
     }
 }
 
-int FFS_isAbsolute(const char* path) {
+int isAbsolute(const char* path) {
     return (path[0] == slash) ? 1 : 0;
 }
 
@@ -100,7 +100,7 @@ static char* normalizePath(const char* pathname, int len, int off) {
 /* Check that the given pathname is normal.  If not, invoke the real
    normalizer on the part of the pathname that requires normalization.
    This way we iterate through the whole pathname string only once. */
-char* FFS_normalize(const char* pathname) {
+char* normalize_path(const char* pathname) {
     int i;
     int n = strlen(pathname);
     char prevChar = 0;
@@ -114,7 +114,7 @@ char* FFS_normalize(const char* pathname) {
     return (char*)pathname;
 }
 
-char* FFS_resolve(const char* parent, const char* child) {
+char* resolve(const char* parent, const char* child) {
     int len;
     char* theChars;
     int pn = strlen(parent);
@@ -153,7 +153,7 @@ char* FFS_resolve(const char* parent, const char* child) {
     return theChars;
 }
 
-char* FFS_fromURIPath(const char* path) {
+char* fromURIPath(const char* path) {
     int len = strlen(path);
     if (len > 1 && path[len-1] == slash) {
         // "/foo/" --> "/foo", but "/" --> "/"

--- a/src/java.instrument/unix/native/libinstrument/FileSystemSupport_md.c
+++ b/src/java.instrument/unix/native/libinstrument/FileSystemSupport_md.c
@@ -35,7 +35,7 @@
 
 #define slash           '/'
 
-char* basePath(const char* path) {
+char* FFS_basePath(const char* path) {
     char* last = strrchr(path, slash);
     if (last == NULL) {
         return (char*)path;
@@ -54,7 +54,7 @@ char* basePath(const char* path) {
     }
 }
 
-int isAbsolute(const char* path) {
+int FFS_isAbsolute(const char* path) {
     return (path[0] == slash) ? 1 : 0;
 }
 
@@ -100,7 +100,7 @@ static char* normalizePath(const char* pathname, int len, int off) {
 /* Check that the given pathname is normal.  If not, invoke the real
    normalizer on the part of the pathname that requires normalization.
    This way we iterate through the whole pathname string only once. */
-char* normalize(const char* pathname) {
+char* FFS_normalize(const char* pathname) {
     int i;
     int n = strlen(pathname);
     char prevChar = 0;
@@ -114,7 +114,7 @@ char* normalize(const char* pathname) {
     return (char*)pathname;
 }
 
-char* resolve(const char* parent, const char* child) {
+char* FFS_resolve(const char* parent, const char* child) {
     int len;
     char* theChars;
     int pn = strlen(parent);
@@ -153,7 +153,7 @@ char* resolve(const char* parent, const char* child) {
     return theChars;
 }
 
-char* fromURIPath(const char* path) {
+char* FFS_fromURIPath(const char* path) {
     int len = strlen(path);
     if (len > 1 && path[len-1] == slash) {
         // "/foo/" --> "/foo", but "/" --> "/"

--- a/src/java.instrument/windows/native/libinstrument/FileSystemSupport_md.c
+++ b/src/java.instrument/windows/native/libinstrument/FileSystemSupport_md.c
@@ -45,7 +45,7 @@ static int isLetter(char c) {
     return ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z'));
 }
 
-char* FFS_basePath(const char* path) {
+char* basePath(const char* path) {
     char* pos = strchr(path, slash);
     char* last = NULL;
     while (pos != NULL) {
@@ -196,7 +196,7 @@ static char* normalizePath(const char* path, int len, int off) {
  * normalizer on the part of the pathname that requires normalization.
  * This way we iterate through the whole pathname string only once.
  */
-char* FFS_normalize(char* path) {
+char* normalize_path(char* path) {
     int n = (int)strlen(path);
     int i;
     int prev = 0;
@@ -219,7 +219,7 @@ char* FFS_normalize(char* path) {
 /* -- Resolution - src/windows/classes/java/io/Win32FileSystem.java */
 
 
-char* FFS_resolve(const char* parent, const char* child) {
+char* resolve(const char* parent, const char* child) {
     char* c;
     char* theChars;
     int parentEnd, childStart, len;
@@ -302,13 +302,13 @@ static int prefixLength(const char* path) {
 }
 
 
-int FFS_isAbsolute(const char* path) {
+int isAbsolute(const char* path) {
     int pl = prefixLength(path);
     return (((pl == 2) && (path[0] == slash)) || (pl == 3));
 }
 
 
-char* FFS_fromURIPath(const char* path) {
+char* fromURIPath(const char* path) {
     int start = 0;
     int len = (int)strlen(path);
 

--- a/src/java.instrument/windows/native/libinstrument/FileSystemSupport_md.c
+++ b/src/java.instrument/windows/native/libinstrument/FileSystemSupport_md.c
@@ -45,7 +45,7 @@ static int isLetter(char c) {
     return ((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z'));
 }
 
-char* basePath(const char* path) {
+char* FFS_basePath(const char* path) {
     char* pos = strchr(path, slash);
     char* last = NULL;
     while (pos != NULL) {
@@ -196,7 +196,7 @@ static char* normalizePath(const char* path, int len, int off) {
  * normalizer on the part of the pathname that requires normalization.
  * This way we iterate through the whole pathname string only once.
  */
-char* normalize(char* path) {
+char* FFS_normalize(char* path) {
     int n = (int)strlen(path);
     int i;
     int prev = 0;
@@ -219,7 +219,7 @@ char* normalize(char* path) {
 /* -- Resolution - src/windows/classes/java/io/Win32FileSystem.java */
 
 
-char* resolve(const char* parent, const char* child) {
+char* FFS_resolve(const char* parent, const char* child) {
     char* c;
     char* theChars;
     int parentEnd, childStart, len;
@@ -302,13 +302,13 @@ static int prefixLength(const char* path) {
 }
 
 
-int isAbsolute(const char* path) {
+int FFS_isAbsolute(const char* path) {
     int pl = prefixLength(path);
     return (((pl == 2) && (path[0] == slash)) || (pl == 3));
 }
 
 
-char* fromURIPath(const char* path) {
+char* FFS_fromURIPath(const char* path) {
     int start = 0;
     int len = (int)strlen(path);
 


### PR DESCRIPTION
Please review this simple change from @cjmoon1 for resolving static linking issue caused by multiple definition of 'normalize'. @cjmoon1's branch can be found at: https://github.com/openjdk/jdk/compare/master...cjmoon1:jdk:fix_normalize.

The change incorporated suggestions from both @sspitsyn and myself:

- https://bugs.openjdk.org/browse/JDK-8313277?focusedCommentId=14604187&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14604187
- https://bugs.openjdk.org/browse/JDK-8313277?focusedCommentId=14604187&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14604187

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313277](https://bugs.openjdk.org/browse/JDK-8313277): Resolve multiple definition of 'normalize' when statically linking JDK native libraries with user code (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Contributors
 * Chris Moon `<cjmoon@google.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15477/head:pull/15477` \
`$ git checkout pull/15477`

Update a local copy of the PR: \
`$ git checkout pull/15477` \
`$ git pull https://git.openjdk.org/jdk.git pull/15477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15477`

View PR using the GUI difftool: \
`$ git pr show -t 15477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15477.diff">https://git.openjdk.org/jdk/pull/15477.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15477#issuecomment-1698282853)