### PR TITLE
JDK-8226420: sun/tools/jstatd tests failed with Port already in use

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -722,9 +722,9 @@ java/util/concurrent/ExecutorService/CloseTest.java             8288899 macosx-a
 
 # svc_tools
 
-sun/tools/jstatd/TestJstatdDefaults.java                        8081569,8226420 windows-all
-sun/tools/jstatd/TestJstatdRmiPort.java                         8226420,8251259,8293577 generic-all
-sun/tools/jstatd/TestJstatdServer.java                          8081569,8226420 windows-all
+sun/tools/jstatd/TestJstatdDefaults.java                        8081569 windows-all
+sun/tools/jstatd/TestJstatdRmiPort.java                         8251259,8293577 generic-all
+sun/tools/jstatd/TestJstatdServer.java                          8081569 windows-all
 
 sun/tools/jstat/jstatLineCounts1.sh                             8268211 linux-aarch64
 sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aarch64


### PR DESCRIPTION
Logic to detect "port in use" case and retry was implemented in the test by JDK-8240711.
Infra issue with some test host when system software listened on port 1099 was resolved long time ago.

So JDK-8226420 has been closed as a duplicate.
The fix removes references to 8226420 from problemlist (the tests remain problemlisted due other issues).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8226420](https://bugs.openjdk.org/browse/JDK-8226420): sun/tools/jstatd tests failed with Port already in use (**Bug** - P4) ⚠️ Issue is not open.
 * [JDK-8315563](https://bugs.openjdk.org/browse/JDK-8315563): Remove references to JDK-8226420 from problem list (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15546/head:pull/15546` \
`$ git checkout pull/15546`

Update a local copy of the PR: \
`$ git checkout pull/15546` \
`$ git pull https://git.openjdk.org/jdk.git pull/15546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15546`

View PR using the GUI difftool: \
`$ git pr show -t 15546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15546.diff">https://git.openjdk.org/jdk/pull/15546.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15546#issuecomment-1703428227)