### PR TITLE
8315377: C2: assert(u->find_out_with(Op_AddP) == nullptr) failed: more than 2 chained AddP nodes?

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1722,6 +1722,8 @@ public:
   bool clone_cmp_loadklass_down(Node* n, const Node* blk1, const Node* blk2);
 
   bool at_relevant_ctrl(Node* n, const Node* blk1, const Node* blk2);
+
+  void update_addp_chain_base(Node* x, Node* old_base, Node* new_base);
 };
 
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestSinkingMoreThan2AddPNodes.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSinkingMoreThan2AddPNodes.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8315377
+ * @requires vm.compiler2.enabled
+ * @summary C2: assert(u->find_out_with(Op_AddP) == nullptr) failed: more than 2 chained AddP nodes?
+ * @library /test/lib
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestSinkingMoreThan2AddPNodes::test TestSinkingMoreThan2AddPNodes
+ *
+ */
+
+import jdk.test.lib.Utils;
+
+public class TestSinkingMoreThan2AddPNodes {
+    public static void main(String[] strArr) throws Exception {
+        Thread t = new Thread(new Runnable() {
+                public void run() {
+                    test();
+                }
+            });
+        t.setDaemon(true);
+        t.start();
+        Thread.sleep(Utils.adjustTimeout(500));
+    }
+
+    static void test() {
+        double dArr[] = new double[10];
+        int i4 = 5, i11, i12 = 2, iArr[] = new int[400];
+        long l1;
+        byte by1 = 0;
+        short s1 = 8;
+
+        for (int i = 0; i < iArr.length; i++) {
+            iArr[i] = (i % 2 == 0) ? 23 : 34;
+        }
+
+        for (i11 = 10; i11 > 9; ) {
+            l1 = 1;
+            do {
+                try {
+                    i4 = 6 % i4;
+                    i12 = iArr[(int) l1];
+                } catch (ArithmeticException a_e) {
+                }
+                by1 += 8;
+                iArr = iArr;
+            } while (++l1 < 11);
+        }
+
+        long meth_res = i12;
+    }
+}
+


### PR DESCRIPTION
`PhaseIdealLoop::try_sink_out_of_loop()` has special logic to handle
`AddP` nodes so, after it has been processed, all nodes in the chain
of `AddP` nodes still have the same base input. That logic assumes a
chain is only composed of at most 2 nodes. That's not true because
`PhaseIdealLoop::remix_address_expressions()` can cause longer chains
to exist. There's actually no clear upper bound on the number of nodes
in such a chain. The fix I propose here is simply to extend the logic
in `PhaseIdealLoop::try_sink_out_of_loop()` to handle arbitrary
chains.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315377](https://bugs.openjdk.org/browse/JDK-8315377): C2: assert(u-&gt;find_out_with(Op_AddP) == nullptr) failed: more than 2 chained AddP nodes? (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15562/head:pull/15562` \
`$ git checkout pull/15562`

Update a local copy of the PR: \
`$ git checkout pull/15562` \
`$ git pull https://git.openjdk.org/jdk.git pull/15562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15562`

View PR using the GUI difftool: \
`$ git pr show -t 15562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15562.diff">https://git.openjdk.org/jdk/pull/15562.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15562#issuecomment-1705497373)