### PR TITLE
8313983: jmod create --target-platform should replace existing ModuleTarget attribute

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/Attributes.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Attributes.java
@@ -461,7 +461,7 @@ public class Attributes {
 
     /** Attribute mapper for the {@code ModuleResolution} attribute */
     public static final AttributeMapper<ModuleResolutionAttribute>
-            MODULE_RESOLUTION = new AbstractAttributeMapper<>(NAME_MODULE_RESOLUTION, true, Classfile.JAVA_9_VERSION) {
+            MODULE_RESOLUTION = new AbstractAttributeMapper<>(NAME_MODULE_RESOLUTION, Classfile.JAVA_9_VERSION) {
                 @Override
                 public ModuleResolutionAttribute readAttribute(AttributedElement e, ClassReader cf, int p) {
                     return new BoundAttribute.BoundModuleResolutionAttribute(cf, this, p);
@@ -475,7 +475,7 @@ public class Attributes {
 
     /** Attribute mapper for the {@code ModuleTarget} attribute */
     public static final AttributeMapper<ModuleTargetAttribute>
-            MODULE_TARGET = new AbstractAttributeMapper<>(NAME_MODULE_TARGET, true, Classfile.JAVA_9_VERSION) {
+            MODULE_TARGET = new AbstractAttributeMapper<>(NAME_MODULE_TARGET, Classfile.JAVA_9_VERSION) {
                 @Override
                 public ModuleTargetAttribute readAttribute(AttributedElement e, ClassReader cf, int p) {
                     return new BoundAttribute.BoundModuleTargetAttribute(cf, this, p);


### PR DESCRIPTION
ModuleTarget and ModuleResolution attributes were flagged as 'allow multiple' in the Classfile API.
This patch removed the flags and allows at most one instance of each attribute.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313983](https://bugs.openjdk.org/browse/JDK-8313983): jmod create --target-platform should replace existing ModuleTarget attribute (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15514/head:pull/15514` \
`$ git checkout pull/15514`

Update a local copy of the PR: \
`$ git checkout pull/15514` \
`$ git pull https://git.openjdk.org/jdk.git pull/15514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15514`

View PR using the GUI difftool: \
`$ git pr show -t 15514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15514.diff">https://git.openjdk.org/jdk/pull/15514.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15514#issuecomment-1700932357)