### PR TITLE
8315584 : java/awt/print/Dialog/DialogType.java fails with option not  supported: yesno

### DIFF
--- a/test/jdk/java/awt/print/Dialog/DialogType.java
+++ b/test/jdk/java/awt/print/Dialog/DialogType.java
@@ -23,7 +23,6 @@
 
 import java.awt.print.PrinterJob;
 import java.lang.reflect.InvocationTargetException;
-import javax.print.attribute.Attribute;
 import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.print.attribute.PrintRequestAttributeSet;
 import javax.print.attribute.standard.DialogTypeSelection;
@@ -45,11 +44,11 @@ public class DialogType {
 
     static String instruction = """
             This test assumes and requires that you have a printer installed.
-            It verifies that the dialogs behave properly when using new API,
+            It verifies that the dialogs behave properly when using new API
             to optionally select a native dialog where one is present.
-            Two dialogs are shown in succession.,
+            Two dialogs are shown in succession.
             The test passes as long as no exceptions are thrown, *AND*,
-            if running on Windows only, the first dialog is a native windows,
+            if running on Windows only, the first dialog is a native windows
             control which differs in appearance from the second dialog.
             Note: You can either press 'ESCAPE' button or click on the 'Cancel'
             to close print dialog.


### PR DESCRIPTION
Test was failing with "test result: Error. Parse Exception: Arguments to `manual' option not supported: yesno"
Following are fixed 
1) Removed yesno 
2) Used PassFailJFrame manual test framework to show the test instruction & allow the user to decide test execution result.
3) Added SkippedException in case Printer is not configured on the test host.
4) Updated the instruction how to close the print dialog that test is showing to the user.
5) Added an extra line to the file that was missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315584](https://bugs.openjdk.org/browse/JDK-8315584): java/awt/print/Dialog/DialogType.java fails with option not supported: yesno (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15554/head:pull/15554` \
`$ git checkout pull/15554`

Update a local copy of the PR: \
`$ git checkout pull/15554` \
`$ git pull https://git.openjdk.org/jdk.git pull/15554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15554`

View PR using the GUI difftool: \
`$ git pr show -t 15554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15554.diff">https://git.openjdk.org/jdk/pull/15554.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15554#issuecomment-1704420103)