### PR TITLE
8314978: Multiple server call from connection failing with expect100 in getOutputStream

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -1431,6 +1431,14 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                                + " if doOutput=false - call setDoOutput(true)");
             }
 
+            if (rememberedException != null) {
+                if (rememberedException instanceof RuntimeException) {
+                    throw new RuntimeException(rememberedException);
+                } else {
+                    throw getChainedException((IOException) rememberedException);
+                }
+            }
+
             if (method.equals("GET")) {
                 method = "POST"; // Backward compatibility
             }
@@ -1490,9 +1498,11 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             int i = responseCode;
             disconnectInternal();
             responseCode = i;
+            rememberedException = e;
             throw e;
         } catch (RuntimeException | IOException e) {
             disconnectInternal();
+            rememberedException = e;
             throw e;
         }
     }

--- a/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java
@@ -404,6 +404,10 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
        calls getInputStream after disconnect */
     private Exception rememberedException = null;
 
+    /* Remembered Exception, we will throw it again if somebody
+       calls getOutputStream after disconnect  or error */
+    private Exception rememberedExceptionOut = null;
+
     /* If we decide we want to reuse a client, we put it here */
     private HttpClient reuseClient = null;
 
@@ -1431,11 +1435,11 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
                                + " if doOutput=false - call setDoOutput(true)");
             }
 
-            if (rememberedException != null) {
-                if (rememberedException instanceof RuntimeException) {
-                    throw new RuntimeException(rememberedException);
+            if (rememberedExceptionOut != null) {
+                if (rememberedExceptionOut instanceof RuntimeException) {
+                    throw new RuntimeException(rememberedExceptionOut);
                 } else {
-                    throw getChainedException((IOException) rememberedException);
+                    throw getChainedException((IOException) rememberedExceptionOut);
                 }
             }
 
@@ -1498,11 +1502,11 @@ public class HttpURLConnection extends java.net.HttpURLConnection {
             int i = responseCode;
             disconnectInternal();
             responseCode = i;
-            rememberedException = e;
+            rememberedExceptionOut = e;
             throw e;
         } catch (RuntimeException | IOException e) {
             disconnectInternal();
-            rememberedException = e;
+            rememberedExceptionOut = e;
             throw e;
         }
     }

--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpect100Test.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpect100Test.java
@@ -67,7 +67,7 @@ public class HttpURLConnectionExpect100Test {
     }
 
     @Test
-    public void test() throws Exception {
+    public void expect100ContinueHitCountTest() throws Exception {
         server.resetHitCount();
         URL url = URIBuilder.newBuilder()
                 .scheme("http")
@@ -84,7 +84,7 @@ public class HttpURLConnectionExpect100Test {
     }
 
     @Test
-    public void test1() throws Exception {
+    public void defaultRequestHitCountTest() throws Exception {
         server.resetHitCount();
         URL url = URIBuilder.newBuilder()
                 .scheme("http")
@@ -197,7 +197,7 @@ public class HttpURLConnectionExpect100Test {
         private void handleConnection(Socket client) throws IOException {
             try ( BufferedReader in = new BufferedReader(
                 new InputStreamReader(client.getInputStream()));
-                PrintStream out = new PrintStream(client.getOutputStream());) {
+                PrintStream out = new PrintStream(client.getOutputStream())) {
                 handle_connection(in, out);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpect100Test.java
+++ b/test/jdk/java/net/HttpURLConnection/HttpURLConnectionExpect100Test.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8314978
+ * @summary Multiple server call from connection failing with expect100 in
+ * getOutputStream
+ * @library /test/lib
+ * @run junit/othervm HttpURLConnectionExpect100Test
+ */
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.net.HttpURLConnection;
+
+import jdk.test.lib.net.URIBuilder;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class HttpURLConnectionExpect100Test {
+
+    private HttpServer server;
+    private int port;
+
+    @BeforeAll
+    void setup() throws Exception {
+        server = HttpServer.create();
+        port = server.getPort();
+    }
+
+    @AfterAll
+    void teardown() throws Exception {
+        server.close();
+    }
+
+    @Test
+    public void test() throws Exception {
+        server.resetHitCount();
+        URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .toURL();
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("PUT");
+        //send expect continue
+        conn.setRequestProperty("Expect", "100-continue");
+        sendRequest(conn);
+        getHeaderField(conn);
+        assertEquals(1, server.getServerHitCount());
+    }
+
+    @Test
+    public void test1() throws Exception {
+        server.resetHitCount();
+        URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(port)
+                .toURL();
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("PUT");
+        sendRequest(conn);
+        getHeaderField(conn);
+        assertEquals(1, server.getServerHitCount());
+    }
+
+    private void sendRequest(final HttpURLConnection conn) throws Exception {
+        conn.setDoOutput(true);
+        conn.setFixedLengthStreamingMode(10);
+        byte[] payload = new byte[10];
+        try ( OutputStream os = conn.getOutputStream()) {
+            os.write(payload);
+            os.flush();
+        } catch (IOException e) {
+            // intentional, server will reject the expect 100
+        }
+    }
+
+    private void getHeaderField(final HttpURLConnection conn) {
+        // Call getHeaderFiels in loop, this should not hit server.
+        for (int i = 0; i < 5; i++) {
+            System.out.println("Getting: field" + i);
+            conn.getHeaderField("field" + i);
+        }
+    }
+
+    static class HttpServer extends Thread {
+
+        private final ServerSocket ss;
+        private static HttpServer inst;
+        private volatile int hitCount;
+        private volatile boolean isRunning;
+        private static final String RESPONSE = "This is default response.";
+        private final int port;
+
+        private HttpServer() throws IOException {
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            ss = new ServerSocket();
+            ss.bind(new InetSocketAddress(loopback, 0));
+            port = ss.getLocalPort();
+            isRunning = true;
+        }
+
+        static HttpServer create() throws IOException {
+            if (inst != null) {
+                return inst;
+            } else {
+                inst = new HttpServer();
+                inst.setDaemon(true);
+                inst.start();
+                return inst;
+            }
+        }
+
+        int getServerHitCount() {
+            return hitCount;
+        }
+
+        void resetHitCount() {
+            hitCount = 0;
+        }
+
+        int getPort() {
+            return port;
+        }
+
+        void close() {
+            isRunning = false;
+            if (ss != null && !ss.isClosed()) {
+                try {
+                    ss.close();
+                } catch (IOException ex) {
+                }
+            }
+        }
+
+        @Override
+        public void run() {
+            Socket client;
+            try {
+                while (isRunning) {
+                    client = ss.accept();
+                    System.out.println(client.getRemoteSocketAddress().toString());
+                    hitCount++;
+                    handleConnection(client);
+                }
+            } catch (IOException ex) {
+                // throw exception only if isRunning is true
+                if (isRunning) {
+                    throw new RuntimeException(ex);
+                }
+            } finally {
+                if (ss != null && !ss.isClosed()) {
+                    try {
+                        ss.close();
+                    } catch (IOException ex) {
+                        //ignore
+                    }
+                }
+            }
+        }
+
+        private void handleConnection(Socket client) throws IOException {
+            try ( BufferedReader in = new BufferedReader(
+                new InputStreamReader(client.getInputStream()));
+                PrintStream out = new PrintStream(client.getOutputStream());) {
+                handle_connection(in, out);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                try {
+                    client.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+
+        private void handle_connection(BufferedReader in, PrintStream out)
+                throws IOException, InterruptedException {
+            StringBuilder clientRequest = new StringBuilder();
+            String line = null;
+            do {
+                line = in.readLine();
+                clientRequest.append(line);
+            } while (line != null && line.length() != 0);
+            if (clientRequest.toString().contains("100-continue")) {
+                rejectExpect100Continue(out);
+            } else {
+                defaultResponse(out);
+            }
+        }
+
+        private void rejectExpect100Continue(PrintStream out) {
+            out.print("HTTP/1.1 417 Expectation Failed\r\n");
+            out.print("Server: Test-Server\r\n");
+            out.print("Connection: close\r\n");
+            out.print("Content-Length: 0\r\n");
+            out.print("\r\n");
+            out.flush();
+        }
+
+        private void defaultResponse(PrintStream out) {
+            // send the 200 OK
+            out.print("HTTP/1.1 200 OK\r\n");
+            out.print("Server: Test-Server\r\n");
+            out.print("Connection: close\r\n");
+            out.print("Content-Length: " + RESPONSE.length() + "\r\n\r\n");
+            out.print(RESPONSE);
+            out.print("\r\n");
+            out.flush();
+        }
+    }
+}


### PR DESCRIPTION
With the current implementation of HttpURLConnection  if server rejects the  “Expect 100-continue” then there will be ‘java.net.ProtocolException’ will be thrown from 'expect100Continue()' method. 

After the exception thrown, If we call any other method on the same instance (ex getHeaderField(), or getHeaderFields()). They will internally call getOuputStream() which invokes writeRequests(), which make the actual server call.

The code change will sets the existing variable ‘rememberedException’ when there is exception and getOutputStream0() will re-throw ‘rememberedException’  if the ‘rememberedException’ is not null. 

Note: getOutputStream0() also call’s  ‘expect100Continue()’  if ‘expectContinue’ is true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314978](https://bugs.openjdk.org/browse/JDK-8314978): Multiple server call from connection failing with expect100 in getOutputStream (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15483/head:pull/15483` \
`$ git checkout pull/15483`

Update a local copy of the PR: \
`$ git checkout pull/15483` \
`$ git pull https://git.openjdk.org/jdk.git pull/15483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15483`

View PR using the GUI difftool: \
`$ git pr show -t 15483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15483.diff">https://git.openjdk.org/jdk/pull/15483.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15483#issuecomment-1698820322)