### PR TITLE
JDK-8315445: 8314748 causes crashes in x64 builds

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
@@ -2131,7 +2131,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
 
   __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc0_addr()), Assembler::AVX_512bit, r15 /*rscratch*/);
   ev_add128(xmm8, xmm8, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
-  __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc4_addr()), Assembler::AVX_512bit);
+  __ evmovdquq(xmm19, ExternalAddress(counter_mask_linc4_addr()), Assembler::AVX_512bit, r15 /*rscratch*/);
   ev_add128(xmm9,  xmm8,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   ev_add128(xmm10, xmm9,  xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);
   ev_add128(xmm11, xmm10, xmm19, Assembler::AVX_512bit, /*ktmp*/k1, ones);


### PR DESCRIPTION
The crash happens during this phase:
[2023-08-31T08:51:27,258Z] Optimizing the exploded image

This is the failure mode:
```
# Internal Error (src/hotspot/cpu/x86/macroAssembler_x86.cpp:2755), pid=20045, tid=20157
# assert(rscratch != noreg || always_reachable(src)) failed: missing
#
# JRE version: OpenJDK Runtime Environment (22.0+14) (fastdebug build 22-ea+14-963)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 22-ea+14-963, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V [libjvm.so+0x12f17b9] MacroAssembler::evmovdquq(XMMRegister, AddressLiteral, int, Register)+0x1a9
``` 