### PR TITLE
JDK-8315499: build using devkit on Linux ppc64le RHEL puts path to devkit into libsplashscreen

### DIFF
--- a/make/autoconf/lib-x11.m4
+++ b/make/autoconf/lib-x11.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -84,6 +84,10 @@ AC_DEFUN_ONCE([LIB_SETUP_X11],
     # AC_PATH_XTRA creates X_LIBS and sometimes adds -R flags. When cross compiling
     # this doesn't make sense so we remove it.
     if test "x$COMPILE_TYPE" = xcross; then
+      X_LIBS=`$ECHO $X_LIBS | $SED 's/-R \{0,1\}[[^ ]]*//g'`
+    fi
+    # Also remove the -R setting for devkit usage
+    if test "x$with_devkit" != "x" && test "x$with_devkit" != "xno"; then
       X_LIBS=`$ECHO $X_LIBS | $SED 's/-R \{0,1\}[[^ ]]*//g'`
     fi
 


### PR DESCRIPTION
After looking at the build results of a jdk22 build on RHEL 8.4 Linux ppc64le that uses a ppc64le-linux-gnu-to-ppc64le-linux-gnu-fedora27-gcc11.3.0
devkit we observed those unwanted paths in libsplashscreen.so .
See those objdump and ldd output :

objdump -x ./lib/libsplashscreen.so | grep PATH
  RUNPATH /mydevkitsfolder/devkits/ppc64le-linux-gnu-to-ppc64le-linux-gnu-fedora27-gcc11.3.0/ppc64le-linux-gnu/sysroot/usr/lib64:$ORIGIN


ldd ./lib/libsplashscreen.so
ldd: warning: you do not have execution permission for `./lib/libsplashscreen.so'
      . . .
               libX11.so.6 => /mydevkitsfolder/devkits/ppc64le-linux-gnu-to-ppc64le-linux-gnu-fedora27-gcc11.3.0/ppc64le-linux-gnu/sysroot/usr/lib64/libX11.so.6 (0x00007fffa3920000)
               libXext.so.6 => /mydevkitsfolder/devkits/ppc64le-linux-gnu-to-ppc64le-linux-gnu-fedora27-gcc11.3.0/ppc64le-linux-gnu/sysroot/usr/lib64/libXext.so.6 (0x00007fffa38e0000)
   . . .

These paths were introduced by the '-R' setting, but it seems to be highly dependent on the environment.  But the '-R' setting should better be avoided anyway when the devkit is used.