### PR TITLE
8315436: HttpsServer does not send TLS alerts

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/SSLStreams.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/SSLStreams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/SSLStreams.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/SSLStreams.java
@@ -286,7 +286,6 @@ class SSLStreams {
                 } while (status == Status.BUFFER_OVERFLOW);
                 if (status == Status.CLOSED && !ignoreClose) {
                     closed = true;
-                    return r;
                 }
                 if (r.result.bytesProduced() > 0) {
                     wrap_dst.flip();

--- a/test/jdk/com/sun/net/httpserver/simpleserver/HttpsServerAlertTest.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/HttpsServerAlertTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8315436
+ * @summary Test if HttpsServer sends the TLS alerts produced
+ * @library /test/lib
+ * @build jdk.test.lib.net.SimpleSSLContext
+ * @run testng/othervm HttpsServerAlertTest
+ */
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsParameters;
+import com.sun.net.httpserver.HttpsServer;
+import jdk.test.lib.net.SimpleSSLContext;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.testng.Assert.fail;
+
+public class HttpsServerAlertTest {
+
+    static final InetSocketAddress LOOPBACK_ADDR = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+
+    static final boolean ENABLE_LOGGING = true;
+    static final Logger LOGGER = Logger.getLogger("com.sun.net.httpserver");
+
+    SSLContext sslContext;
+
+    @BeforeTest
+    public void setup() throws IOException {
+        if (ENABLE_LOGGING) {
+            ConsoleHandler ch = new ConsoleHandler();
+            LOGGER.setLevel(Level.ALL);
+            ch.setLevel(Level.ALL);
+            LOGGER.addHandler(ch);
+        }
+        sslContext = new SimpleSSLContext().get();
+        SSLContext.setDefault(sslContext);
+    }
+
+    @Test
+    public void testProtocolMismatch() throws Exception {
+        SSLSocketFactory sf = sslContext.getSocketFactory();
+        var server = HttpsServer.create(LOOPBACK_ADDR, 0);
+        server.setHttpsConfigurator(new Configurator(sslContext));
+        server.start();
+        try (SSLSocket s = (SSLSocket) sf.createSocket()) {
+            // server only accepts TLS 1.3
+            s.setEnabledProtocols(new String[]{"TLSv1.2"});
+            s.connect(server.getAddress());
+            s.startHandshake();
+            fail("Expected a handshake failure");
+        } catch (SSLHandshakeException e) {
+            System.out.println("Got exception: " + e);
+            if (e.getCause() instanceof EOFException ||
+                    !e.getMessage().contains("protocol_version"))
+                throw e;
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static class Configurator extends HttpsConfigurator {
+        public Configurator(SSLContext sslContext) {
+            super(sslContext);
+        }
+
+        @Override
+        public void configure(HttpsParameters params) {
+            SSLParameters sslParams = getSSLContext().getDefaultSSLParameters();
+            sslParams.setProtocols(new String[]{"TLSv1.3"});
+            params.setSSLParameters(sslParams);
+        }
+    }
+}


### PR DESCRIPTION
Please review this patch that ensures that alerts produced by `wrap` are sent to the peer.

When a fatal alert is produced by a `wrap` call, the returned status is `CLOSED`, but some bytes are produced in the destination buffer. These bytes need to be sent to the client.

The new test verifies this fix; without the fix the test fails with:
```
javax.net.ssl.SSLHandshakeException: Remote host terminated the handshake
```
With the fix the test passes; the exception thrown is :
```
javax.net.ssl.SSLHandshakeException: Received fatal alert: protocol_version
```
Existing tier1-3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315436](https://bugs.openjdk.org/browse/JDK-8315436): HttpsServer does not send TLS alerts (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15505/head:pull/15505` \
`$ git checkout pull/15505`

Update a local copy of the PR: \
`$ git checkout pull/15505` \
`$ git pull https://git.openjdk.org/jdk.git pull/15505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15505`

View PR using the GUI difftool: \
`$ git pr show -t 15505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15505.diff">https://git.openjdk.org/jdk/pull/15505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15505#issuecomment-1700595180)