### PR TITLE
8315648: Add test for JDK-8309979 changes

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java
@@ -92,6 +92,7 @@ public class ClhsdbDumpclass {
             // containing only methods with sequential control flows.
             // But the class used here (LingeredApp) is not such a case.
             out.shouldContain("StackMapTable:");
+            out.shouldContain("BootstrapMethods:");
             out.shouldNotContain("Error:");
         } catch (SkippedException se) {
             throw se;


### PR DESCRIPTION
This change added a simple check in test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.java if BootstrapMethods attribute was dumped. (similar to test changes in PR #14556)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315648](https://bugs.openjdk.org/browse/JDK-8315648): Add test for JDK-8309979 changes (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15561/head:pull/15561` \
`$ git checkout pull/15561`

Update a local copy of the PR: \
`$ git checkout pull/15561` \
`$ git pull https://git.openjdk.org/jdk.git pull/15561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15561`

View PR using the GUI difftool: \
`$ git pr show -t 15561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15561.diff">https://git.openjdk.org/jdk/pull/15561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15561#issuecomment-1705360500)