### PR TITLE
8315765: G1: Incorrect use of G1LastPLABAverageOccupancy

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -339,7 +339,7 @@ G1PLABAllocator::G1PLABAllocator(G1Allocator* allocator) :
   if (ResizePLAB) {
     // See G1EvacStats::compute_desired_plab_sz for the reasoning why this is the
     // expected number of refills.
-    double const ExpectedNumberOfRefills = G1LastPLABAverageOccupancy / TargetPLABWastePct;
+    double const ExpectedNumberOfRefills = (100 - G1LastPLABAverageOccupancy) / TargetPLABWastePct;
     // Add some padding to the threshold to not boost exactly when the targeted refills
     // were reached.
     // E.g. due to limitation of PLAB size to non-humongous objects and region boundaries

--- a/src/hotspot/share/gc/g1/g1EvacStats.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacStats.cpp
@@ -85,7 +85,7 @@ size_t G1EvacStats::compute_desired_plab_size() const {
   // also assume that that buffer is typically half-full (G1LastPLABAverageOccupancy),
   // the new desired PLAB size is set to 20 words.
   //
-  // (This also implies that we expect G1LastPLABAverageOccupancy/TargetPLABWastePct
+  // (This also implies that we expect (100-G1LastPLABAverageOccupancy)/TargetPLABWastePct
   // number of refills during allocation).
   //
   // The amount of allocation performed should be independent of the number of
@@ -113,7 +113,7 @@ size_t G1EvacStats::compute_desired_plab_size() const {
   size_t const used_for_waste_calculation = used() > _region_end_waste ? used() - _region_end_waste : 0;
 
   size_t const total_waste_allowed = used_for_waste_calculation * TargetPLABWastePct;
-  return (size_t)((double)total_waste_allowed / G1LastPLABAverageOccupancy);
+  return (size_t)((double)total_waste_allowed / (100 - G1LastPLABAverageOccupancy));
 }
 
 G1EvacStats::G1EvacStats(const char* description, size_t default_per_thread_plab_size, unsigned wt) :


### PR DESCRIPTION
Simple fix in calculating the number of plab refills. The default value is 50, so no real effect.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315765](https://bugs.openjdk.org/browse/JDK-8315765): G1: Incorrect use of G1LastPLABAverageOccupancy (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15587/head:pull/15587` \
`$ git checkout pull/15587`

Update a local copy of the PR: \
`$ git checkout pull/15587` \
`$ git pull https://git.openjdk.org/jdk.git pull/15587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15587`

View PR using the GUI difftool: \
`$ git pr show -t 15587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15587.diff">https://git.openjdk.org/jdk/pull/15587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15587#issuecomment-1708077052)