### PR TITLE
8315127: CDSMapTest fails with incorrect number of oop references

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/CDSMapTest.java
+++ b/test/hotspot/jtreg/runtime/cds/CDSMapTest.java
@@ -76,11 +76,6 @@ public class CDSMapTest {
         CDSTestUtils.createArchiveAndCheck(opts);
 
         CDSMapReader.MapFile mapFile = CDSMapReader.read(mapName);
-        int oopFieldCount = CDSMapReader.validate(mapFile);
-        if (mapFile.heapObjectCount() > 0 && oopFieldCount < 10000) {
-            // heapObjectCount() may be zero if the selected GC doesn't support heap object archiving.
-            throw new RuntimeException("CDS map file seems incorrect: " + mapFile.heapObjectCount() +
-                                       " objects but only " + oopFieldCount + " oop field references");
-        }
+        CDSMapReader.validate(mapFile);
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/CDSMapTest.java
+++ b/test/hotspot/jtreg/runtime/cds/CDSMapTest.java
@@ -33,8 +33,6 @@
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.Platform;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 
 public class CDSMapTest {


### PR DESCRIPTION
This is a bug in the test case. The test parses patterns like this in the map file

```
0x00000000ffe00000: @@ Object (0xffe00000) java.lang.String
 - klass: 'java/lang/String' 0x0000000800010220
 - fields (3 words):
 - private 'hash' 'I' @12  0 (0x00000000)
 - private final 'coder' 'B' @16  0 (0x00)
 - private 'hashIsZero' 'Z' @17  true (0x01)
 - injected 'flags' 'B' @18  1 (0x01)
 - private final 'value' '[B' @20 0x00000000ffe00018 (0xffe00018) [B length: 0
0x00000000ffe00018: @@ Object (0xffe00018) [B length: 0
 - klass: {type array byte} 0x00000008000024d8
```

Before this fix, the test assets that there are at least 10000 oop references (such as the `value` field in the above String). However, some JDK builds may have fewer archived heap objects, resulting in less than 10000 references (the graal build in the bug report has only 8286 references).

After this fix, we check that the number of oop references is not fewer than the number of strings, as we know each string contains one oop field. This is sufficient to check that the map file contains expected output, without using a hard-coded number.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315127](https://bugs.openjdk.org/browse/JDK-8315127): CDSMapTest fails with incorrect number of oop references (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15527/head:pull/15527` \
`$ git checkout pull/15527`

Update a local copy of the PR: \
`$ git checkout pull/15527` \
`$ git pull https://git.openjdk.org/jdk.git pull/15527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15527`

View PR using the GUI difftool: \
`$ git pr show -t 15527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15527.diff">https://git.openjdk.org/jdk/pull/15527.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15527#issuecomment-1701944892)