### PR TITLE
8314226: Series of colon-style fallthrough switch cases with guards compiled incorrectly

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -588,11 +588,6 @@ public class TransPatterns extends TreeTranslator {
                         continueSwitch.target = tree;
 
                         if (previousC != null && hasGuard && previousCompletesNormally) {
-                            JCExpression or = make.Literal(false);
-                            for (JCPatternCaseLabel label: labels) {
-                                or = makeBinary(Tag.OR, makeTypeTest(make.Ident(temp), make.Type(label.pat.type)), or);
-                            }
-                            test = makeBinary(Tag.AND, or, test);
                             previousC.stats = previousC.stats.appendList(c.stats); // copying to previous
                         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -524,7 +524,7 @@ public class TransPatterns extends TreeTranslator {
             boolean previousCompletesNormally = false;
             boolean hasDefault = false;
 
-            cases = patchCompletingNormallyCases(cases);
+            patchCompletingNormallyCases(cases);
 
             for (var c : cases) {
                 List<JCCaseLabel> clearedPatterns = c.labels;
@@ -543,7 +543,8 @@ public class TransPatterns extends TreeTranslator {
                     validCaseLabelList = clearedPatterns.head.hasTag(Tag.PATTERNCASELABEL);
                 }
 
-                if (validCaseLabelList && !previousCompletesNormally || c.guard != null) {
+                if ((validCaseLabelList && !previousCompletesNormally) ||
+                        c.guard != null) {
                     List<JCPatternCaseLabel> labels = clearedPatterns.stream().map(cp -> (JCPatternCaseLabel)cp).collect(List.collector());
                     bindingContext = new BasicBindingContext();
                     VarSymbol prevCurrentValue = currentValue;
@@ -661,7 +662,7 @@ public class TransPatterns extends TreeTranslator {
     }
 
     // Duplicates the block statement where needed.
-    // Processes cases in reverse order, e.g.
+    // Processes cases in place, e.g.
     // switch (obj) {
     //     case Integer _ when ((Integer) obj) > 0:
     //     case String _  when !((String) obj).isEmpty():
@@ -678,8 +679,7 @@ public class TransPatterns extends TreeTranslator {
     //         return 1;
     //     ...
     // }
-    private static List<JCCase> patchCompletingNormallyCases(List<JCCase> cases) {
-        ListBuffer<JCCase> newCases = new ListBuffer<>();
+    private static void patchCompletingNormallyCases(List<JCCase> cases) {
         for (int j = cases.size() - 1; j >= 0; j--) {
             var currentCase = cases.get(j);
 
@@ -689,9 +689,7 @@ public class TransPatterns extends TreeTranslator {
                 var nextCase = cases.get(j + 1);
                 currentCase.stats = currentCase.stats.appendList(nextCase.stats);
             }
-            newCases.add(currentCase);
         }
-        return newCases.toList().reverse();
     }
 
     //where:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -66,8 +66,13 @@ import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Names;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Set;
 
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.RecordComponent;
@@ -582,14 +587,12 @@ public class TransPatterns extends TreeTranslator {
                         c.stats = translate(c.stats);
                         JCContinue continueSwitch = make.at(clearedPatterns.head.pos()).Continue(null);
                         continueSwitch.target = tree;
-
-                        JCIf ifStatement = make.If(makeUnary(Tag.NOT, test).setType(syms.booleanType),
-                                make.Block(0, List.of(make.Exec(make.Assign(make.Ident(index),
-                                                        makeLit(syms.intType, i + labels.length()))
-                                                .setType(syms.intType)),
-                                        continueSwitch)),
-                                null);
-                        c.stats = c.stats.prepend(ifStatement);
+                        c.stats = c.stats.prepend(make.If(makeUnary(Tag.NOT, test).setType(syms.booleanType),
+                                                           make.Block(0, List.of(make.Exec(make.Assign(make.Ident(index),
+                                                                                                       makeLit(syms.intType, i + labels.length()))
+                                                                                     .setType(syms.intType)),
+                                                                                 continueSwitch)),
+                                                           null));
                         c.stats = c.stats.prependList(bindingContext.bindingVars(c.pos));
                     } finally {
                         currentValue = prevCurrentValue;
@@ -631,6 +634,7 @@ public class TransPatterns extends TreeTranslator {
                         c.caseKind == CaseTree.CaseKind.STATEMENT &&
                         c.completesNormally;
             }
+
             if (tree.hasTag(Tag.SWITCH)) {
                 ((JCSwitch) tree).selector = selector;
                 ((JCSwitch) tree).cases = cases;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -683,7 +683,7 @@ public class TransPatterns extends TreeTranslator {
         for (int j = cases.size() - 1; j >= 0; j--) {
             var currentCase = cases.get(j);
 
-            if (currentCase != cases.last() && currentCase.guard != null &&
+            if (currentCase != cases.last() && (currentCase.guard != null || TreeInfo.isNullCaseLabel(currentCase.labels.head)) &&
                     currentCase.caseKind == CaseKind.STATEMENT &&
                     currentCase.completesNormally) {
                 var nextCase = cases.get(j + 1);

--- a/test/langtools/tools/javac/patterns/T8314226.java
+++ b/test/langtools/tools/javac/patterns/T8314226.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8314226
+ * @summary Series of colon-style fallthrough switch cases with guards compiled incorrectly
+ * @enablePreview
+ * @compile T8314226.java
+ * @run main T8314226
+ */
+
+public class T8314226 {
+    int multipleGuardedCases(Object obj) {
+        switch (obj) {
+            case Integer _ when ((Integer) obj) > 0:
+            case String _ when !((String) obj).isEmpty():
+                return 1;
+            default:
+                return -1;
+        }
+    }
+
+    int multipleGuardedCasesMultiplePatterns(Object obj) {
+        switch (obj) {
+            case String _ when !((String) obj).isEmpty():
+            case Integer _, Byte _ when ((Number) obj).intValue() > 0:
+                return 1;
+            default:
+                return -1;
+        }
+    }
+
+    int singleGuardedCase(Object obj) {
+        switch (obj) {
+            case String _ when !((String) obj).isEmpty():
+                return 1;
+            default:
+                return -1;
+        }
+    }
+
+    public static void main(String[] args) {
+        new T8314226().run();
+    }
+
+    private void run() {
+        assertEquals(1, multipleGuardedCases(42));
+        assertEquals(1, multipleGuardedCases("test"));
+        assertEquals(-1, multipleGuardedCases(""));
+        assertEquals(1, multipleGuardedCasesMultiplePatterns((byte) 42));
+        assertEquals(1, multipleGuardedCasesMultiplePatterns("test"));
+        assertEquals(-1, multipleGuardedCasesMultiplePatterns(""));
+        assertEquals(-1, singleGuardedCase(42));
+        assertEquals(1, singleGuardedCase("test"));
+        assertEquals(-1, singleGuardedCase(""));
+    }
+
+    void assertEquals(int expected, int actual) {
+        if (expected != actual) {
+            throw new AssertionError("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8314226.java
+++ b/test/langtools/tools/javac/patterns/T8314226.java
@@ -33,7 +33,29 @@ public class T8314226 {
     int multipleGuardedCases(Object obj) {
         switch (obj) {
             case Integer _ when ((Integer) obj) > 0:
-            case String _ when !((String) obj).isEmpty():
+            case String _  when !((String) obj).isEmpty():
+                return 1;
+            default:
+                return -1;
+        }
+    }
+
+    int multipleGuardedCases2a(Object obj) {
+        switch (obj) {
+            case Integer _ when ((Integer) obj) > 0:
+            case Float _   when ((Float) obj) > 0.0f:
+            case String _  when !((String) obj).isEmpty():
+                return 1;
+            default:
+                return -1;
+        }
+    }
+
+    int multipleGuardedCases2b(Object obj) {
+        switch (obj) {
+            case Float _   when ((Float) obj) > 0.0f: // reversing the order
+            case Integer _ when ((Integer) obj) > 0:
+            case String _  when !((String) obj).isEmpty():
                 return 1;
             default:
                 return -1;
@@ -42,7 +64,7 @@ public class T8314226 {
 
     int multipleGuardedCasesMultiplePatterns(Object obj) {
         switch (obj) {
-            case String _ when !((String) obj).isEmpty():
+            case String _          when !((String) obj).isEmpty():
             case Integer _, Byte _ when ((Number) obj).intValue() > 0:
                 return 1;
             default:
@@ -67,6 +89,12 @@ public class T8314226 {
         assertEquals(1, multipleGuardedCases(42));
         assertEquals(1, multipleGuardedCases("test"));
         assertEquals(-1, multipleGuardedCases(""));
+        assertEquals(1, multipleGuardedCases2a(42.0f));
+        assertEquals(1, multipleGuardedCases2a("test"));
+        assertEquals(-1, multipleGuardedCases2a(""));
+        assertEquals(1, multipleGuardedCases2b(42.0f));
+        assertEquals(1, multipleGuardedCases2b("test"));
+        assertEquals(-1, multipleGuardedCases2b(""));
         assertEquals(1, multipleGuardedCasesMultiplePatterns((byte) 42));
         assertEquals(1, multipleGuardedCasesMultiplePatterns("test"));
         assertEquals(-1, multipleGuardedCasesMultiplePatterns(""));

--- a/test/langtools/tools/javac/patterns/T8314226.java
+++ b/test/langtools/tools/javac/patterns/T8314226.java
@@ -108,15 +108,21 @@ public class T8314226 {
     }
 
     int multipleCasesWithLoop(Object obj) {
+        int i = 0;
         switch (obj) {
             case Integer _ when ((Integer) obj) > 0:
             case String _ when !((String) obj).isEmpty():
-                return 1;
+                i = i + 1;
             case null:
-                while (true) {break;}
+                while (true) {
+                    i = i + 10;
+                    break;
+                }
             default:
-                return 3;
+                i = i + 100;
         }
+
+        return i;
     }
 
     public static void main(String[] args) {
@@ -147,10 +153,10 @@ public class T8314226 {
         assertEquals(111, multipleCasesWithEffectNoReturn("test"));
         assertEquals(110, multipleCasesWithEffectNoReturn(null));
         assertEquals(100, multipleCasesWithEffectNoReturn(""));
-        assertEquals(1, multipleCasesWithLoop(42));
-        assertEquals(1, multipleCasesWithLoop("test"));
-        assertEquals(3, multipleCasesWithLoop(null));
-        assertEquals(3, multipleCasesWithLoop(""));
+        assertEquals(111, multipleCasesWithLoop(42));
+        assertEquals(111, multipleCasesWithLoop("test"));
+        assertEquals(110, multipleCasesWithLoop(null));
+        assertEquals(100, multipleCasesWithLoop(""));
     }
 
     void assertEquals(Object expected, Object actual) {

--- a/test/langtools/tools/javac/patterns/T8314226.java
+++ b/test/langtools/tools/javac/patterns/T8314226.java
@@ -81,6 +81,44 @@ public class T8314226 {
         }
     }
 
+    int multipleCasesWithReturn(Object obj) {
+        switch (obj) {
+            case Integer _ when ((Integer) obj) > 0:
+            case String _ when !((String) obj).isEmpty():
+                return 1;
+            case null:
+                return 2;
+            default:
+                return 3;
+        }
+    }
+
+    int multipleCasesWithEffectNoReturn(Object obj) {
+        int i = 0;
+        switch (obj) {
+            case Integer _ when ((Integer) obj) > 0:
+            case String _ when !((String) obj).isEmpty():
+                i = i + 1;
+            case null:
+                i = i + 10;
+            default:
+                i = i + 100;
+        }
+        return i;
+    }
+
+    int multipleCasesWithLoop(Object obj) {
+        switch (obj) {
+            case Integer _ when ((Integer) obj) > 0:
+            case String _ when !((String) obj).isEmpty():
+                return 1;
+            case null:
+                while (true) {break;}
+            default:
+                return 3;
+        }
+    }
+
     public static void main(String[] args) {
         new T8314226().run();
     }
@@ -101,9 +139,21 @@ public class T8314226 {
         assertEquals(-1, singleGuardedCase(42));
         assertEquals(1, singleGuardedCase("test"));
         assertEquals(-1, singleGuardedCase(""));
+        assertEquals(1, multipleCasesWithReturn(42));
+        assertEquals(1, multipleCasesWithReturn("test"));
+        assertEquals(2, multipleCasesWithReturn(null));
+        assertEquals(3, multipleCasesWithReturn(""));
+        assertEquals(111, multipleCasesWithEffectNoReturn(42));
+        assertEquals(111, multipleCasesWithEffectNoReturn("test"));
+        assertEquals(110, multipleCasesWithEffectNoReturn(null));
+        assertEquals(100, multipleCasesWithEffectNoReturn(""));
+        assertEquals(1, multipleCasesWithLoop(42));
+        assertEquals(1, multipleCasesWithLoop("test"));
+        assertEquals(3, multipleCasesWithLoop(null));
+        assertEquals(3, multipleCasesWithLoop(""));
     }
 
-    void assertEquals(int expected, int actual) {
+    void assertEquals(Object expected, Object actual) {
         if (expected != actual) {
             throw new AssertionError("Expected: " + expected + ", but got: " + actual);
         }


### PR DESCRIPTION
The `switch` structure is translated in `handleSwitch` where we rewrite pattern matching switches. In some occasions a switch has multiple cases with multiple patterns where the n-th case does not complete normally and falls through to the n+1-st case:

```
switch (obj) {
   case Integer _ when ((Integer) obj) > 0:
   case String _ when !((String) obj).isEmpty():
      return 1;
   default:
      return -1;
}
```

This PR addresses that by translating the second case correctly and also replicates the body of the latter to the former (which we can do because no bindings are introduced in either statement blocks by the definition of unnamed variables.).

Previously the code was translated into:

```
switch (java.lang.runtime.SwitchBootstraps.typeSwitch(selector0$temp, index$1)) {
    case 0:
        Integer _;
        if (!(true && ((Integer)obj) > 0)) {
            index$1 = 1;
            continue;
        }

    case 1 when !((String)obj).isEmpty():
        return 1;

    default:
        return -1;
}
```

This PR adjusts the translation into:

```
switch (java.lang.runtime.SwitchBootstraps.typeSwitch(selector0$temp, index$1)) {
case 0:
    Integer _;
    if (!(true && ((Integer)obj) > 0)) {
        index$1 = 1;
        continue;
    }
    return 1;

case 1:
    String _;
    if (!((selector0$temp instanceof String || false) && (true && !((String)obj).isEmpty()))) {
        index$1 = 2;
        continue;
    }
    return 1;
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314226](https://bugs.openjdk.org/browse/JDK-8314226): Series of colon-style fallthrough switch cases with guards compiled incorrectly (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [c46952b3](https://git.openjdk.org/jdk/pull/15532/files/c46952b3dc9fad2cc37e14ddbb24e5831382817e)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15532/head:pull/15532` \
`$ git checkout pull/15532`

Update a local copy of the PR: \
`$ git checkout pull/15532` \
`$ git pull https://git.openjdk.org/jdk.git pull/15532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15532`

View PR using the GUI difftool: \
`$ git pr show -t 15532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15532.diff">https://git.openjdk.org/jdk/pull/15532.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15532#issuecomment-1702534452)