### PR TITLE
JDK-8315321: [aix] os::attempt_reserve_memory_at must map at the requested address or fail

### DIFF
--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -25,6 +25,7 @@
 #include "memory/allocation.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/frame.inline.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/os.inline.hpp"
 #include "runtime/thread.hpp"
 #include "runtime/threads.hpp"
@@ -947,3 +948,15 @@ TEST_VM(os, reserve_at_wish_address_shall_not_replace_mappings_largepages) {
     tty->print_cr("Skipped.");
   }
 }
+
+#ifdef AIX
+// On Aix, we should fail attach attempts not aligned to segment boundaries (256m)
+TEST_VM(os, aix_reserve_at_non_shmlba_aligned_address) {
+  if (Use64KPages && Use64KPagesThreshold == 0) {
+    char* p = os::attempt_reserve_memory_at((char*)0x1f00000, M);
+    ASSERT_EQ(p, nullptr); // should have failed
+    p = os::attempt_reserve_memory_at((char*)((64 * G) + M), M);
+    ASSERT_EQ(p, nullptr); // should have failed
+  }
+}
+#endif // AIX


### PR DESCRIPTION
There is a long-standing bug on our AIX-port that may cause `os::attempt_reserve_memory_at()` to return a different address than requested.

All other implementations - usually just using mmap(2) - will unmap again if the attach address differs from the requested one.

On AIX, we use either mmap or shmat, depending on some internal logic and our page size goal. If we use shmat (mostly this is the default nowadays on AIX since we need to use System V APIs for 64K pages), we may end up with an address mapped to the next lower segment boundary. Not only may this round down the requested address by SHMLBA, but it has been observed to result in a very high address if the requested address had been very low (e.g. attempting to map below 0x20_0000 gave us 0xa00_0100_a000_0000). I assume (not having the sources to the AIX kernel) that this is either the result of a wraparound while looking for the next lower segment boundary or it is a segment chosen at random.

Whatever the reason for that behavior, the contract for `os::attempt_reserve_memory_at()` is to return either the wish address or NULL, not some other address.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315321](https://bugs.openjdk.org/browse/JDK-8315321): [aix] os::attempt_reserve_memory_at must map at the requested address or fail (**Enhancement** - P4)


### Reviewers
 * @TOatGithub (no known openjdk.org user name / role)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15481/head:pull/15481` \
`$ git checkout pull/15481`

Update a local copy of the PR: \
`$ git checkout pull/15481` \
`$ git pull https://git.openjdk.org/jdk.git pull/15481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15481`

View PR using the GUI difftool: \
`$ git pr show -t 15481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15481.diff">https://git.openjdk.org/jdk/pull/15481.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15481#issuecomment-1698717803)