### PR TITLE
8315338: RISC-V: Change flags for stable extensions to non-experimental

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -101,10 +101,10 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseRVA20U64, true, "Use RVA20U64 profile")                       \
   product(bool, UseRVC, false, "Use RVC instructions")                           \
   product(bool, UseRVA22U64, false, EXPERIMENTAL, "Use RVA22U64 profile")        \
-  product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")             \
-  product(bool, UseZba, false, EXPERIMENTAL, "Use Zba instructions")             \
-  product(bool, UseZbb, false, EXPERIMENTAL, "Use Zbb instructions")             \
-  product(bool, UseZbs, false, EXPERIMENTAL, "Use Zbs instructions")             \
+  product(bool, UseRVV, false, "Use RVV instructions")                           \
+  product(bool, UseZba, false, "Use Zba instructions")                           \
+  product(bool, UseZbb, false, "Use Zbb instructions")                           \
+  product(bool, UseZbs, false, "Use Zbs instructions")                           \
   product(bool, UseZic64b, false, EXPERIMENTAL, "Use Zic64b instructions")       \
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \


### PR DESCRIPTION
Hi all, please consider.

These flags can be automatically turned on if you are using a 6.5 kernel with the proper hardware.
So they are not considered experimental.

Running tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315338](https://bugs.openjdk.org/browse/JDK-8315338): RISC-V: Change flags for stable extensions to non-experimental (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15585/head:pull/15585` \
`$ git checkout pull/15585`

Update a local copy of the PR: \
`$ git checkout pull/15585` \
`$ git pull https://git.openjdk.org/jdk.git pull/15585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15585`

View PR using the GUI difftool: \
`$ git pr show -t 15585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15585.diff">https://git.openjdk.org/jdk/pull/15585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15585#issuecomment-1707955075)