### PR TITLE
8315446: G1: Remove unused G1AllocRegion::attempt_allocation

### DIFF
--- a/src/hotspot/share/gc/g1/g1AllocRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.hpp
@@ -151,10 +151,6 @@ public:
 
   // The following two are the building blocks for the allocation method.
 
-  // First-level allocation: Should be called without holding a
-  // lock. It will try to allocate lock-free out of the active region,
-  // or return null if it was unable to.
-  inline HeapWord* attempt_allocation(size_t word_size);
   // Perform an allocation out of the current allocation region, with the given
   // minimum and desired size. Returns the actual size allocated (between
   // minimum and desired size) in actual_word_size if the allocation has been

--- a/src/hotspot/share/gc/g1/g1AllocRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.inline.hpp
@@ -63,11 +63,6 @@ inline HeapWord* G1AllocRegion::par_allocate(HeapRegion* alloc_region,
   return alloc_region->par_allocate(min_word_size, desired_word_size, actual_word_size);
 }
 
-inline HeapWord* G1AllocRegion::attempt_allocation(size_t word_size) {
-  size_t temp;
-  return attempt_allocation(word_size, word_size, &temp);
-}
-
 inline HeapWord* G1AllocRegion::attempt_allocation(size_t min_word_size,
                                                    size_t desired_word_size,
                                                    size_t* actual_word_size) {


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315446](https://bugs.openjdk.org/browse/JDK-8315446): G1: Remove unused G1AllocRegion::attempt_allocation (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15509/head:pull/15509` \
`$ git checkout pull/15509`

Update a local copy of the PR: \
`$ git checkout pull/15509` \
`$ git pull https://git.openjdk.org/jdk.git pull/15509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15509`

View PR using the GUI difftool: \
`$ git pr show -t 15509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15509.diff">https://git.openjdk.org/jdk/pull/15509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15509#issuecomment-1700734863)