### PR TITLE
8314191: C2 compilation fails with "bad AD file"

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -1556,12 +1556,14 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // and    "cmp (add X min_jint) c" into "cmpu X (c + min_jint)"
   if (cop == Op_CmpI &&
       cmp1_op == Op_AddI &&
+      !is_cloop_increment(cmp1) &&
       phase->type(cmp1->in(2)) == TypeInt::MIN) {
     if (cmp2_op == Op_ConI) {
       Node* ncmp2 = phase->intcon(java_add(cmp2->get_int(), min_jint));
       Node* ncmp = phase->transform(new CmpUNode(cmp1->in(1), ncmp2));
       return new BoolNode(ncmp, _test._test);
     } else if (cmp2_op == Op_AddI &&
+               !is_cloop_increment(cmp2) &&
                phase->type(cmp2->in(2)) == TypeInt::MIN) {
       Node* ncmp = phase->transform(new CmpUNode(cmp1->in(1), cmp2->in(1)));
       return new BoolNode(ncmp, _test._test);
@@ -1572,12 +1574,14 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // and    "cmp (add X min_jlong) c" into "cmpu X (c + min_jlong)"
   if (cop == Op_CmpL &&
       cmp1_op == Op_AddL &&
+      !is_cloop_increment(cmp1) &&
       phase->type(cmp1->in(2)) == TypeLong::MIN) {
     if (cmp2_op == Op_ConL) {
       Node* ncmp2 = phase->longcon(java_add(cmp2->get_long(), min_jlong));
       Node* ncmp = phase->transform(new CmpULNode(cmp1->in(1), ncmp2));
       return new BoolNode(ncmp, _test._test);
     } else if (cmp2_op == Op_AddL &&
+               !is_cloop_increment(cmp2) &&
                phase->type(cmp2->in(2)) == TypeLong::MIN) {
       Node* ncmp = phase->transform(new CmpULNode(cmp1->in(1), cmp2->in(1)));
       return new BoolNode(ncmp, _test._test);

--- a/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2;
+
+/*
+ * @test
+ * @bug 8314191
+ * @summary Loop increment should not be transformed into unsigned comparison
+ *
+ * @run main/othervm -Xcomp -XX:+TraceLoopOpts -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,MinValueStrideCountedLoop::test*
+ *                   compiler.c2.MinValueStrideCountedLoop
+ */
+public class MinValueStrideCountedLoop {
+    static int limit = 0;
+    static int res = 0;
+
+    static void test() {
+        for (int i = 0; i >= limit + -2147483647; i += -2147483648) {
+            res += 42;
+        }
+    }
+
+    public static void main(String[] args) {
+        test();
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
@@ -28,7 +28,7 @@ package compiler.c2;
  * @summary Loop increment should not be transformed into unsigned comparison
  *
  * @run main/othervm -Xcomp -XX:+TraceLoopOpts -XX:-TieredCompilation
- *                   -XX:CompileCommand=compileonly,MinValueStrideCountedLoop::test*
+ *                   -XX:CompileCommand=compileonly,*MinValueStrideCountedLoop::test*
  *                   compiler.c2.MinValueStrideCountedLoop
  */
 public class MinValueStrideCountedLoop {


### PR DESCRIPTION
Hi,

The root cause is that the comparison in the form `x + inc <=> bound` being transformed into `x u<=> bound - min_value` when `inc` is the min value of the loop type. The fix I propose is to avoid the transformation when either side is a counted loop increment.

Thanks a lot.