### PR TITLE
JDK-8315644: increase timeout of sun/security/tools/jarsigner/Warning.java

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/Warning.java
+++ b/test/jdk/sun/security/tools/jarsigner/Warning.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
  * @summary warnings, errors and -strict
  * @library /lib/testlibrary /test/lib
  * @build jdk.test.lib.util.JarUtils
- * @run main Warning
+ * @run main/othervm/timeout=400 Warning
  */
 public class Warning {
 


### PR DESCRIPTION
on some slow machines, sun/security/tools/jarsigner/Warning.java runs sometimes into timeouts (with fastdebug binaries).
So the current timeout of the test should be increased.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315644](https://bugs.openjdk.org/browse/JDK-8315644): increase timeout of sun/security/tools/jarsigner/Warning.java (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15560/head:pull/15560` \
`$ git checkout pull/15560`

Update a local copy of the PR: \
`$ git checkout pull/15560` \
`$ git pull https://git.openjdk.org/jdk.git pull/15560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15560`

View PR using the GUI difftool: \
`$ git pr show -t 15560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15560.diff">https://git.openjdk.org/jdk/pull/15560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15560#issuecomment-1705258081)