### PR TITLE
8315444: Convert test/jdk/tools to Classfile API

### DIFF
--- a/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
+++ b/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
@@ -34,7 +34,12 @@ import tests.JImageGenerator;
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library /tools/lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.compiler
  * @build HijrahConfigCheck tests.*

--- a/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
+++ b/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
@@ -39,7 +39,6 @@ import tests.JImageGenerator;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.compiler
  * @build HijrahConfigCheck tests.*

--- a/test/jdk/tools/jimage/JImageNonAsciiNameTest.java
+++ b/test/jdk/tools/jimage/JImageNonAsciiNameTest.java
@@ -38,7 +38,12 @@ import tests.Result;
  * @library ../lib
  *          /test/lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.*
  * @run main/othervm JImageNonAsciiNameTest

--- a/test/jdk/tools/jimage/JImageNonAsciiNameTest.java
+++ b/test/jdk/tools/jimage/JImageNonAsciiNameTest.java
@@ -43,7 +43,6 @@ import tests.Result;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.*
  * @run main/othervm JImageNonAsciiNameTest

--- a/test/jdk/tools/jimage/JImageTest.java
+++ b/test/jdk/tools/jimage/JImageTest.java
@@ -48,7 +48,12 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
  * @bug 8222100
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.jlink/jdk.tools.jlink.internal

--- a/test/jdk/tools/jimage/JImageTest.java
+++ b/test/jdk/tools/jimage/JImageTest.java
@@ -53,7 +53,6 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.jlink/jdk.tools.jlink.internal

--- a/test/jdk/tools/jlink/DefaultProviderTest.java
+++ b/test/jdk/tools/jlink/DefaultProviderTest.java
@@ -43,7 +43,12 @@ import tests.Helper;
  * @requires vm.compMode != "Xcomp"
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/DefaultProviderTest.java
+++ b/test/jdk/tools/jlink/DefaultProviderTest.java
@@ -48,7 +48,6 @@ import tests.Helper;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/ExplodedModuleNameTest.java
+++ b/test/jdk/tools/jlink/ExplodedModuleNameTest.java
@@ -39,7 +39,12 @@ import tests.Result;
  * @summary Inconsistent handling of exploded modules in jlink
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/ExplodedModuleNameTest.java
+++ b/test/jdk/tools/jlink/ExplodedModuleNameTest.java
@@ -44,7 +44,6 @@ import tests.Result;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/IntegrationTest.java
+++ b/test/jdk/tools/jlink/IntegrationTest.java
@@ -61,7 +61,12 @@ import tests.JImageGenerator;
  * @author Jean-Francois Denise
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.builder
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.internal.plugins

--- a/test/jdk/tools/jlink/IntegrationTest.java
+++ b/test/jdk/tools/jlink/IntegrationTest.java
@@ -66,7 +66,6 @@ import tests.JImageGenerator;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.builder
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.internal.plugins

--- a/test/jdk/tools/jlink/JLink100Modules.java
+++ b/test/jdk/tools/jlink/JLink100Modules.java
@@ -36,7 +36,12 @@ import tests.JImageGenerator;
  * @bug 8240567
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/JLink100Modules.java
+++ b/test/jdk/tools/jlink/JLink100Modules.java
@@ -41,7 +41,6 @@ import tests.JImageGenerator;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/JLink2Test.java
+++ b/test/jdk/tools/jlink/JLink2Test.java
@@ -27,7 +27,12 @@
  * @author Jean-Francois Denise
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/JLink2Test.java
+++ b/test/jdk/tools/jlink/JLink2Test.java
@@ -32,7 +32,6 @@
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/JLinkDedupTestBatchSizeOne.java
+++ b/test/jdk/tools/jlink/JLinkDedupTestBatchSizeOne.java
@@ -37,7 +37,12 @@ import java.nio.file.Paths;
  * @library /test/lib
  *          ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/JLinkDedupTestBatchSizeOne.java
+++ b/test/jdk/tools/jlink/JLinkDedupTestBatchSizeOne.java
@@ -42,7 +42,6 @@ import java.nio.file.Paths;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/JLinkNegativeTest.java
+++ b/test/jdk/tools/jlink/JLinkNegativeTest.java
@@ -33,7 +33,12 @@
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.jimage
  *          java.base/jdk.internal.module
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/JLinkNegativeTest.java
+++ b/test/jdk/tools/jlink/JLinkNegativeTest.java
@@ -38,7 +38,6 @@
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/JLinkOptionsTest.java
+++ b/test/jdk/tools/jlink/JLinkOptionsTest.java
@@ -37,7 +37,12 @@ import tests.Helper;
  * @author Jean-Francois Denise
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/JLinkOptionsTest.java
+++ b/test/jdk/tools/jlink/JLinkOptionsTest.java
@@ -42,7 +42,6 @@ import tests.Helper;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/JLinkPluginsTest.java
+++ b/test/jdk/tools/jlink/JLinkPluginsTest.java
@@ -36,7 +36,12 @@ import tests.Helper;
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/JLinkPluginsTest.java
+++ b/test/jdk/tools/jlink/JLinkPluginsTest.java
@@ -41,7 +41,6 @@ import tests.Helper;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/JLinkTest.java
+++ b/test/jdk/tools/jlink/JLinkTest.java
@@ -52,7 +52,12 @@ import tests.JImageGenerator;
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/JLinkTest.java
+++ b/test/jdk/tools/jlink/JLinkTest.java
@@ -57,7 +57,6 @@ import tests.JImageGenerator;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/ModuleNamesOrderTest.java
+++ b/test/jdk/tools/jlink/ModuleNamesOrderTest.java
@@ -42,7 +42,12 @@ import tests.JImageGenerator.JLinkTask;
  * @summary MODULES property should be topologically ordered and space-separated list
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/ModuleNamesOrderTest.java
+++ b/test/jdk/tools/jlink/ModuleNamesOrderTest.java
@@ -47,7 +47,6 @@ import tests.JImageGenerator.JLinkTask;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/NativeTest.java
+++ b/test/jdk/tools/jlink/NativeTest.java
@@ -27,7 +27,12 @@
  * @author Andrei Eremeev
  * @library ../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/NativeTest.java
+++ b/test/jdk/tools/jlink/NativeTest.java
@@ -32,7 +32,6 @@
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/plugins/AddOptionsPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/AddOptionsPluginTest.java
@@ -31,7 +31,12 @@ import tests.Helper;
  * @library ../../lib
  * @library /test/lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/plugins/AddOptionsPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/AddOptionsPluginTest.java
@@ -36,7 +36,6 @@ import tests.Helper;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/plugins/CDSPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CDSPluginTest.java
@@ -38,7 +38,12 @@ import jtreg.SkippedException;
  * @library ../../lib
  * @library /test/lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/plugins/CDSPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CDSPluginTest.java
@@ -43,7 +43,6 @@ import jtreg.SkippedException;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/plugins/GenerateJLIClassesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/GenerateJLIClassesPluginTest.java
@@ -43,7 +43,12 @@ import org.testng.annotations.Test;
  * @library ../../lib
  * @summary Test --generate-jli-classes plugin
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.internal.plugins
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/plugins/GenerateJLIClassesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/GenerateJLIClassesPluginTest.java
@@ -48,7 +48,6 @@ import org.testng.annotations.Test;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.internal.plugins
  *          jdk.jlink/jdk.tools.jmod

--- a/test/jdk/tools/jlink/plugins/IncludeLocalesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/IncludeLocalesPluginTest.java
@@ -48,7 +48,12 @@ import tests.Result;
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
  * @library ../../lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.internal.plugins
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/plugins/IncludeLocalesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/IncludeLocalesPluginTest.java
@@ -53,7 +53,6 @@ import tests.Result;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jlink.internal.plugins
  *          jdk.jlink/jdk.tools.jlink.plugin

--- a/test/jdk/tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java
@@ -28,7 +28,12 @@
  * @library ../../lib
  * @library /test/lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/SaveJlinkArgfilesPluginTest.java
@@ -33,7 +33,6 @@
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/plugins/StringSharingPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/StringSharingPluginTest.java
@@ -33,7 +33,12 @@
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.compiler
  * @run build tests.*
  * @run main StringSharingPluginTest

--- a/test/jdk/tools/jlink/plugins/StringSharingPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/StringSharingPluginTest.java
@@ -38,7 +38,6 @@
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.compiler
  * @run build tests.*
  * @run main StringSharingPluginTest

--- a/test/jdk/tools/jlink/plugins/StripJavaDebugAttributesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/StripJavaDebugAttributesPluginTest.java
@@ -33,7 +33,12 @@
  *          jdk.jlink/jdk.tools.jlink.plugin
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.jlink/jdk.tools.jmod
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.compiler
  * @run main StripJavaDebugAttributesPluginTest
  */
@@ -42,19 +47,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Stream;
 
-import com.sun.tools.classfile.Attribute;
-import com.sun.tools.classfile.ClassFile;
-import com.sun.tools.classfile.Code_attribute;
-import com.sun.tools.classfile.ConstantPoolException;
-import com.sun.tools.classfile.Method;
-
+import jdk.internal.classfile.*;
+import jdk.internal.classfile.attribute.CodeAttribute;
 import jdk.tools.jlink.internal.ResourcePoolManager;
 import jdk.tools.jlink.internal.plugins.StripJavaDebugAttributesPlugin;
 import jdk.tools.jlink.plugin.Plugin;
@@ -141,21 +138,22 @@ public class StripJavaDebugAttributesPluginTest {
         return resPool.findEntry(classResource.path()).get();
     }
 
-    private void checkDebugAttributes(byte[] strippedClassFile) throws IOException, ConstantPoolException {
-        ClassFile classFile = ClassFile.read(new ByteArrayInputStream(strippedClassFile));
-        String[] debugAttributes = new String[]{
-                Attribute.LineNumberTable,
-                Attribute.LocalVariableTable,
-                Attribute.LocalVariableTypeTable
-        };
-        for (Method method : classFile.methods) {
-            String methodName = method.getName(classFile.constant_pool);
-            Code_attribute code = (Code_attribute) method.attributes.get(Attribute.Code);
-            for (String attr : debugAttributes) {
-                if (code.attributes.get(attr) != null) {
-                    throw new AssertionError("Debug attribute was not removed: " + attr +
-                            " from method " + classFile.getName() + "#" + methodName);
-                }
+    private <T extends Attribute<T>> void checkDebugAttributes(byte[] strippedClassFile) {
+        ClassModel classFile = Classfile.of().parse(strippedClassFile);
+        for (MethodModel method : classFile.methods()) {
+            String methodName = method.methodName().stringValue();
+            CodeAttribute code = method.findAttribute(Attributes.CODE).orElseThrow();
+            if (code.findAttribute(Attributes.LINE_NUMBER_TABLE).orElse(null) != null) {
+                throw new AssertionError("Debug attribute was not removed: " + "LINE_NUMBER_TABLE" +
+                        " from method " + classFile.thisClass().asInternalName() + "#" + methodName);
+            }
+            if (code.findAttribute(Attributes.LOCAL_VARIABLE_TABLE).orElse(null) != null) {
+                throw new AssertionError("Debug attribute was not removed: " + "LOCAL_VARIABLE_TABLE" +
+                        " from method " + classFile.thisClass().asInternalName() + "#" + methodName);
+            }
+            if (code.findAttribute(Attributes.LOCAL_VARIABLE_TYPE_TABLE).orElse(null) != null) {
+                throw new AssertionError("Debug attribute was not removed: " + "LOCAL_VARIABLE_TYPE_TABLE" +
+                        " from method " + classFile.thisClass().asInternalName() + "#" + methodName);
             }
         }
     }

--- a/test/jdk/tools/jlink/plugins/StripJavaDebugAttributesPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/StripJavaDebugAttributesPluginTest.java
@@ -38,7 +38,6 @@
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.compiler
  * @run main StripJavaDebugAttributesPluginTest
  */

--- a/test/jdk/tools/jlink/plugins/VendorInfoPluginsTest.java
+++ b/test/jdk/tools/jlink/plugins/VendorInfoPluginsTest.java
@@ -31,7 +31,12 @@ import tests.Helper;
  * @library ../../lib
  * @library /test/lib
  * @modules java.base/jdk.internal.jimage
- *          jdk.jdeps/com.sun.tools.classfile
+ *          java.base/jdk.internal.classfile
+ *          java.base/jdk.internal.classfile.attribute
+ *          java.base/jdk.internal.classfile.constantpool
+ *          java.base/jdk.internal.classfile.instruction
+ *          java.base/jdk.internal.classfile.components
+ *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/jlink/plugins/VendorInfoPluginsTest.java
+++ b/test/jdk/tools/jlink/plugins/VendorInfoPluginsTest.java
@@ -36,7 +36,6 @@ import tests.Helper;
  *          java.base/jdk.internal.classfile.constantpool
  *          java.base/jdk.internal.classfile.instruction
  *          java.base/jdk.internal.classfile.components
- *          java.base/jdk.internal.classfile.impl
  *          jdk.jlink/jdk.tools.jlink.internal
  *          jdk.jlink/jdk.tools.jmod
  *          jdk.jlink/jdk.tools.jimage

--- a/test/jdk/tools/lib/tests/JImageValidator.java
+++ b/test/jdk/tools/lib/tests/JImageValidator.java
@@ -22,19 +22,16 @@
  */
 package tests;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import com.sun.tools.classfile.ClassFile;
-import com.sun.tools.classfile.ConstantPoolException;
+import jdk.internal.classfile.Classfile;
 import jdk.internal.jimage.BasicImageReader;
 import jdk.internal.jimage.ImageLocation;
 
@@ -225,10 +222,6 @@ public class JImageValidator {
     }
 
     public static void readClass(byte[] clazz) throws IOException {
-        try (InputStream stream = new ByteArrayInputStream(clazz)) {
-            ClassFile.read(stream);
-        } catch (ConstantPoolException e) {
-            throw new IOException(e);
-        }
+        Classfile.of().parse(clazz);
     }
 }

--- a/test/jdk/tools/lib/tests/JImageValidator.java
+++ b/test/jdk/tools/lib/tests/JImageValidator.java
@@ -221,7 +221,13 @@ public class JImageValidator {
         return moduleExecutionTime;
     }
 
-    public static void readClass(byte[] clazz) throws IOException {
-        Classfile.of().parse(clazz);
-    }
+    public static void readClass(byte[] clazz) throws IOException{
+        var errors = Classfile.of().parse(clazz).verify(null);
+        if (!errors.isEmpty()) {
+            var itr = errors.iterator();
+            var thrown = itr.next();
+            itr.forEachRemaining(thrown::addSuppressed);
+            throw new IOException(thrown);
+        }
+	}
 }

--- a/test/jdk/tools/lib/tests/JImageValidator.java
+++ b/test/jdk/tools/lib/tests/JImageValidator.java
@@ -229,5 +229,5 @@ public class JImageValidator {
             itr.forEachRemaining(thrown::addSuppressed);
             throw new IOException(thrown);
         }
-	}
+    }
 }


### PR DESCRIPTION
`/test/jdk/tools/lib/tests/JImageValidator.java`, tests in `/test/jdk/tools/jlink`, and `/test/jdk/tools/jimage`, `/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java` use on com.sun.tools.classfile and should be converted to Classfile API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315444](https://bugs.openjdk.org/browse/JDK-8315444): Convert test/jdk/tools to Classfile API (**Sub-task** - P5)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15529/head:pull/15529` \
`$ git checkout pull/15529`

Update a local copy of the PR: \
`$ git checkout pull/15529` \
`$ git pull https://git.openjdk.org/jdk.git pull/15529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15529`

View PR using the GUI difftool: \
`$ git pr show -t 15529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15529.diff">https://git.openjdk.org/jdk/pull/15529.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15529#issuecomment-1702950299)