### PR TITLE
8315609: Open source few more swing text/html tests

### DIFF
--- a/test/jdk/javax/swing/text/html/Map/bug4322891.java
+++ b/test/jdk/javax/swing/text/html/Map/bug4322891.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4322891
+ * @summary  Tests if image map receives correct coordinates.
+ * @key headful
+ * @run main bug4322891
+*/
+
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import javax.swing.JFrame;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4322891 {
+
+    private boolean finished = false;
+    private static boolean passed = false;
+    private static Robot robot;
+    private static JFrame f;
+    private static JEditorPane jep;
+    private static volatile Point p;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            bug4322891 test = new bug4322891();
+            SwingUtilities.invokeAndWait(test::init);
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                p = jep.getLocationOnScreen();
+            });
+            robot.mouseMove(p.x, p.y);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            for (int i = 1; i < 30; i++) {
+                robot.mouseMove(p.x + i, p.y + i);
+                robot.waitForIdle();
+            }
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    public void init() {
+        String text = "<img src=\"aaa\" height=100 width=100 usemap=\"#mymap\">" +
+                      "<map name=\"mymap\">" +
+                      "<area href=\"aaa\" shape=rect coords=\"0,0,100,100\">" +
+                      "</map>";
+
+        f = new JFrame();
+        jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(text);
+
+        jep.addHyperlinkListener(new HyperlinkListener() {
+                                    public void hyperlinkUpdate(HyperlinkEvent e) {
+                                        passed = true;
+                                    }
+                                });
+        f.getContentPane().add(jep);
+        f.setSize(500,500);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+}

--- a/test/jdk/javax/swing/text/html/StyleSheet/bug4476002.java
+++ b/test/jdk/javax/swing/text/html/StyleSheet/bug4476002.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4476002
+ * @summary  Verifies JEditorPane: <ol> list numbers do not pick up color of the list text
+ * @key headful
+ * @run main bug4476002
+*/
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+
+public class bug4476002 {
+
+    private static boolean passed = true;
+    private static JLabel htmlComponent;
+
+    private static Robot robot;
+    private static JFrame mainFrame;
+    private static volatile Point p;
+    private static volatile Dimension d;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                String htmlText =
+                    "<html><head><style>" +
+                    "OL { list-style-type: disc; color: red }" +
+                    "</style></head>" +
+                    "<body><ol><li>wwwww</li></ol></body></html>";
+
+                mainFrame = new JFrame("bug4476002");
+
+                htmlComponent = new JLabel(htmlText);
+                mainFrame.getContentPane().add(htmlComponent);
+
+                mainFrame.pack();
+                mainFrame.setLocationRelativeTo(null);
+                mainFrame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                p = htmlComponent.getLocationOnScreen();
+                d = htmlComponent.getSize();
+            });
+            int x0 = p.x;
+            int y = p.y + d.height/2;
+
+            for (int x = x0; x < x0 + d.width; x++) {
+                if (robot.getPixelColor(x, y).equals(Color.black)) {
+                    passed = false;
+                    break;
+                }
+            }
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (mainFrame != null) {
+                    mainFrame.dispose();
+                }
+            });
+        }
+    }
+
+}

--- a/test/jdk/javax/swing/text/html/TableView/bug4412522.java
+++ b/test/jdk/javax/swing/text/html/TableView/bug4412522.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4412522
+ * @summary  Tests if HTML that has comments inside of tables is rendered correctly
+ * @key headful
+ * @run main bug4412522
+*/
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.text.View;
+import javax.swing.text.html.HTMLEditorKit;
+
+import java.awt.Robot;
+import java.awt.Shape;
+
+public class bug4412522 {
+
+    private static boolean passed = false;
+
+    private static JEditorPane jep;
+    private static JFrame f;
+    private static Robot robot;
+
+    public void init() {
+
+        String text =
+                "<html><head><table border>" +
+                "<tr><td>first cell</td><td>second cell</td></tr>" +
+                "<tr><!-- this is a comment --><td>row heading</td></tr>" +
+                "</table></body></html>";
+
+        JFrame f = new JFrame();
+        jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(text);
+
+        f.getContentPane().add(jep);
+        f.setSize(500,500);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+
+    public static void main(String args[]) throws Exception {
+        robot = new Robot();
+        robot.setAutoDelay(100);
+        bug4412522 test = new bug4412522();
+        try {
+            SwingUtilities.invokeAndWait(() -> test.init());
+            robot.waitForIdle();
+            robot.delay(1000);
+            Shape r = jep.getBounds();
+            View v = jep.getUI().getRootView(jep);
+            int tableWidth = 0;
+            int cellsWidth = 0;
+
+            while (!(v instanceof javax.swing.text.html.ParagraphView)) {
+
+                int n = v.getViewCount();
+                Shape sh = v.getChildAllocation(n - 1,  r);
+                String viewName = v.getClass().getName();
+                if (viewName.endsWith("TableView")) {
+                    tableWidth = r.getBounds().width;
+                }
+
+                if (viewName.endsWith("CellView")) {
+                    cellsWidth = r.getBounds().x + r.getBounds().width;
+                }
+
+                v = v.getView(n - 1);
+                if (sh != null) {
+                    r = sh;
+                }
+            }
+
+            passed = ((tableWidth - cellsWidth) > 10);
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/html/TableView/bug4412522.java
+++ b/test/jdk/javax/swing/text/html/TableView/bug4412522.java
@@ -84,7 +84,7 @@ public class bug4412522 {
             while (!(v instanceof javax.swing.text.html.ParagraphView)) {
 
                 int n = v.getViewCount();
-                Shape sh = v.getChildAllocation(n - 1,  r);
+                Shape sh = v.getChildAllocation(n - 1, r);
                 String viewName = v.getClass().getName();
                 if (viewName.endsWith("TableView")) {
                     tableWidth = r.getBounds().width;

--- a/test/jdk/javax/swing/text/html/TableView/bug4690812.java
+++ b/test/jdk/javax/swing/text/html/TableView/bug4690812.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4690812
+ * @summary  Tests if tables are correctly formatted in some cases
+ * @key headful
+ * @run main bug4690812
+*/
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.text.View;
+import javax.swing.text.html.HTMLEditorKit;
+
+import java.awt.Robot;
+import java.awt.Shape;
+
+public class bug4690812 {
+
+    private static boolean passed = false;
+
+    private static JEditorPane jep;
+    private static JFrame f;
+
+    public void init() {
+
+        String text =
+            "<table cellpadding=0 cellspacing=0 border=0 width=100%>" +
+            "<tr><td width=100%>a</td><td></td></tr>" +
+            "<tr><td width=100%>something</td>" +
+            "<td width=1><img src=\"file:/a.jpg\" width=1 height=1></td></tr>" +
+            "</table>";
+
+        JFrame f = new JFrame();
+        jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+
+        jep.setText(text);
+
+        f.getContentPane().add(jep);
+        f.setSize(500,500);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+
+    public static void main(String args[]) throws Exception {
+        Robot robot = new Robot();
+        bug4690812 test = new bug4690812();
+        try {
+            SwingUtilities.invokeAndWait(() -> test.init());
+            robot.waitForIdle();
+            robot.delay(1000);
+            Shape r = jep.getBounds();
+            View v = jep.getUI().getRootView(jep);
+            int tableHeight = 0;
+            while (!(v instanceof javax.swing.text.html.ParagraphView)) {
+                int n = v.getViewCount();
+                Shape sh = v.getChildAllocation(n - 1,  r);
+                v = v.getView(n - 1);
+                if (sh != null) {
+                    r = sh;
+                }
+            }
+            // left column in the second table row should have width == 1
+            passed = (r.getBounds().width == 1) ? true : false;
+            if (!passed) {
+                throw new RuntimeException("Test failed.");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/text/html/TableView/bug4690812.java
+++ b/test/jdk/javax/swing/text/html/TableView/bug4690812.java
@@ -79,7 +79,7 @@ public class bug4690812 {
             int tableHeight = 0;
             while (!(v instanceof javax.swing.text.html.ParagraphView)) {
                 int n = v.getViewCount();
-                Shape sh = v.getChildAllocation(n - 1,  r);
+                Shape sh = v.getChildAllocation(n - 1, r);
                 v = v.getView(n - 1);
                 if (sh != null) {
                     r = sh;


### PR DESCRIPTION
Few closed swing text/html tests are open sourced

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315609](https://bugs.openjdk.org/browse/JDK-8315609): Open source few more swing text/html tests (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [e1c145ce](https://git.openjdk.org/jdk/pull/15607/files/e1c145cec0c33e97bd9262c838300407833824c3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15607/head:pull/15607` \
`$ git checkout pull/15607`

Update a local copy of the PR: \
`$ git checkout pull/15607` \
`$ git pull https://git.openjdk.org/jdk.git pull/15607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15607`

View PR using the GUI difftool: \
`$ git pr show -t 15607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15607.diff">https://git.openjdk.org/jdk/pull/15607.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15607#issuecomment-1709458739)