### PR TITLE
8315452: Erroneous AST missing modifiers for partial input

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3918,7 +3918,7 @@ public class JavacParser implements Parser {
 
         boolean firstTypeDecl = true;   // have we see a class, enum, or interface declaration yet?
         boolean isUnnamedClass = false;
-        while (token.kind != EOF) {
+        OUTER: while (token.kind != EOF) {
             if (token.pos <= endPosTable.errorEndPos) {
                 // error recovery
                 skip(firstTypeDecl, false, false, false);
@@ -3933,6 +3933,8 @@ public class JavacParser implements Parser {
             while (firstTypeDecl && mods == null && token.kind == SEMI) {
                 semiList.append(toP(F.at(token.pos).Skip()));
                 nextToken();
+                if (token.kind == EOF)
+                    break OUTER;
             }
             if (firstTypeDecl && mods == null && token.kind == IMPORT) {
                 if (!semiList.isEmpty()) {
@@ -3999,7 +4001,7 @@ public class JavacParser implements Parser {
                     checkSourceLevel(token.pos, Feature.UNNAMED_CLASSES);
                     defs.appendList(topLevelMethodOrFieldDeclaration(mods));
                     isUnnamedClass = true;
-                } else if (token.kind != EOF) {
+                } else {
                     JCTree def = typeDeclaration(mods, docComment);
                     if (def instanceof JCExpressionStatement statement)
                         def = statement.expr;

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093 8312204
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093 8312204 8315452
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -60,6 +60,8 @@ import com.sun.tools.javac.main.Main.Result;
 import com.sun.tools.javac.tree.JCTree;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -70,6 +72,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeKind;
@@ -88,7 +91,8 @@ import com.sun.source.tree.ModuleTree;
 import com.sun.source.util.TreePathScanner;
 import com.sun.tools.javac.api.JavacTaskPool;
 import com.sun.tools.javac.api.JavacTaskPool.Worker;
-import java.util.Objects;
+import com.sun.tools.javac.tree.JCTree.JCErroneous;
+import com.sun.tools.javac.tree.Pretty;
 
 public class JavacParserTest extends TestCase {
     static final JavaCompiler tool = ToolProvider.getSystemJavaCompiler();
@@ -2486,6 +2490,28 @@ public class JavacParserTest extends TestCase {
                      codes);
     }
 
+    @Test //JDK-8315452
+    void testPartialTopLevelModifiers() throws IOException {
+        String code = """
+                      package test;
+                      public
+                      """;
+        DiagnosticCollector<JavaFileObject> coll =
+                new DiagnosticCollector<>();
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, coll,
+                List.of("--enable-preview", "--source", SOURCE_VERSION),
+                null, Arrays.asList(new MyFileObject(code)));
+        CompilationUnitTree cut = ct.parse().iterator().next();
+
+        String result = toStringWithErrors(cut).replaceAll("\\R", "\n");
+        System.out.println("RESULT\n" + result);
+        assertEquals("incorrect AST",
+                     result,
+                     """
+                     package test;
+                     (ERROR: public )""");
+    }
+
     void run(String[] args) throws Exception {
         int passed = 0, failed = 0;
         final Pattern p = (args != null && args.length > 0)
@@ -2515,6 +2541,38 @@ public class JavacParserTest extends TestCase {
                     passed + ", failed = " + failed + " ??????????");
         }
     }
+
+    private String toStringWithErrors(Tree tree) {
+        StringWriter s = new StringWriter();
+        try {
+            new PrettyWithErrors(s, false).printExpr((JCTree) tree);
+        } catch (IOException e) {
+            // should never happen, because StringWriter is defined
+            // never to throw any IOExceptions
+            throw new AssertionError(e);
+        }
+        return s.toString();
+    }
+
+    private static final class PrettyWithErrors extends Pretty {
+
+        public PrettyWithErrors(Writer out, boolean sourceOutput) {
+            super(out, sourceOutput);
+        }
+
+        @Override
+        public void visitErroneous(JCErroneous tree) {
+            try {
+                print("(ERROR: ");
+                print(tree.errs);
+                print(")");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+    }
+
 }
 
 abstract class TestCase {


### PR DESCRIPTION
Consider code like:
```
package test;
public
```

Before [JDK-8305671](https://bugs.openjdk.org/browse/JDK-8305671), this was producing an AST which included the package clause + an ErroneousTree, which contained the `public` as partial modifiers.

After [JDK-8305671](https://bugs.openjdk.org/browse/JDK-8305671), the `public` is no longer included in the AST, and hence it is invisible for tools that operate on the AST.

My proposal is to return the `public` back to the AST. Seems that the problem from [JDK-8305671](https://bugs.openjdk.org/browse/JDK-8305671) can be solved by breaking out of the outter loop, instead of inner loop, as it was before [JDK-8305671](https://bugs.openjdk.org/browse/JDK-8305671), without affecting non-eof situations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315452](https://bugs.openjdk.org/browse/JDK-8315452): Erroneous AST missing modifiers for partial input (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15517/head:pull/15517` \
`$ git checkout pull/15517`

Update a local copy of the PR: \
`$ git checkout pull/15517` \
`$ git pull https://git.openjdk.org/jdk.git pull/15517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15517`

View PR using the GUI difftool: \
`$ git pr show -t 15517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15517.diff">https://git.openjdk.org/jdk/pull/15517.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15517#issuecomment-1701170630)