### PR TITLE
8315696: SignedLoggerFinderTest.java test failed

### DIFF
--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
@@ -26,12 +26,11 @@
  * @bug 8314263
  * @summary Creating a logger while loading the Logger finder
  *          triggers recursion and StackOverflowError
- * @modules java.base/sun.util.logging
+ * @modules java.base/sun.util.logging java.base/jdk.internal.logger:+open
  * @library /test/lib
  * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
  * @run main/othervm PlatformRecursiveLoadingTest
  */
-
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -39,6 +38,8 @@ import java.util.List;
 import java.util.logging.LogRecord;
 
 import sun.util.logging.PlatformLogger;
+
+import jdk.test.lib.util.BootstrapLoggerUtils;
 
 public class PlatformRecursiveLoadingTest {
 
@@ -50,6 +51,8 @@ public class PlatformRecursiveLoadingTest {
      */
     public static void main(String[] args) throws Throwable {
         PlatformLogger.getLogger("main").info("in main");
+        // allow time to let bootstrap logger flush data
+        BootstrapLoggerUtils.awaitPending();
         List<Object> logs = loggerfinder.SimpleLoggerFinder.LOGS;
         logs.stream().map(SimpleLogRecord::of).forEach(System.out::println);
         logs.stream().map(SimpleLogRecord::of).forEach(SimpleLogRecord::check);

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/PlatformRecursiveLoadingTest.java
@@ -27,7 +27,7 @@
  * @summary Creating a logger while loading the Logger finder
  *          triggers recursion and StackOverflowError
  * @modules java.base/sun.util.logging java.base/jdk.internal.logger:+open
- * @library /test/lib
+ * @library ../lib
  * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
  * @run main/othervm PlatformRecursiveLoadingTest
  */
@@ -38,8 +38,6 @@ import java.util.List;
 import java.util.logging.LogRecord;
 
 import sun.util.logging.PlatformLogger;
-
-import jdk.test.lib.util.BootstrapLoggerUtils;
 
 public class PlatformRecursiveLoadingTest {
 

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
@@ -26,6 +26,8 @@
  * @bug 8314263
  * @summary Creating a logger while loading the Logger finder
  *          triggers recursion and StackOverflowError
+ * @modules java.base/jdk.internal.logger:+open
+ * @library /test/lib
  * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
  * @run main/othervm RecursiveLoadingTest
  */
@@ -34,6 +36,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.LogRecord;
+
+import jdk.test.lib.util.BootstrapLoggerUtils;
 
 public class RecursiveLoadingTest {
 
@@ -45,6 +49,8 @@ public class RecursiveLoadingTest {
      */
     public static void main(String[] args) throws Throwable {
         System.getLogger("main").log(System.Logger.Level.INFO, "in main");
+        // allow time to let bootstrap logger flush data
+        BootstrapLoggerUtils.awaitPending();
         List<Object> logs = loggerfinder.SimpleLoggerFinder.LOGS;
         logs.stream().map(SimpleLogRecord::of).forEach(System.out::println);
         logs.stream().map(SimpleLogRecord::of).forEach(SimpleLogRecord::check);

--- a/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/RecursiveLoading/RecursiveLoadingTest.java
@@ -27,7 +27,7 @@
  * @summary Creating a logger while loading the Logger finder
  *          triggers recursion and StackOverflowError
  * @modules java.base/jdk.internal.logger:+open
- * @library /test/lib
+ * @library ../lib
  * @compile RecursiveLoadingTest.java SimpleLoggerFinder.java
  * @run main/othervm RecursiveLoadingTest
  */
@@ -36,8 +36,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.LogRecord;
-
-import jdk.test.lib.util.BootstrapLoggerUtils;
 
 public class RecursiveLoadingTest {
 

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8314263
  * @summary Signed jars triggering Logger finder recursion and StackOverflowError
+ * @modules java.base/jdk.internal.logger:+open
  * @library /test/lib
  * @build jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.process.*
@@ -47,6 +48,7 @@ import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.util.BootstrapLoggerUtils;
 import jdk.test.lib.util.JarUtils;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -146,6 +148,8 @@ public class SignedLoggerFinderTest {
 
             // LoggerFinder should be initialized, trigger a simple log call
             Security.setProperty("test_2", "test");
+            // allow time to let bootstrap logger flush data
+            BootstrapLoggerUtils.awaitPending();
         }
     }
 
@@ -165,6 +169,8 @@ public class SignedLoggerFinderTest {
                 System.getProperty("test.classes")));
         }
         cmds.addAll(List.of(
+            // allow test to access internal bootstrap logger functionality
+            "--add-opens=java.base/jdk.internal.logger=ALL-UNNAMED",
             // following debug property seems useful to tickle the issue
             "-Dsun.misc.URLClassPath.debug=true",
             // console logger level to capture event output

--- a/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/SignedLoggerFinderTest/SignedLoggerFinderTest.java
@@ -26,7 +26,7 @@
  * @bug 8314263
  * @summary Signed jars triggering Logger finder recursion and StackOverflowError
  * @modules java.base/jdk.internal.logger:+open
- * @library /test/lib
+ * @library /test/lib ../lib
  * @build jdk.test.lib.compiler.CompilerUtils
  *        jdk.test.lib.process.*
  *        jdk.test.lib.util.JarUtils
@@ -48,7 +48,6 @@ import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.util.BootstrapLoggerUtils;
 import jdk.test.lib.util.JarUtils;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerAPIsTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerAPIsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,18 +29,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.ResourceBundle;
-import java.util.Set;
+
 import jdk.internal.logger.BootstrapLogger;
 import jdk.internal.logger.LazyLoggers;
+
+import jdk.test.lib.util.BootstrapLoggerUtils;
 
 /*
  * @test
  * @bug     8144460 8144214
  * @summary Cover the logXX and LogEvent.valueOf APIs of BootstrapLogger
  *          and logXX APIs of SimpleConsoleLogger.
+ * @library /test/lib
  * @modules java.base/jdk.internal.logger:+open
  *          java.base/sun.util.logging
- * @build BootstrapLoggerUtils LogStream
+ * @build LogStream
  * @run main/othervm BootstrapLoggerAPIsTest
  */
 

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerAPIsTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerAPIsTest.java
@@ -33,14 +33,12 @@ import java.util.ResourceBundle;
 import jdk.internal.logger.BootstrapLogger;
 import jdk.internal.logger.LazyLoggers;
 
-import jdk.test.lib.util.BootstrapLoggerUtils;
-
 /*
  * @test
  * @bug     8144460 8144214
  * @summary Cover the logXX and LogEvent.valueOf APIs of BootstrapLogger
  *          and logXX APIs of SimpleConsoleLogger.
- * @library /test/lib
+ * @library ../../lib
  * @modules java.base/jdk.internal.logger:+open
  *          java.base/sun.util.logging
  * @build LogStream

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,8 @@ import java.util.stream.Stream;
 import jdk.internal.logger.BootstrapLogger;
 import jdk.internal.logger.LazyLoggers;
 
+import jdk.test.lib.util.BootstrapLoggerUtils;
+
 /*
  * @test
  * @bug     8140364 8189291
@@ -53,9 +55,10 @@ import jdk.internal.logger.LazyLoggers;
  * @summary JDK implementation specific unit test for JDK internal artifacts.
             Tests the behavior of bootstrap loggers (and SimpleConsoleLoggers
  *          too).
+ * @library /test/lib
  * @modules java.base/jdk.internal.logger:+open
  *          java.logging
- * @build BootstrapLoggerUtils LogStream
+ * @build LogStream
  * @run main/othervm BootstrapLoggerTest NO_SECURITY
  * @run main/othervm -Djava.security.manager=allow BootstrapLoggerTest SECURE
  * @run main/othervm/timeout=120 -Djava.security.manager=allow BootstrapLoggerTest SECURE_AND_WAIT

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/BootstrapLoggerTest.java
@@ -46,8 +46,6 @@ import java.util.stream.Stream;
 import jdk.internal.logger.BootstrapLogger;
 import jdk.internal.logger.LazyLoggers;
 
-import jdk.test.lib.util.BootstrapLoggerUtils;
-
 /*
  * @test
  * @bug     8140364 8189291
@@ -55,7 +53,7 @@ import jdk.test.lib.util.BootstrapLoggerUtils;
  * @summary JDK implementation specific unit test for JDK internal artifacts.
             Tests the behavior of bootstrap loggers (and SimpleConsoleLoggers
  *          too).
- * @library /test/lib
+ * @library ../../lib
  * @modules java.base/jdk.internal.logger:+open
  *          java.logging
  * @build LogStream

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/LogStream.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/LogStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
-import jdk.internal.logger.BootstrapLogger;
+import jdk.test.lib.util.BootstrapLoggerUtils;
 
 /**
  * We use an instance of this class to check what the logging system has printed

--- a/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/LogStream.java
+++ b/test/jdk/java/lang/System/LoggerFinder/internal/BootstrapLogger/LogStream.java
@@ -25,8 +25,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 
-import jdk.test.lib.util.BootstrapLoggerUtils;
-
 /**
  * We use an instance of this class to check what the logging system has printed
  * on System.err.

--- a/test/jdk/java/lang/System/LoggerFinder/lib/BootstrapLoggerUtils.java
+++ b/test/jdk/java/lang/System/LoggerFinder/lib/BootstrapLoggerUtils.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-package jdk.test.lib.util;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/test/lib/jdk/test/lib/util/BootstrapLoggerUtils.java
+++ b/test/lib/jdk/test/lib/util/BootstrapLoggerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,8 @@
  * questions.
  */
 
+package jdk.test.lib.util;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -28,7 +30,7 @@ import java.util.function.BooleanSupplier;
 
 import jdk.internal.logger.BootstrapLogger;
 
-class BootstrapLoggerUtils {
+public final class BootstrapLoggerUtils {
 
     private static final Field IS_BOOTED;
     private static final Method AWAIT_PENDING;
@@ -46,11 +48,11 @@ class BootstrapLoggerUtils {
         }
     }
 
-    static void setBootedHook(BooleanSupplier supplier) throws IllegalAccessException {
+    public static void setBootedHook(BooleanSupplier supplier) throws IllegalAccessException {
         IS_BOOTED.set(null, supplier);
     }
 
-    static void awaitPending() {
+    public static void awaitPending() {
         try {
             AWAIT_PENDING.invoke(null);
         } catch (IllegalAccessException | IllegalArgumentException


### PR DESCRIPTION
Update the recently added LoggerFinder tests to cater for a possible condition where the test finishes before the boot logger executor service has flushed its pending data.

By simulating a slow thread in the ExecutorService used in BootstrapLogger, I was able to reproduce the issue described. Adding the `BootstrapLoggerUtils.awaitPending();` call allows the tests to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315696](https://bugs.openjdk.org/browse/JDK-8315696): SignedLoggerFinderTest.java test failed (**Bug** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Contributors
 * Daniel Fuchs `<dfuchs@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15571/head:pull/15571` \
`$ git checkout pull/15571`

Update a local copy of the PR: \
`$ git checkout pull/15571` \
`$ git pull https://git.openjdk.org/jdk.git pull/15571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15571`

View PR using the GUI difftool: \
`$ git pr show -t 15571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15571.diff">https://git.openjdk.org/jdk/pull/15571.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15571#issuecomment-1708133145)