### PR TITLE
8315576: compiler/codecache/CodeCacheFullCountTest.java fails after JDK-8314837

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -27,8 +27,6 @@
 #
 #############################################################################
 
-compiler/codecache/CodeCacheFullCountTest.java 8315576 generic-all
-
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -58,11 +58,6 @@ public class CodeCacheFullCountTest {
         ProcessBuilder pb = ProcessTools.createTestJvm(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
-        // Ignore adapter creation failures
-        if (oa.getExitValue() != 0 && !oa.getStderr().contains("Out of space in CodeCache for adapters")) {
-            oa.reportDiagnosticSummary();
-            throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
-        }
         String stdout = oa.getStdout();
 
         Pattern pattern = Pattern.compile("full_count=(\\d)");

--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -45,12 +45,20 @@ public class CodeCacheFullCountTest {
         }
     }
 
-    public static void wasteCodeCache()  throws Exception {
+    public static void wasteCodeCache() throws Throwable {
         URL url = CodeCacheFullCountTest.class.getProtectionDomain().getCodeSource().getLocation();
 
-        for (int i = 0; i < 500; i++) {
-            ClassLoader cl = new MyClassLoader(url);
-            refClass(cl.loadClass("SomeClass"));
+        try {
+            for (int i = 0; i < 500; i++) {
+                ClassLoader cl = new MyClassLoader(url);
+                refClass(cl.loadClass("SomeClass"));
+            }
+        } catch (Throwable t) {
+            // Expose the root cause of the Throwable instance.
+            while (t.getCause() != null) {
+                t = t.getCause();
+            }
+            throw t;
         }
     }
 
@@ -58,6 +66,11 @@ public class CodeCacheFullCountTest {
         ProcessBuilder pb = ProcessTools.createTestJvm(
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
+        // Ignore adapter creation failures
+        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache for adapters")) {
+            oa.reportDiagnosticSummary();
+            throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
+        }
         String stdout = oa.getStdout();
 
         Pattern pattern = Pattern.compile("full_count=(\\d)");


### PR DESCRIPTION
CodeCacheFullCountTest disables code cache flushing, and loads classes to fill up the code cache.

The test expected two scenarios:
1. The compilers are disabled, adapters could still be created, and the process continues and terminates normally.
2. The adapters cannot be allocated and VirtualMachineError has been thrown and printed to stderr in `ThreadGroup.uncaughtException`.

When the test runs with option `-Xcomp`, `-esa`, and `-XX:-TieredCompilation`, more codes are compiled and the code cache becomes full earlier. Two more scenarios are found:

3. The adapters cannot be allocated during initialization of VM. The error message is printed to tty/stdout (`vm_exit_during_initialization` in `Method::make_adapters`) rather than stderr. (This is scenario of the bug report on windows-x64.)
4. The adapters could not be allocated, and an VirtualMachineError was thrown and wrapped in other exceptions. The nested exceptions could not be printed by `printStackTrace` in `ThreadGroup.uncaughtException` while the code cache is full. Another VirtualMachineError was thrown and eventually printed by `JavaThread::exit` without its message. (This scenario was found with the same options of the bug report on linux-x64.)

More details of an example of scenario 4: the adapters could not be allocated in `loadClass`, and an VirtualMachineError was thrown and wrapped in LambdaConversionException in `InnerClassLambdaMetafactory.buildCallSite` and then BootstrapMethodError in `BootstrapMethodInvoker.invoke`. Printing these chained Throwable's in `ThreadGroup.uncaughtException` causes another VirtualMachineError thrown by `java.lang.StackTraceElement`. 
```
 stderr: [OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=
OpenJDK 64-Bit Server VM warning: C2 initialization failed. Shutting down all compilers
Exception in thread "main" java.lang.BootstrapMethodError: bootstrap method initialization exception

Exception: java.lang.VirtualMachineError thrown from the UncaughtExceptionHandler in thread "main"
]
```

This change handles scenario 3 by checking the message in both stdout and stderr, and handles scenario 4 by exposing the root cause of VirtualMachineError. The second part is similar to  `CodeCacheOverflowProcessor.isThrowableCausedByVME` but without calling `String.matches` while code cache is full.

The test has passed as below.
```
make test \
    TEST="test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java" \
    JTREG="JAVA_OPTIONS=-Xcomp -ea -esa -XX:-TieredCompilation"
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8315576](https://bugs.openjdk.org/browse/JDK-8315576): compiler/codecache/CodeCacheFullCountTest.java fails after JDK-8314837 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15604/head:pull/15604` \
`$ git checkout pull/15604`

Update a local copy of the PR: \
`$ git checkout pull/15604` \
`$ git pull https://git.openjdk.org/jdk.git pull/15604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15604`

View PR using the GUI difftool: \
`$ git pr show -t 15604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15604.diff">https://git.openjdk.org/jdk/pull/15604.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15604#issuecomment-1709186200)