### PR TITLE
8315406: [REDO] serviceability/jdwp/AllModulesCommandTest.java ignores VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,12 +70,6 @@ public class AllModulesCommandTest implements DebuggeeLauncher.Listener {
         // The debuggee has completed sending all the info
         // We can start the JDWP session
         jdwpLatch.countDown();
-    }
-
-    @Override
-    public void onDebuggeeError(String message) {
-        System.err.println("Debuggee error: '" + message + "'");
-        System.exit(1);
     }
 
     private void doJdwp() throws Exception {

--- a/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
@@ -61,7 +61,6 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
     private Process p;
     private final Listener listener;
     private StreamHandler inputHandler;
-    private StreamHandler errorHandler;
 
     /**
      * @param listener the listener we report the debuggee events to
@@ -81,9 +80,7 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
         ProcessBuilder pb = ProcessTools.createTestJvm(JDWP_OPT, DEBUGGEE);
         p = pb.start();
         inputHandler = new StreamHandler(p.getInputStream(), this);
-        errorHandler = new StreamHandler(p.getErrorStream(), this);
         inputHandler.start();
-        errorHandler.start();
     }
 
     /**
@@ -107,12 +104,7 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
 
     @Override
     public void onStringRead(StreamHandler handler, String line) {
-        if (handler.equals(errorHandler)) {
-            terminateDebuggee();
-            listener.onDebuggeeError(line);
-        } else {
-            processDebuggeeOutput(line);
-        }
+        processDebuggeeOutput(line);
     }
 
     private void processDebuggeeOutput(String line) {

--- a/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
@@ -61,6 +61,7 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
     private Process p;
     private final Listener listener;
     private StreamHandler inputHandler;
+    private StreamHandler errorHandler;
 
     /**
      * @param listener the listener we report the debuggee events to
@@ -80,7 +81,9 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
         ProcessBuilder pb = ProcessTools.createTestJvm(JDWP_OPT, DEBUGGEE);
         p = pb.start();
         inputHandler = new StreamHandler(p.getInputStream(), this);
+        errorHandler = new StreamHandler(p.getErrorStream(), this);
         inputHandler.start();
+        errorHandler.start();
     }
 
     /**

--- a/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
@@ -22,7 +22,6 @@
  */
 
 import java.util.StringTokenizer;
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.JDWP;
 import static jdk.test.lib.Asserts.assertFalse;
 import jdk.test.lib.process.ProcessTools;
@@ -54,8 +53,6 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
 
     private Process p;
     private final Listener listener;
-    private StreamHandler inputHandler;
-    private StreamHandler errorHandler;
 
     /**
      * @param listener the listener we report the debuggee events to
@@ -74,8 +71,8 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
 
         ProcessBuilder pb = ProcessTools.createTestJvm(JDWP_OPT, DEBUGGEE);
         p = pb.start();
-        inputHandler = new StreamHandler(p.getInputStream(), this);
-        errorHandler = new StreamHandler(p.getErrorStream(), this);
+        StreamHandler inputHandler = new StreamHandler(p.getInputStream(), this);
+        StreamHandler errorHandler = new StreamHandler(p.getErrorStream(), System.out::println);
         inputHandler.start();
         errorHandler.start();
     }
@@ -100,11 +97,7 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
     }
 
     @Override
-    public void onStringRead(StreamHandler handler, String line) {
-        processDebuggeeOutput(line);
-    }
-
-    private void processDebuggeeOutput(String line) {
+    public void onStringRead(String line) {
         if (jdwpPort == -1) {
             JDWP.ListenAddress addr = JDWP.parseListenAddress(line);
             if (addr != null) {

--- a/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
@@ -46,12 +46,6 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
          */
         void onDebuggeeSendingCompleted();
 
-        /**
-         * Callback to handle any debuggee error
-         *
-         * @param line line from the debuggee's stderr
-         */
-        void onDebuggeeError(String line);
     }
 
     private int jdwpPort = -1;

--- a/test/hotspot/jtreg/serviceability/jdwp/StreamHandler.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/StreamHandler.java
@@ -37,10 +37,9 @@ public class StreamHandler implements Runnable {
     public interface Listener {
         /**
          * Called when a line has been read from the process output stream
-         * @param handler this StreamHandler
          * @param s the line
          */
-        void onStringRead(StreamHandler handler, String s);
+        void onStringRead(String s);
     }
 
     private final ExecutorService executor;
@@ -71,7 +70,7 @@ public class StreamHandler implements Runnable {
             BufferedReader br = new BufferedReader(new InputStreamReader(is));
             String line;
             while ((line = br.readLine()) != null) {
-                listener.onStringRead(this, line);
+                listener.onStringRead(line);
             }
         } catch (Exception x) {
             throw new RuntimeException(x);


### PR DESCRIPTION
Test failed because of unexpected output of version string. 
The standard convention for tests is to skip any unexpected output (version string, VM warning, vm logging) and only fail on expected error patterns. 
Fix is tested by running with default options and  with '-showversion' vm option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315406](https://bugs.openjdk.org/browse/JDK-8315406): [REDO] serviceability/jdwp/AllModulesCommandTest.java ignores VM flags (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15499/head:pull/15499` \
`$ git checkout pull/15499`

Update a local copy of the PR: \
`$ git checkout pull/15499` \
`$ git pull https://git.openjdk.org/jdk.git pull/15499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15499`

View PR using the GUI difftool: \
`$ git pr show -t 15499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15499.diff">https://git.openjdk.org/jdk/pull/15499.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15499#issuecomment-1699869217)