### PR TITLE
8315582: Exclude compiler/codecache/CodeCacheFullCountTest.java with Xcomp

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -27,6 +27,8 @@
 #
 #############################################################################
 
+compiler/codecache/CodeCacheFullCountTest.java 8315576 generic-all
+
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64


### PR DESCRIPTION
Please review following fix which disable execution of compiler/codecache/CodeCacheFullCountTest.java  with -Xcomp.
Test fails because it is not enough to stat VM with Xcomp and other VM falgs. So just exclude it to reduce noise for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315582](https://bugs.openjdk.org/browse/JDK-8315582): Exclude compiler/codecache/CodeCacheFullCountTest.java  with Xcomp (**Sub-task** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15553/head:pull/15553` \
`$ git checkout pull/15553`

Update a local copy of the PR: \
`$ git checkout pull/15553` \
`$ git pull https://git.openjdk.org/jdk.git pull/15553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15553`

View PR using the GUI difftool: \
`$ git pr show -t 15553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15553.diff">https://git.openjdk.org/jdk/pull/15553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15553#issuecomment-1704615293)