### PR TITLE
8314662: jshell shows duplicated signatures of javap

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -1188,10 +1188,10 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             }
         };
         @SuppressWarnings("unchecked")
-        List<Element> result = Util.stream(scopeIterable)
+        Set<Element> result = Util.stream(scopeIterable)
                              .flatMap(this::localElements)
                              .flatMap(el -> Util.stream((Iterable<Element>)elementConvertor.apply(el)))
-                             .collect(toCollection(ArrayList :: new));
+                             .collect(toCollection(LinkedHashSet :: new));
         result.addAll(listPackages(at, ""));
         return result;
     }


### PR DESCRIPTION
The Scope may contain duplicated entries (e.g. for duplicated static imports, as in this case), which may then show as duplicate signatures in JShell.

The proposal here is to avoid using the duplicates, by using `LinkedHashSet`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314662](https://bugs.openjdk.org/browse/JDK-8314662): jshell shows duplicated signatures of javap (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15489/head:pull/15489` \
`$ git checkout pull/15489`

Update a local copy of the PR: \
`$ git checkout pull/15489` \
`$ git pull https://git.openjdk.org/jdk.git pull/15489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15489`

View PR using the GUI difftool: \
`$ git pr show -t 15489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15489.diff">https://git.openjdk.org/jdk/pull/15489.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15489#issuecomment-1698945356)