### PR TITLE
8307468: CDS Lambda Proxy classes are regenerated in dynamic dump

### DIFF
--- a/src/hotspot/share/classfile/systemDictionaryShared.hpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.hpp
@@ -199,6 +199,7 @@ private:
   static bool check_for_exclusion_impl(InstanceKlass* k);
   static void remove_dumptime_info(InstanceKlass* k) NOT_CDS_RETURN;
   static bool has_been_redefined(InstanceKlass* k);
+  static InstanceKlass* retrieve_lambda_proxy_class(const RunTimeLambdaProxyClassInfo* info) NOT_CDS_RETURN_(nullptr);
 
   DEBUG_ONLY(static bool _class_loading_may_happen;)
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3627,8 +3627,16 @@ JVM_ENTRY(void, JVM_RegisterLambdaProxyClassForArchiving(JNIEnv* env,
   Handle dynamic_method_type_oop(THREAD, JNIHandles::resolve_non_null(dynamicMethodType));
   Symbol* dynamic_method_type = java_lang_invoke_MethodType::as_signature(dynamic_method_type_oop(), true);
 
-  SystemDictionaryShared::add_lambda_proxy_class(caller_ik, lambda_ik, interface_method_name, factory_type,
-                                                 interface_method_type, m, dynamic_method_type, THREAD);
+  InstanceKlass* shared_lambda = nullptr;
+  if (caller_ik->is_shared()) {
+    shared_lambda = SystemDictionaryShared::get_shared_lambda_proxy_class(caller_ik, interface_method_name, factory_type,
+                                                                          interface_method_type, m, dynamic_method_type);
+  }
+
+  if (shared_lambda == nullptr) {
+    SystemDictionaryShared::add_lambda_proxy_class(caller_ik, lambda_ik, interface_method_name, factory_type,
+                                                   interface_method_type, m, dynamic_method_type, THREAD);
+  }
 #endif // INCLUDE_CDS
 JVM_END
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3627,16 +3627,8 @@ JVM_ENTRY(void, JVM_RegisterLambdaProxyClassForArchiving(JNIEnv* env,
   Handle dynamic_method_type_oop(THREAD, JNIHandles::resolve_non_null(dynamicMethodType));
   Symbol* dynamic_method_type = java_lang_invoke_MethodType::as_signature(dynamic_method_type_oop(), true);
 
-  InstanceKlass* shared_lambda = nullptr;
-  if (caller_ik->is_shared()) {
-    shared_lambda = SystemDictionaryShared::get_shared_lambda_proxy_class(caller_ik, interface_method_name, factory_type,
-                                                                          interface_method_type, m, dynamic_method_type);
-  }
-
-  if (shared_lambda == nullptr) {
-    SystemDictionaryShared::add_lambda_proxy_class(caller_ik, lambda_ik, interface_method_name, factory_type,
-                                                   interface_method_type, m, dynamic_method_type, THREAD);
-  }
+  SystemDictionaryShared::add_lambda_proxy_class(caller_ik, lambda_ik, interface_method_name, factory_type,
+                                                 interface_method_type, m, dynamic_method_type, THREAD);
 #endif // INCLUDE_CDS
 JVM_END
 

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -255,6 +255,20 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
     private Class<?> spinInnerClass() throws LambdaConversionException {
         // CDS does not handle disableEagerInitialization or useImplMethodHandle
         if (!disableEagerInitialization && !useImplMethodHandle) {
+            if (CDS.isSharingEnabled()) {
+                // load from CDS archive if present
+                Class<?> innerClass = LambdaProxyClassArchive.find(targetClass,
+                                                                   interfaceMethodName,
+                                                                   factoryType,
+                                                                   interfaceMethodType,
+                                                                   implementation,
+                                                                   dynamicMethodType,
+                                                                   isSerializable,
+                                                                   altInterfaces,
+                                                                   altMethods);
+                if (innerClass != null) return innerClass;
+            }
+
             // include lambda proxy class in CDS archive at dump time
             if (CDS.isDumpingArchive()) {
                 Class<?> innerClass = generateInnerClass();
@@ -271,17 +285,6 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
                 return innerClass;
             }
 
-            // load from CDS archive if present
-            Class<?> innerClass = LambdaProxyClassArchive.find(targetClass,
-                                                               interfaceMethodName,
-                                                               factoryType,
-                                                               interfaceMethodType,
-                                                               implementation,
-                                                               dynamicMethodType,
-                                                               isSerializable,
-                                                               altInterfaces,
-                                                               altMethods);
-            if (innerClass != null) return innerClass;
         }
         return generateInnerClass();
     }

--- a/src/java.base/share/classes/java/lang/invoke/LambdaProxyClassArchive.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaProxyClassArchive.java
@@ -101,9 +101,6 @@ final class LambdaProxyClassArchive {
                          boolean isSerializable,
                          Class<?>[] altInterfaces,
                          MethodType[] altMethods) {
-        if (CDS.isDumpingArchive())
-            throw new IllegalStateException("cannot load class from CDS archive at dump time");
-
         if (!loadedByBuiltinLoader(caller) ||
             !CDS.isSharingEnabled() || isSerializable || altInterfaces.length > 0 || altMethods.length > 0)
             return null;

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdasInTwoArchives.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdasInTwoArchives.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8307468
+ * @summary Test archiving of lambda proxy classes with the same LambdaProxyClassKey
+ *          (see cds/lambdaProxyClassDictionary.hpp). If some lambda proxy classes
+ *          are already in the static archive, during dynamic dump with the static archive,
+ *          the ones in the static archive should not be generated and archived
+ *          in the dynamic archive.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes
+ * @build LambdasWithSameKey
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar lambdas_same_key.jar LambdasWithSameKey
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. LambdasInTwoArchives
+ */
+
+import java.io.File;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.helpers.ClassFileInstaller;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class LambdasInTwoArchives extends DynamicArchiveTestBase {
+    static final String lambdaPattern =
+        ".*cds.class.*klasses.*LambdasWithSameKey[$][$]Lambda.*/0x.*hidden";
+    static final String loadFromStatic =
+        ".*class.load.*LambdasWithSameKey[$][$]Lambda/0x.*source:.*shared.*objects.*file";
+    static final String loadFromTop = loadFromStatic + ".*(top).*";
+
+    public static void main(String[] args) throws Exception {
+        runTest(LambdasInTwoArchives::test);
+    }
+
+    static void checkLambdas(OutputAnalyzer output, String matchPattern, int numLambdas) throws Exception {
+        List<String> lines = output.asLines();
+        Pattern pattern = Pattern.compile(matchPattern);
+        int count = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            if (pattern.matcher(lines.get(i)).matches()) {
+                count++;
+            }
+        }
+        if (count != numLambdas) {
+            throw new RuntimeException("Expecting " + numLambdas + " lambda proxy classes, but got " + count);
+        }
+    }
+
+    static void test() throws Exception {
+        String classListFileName = "lambda-classes.list";
+        File fileList = new File(classListFileName);
+        if (fileList.exists()) {
+            fileList.delete();
+        }
+        String appJar = ClassFileInstaller.getJarPath("lambdas_same_key.jar");
+        String mainClass = "LambdasWithSameKey";
+        // Generate a class list for static dump.
+        // Note that the class list contains one less lambda proxy class comparing
+        // with running the LambdasWithSameKey app with the "run" argument.
+        String[] launchArgs  = {
+                "-Xshare:off",
+                "-XX:DumpLoadedClassList=" + classListFileName,
+                "-Xlog:cds",
+                "-Xlog:cds+lambda",
+                "-cp", appJar, mainClass};
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(launchArgs);
+        OutputAnalyzer oa = TestCommon.executeAndLog(pb, "lambda-classes");
+        oa.shouldHaveExitValue(0);
+
+        String logOptions = "-Xlog:cds=debug,class+load,cds+class=debug";
+        String baseArchiveName = CDSTestUtils.getOutputFileName("lambda-base.jsa");
+        // Static dump based on the class list.
+        dumpBaseArchive(baseArchiveName,
+                        "-XX:SharedClassListFile=" + classListFileName,
+                        logOptions,
+                        "-cp", appJar, mainClass)
+            // Expects 2 lambda proxy classes with LambdasWithSameKey as the
+            // caller class in the static dump log.
+            .assertNormalExit(output -> checkLambdas(output, lambdaPattern, 2));
+
+        String topArchiveName = getNewArchiveName("lambda-classes-top");
+
+        // Dynamic dump with the static archive.
+        dump2(baseArchiveName, topArchiveName,
+                 logOptions,
+                 "-cp", appJar, mainClass, "run")
+            // Expects only 1 lambda proxy class with LambdasWithSameKey as the
+            // caller class in the dynamic dump log.
+            .assertNormalExit(output -> checkLambdas(output, lambdaPattern, 1));
+
+        // Run with both static and dynamic archives.
+        run2(baseArchiveName, topArchiveName,
+            logOptions,
+            "-cp", appJar, mainClass, "run")
+            // Two lambda proxy classes should be loaded from the static archive.
+            .assertNormalExit(output -> checkLambdas(output, loadFromStatic, 2))
+            // One lambda proxy class should be loaded from the dynamic archive.
+            .assertNormalExit(output -> checkLambdas(output, loadFromTop, 1));
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UsedAllArchivedLambdas.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/UsedAllArchivedLambdas.java
@@ -66,7 +66,7 @@ public class UsedAllArchivedLambdas extends DynamicArchiveTestBase {
             "-Xlog:cds=debug",
             "-cp", appJar, mainClass, "run")
             .assertNormalExit(output -> {
-                output.shouldContain("Used all archived lambda proxy classes for: UsedAllArchivedLambdasApp run()Ljava/lang/Runnable;")
+                output.shouldContain("Used all dynamic archived lambda proxy classes for: UsedAllArchivedLambdasApp run()Ljava/lang/Runnable;")
                       .shouldHaveExitValue(0);
             });
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/LambdasWithSameKey.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/LambdasWithSameKey.java
@@ -33,7 +33,7 @@ public class LambdasWithSameKey {
         boolean isRun = (args.length == 1 && args[0].equals("run")) ? true : false;
         {Runnable run1 = LambdasWithSameKey::myrun; run1.run();}
         {Runnable run1 = LambdasWithSameKey::myrun; run1.run();}
-        if (isRun) { 
+        if (isRun) {
             {Runnable run1 = LambdasWithSameKey::myrun; run1.run();}
         }
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/LambdasWithSameKey.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes/LambdasWithSameKey.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * This class is for generating lambda proxy classes with the same invoke dynamic
+ * info such as: caller class, invoked name, invoked type, method type, etc.
+ *
+ */
+
+public class LambdasWithSameKey {
+    public static void main(String args[]) {
+        boolean isRun = (args.length == 1 && args[0].equals("run")) ? true : false;
+        {Runnable run1 = LambdasWithSameKey::myrun; run1.run();}
+        {Runnable run1 = LambdasWithSameKey::myrun; run1.run();}
+        if (isRun) { 
+            {Runnable run1 = LambdasWithSameKey::myrun; run1.run();}
+        }
+    }
+
+    static void myrun() {
+        System.out.println("myrun");
+    }
+}


### PR DESCRIPTION
Please review this changeset for fixing the following issues:

1. for lambda proxy classes already stored in the static archive, during CDS dynamic dump, those classes should not be regenerated and stored in the dynamic archive; (see changes in jvm.cpp)
2. handle multiple lambda proxy classes with the same invoke dynamic info stored in both static and dynamic archives. (see changes in systemDictionaryShared.cpp)

Also added a test.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307468](https://bugs.openjdk.org/browse/JDK-8307468): CDS Lambda Proxy classes are regenerated in dynamic dump (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * @ashu-mehra (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15524/head:pull/15524` \
`$ git checkout pull/15524`

Update a local copy of the PR: \
`$ git checkout pull/15524` \
`$ git pull https://git.openjdk.org/jdk.git pull/15524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15524`

View PR using the GUI difftool: \
`$ git pr show -t 15524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15524.diff">https://git.openjdk.org/jdk/pull/15524.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15524#issuecomment-1701863838)