### PR TITLE
8315369: [JVMCI] failure to attach to a libgraal isolate during shutdown should not be fatal

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2203,7 +2203,14 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
       compilable = ciEnv::MethodCompilable_never;
     } else {
       JVMCIEnv env(thread, &compile_state, __FILE__, __LINE__);
-      failure_reason = compile_state.failure_reason();
+      if (env.init_error() != JNI_OK) {
+        failure_reason = os::strdup(err_msg("Error attaching to libjvmci (err: %d)", env.init_error()), mtJVMCI);
+        bool reason_on_C_heap = true;
+        // In case of JNI_ENOMEM, there's a good chance a subsequent attempt to create libjvmci or attach to it
+        // might succeed. Other errors most likely indicate a non-recoverable error in the JVMCI runtime.
+        bool retryable = env.init_error() == JNI_ENOMEM;
+        compile_state.set_failure(retryable, failure_reason, reason_on_C_heap);
+      }
       if (failure_reason == nullptr) {
         if (WhiteBoxAPI && WhiteBox::compilation_locked) {
           // Must switch to native to block

--- a/src/hotspot/share/jvmci/jniAccessMark.inline.hpp
+++ b/src/hotspot/share/jvmci/jniAccessMark.inline.hpp
@@ -44,7 +44,7 @@ class JNIAccessMark : public StackObj {
   inline JNIAccessMark(JVMCIEnv* jvmci_env, JavaThread* thread=JavaThread::current()) :
     _ttnfv(thread), _hm(thread) {
     _env = jvmci_env->_env;
-    assert(jvmci_env->init_error() == JNI_OK, "invalid JVMCIEnv (err: %d)", jvmci_env->init_error());
+    guarantee(jvmci_env->init_error() == JNI_OK, "invalid JVMCIEnv (err: %d)", jvmci_env->init_error());
   }
   JNIEnv* env() const { return _env; }
   JNIEnv* operator () () const { return _env; }

--- a/src/hotspot/share/jvmci/jniAccessMark.inline.hpp
+++ b/src/hotspot/share/jvmci/jniAccessMark.inline.hpp
@@ -44,6 +44,7 @@ class JNIAccessMark : public StackObj {
   inline JNIAccessMark(JVMCIEnv* jvmci_env, JavaThread* thread=JavaThread::current()) :
     _ttnfv(thread), _hm(thread) {
     _env = jvmci_env->_env;
+    assert(jvmci_env->init_error() == JNI_OK, "invalid JVMCIEnv (err: %d)", jvmci_env->init_error());
   }
   JNIEnv* env() const { return _env; }
   JNIEnv* operator () () const { return _env; }

--- a/src/hotspot/share/jvmci/jvmciExceptions.hpp
+++ b/src/hotspot/share/jvmci/jvmciExceptions.hpp
@@ -31,14 +31,20 @@ class JVMCIEnv;
 
 #define JVMCIENV __jvmci_env__
 #define JVMCI_TRAPS  JVMCIEnv* JVMCIENV
+#define PEER_JVMCIENV __peer_jvmci_env__
 
-#define JNI_JVMCIENV(thread, env)                                     \
+#define JVMCIENV_FROM_JNI(thread, env)                                     \
   JVMCIEnv __stack_jvmci_env__(thread, env, __FILE__, __LINE__);      \
   JVMCIEnv* JVMCIENV = &__stack_jvmci_env__
 
-#define THREAD_JVMCIENV(thread)                               \
+#define JVMCIENV_FROM_THREAD(thread)                               \
   JVMCIEnv __stack_jvmci_env__(thread, __FILE__, __LINE__);   \
   JVMCIEnv* JVMCIENV = &__stack_jvmci_env__
+
+#define PEER_JVMCIENV_FROM_THREAD(thread, is_hotspot)                  \
+  JVMCIEnv __peer_stack_jvmci_env__(thread, is_hotspot, __FILE__, __LINE__);   \
+  JVMCIEnv* PEER_JVMCIENV = &__peer_stack_jvmci_env__
+
 
 #define JVMCI_PENDING_EXCEPTION                        (JVMCIENV->pending_exception())
 #define JVMCI_HAS_PENDING_EXCEPTION                    (JVMCIENV->has_pending_exception())

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -744,9 +744,10 @@ JRT_ENTRY(jint, JVMCIRuntime::test_deoptimize_call_int(JavaThread* current, int 
 JRT_END
 
 
-// private static JVMCIRuntime JVMCI.initializeRuntime()
-JVM_ENTRY_NO_ENV(jobject, JVM_GetJVMCIRuntime(JNIEnv *env, jclass c))
-  JNI_JVMCIENV(thread, env);
+// Implementation of JVMCI.initializeRuntime()
+// When called from libjvmci, `libjvmciOrHotspotEnv` is a libjvmci env so use JVM_ENTRY_NO_ENV.
+JVM_ENTRY_NO_ENV(jobject, JVM_GetJVMCIRuntime(JNIEnv *libjvmciOrHotspotEnv, jclass c))
+  JVMCIENV_FROM_JNI(thread, libjvmciOrHotspotEnv);
   if (!EnableJVMCI) {
     JVMCI_THROW_MSG_NULL(InternalError, "JVMCI is not enabled");
   }
@@ -755,9 +756,10 @@ JVM_ENTRY_NO_ENV(jobject, JVM_GetJVMCIRuntime(JNIEnv *env, jclass c))
   return JVMCIENV->get_jobject(runtime);
 JVM_END
 
-// private static long Services.readSystemPropertiesInfo(int[] offsets)
+// Implementation of Services.readSystemPropertiesInfo(int[] offsets)
+// When called from libjvmci, `env` is a libjvmci env so use JVM_ENTRY_NO_ENV.
 JVM_ENTRY_NO_ENV(jlong, JVM_ReadSystemPropertiesInfo(JNIEnv *env, jclass c, jintArray offsets_handle))
-  JNI_JVMCIENV(thread, env);
+  JVMCIENV_FROM_JNI(thread, env);
   if (!EnableJVMCI) {
     JVMCI_THROW_MSG_0(InternalError, "JVMCI is not enabled");
   }
@@ -771,7 +773,8 @@ JVM_END
 
 
 void JVMCIRuntime::call_getCompiler(TRAPS) {
-  THREAD_JVMCIENV(JavaThread::current());
+  JVMCIENV_FROM_THREAD(THREAD);
+  JVMCIENV->check_init(CHECK);
   JVMCIObject jvmciRuntime = JVMCIRuntime::get_HotSpotJVMCIRuntime(JVMCI_CHECK);
   initialize(JVMCI_CHECK);
   JVMCIENV->call_HotSpotJVMCIRuntime_getCompiler(jvmciRuntime, JVMCI_CHECK);
@@ -1525,9 +1528,10 @@ JVMCIObject JVMCIRuntime::get_HotSpotJVMCIRuntime(JVMCI_TRAPS) {
   return _HotSpotJVMCIRuntime_instance;
 }
 
-// private static void CompilerToVM.registerNatives()
-JVM_ENTRY_NO_ENV(void, JVM_RegisterJVMCINatives(JNIEnv *env, jclass c2vmClass))
-  JNI_JVMCIENV(thread, env);
+// Implementation of CompilerToVM.registerNatives()
+// When called from libjvmci, `libjvmciOrHotspotEnv` is a libjvmci env so use JVM_ENTRY_NO_ENV.
+JVM_ENTRY_NO_ENV(void, JVM_RegisterJVMCINatives(JNIEnv *libjvmciOrHotspotEnv, jclass c2vmClass))
+  JVMCIENV_FROM_JNI(thread, libjvmciOrHotspotEnv);
 
   if (!EnableJVMCI) {
     JVMCI_THROW_MSG(InternalError, "JVMCI is not enabled");
@@ -1542,7 +1546,7 @@ JVM_ENTRY_NO_ENV(void, JVM_RegisterJVMCINatives(JNIEnv *env, jclass c2vmClass))
 
     // Ensure _non_oop_bits is initialized
     Universe::non_oop_word();
-
+    JNIEnv *env = libjvmciOrHotspotEnv;
     if (JNI_OK != env->RegisterNatives(c2vmClass, CompilerToVM::methods, CompilerToVM::methods_count())) {
       if (!env->ExceptionCheck()) {
         for (int i = 0; i < CompilerToVM::methods_count(); i++) {
@@ -1562,11 +1566,14 @@ JVM_END
 
 void JVMCIRuntime::shutdown() {
   if (_HotSpotJVMCIRuntime_instance.is_non_null()) {
-    bool jni_enomem_is_fatal = true;
     JVMCI_event_1("shutting down HotSpotJVMCIRuntime for JVMCI runtime %d", _id);
-    JVMCIEnv __stack_jvmci_env__(JavaThread::current(), _HotSpotJVMCIRuntime_instance.is_hotspot(), jni_enomem_is_fatal, __FILE__, __LINE__);
+    JVMCIEnv __stack_jvmci_env__(JavaThread::current(), _HotSpotJVMCIRuntime_instance.is_hotspot(),__FILE__, __LINE__);
     JVMCIEnv* JVMCIENV = &__stack_jvmci_env__;
-    JVMCIENV->call_HotSpotJVMCIRuntime_shutdown(_HotSpotJVMCIRuntime_instance);
+    if (JVMCIENV->init_error() == JNI_OK) {
+      JVMCIENV->call_HotSpotJVMCIRuntime_shutdown(_HotSpotJVMCIRuntime_instance);
+    } else {
+      JVMCI_event_1("Error in JVMCIEnv for shutdown (err: %d)", JVMCIENV->init_error());
+    }
     if (_num_attached_threads == cannot_be_attached) {
       // Only when no other threads are attached to this runtime
       // is it safe to reset these fields.
@@ -1611,7 +1618,8 @@ bool JVMCIRuntime::destroy_shared_library_javavm() {
 
 void JVMCIRuntime::bootstrap_finished(TRAPS) {
   if (_HotSpotJVMCIRuntime_instance.is_non_null()) {
-    THREAD_JVMCIENV(JavaThread::current());
+    JVMCIENV_FROM_THREAD(THREAD);
+    JVMCIENV->check_init(CHECK);
     JVMCIENV->call_HotSpotJVMCIRuntime_bootstrapFinished(_HotSpotJVMCIRuntime_instance, JVMCIENV);
   }
 }


### PR DESCRIPTION
This PR moves handling of errors in some JVMCIEnv constructors to the caller. This avoids VM crashes in contexts where errors are recoverable, such as the problem of running out of file descriptors described in the JBS issue for this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315369](https://bugs.openjdk.org/browse/JDK-8315369): [JVMCI] failure to attach to a libgraal isolate during shutdown should not be fatal (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [3634bd6b](https://git.openjdk.org/jdk/pull/15542/files/3634bd6b80fbf96bd7f7be5348c25de53c6a98bf)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15542/head:pull/15542` \
`$ git checkout pull/15542`

Update a local copy of the PR: \
`$ git checkout pull/15542` \
`$ git pull https://git.openjdk.org/jdk.git pull/15542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15542`

View PR using the GUI difftool: \
`$ git pr show -t 15542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15542.diff">https://git.openjdk.org/jdk/pull/15542.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15542#issuecomment-1703081341)