### PR TITLE
8314905: jdk/jfr/tool/TestView.java fails with RuntimeException 'Invoked Concurrent' missing from stdout/stderr

### DIFF
--- a/test/jdk/jdk/jfr/tool/TestView.java
+++ b/test/jdk/jdk/jfr/tool/TestView.java
@@ -91,13 +91,13 @@ public class TestView {
 
     private static void testEventType(String recording) throws Throwable {
         OutputAnalyzer output = ExecuteHelper.jfr(
-             "view", "--verbose", "--width", "300", "--cell-height", "100", "SystemGC", recording);
+             "view", "--verbose", "--width", "300", "--cell-height", "100", "ThreadSleep", recording);
         // Verify title
-        output.shouldContain("System GC");
+        output.shouldContain("Thread Sleep");
         // Verify headings
-        output.shouldContain("Invoked Concurrent");
+        output.shouldContain("Sleep Time");
         // Verify verbose headings
-        output.shouldContain("invokedConcurrent");
+        output.shouldContain("time");
         // Verify thread value
         output.shouldContain(Thread.currentThread().getName());
         // Verify stack frame


### PR DESCRIPTION
Could I have a review of a test fix? The test now uses a more predictable event than the SystemGC event. 

Testing: jdk/jfr/tool/TestView.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314905](https://bugs.openjdk.org/browse/JDK-8314905): jdk/jfr/tool/TestView.java fails with RuntimeException 'Invoked Concurrent' missing from stdout/stderr (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15513/head:pull/15513` \
`$ git checkout pull/15513`

Update a local copy of the PR: \
`$ git checkout pull/15513` \
`$ git pull https://git.openjdk.org/jdk.git pull/15513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15513`

View PR using the GUI difftool: \
`$ git pr show -t 15513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15513.diff">https://git.openjdk.org/jdk/pull/15513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15513#issuecomment-1833555763)