### PR TITLE
8233160: Add java.vendor.url.bug to list of recognized standard system properties

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -723,6 +723,8 @@ public final class System {
      *     <td>Java Runtime Environment vendor</td></tr>
      * <tr><th scope="row">{@systemProperty java.vendor.url}</th>
      *     <td>Java vendor URL</td></tr>
+     * <tr><th scope="row">{@systemProperty java.vendor.url.bug}</th>
+     *     <td>Java vendor's bug tracker URL</td></tr>
      * <tr><th scope="row">{@systemProperty java.vendor.version}</th>
      *     <td>Java vendor version <em>(optional)</em> </td></tr>
      * <tr><th scope="row">{@systemProperty java.home}</th>

--- a/test/jdk/java/lang/System/PropertyTest.java
+++ b/test/jdk/java/lang/System/PropertyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ public class PropertyTest {
                 {"java.version.date"},
                 {"java.vendor"},
                 {"java.vendor.url"},
+                {"java.vendor.url.bug"},
                 {"java.home"},
                 {"java.vm.specification.version"},
                 {"java.vm.specification.vendor"},


### PR DESCRIPTION
Can I please get a review of this change which proposes to address https://bugs.openjdk.org/browse/JDK-8233160?

It has been noted in https://bugs.openjdk.org/browse/JDK-8232753 that:

> The java.vendor.url.bug property has been defined by every Sun/Oracle JDK going all the way back to JDK 5 (and possibly earlier; JDK 5 is the oldest release that I can still run on my development machine). Yet, it's never been specified.

The OpenJDK builds too by default set a value for this system property.

The commit in this PR updates the javadoc of `System.getProperties()` to include this system property in the list of specified properties. Additionally, the `test/jdk/java/lang/System/PropertyTest.java` test has been updated to verify that this property is indeed available in the Properties returned by `System.getProperites()`.

I'll create a CSR shortly for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 23 to be approved (needs to be created)

### Issue
 * [JDK-8233160](https://bugs.openjdk.org/browse/JDK-8233160): Add java.vendor.url.bug to list of recognized standard system properties (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15504/head:pull/15504` \
`$ git checkout pull/15504`

Update a local copy of the PR: \
`$ git checkout pull/15504` \
`$ git pull https://git.openjdk.org/jdk.git pull/15504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15504`

View PR using the GUI difftool: \
`$ git pr show -t 15504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15504.diff">https://git.openjdk.org/jdk/pull/15504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15504#issuecomment-1700473020)