### PR TITLE
8315351: Rid synchronization in PipedInputStream.close() in favour of benign race

### DIFF
--- a/src/java.base/share/classes/java/io/PipedInputStream.java
+++ b/src/java.base/share/classes/java/io/PipedInputStream.java
@@ -76,7 +76,7 @@ public class PipedInputStream extends InputStream {
      * The circular buffer into which incoming data is placed.
      * @since   1.1
      */
-    protected byte buffer[];
+    protected byte[] buffer;
 
     /**
      * The index of the position in the circular buffer at which the
@@ -444,10 +444,8 @@ public class PipedInputStream extends InputStream {
      * @throws     IOException  {@inheritDoc}
      */
     @Override
-    public void close()  throws IOException {
+    public void close() throws IOException {
+        in = -1;
         closedByReader = true;
-        synchronized (this) {
-            in = -1;
-        }
     }
 }


### PR DESCRIPTION
Assuming that the value written into `in` is always `-1` we can rid synchronized block in favour of guarding `in = - 1` with writing into volatile `closedByReader `:
```java
public void close() throws IOException {
    closedByReader = true;
    synchronized (this) {
        in = -1;
    }
}
```
-->
```java
public void close() throws IOException {
    in = -1;
    closedByReader = true;
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315351](https://bugs.openjdk.org/browse/JDK-8315351): Rid synchronization in PipedInputStream.close() in favour of benign race (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15486/head:pull/15486` \
`$ git checkout pull/15486`

Update a local copy of the PR: \
`$ git checkout pull/15486` \
`$ git pull https://git.openjdk.org/jdk.git pull/15486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15486`

View PR using the GUI difftool: \
`$ git pr show -t 15486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15486.diff">https://git.openjdk.org/jdk/pull/15486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15486#issuecomment-1698862844)