### PR TITLE
8315818: vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java fails on libgraal

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1320,6 +1320,13 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   AbstractCompiler *comp = CompileBroker::compiler(comp_level);
   assert(comp != nullptr, "Ensure we have a compiler");
 
+#if INCLUDE_JVMCI
+  if (comp->is_jvmci() && !JVMCI::can_initialize_JVMCI()) {
+    // JVMCI compilation is not yet initializable.
+    return nullptr;
+  }
+#endif
+
   DirectiveSet* directive = DirectivesStack::getMatchingDirective(method, comp);
   // CompileBroker::compile_method can trap and can have pending async exception.
   nmethod* nm = CompileBroker::compile_method(method, osr_bci, comp_level, hot_method, hot_count, compile_reason, directive, THREAD);
@@ -1347,12 +1354,6 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   if (comp == nullptr || compilation_is_prohibited(method, osr_bci, comp_level, directive->ExcludeOption)) {
     return nullptr;
   }
-
-#if INCLUDE_JVMCI
-  if (comp->is_jvmci() && !JVMCI::can_initialize_JVMCI()) {
-    return nullptr;
-  }
-#endif
 
   if (osr_bci == InvocationEntryBci) {
     // standard compilation

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -301,7 +301,7 @@ public:
                                  int hot_count,
                                  CompileTask::CompileReason compile_reason,
                                  TRAPS);
-
+private:
   static nmethod* compile_method(const methodHandle& method,
                                    int osr_bci,
                                    int comp_level,
@@ -311,6 +311,7 @@ public:
                                    DirectiveSet* directive,
                                    TRAPS);
 
+public:
   // Acquire any needed locks and assign a compile id
   static int assign_compile_id_unlocked(Thread* thread, const methodHandle& method, int osr_bci);
 

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -56,6 +56,11 @@ const char* JVMCI::_fatal_log_filename = nullptr;
 void jvmci_vmStructs_init() NOT_DEBUG_RETURN;
 
 bool JVMCI::can_initialize_JVMCI() {
+  if (UseJVMCINativeLibrary) {
+    // Initializing libjvmci does not execute Java code so
+    // can be done any time.
+    return true;
+  }
   // Initializing JVMCI requires the module system to be initialized past phase 3.
   // The JVMCI API itself isn't available until phase 2 and ServiceLoader (which
   // JVMCI initialization requires) isn't usable until after phase 3. Testing

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -693,23 +693,23 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   // initialize compiler(s)
 #if defined(COMPILER1) || COMPILER2_OR_JVMCI
 #if INCLUDE_JVMCI
-  bool force_JVMCI_intialization = false;
+  bool force_JVMCI_initialization = false;
   if (EnableJVMCI) {
     // Initialize JVMCI eagerly when it is explicitly requested.
     // Or when JVMCILibDumpJNIConfig or JVMCIPrintProperties is enabled.
-    force_JVMCI_intialization = EagerJVMCI || JVMCIPrintProperties || JVMCILibDumpJNIConfig;
+    force_JVMCI_initialization = EagerJVMCI || JVMCIPrintProperties || JVMCILibDumpJNIConfig;
 
-    if (!force_JVMCI_intialization) {
+    if (!force_JVMCI_initialization) {
       // 8145270: Force initialization of JVMCI runtime otherwise requests for blocking
       // compilations via JVMCI will not actually block until JVMCI is initialized.
-      force_JVMCI_intialization = UseJVMCICompiler && (!UseInterpreter || !BackgroundCompilation);
+      force_JVMCI_initialization = UseJVMCICompiler && (!UseInterpreter || !BackgroundCompilation);
     }
   }
 #endif
   CompileBroker::compilation_init_phase1(CHECK_JNI_ERR);
   // Postpone completion of compiler initialization to after JVMCI
   // is initialized to avoid timeouts of blocking compilations.
-  if (JVMCI_ONLY(!force_JVMCI_intialization) NOT_JVMCI(true)) {
+  if (JVMCI_ONLY(!force_JVMCI_initialization) NOT_JVMCI(true)) {
     CompileBroker::compilation_init_phase2();
   }
 #endif
@@ -754,8 +754,8 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 #endif
 
 #if INCLUDE_JVMCI
-  if (force_JVMCI_intialization) {
-    JVMCI::initialize_compiler(CHECK_JNI_ERR);
+  if (force_JVMCI_initialization) {
+    JVMCI::initialize_compiler(THREAD);
     CompileBroker::compilation_init_phase2();
   }
 #endif


### PR DESCRIPTION
Instead of eagerly initializing JVMCI for `-Xcomp`, this defers JVMCI compilations until JVMCI is initializable. In the case of libgraal, no compilations are deferred since libgraal is always initializable. For jargraal, it still has to wait until the VM has reached a certain initialization phase so as to avoid deadlocks bewteen the main thread and a compiler thread.

This allows tests such as `vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java` to succeed on libgraal, even when there is insufficient virtual memory to mmap libgraal. Failing to initialize libgraal in that scenario now results in a bailout instead of exiting the VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315818](https://bugs.openjdk.org/browse/JDK-8315818): vmTestbase/nsk/jvmti/Allocate/alloc001/alloc001.java fails on libgraal (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15602/head:pull/15602` \
`$ git checkout pull/15602`

Update a local copy of the PR: \
`$ git checkout pull/15602` \
`$ git pull https://git.openjdk.org/jdk.git pull/15602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15602`

View PR using the GUI difftool: \
`$ git pr show -t 15602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15602.diff">https://git.openjdk.org/jdk/pull/15602.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15602#issuecomment-1709106144)