### PR TITLE
8315686: G1: Disallow evacuation of marking regions in a Prepare Mixed gc

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -326,10 +326,14 @@ void G1CollectionSet::finalize_old_part(double time_remaining_ms) {
     G1CollectionCandidateRegionList initial_old_regions;
     assert(_optional_old_regions.length() == 0, "must be");
 
-    time_remaining_ms = _policy->select_candidates_from_marking(&candidates()->marking_regions(),
-                                                                time_remaining_ms,
-                                                                &initial_old_regions,
-                                                                &_optional_old_regions);
+    if (!collector_state()->in_young_gc_before_mixed()) {
+      time_remaining_ms = _policy->select_candidates_from_marking(&candidates()->marking_regions(),
+                                                                  time_remaining_ms,
+                                                                  &initial_old_regions,
+                                                                  &_optional_old_regions);
+    } else {
+      log_debug(gc, ergo, cset)("Do not add marking candidates to collection set due to pause type.");
+    }
 
     _policy->select_candidates_from_retained(&candidates()->retained_regions(),
                                              time_remaining_ms,

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -326,7 +326,7 @@ void G1CollectionSet::finalize_old_part(double time_remaining_ms) {
     G1CollectionCandidateRegionList initial_old_regions;
     assert(_optional_old_regions.length() == 0, "must be");
 
-    if (!collector_state()->in_young_gc_before_mixed()) {
+    if (collector_state()->in_mixed_phase()) {
       time_remaining_ms = _policy->select_candidates_from_marking(&candidates()->marking_regions(),
                                                                   time_remaining_ms,
                                                                   &initial_old_regions,


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that disables "Prepare Mixed" GCs (opportunistically) taking collection set candidates from marking into their collection set?
The problem when doing so is related to pause time predictions:
* Prepare Mixed young gen prediction did never take (marking) old gen regions into account in the first place, potentially blowing MMU (that there is a minimum regions to take per GC does not help)
* another problem is how to account this "half-young-only" in the predictions: what kind of predictions to take here, the ones for young-only gcs or mixed gcs? What predictions to update for this kind of GC?
* a third problem is adaptive IHOP: there are cases where that "Prepare Mixed" gc would take all marking collection set candidates, which means that the adaptive IHOP algorithm may never get a full "Concurrent Start" to first "Mixed GC" cycle, leading to IHOP not being changed dynamically.
* another problem related to "Prepare Mixed" gc taking all marking collection set candidates is that the next Mixed GC will be somewhat degenerate, having no old gen regions to collect, impacting mixed phase predictions as well.

For all these reasons it is best to disable Prepare Mixed GC taking marking collection set candidates.

Testing: gha, manual behavior checking

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315686](https://bugs.openjdk.org/browse/JDK-8315686): G1: Disallow evacuation of marking regions in a Prepare Mixed gc (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15611/head:pull/15611` \
`$ git checkout pull/15611`

Update a local copy of the PR: \
`$ git checkout pull/15611` \
`$ git pull https://git.openjdk.org/jdk.git pull/15611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15611`

View PR using the GUI difftool: \
`$ git pr show -t 15611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15611.diff">https://git.openjdk.org/jdk/pull/15611.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15611#issuecomment-1709695552)