### PR TITLE
8315406: [REDO] serviceability/jdwp/AllModulesCommandTest.java ignores VM flags

### DIFF
--- a/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/AllModulesCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,12 +70,6 @@ public class AllModulesCommandTest implements DebuggeeLauncher.Listener {
         // The debuggee has completed sending all the info
         // We can start the JDWP session
         jdwpLatch.countDown();
-    }
-
-    @Override
-    public void onDebuggeeError(String message) {
-        System.err.println("Debuggee error: '" + message + "'");
-        System.exit(1);
     }
 
     private void doJdwp() throws Exception {

--- a/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
@@ -63,7 +63,7 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
 
     /**
      * Starts the debuggee with the necessary JDWP options and handles the
-     * debuggee's stdout output. stderr migth contain jvm output and just printed to the log
+     * debuggee's stdout output. stderr might contain jvm output, which is just printed to the log.
      *
      * @throws Throwable
      */

--- a/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,9 +22,9 @@
  */
 
 import java.util.StringTokenizer;
-import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.JDWP;
 import static jdk.test.lib.Asserts.assertFalse;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * Launches the debuggee with the necessary JDWP options and handles the output
@@ -45,21 +45,14 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
          */
         void onDebuggeeSendingCompleted();
 
-        /**
-         * Callback to handle any debuggee error
-         *
-         * @param line line from the debuggee's stderr
-         */
-        void onDebuggeeError(String line);
     }
 
     private int jdwpPort = -1;
-    private static final String CLS_DIR = System.getProperty("test.classes", "").trim();
     private static final String DEBUGGEE = "AllModulesCommandTestDebuggee";
+    private static final String JDWP_OPT = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0";
+
     private Process p;
     private final Listener listener;
-    private StreamHandler inputHandler;
-    private StreamHandler errorHandler;
 
     /**
      * @param listener the listener we report the debuggee events to
@@ -70,34 +63,18 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
 
     /**
      * Starts the debuggee with the necessary JDWP options and handles the
-     * debuggee's stdout and stderr outputs
+     * debuggee's stdout output. stderr migth contain jvm output and just printed to the log
      *
      * @throws Throwable
      */
     public void launchDebuggee() throws Throwable {
 
-        ProcessBuilder pb = new ProcessBuilder(getCommand());
+        ProcessBuilder pb = ProcessTools.createTestJvm(JDWP_OPT, DEBUGGEE);
         p = pb.start();
-        inputHandler = new StreamHandler(p.getInputStream(), this);
-        errorHandler = new StreamHandler(p.getErrorStream(), this);
+        StreamHandler inputHandler = new StreamHandler(p.getInputStream(), this);
+        StreamHandler errorHandler = new StreamHandler(p.getErrorStream(), System.out::println);
         inputHandler.start();
         errorHandler.start();
-    }
-
-    /**
-     * Command to start the debuggee with the JDWP options and using the JDK
-     * under test
-     *
-     * @return the command
-     */
-    private String[] getCommand() {
-        return new String[]{
-            JDKToolFinder.getTestJDKTool("java"),
-            getJdwpOptions(),
-            "-cp",
-            CLS_DIR,
-            DEBUGGEE
-        };
     }
 
     /**
@@ -107,15 +84,6 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
         if (p.isAlive()) {
             p.destroyForcibly();
         }
-    }
-
-    /**
-     * Debuggee JDWP options
-     *
-     * @return the JDWP options to start the debuggee with
-     */
-    private static String getJdwpOptions() {
-        return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0";
     }
 
     /**
@@ -129,16 +97,7 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
     }
 
     @Override
-    public void onStringRead(StreamHandler handler, String line) {
-        if (handler.equals(errorHandler)) {
-            terminateDebuggee();
-            listener.onDebuggeeError(line);
-        } else {
-            processDebuggeeOutput(line);
-        }
-    }
-
-    private void processDebuggeeOutput(String line) {
+    public void onStringRead(String line) {
         if (jdwpPort == -1) {
             JDWP.ListenAddress addr = JDWP.parseListenAddress(line);
             if (addr != null) {

--- a/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/DebuggeeLauncher.java
@@ -72,7 +72,7 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
         ProcessBuilder pb = ProcessTools.createTestJvm(JDWP_OPT, DEBUGGEE);
         p = pb.start();
         StreamHandler inputHandler = new StreamHandler(p.getInputStream(), this);
-        StreamHandler errorHandler = new StreamHandler(p.getErrorStream(), System.out::println);
+        StreamHandler errorHandler = new StreamHandler(p.getErrorStream(), l -> System.out.println("[stderr]: " + l));
         inputHandler.start();
         errorHandler.start();
     }
@@ -98,6 +98,7 @@ public class DebuggeeLauncher implements StreamHandler.Listener {
 
     @Override
     public void onStringRead(String line) {
+        System.out.println("[stdout]: " + line);
         if (jdwpPort == -1) {
             JDWP.ListenAddress addr = JDWP.parseListenAddress(line);
             if (addr != null) {

--- a/test/hotspot/jtreg/serviceability/jdwp/StreamHandler.java
+++ b/test/hotspot/jtreg/serviceability/jdwp/StreamHandler.java
@@ -37,10 +37,9 @@ public class StreamHandler implements Runnable {
     public interface Listener {
         /**
          * Called when a line has been read from the process output stream
-         * @param handler this StreamHandler
          * @param s the line
          */
-        void onStringRead(StreamHandler handler, String s);
+        void onStringRead(String s);
     }
 
     private final ExecutorService executor;
@@ -71,7 +70,7 @@ public class StreamHandler implements Runnable {
             BufferedReader br = new BufferedReader(new InputStreamReader(is));
             String line;
             while ((line = br.readLine()) != null) {
-                listener.onStringRead(this, line);
+                listener.onStringRead(line);
             }
         } catch (Exception x) {
             throw new RuntimeException(x);


### PR DESCRIPTION
The fix changes test serviceability/jdwp/AllModulesCommandTest.java to accept VM flags. 
1) The 'ProcessTools.createTestJvm(JDWP_OPT, DEBUGGEE);'  is used to start debugee
2) The stderr is just logging and tests doesn't check if it is empty. stderr might contain some VM output which doesn't mean failure
3) Some refactoring is done. Method ' public void onStringRead(StreamHandler handler, String line) {' doesn't need to check which handler is used and corresponding code and methods are deleted. The field 'inputHandler' and 'errorHandler' were moved into method.

Tested with tier1-5 to ensure that test correctly work with CI options.

The serviceability/jdwp/AllModulesCommandTest.java is the only one test in serviceability/jdwp directory so no other tests should be affected.

I closed my previous PR https://github.com/openjdk/jdk/pull/15499 because GitHub incorrectly show changes after merge with backout if the first fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315406](https://bugs.openjdk.org/browse/JDK-8315406): [REDO] serviceability/jdwp/AllModulesCommandTest.java ignores VM flags (**Bug** - P2)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15544/head:pull/15544` \
`$ git checkout pull/15544`

Update a local copy of the PR: \
`$ git checkout pull/15544` \
`$ git pull https://git.openjdk.org/jdk.git pull/15544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15544`

View PR using the GUI difftool: \
`$ git pr show -t 15544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15544.diff">https://git.openjdk.org/jdk/pull/15544.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15544#issuecomment-1703301225)