### PR TITLE
8315061: Make LockingMode a product flag

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1979,7 +1979,7 @@ const int ObjectAlignmentInBytes = 8;
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
                                                                             \
-  product(int, LockingMode, LM_LEGACY, EXPERIMENTAL,                        \
+  product(int, LockingMode, LM_LEGACY,                                      \
           "Select locking mode: "                                           \
           "0: monitors only (LM_MONITOR), "                                 \
           "1: monitors & legacy stack-locking (LM_LEGACY, default), "       \


### PR DESCRIPTION
A trivial fix to make LockingMode a product flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8315275](https://bugs.openjdk.org/browse/JDK-8315275) to be approved

### Issues
 * [JDK-8315061](https://bugs.openjdk.org/browse/JDK-8315061): Make LockingMode a product flag (**Enhancement** - P4)
 * [JDK-8315275](https://bugs.openjdk.org/browse/JDK-8315275): Make LockingMode a product flag (**CSR**)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15496/head:pull/15496` \
`$ git checkout pull/15496`

Update a local copy of the PR: \
`$ git checkout pull/15496` \
`$ git pull https://git.openjdk.org/jdk.git pull/15496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15496`

View PR using the GUI difftool: \
`$ git pr show -t 15496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15496.diff">https://git.openjdk.org/jdk/pull/15496.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15496#issuecomment-1699737934)