### PR TITLE
8315413: Remove special filtering of Continuation.yield0 in StackWalker

### DIFF
--- a/src/java.base/share/classes/java/lang/StackStreamFactory.java
+++ b/src/java.base/share/classes/java/lang/StackStreamFactory.java
@@ -543,12 +543,6 @@ final class StackStreamFactory {
             final Class<?> at(int index) {
                 return stackFrames[index].declaringClass();
             }
-
-            @Override
-            final boolean filter(int index) {
-                return stackFrames[index].declaringClass() == Continuation.class
-                        && "yield0".equals(stackFrames[index].getMethodName());
-            }
         }
 
         final Function<? super Stream<StackFrame>, ? extends T> function;  // callback
@@ -685,10 +679,6 @@ final class StackStreamFactory {
             @Override
             final Class<?> at(int index) { return classes[index];}
 
-            @Override
-            final boolean filter(int index) { return false; }
-
-
             // ------ subclass may override the following methods -------
             /**
              * Resizes the buffers for VM to fill in the next batch of stack frames.
@@ -820,12 +810,6 @@ final class StackStreamFactory {
             final Class<?> at(int index) {
                 return stackFrames[index].declaringClass();
             }
-
-            @Override
-            final boolean filter(int index) {
-                return stackFrames[index].declaringClass() == Continuation.class
-                        && "yield0".equals(stackFrames[index].getMethodName());
-            }
         }
 
         LiveStackInfoTraverser(StackWalker walker,
@@ -894,13 +878,6 @@ final class StackStreamFactory {
          * @return the class at the given position in the current batch.
          */
         abstract Class<?> at(int index);
-
-        /**
-         * Filter out frames at the top of a batch
-         * @param index the position of the frame.
-         * @return true if the frame should be skipped
-         */
-        abstract boolean filter(int index);
 
         // ------ subclass may override the following methods -------
 
@@ -1007,8 +984,7 @@ final class StackStreamFactory {
             this.fence = endIndex;
             for (int i = START_POS; i < fence; i++) {
                 if (isDebug) System.err.format("  frame %d: %s%n", i, at(i));
-                if ((depth == 0 && filterStackWalkImpl(at(i))) // filter the frames due to the stack stream implementation
-                        || filter(i)) {
+                if (depth == 0 && filterStackWalkImpl(at(i))) { // filter the frames due to the stack stream implementation
                     origin++;
                 } else {
                     break;

--- a/test/jdk/jdk/internal/vm/Continuation/Basic.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Basic.java
@@ -92,7 +92,7 @@ public class Basic {
             assertEquals(cont.isPreempted(), false);
 
             List<String> frames = cont.stackWalker().walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
-            assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "bar", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+            assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "bar", "foo", "lambda$test1$0", "run", "enter0", "enter"));
         }
         assertEquals(res.get(), 247);
         assertEquals(cont.isPreempted(), false);

--- a/test/jdk/jdk/internal/vm/Continuation/BasicExt.java
+++ b/test/jdk/jdk/internal/vm/Continuation/BasicExt.java
@@ -798,7 +798,7 @@ public class BasicExt {
                 cont.stackWalker()
                 .walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
             assertEquals(frames, cont.isDone() ? List.of()
-                         : Arrays.asList("yield", "ord104_testMethod_dontinline",
+                         : Arrays.asList("yield0", "yield", "ord104_testMethod_dontinline",
                                          "ord103_testMethod_dontinline",
                                          "ord102_testMethod_dontinline",
                                          "ord101_testMethod_dontinline",

--- a/test/jdk/jdk/internal/vm/Continuation/Scoped.java
+++ b/test/jdk/jdk/internal/vm/Continuation/Scoped.java
@@ -74,27 +74,27 @@ public class Scoped {
 
                         frames = cont.stackWalker().walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("No scope: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "yield0", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), A).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("A: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "yield0", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), B).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("B: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), C).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("C: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), K).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("K: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "yield0", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
 
                         frames = cont.stackWalker(EnumSet.noneOf(StackWalker.Option.class), null).walk(fs -> fs.map(StackWalker.StackFrame::getMethodName).collect(Collectors.toList()));
                         System.out.println("null: " + frames);
-                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
+                        assertEquals(frames, cont.isDone() ? List.of() : Arrays.asList("yield0", "yield", "lambda$bar$14", "run", "enter0", "enter", "run", "bar", "lambda$foo$8", "run", "enter0", "enter", "yield0", "run", "foo", "lambda$test1$0", "run", "enter0", "enter"));
                 }
                 assertEquals(res.get(), 2);
         }


### PR DESCRIPTION
Loom added a special filtering of Continuation.yield0 in stack walker.  After the initial implementation, JDK-8304919 marks the yielding and entering methods with `@Hidden` and hidden frames are filtered by stack walker by default.   With `@Hidden` the special filtering should not be needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315413](https://bugs.openjdk.org/browse/JDK-8315413): Remove special filtering of Continuation.yield0 in StackWalker (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15498/head:pull/15498` \
`$ git checkout pull/15498`

Update a local copy of the PR: \
`$ git checkout pull/15498` \
`$ git pull https://git.openjdk.org/jdk.git pull/15498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15498`

View PR using the GUI difftool: \
`$ git pr show -t 15498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15498.diff">https://git.openjdk.org/jdk/pull/15498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15498#issuecomment-1699868959)