### PR TITLE
8315739: Missing null check in os::vm_min_address

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4253,11 +4253,16 @@ size_t os::vm_min_address() {
   static size_t value = 0;
   if (value == 0) {
     assert(is_aligned(_vm_min_address_default, os::vm_allocation_granularity()), "Sanity");
-    FILE* f = fopen("/proc/sys/vm/mmap_min_addr", "r");
-    if (fscanf(f, "%zu", &value) != 1) {
+    FILE* f = os::fopen("/proc/sys/vm/mmap_min_addr", "r");
+    if (f != nullptr) {
+      if (fscanf(f, "%zu", &value) != 1) {
+        value = _vm_min_address_default;
+      }
+      value = MAX2(_vm_min_address_default, value);
+      fclose(f);
+    } else {
       value = _vm_min_address_default;
     }
-    value = MAX2(_vm_min_address_default, value);
   }
   return value;
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4258,11 +4258,9 @@ size_t os::vm_min_address() {
       if (fscanf(f, "%zu", &value) != 1) {
         value = _vm_min_address_default;
       }
-      value = MAX2(_vm_min_address_default, value);
       fclose(f);
-    } else {
-      value = _vm_min_address_default;
     }
+    value = MAX2(_vm_min_address_default, value);
   }
   return value;
 }


### PR DESCRIPTION
Please review this fix for handling of file `/proc/sys/vm/mmap_min_addr` which does not exist on WSL1.

This fixes a crash if the file is absent, and a file handle leak (missing `fclose`) when the file is present.

Linux tier1 tests clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315739](https://bugs.openjdk.org/browse/JDK-8315739): Missing null check in os::vm_min_address (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15596/head:pull/15596` \
`$ git checkout pull/15596`

Update a local copy of the PR: \
`$ git checkout pull/15596` \
`$ git pull https://git.openjdk.org/jdk.git pull/15596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15596`

View PR using the GUI difftool: \
`$ git pr show -t 15596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15596.diff">https://git.openjdk.org/jdk/pull/15596.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15596#issuecomment-1708727690)