### PR TITLE
JDK-8315459: Print G1 reserved and committed sizes as separate items in VM.info and hs_err

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2199,7 +2199,7 @@ void G1CollectedHeap::print_heap_regions() const {
 void G1CollectedHeap::print_on(outputStream* st) const {
   size_t heap_used = Heap_lock->owned_by_self() ? used() : used_unlocked();
   st->print(" %-20s", "garbage-first heap");
-  st->print(" total reserved " SIZE_FORMAT "K, committed " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+  st->print(" total reserved %zuK, committed %zuK, used %zuK",
             _hrm.reserved().byte_size()/K, capacity()/K, heap_used/K);
   st->print(" [" PTR_FORMAT ", " PTR_FORMAT ")",
             p2i(_hrm.reserved().start()),

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2199,8 +2199,8 @@ void G1CollectedHeap::print_heap_regions() const {
 void G1CollectedHeap::print_on(outputStream* st) const {
   size_t heap_used = Heap_lock->owned_by_self() ? used() : used_unlocked();
   st->print(" %-20s", "garbage-first heap");
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
-            capacity()/K, heap_used/K);
+  st->print(" total reserved " SIZE_FORMAT "K, committed " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+            _hrm.reserved().byte_size()/K, capacity()/K, heap_used/K);
   st->print(" [" PTR_FORMAT ", " PTR_FORMAT ")",
             p2i(_hrm.reserved().start()),
             p2i(_hrm.reserved().end()));


### PR DESCRIPTION
Trivial printing change.

```
Heap:
 garbage-first heap total 1040384K, used 4985K [0x0000000414000000, 0x0000000800000000)
```

We print the committed heap size as "total". Reserved size is missing and can only be deduced using the following address range size. And the apparent mismatch between that range size and the printed "total" value also confused some customers.

Let's print the reserved and committed total separately:

```
Heap:
 garbage-first heap   total reserved 16449536K, committed 1040384K, used 4985K [0x0000000414000000, 0x0000000800000000)
 ```

Tests: I ran `serviceability/sa/TestUniverse.java`, which was the only test I could find that parsed this output. GHAs also ran successfully (not sure why they are marked as still running, though, they are long finished).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315459](https://bugs.openjdk.org/browse/JDK-8315459): Print G1 reserved and committed sizes as separate items in VM.info and hs_err (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [b8ca4121](https://git.openjdk.org/jdk/pull/15516/files/b8ca4121feb78861ae6fb39e405d24a51e6d8b1f)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15516/head:pull/15516` \
`$ git checkout pull/15516`

Update a local copy of the PR: \
`$ git checkout pull/15516` \
`$ git pull https://git.openjdk.org/jdk.git pull/15516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15516`

View PR using the GUI difftool: \
`$ git pr show -t 15516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15516.diff">https://git.openjdk.org/jdk/pull/15516.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15516#issuecomment-1701487401)