### PR TITLE
8315378: [BACKOUT] runtime/NMT/SummarySanityCheck.java failed with "Total committed (MMMMMM) did not match the summarized committed (NNNNNN)"

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -70,30 +70,6 @@ size_t MallocMemorySnapshot::total_arena() const {
   return amount;
 }
 
-void MallocMemorySnapshot::copy_to(MallocMemorySnapshot* s) {
-  // Need to make sure that mtChunks don't get deallocated while the
-  // copy is going on, because their size is adjusted using this
-  // buffer in make_adjustment().
-  ThreadCritical tc;
-  size_t total_size;
-  size_t loop_counter = 0;
-  const size_t loop_limit = 100;
-  // It is observed that other threads can allocate during the loop of copying.
-  // This results in inconsistent total and sum of parts. So, the while-loop and
-  // the local total_size are used to find and try again a limited number of times.
-  // Acheiving fully consistent total and sum of parts requires to block all mallooc's during
-  // the copy which is a performance obstacle.
-  do {
-    total_size = 0;
-    s->_all_mallocs = _all_mallocs;
-    for (int index = 0; index < mt_number_of_types; index ++) {
-      s->_malloc[index] = _malloc[index];
-      total_size += _malloc[index].malloc_size();
-    }
-  } while(s->_all_mallocs.size() != total_size && ++loop_counter < loop_limit);
-  assert(s->_all_mallocs.size() == total_size, "Total != sum of parts");
-}
-
 // Make adjustment by subtracting chunks used by arenas
 // from total chunks to get total free chunk size
 void MallocMemorySnapshot::make_adjustment() {

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -186,7 +186,16 @@ class MallocMemorySnapshot : public ResourceObj {
     return s->by_type(mtThreadStack)->malloc_count();
   }
 
-  void copy_to(MallocMemorySnapshot* s);
+  void copy_to(MallocMemorySnapshot* s) {
+     // Need to make sure that mtChunks don't get deallocated while the
+     // copy is going on, because their size is adjusted using this
+     // buffer in make_adjustment().
+     ThreadCritical tc;
+     s->_all_mallocs = _all_mallocs;
+     for (int index = 0; index < mt_number_of_types; index ++) {
+       s->_malloc[index] = _malloc[index];
+     }
+   }
 
   // Make adjustment by subtracting chunks used by arenas
   // from total chunks to get total free chunk size


### PR DESCRIPTION
This is a BACKOUT of https://bugs.openjdk.org/browse/JDK-8298992

Should be inverse of https://github.com/openjdk/jdk/pull/15306/files

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315378](https://bugs.openjdk.org/browse/JDK-8315378): [BACKOUT] runtime/NMT/SummarySanityCheck.java failed with "Total committed (MMMMMM) did not match the summarized committed (NNNNNN)" (**Sub-task** - P2)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15522/head:pull/15522` \
`$ git checkout pull/15522`

Update a local copy of the PR: \
`$ git checkout pull/15522` \
`$ git pull https://git.openjdk.org/jdk.git pull/15522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15522`

View PR using the GUI difftool: \
`$ git pr show -t 15522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15522.diff">https://git.openjdk.org/jdk/pull/15522.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15522#issuecomment-1701627238)