### PR TITLE
8315735: VerifyError when switch statement used with synchronized block

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1278,7 +1278,7 @@ public class Gen extends JCTree.Visitor {
     }
     //where:
         private boolean hasTry(JCSwitchExpression tree) {
-            var scan = new TreeScanner() {
+            class HasTryScanner extends TreeScanner {
                 private boolean hasTry;
 
                 @Override
@@ -1299,8 +1299,11 @@ public class Gen extends JCTree.Visitor {
                 public void visitLambda(JCLambda tree) {
                 }
             };
-            scan.scan(tree);
-            return scan.hasTry;
+
+            HasTryScanner hasTryScanner = new HasTryScanner();
+
+            hasTryScanner.scan(tree);
+            return hasTryScanner.hasTry;
         }
 
     private void handleSwitch(JCTree swtch, JCExpression selector, List<JCCase> cases,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1278,16 +1278,17 @@ public class Gen extends JCTree.Visitor {
     }
     //where:
         private boolean hasTry(JCSwitchExpression tree) {
-            boolean[] hasTry = new boolean[1];
-            new TreeScanner() {
+            var scan = new TreeScanner() {
+                private boolean hasTry;
+
                 @Override
                 public void visitTry(JCTry tree) {
-                    hasTry[0] = true;
+                    hasTry = true;
                 }
 
                 @Override
                 public void visitSynchronized(JCSynchronized tree) {
-                    hasTry[0] = true;
+                    hasTry = true;
                 }
 
                 @Override
@@ -1297,8 +1298,9 @@ public class Gen extends JCTree.Visitor {
                 @Override
                 public void visitLambda(JCLambda tree) {
                 }
-            }.scan(tree);
-            return hasTry[0];
+            };
+            scan.scan(tree);
+            return scan.hasTry;
         }
 
     private void handleSwitch(JCTree swtch, JCExpression selector, List<JCCase> cases,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1286,6 +1286,11 @@ public class Gen extends JCTree.Visitor {
                 }
 
                 @Override
+                public void visitSynchronized(JCSynchronized tree) {
+                    hasTry[0] = true;
+                }
+
+                @Override
                 public void visitClassDef(JCClassDecl tree) {
                 }
 

--- a/test/langtools/tools/javac/switchexpr/ExpressionSwitchSynchronized.java
+++ b/test/langtools/tools/javac/switchexpr/ExpressionSwitchSynchronized.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8315735
+ * @summary Verify valid classfile is produced when synchronized block is used
+ *          inside a switch expression.
+ * @compile ExpressionSwitchSynchronized.java
+ * @run main ExpressionSwitchSynchronized
+ */
+public class ExpressionSwitchSynchronized {
+
+    public static void main(String... args) {
+        int i1 = 2 + switch (args.length) {
+            default -> {
+                synchronized (args) {
+                    yield 1;
+                }
+            }
+        };
+        if (i1 != 3) {
+            throw new AssertionError("Incorrect value, got: " + i1 +
+                                     ", expected: " + 3);
+        }
+        int i2 = 2 + switch (args) {
+            case String[] a -> {
+                synchronized (args) {
+                    yield a.length + 1;
+                }
+            }
+        };
+        if (i2 != 3) {
+            throw new AssertionError("Incorrect value, got: " + i2 +
+                                     ", expected: " + 3);
+        }
+    }
+
+}


### PR DESCRIPTION
Having code like:
```
    public static void main(String... args) {
        int i1 = 0 + switch (args.length) {
            default -> {
                synchronized (args) {
                    yield 1;
                }
            }
        };
    }
```

fails with a verification error at runtime. In the classfile, the synchronized block is basically a try-finally (which has an implicit "catch (any)" block), and so it needs the same handling as ordinary try statements.

(When there's a try statement inside a switch expression, the pre-existing stack is stored in local variables, and restored at return from the case. This is because catch clauses start with an empty stack.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315735](https://bugs.openjdk.org/browse/JDK-8315735): VerifyError when switch statement used with synchronized block (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to [26e29fe0](https://git.openjdk.org/jdk/pull/15584/files/26e29fe0c06732b4d1cffc118d820bec6a3b93b2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15584/head:pull/15584` \
`$ git checkout pull/15584`

Update a local copy of the PR: \
`$ git checkout pull/15584` \
`$ git pull https://git.openjdk.org/jdk.git pull/15584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15584`

View PR using the GUI difftool: \
`$ git pr show -t 15584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15584.diff">https://git.openjdk.org/jdk/pull/15584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15584#issuecomment-1707913221)