### PR TITLE
8315364: Assert thread state invariant for JFR stack trace capture

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrEvent.hpp
@@ -114,14 +114,6 @@ class JfrEvent {
     return JfrEventSetting::has_stacktrace(T::eventId);
   }
 
-  static bool is_large() {
-    return JfrEventSetting::is_large(T::eventId);
-  }
-
-  static void set_large() {
-    JfrEventSetting::set_large(T::eventId);
-  }
-
   static JfrEventId id() {
     return T::eventId;
   }
@@ -246,6 +238,14 @@ class JfrEvent {
     // Payload.
     static_cast<T*>(this)->writeData(writer);
     return writer.end_event_write(large_size) > 0;
+  }
+
+  static bool is_large() {
+    return JfrEventSetting::is_large(T::eventId);
+  }
+
+  static void set_large() {
+    JfrEventSetting::set_large(T::eventId);
   }
 
 #ifdef ASSERT

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -233,6 +233,7 @@ bool JfrStackTrace::record_async(JavaThread* jt, const frame& frame) {
   assert(jt != nullptr, "invariant");
   assert(!_lineno, "invariant");
   Thread* current_thread = Thread::current();
+  assert(current_thread->is_JfrSampler_thread(), "invariant");
   assert(jt != current_thread, "invariant");
   // Explicitly monitor the available space of the thread-local buffer used for enqueuing klasses as part of tagging methods.
   // We do this because if space becomes sparse, we cannot rely on the implicit allocation of a new buffer as part of the
@@ -285,6 +286,7 @@ bool JfrStackTrace::record_async(JavaThread* jt, const frame& frame) {
 bool JfrStackTrace::record(JavaThread* jt, const frame& frame, int skip) {
   assert(jt != nullptr, "invariant");
   assert(jt == Thread::current(), "invariant");
+  assert(jt->thread_state() == _thread_in_vm, "invariant");
   assert(!_lineno, "invariant");
   // Must use ResetNoHandleMark here to bypass if any NoHandleMark exist on stack.
   // This is because RegisterMap uses Handles to support continuations.

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTrace.cpp
@@ -286,7 +286,7 @@ bool JfrStackTrace::record_async(JavaThread* jt, const frame& frame) {
 bool JfrStackTrace::record(JavaThread* jt, const frame& frame, int skip) {
   assert(jt != nullptr, "invariant");
   assert(jt == Thread::current(), "invariant");
-  assert(jt->thread_state() == _thread_in_vm, "invariant");
+  assert(jt->thread_state() != _thread_in_native, "invariant");
   assert(!_lineno, "invariant");
   // Must use ResetNoHandleMark here to bypass if any NoHandleMark exist on stack.
   // This is because RegisterMap uses Handles to support continuations.


### PR DESCRIPTION
Greetings,

A JavaThread running in state _thread_in_native cannot capture a JFR stack trace because tagging of artefacts (klasses, methods, etc.) is a function of an epoch, which evolves during safepoints.

Asserting this invariant would have helped prevent the issue detailed in [JDK-8315220](https://bugs.openjdk.org/browse/JDK-8315220).

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315364](https://bugs.openjdk.org/browse/JDK-8315364): Assert thread state invariant for JFR stack trace capture (**Enhancement** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**) ⚠️ Review applies to [1e439601](https://git.openjdk.org/jdk/pull/15491/files/1e439601acd425c8fd5090739d6185f6bcc8244c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15491/head:pull/15491` \
`$ git checkout pull/15491`

Update a local copy of the PR: \
`$ git checkout pull/15491` \
`$ git pull https://git.openjdk.org/jdk.git pull/15491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15491`

View PR using the GUI difftool: \
`$ git pr show -t 15491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15491.diff">https://git.openjdk.org/jdk/pull/15491.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15491#issuecomment-1699102450)