### PR TITLE
8315219: G1: Improve allocator pathological case where it keeps doing direct allocations instead of retiring a PLAB

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -358,8 +358,8 @@ G1PLABAllocator::G1PLABAllocator(G1Allocator* allocator) :
   }
 }
 
-bool G1PLABAllocator::may_throw_away_buffer(size_t const allocation_word_sz, size_t const buffer_size) const {
-  return (allocation_word_sz * 100 < buffer_size * ParallelGCBufferWastePct);
+bool G1PLABAllocator::may_throw_away_buffer(size_t const words_remaining, size_t const buffer_size) const {
+  return (words_remaining * 100 < buffer_size * ParallelGCBufferWastePct);
 }
 
 HeapWord* G1PLABAllocator::allocate_direct_or_new_plab(G1HeapRegionAttr dest,

--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -377,14 +377,16 @@ HeapWord* G1PLABAllocator::allocate_direct_or_new_plab(G1HeapRegionAttr dest,
 
   size_t required_in_plab = PLAB::size_required_for_allocation(word_sz);
 
-  // Only get a new PLAB if the allocation fits into the to-be-allocated PLAB and
-  // it would not waste more than ParallelGCBufferWastePct in the current PLAB.
-  // Boosting the PLAB also increasingly allows more waste to occur.
-  if ((required_in_plab <= next_plab_word_size) &&
-    may_throw_away_buffer(required_in_plab, plab_word_size)) {
 
-    PLAB* alloc_buf = alloc_buffer(dest, node_index);
-    guarantee(alloc_buf->words_remaining() <= required_in_plab, "must be");
+  PLAB* alloc_buf = alloc_buffer(dest, node_index);
+  size_t words_remaining = alloc_buf->words_remaining();
+  // Only get a new PLAB if the allocation fits into the to-be-allocated PLAB and
+  // retiring the current PLAB would not waste more than ParallelGCBufferWastePct
+  // in the current PLAB. Boosting the PLAB also increasingly allows more waste to occur.
+  if ((required_in_plab <= next_plab_word_size) &&
+    may_throw_away_buffer(words_remaining, plab_word_size)) {
+
+    guarantee(words_remaining <= required_in_plab, "must be");
 
     alloc_buf->retire();
 

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -45,6 +45,7 @@ import gc.g1.plab.lib.LogParser;
 import gc.g1.plab.lib.PLABUtils;
 import gc.g1.plab.lib.PlabInfo;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
@@ -62,17 +63,18 @@ public class TestPLABPromotion {
     private final static String PLAB_DIRECT_ALLOCATED_FIELD_NAME = "direct allocated";
     private final static List<String> FIELDS_TO_EXTRACT = Arrays.asList(PLAB_USED_FIELD_NAME, PLAB_DIRECT_ALLOCATED_FIELD_NAME);
 
+    public final static int heapWordSize = Platform.is32bit() ? 4 : 8;
+
     private static String output;
 
     // Allowable difference for memory consumption (percentage)
     private final static long MEM_DIFFERENCE_PCT = 5;
-
     private static final int PLAB_SIZE_SMALL = 1024;
     private static final int PLAB_SIZE_MEDIUM = 4096;
     private static final int PLAB_SIZE_HIGH = 65536;
-    private static final int OBJECT_SIZE_SMALL = 10;
-    private static final int OBJECT_SIZE_MEDIUM = 100;
-    private static final int OBJECT_SIZE_HIGH = 3250;
+    private static final int OBJECT_SIZE_SMALL  = 10 * heapWordSize;
+    private static final int OBJECT_SIZE_MEDIUM = 128 * heapWordSize;
+    private static final int OBJECT_SIZE_HIGH   = 3072 * heapWordSize;
     private static final int GC_NUM_SMALL = 1;
     private static final int GC_NUM_MEDIUM = 3;
     private static final int GC_NUM_HIGH = 7;
@@ -94,7 +96,8 @@ public class TestPLABPromotion {
         new TestCase(WASTE_PCT_SMALL, PLAB_SIZE_SMALL, OBJECT_SIZE_HIGH, GC_NUM_MEDIUM, YOUNG_SIZE_LOW, PLAB_FIXED, true, false),
         new TestCase(WASTE_PCT_MEDIUM, PLAB_SIZE_HIGH, OBJECT_SIZE_SMALL, GC_NUM_HIGH, YOUNG_SIZE_HIGH, PLAB_FIXED, true, true),
         new TestCase(WASTE_PCT_MEDIUM, PLAB_SIZE_SMALL, OBJECT_SIZE_MEDIUM, GC_NUM_SMALL, YOUNG_SIZE_LOW, PLAB_FIXED, true, true),
-        new TestCase(WASTE_PCT_MEDIUM, PLAB_SIZE_MEDIUM, OBJECT_SIZE_HIGH, GC_NUM_MEDIUM, YOUNG_SIZE_LOW, PLAB_FIXED, true, true),
+        new TestCase(WASTE_PCT_MEDIUM, PLAB_SIZE_MEDIUM, OBJECT_SIZE_HIGH, GC_NUM_MEDIUM, YOUNG_SIZE_LOW, PLAB_FIXED, true, false),
+        new TestCase(WASTE_PCT_HIGH, PLAB_SIZE_MEDIUM, OBJECT_SIZE_HIGH, GC_NUM_MEDIUM, YOUNG_SIZE_LOW, PLAB_FIXED, true, true),
         new TestCase(WASTE_PCT_HIGH, PLAB_SIZE_SMALL, OBJECT_SIZE_SMALL, GC_NUM_HIGH, YOUNG_SIZE_HIGH, PLAB_FIXED, true, true),
         new TestCase(WASTE_PCT_HIGH, PLAB_SIZE_HIGH, OBJECT_SIZE_MEDIUM, GC_NUM_SMALL, YOUNG_SIZE_LOW, PLAB_FIXED, true, true),
         new TestCase(WASTE_PCT_HIGH, PLAB_SIZE_SMALL, OBJECT_SIZE_HIGH, GC_NUM_MEDIUM, YOUNG_SIZE_HIGH, PLAB_FIXED, true, false),
@@ -104,8 +107,6 @@ public class TestPLABPromotion {
         new TestCase(WASTE_PCT_SMALL, PLAB_SIZE_HIGH, OBJECT_SIZE_SMALL, GC_NUM_HIGH, YOUNG_SIZE_HIGH, PLAB_DYNAMIC, true, true),
         new TestCase(WASTE_PCT_MEDIUM, PLAB_SIZE_MEDIUM, OBJECT_SIZE_SMALL, GC_NUM_SMALL, YOUNG_SIZE_LOW, PLAB_DYNAMIC, true, true),
         new TestCase(WASTE_PCT_SMALL, PLAB_SIZE_MEDIUM, OBJECT_SIZE_HIGH, GC_NUM_HIGH, YOUNG_SIZE_HIGH, PLAB_DYNAMIC, true, false),
-        new TestCase(WASTE_PCT_MEDIUM, PLAB_SIZE_SMALL, OBJECT_SIZE_MEDIUM, GC_NUM_MEDIUM, YOUNG_SIZE_LOW, PLAB_DYNAMIC, true, true),
-        new TestCase(WASTE_PCT_HIGH, PLAB_SIZE_HIGH, OBJECT_SIZE_MEDIUM, GC_NUM_SMALL, YOUNG_SIZE_HIGH, PLAB_DYNAMIC, true, true),
         new TestCase(WASTE_PCT_HIGH, PLAB_SIZE_HIGH, OBJECT_SIZE_SMALL, GC_NUM_HIGH, YOUNG_SIZE_LOW, PLAB_DYNAMIC, true, true)
     };
 

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -63,7 +63,7 @@ public class TestPLABPromotion {
     private final static String PLAB_DIRECT_ALLOCATED_FIELD_NAME = "direct allocated";
     private final static List<String> FIELDS_TO_EXTRACT = Arrays.asList(PLAB_USED_FIELD_NAME, PLAB_DIRECT_ALLOCATED_FIELD_NAME);
 
-    private final static int HEAP_WORD_SIZE = Platform.is32bit() ? 4 : 8;
+    private static final int HEAP_WORD_SIZE = Platform.is32bit() ? 4 : 8;
 
     private static String output;
 

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -63,7 +63,7 @@ public class TestPLABPromotion {
     private final static String PLAB_DIRECT_ALLOCATED_FIELD_NAME = "direct allocated";
     private final static List<String> FIELDS_TO_EXTRACT = Arrays.asList(PLAB_USED_FIELD_NAME, PLAB_DIRECT_ALLOCATED_FIELD_NAME);
 
-    public final static int HEAP_WORD_SIZE = Platform.is32bit() ? 4 : 8;
+    private final static int HEAP_WORD_SIZE = Platform.is32bit() ? 4 : 8;
 
     private static String output;
 

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -63,7 +63,7 @@ public class TestPLABPromotion {
     private final static String PLAB_DIRECT_ALLOCATED_FIELD_NAME = "direct allocated";
     private final static List<String> FIELDS_TO_EXTRACT = Arrays.asList(PLAB_USED_FIELD_NAME, PLAB_DIRECT_ALLOCATED_FIELD_NAME);
 
-    public final static int heapWordSize = Platform.is32bit() ? 4 : 8;
+    public final static int HEAP_WORD_SIZE = Platform.is32bit() ? 4 : 8;
 
     private static String output;
 
@@ -72,9 +72,9 @@ public class TestPLABPromotion {
     private static final int PLAB_SIZE_SMALL = 1024;
     private static final int PLAB_SIZE_MEDIUM = 4096;
     private static final int PLAB_SIZE_HIGH = 65536;
-    private static final int OBJECT_SIZE_SMALL  = 10 * heapWordSize;
-    private static final int OBJECT_SIZE_MEDIUM = 128 * heapWordSize;
-    private static final int OBJECT_SIZE_HIGH   = 3072 * heapWordSize;
+    private static final int OBJECT_SIZE_SMALL  = 10 * HEAP_WORD_SIZE;
+    private static final int OBJECT_SIZE_MEDIUM = 128 * HEAP_WORD_SIZE;
+    private static final int OBJECT_SIZE_HIGH   = 3072 * HEAP_WORD_SIZE;
     private static final int GC_NUM_SMALL = 1;
     private static final int GC_NUM_MEDIUM = 3;
     private static final int GC_NUM_HIGH = 7;


### PR DESCRIPTION
Hi all,

Please review this change to improve on how G1 deals with ParallelGCBufferWastePct. Currently, any allocations larger than  ParallelGCBufferWastePct of the current PLAB size are allocated directly without regard for the state of the current PLAB.  This creates a pathological case where fully used up PLAB are not retired given that allocation sizes larger than ParallelGCBufferWastePct current PLAB.

In this change, we directly check whether the current PLAB can be retired i.e. the remaining PLAB space is < ParallelGCBufferWastePct of current PLAB size. This should reduce the number of direct allocations.

Testing: - mach5 Tier 1-6
              - No regression was observed on perf benchmarks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315219](https://bugs.openjdk.org/browse/JDK-8315219): G1: Improve allocator pathological case where it keeps doing direct allocations instead of retiring a PLAB (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [f10d7f89](https://git.openjdk.org/jdk/pull/15482/files/f10d7f891787cd36b389af353d6b669efd6fce50)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15482/head:pull/15482` \
`$ git checkout pull/15482`

Update a local copy of the PR: \
`$ git checkout pull/15482` \
`$ git pull https://git.openjdk.org/jdk.git pull/15482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15482`

View PR using the GUI difftool: \
`$ git pr show -t 15482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15482.diff">https://git.openjdk.org/jdk/pull/15482.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15482#issuecomment-1698728664)