### PR TITLE
8315549: CITime misreports code/total nmethod sizes

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2662,8 +2662,8 @@ void CompileBroker::print_times(bool per_compiler, bool aggregate) {
   uint total_bailout_count = CompileBroker::_total_bailout_count;
   uint total_invalidated_count = CompileBroker::_total_invalidated_count;
 
-  uint nmethods_size = CompileBroker::_sum_nmethod_code_size;
-  uint nmethods_code_size = CompileBroker::_sum_nmethod_size;
+  uint nmethods_code_size = CompileBroker::_sum_nmethod_code_size;
+  uint nmethods_size = CompileBroker::_sum_nmethod_size;
 
   tty->cr();
   tty->print_cr("Accumulated compiler times");


### PR DESCRIPTION
If you run with -XX:+CITime, then it would print the odd data:

```
% build/macosx-aarch64-server-fastdebug/images/jdk/bin/java -Xcomp -XX:+CITime Hello.java

...
  nmethod code size : 42544128 bytes
  nmethod total size : 23678448 bytes
```

Note how `total` is smaller than `code`! This is just a simple problem in printing code. 

Additional testing:
 - [x] Eyeballing `-XX:+CITime` output

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315549](https://bugs.openjdk.org/browse/JDK-8315549): CITime misreports code/total nmethod sizes (**Bug** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15538/head:pull/15538` \
`$ git checkout pull/15538`

Update a local copy of the PR: \
`$ git checkout pull/15538` \
`$ git pull https://git.openjdk.org/jdk.git pull/15538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15538`

View PR using the GUI difftool: \
`$ git pr show -t 15538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15538.diff">https://git.openjdk.org/jdk/pull/15538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15538#issuecomment-1702893729)