### PR TITLE
8315534: Incorrect warnings about implicit annotation processing

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -915,8 +915,6 @@ public class JavaCompiler {
             taskListener.started(new TaskEvent(TaskEvent.Kind.COMPILATION));
         }
 
-        if (processors != null && processors.iterator().hasNext())
-            explicitAnnotationProcessingRequested = true;
         // as a JavaCompiler can only be used once, throw an exception if
         // it has been used before.
         if (hasBeenUsed)
@@ -1143,6 +1141,9 @@ public class JavaCompiler {
     public void initProcessAnnotations(Iterable<? extends Processor> processors,
                                        Collection<? extends JavaFileObject> initialFiles,
                                        Collection<String> initialClassNames) {
+        if (processors != null && processors.iterator().hasNext())
+            explicitAnnotationProcessingRequested = true;
+
         // Process annotations if processing is not disabled and there
         // is at least one Processor available.
         if (options.isSet(PROC, "none")) {


### PR DESCRIPTION
When the API client sets annotation processors using `CompilationTask.setProcessors` and then uses `JavacTask` to drive the compiler using the `analyze()` method, the `compiler.note.implicit.annotation.processing` note is printed even though the annotation processing is explicit.

This patch is attempting to solve that by marking all processing with explicit processors as explicit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315534](https://bugs.openjdk.org/browse/JDK-8315534): Incorrect warnings about implicit annotation processing (**Bug** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15540/head:pull/15540` \
`$ git checkout pull/15540`

Update a local copy of the PR: \
`$ git checkout pull/15540` \
`$ git pull https://git.openjdk.org/jdk.git pull/15540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15540`

View PR using the GUI difftool: \
`$ git pr show -t 15540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15540.diff">https://git.openjdk.org/jdk/pull/15540.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15540#issuecomment-1702964893)