### PR TITLE
8315786: [AIX] Build Disk Local Detection Issue with GNU-utils df on AIX

### DIFF
--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -479,7 +479,7 @@ AC_DEFUN([BASIC_CHECK_DIR_ON_LOCAL_DISK],
     # df on AIX does not understand -l. On modern AIXes it understands "-T local" which
     # is the same. On older AIXes we just continue to live with a "not local build" warning.
     if test "x$OPENJDK_TARGET_OS" = xaix; then
-      if "$DF -T local > /dev/null 2>&1"; then
+      if ""$DF" -T local > /dev/null 2>&1"; then
         DF_LOCAL_ONLY_OPTION='-T local'
       else # AIX may use GNU-utils instead
         DF_LOCAL_ONLY_OPTION='-l'

--- a/make/autoconf/basic.m4
+++ b/make/autoconf/basic.m4
@@ -479,7 +479,7 @@ AC_DEFUN([BASIC_CHECK_DIR_ON_LOCAL_DISK],
     # df on AIX does not understand -l. On modern AIXes it understands "-T local" which
     # is the same. On older AIXes we just continue to live with a "not local build" warning.
     if test "x$OPENJDK_TARGET_OS" = xaix; then
-      if ""$DF" -T local > /dev/null 2>&1"; then
+      if $DF -T local > /dev/null 2>&1; then
         DF_LOCAL_ONLY_OPTION='-T local'
       else # AIX may use GNU-utils instead
         DF_LOCAL_ONLY_OPTION='-l'


### PR DESCRIPTION
Previously [JDK-8304364](https://github.com/openjdk/jdk/pull/13066/files) , the AIX build process raised complaints about the disk location detection, incorrectly determining that the build wasn't on a local disk. However, a partial fix introduced a new problem, the build process consistently reports that it's on a local disk, even when it's not
The core problem here seems to be that Bash treats quoted commands as string literals, and it only evaluates them if you use 'eval' directly.
 The  change ensure that Bash correctly evaluates the **DF** variable as a command.

Reported Issue : [JDK-8315786](https://bugs.openjdk.org/browse/JDK-8315786)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315786](https://bugs.openjdk.org/browse/JDK-8315786): [AIX] Build Disk Local Detection Issue with GNU-utils df on AIX (**Bug** - P5)


### Reviewers
 * [Tyler Steele](https://openjdk.org/census#tsteele) (@backwaterred - Committer) ⚠️ Review applies to [510a327d](https://git.openjdk.org/jdk/pull/15592/files/510a327df9c4f1dd9539318d341c71852c918c87)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15592/head:pull/15592` \
`$ git checkout pull/15592`

Update a local copy of the PR: \
`$ git checkout pull/15592` \
`$ git pull https://git.openjdk.org/jdk.git pull/15592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15592`

View PR using the GUI difftool: \
`$ git pr show -t 15592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15592.diff">https://git.openjdk.org/jdk/pull/15592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15592#issuecomment-1710508986)