### PR TITLE
8161536: sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java fails with ProviderException

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -580,8 +580,6 @@ com/sun/nio/sctp/SctpChannel/SocketOptionTests.java             8141694 linux-al
 
 # jdk_security
 
-sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8161536 generic-all
-
 sun/security/smartcardio/TestChannel.java                       8039280 generic-all
 sun/security/smartcardio/TestConnect.java                       8039280 generic-all
 sun/security/smartcardio/TestConnectAgain.java                  8039280 generic-all

--- a/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
+++ b/test/jdk/sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
  * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1"
  *      ClientJSSEServerJSSE
  * @run main/othervm -Djdk.tls.namedGroups="secp256r1,sect193r1"
- *      ClientJSSEServerJSSE sm policy
+ *      -Djava.security.manager=allow ClientJSSEServerJSSE sm policy
  */
 
 import java.security.Provider;


### PR DESCRIPTION
This test is removed from ProblemList. I ran test locally and on CI with hundred iteration. Failure is not seen as [JDK-8240256](https://bugs.openjdk.org/browse/JDK-8240256) is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8161536](https://bugs.openjdk.org/browse/JDK-8161536): sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java fails with ProviderException (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15497/head:pull/15497` \
`$ git checkout pull/15497`

Update a local copy of the PR: \
`$ git checkout pull/15497` \
`$ git pull https://git.openjdk.org/jdk.git pull/15497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15497`

View PR using the GUI difftool: \
`$ git pr show -t 15497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15497.diff">https://git.openjdk.org/jdk/pull/15497.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15497#issuecomment-1699824419)