### PR TITLE
8315410: Undocumented exceptions in java.text.StringCharacterIterator

### DIFF
--- a/src/java.base/share/classes/java/text/StringCharacterIterator.java
+++ b/src/java.base/share/classes/java/text/StringCharacterIterator.java
@@ -40,6 +40,8 @@
 
 package java.text;
 
+import java.util.Objects;
+
 /**
  * {@code StringCharacterIterator} implements the
  * {@code CharacterIterator} protocol for a {@code String}.
@@ -62,9 +64,9 @@ public final class StringCharacterIterator implements CharacterIterator
      * Constructs an iterator with an initial index of 0.
      *
      * @param text the {@code String} to be iterated over
+     * @throws NullPointerException if {@code text} is {@code null}
      */
-    public StringCharacterIterator(String text)
-    {
+    public StringCharacterIterator(String text) {
         this(text, 0);
     }
 
@@ -73,10 +75,12 @@ public final class StringCharacterIterator implements CharacterIterator
      *
      * @param  text   The String to be iterated over
      * @param  pos    Initial iterator position
+     * @throws NullPointerException if {@code text} is {@code null}
+     * @throws IllegalArgumentException if {@code pos} is not within the bounds of
+     * range (inclusive) from {@code 0} to the length of {@code text}
      */
-    public StringCharacterIterator(String text, int pos)
-    {
-    this(text, 0, text.length(), pos);
+    public StringCharacterIterator(String text, int pos) {
+        this(text, 0, text.length(), pos);
     }
 
     /**
@@ -87,11 +91,14 @@ public final class StringCharacterIterator implements CharacterIterator
      * @param  begin  Index of the first character
      * @param  end    Index of the character following the last character
      * @param  pos    Initial iterator position
+     * @throws NullPointerException if {@code text} is {@code null}
+     * @throws IllegalArgumentException if {@code begin} and {@code end} are not
+     * within the bounds of range (inclusive) from {@code 0} to the length of {@code text},
+     * {@code begin} is greater than {@code end}, or {@code pos} is not within
+     * the bounds of range (inclusive) from {@code begin} to {@code end}
      */
     public StringCharacterIterator(String text, int begin, int end, int pos) {
-        if (text == null)
-            throw new NullPointerException();
-        this.text = text;
+        this.text = Objects.requireNonNull(text, "text must not be null");
 
         if (begin < 0 || begin > end || end > text.length())
             throw new IllegalArgumentException("Invalid substring range");
@@ -111,12 +118,11 @@ public final class StringCharacterIterator implements CharacterIterator
      * is called.
      *
      * @param  text   The String to be iterated over
+     * @throws NullPointerException if {@code text} is {@code null}
      * @since 1.2
      */
     public void setText(String text) {
-        if (text == null)
-            throw new NullPointerException();
-        this.text = text;
+        this.text = Objects.requireNonNull(text, "text must not be null");
         this.begin = 0;
         this.end = text.length();
         this.pos = 0;
@@ -148,6 +154,8 @@ public final class StringCharacterIterator implements CharacterIterator
 
     /**
      * Implements CharacterIterator.setIndex() for String.
+     *
+     * @throws IllegalArgumentException if {@code p} is an invalid index
      * @see CharacterIterator#setIndex
      */
     public char setIndex(int p)

--- a/src/java.base/share/classes/java/text/StringCharacterIterator.java
+++ b/src/java.base/share/classes/java/text/StringCharacterIterator.java
@@ -155,7 +155,8 @@ public final class StringCharacterIterator implements CharacterIterator
     /**
      * Implements CharacterIterator.setIndex() for String.
      *
-     * @throws IllegalArgumentException if {@code p} is an invalid index
+     * @throws IllegalArgumentException if {@code p} is not within the bounds
+     * (inclusive) of {@link #getBeginIndex()} to {@link #getEndIndex()}
      * @see CharacterIterator#setIndex
      */
     public char setIndex(int p)

--- a/src/java.base/share/classes/java/text/StringCharacterIterator.java
+++ b/src/java.base/share/classes/java/text/StringCharacterIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/text/StringCharacterIterator.java
+++ b/src/java.base/share/classes/java/text/StringCharacterIterator.java
@@ -46,7 +46,8 @@ import java.util.Objects;
  * {@code StringCharacterIterator} implements the
  * {@code CharacterIterator} protocol for a {@code String}.
  * The {@code StringCharacterIterator} class iterates over the
- * entire {@code String}.
+ * entire {@code String}. All constructors throw {@code NullPointerException}
+ * if {@code text} is {@code null}.
  *
  * @see CharacterIterator
  * @since 1.1
@@ -64,7 +65,6 @@ public final class StringCharacterIterator implements CharacterIterator
      * Constructs an iterator with an initial index of 0.
      *
      * @param text the {@code String} to be iterated over
-     * @throws NullPointerException if {@code text} is {@code null}
      */
     public StringCharacterIterator(String text) {
         this(text, 0);
@@ -75,7 +75,6 @@ public final class StringCharacterIterator implements CharacterIterator
      *
      * @param  text   The String to be iterated over
      * @param  pos    Initial iterator position
-     * @throws NullPointerException if {@code text} is {@code null}
      * @throws IllegalArgumentException if {@code pos} is not within the bounds of
      * range (inclusive) from {@code 0} to the length of {@code text}
      */
@@ -91,7 +90,6 @@ public final class StringCharacterIterator implements CharacterIterator
      * @param  begin  Index of the first character
      * @param  end    Index of the character following the last character
      * @param  pos    Initial iterator position
-     * @throws NullPointerException if {@code text} is {@code null}
      * @throws IllegalArgumentException if {@code begin} and {@code end} are not
      * within the bounds of range (inclusive) from {@code 0} to the length of {@code text},
      * {@code begin} is greater than {@code end}, or {@code pos} is not within


### PR DESCRIPTION
Please review this PR and [CSR](https://bugs.openjdk.org/browse/JDK-8315558) which is a conformance change to document some exceptions in the specification of java.text.StringCharacterIterator.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8315558](https://bugs.openjdk.org/browse/JDK-8315558) to be approved

### Issues
 * [JDK-8315410](https://bugs.openjdk.org/browse/JDK-8315410): Undocumented exceptions in java.text.StringCharacterIterator (**Bug** - P4)
 * [JDK-8315558](https://bugs.openjdk.org/browse/JDK-8315558): Undocumented exceptions in java.text.StringCharacterIterator (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [58c3f396](https://git.openjdk.org/jdk/pull/15547/files/58c3f39648e8066c4055ef1b2ef935dec1518d37)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15547/head:pull/15547` \
`$ git checkout pull/15547`

Update a local copy of the PR: \
`$ git checkout pull/15547` \
`$ git pull https://git.openjdk.org/jdk.git pull/15547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15547`

View PR using the GUI difftool: \
`$ git pr show -t 15547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15547.diff">https://git.openjdk.org/jdk/pull/15547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15547#issuecomment-1703468399)