### PR TITLE
JDK-8315248: AssertionError in Name.compareTo

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Utf8NameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Utf8NameTable.java
@@ -25,8 +25,6 @@
 
 package com.sun.tools.javac.util;
 
-import com.sun.tools.javac.util.DefinedBy.Api;
-
 /**
  * Support superclass for {@link Name.Table} implementations that store
  * names as Modified UTF-8 data in {@code byte[]} arrays.
@@ -132,13 +130,16 @@ public abstract class Utf8NameTable extends Name.Table {
         public int compareTo(Name name0) {
             // While most operations on Name that take a Name as an argument expect the argument
             // to come from the same table, in many cases, including here, that is not strictly
-            // required. Moreover, java.util.Name implements javax.lang.model.element.Name,
+            // required. Moreover, javac.util.Name implements javax.lang.model.element.Name,
             // which extends CharSequence, which provides
             //   static int compare(CharSequence cs1, CharSequence cs2)
-            // which ends up calling to this method when the two arguments have the same class.
-            // Therefore, for this method, we relax "same table" to "same class".
-            Assert.check(name0.getClass() == getClass());
-            NameImpl name = (NameImpl)name0;
+            // which ends up calling to this method via the Comparable<Object> interface
+            // and a bridge method when the two arguments have the same class.
+            // Therefore, for this method, we relax "same table", and delegate to the more
+            // general super method if necessary.
+            if (!(name0 instanceof NameImpl name)) {
+                return super.compareTo(name0);
+            }
             byte[] buf1 = getByteData();
             byte[] buf2 = name.getByteData();
             int off1 = getByteOffset();

--- a/test/langtools/tools/javac/nametable/TestNameTables.java
+++ b/test/langtools/tools/javac/nametable/TestNameTables.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8315248
+ * @summary AssertionError in Name.compareTo
+ * @modules jdk.compiler/com.sun.tools.javac.util
+ *
+ * @run main TestNameTables
+ */
+
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Objects;
+
+import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Name;
+import com.sun.tools.javac.util.Names;
+import com.sun.tools.javac.util.Options;
+
+/**
+ * Tests that CharSequence.compareTo works on CharSequence objects that may
+ * come from different name tables.
+ *
+ * While the java.util.Name class generally specifies that operations involving
+ * multiple Name objects should use names from the same table, that restriction
+ * is harder to specify when the names are widened CharSequence objects.
+ *
+ * The test can be extended if necessary to cover other methods on Name,
+ * if the restrictions on Name are relaxed to permit more mix-and-match usages.
+ */
+public class TestNameTables {
+    public static void main(String... args) {
+        new TestNameTables().run();
+    }
+
+    public static final String USE_SHARED_TABLE = "useSharedTable";
+    public static final String USE_UNSHARED_TABLE = "useUnsharedTable";
+    public static final String USE_STRING_TABLE = "useStringTable";
+
+    public final List<String> ALL_TABLES = List.of(USE_SHARED_TABLE, USE_UNSHARED_TABLE, USE_STRING_TABLE);
+
+    private final PrintStream out = System.err;
+
+    void run() {
+        for (var s : ALL_TABLES) {
+            test(createNameTable(s));
+        }
+
+        for (var s1 : ALL_TABLES) {
+            for (var s2 : ALL_TABLES) {
+                test(createNameTable(s1), createNameTable(s2));
+            }
+        }
+    }
+
+    Name.Table createNameTable(String option) {
+        Context c = new Context();
+        Options o = Options.instance(c);
+        o.put(option, "true");
+        Names n = new Names(c);
+        return n.table;
+    }
+
+    /**
+     * Tests operations using a single name tbale
+     *
+     * @param table the name table
+     */
+    void test(Name.Table table) {
+        test(table, table);
+    }
+
+    /**
+     * Tests operations using distinct name tables, of either the same
+     * or different impl types.
+     *
+     * @param table1 the first name table
+     * @param table2 the second name table
+     */
+    void test(Name.Table table1, Name.Table table2) {
+        if (table1 == table2) {
+            out.println("Testing " + table1);
+        } else {
+            out.println("Testing " + table1 + " : " + table2);
+        }
+
+        // tests are primarily that there are no issues manipulating names from
+        // distinct name tables
+        testCharSequenceCompare(table1, table2);
+    }
+
+    void testCharSequenceCompare(Name.Table table1, Name.Table table2) {
+        Name n1 = table1.fromString("abc");
+        Name n2 = table2.fromString("abc");
+        checkEquals(CharSequence.compare(n1, n2), 0, "CharSequence.compare");
+    }
+
+    void checkEquals(Object found, Object expect, String op) {
+        if (!Objects.equals(found, expect)) {
+            out.println("Failed: " + op);
+            out.println("     found: " + found);
+            out.println("    expect: " + expect);
+        }
+    }
+}

--- a/test/langtools/tools/javac/nametable/TestNameTables.java
+++ b/test/langtools/tools/javac/nametable/TestNameTables.java
@@ -84,7 +84,7 @@ public class TestNameTables {
     }
 
     /**
-     * Tests operations using a single name tbale
+     * Tests operations using a single name table.
      *
      * @param table the name table
      */


### PR DESCRIPTION
Please review a small fix to avoid an `AssertionError` coming out of `CharSequence.compare` for two `CharSequence` objects obtained from different instances of the `javax.lang.model` API.

Full details in the JBS issue and comments.

There are some minor cleanup edits as well, and some improvements to the code to throw AssertionError in a few places.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315248](https://bugs.openjdk.org/browse/JDK-8315248): AssertionError in Name.compareTo (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15478/head:pull/15478` \
`$ git checkout pull/15478`

Update a local copy of the PR: \
`$ git checkout pull/15478` \
`$ git pull https://git.openjdk.org/jdk.git pull/15478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15478`

View PR using the GUI difftool: \
`$ git pr show -t 15478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15478.diff">https://git.openjdk.org/jdk/pull/15478.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15478#issuecomment-1698319715)