### PR TITLE
8315794: RISC-V: build fails with GCC 12.3

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -166,8 +166,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_interp_masm_x86.cpp := uninitialized, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
-    DISABLED_WARNINGS_gcc_xPageAllocator.cpp := stringop-overflow, \
-    DISABLED_WARNINGS_gcc_zPageAllocator.cpp := stringop-overflow, \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_clang_arguments.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_codeBuffer.cpp := tautological-undefined-compare, \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -166,6 +166,8 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_interp_masm_x86.cpp := uninitialized, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
+    DISABLED_WARNINGS_gcc_xPageAllocator.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_zPageAllocator.cpp := stringop-overflow, \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_clang_arguments.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_codeBuffer.cpp := tautological-undefined-compare, \

--- a/src/hotspot/share/gc/x/xPageAllocator.cpp
+++ b/src/hotspot/share/gc/x/xPageAllocator.cpp
@@ -785,8 +785,11 @@ size_t XPageAllocator::uncommit(uint64_t* timeout) {
       return 0;
     }
 
+    RISCV_ONLY(PRAGMA_DIAG_PUSH)
+    RISCV_ONLY(PRAGMA_STRINGOP_OVERFLOW_IGNORED)
     // Record flushed pages as claimed
     Atomic::add(&_claimed, flushed);
+    RISCV_ONLY(PRAGMA_DIAG_POP)
   }
 
   // Unmap, uncommit, and destroy flushed pages

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -883,8 +883,11 @@ size_t ZPageAllocator::uncommit(uint64_t* timeout) {
       return 0;
     }
 
+    RISCV_ONLY(PRAGMA_DIAG_PUSH)
+    RISCV_ONLY(PRAGMA_STRINGOP_OVERFLOW_IGNORED)
     // Record flushed pages as claimed
     Atomic::add(&_claimed, flushed);
+    RISCV_ONLY(PRAGMA_DIAG_POP)
   }
 
   // Unmap, uncommit, and destroy flushed pages


### PR DESCRIPTION
The build failure happens when building on RISC-V with GCC 12.3. Is there a better way to address this than disabling the stringop-overflow warnings for the two files in question?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315794](https://bugs.openjdk.org/browse/JDK-8315794): RISC-V: build fails with GCC 12.3 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [93f0d876](https://git.openjdk.org/jdk/pull/15593/files/93f0d876e3287ac9af02779acefc5b64feeaa6e0)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15593/head:pull/15593` \
`$ git checkout pull/15593`

Update a local copy of the PR: \
`$ git checkout pull/15593` \
`$ git pull https://git.openjdk.org/jdk.git pull/15593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15593`

View PR using the GUI difftool: \
`$ git pr show -t 15593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15593.diff">https://git.openjdk.org/jdk/pull/15593.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15593#issuecomment-1708500797)