### PR TITLE
JDK-8315486: vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java timed out

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -141,14 +141,14 @@ public class forceEarlyReturn002 extends TestDebuggerType1 {
 
     // get thread ID for "startNewThread" command
     private long getNewThreadId() throws Exception {
-		final String debugeeClassSig = "L" + getDebugeeClassName().replace('.', '/') + ";";
+        final String debugeeClassSig = "L" + getDebugeeClassName().replace('.', '/') + ";";
         log.display("  getting classID for " + debugeeClassSig);
         long classID = debuggee.getReferenceTypeID(debugeeClassSig);
         log.display("  got classID: " + classID);
 
         log.display("  getting testNewThread field value");
         JDWP.Value value = debuggee.getStaticFieldValue(classID, "testNewThread", JDWP.Tag.THREAD);
-		
+
         long threadID = ((Long)value.getValue()).longValue();
         log.display("  got threadID: " + threadID);
         return threadID;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -139,13 +139,32 @@ public class forceEarlyReturn002 extends TestDebuggerType1 {
         }
     }
 
+    // get thread ID for "startNewThread" command
+    private long getNewThreadId() throws Exception {
+		final String debugeeClassSig = "L" + getDebugeeClassName().replace('.', '/') + ";";
+        log.display("  getting classID for " + debugeeClassSig);
+        long classID = debuggee.getReferenceTypeID(debugeeClassSig);
+        log.display("  got classID: " + classID);
+
+        log.display("  getting testNewThread field value");
+        JDWP.Value value = debuggee.getStaticFieldValue(classID, "testNewThread", JDWP.Tag.THREAD);
+		
+        long threadID = ((Long)value.getValue()).longValue();
+        log.display("  got threadID: " + threadID);
+        return threadID;
+    }
+
     private int createThreadStartEventRequest() {
         try {
+            long newThreadId = getNewThreadId();
             // create command packet and fill requred out data
             CommandPacket command = new CommandPacket(JDWP.Command.EventRequest.Set);
             command.addByte(JDWP.EventKind.THREAD_START);
             command.addByte(JDWP.SuspendPolicy.ALL);
-            command.addInt(0);
+            // THREAD_ONLY modifier
+            command.addInt(1);
+            command.addByte(JDWP.EventModifierKind.THREAD_ONLY);
+            command.addObjectID(newThreadId);
             command.setLength();
 
             transport.write(command);
@@ -175,7 +194,7 @@ public class forceEarlyReturn002 extends TestDebuggerType1 {
         Value value;
 
         value = new Value(JDWP.Tag.INT, 0);
-        // create command with invalid trheadID, expect INVALID_OBJECT error
+        // create command with invalid threadID, expect INVALID_OBJECT error
         sendCommand(-1, value, true, JDWP.Error.INVALID_OBJECT);
 
         // create StateTestThread

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java
@@ -161,7 +161,9 @@ public class forceEarlyReturn002 extends TestDebuggerType1 {
             CommandPacket command = new CommandPacket(JDWP.Command.EventRequest.Set);
             command.addByte(JDWP.EventKind.THREAD_START);
             command.addByte(JDWP.SuspendPolicy.ALL);
-            // THREAD_ONLY modifier
+            // we want the THREAD_START event only for the test thread
+            // and not any others that might be started by debuggee VM,
+            // so add THREAD_ONLY modifier
             command.addInt(1);
             command.addByte(JDWP.EventModifierKind.THREAD_ONLY);
             command.addObjectID(newThreadId);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002a.java
@@ -57,20 +57,28 @@ public class forceEarlyReturn002a extends AbstractJDWPDebuggee {
 
             return true;
         } else if (command.equals(COMMAND_START_NEW_THREAD)) {
-            Thread thread = new Thread(new Runnable() {
-                public void run() {
-                    log.display("Thread exit");
-                }
-            });
-
-            thread.setName("forceEarlyReturn002a_NewThread");
-            thread.start();
+            testNewThread.start();
 
             return true;
         }
 
         return false;
     }
+
+    @Override
+    protected void init(String args[]) {
+        super.init(args);
+
+        // create thread for "NewThread" command in advance
+        testNewThread = new Thread(new Runnable() {
+            public void run() {
+                log.display("Thread exit");
+            }
+        });
+        testNewThread.setName("forceEarlyReturn002a_NewThread");
+    }
+
+    private static Thread testNewThread;
 
     private Thread testThreadInNative;
 


### PR DESCRIPTION
To test ForceEarlyReturn command for NO_MORE_FRAMES case the test creates ThreadStartEventRequest with SUSPEND_ALL policy and requests debuggee to start new thread.
If debuggee JVM starts some internal threads before the request is cleared (i.e. we have several ThreadStart events), 2nd event suspends debuggee again and the test fails with timeout.
The change adds THREAD_ONLY modifier to the ThreadStartEventRequest to generate event only for desired thread.
It requires thread ID, so debuggee was updated to create Thread object in advance, debugger reads the thread ID from static field (it does not need to be static, but Debugee class has convenient methods to retrieve class ID and static field value).

Testing: 100 runs of the test on windows-x64-debug,linux-x64-debug,macosx-x64-debug with JTREG_TEST_THREAD_FACTORY=Virtual, with and without "-XX:+UseZGC -XX:+ZGenerational"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315486](https://bugs.openjdk.org/browse/JDK-8315486): vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn002/forceEarlyReturn002.java timed out (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [310115de](https://git.openjdk.org/jdk/pull/15601/files/310115de84675d505c90242f9bac756b3a56f21b)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15601/head:pull/15601` \
`$ git checkout pull/15601`

Update a local copy of the PR: \
`$ git checkout pull/15601` \
`$ git pull https://git.openjdk.org/jdk.git pull/15601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15601`

View PR using the GUI difftool: \
`$ git pr show -t 15601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15601.diff">https://git.openjdk.org/jdk/pull/15601.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15601#issuecomment-1709268298)