### PR TITLE
8315789: Minor HexFormat performance improvements

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/HexFormatBench.java
+++ b/test/micro/org/openjdk/bench/java/util/HexFormatBench.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.HexFormat;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests java.net.URLEncoder.encode and Decoder.decode.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
+public class HexFormatBench {
+
+    @Param({"512"})
+    public int size;
+
+    public byte[] bytes;
+
+    public StringBuilder builder = new StringBuilder(size * 2);
+
+    HexFormat LOWER_FORMATTER = HexFormat.of();
+    HexFormat UPPER_FORMATTER = HexFormat.of().withUpperCase();
+
+    @Setup
+    public void setupStrings() {
+        Random random = new Random(3);
+        bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte)random.nextInt(16);
+        }
+    }
+
+    @Benchmark
+    public StringBuilder appenderLower() {
+        builder.setLength(0);
+        return HexFormat.of().formatHex(builder, bytes);
+    }
+
+    @Benchmark
+    public StringBuilder appenderUpper() {
+        builder.setLength(0);
+        return HexFormat.of().withUpperCase().formatHex(builder, bytes);
+    }
+
+    @Benchmark
+    public StringBuilder appenderLowerCached() {
+        builder.setLength(0);
+        return LOWER_FORMATTER.formatHex(builder, bytes);
+    }
+
+    @Benchmark
+    public StringBuilder appenderUpperCached() {
+        builder.setLength(0);
+        return UPPER_FORMATTER.formatHex(builder, bytes);
+    }
+
+
+    @Benchmark
+    public void toHexLower(Blackhole bh) {
+        for (byte b : bytes) {
+            bh.consume(HexFormat.of().toHighHexDigit(b));
+            bh.consume(HexFormat.of().toLowHexDigit(b));
+        }
+    }
+
+    @Benchmark
+    public void toHexUpper(Blackhole bh) {
+        for (byte b : bytes) {
+            bh.consume(HexFormat.of().withUpperCase().toHighHexDigit(b));
+            bh.consume(HexFormat.of().withUpperCase().toLowHexDigit(b));
+        }
+    }
+
+    @Benchmark
+    public void toHexLowerCached(Blackhole bh) {
+        for (byte b : bytes) {
+            bh.consume(LOWER_FORMATTER.toHighHexDigit(b));
+            bh.consume(LOWER_FORMATTER.toLowHexDigit(b));
+        }
+    }
+
+    @Benchmark
+    public void toHexUpperCached(Blackhole bh) {
+        for (byte b : bytes) {
+            bh.consume(UPPER_FORMATTER.toHighHexDigit(b));
+            bh.consume(UPPER_FORMATTER.toLowHexDigit(b));
+        }
+    }
+
+
+}

--- a/test/micro/org/openjdk/bench/java/util/HexFormatBench.java
+++ b/test/micro/org/openjdk/bench/java/util/HexFormatBench.java
@@ -126,5 +126,31 @@ public class HexFormatBench {
         }
     }
 
+    @Benchmark
+    public void toHexDigitsByte(Blackhole bh) {
+        for (byte b : bytes) {
+            bh.consume(LOWER_FORMATTER.toHexDigits(b));
+        }
+    }
 
+    @Benchmark
+    public void toHexDigitsShort(Blackhole bh) {
+        for (short b : bytes) {
+            bh.consume(LOWER_FORMATTER.toHexDigits(b));
+        }
+    }
+
+    @Benchmark
+    public void toHexDigitsInt(Blackhole bh) {
+        for (int b : bytes) {
+            bh.consume(LOWER_FORMATTER.toHexDigits(b));
+        }
+    }
+
+    @Benchmark
+    public void toHexDigitsLong(Blackhole bh) {
+        for (long b : bytes) {
+            bh.consume(LOWER_FORMATTER.toHexDigits(b));
+        }
+    }
 }


### PR DESCRIPTION
This PR seeks to improve formatting of hex digits using `java.util.HexFormat` somewhat.

This is achieved getting rid of a couple of lookup tables, caching the result of `HexFormat.of().withUpperCase()`, and removing tiny allocation that happens in the `formatHex(A, byte)` method. Improvements range from 20-40% on throughput, and some operations allocate less:

```
Name                               Cnt   Base   Error   Test   Error   Unit   Diff%
HexFormatBench.appenderLower        15  1,330 ± 0,021  1,065 ± 0,067  us/op   19,9% (p = 0,000*)
  :gc.alloc.rate                    15 11,481 ± 0,185  0,007 ± 0,000 MB/sec  -99,9% (p = 0,000*)
  :gc.alloc.rate.norm               15 16,009 ± 0,000  0,007 ± 0,000   B/op -100,0% (p = 0,000*)
  :gc.count                         15  3,000          0,000         counts
  :gc.time                           3  2,000                            ms
HexFormatBench.appenderLowerCached  15  1,317 ± 0,013  1,065 ± 0,054  us/op   19,1% (p = 0,000*)
  :gc.alloc.rate                    15 11,590 ± 0,111  0,007 ± 0,000 MB/sec  -99,9% (p = 0,000*)
  :gc.alloc.rate.norm               15 16,009 ± 0,000  0,007 ± 0,000   B/op -100,0% (p = 0,000*)
  :gc.count                         15  3,000          0,000         counts
  :gc.time                           3  2,000                            ms
HexFormatBench.appenderUpper        15  1,330 ± 0,022  1,065 ± 0,036  us/op   19,9% (p = 0,000*)
  :gc.alloc.rate                    15 34,416 ± 0,559  0,007 ± 0,000 MB/sec -100,0% (p = 0,000*)
  :gc.alloc.rate.norm               15 48,009 ± 0,000  0,007 ± 0,000   B/op -100,0% (p = 0,000*)
  :gc.count                         15  0,000          0,000         counts
HexFormatBench.appenderUpperCached  15  1,353 ± 0,009  1,033 ± 0,014  us/op   23,6% (p = 0,000*)
  :gc.alloc.rate                    15 11,284 ± 0,074  0,007 ± 0,000 MB/sec  -99,9% (p = 0,000*)
  :gc.alloc.rate.norm               15 16,009 ± 0,000  0,007 ± 0,000   B/op -100,0% (p = 0,000*)
  :gc.count                         15  3,000          0,000         counts
  :gc.time                           3  2,000                            ms
HexFormatBench.toHexLower           15  0,198 ± 0,001  0,119 ± 0,008  us/op   40,1% (p = 0,000*)
  :gc.alloc.rate                    15  0,007 ± 0,000  0,007 ± 0,000 MB/sec   -0,0% (p = 0,816 )
  :gc.alloc.rate.norm               15  0,001 ± 0,000  0,001 ± 0,000   B/op  -40,1% (p = 0,000*)
  :gc.count                         15  0,000          0,000         counts
HexFormatBench.toHexLowerCached     15  0,201 ± 0,002  0,114 ± 0,001  us/op   43,0% (p = 0,000*)
  :gc.alloc.rate                    15  0,007 ± 0,000  0,007 ± 0,000 MB/sec   -0,2% (p = 0,116 )
  :gc.alloc.rate.norm               15  0,001 ± 0,000  0,001 ± 0,000   B/op  -43,1% (p = 0,000*)
  :gc.count                         15  0,000          0,000         counts
HexFormatBench.toHexUpper           15  0,146 ± 0,002  0,114 ± 0,001  us/op   21,6% (p = 0,000*)
  :gc.alloc.rate                    15  0,007 ± 0,000  0,007 ± 0,000 MB/sec    0,0% (p = 0,668 )
  :gc.alloc.rate.norm               15  0,001 ± 0,000  0,001 ± 0,000   B/op  -21,5% (p = 0,000*)
  :gc.count                         15  0,000          0,000         counts
HexFormatBench.toHexUpperCached     15  0,199 ± 0,002  0,116 ± 0,003  us/op   41,7% (p = 0,000*)
  :gc.alloc.rate                    15  0,007 ± 0,000  0,007 ± 0,000 MB/sec    0,0% (p = 0,684 )
  :gc.alloc.rate.norm               15  0,001 ± 0,000  0,001 ± 0,000   B/op  -41,7% (p = 0,000*)
  :gc.count                         15  0,000          0,000         counts
  * = significant

Invariant parameters used by above microbenchmarks:
size:   512
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315789](https://bugs.openjdk.org/browse/JDK-8315789): Minor HexFormat performance improvements (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15591/head:pull/15591` \
`$ git checkout pull/15591`

Update a local copy of the PR: \
`$ git checkout pull/15591` \
`$ git pull https://git.openjdk.org/jdk.git pull/15591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15591`

View PR using the GUI difftool: \
`$ git pr show -t 15591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15591.diff">https://git.openjdk.org/jdk/pull/15591.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15591#issuecomment-1708398245)