### PR TITLE
JDK-8315422: getSoTimeout() would be in try block in SSLSocketImpl

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketImpl.java
@@ -1782,21 +1782,24 @@ public final class SSLSocketImpl
             if (conContext.inputRecord instanceof
                     SSLSocketInputRecord inputRecord && isConnected) {
                 if (appInput.readLock.tryLock()) {
-                    int soTimeout = getSoTimeout();
                     try {
-                        // deplete could hang on the skip operation
-                        // in case of infinite socket read timeout.
-                        // Change read timeout to avoid deadlock.
-                        // This workaround could be replaced later
-                        // with the right synchronization
-                        if (soTimeout == 0)
-                            setSoTimeout(DEFAULT_SKIP_TIMEOUT);
-                        inputRecord.deplete(false);
-                    } catch (java.net.SocketTimeoutException stEx) {
-                        // skip timeout exception during deplete
+                        int soTimeout = getSoTimeout();
+                        try {
+                            // deplete could hang on the skip operation
+                            // in case of infinite socket read timeout.
+                            // Change read timeout to avoid deadlock.
+                            // This workaround could be replaced later
+                            // with the right synchronization
+                            if (soTimeout == 0)
+                                setSoTimeout(DEFAULT_SKIP_TIMEOUT);
+                            inputRecord.deplete(false);
+                        } catch (java.net.SocketTimeoutException stEx) {
+                            // skip timeout exception during deplete
+                        } finally {
+                            if (soTimeout == 0)
+                                setSoTimeout(soTimeout);
+                        }
                     } finally {
-                        if (soTimeout == 0)
-                            setSoTimeout(soTimeout);
                         appInput.readLock.unlock();
                     }
                 }


### PR DESCRIPTION
The method `SSLSocketImpl::closeSocket` has the below code snippet,

```
if (appInput.readLock.tryLock()) {
    int soTimeout = getSoTimeout();
    try {
        // deplete could hang on the skip operation
        // in case of infinite socket read timeout.
        // Change read timeout to avoid deadlock.
        // This workaround could be replaced later
        // with the right synchronization
        if (soTimeout == 0)
            setSoTimeout(DEFAULT_SKIP_TIMEOUT);
        inputRecord.deplete(false);
    } catch (java.net.SocketTimeoutException stEx) {
        // skip timeout exception during deplete
    } finally {
        if (soTimeout == 0)
            setSoTimeout(soTimeout);
        appInput.readLock.unlock();
    }
}
```

If `getSoTimeout()` throws an exception, say `SocketException`, `appInput.readLock.unlock()` cannot be called.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315422](https://bugs.openjdk.org/browse/JDK-8315422): getSoTimeout() would be in try block in SSLSocketImpl (**Bug** - P4)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15503/head:pull/15503` \
`$ git checkout pull/15503`

Update a local copy of the PR: \
`$ git checkout pull/15503` \
`$ git pull https://git.openjdk.org/jdk.git pull/15503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15503`

View PR using the GUI difftool: \
`$ git pr show -t 15503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15503.diff">https://git.openjdk.org/jdk/pull/15503.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15503#issuecomment-1700289396)