### PR TITLE
8315550: G1: Fix -Wconversion warnings in g1NUMA

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2216,10 +2216,10 @@ void G1CollectedHeap::print_on(outputStream* st) const {
   if (_numa->is_enabled()) {
     uint num_nodes = _numa->num_active_nodes();
     st->print("  remaining free region(s) on each NUMA node: ");
-    const int* node_ids = _numa->node_ids();
+    const uint* node_ids = _numa->node_ids();
     for (uint node_index = 0; node_index < num_nodes; node_index++) {
       uint num_free_regions = _hrm.num_free_regions(node_index);
-      st->print("%d=%u ", node_ids[node_index], num_free_regions);
+      st->print("%u=%u ", node_ids[node_index], num_free_regions);
     }
     st->cr();
   }

--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -115,10 +115,10 @@ static void log_regions(const char* msg, size_t before_length, size_t after_leng
     if (before_per_node_length != nullptr && after_per_node_length != nullptr) {
       G1NUMA* numa = G1NUMA::numa();
       uint num_nodes = numa->num_active_nodes();
-      const int* node_ids = numa->node_ids();
+      const uint* node_ids = numa->node_ids();
       ls.print(" (");
       for (uint i = 0; i < num_nodes; i++) {
-        ls.print("%d: %u->%u", node_ids[i], before_per_node_length[i], after_per_node_length[i]);
+        ls.print("%u: %u->%u", node_ids[i], before_per_node_length[i], after_per_node_length[i]);
         // Skip adding below if it is the last one.
         if (i != num_nodes - 1) {
           ls.print(", ");

--- a/src/hotspot/share/gc/g1/g1NUMA.hpp
+++ b/src/hotspot/share/gc/g1/g1NUMA.hpp
@@ -39,10 +39,10 @@ class G1NUMA: public CHeapObj<mtGC> {
   // For invalid node id, return UnknownNodeIndex.
   uint* _node_id_to_index_map;
   // Length of _num_active_node_ids_id to index map.
-  int _len_node_id_to_index_map;
+  uint _len_node_id_to_index_map;
 
   // Current active node ids.
-  int* _node_ids;
+  uint* _node_ids;
   // Total number of node ids.
   uint _num_active_node_ids;
 
@@ -59,7 +59,7 @@ class G1NUMA: public CHeapObj<mtGC> {
 
   // Returns node index of the given node id.
   // Precondition: node_id is an active node id.
-  inline uint index_of_node_id(int node_id) const;
+  inline uint index_of_node_id(uint node_id) const;
 
   static G1NUMA* _inst;
 
@@ -86,10 +86,10 @@ public:
 
   bool is_enabled() const;
 
-  int numa_id(int index) const;
+  uint numa_id(uint index) const;
 
   // Returns memory node ids
-  const int* node_ids() const;
+  const uint* node_ids() const;
 
   // Returns node index of current calling thread.
   uint index_of_current_thread() const;

--- a/src/hotspot/share/gc/g1/g1NUMAStats.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMAStats.cpp
@@ -119,7 +119,7 @@ void G1NUMAStats::NodeDataArray::copy(uint req_index, size_t* stat) {
   }
 }
 
-G1NUMAStats::G1NUMAStats(const int* node_ids, uint num_node_ids) :
+G1NUMAStats::G1NUMAStats(const uint* node_ids, uint num_node_ids) :
   _node_ids(node_ids), _num_node_ids(num_node_ids), _node_data() {
 
   assert(_num_node_ids > 1, "Should have at least one node id: %u", _num_node_ids);

--- a/src/hotspot/share/gc/g1/g1NUMAStats.hpp
+++ b/src/hotspot/share/gc/g1/g1NUMAStats.hpp
@@ -91,7 +91,7 @@ public:
   };
 
 private:
-  const int* _node_ids;
+  const uint* _node_ids;
   uint _num_node_ids;
 
   NodeDataArray* _node_data[NodeDataItemsSentinel];
@@ -101,7 +101,7 @@ private:
   void print_mutator_alloc_stat_debug();
 
 public:
-  G1NUMAStats(const int* node_ids, uint num_node_ids);
+  G1NUMAStats(const uint* node_ids, uint num_node_ids);
   ~G1NUMAStats();
 
   void clear(G1NUMAStats::NodeDataItems phase);

--- a/src/hotspot/share/gc/g1/heapRegion.cpp
+++ b/src/hotspot/share/gc/g1/heapRegion.cpp
@@ -427,7 +427,7 @@ void HeapRegion::print_on(outputStream* st) const {
   if (UseNUMA) {
     G1NUMA* numa = G1NUMA::numa();
     if (node_index() < numa->num_active_nodes()) {
-      st->print("|%d", numa->numa_id(node_index()));
+      st->print("|%u", numa->numa_id(node_index()));
     } else {
       st->print("|-");
     }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -585,12 +585,12 @@ WB_END
 WB_ENTRY(jintArray, WB_G1MemoryNodeIds(JNIEnv* env, jobject o))
   if (UseG1GC) {
     G1NUMA* numa = G1NUMA::numa();
-    int num_node_ids = (int)numa->num_active_nodes();
-    const int* node_ids = numa->node_ids();
+    int num_node_ids = checked_cast<int>(numa->num_active_nodes());
+    const uint* node_ids = numa->node_ids();
 
     typeArrayOop result = oopFactory::new_intArray(num_node_ids, CHECK_NULL);
     for (int i = 0; i < num_node_ids; i++) {
-      result->int_at_put(i, (jint)node_ids[i]);
+      result->int_at_put(i, checked_cast<jint>(node_ids[i]));
     }
     return (jintArray) JNIHandles::make_local(THREAD, result);
   }


### PR DESCRIPTION
Simple `int` to `uint` for NUMA node-id.

Possibly, `numa_get_leaf_groups` should accept `uint[]`. I will attempt that in another PR, as that will be mostly runtime, not G1 specific.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315550](https://bugs.openjdk.org/browse/JDK-8315550): G1: Fix -Wconversion warnings in g1NUMA (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15541/head:pull/15541` \
`$ git checkout pull/15541`

Update a local copy of the PR: \
`$ git checkout pull/15541` \
`$ git pull https://git.openjdk.org/jdk.git pull/15541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15541`

View PR using the GUI difftool: \
`$ git pr show -t 15541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15541.diff">https://git.openjdk.org/jdk/pull/15541.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15541#issuecomment-1702968626)