### PR TITLE
JDK-8315751: RandomTestBsi1999 fails often with timeouts on Linux ppc64le

### DIFF
--- a/test/jdk/java/util/Random/RandomTestBsi1999.java
+++ b/test/jdk/java/util/Random/RandomTestBsi1999.java
@@ -43,9 +43,9 @@ import static java.util.stream.Collectors.toSet;
 
 /**
  * @test
- * @summary test bit sequences produced by clases that implement interface RandomGenerator
+ * @summary test bit sequences produced by classes that implement interface RandomGenerator
  * @bug 8248862
- * @run main RandomTestBsi1999
+ * @run main/othervm/timeout=400 RandomTestBsi1999
  * @key randomness
  */
 


### PR DESCRIPTION
The test RandomTestBsi1999 fails often with timeouts on Linux ppc64le; even when it succeeds the test takes a lot of time and is close to timing out. Probably we should increase the timeout value for this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315751](https://bugs.openjdk.org/browse/JDK-8315751): RandomTestBsi1999 fails often with timeouts on Linux ppc64le (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15594/head:pull/15594` \
`$ git checkout pull/15594`

Update a local copy of the PR: \
`$ git checkout pull/15594` \
`$ git pull https://git.openjdk.org/jdk.git pull/15594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15594`

View PR using the GUI difftool: \
`$ git pr show -t 15594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15594.diff">https://git.openjdk.org/jdk/pull/15594.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15594#issuecomment-1708531650)