### PR TITLE
JDK-8315278: Patch 'print-targets' target to print targets separated by new line

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1425,7 +1425,7 @@ ALL_TARGETS += $(addsuffix -only, $(filter-out dist-clean clean%, $(ALL_TARGETS)
 # are internal only, to support Init.gmk.
 
 print-targets:
-	  @$(ECHO) $(sort $(ALL_TARGETS))
+	  @$(ECHO) $(sort $(ALL_TARGETS)) | $(TR) ' ' '\n'
 
 print-modules:
 	  @$(ECHO) $(sort $(ALL_MODULES))

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1428,10 +1428,10 @@ print-targets:
 	$(info $(subst $(SPACE),$(NEWLINE),$(sort $(ALL_TARGETS))))
 
 print-modules:
-	  @$(ECHO) $(sort $(ALL_MODULES))
+	$(info $(subst $(SPACE),$(NEWLINE),$(sort $(ALL_MODULES))))
 
 print-tests:
-	  @$(ECHO) $(sort $(ALL_NAMED_TESTS))
+	$(info $(subst $(SPACE),$(NEWLINE),$(sort $(ALL_NAMED_TESTS))))
 
 create-main-targets-include:
 	  $(call LogInfo, Generating main target list)

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1425,7 +1425,7 @@ ALL_TARGETS += $(addsuffix -only, $(filter-out dist-clean clean%, $(ALL_TARGETS)
 # are internal only, to support Init.gmk.
 
 print-targets:
-	  @$(ECHO) $(sort $(ALL_TARGETS)) | $(TR) ' ' '\n'
+	$(info $(subst $(SPACE),$(NEWLINE),$(sort $(ALL_TARGETS))))
 
 print-modules:
 	  @$(ECHO) $(sort $(ALL_MODULES))


### PR DESCRIPTION
Currently 'make print-targets' print all targets on the same line separated by space. That isn't only terribly to read but hard to "grep". Printing each target on a separate line seems much better.

Tested on: Linux x64, Windows x64 and MacOS AArch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315278](https://bugs.openjdk.org/browse/JDK-8315278): Patch 'print-targets' target to print targets separated by new line (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Koichi Sakata](https://openjdk.org/census#ksakata) (@jyukutyo - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15479/head:pull/15479` \
`$ git checkout pull/15479`

Update a local copy of the PR: \
`$ git checkout pull/15479` \
`$ git pull https://git.openjdk.org/jdk.git pull/15479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15479`

View PR using the GUI difftool: \
`$ git pr show -t 15479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15479.diff">https://git.openjdk.org/jdk/pull/15479.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15479#issuecomment-1698426630)