### PR TITLE
8315781: Reduce the max value of GCDrainStackTargetSize

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -230,11 +230,6 @@ void G1Arguments::initialize() {
     FLAG_SET_DEFAULT(ParallelRefProcEnabled, true);
   }
 
-  // By default do not let the target stack size to be more than 1/4 of the entries
-  if (FLAG_IS_DEFAULT(GCDrainStackTargetSize)) {
-    FLAG_SET_ERGO(GCDrainStackTargetSize, MIN2(GCDrainStackTargetSize, TASKQUEUE_SIZE / 4));
-  }
-
 #ifdef COMPILER2
   // Enable loop strip mining to offer better pause time guarantees
   if (FLAG_IS_DEFAULT(UseCountedLoopSafepoints)) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2319,7 +2319,7 @@ void G1CMTask::drain_local_queue(bool partially) {
   // of things to do) or totally (at the very end).
   uint target_size;
   if (partially) {
-    target_size = MIN2(_task_queue->max_elems() / 3, GCDrainStackTargetSize);
+    target_size = GCDrainStackTargetSize;
   } else {
     target_size = 0;
   }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -183,8 +183,7 @@ PSPromotionManager::PSPromotionManager() {
   if (ParallelGCThreads == 1) {
     _target_stack_size = 0;
   } else {
-    // don't let the target stack size to be more than 1/4 of the entries
-    _target_stack_size = MIN2(GCDrainStackTargetSize, (queue_size / 4));
+    _target_stack_size = GCDrainStackTargetSize;
   }
 
   _array_chunk_size = ParGCArrayScanChunk;

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -687,7 +687,7 @@
   product(uint, GCDrainStackTargetSize, 64,                                 \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, (UINT_MAX - 1) / 2)                                      \
+          range(0, 8*1024)                                                  \
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -687,7 +687,7 @@
   product(uint, GCDrainStackTargetSize, 64,                                 \
           "Number of entries we will try to leave on the stack "            \
           "during parallel gc")                                             \
-          range(0, 8*1024)                                                  \
+          range(0, 8 * 1024)                                                \
                                                                             \
   product(uint, GCCardSizeInBytes, 512,                                     \
           "Card table entry size (in bytes) for card based collectors")     \


### PR DESCRIPTION
Simple adjustment to the max value of `GCDrainStackTargetSize`.

I picked 8K because the default queue capacity is ~16K and G1 use 2x of `GCDrainStackTargetSize` as some threshold.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315781](https://bugs.openjdk.org/browse/JDK-8315781): Reduce the max value of GCDrainStackTargetSize (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [6104cf26](https://git.openjdk.org/jdk/pull/15590/files/6104cf2688b67d6e874b5f324d4fc87f0f1425c0)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15590/head:pull/15590` \
`$ git checkout pull/15590`

Update a local copy of the PR: \
`$ git checkout pull/15590` \
`$ git pull https://git.openjdk.org/jdk.git pull/15590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15590`

View PR using the GUI difftool: \
`$ git pr show -t 15590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15590.diff">https://git.openjdk.org/jdk/pull/15590.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15590#issuecomment-1708250229)