### PR TITLE
8314260: Unable to load system libraries on Windows when using a SecurityManager

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -29,6 +29,8 @@ import java.lang.foreign.*;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -72,7 +74,14 @@ public final class SystemLookup implements SymbolLookup {
     }
 
     private static SymbolLookup makeWindowsLookup() {
-        Path system32 = Path.of(System.getenv("SystemRoot"), "System32");
+        @SuppressWarnings("removal")
+        String systemRoot = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.getenv("SystemRoot");
+            }
+        });
+        Path system32 = Path.of(systemRoot, "System32");
         Path ucrtbase = system32.resolve("ucrtbase.dll");
         Path msvcrt = system32.resolve("msvcrt.dll");
 

--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -85,7 +85,13 @@ public final class SystemLookup implements SymbolLookup {
         Path ucrtbase = system32.resolve("ucrtbase.dll");
         Path msvcrt = system32.resolve("msvcrt.dll");
 
-        boolean useUCRT = Files.exists(ucrtbase);
+        @SuppressWarnings("removal")
+        boolean useUCRT = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            @Override
+            public Boolean run() {
+                return Files.exists(ucrtbase);
+            }
+        });
         Path stdLib = useUCRT ? ucrtbase : msvcrt;
         SymbolLookup lookup = libLookup(libs -> libs.load(stdLib));
 

--- a/test/jdk/java/foreign/TestLinker.java
+++ b/test/jdk/java/foreign/TestLinker.java
@@ -26,7 +26,8 @@
  * @enablePreview
  * @requires jdk.foreign.linker != "UNSUPPORTED"
  * @modules java.base/jdk.internal.foreign
- * @run testng TestLinker
+ * @run testng/othervm/policy=security.policy
+ *          -Djava.security.manager=default TestLinker
  */
 
 import jdk.internal.foreign.CABI;

--- a/test/jdk/java/foreign/TestLinker.java
+++ b/test/jdk/java/foreign/TestLinker.java
@@ -26,6 +26,7 @@
  * @enablePreview
  * @requires jdk.foreign.linker != "UNSUPPORTED"
  * @modules java.base/jdk.internal.foreign
+ * @run testng TestLinker
  * @run testng/othervm/policy=security.policy
  *          -Djava.security.manager=default TestLinker
  */

--- a/test/jdk/java/foreign/security.policy
+++ b/test/jdk/java/foreign/security.policy
@@ -1,0 +1,7 @@
+grant {
+    // Permissions needed to run the test
+    permission java.util.PropertyPermission "os.name", "read";
+    permission java.util.PropertyPermission "NativeTestHelper.DEFAULT_RANDOM.seed", "read";
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.foreign";
+};
+

--- a/test/jdk/java/foreign/security.policy
+++ b/test/jdk/java/foreign/security.policy
@@ -1,4 +1,4 @@
-grant {
+grant codeBase "file:${test.classes}/*" {
     // Permissions needed to run the test
     permission java.util.PropertyPermission "os.name", "read";
     permission java.util.PropertyPermission "NativeTestHelper.DEFAULT_RANDOM.seed", "read";


### PR DESCRIPTION
This PR proposes to read the system environment variable "SystemRoot" using a privileged operation so it will work in the event a default SecurityManager is in place.

As the `SecurityManager` is deprecated for removal, no support methods were added for reading environmental variables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314260](https://bugs.openjdk.org/browse/JDK-8314260): Unable to load system libraries on Windows when using a SecurityManager (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Contributors
 * Jorn Vernee `<jvernee@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15564/head:pull/15564` \
`$ git checkout pull/15564`

Update a local copy of the PR: \
`$ git checkout pull/15564` \
`$ git pull https://git.openjdk.org/jdk.git pull/15564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15564`

View PR using the GUI difftool: \
`$ git pr show -t 15564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15564.diff">https://git.openjdk.org/jdk/pull/15564.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15564#issuecomment-1706222425)