### PR TITLE
8315088: C2: assert(wq.size() - before == EMPTY_LOOP_SIZE) failed: expect the EMPTY_LOOP_SIZE nodes of this body if empty

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3526,7 +3526,7 @@ void IdealLoopTree::enqueue_data_nodes(PhaseIdealLoop* phase, Unique_Node_List& 
 void IdealLoopTree::collect_loop_core_nodes(PhaseIdealLoop* phase, Unique_Node_List& wq) const {
   uint before = wq.size();
   wq.push(_head->in(LoopNode::LoopBackControl));
-  for (uint i = 0; i < wq.size(); ++i) {
+  for (uint i = before; i < wq.size(); ++i) {
     Node* n = wq.at(i);
     for (uint j = 0; j < n->req(); ++j) {
       Node* in = n->in(j);

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestBrokenEmptyLoopLogic.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestBrokenEmptyLoopLogic.java
@@ -43,7 +43,7 @@ public class TestBrokenEmptyLoopLogic {
             for (int j = 5; j > 1; j -= 2) {
                 i12 = 1;
                 do {
-                }  while (++i12 < 3);
+                } while (++i12 < 3);
             }
             for (int j = i; j < 5; ++j) {
                 i8 += i12;

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestBrokenEmptyLoopLogic.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestBrokenEmptyLoopLogic.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8315088
+ * @summary C2: assert(wq.size() - before == EMPTY_LOOP_SIZE) failed: expect the EMPTY_LOOP_SIZE nodes of this body if empty
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,TestBrokenEmptyLoopLogic::* -XX:-TieredCompilation TestBrokenEmptyLoopLogic
+ *
+ */
+
+public class TestBrokenEmptyLoopLogic {
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        int i8 = 209, i = 1, i12 = 1;
+        while (++i < 8) {
+            for (int j = 5; j > 1; j -= 2) {
+                i12 = 1;
+                do {
+                }  while (++i12 < 3);
+            }
+            for (int j = i; j < 5; ++j) {
+                i8 += i12;
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestBrokenEmptyLoopLogic.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestBrokenEmptyLoopLogic.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8315088
+ * @requires vm.compiler2.enabled
  * @summary C2: assert(wq.size() - before == EMPTY_LOOP_SIZE) failed: expect the EMPTY_LOOP_SIZE nodes of this body if empty
  * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,TestBrokenEmptyLoopLogic::* -XX:-TieredCompilation TestBrokenEmptyLoopLogic
  *


### PR DESCRIPTION
The assert fires in code that looks for counted loops that would be
empty if not part of a loop strip mining nest (that is some nodes in
the the loop body are kept alive because of the safepoint in the outer
loop, the loop would otherwise be empty). That logic starts by finding
the set of `EMPTY_LOOP_SIZE` nodes that are core to all counted loops
(exit test, iv phi etc) and store them in the `empty_loop_nodes`
list.

Finding the "core" nodes is performed by
`IdealLoopTree::collect_loop_core_nodes`. It enqueues the backedge of
the loop in `empty_loop_nodes` and then iteratively pushes inputs of
nodes in `empty_loop_nodes` that belongs to the loop until it can't
make progress. There should be `EMPTY_LOOP_SIZE` of those nodes.

 It's possible that that 2 or more loops are involved in the process:
a node n in loop 1 could be kept alive by the safepoint of loop 2 so
loop 2 needs to be empty for n to become dead and possibly loop 1 to
be empty. When that happens while the logic is in the process of
determining if loop 1 is empty, it needs to also collect the
`EMPTY_LOOP_SIZE` nodes that make the "core" of loop 2. They are
enqueued to the `empty_loop_nodes` list too.

The failure happens when `empty_loop_nodes` already has the "core"
nodes of loop 1 and "core" nodes for loop 2 are collected. In the
process`IdealLoopTree::collect_loop_core_nodes` iterates on all
`empty_loop_nodes` (loop 1 nodes included, not just starting from the
loop 2 backedge). That's inefficient (loop 1 nodes can't help find
nodes that belong to loop 2) and wrong because there could be an edge
from a node in loop 1 to a node in the body of loop 2. That node in
loop 2 is them pushed to the `empty_loop_nodes` list. 

The fix I propose is to only iterate over loop 2 nodes when loop 2 is
processed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315088](https://bugs.openjdk.org/browse/JDK-8315088): C2: assert(wq.size() - before == EMPTY_LOOP_SIZE) failed: expect the EMPTY_LOOP_SIZE nodes of this body if empty (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [cf9f66bb](https://git.openjdk.org/jdk/pull/15520/files/cf9f66bb1cb0ea57401e322f5ca16b163a0fd2f8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15520/head:pull/15520` \
`$ git checkout pull/15520`

Update a local copy of the PR: \
`$ git checkout pull/15520` \
`$ git pull https://git.openjdk.org/jdk.git pull/15520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15520`

View PR using the GUI difftool: \
`$ git pr show -t 15520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15520.diff">https://git.openjdk.org/jdk/pull/15520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15520#issuecomment-1701316646)