### PR TITLE
8315637: JDK-8314249 broke libgraal

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -336,48 +336,55 @@ final class CompilerToVM {
 
     /**
      * Gets the name of the {@code JVM_CONSTANT_NameAndType} entry in {@code constantPool}
-     * referenced by the {@code rawIndex}. The meaning of {@code rawIndex} is dependent
-     * on the given {@opcode}.
+     * referenced by the {@code which}.
      *
      * The behavior of this method is undefined if the class holding the {@code constantPool}
-     * has not yet been rewritten, or {@code rawIndex} is not a valid index for
+     * has not yet been rewritten, or {@code which} is not a valid index for
      * this class for the given {@code opcode}
+     *
+     * @param which  for INVOKE{VIRTUAL,SPECIAL,STATIC,INTERFACE}, must be {@code cpci}. For all other bytecodes,
+     *               must be {@code rawIndex}
      */
-    String lookupNameInPool(HotSpotConstantPool constantPool, int rawIndex, int opcode) {
-        return lookupNameInPool(constantPool, constantPool.getConstantPoolPointer(), rawIndex, opcode);
+    String lookupNameInPool(HotSpotConstantPool constantPool, int which, int opcode) {
+        return lookupNameInPool(constantPool, constantPool.getConstantPoolPointer(), which, opcode);
     }
 
-    private native String lookupNameInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int rawIndex, int opcode);
+    private native String lookupNameInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int which, int opcode);
 
     /**
      * Gets the signature of the {@code JVM_CONSTANT_NameAndType} entry in {@code constantPool}
-     * referenced by the {@code rawIndex}. The meaning of {@code rawIndex} is dependent
-     * on the given {@opcode}.
+     * referenced by the {@code which}.
      *
      * The behavior of this method is undefined if the class holding the {@code constantPool}
-     * has not yet been rewritten, or {@code rawIndex} is not a valid index for
+     * has not yet been rewritten, or {@code which} is not a valid index for
      * this class for the given {@code opcode}
+     *
+     * @param which  for INVOKE{VIRTUAL,SPECIAL,STATIC,INTERFACE}, must be {@code cpci}. For all other bytecodes,
+     *               must be {@code rawIndex}
      */
-    String lookupSignatureInPool(HotSpotConstantPool constantPool, int rawIndex, int opcode) {
-        return lookupSignatureInPool(constantPool, constantPool.getConstantPoolPointer(), rawIndex, opcode);
+    String lookupSignatureInPool(HotSpotConstantPool constantPool, int which, int opcode) {
+        return lookupSignatureInPool(constantPool, constantPool.getConstantPoolPointer(), which, opcode);
     }
 
-    private native String lookupSignatureInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int rawIndex, int opcode);
+    private native String lookupSignatureInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int which, int opcode);
 
     /**
      * Gets the {@code JVM_CONSTANT_Class} index from the entry in {@code constantPool}
-     * referenced by the {@code rawIndex}. The meaning of {@code rawIndex} is dependent
+     * referenced by the {@code which}. The meaning of {@code which} is dependent
      * on the given {@opcode}.
      *
      * The behavior of this method is undefined if the class holding the {@code constantPool}
-     * has not yet been rewritten, or {@code rawIndex} is not a valid index for
+     * has not yet been rewritten, or {@code which} is not a valid index for
      * this class for the given {@code opcode}
+     *
+     * @param which  for INVOKE{VIRTUAL,SPECIAL,STATIC,INTERFACE}, must be {@code cpci}. For all other bytecodes,
+     *               must be {@code rawIndex}
      */
-    int lookupKlassRefIndexInPool(HotSpotConstantPool constantPool, int rawIndex, int opcode) {
-        return lookupKlassRefIndexInPool(constantPool, constantPool.getConstantPoolPointer(), rawIndex, opcode);
+    int lookupKlassRefIndexInPool(HotSpotConstantPool constantPool, int which, int opcode) {
+        return lookupKlassRefIndexInPool(constantPool, constantPool.getConstantPoolPointer(), which, opcode);
     }
 
-    private native int lookupKlassRefIndexInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int rawIndex, int opcode);
+    private native int lookupKlassRefIndexInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int which, int opcode);
 
     /**
      * Looks up a class denoted by the {@code JVM_CONSTANT_Class} entry at index {@code cpi} in

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/ConstantPoolTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/ConstantPoolTest.java
@@ -160,6 +160,11 @@ public class ConstantPoolTest {
         return a + b;
     }
 
+    // We never call this method, so its indy is never resolved.
+    static String concatString3_never_call(String a, String b) {
+        return a + b;
+    }
+
     static void invokeHandle(MethodHandle mh) throws Throwable  {
         mh.invokeExact(0);
     }
@@ -184,7 +189,7 @@ public class ConstantPoolTest {
         lookupAppendixTest_virtual();
     }
 
-    public void lookupAppendixTest_dynamic(String methodName) throws Exception {
+    private void lookupAppendixTest_dynamic(String methodName) throws Exception {
         MetaAccessProvider metaAccess = JVMCI.getRuntime().getHostJVMCIBackend().getMetaAccess();
         ResolvedJavaType type = metaAccess.lookupJavaType(ConstantPoolTest.class);
         Signature methodSig = metaAccess.parseMethodDescriptor("(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
@@ -209,7 +214,7 @@ public class ConstantPoolTest {
         Assert.assertTrue(constant.toString().startsWith("Object["), "wrong appendix: " + constant);
     }
 
-    public void lookupAppendixTest_virtual() throws Exception {
+    private void lookupAppendixTest_virtual() throws Exception {
         MetaAccessProvider metaAccess = JVMCI.getRuntime().getHostJVMCIBackend().getMetaAccess();
         ResolvedJavaType type = metaAccess.lookupJavaType(ConstantPoolTest.class);
         Signature methodSig = metaAccess.parseMethodDescriptor("(Ljava/lang/invoke/MethodHandle;)V");
@@ -232,5 +237,92 @@ public class ConstantPoolTest {
         JavaConstant constant = m.getConstantPool().lookupAppendix(rawIndex, INVOKEVIRTUAL);
         //System.out.println("constant = " + constant);
         Assert.assertTrue(constant.toString().startsWith("Object["), "wrong appendix: " + constant);
+    }
+
+    static void invokeVirtual(Object o) {
+        o.hashCode();
+    }
+
+    @Test
+    public void lookupMethodTest_dynamic() throws Exception {
+        concatString1("aaa", "bbb"); // force the indy to be resolved
+        
+        MetaAccessProvider metaAccess = JVMCI.getRuntime().getHostJVMCIBackend().getMetaAccess();
+        ResolvedJavaType type = metaAccess.lookupJavaType(ConstantPoolTest.class);
+        Signature methodSig = metaAccess.parseMethodDescriptor("(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+        ResolvedJavaMethod m = type.findMethod("concatString1", methodSig);
+        Assert.assertNotNull(m);
+
+        // Expected:
+        // aload_0;
+        // aload_1;
+        // invokedynamic ...StringConcatFactory.makeConcatWithConstants...
+        byte[] bytecode = m.getCode();
+        Assert.assertNotNull(bytecode);
+        Assert.assertEquals(8, bytecode.length);
+        Assert.assertEquals(ALOAD_0, beU1(bytecode, 0));
+        Assert.assertEquals(ALOAD_1, beU1(bytecode, 1));
+        Assert.assertEquals(INVOKEDYNAMIC, beU1(bytecode, 2));
+
+        // Note: internally HotSpot stores the indy index as a native int32, but m.getCode() byte-swaps all such
+        // indices so they appear to be big-endian.
+        int rawIndex = beS4(bytecode, 3);
+        System.out.println("rawIndex = " + rawIndex);
+        JavaMethod callee = m.getConstantPool().lookupMethod(rawIndex, INVOKEDYNAMIC, /*caller=*/m);
+        System.out.println("callee = " + callee);
+        Assert.assertTrue(callee.toString().equals("HotSpotMethod<Invokers$Holder.linkToTargetMethod(Object, Object, Object)>"),
+                          "wrong method: " + callee);
+    }
+
+    @Test
+    public void lookupMethodTest_dynamic_unresolved() throws Exception {
+        MetaAccessProvider metaAccess = JVMCI.getRuntime().getHostJVMCIBackend().getMetaAccess();
+        ResolvedJavaType type = metaAccess.lookupJavaType(ConstantPoolTest.class);
+        Signature methodSig = metaAccess.parseMethodDescriptor("(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+        ResolvedJavaMethod m = type.findMethod("concatString3_never_call", methodSig);
+        Assert.assertNotNull(m);
+
+        // Expected:
+        // aload_0;
+        // aload_1;
+        // invokedynamic ...StringConcatFactory.makeConcatWithConstants...
+        byte[] bytecode = m.getCode();
+        Assert.assertNotNull(bytecode);
+        Assert.assertEquals(8, bytecode.length);
+        Assert.assertEquals(ALOAD_0, beU1(bytecode, 0));
+        Assert.assertEquals(ALOAD_1, beU1(bytecode, 1));
+        Assert.assertEquals(INVOKEDYNAMIC, beU1(bytecode, 2));
+
+        // Note: internally HotSpot stores the indy index as a native int32, but m.getCode() byte-swaps all such
+        // indices so they appear to be big-endian.
+        int rawIndex = beS4(bytecode, 3);
+        System.out.println("rawIndex = " + rawIndex);
+        JavaMethod callee = m.getConstantPool().lookupMethod(rawIndex, INVOKEDYNAMIC, /*caller=*/m);
+        System.out.println("callee = " + callee);
+        Assert.assertTrue(callee.toString().startsWith("jdk.vm.ci.meta.UnresolvedJavaMethod"),
+                          "wrong method: " + callee);
+    }
+ 
+    @Test
+    public void lookupMethodTest_virtual() throws Exception {
+        MetaAccessProvider metaAccess = JVMCI.getRuntime().getHostJVMCIBackend().getMetaAccess();
+        ResolvedJavaType type = metaAccess.lookupJavaType(ConstantPoolTest.class);
+        Signature methodSig = metaAccess.parseMethodDescriptor("(Ljava/lang/Object;)V");
+        ResolvedJavaMethod m = type.findMethod("invokeVirtual", methodSig);
+        Assert.assertNotNull(m);
+
+        // Expected
+        // 0: aload_0
+        // 1: invokevirtual #rawIndex // Method Method java/lang/Object.hashCode:()I
+        byte[] bytecode = m.getCode();
+        Assert.assertNotNull(bytecode);
+        Assert.assertEquals(ALOAD_0, beU1(bytecode, 0));
+        Assert.assertEquals(INVOKEVIRTUAL, beU1(bytecode, 1));
+        int rawIndex = beU2(bytecode, 2);
+        System.out.println("rawIndex = " + rawIndex);
+        JavaMethod callee = m.getConstantPool().lookupMethod(rawIndex, INVOKEVIRTUAL, /*caller=*/m);
+        System.out.println("callee = " + callee);
+        Assert.assertTrue(callee.toString().equals("HotSpotMethod<Object.hashCode()>"),
+                          "wrong method: " + callee);
     }
 }


### PR DESCRIPTION
Please review this change in JVMCI. The actual functional change is essentially the same as the patch provided by @dougxc in [JDK-8315637](https://bugs.openjdk.org/browse/JDK-8315637) -- convert the `rawIndex` to `cpci` only if the bytecode is INVOKE{VIRTUAL,SPECIAL,STATIC,INTERFACE}.

The rest of the changes is to rename the parameters from `rawIndex` to `which`, so we know the correct type of index is passed. I also added a test case.

(This code should be much simpler after [JDK-8301993](https://bugs.openjdk.org/browse/JDK-8301993) is complete: we won't have `cpci` anymore and all `which` can be replaced with `rawInex`).