### PR TITLE
8315454: Add a way to create an immutable snapshot of a BitSet

### DIFF
--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -34,6 +34,7 @@ import java.util.BitSet;
 import java.util.Objects;
 import java.util.function.IntPredicate;
 
+import jdk.internal.util.ImmutableBitSetPredicate;
 import jdk.internal.util.StaticProperty;
 
 /**
@@ -132,7 +133,7 @@ public class URLEncoder {
         bitSet.set('.');
         bitSet.set('*');
 
-        DONT_NEED_ENCODING = bitSet.toPredicate();
+        DONT_NEED_ENCODING = ImmutableBitSetPredicate.of(bitSet);
 
         DEFAULT_ENCODING_NAME = StaticProperty.fileEncoding();
     }

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -32,6 +32,7 @@ import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException ;
 import java.util.BitSet;
 import java.util.Objects;
+import java.util.function.IntPredicate;
 
 import jdk.internal.util.StaticProperty;
 
@@ -78,7 +79,7 @@ import jdk.internal.util.StaticProperty;
  * @since   1.0
  */
 public class URLEncoder {
-    private static final BitSet DONT_NEED_ENCODING;
+    private static final IntPredicate DONT_NEED_ENCODING;
     private static final int CASE_DIFF = ('a' - 'A');
     private static final String DEFAULT_ENCODING_NAME;
 
@@ -120,17 +121,18 @@ public class URLEncoder {
          *
          */
 
-        DONT_NEED_ENCODING = new BitSet(128);
-
-        DONT_NEED_ENCODING.set('a', 'z' + 1);
-        DONT_NEED_ENCODING.set('A', 'Z' + 1);
-        DONT_NEED_ENCODING.set('0', '9' + 1);
-        DONT_NEED_ENCODING.set(' '); /* encoding a space to a + is done
+        var bitSet = new BitSet(128);
+        bitSet.set('a', 'z' + 1);
+        bitSet.set('A', 'Z' + 1);
+        bitSet.set('0', '9' + 1);
+        bitSet.set(' '); /* encoding a space to a + is done
                                     * in the encode() method */
-        DONT_NEED_ENCODING.set('-');
-        DONT_NEED_ENCODING.set('_');
-        DONT_NEED_ENCODING.set('.');
-        DONT_NEED_ENCODING.set('*');
+        bitSet.set('-');
+        bitSet.set('_');
+        bitSet.set('.');
+        bitSet.set('*');
+
+        DONT_NEED_ENCODING = bitSet.toPredicate();
 
         DEFAULT_ENCODING_NAME = StaticProperty.fileEncoding();
     }
@@ -226,7 +228,7 @@ public class URLEncoder {
         for (int i = 0; i < s.length();) {
             int c = s.charAt(i);
             //System.out.println("Examining character: " + c);
-            if (DONT_NEED_ENCODING.get(c)) {
+            if (DONT_NEED_ENCODING.test(c)) {
                 if (c == ' ') {
                     c = '+';
                     needToChange = true;
@@ -269,7 +271,7 @@ public class URLEncoder {
                         }
                     }
                     i++;
-                } while (i < s.length() && !DONT_NEED_ENCODING.get((c = s.charAt(i))));
+                } while (i < s.length() && !DONT_NEED_ENCODING.test((c = s.charAt(i))));
 
                 charArrayWriter.flush();
                 String str = charArrayWriter.toString();

--- a/src/java.base/share/classes/java/util/BitSet.java
+++ b/src/java.base/share/classes/java/util/BitSet.java
@@ -30,13 +30,10 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.LongBuffer;
 import java.util.function.IntConsumer;
-import java.util.function.IntPredicate;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
-import jdk.internal.ValueBased;
 import jdk.internal.util.ArraysSupport;
-import jdk.internal.vm.annotation.Stable;
 
 /**
  * This class implements a vector of bits that grows as needed. Each

--- a/src/java.base/share/classes/java/util/BitSet.java
+++ b/src/java.base/share/classes/java/util/BitSet.java
@@ -1401,48 +1401,4 @@ public class BitSet implements Cloneable, java.io.Serializable {
         }
     }
 
-    /**
-     * {@return a new {@link IntPredicate} representing the {@link BitSet#get(int)} method applied
-     * on an immutable snapshot of the current state of this BitSet}.
-     * <p>
-     * If the returned predicate is invoked with a {@code bitIndex} that is negative, the predicate
-     * will throw an IndexOutOfBoundsException just as the {@link BitSet#get(int)} method would.
-     * <p>
-     * Returned predicates are threadsafe and can be used without external synchronisation.  Furthermore,
-     * they are eligible for constant-folding optimization by the VM.
-     *
-     * @implNote The method is free to return a {@link ValueBased} implementation.
-     *
-     * @since 22
-     */
-    public IntPredicate toPredicate() {
-        return OfImmutable.of(this);
-    }
-
-    @ValueBased
-    private static final class OfImmutable implements IntPredicate {
-
-        @Stable
-        private final long[] words;
-
-        private OfImmutable(BitSet original) {
-            this.words = original.toLongArray();
-        }
-
-        @Override
-        public boolean test(int bitIndex) {
-            if (bitIndex < 0)
-                throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
-
-            int wordIndex = wordIndex(bitIndex);
-            return (wordIndex < words.length)
-                    && ((words[wordIndex] & (1L << bitIndex)) != 0);
-        }
-
-        private static IntPredicate of(BitSet original) {
-            return new OfImmutable(original);
-        }
-
-    }
-
 }

--- a/src/java.base/share/classes/java/util/BitSet.java
+++ b/src/java.base/share/classes/java/util/BitSet.java
@@ -30,10 +30,13 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.LongBuffer;
 import java.util.function.IntConsumer;
+import java.util.function.IntPredicate;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
+import jdk.internal.ValueBased;
 import jdk.internal.util.ArraysSupport;
+import jdk.internal.vm.annotation.Stable;
 
 /**
  * This class implements a vector of bits that grows as needed. Each
@@ -1396,6 +1399,50 @@ public class BitSet implements Cloneable, java.io.Serializable {
                 return -1;
             word = words[u];
         }
+    }
+
+    /**
+     * {@return a new {@link IntPredicate} representing the {@link BitSet#get(int)} method applied
+     * on an immutable snapshot of the current state of this BitSet}.
+     * <p>
+     * If the returned predicate is invoked with a {@code bitIndex} that is negative, the predicate
+     * will throw an IndexOutOfBoundsException just as the {@link BitSet#get(int)} method would.
+     * <p>
+     * Returned predicates are threadsafe and can be used without external synchronisation.  Furthermore,
+     * they are eligible for constant-folding optimization by the VM.
+     *
+     * @implNote The method is free to return a {@link ValueBased} implementation.
+     *
+     * @since 22
+     */
+    public IntPredicate toPredicate() {
+        return OfImmutable.of(this);
+    }
+
+    @ValueBased
+    private static final class OfImmutable implements IntPredicate {
+
+        @Stable
+        private final long[] words;
+
+        private OfImmutable(BitSet original) {
+            this.words = original.toLongArray();
+        }
+
+        @Override
+        public boolean test(int bitIndex) {
+            if (bitIndex < 0)
+                throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
+
+            int wordIndex = wordIndex(bitIndex);
+            return (wordIndex < words.length)
+                    && ((words[wordIndex] & (1L << bitIndex)) != 0);
+        }
+
+        private static IntPredicate of(BitSet original) {
+            return new OfImmutable(original);
+        }
+
     }
 
 }

--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -16,6 +16,10 @@ public class ImmutableBitSetPredicate implements IntPredicate {
     private final long[] words;
 
     private ImmutableBitSetPredicate(BitSet original) {
+        // If this class is made public, we need to do
+        // a defensive array copy as certain BitSet implementations
+        // may return a shared array. The spec says the array should be _new_ though but
+        // the consequences might be unspecified for a malicious BitSet.
         this.words = original.toLongArray();
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.util;
 
 import jdk.internal.ValueBased;
@@ -47,8 +72,6 @@ public class ImmutableBitSetPredicate implements IntPredicate {
      * If the returned predicate is invoked with a {@code bitIndex} that is negative, the predicate
      * will throw an IndexOutOfBoundsException just as the {@link BitSet#get(int)} method would.
      * <p>
-     * The method only supports BitSets where the highest bit that is set has an index less than {@link Integer#MAX_VALUE}.
-     * <p>
      * Returned predicates are threadsafe and can be used without external synchronisation.
      *
      * @implNote The method is free to return a {@link ValueBased} implementation.
@@ -56,10 +79,6 @@ public class ImmutableBitSetPredicate implements IntPredicate {
      * @since 22
      */
     public static IntPredicate of(BitSet original) {
-        // Do not propagate the Integer.MAX_VALUE issue
-        if (Integer.toUnsignedLong(original.length()) > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException();
-        }
         return new ImmutableBitSetPredicate(original);
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -47,6 +47,8 @@ public class ImmutableBitSetPredicate implements IntPredicate {
      * If the returned predicate is invoked with a {@code bitIndex} that is negative, the predicate
      * will throw an IndexOutOfBoundsException just as the {@link BitSet#get(int)} method would.
      * <p>
+     * The method only supports BitSets where the highest bit that is set has an index less than {@link Integer#MAX_VALUE}.
+     * <p>
      * Returned predicates are threadsafe and can be used without external synchronisation.
      *
      * @implNote The method is free to return a {@link ValueBased} implementation.
@@ -54,6 +56,10 @@ public class ImmutableBitSetPredicate implements IntPredicate {
      * @since 22
      */
     public static IntPredicate of(BitSet original) {
+        // Do not propagate the Integer.MAX_VALUE issue
+        if (Integer.toUnsignedLong(original.length()) > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException();
+        }
         return new ImmutableBitSetPredicate(original);
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -1,0 +1,56 @@
+package jdk.internal.util;
+
+import jdk.internal.ValueBased;
+import jdk.internal.vm.annotation.Stable;
+
+import java.util.BitSet;
+import java.util.function.IntPredicate;
+
+/**
+ * Class for working with immutable BitSets.
+ */
+@ValueBased
+public class ImmutableBitSetPredicate implements IntPredicate {
+
+    @Stable
+    private final long[] words;
+
+    private ImmutableBitSetPredicate(BitSet original) {
+        this.words = original.toLongArray();
+    }
+
+    @Override
+    public boolean test(int bitIndex) {
+        if (bitIndex < 0)
+            throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
+
+        int wordIndex = wordIndex(bitIndex);
+        return (wordIndex < words.length)
+                && ((words[wordIndex] & (1L << bitIndex)) != 0);
+    }
+
+    /**
+     * Given a bit index, return word index containing it.
+     */
+    private static int wordIndex(int bitIndex) {
+        return bitIndex >> 6;
+    }
+
+    /**
+     * {@return a new {@link IntPredicate } representing the {@link BitSet#get(int)} method applied
+     * on an immutable snapshot of the current state of this BitSet}.
+     * <p>
+     * If the returned predicate is invoked with a {@code bitIndex} that is negative, the predicate
+     * will throw an IndexOutOfBoundsException just as the {@link BitSet#get(int)} method would.
+     * <p>
+     * Returned predicates are threadsafe and can be used without external synchronisation.
+     *
+     * @implNote The method is free to return a {@link ValueBased} implementation.
+     *
+     * @since 22
+     */
+    public static IntPredicate of(BitSet original) {
+        return new ImmutableBitSetPredicate(original);
+    }
+
+}

--- a/test/jdk/java/util/BitSet/ImmutableBitSet.java
+++ b/test/jdk/java/util/BitSet/ImmutableBitSet.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @summary Basic tests of immutable BitSets
+ * @modules java.base/jdk.internal.util
  * @run junit ImmutableBitSet
  */
 

--- a/test/jdk/java/util/BitSet/ImmutableBitSet.java
+++ b/test/jdk/java/util/BitSet/ImmutableBitSet.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Basic tests of immutable BitSets
+ * @run junit ImmutableBitSet
+ */
+
+import org.junit.jupiter.api.Test;
+
+import java.util.BitSet;
+import java.util.Random;
+import java.util.function.IntPredicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ImmutableBitSet {
+
+    @Test
+    void empty() {
+        BitSet bs = new BitSet();
+        IntPredicate ibs = bs.toPredicate();
+        test(bs, ibs);
+    }
+
+    @Test
+    void negativeIndex() {
+        BitSet bs = new BitSet();
+        IntPredicate ibs = bs.toPredicate();
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            ibs.test(-1);
+        });
+    }
+
+    @Test
+    void basic() {
+        BitSet bs = createReference(147);
+        IntPredicate ibs = bs.toPredicate();
+        test(bs, ibs);
+    }
+
+    @Test
+    void clearedAtTheTail() {
+        for (int i = Long.BYTES - 1; i < Long.BYTES + 2; i++) {
+            BitSet bs = createReference(i);
+            for (int j = bs.length() - 1; j > Long.BYTES - 1; j++) {
+                bs.clear(j);
+            }
+            IntPredicate ibs = bs.toPredicate();
+            test(bs, ibs);
+        }
+    }
+
+    static void test(BitSet expected, IntPredicate actual) {
+        for (int i = 0; i < expected.length() + 17; i++) {
+            assertEquals(expected.get(i), actual.test(i), "at index " + i);
+        }
+    }
+
+    private static BitSet createReference(int length) {
+        BitSet result = new BitSet();
+        Random random = new Random(length);
+        for (int i = 0; i < length; i++) {
+            result.set(i, random.nextBoolean());
+        }
+        return result;
+    }
+
+}

--- a/test/jdk/java/util/BitSet/ImmutableBitSet.java
+++ b/test/jdk/java/util/BitSet/ImmutableBitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/BitSet/ImmutableBitSet.java
+++ b/test/jdk/java/util/BitSet/ImmutableBitSet.java
@@ -27,6 +27,7 @@
  * @run junit ImmutableBitSet
  */
 
+import jdk.internal.util.ImmutableBitSetPredicate;
 import org.junit.jupiter.api.Test;
 
 import java.util.BitSet;
@@ -40,14 +41,14 @@ public class ImmutableBitSet {
     @Test
     void empty() {
         BitSet bs = new BitSet();
-        IntPredicate ibs = bs.toPredicate();
+        IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
         test(bs, ibs);
     }
 
     @Test
     void negativeIndex() {
         BitSet bs = new BitSet();
-        IntPredicate ibs = bs.toPredicate();
+        IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
         assertThrows(IndexOutOfBoundsException.class, () -> {
             ibs.test(-1);
         });
@@ -56,7 +57,7 @@ public class ImmutableBitSet {
     @Test
     void basic() {
         BitSet bs = createReference(147);
-        IntPredicate ibs = bs.toPredicate();
+        IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
         test(bs, ibs);
     }
 
@@ -67,7 +68,7 @@ public class ImmutableBitSet {
             for (int j = bs.length() - 1; j > Long.BYTES - 1; j++) {
                 bs.clear(j);
             }
-            IntPredicate ibs = bs.toPredicate();
+            IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
             test(bs, ibs);
         }
     }


### PR DESCRIPTION
This PR proposes adding a new method to BitSet that provides an immutable snapshot of the set in the form of an `IntPredicate`.

The predicate is eligible for constant folding.

Here are some classes in the JDK that would benefit directly from constant-folding of BitSets:

PoolReader (6)
URLEncoder (1) - Updated in this PR
HtmlTree (2)

More over, the implementation of the predicate is @ValueBased and this would provide additional benefits in the future.

Initial benchmarks with the URLEncoder show encouraging results:

```
Name                           (encodeChars) (maxLength) (unchanged) Cnt  Base   Error   Test   Error  Unit  Diff%
URLEncodeDecode.testEncodeUTF8             6        1024           0  15 2,371 ± 0,016  2,073 ± 0,184 ms/op  12,6% (p = 0,000*)
URLEncodeDecode.testEncodeUTF8             6        1024          75  15 1,772 ± 0,013  1,387 ± 0,032 ms/op  21,8% (p = 0,000*)
URLEncodeDecode.testEncodeUTF8             6        1024         100  15 1,230 ± 0,009  1,140 ± 0,011 ms/op   7,3% (p = 0,000*)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315454](https://bugs.openjdk.org/browse/JDK-8315454): Add a way to create an immutable snapshot of a BitSet (**Enhancement** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [6f80e0b6](https://git.openjdk.org/jdk/pull/15530/files/6f80e0b62a648b19c84123d801113c18b13c758b)


### Contributors
 * Claes Redestad `<redestad@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15530/head:pull/15530` \
`$ git checkout pull/15530`

Update a local copy of the PR: \
`$ git checkout pull/15530` \
`$ git pull https://git.openjdk.org/jdk.git pull/15530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15530`

View PR using the GUI difftool: \
`$ git pr show -t 15530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15530.diff">https://git.openjdk.org/jdk/pull/15530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15530#issuecomment-1702373718)