### PR TITLE
8315602: Open source swing security manager test

### DIFF
--- a/test/jdk/javax/swing/text/rtf/bug4178276.java
+++ b/test/jdk/javax/swing/text/rtf/bug4178276.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4178276
+ * @key headful
+ * @summary  RTFEditorkit.write(...) doesn't throw NPE when used in SecurityManager
+ * @run main/othervm/secure=allow bug4178276
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import javax.swing.text.Document;
+import javax.swing.text.rtf.RTFEditorKit;
+
+public class bug4178276 {
+
+    public static void main(String[] argv) throws Exception {
+        System.setSecurityManager(new SecurityManager());
+
+        String test="{\\rtf1\\ansi\\deff0\\deftab720{\\fonttbl{\\f0\\f swiss MS Sans Serif;}}{\\colortbl\\red0\\green0\\blue0;}\\qc\\plain\\f0 Test 1 \\par \\ql\\plain\\f0 Test 2 \\par \\qr\\plain\\f0 Test 3 \\par \\qj\\plain\\f0 Test 4}";
+        RTFEditorKit c = new RTFEditorKit();
+        Document doc = c.createDefaultDocument();
+        try {
+            c.read(new ByteArrayInputStream(test.getBytes(
+                                        StandardCharsets.ISO_8859_1)), doc, 0);
+            ByteArrayOutputStream sw = new ByteArrayOutputStream();
+            c.write(sw, doc, 0, 0);
+        } catch (Exception e) {
+            throw new RuntimeException("Unexpected NPE exception...", e);
+        }
+    }
+}


### PR DESCRIPTION
A security manager swing test is open sourced

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315602](https://bugs.openjdk.org/browse/JDK-8315602): Open source swing security manager test (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15597/head:pull/15597` \
`$ git checkout pull/15597`

Update a local copy of the PR: \
`$ git checkout pull/15597` \
`$ git pull https://git.openjdk.org/jdk.git pull/15597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15597`

View PR using the GUI difftool: \
`$ git pr show -t 15597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15597.diff">https://git.openjdk.org/jdk/pull/15597.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15597#issuecomment-1708644202)