### PR TITLE
8315545: C1: x86 cmove can use short branches

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -2047,7 +2047,7 @@ void LIR_Assembler::cmove(LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, L
 
   } else {
     Label skip;
-    __ jcc (acond, skip);
+    __ jccb(acond, skip);
     if (opr2->is_cpu_register()) {
       reg2reg(opr2, result);
     } else if (opr2->is_stack()) {


### PR DESCRIPTION
Spotted this minor inefficiency when looking at profiling code. C1 profiling code uses `cmove`-s often, and often with immediates, so `LIR_Assembler::cmove` ends up emitting the real jump over the alternative branch. But the alternative branch is just `{reg,stack,const}2reg` conversion, and AFAICS is guaranteed to be short. Therefore, we can use the short branch for that forward jump. 

Sample `cmov` disassembly:

```
# Before
   0.19%          0x00007f1c98cc2d1d:   cmp    $0x0,%eax
              ╭   0x00007f1c98cc2d20:   jne    0x00007f1c98cc2d2b
              │   0x00007f1c98cc2d26:   mov    $0x2,%ecx
              ↘   0x00007f1c98cc2d2b:   and    $0x3ffe,%ecx
   0.54%          0x00007f1c98cc2d31:   cmp    $0x0,%ecx

# After
   0.17%          0x00007fcf18dda199:   cmp    $0x0,%eax
              ╭   0x00007fcf18dda19c:   jne    0x00007fcf18dda1a3
              │   0x00007fcf18dda19e:   mov    $0x2,%ecx
              ↘   0x00007fcf18dda1a3:   and    $0x3ffe,%ecx
   1.24%          0x00007fcf18dda1a9:   cmp    $0x0,%ecx
```

There are some code space savings, visible even on trivial `-Xcomp -XX:TieredStopAtLevel=... HelloWorld`.

```
# Before
tier1: nmethod total size        :   430104 bytes
tier2: nmethod total size        :   467336 bytes
tier3: nmethod total size        :   923368 bytes

# After
tier1: nmethod total size        :   429000 bytes (-0.25%)
tier2: nmethod total size        :   466016 bytes (-0.28%)
tier3: nmethod total size        :   915632 bytes (-0.84%)
```

Additional testing:
 - [x] Linux x86_64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315545](https://bugs.openjdk.org/browse/JDK-8315545): C1: x86 cmove can use short branches (**Enhancement** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15537/head:pull/15537` \
`$ git checkout pull/15537`

Update a local copy of the PR: \
`$ git checkout pull/15537` \
`$ git pull https://git.openjdk.org/jdk.git pull/15537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15537`

View PR using the GUI difftool: \
`$ git pr show -t 15537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15537.diff">https://git.openjdk.org/jdk/pull/15537.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15537#issuecomment-1702921986)