### PR TITLE
Cannot resolve the specified port when passing kdc using the java. se…

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Config.java
@@ -192,7 +192,7 @@ public class Config {
                 .privilegedGetProperty("java.security.krb5.kdc");
         if (tmp != null) {
             // The user can specify a list of kdc hosts separated by ":"
-            defaultKDC = tmp.replace(':', ' ');
+            defaultKDC = tmp.replace(',', ' ');
         } else {
             defaultKDC = null;
         }


### PR DESCRIPTION
…curity. krb5. kdc attribute

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15488/head:pull/15488` \
`$ git checkout pull/15488`

Update a local copy of the PR: \
`$ git checkout pull/15488` \
`$ git pull https://git.openjdk.org/jdk.git pull/15488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15488`

View PR using the GUI difftool: \
`$ git pr show -t 15488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15488.diff">https://git.openjdk.org/jdk/pull/15488.diff</a>

</details>
