### PR TITLE
8315541: Classfile API TypeAnnotation.TargetInfo factory methods accept null labels

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/TargetInfoImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/TargetInfoImpl.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import jdk.internal.classfile.Label;
 import jdk.internal.classfile.TypeAnnotation.*;
 import static jdk.internal.classfile.Classfile.*;
+import static java.util.Objects.requireNonNull;
 
 public final class TargetInfoImpl {
 
@@ -104,6 +105,11 @@ public final class TargetInfoImpl {
 
     public record LocalVarTargetInfoImpl(Label startLabel, Label endLabel, int index)
             implements LocalVarTargetInfo {
+
+        public LocalVarTargetInfoImpl {
+            requireNonNull(startLabel);
+            requireNonNull(endLabel);
+        }
     }
 
     public record CatchTargetImpl(int exceptionTableIndex) implements CatchTarget {
@@ -117,7 +123,7 @@ public final class TargetInfoImpl {
 
         public OffsetTargetImpl(TargetType targetType, Label target) {
             this.targetType = checkValid(targetType, TAT_INSTANCEOF, TAT_METHOD_REFERENCE);
-            this.target = target;
+            this.target = requireNonNull(target);
         }
     }
 
@@ -126,7 +132,7 @@ public final class TargetInfoImpl {
 
         public TypeArgumentTargetImpl(TargetType targetType, Label target, int typeArgumentIndex) {
             this.targetType = checkValid(targetType, TAT_CAST, TAT_METHOD_REFERENCE_TYPE_ARGUMENT);
-            this.target = target;
+            this.target = requireNonNull(target);
             this.typeArgumentIndex = typeArgumentIndex;
         }
     }


### PR DESCRIPTION
This patch performs null checks in to refuse null labels in  TypeAnnotation.TargetInfo implementations.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315541](https://bugs.openjdk.org/browse/JDK-8315541): Classfile API TypeAnnotation.TargetInfo factory methods accept null labels (**Bug** - P4)


### Reviewers
 * [Brian Goetz](https://openjdk.org/census#briangoetz) (@briangoetz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15565/head:pull/15565` \
`$ git checkout pull/15565`

Update a local copy of the PR: \
`$ git checkout pull/15565` \
`$ git pull https://git.openjdk.org/jdk.git pull/15565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15565`

View PR using the GUI difftool: \
`$ git pr show -t 15565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15565.diff">https://git.openjdk.org/jdk/pull/15565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15565#issuecomment-1706411247)