### PR TITLE
8315563: Remove references to JDK-8226420 from problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -722,9 +722,9 @@ java/util/concurrent/ExecutorService/CloseTest.java             8288899 macosx-a
 
 # svc_tools
 
-sun/tools/jstatd/TestJstatdDefaults.java                        8081569,8226420 windows-all
-sun/tools/jstatd/TestJstatdRmiPort.java                         8226420,8251259,8293577 generic-all
-sun/tools/jstatd/TestJstatdServer.java                          8081569,8226420 windows-all
+sun/tools/jstatd/TestJstatdDefaults.java                        8081569 windows-all
+sun/tools/jstatd/TestJstatdRmiPort.java                         8251259,8293577 generic-all
+sun/tools/jstatd/TestJstatdServer.java                          8081569 windows-all
 
 sun/tools/jstat/jstatLineCounts1.sh                             8268211 linux-aarch64
 sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aarch64


### PR DESCRIPTION
JDK-8226420 has been closed as a duplicate.
The fix removes references to 8226420 from problemlist (the tests remain problem-listed due other issues).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315563](https://bugs.openjdk.org/browse/JDK-8315563): Remove references to JDK-8226420 from problem list (**Sub-task** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15548/head:pull/15548` \
`$ git checkout pull/15548`

Update a local copy of the PR: \
`$ git checkout pull/15548` \
`$ git pull https://git.openjdk.org/jdk.git pull/15548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15548`

View PR using the GUI difftool: \
`$ git pr show -t 15548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15548.diff">https://git.openjdk.org/jdk/pull/15548.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15548#issuecomment-1703609576)