### PR TITLE
JDK-8314121: test tools/jpackage/share/RuntimePackageTest.java#id0 fails on RHEL8

### DIFF
--- a/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
+++ b/src/jdk.jpackage/linux/classes/jdk/jpackage/internal/resources/template.spec
@@ -30,6 +30,9 @@ Requires: PACKAGE_DEFAULT_DEPENDENCIES PACKAGE_CUSTOM_DEPENDENCIES
 #build time will substantially increase and it may require unpack200/system java to install
 %define __jar_repack %{nil}
 
+# on RHEL we got unwanted improved debugging enhancements
+%define _build_id_links none
+
 %define package_filelist %{_builddir}/%{name}.files
 %define app_filelist %{_builddir}/%{name}.app.files
 %define filesystem_filelist %{_builddir}/%{name}.filesystem.files

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -702,6 +702,10 @@ public final class PackageTest extends RunnablePackageTest {
             }
 
             try ( var files = Files.list(unpackedDir)) {
+                System.out.println("Unpacked dir contains:");
+                var files2 = Files.list(unpackedDir);
+                files2.forEach(System.out::println);
+
                 TKit.assertEquals(expectedRootCount, files.count(),
                         String.format(
                                 "Check the package has %d top installation directories",

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -702,10 +702,6 @@ public final class PackageTest extends RunnablePackageTest {
             }
 
             try ( var files = Files.list(unpackedDir)) {
-                System.out.println("Unpacked dir contains:");
-                var files2 = Files.list(unpackedDir);
-                files2.forEach(System.out::println);
-
                 TKit.assertEquals(expectedRootCount, files.count(),
                         String.format(
                                 "Check the package has %d top installation directories",


### PR DESCRIPTION
on some RHEL Linux 8.X machines , we run into errors in test tools/jpackage/share/RuntimePackageTest.java#id0 , error can be seen below.
It looks like these errors occur when running the jtreg tests with higher concurrency, I did not see them when running just the single test.

When adding some test output , we see the 2 top install dirs below (1 is expected, not 2) :
./test/unpacked-rpm/opt
./test/unpacked-rpm/usr

error output :

java.lang.AssertionError: Expected [1]. Actual [2]: Check the package has 1 top installation directories
       at jdk.jpackage.test.TKit.error(TKit.java:273)
       at jdk.jpackage.test.TKit.assertEquals(TKit.java:576)
       at jdk.jpackage.test.PackageTest$Handler.verifyRootCountInUnpackedPackage(PackageTest.java:705)
       at jdk.jpackage.test.PackageTest$Handler.lambda$verifyPackageInstalled$3(PackageTest.java:635)
       at java.base/java.util.Optional.ifPresent(Optional.java:178)
       at jdk.jpackage.test.PackageTest$Handler.verifyPackageInstalled(PackageTest.java:633)
       at jdk.jpackage.test.PackageTest$Handler.accept(PackageTest.java:592)
       at jdk.jpackage.test.PackageTest$2.accept(PackageTest.java:504)
       at jdk.jpackage.test.PackageTest$2.accept(PackageTest.java:411)
       at jdk.jpackage.test.Functional$ThrowingConsumer.lambda$toConsumer$0(Functional.java:41)
       at java.base/java.lang.Iterable.forEach(Iterable.java:75)
       at jdk.jpackage.test.PackageTest.lambda$runActions$24(PackageTest.java:381)
       at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
       at jdk.jpackage.test.PackageTest.lambda$runActions$25(PackageTest.java:380)
       at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
       at jdk.jpackage.test.PackageTest.runActions(PackageTest.java:379)
       at jdk.jpackage.test.RunnablePackageTest.run(RunnablePackageTest.java:58)
       at RuntimePackageTest.test(RuntimePackageTest.java:83)
       at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
       at java.base/java.lang.reflect.Method.invoke(Method.java:580)
       at jdk.jpackage.test.MethodCall.accept(MethodCall.java:145)
       at jdk.jpackage.test.TestInstance.run(TestInstance.java:230)
       at jdk.jpackage.test.TKit.lambda$ignoreExceptions$5(TKit.java:141)
       at jdk.jpackage.test.TKit.lambda$runTests$3(TKit.java:126)
       at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
       at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
       at jdk.jpackage.test.TKit.lambda$runTests$4(TKit.java:123)
       at jdk.jpackage.test.Functional$ThrowingRunnable.lambda$toRunnable$0(Functional.java:105)
       at jdk.jpackage.test.TKit.withExtraLogStream(TKit.java:109)
       at jdk.jpackage.test.TKit.runTests(TKit.java:122)
       at jdk.jpackage.test.Main.runTests(Main.java:79)
       at jdk.jpackage.test.Main.lambda$main$2(Main.java:75)
       at jdk.jpackage.test.Functional$ThrowingRunnable.lambda$toRunnable$0(Functional.java:105)
       at jdk.jpackage.test.TKit.withExtraLogStream(TKit.java:109)
       at jdk.jpackage.test.Main.main(Main.java:75)
       at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
       at java.base/java.lang.reflect.Method.invoke(Method.java:580)
       at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
       at java.base/java.lang.Thread.run(Thread.java:1570)

Looks like the additional dir /usr/lib/.build-id  is coming from automatically adding /usr/lib/.build-id to package; this seems to be a feature of the rpmbuild according to https://bugzilla.redhat.com/show_bug.cgi?id=1724153   and must be configured in template.spec if it is unwanted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314121](https://bugs.openjdk.org/browse/JDK-8314121): test tools/jpackage/share/RuntimePackageTest.java#id0 fails on RHEL8 (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [b630eef0](https://git.openjdk.org/jdk/pull/15528/files/b630eef043f0576cd436122fbe5ac951f8a9642a)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15528/head:pull/15528` \
`$ git checkout pull/15528`

Update a local copy of the PR: \
`$ git checkout pull/15528` \
`$ git pull https://git.openjdk.org/jdk.git pull/15528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15528`

View PR using the GUI difftool: \
`$ git pr show -t 15528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15528.diff">https://git.openjdk.org/jdk/pull/15528.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15528#issuecomment-1702298932)