### PR TITLE
8313258: RuntimeInvisibleTypeAnnotationsAttribute.annotations() API Index out of Bound error

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
@@ -97,6 +97,9 @@ public final class CodeImpl
 
     @Override
     public Label getLabel(int bci) {
+        if (bci < 0 || bci > codeLength)
+            throw new IllegalArgumentException(String.format("Bytecode offset out of range; bci=%d, codeLength=%d",
+                                                             bci, codeLength));
         if (labels == null)
             labels = new LabelImpl[codeLength + 1];
         LabelImpl l = labels[bci];

--- a/test/jdk/jdk/classfile/LimitsTest.java
+++ b/test/jdk/jdk/classfile/LimitsTest.java
@@ -32,6 +32,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import jdk.internal.classfile.Classfile;
+import jdk.internal.classfile.impl.LabelContext;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -70,5 +71,14 @@ class LimitsTest {
     void testEmptyCode() {
         assertThrows(IllegalArgumentException.class, () -> Classfile.of().build(ClassDesc.of("EmptyClass"), cb -> cb.withMethodBody(
                 "emptyMethod", MethodTypeDesc.of(ConstantDescs.CD_void), 0, cob -> {})));
+    }
+
+    @Test
+    void testCodeRange() {
+        var cf = Classfile.of();
+        var lc = (LabelContext)cf.parse(cf.build(ClassDesc.of("EmptyClass"), cb -> cb.withMethodBody(
+                "aMethod", MethodTypeDesc.of(ConstantDescs.CD_void), 0, cob -> cob.return_()))).methods().get(0).code().get();
+        assertThrows(IllegalArgumentException.class, () -> lc.getLabel(-1));
+        assertThrows(IllegalArgumentException.class, () -> lc.getLabel(10));
     }
 }


### PR DESCRIPTION
Classfile API suppose to throw IllegalArgumentException in situations where bytecode offset is out of allowed range. Such situation includes invalid offset parsed from a TypeAnnotation as well as from other CodeAttribute attributes.

This patch throws IAE for invalid bytecode offset when requested Label for the parsed CodeAttribute, so it cover even wider range of cases than mentioned in the bug report.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313258](https://bugs.openjdk.org/browse/JDK-8313258): RuntimeInvisibleTypeAnnotationsAttribute.annotations() API Index out of Bound error (**Bug** - P4)


### Reviewers
 * [Brian Goetz](https://openjdk.org/census#briangoetz) (@briangoetz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15511/head:pull/15511` \
`$ git checkout pull/15511`

Update a local copy of the PR: \
`$ git checkout pull/15511` \
`$ git pull https://git.openjdk.org/jdk.git pull/15511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15511`

View PR using the GUI difftool: \
`$ git pr show -t 15511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15511.diff">https://git.openjdk.org/jdk/pull/15511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15511#issuecomment-1700847093)