### PR TITLE
8315548: G1: Document why VM_G1CollectForAllocation::doit() may allocate without completing a GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -127,6 +127,10 @@ void VM_G1CollectForAllocation::doit() {
 
   if (_word_size > 0) {
     // An allocation has been requested. So, try to do that first.
+    // During the execution of this VM operation, there may have been a concurrent active
+    // GCLocker, potentially leading to expansion of the Eden space by other mutators.
+    // If the Eden space was expanded, the allocation request might succeed without
+    // triggering a garbage collection.
     _result = g1h->attempt_allocation_at_safepoint(_word_size,
                                                    false /* expect_null_cur_alloc_region */);
     if (_result != nullptr) {


### PR DESCRIPTION
Hi all,

Please review this trivial change to add a comment explaining why we attempt to allocate at a VM_G1CollectForAllocation safepoint before triggering garbage collection.

Thanks,
Ivan