### PR TITLE
8315612: RISC-V: intrinsic for unsignedMultiplyHigh

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6872,8 +6872,8 @@ instruct umulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2)
 
   ins_encode %{
     __ mulhu(as_Register($dst$$reg),
-            as_Register($src1$$reg),
-            as_Register($src2$$reg));
+             as_Register($src1$$reg),
+             as_Register($src2$$reg));
   %}
 
   ins_pipe(lmul_reg_reg);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6864,6 +6864,21 @@ instruct mulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2)
   ins_pipe(lmul_reg_reg);
 %}
 
+instruct umulHiL_rReg(iRegLNoSp dst, iRegL src1, iRegL src2)
+%{
+  match(Set dst (UMulHiL src1 src2));
+  ins_cost(IMUL_COST);
+  format %{ "mulhu  $dst, $src1, $src2\t# umulhi, #@umulHiL_rReg" %}
+
+  ins_encode %{
+    __ mulhu(as_Register($dst$$reg),
+            as_Register($src1$$reg),
+            as_Register($src2$$reg));
+  %}
+
+  ins_pipe(lmul_reg_reg);
+%}
+
 // Integer Divide
 
 instruct divI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{


### PR DESCRIPTION
Hello
Please review this simple patch, it add c2 implementation of intrinsic for unsignedMultiplyHigh.
The generated code changes from:
```
            0x0000003fbcfb12f8:   mulh	t4,t2,t3
   2.99%    0x0000003fbcfb12fc:   srai	t5,t2,0x3f
            0x0000003fbcfb1300:   and	t5,t5,t3
            0x0000003fbcfb1304:   srai	t3,t3,0x3f
            0x0000003fbcfb1308:   and	t2,t3,t2
            0x0000003fbcfb130c:   add	t4,t4,t5
            0x0000003fbcfb130e:   add	t2,t2,t4                    ;*ladd {reexecute=0 rethrow=0 return_oop=0}
```
to
```
            0x0000003fdcfb6668:   mulhu	t2,t2,t3                    ;*invokestatic unsignedMultiplyHigh {reexecute=0 rethrow=0 return_oop=0}
```

Clear code size reduction and potentially some performance boost.
on hifive I can see the perf boost:
```
before:
MathBench.unsignedMultiplyHighLongLong       0  thrpt    8  67459.527 ± 10110.941  ops/ms

after:
MathBench.unsignedMultiplyHighLongLong       0  thrpt    8  86207.949 ± 8636.131  ops/ms
```
However on thead the jmh benchmark unsignedMultiplyHighLongLong  didn't show any difference as the hottest place is the fence ( getfield isDone ):
```
            0x0000003fdcfb6660:   ld	t3,64(t4)
            0x0000003fdcfb6664:   ld	t2,56(t4)
            0x0000003fdcfb6668:   mulhu	t2,t2,t3                    ;*invokestatic unsignedMultiplyHigh {reexecute=0 rethrow=0 return_oop=0}
                                                                      ; - org.openjdk.bench.java.lang.MathBench::unsignedMultiplyHighLongLong@8 (line 545)
                                                                      ; - org.openjdk.bench.java.lang.jmh_generated.MathBench_unsignedMultiplyHighLongLong_jmhTest::unsignedMultiplyHighLongLong_thrpt_jmhStub@17 (line 119)
   3.12%    0x0000003fdcfb666c:   lbu	t3,148(s3)                  ;*invokestatic consumeCompiler {reexecute=0 rethrow=0 return_oop=0}
                                                                      ; - org.openjdk.jmh.infra.Blackhole::consume@7 (line 393)
                                                                      ; - org.openjdk.bench.java.lang.jmh_generated.MathBench_unsignedMultiplyHighLongLong_jmhTest::unsignedMultiplyHighLongLong_thrpt_jmhStub@20 (line 119)
            0x0000003fdcfb6670:   fence	ir,iorw                     ;*getfield isDone {reexecute=0 rethrow=0 return_oop=0}
                                                                      ; - org.openjdk.bench.java.lang.jmh_generated.MathBench_unsignedMultiplyHighLongLong_jmhTest::unsignedMultiplyHighLongLong_thrpt_jmhStub@30 (line 121)
  62.78%    0x0000003fdcfb6674:   addi	s2,s2,1                     ;*ladd {reexecute=0 rethrow=0 return_oop=0}
                                                                      ; - org.openjdk.bench.java.lang.jmh_generated.MathBench_unsignedMultiplyHighLongLong_jmhTest::unsignedMultiplyHighLongLong_thrpt_jmhStub@26 (line 120)
```

tier1/tier2 tbd

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315612](https://bugs.openjdk.org/browse/JDK-8315612): RISC-V: intrinsic for unsignedMultiplyHigh (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [55f34287](https://git.openjdk.org/jdk/pull/15558/files/55f34287facffedc6573b9273b6c06fb9400a926)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15558/head:pull/15558` \
`$ git checkout pull/15558`

Update a local copy of the PR: \
`$ git checkout pull/15558` \
`$ git pull https://git.openjdk.org/jdk.git pull/15558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15558`

View PR using the GUI difftool: \
`$ git pr show -t 15558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15558.diff">https://git.openjdk.org/jdk/pull/15558.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15558#issuecomment-1704978958)