### PR TITLE
8315651: Stop hiding AIX specific multicast socket errors via NetworkConfiguration (aix)

### DIFF
--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -183,9 +183,10 @@ public class NetworkConfiguration {
             // could be in both, IPv4 or IPv6 space). But both possible setsockopt
             // calls for either IPV6_MULTICAST_IF or IP_MULTICAST_IF return
             // EADDRNOTAVAIL. So we must skip such interfaces here.
-            if (Platform.isAix() && isIPv6Available() && !hasIp6Addresses(nif)) {
-                return false;
-            }
+            // to be fixed with JDK-8308807 -> comment this aviation
+            //if (Platform.isAix() && isIPv6Available() && !hasIp6Addresses(nif)) {
+            //    return false;
+            //}
 
             if (Platform.isOSX()) {
                 // multicasting may not work on interfaces that only

--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -176,18 +176,6 @@ public class NetworkConfiguration {
                 return false;
             }
 
-            // On AIX there is a bug:
-            // When IPv6 is enabled on the system, the JDK opens sockets as AF_INET6.
-            // If there's an interface configured with IPv4 addresses only, it should
-            // be able to become the network interface for a multicast socket (that
-            // could be in both, IPv4 or IPv6 space). But both possible setsockopt
-            // calls for either IPV6_MULTICAST_IF or IP_MULTICAST_IF return
-            // EADDRNOTAVAIL. So we must skip such interfaces here.
-            // to be fixed with JDK-8308807 -> comment this aviation
-            //if (Platform.isAix() && isIPv6Available() && !hasIp6Addresses(nif)) {
-            //    return false;
-            //}
-
             if (Platform.isOSX()) {
                 // multicasting may not work on interfaces that only
                 // have link local addresses


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315651](https://bugs.openjdk.org/browse/JDK-8315651): Stop hiding AIX specific multicast socket errors via NetworkConfiguration (aix) (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15586/head:pull/15586` \
`$ git checkout pull/15586`

Update a local copy of the PR: \
`$ git checkout pull/15586` \
`$ git pull https://git.openjdk.org/jdk.git pull/15586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15586`

View PR using the GUI difftool: \
`$ git pr show -t 15586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15586.diff">https://git.openjdk.org/jdk/pull/15586.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15586#issuecomment-1708026161)