### PR TITLE
8314632: Intra-case dominance check fails in the presence of a guard

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4712,7 +4712,7 @@ public class Check {
                                          TreeInfo.unguardedCase(testCase);
                         } else if (label instanceof JCPatternCaseLabel patternCL &&
                                    testCaseLabel instanceof JCPatternCaseLabel testPatternCaseLabel &&
-                                   TreeInfo.unguardedCase(testCase)) {
+                                   (testCase.equals(c) || TreeInfo.unguardedCase(testCase))) {
                             dominated = patternDominated(testPatternCaseLabel.pat,
                                                          patternCL.pat);
                         }

--- a/test/langtools/tools/javac/patterns/T8314632.java
+++ b/test/langtools/tools/javac/patterns/T8314632.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8314632
+ * @summary Intra-case dominance check fails in the presence of a guard
+ * @enablePreview
+ * @compile/fail/ref=T8314632.out -XDrawDiagnostics T8314632.java
+ */
+public class T8314632 {
+    void test1(Object obj) {
+        switch (obj) {
+            case Float _ -> {}
+            case Integer _, CharSequence _, String _ when obj.hashCode() > 0 -> { } // error
+            default -> throw new IllegalStateException("Unexpected value: " + obj);
+        }
+    }
+
+    void test2(Object obj) {
+        switch (obj) {
+            case Float _ -> {}
+            case Integer _, CharSequence _, String _ -> { }
+            default -> throw new IllegalStateException("Unexpected value: " + obj); // error
+        }
+    }
+
+    void test3(Object obj) {
+        switch (obj) {
+            case Float _, CharSequence _ when obj.hashCode() > 0 -> { } // OK
+            case Integer _, String _     when obj.hashCode() > 0 -> { } // OK, since the previous case is guarded
+            default -> throw new IllegalStateException("Unexpected value: " + obj);
+        }
+    }
+
+    void test4(Object obj) {
+        switch (obj) {
+            case Float _, CharSequence _ -> { } // OK
+            case Integer _, String _     when obj.hashCode() > 0 -> { } // error, since the previous case is unguarded
+            default -> throw new IllegalStateException("Unexpected value: " + obj);
+        }
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8314632.java
+++ b/test/langtools/tools/javac/patterns/T8314632.java
@@ -1,27 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
- *
- * This code is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
- *
- * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
- * accompanied this code).
- *
- * You should have received a copy of the GNU General Public License version
- * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
- *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit www.oracle.com if you need additional information or have any
- * questions.
- */
-/*
- * @test
+ * @test /nodynamiccopyright/
  * @bug 8314632
  * @summary Intra-case dominance check fails in the presence of a guard
  * @enablePreview

--- a/test/langtools/tools/javac/patterns/T8314632.out
+++ b/test/langtools/tools/javac/patterns/T8314632.out
@@ -1,6 +1,6 @@
-T8314632.java:34:45: compiler.err.pattern.dominated
-T8314632.java:42:45: compiler.err.pattern.dominated
-T8314632.java:58:29: compiler.err.pattern.dominated
+T8314632.java:12:45: compiler.err.pattern.dominated
+T8314632.java:20:45: compiler.err.pattern.dominated
+T8314632.java:36:29: compiler.err.pattern.dominated
 - compiler.note.preview.filename: T8314632.java, DEFAULT
 - compiler.note.preview.recompile
 3 errors

--- a/test/langtools/tools/javac/patterns/T8314632.out
+++ b/test/langtools/tools/javac/patterns/T8314632.out
@@ -1,0 +1,6 @@
+T8314632.java:34:45: compiler.err.pattern.dominated
+T8314632.java:42:45: compiler.err.pattern.dominated
+T8314632.java:58:29: compiler.err.pattern.dominated
+- compiler.note.preview.filename: T8314632.java, DEFAULT
+- compiler.note.preview.recompile
+3 errors


### PR DESCRIPTION
Intra-case domination should be affected by the presence of a guard. A missing check in dominance ensures that requirement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314632](https://bugs.openjdk.org/browse/JDK-8314632): Intra-case dominance check fails in the presence of a guard (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to [d3a194cf](https://git.openjdk.org/jdk/pull/15515/files/d3a194cfae80fa23895963cb13c5e3c0fd4a2e81)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15515/head:pull/15515` \
`$ git checkout pull/15515`

Update a local copy of the PR: \
`$ git checkout pull/15515` \
`$ git pull https://git.openjdk.org/jdk.git pull/15515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15515`

View PR using the GUI difftool: \
`$ git pr show -t 15515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15515.diff">https://git.openjdk.org/jdk/pull/15515.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15515#issuecomment-1700966855)