### PR TITLE
8315841: RISC-V: Check for hardware TSO support

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -109,6 +109,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \
   product(bool, UseZicboz, false, EXPERIMENTAL, "Use Zicboz instructions")       \
+  product(bool, UseZtso, false, EXPERIMENTAL, "Assume Ztso memory model")        \
   product(bool, UseZihintpause, false, EXPERIMENTAL,                             \
           "Use Zihintpause instructions")                                        \
   product(bool, UseRVVForBigIntegerShiftIntrinsics, true,                        \

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -387,6 +387,7 @@ class MacroAssembler: public Assembler {
         // TSO guarantees other fences already.
       }
     } else {
+      // always generate fence for RVWMO
       Assembler::fence(predecessor, successor);
     }
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -378,7 +378,7 @@ class MacroAssembler: public Assembler {
 
   void fence(uint32_t predecessor, uint32_t successor) {
     if (UseZtso) {
-      if (pred_succ_to_membar_mask(predecessor, successor) & StoreLoad) {
+      if ((pred_succ_to_membar_mask(predecessor, successor) & StoreLoad) != 0) {
         // TSO allows for stores to be reordered after loads. When the compiler
         // generates a fence to disallow that, we are required to generate the
         // fence for correctness.

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -376,8 +376,18 @@ class MacroAssembler: public Assembler {
     return ((predecessor & 0x3) << 2) | (successor & 0x3);
   }
 
+  void fence(uint32_t predecessor, uint32_t successor) {
+    if (UseZtso) {
+      // do not emit fence if it's not at least a StoreLoad fence
+      if (!((predecessor & w) && (successor & r))) {
+        return;
+      }
+    }
+    Assembler::fence(predecessor, successor);
+  }
+
   void pause() {
-    fence(w, 0);
+    Assembler::fence(w, 0);
   }
 
   // prints msg, dumps registers and stops execution

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -382,12 +382,13 @@ class MacroAssembler: public Assembler {
         // TSO allows for stores to be reordered after loads. When the compiler
         // generates a fence to disallow that, we are required to generate the
         // fence for correctness.
+        Assembler::fence(predecessor, successor);
       } else {
         // TSO guarantees other fences already.
-        return;
       }
+    } else {
+      Assembler::fence(predecessor, successor);
     }
-    Assembler::fence(predecessor, successor);
   }
 
   void pause() {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -378,7 +378,7 @@ class MacroAssembler: public Assembler {
 
   void fence(uint32_t predecessor, uint32_t successor) {
     if (UseZtso) {
-      if ((pred_succ_to_membar_mask(predecessor, successor) & StoreLoad) != 0) {
+      if ((pred_succ_to_membar_mask(predecessor, successor) & StoreLoad) == StoreLoad) {
         // TSO allows for stores to be reordered after loads. When the compiler
         // generates a fence to disallow that, we are required to generate the
         // fence for correctness.

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -378,8 +378,12 @@ class MacroAssembler: public Assembler {
 
   void fence(uint32_t predecessor, uint32_t successor) {
     if (UseZtso) {
-      // do not emit fence if it's not at least a StoreLoad fence
-      if (!((predecessor & w) && (successor & r))) {
+      if (pred_succ_to_membar_mask(predecessor, successor) & StoreLoad) {
+        // TSO allows for stores to be reordered after loads. When the compiler
+        // generates a fence to disallow that, we are required to generate the
+        // fence for correctness.
+      } else {
+        // TSO guarantees other fences already.
         return;
       }
     }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -210,7 +210,7 @@ void VM_Version::initialize() {
       unaligned_access.value() == MISALIGNED_FAST);
   }
 
-#if TARGET_ZTSO
+#if defined(TARGET_ZTSO) && TARGET_ZTSO
   // Hotspot is compiled with TSO support, it will only run on hardware which
   // supports Ztso
   if (FLAG_IS_DEFAULT(UseZtso)) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -210,6 +210,14 @@ void VM_Version::initialize() {
       unaligned_access.value() == MISALIGNED_FAST);
   }
 
+#if TARGET_ZTSO
+  // Hotspot is compiled with TSO support, it will only run on hardware which
+  // supports Ztso
+  if (FLAG_IS_DEFAULT(UseZtso)) {
+    FLAG_SET_DEFAULT(UseZtso, true);
+  }
+#endif
+
   if (UseZbb) {
     if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
       FLAG_SET_DEFAULT(UsePopCountInstruction, true);

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -210,7 +210,7 @@ void VM_Version::initialize() {
       unaligned_access.value() == MISALIGNED_FAST);
   }
 
-#if defined(TARGET_ZTSO) && TARGET_ZTSO
+#ifdef __riscv_ztso
   // Hotspot is compiled with TSO support, it will only run on hardware which
   // supports Ztso
   if (FLAG_IS_DEFAULT(UseZtso)) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -134,6 +134,7 @@ class VM_Version : public Abstract_VM_Version {
   decl(ext_Zicsr       , "Zicsr"       , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \
   decl(ext_Zifencei    , "Zifencei"    , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \
   decl(ext_Zic64b      , "Zic64b"      , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZic64b))      \
+  decl(ext_Ztso        , "Ztso"        , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZtso))        \
   decl(ext_Zihintpause , "Zihintpause" , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZihintpause)) \
   decl(mvendorid       , "VendorId"    , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)              \
   decl(marchid         , "ArchId"      , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)              \

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -236,6 +236,7 @@ void VM_Version::rivos_features() {
   ext_Zicsr.enable_feature();
   ext_Zifencei.enable_feature();
   ext_Zic64b.enable_feature();
+  ext_Ztso.enable_feature();
   ext_Zihintpause.enable_feature();
 
   unaligned_access.enable_feature(MISALIGNED_FAST);


### PR DESCRIPTION
With the Ztso extension [1], some hardware will support TSO on RISC-V. That allows us to reduce the generation of memory fences, given the stronger memory model compared to RVWMO.

[1] https://github.com/riscv/riscv-isa-manual/blob/6dcbc6da9ada01f0f57da83cda6059bdec57619f/src/ztso-st-ext.adoc#L1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315841](https://bugs.openjdk.org/browse/JDK-8315841): RISC-V: Check for hardware TSO support (**Task** - P4)


### Reviewers
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - Committer) ⚠️ Review applies to [5f80c7ca](https://git.openjdk.org/jdk/pull/15613/files/5f80c7ca355598904500ce2e9801101510522c9f)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15613/head:pull/15613` \
`$ git checkout pull/15613`

Update a local copy of the PR: \
`$ git checkout pull/15613` \
`$ git pull https://git.openjdk.org/jdk.git pull/15613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15613`

View PR using the GUI difftool: \
`$ git pr show -t 15613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15613.diff">https://git.openjdk.org/jdk/pull/15613.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15613#issuecomment-1709775197)