### PR TITLE
8315450: G1: Remove redundant adjustment to GCDrainStackTargetSize

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -230,11 +230,6 @@ void G1Arguments::initialize() {
     FLAG_SET_DEFAULT(ParallelRefProcEnabled, true);
   }
 
-  // By default do not let the target stack size to be more than 1/4 of the entries
-  if (FLAG_IS_DEFAULT(GCDrainStackTargetSize)) {
-    FLAG_SET_ERGO(GCDrainStackTargetSize, MIN2(GCDrainStackTargetSize, TASKQUEUE_SIZE / 4));
-  }
-
 #ifdef COMPILER2
   // Enable loop strip mining to offer better pause time guarantees
   if (FLAG_IS_DEFAULT(UseCountedLoopSafepoints)) {


### PR DESCRIPTION
Simple removing redundant check & write to an global VM flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315450](https://bugs.openjdk.org/browse/JDK-8315450): G1: Remove redundant adjustment to GCDrainStackTargetSize (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15510/head:pull/15510` \
`$ git checkout pull/15510`

Update a local copy of the PR: \
`$ git checkout pull/15510` \
`$ git pull https://git.openjdk.org/jdk.git pull/15510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15510`

View PR using the GUI difftool: \
`$ git pr show -t 15510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15510.diff">https://git.openjdk.org/jdk/pull/15510.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15510#issuecomment-1700762587)