### PR TITLE
8315843: C1: Use MDO offsets as int consts instead of intptr consts

### DIFF
--- a/src/hotspot/cpu/x86/c1_LIR_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIR_x86.cpp
@@ -61,7 +61,7 @@ LIR_Opr LIR_OprFact::double_fpu(int reg1, int reg2) {
 void LIR_Address::verify() const {
 #ifdef _LP64
   assert(base()->is_cpu_register(), "wrong base operand");
-  assert(index()->is_illegal() || index()->is_double_cpu(), "wrong index operand");
+  assert(index()->is_illegal() || index()->is_single_cpu() || index()->is_double_cpu(), "wrong index operand");
   assert(base()->type() == T_ADDRESS || base()->type() == T_OBJECT || base()->type() == T_LONG || base()->type() == T_METADATA,
          "wrong type for addresses");
 #else

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -926,10 +926,10 @@ void LIRGenerator::profile_branch(If* if_instr, If::Condition cond) {
     LIR_Opr md_reg = new_register(T_METADATA);
     __ metadata2reg(md->constant_encoding(), md_reg);
 
-    LIR_Opr data_offset_reg = new_pointer_register();
+    LIR_Opr data_offset_reg = new_register(T_INT);
     __ cmove(lir_cond(cond),
-             LIR_OprFact::intptrConst(taken_count_offset),
-             LIR_OprFact::intptrConst(not_taken_count_offset),
+             LIR_OprFact::intConst(taken_count_offset),
+             LIR_OprFact::intConst(not_taken_count_offset),
              data_offset_reg, as_BasicType(if_instr->x()->type()));
 
     // MDO cells are intptr_t, so the data_reg width is arch-dependent.
@@ -2329,16 +2329,16 @@ void LIRGenerator::do_TableSwitch(TableSwitch* x) {
     int default_count_offset = md->byte_offset_of_slot(data, MultiBranchData::default_count_offset());
     LIR_Opr md_reg = new_register(T_METADATA);
     __ metadata2reg(md->constant_encoding(), md_reg);
-    LIR_Opr data_offset_reg = new_pointer_register();
-    LIR_Opr tmp_reg = new_pointer_register();
+    LIR_Opr data_offset_reg = new_register(T_INT);
+    LIR_Opr tmp_reg = new_register(T_INT);
 
-    __ move(LIR_OprFact::intptrConst(default_count_offset), data_offset_reg);
+    __ move(LIR_OprFact::intConst(default_count_offset), data_offset_reg);
     for (int i = 0; i < len; i++) {
       int count_offset = md->byte_offset_of_slot(data, MultiBranchData::case_count_offset(i));
       __ cmp(lir_cond_equal, value, i + lo_key);
       __ move(data_offset_reg, tmp_reg);
       __ cmove(lir_cond_equal,
-               LIR_OprFact::intptrConst(count_offset),
+               LIR_OprFact::intConst(count_offset),
                tmp_reg,
                data_offset_reg, T_INT);
     }
@@ -2387,16 +2387,16 @@ void LIRGenerator::do_LookupSwitch(LookupSwitch* x) {
     int default_count_offset = md->byte_offset_of_slot(data, MultiBranchData::default_count_offset());
     LIR_Opr md_reg = new_register(T_METADATA);
     __ metadata2reg(md->constant_encoding(), md_reg);
-    LIR_Opr data_offset_reg = new_pointer_register();
-    LIR_Opr tmp_reg = new_pointer_register();
+    LIR_Opr data_offset_reg = new_register(T_INT);
+    LIR_Opr tmp_reg = new_register(T_INT);
 
-    __ move(LIR_OprFact::intptrConst(default_count_offset), data_offset_reg);
+    __ move(LIR_OprFact::intConst(default_count_offset), data_offset_reg);
     for (int i = 0; i < len; i++) {
       int count_offset = md->byte_offset_of_slot(data, MultiBranchData::case_count_offset(i));
       __ cmp(lir_cond_equal, value, x->key_at(i));
       __ move(data_offset_reg, tmp_reg);
       __ cmove(lir_cond_equal,
-               LIR_OprFact::intptrConst(count_offset),
+               LIR_OprFact::intConst(count_offset),
                tmp_reg,
                data_offset_reg, T_INT);
     }

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -930,7 +930,7 @@ void LIRGenerator::profile_branch(If* if_instr, If::Condition cond) {
     __ cmove(lir_cond(cond),
              LIR_OprFact::intConst(taken_count_offset),
              LIR_OprFact::intConst(not_taken_count_offset),
-             data_offset_reg, as_BasicType(if_instr->x()->type()));
+             data_offset_reg, T_INT);
 
     // MDO cells are intptr_t, so the data_reg width is arch-dependent.
     LIR_Opr data_reg = new_pointer_register();


### PR DESCRIPTION
Noticed this when looking at C1 profiling code. We use MDO offsets as `intptrConst`, despite them being very small. This leads to loads with `movabs` with large immediates on x86. We can instead just load them as `intConst`-s. This affects tier3 profiling code only. 

Sample branch profiling hunk from C1 tier3 on x86_64:

```
Before:
   0x00007f269065ed02:   test   %edx,%edx
   0x00007f269065ed04:   movabs $0x7f260a4ddd68,%rax  ;   {metadata(method data for {method} …
   0x00007f269065ed0e:   movabs $0x138,%rsi
 ╭ 0x00007f269065ed18:   je     0x00007f269065ed24
 │ 0x00007f269065ed1a:   movabs $0x148,%rsi
 ↘ 0x00007f269065ed24:   mov    (%rax,%rsi,1),%rdi
   0x00007f269065ed28:   lea    0x1(%rdi),%rdi
   0x00007f269065ed2c:   mov    %rdi,(%rax,%rsi,1)
   0x00007f269065ed30:   je     0x00007f269065ed4e     

After:
   0x00007f1370dcd782:   test   %edx,%edx
   0x00007f1370dcd784:   movabs $0x7f12f64ddd68,%rax   ;   {metadata(method data for {method} …
   0x00007f1370dcd78e:   mov    $0x138,%esi
 ╭ 0x00007f1370dcd793:   je     0x00007f1370dcd79a        
 │ 0x00007f1370dcd795:   mov    $0x148,%esi
 ↘ 0x00007f1370dcd79a:   mov    (%rax,%rsi,1),%rdi        
   0x00007f1370dcd79e:   lea    0x1(%rdi),%rdi
   0x00007f1370dcd7a2:   mov    %rdi,(%rax,%rsi,1)       
   0x00007f1370dcd7a6:   je     0x00007f1370dcd7c4 
```

In the hunk above, this saves about 8 bytes. This leads to observable code space savings on larger tests, e.g. on `-Xcomp -XX:TieredStopAtLevel=... HelloWorld`.

```
# Before
tier1: nmethod code size         :   426448 bytes
tier2: nmethod code size         :   463008 bytes
tier3: nmethod code size         :   910656 bytes

# After
tier1: nmethod code size         :   426448 bytes
tier2: nmethod code size         :   463008 bytes
tier3: nmethod code size         :   892448 bytes (-2.0%)
```

Additional testing:
 - [ ] Linux x86_64 fastdebug `tier1 tier2 tier3`
 - [ ] Linux AArch64 fastdebug `tier1 tier2 tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315843](https://bugs.openjdk.org/browse/JDK-8315843): C1: Use MDO offsets as int consts instead of intptr consts (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**) ⚠️ Review applies to [f4b94d01](https://git.openjdk.org/jdk/pull/15612/files/f4b94d0126b7bed2ef71caf8d09392be720f3691)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15612/head:pull/15612` \
`$ git checkout pull/15612`

Update a local copy of the PR: \
`$ git checkout pull/15612` \
`$ git pull https://git.openjdk.org/jdk.git pull/15612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15612`

View PR using the GUI difftool: \
`$ git pr show -t 15612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15612.diff">https://git.openjdk.org/jdk/pull/15612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15612#issuecomment-1709769279)