### PR TITLE
8253620: Debug symbols for tests missing on macos and windows

### DIFF
--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -87,6 +87,15 @@ define SetupTestFilesCompilationBody
 
   $1_BUILD_INFO := $$($1_OUTPUT_DIR)/_$1-build-info.marker
 
+  # Tests are built with internal debug symbols where supported.
+  # With Visual Studio or on macosx, we revert to external.
+  $1_COPY_DEBUG_SYMBOLS := false
+  ifeq ($(TOOLCHAIN_TYPE), microsoft)
+    $1_COPY_DEBUG_SYMBOLS := true
+  else ifeq ($(call isTargetOs, macosx), true)
+    $1_COPY_DEBUG_SYMBOLS := true
+  endif
+
   # Setup a compilation for each and every one of them
   $$(foreach file, $$($1_FILTERED_FILE_LIST),\
     $$(eval name := $$(strip $$(basename $$(notdir $$(file))))) \
@@ -106,7 +115,7 @@ define SetupTestFilesCompilationBody
         LIBS := $$($1_LIBS_$$(name)), \
         TOOLCHAIN := $(if $$(filter %.cpp, $$(file)), TOOLCHAIN_LINK_CXX, TOOLCHAIN_DEFAULT), \
         OPTIMIZATION := $$(if $$($1_OPTIMIZATION_$$(name)),$$($1_OPTIMIZATION_$$(name)),LOW), \
-        COPY_DEBUG_SYMBOLS := $$(if $$($1_COPY_DEBUG_SYMBOLS_$$(name)),$$($1_COPY_DEBUG_SYMBOLS_$$(name)),false), \
+        COPY_DEBUG_SYMBOLS := $$($1_COPY_DEBUG_SYMBOLS), \
         STRIP_SYMBOLS := $$(if $$($1_STRIP_SYMBOLS_$$(name)),$$($1_STRIP_SYMBOLS_$$(name)),false), \
         BUILD_INFO_LOG_MACRO := LogInfo, \
     )) \

--- a/make/test/JtregNativeHotspot.gmk
+++ b/make/test/JtregNativeHotspot.gmk
@@ -863,7 +863,6 @@ ifeq ($(call isTargetOs, windows), true)
   BUILD_HOTSPOT_JTREG_EXCLUDE += exesigtest.c libterminatedThread.c libTestJNI.c libCompleteExit.c libTestPsig.c exeGetCreatedJavaVMs.c
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libatExit := jvm.lib
   BUILD_HOTSPOT_JTREG_LIBRARIES_LIBS_libnativeStack := jvm.lib
-  BUILD_HOTSPOT_JTREG_LIBRARIES_COPY_DEBUG_SYMBOLS_libnativeStack := true
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exedaemonDestroy := jvm.lib
 else
   BUILD_HOTSPOT_JTREG_EXECUTABLES_LIBS_exedaemonDestroy := -ljvm


### PR DESCRIPTION
Tests on Linux (and I assume other unix like OSes) are built with debug enabled and debug symbols internal. On Windows and macos, internal debug symbols aren't possible, and we have for some reason hard coded not including the external debug symbols in the test-image. In this patch I'm changing this so that we include debug symbols in the easiest possible way on all three platforms.

This patch also invalidates [JDK-8311545](https://bugs.openjdk.org/browse/JDK-8311545) since we now include debug symbols for all test libs and executables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8253620](https://bugs.openjdk.org/browse/JDK-8253620): Debug symbols for tests missing on macos and windows (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15574/head:pull/15574` \
`$ git checkout pull/15574`

Update a local copy of the PR: \
`$ git checkout pull/15574` \
`$ git pull https://git.openjdk.org/jdk.git pull/15574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15574`

View PR using the GUI difftool: \
`$ git pr show -t 15574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15574.diff">https://git.openjdk.org/jdk/pull/15574.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15574#issuecomment-1707422043)