### PR TITLE
8314837: 5 compiled/codecache tests ignore VM flags

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
@@ -29,7 +29,7 @@
  * @requires vm.debug
  *
  * @run driver jdk.test.lib.helpers.ClassFileInstaller
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ * @run main/othervm -Xbootclasspath/a:.
  *                   compiler.codecache.CheckCodeCacheInfo
  */
 
@@ -68,9 +68,9 @@ public class CheckCodeCacheInfo {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb;
 
-        pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintCodeCache",
-                                                   "-XX:+Verbose",
-                                                   "-version");
+        pb = ProcessTools.createTestJvm("-XX:+PrintCodeCache",
+                                        "-XX:+Verbose",
+                                        "-version");
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
         out.shouldHaveExitValue(0);
         out.stdoutShouldMatch(VERBOSE_REGEXP);

--- a/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
@@ -26,7 +26,7 @@
  * @bug 8005885
  * @summary Checks VM verbose information related to the code cache
  * @library /test/lib
- * @requires vm.debug & vm.flagless
+ * @requires vm.debug
  *
  * @run driver compiler.codecache.CheckCodeCacheInfo
  */
@@ -66,9 +66,9 @@ public class CheckCodeCacheInfo {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb;
 
-        pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintCodeCache",
-                                                   "-XX:+Verbose",
-                                                   "-version");
+        pb = ProcessTools.createTestJvm("-XX:+PrintCodeCache",
+                                        "-XX:+Verbose",
+                                        "-version");
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
         out.shouldHaveExitValue(0);
         out.stdoutShouldMatch(VERBOSE_REGEXP);

--- a/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckCodeCacheInfo.java
@@ -26,11 +26,9 @@
  * @bug 8005885
  * @summary Checks VM verbose information related to the code cache
  * @library /test/lib
- * @requires vm.debug
+ * @requires vm.debug & vm.flagless
  *
- * @run driver jdk.test.lib.helpers.ClassFileInstaller
- * @run main/othervm -Xbootclasspath/a:.
- *                   compiler.codecache.CheckCodeCacheInfo
+ * @run driver compiler.codecache.CheckCodeCacheInfo
  */
 
 package compiler.codecache;
@@ -68,9 +66,9 @@ public class CheckCodeCacheInfo {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb;
 
-        pb = ProcessTools.createTestJvm("-XX:+PrintCodeCache",
-                                        "-XX:+Verbose",
-                                        "-version");
+        pb = ProcessTools.createJavaProcessBuilder("-XX:+PrintCodeCache",
+                                                   "-XX:+Verbose",
+                                                   "-version");
         OutputAnalyzer out = new OutputAnalyzer(pb.start());
         out.shouldHaveExitValue(0);
         out.stdoutShouldMatch(VERBOSE_REGEXP);

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -33,6 +33,7 @@ import jdk.test.lib.process.ProcessTools;
  * @test
  * @bug 8276036 8277213 8277441
  * @summary test for the value of full_count in the message of insufficient codecache
+ * @requires vm.flagless
  * @library /test/lib
  */
 public class CodeCacheFullCountTest {

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -33,7 +33,6 @@ import jdk.test.lib.process.ProcessTools;
  * @test
  * @bug 8276036 8277213 8277441
  * @summary test for the value of full_count in the message of insufficient codecache
- * @requires vm.flagless
  * @library /test/lib
  */
 public class CodeCacheFullCountTest {
@@ -55,7 +54,7 @@ public class CodeCacheFullCountTest {
     }
 
     public static void runTest() throws Throwable {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJvm(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         // Ignore adapter creation failures

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -33,6 +33,7 @@ import jdk.test.lib.process.ProcessTools;
  * @test
  * @bug 8276036 8277213 8277441
  * @summary test for the value of full_count in the message of insufficient codecache
+ * @requires vm.compMode != "Xint"
  * @library /test/lib
  */
 public class CodeCacheFullCountTest {

--- a/test/hotspot/jtreg/compiler/codecache/cli/TestSegmentedCodeCacheOption.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/TestSegmentedCodeCacheOption.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8015774
  * @summary Verify SegmentedCodeCache option's processing
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/codeheapsize/TestCodeHeapSizeOptions.java
@@ -26,6 +26,7 @@
  * @key randomness
  * @bug 8015774
  * @summary Verify processing of options related to code heaps sizing.
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/compiler/codecache/cli/printcodecache/TestPrintCodeCacheOption.java
+++ b/test/hotspot/jtreg/compiler/codecache/cli/printcodecache/TestPrintCodeCacheOption.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8015774
  * @summary Verify that PrintCodeCache option print correct information.
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  *          java.compiler


### PR DESCRIPTION
3 codecache/cli tests are marked with `@requires vm.flagless` as they ignore VM flags. These tests enumerate combinations of flags, and some (e.g. `-Xint`) are incompatible with flags of compiler modes.

External VM flags are passed to the created processes in CodeCacheFullCountTest and CheckCodeCacheInfo. The former creates the process with code cache flushing disabled, and is compatible with flags except the interpreter mode. The later creates a process to print verbose code cache info, and the feature is independent of other flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314837](https://bugs.openjdk.org/browse/JDK-8314837): 5 compiled/codecache tests ignore VM flags (**Sub-task** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [ab642336](https://git.openjdk.org/jdk/pull/15485/files/ab642336f8e5d22fd1f61d312fbb000fc3d5a341)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15485/head:pull/15485` \
`$ git checkout pull/15485`

Update a local copy of the PR: \
`$ git checkout pull/15485` \
`$ git pull https://git.openjdk.org/jdk.git pull/15485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15485`

View PR using the GUI difftool: \
`$ git pr show -t 15485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15485.diff">https://git.openjdk.org/jdk/pull/15485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15485#issuecomment-1698858367)