### PR TITLE
8315855: G1: Revise signature of set_humongous_candidate

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -209,7 +209,7 @@ G1HeapRegionAttr G1CollectedHeap::region_attr(uint idx) const {
 }
 
 void G1CollectedHeap::register_humongous_candidate_region_with_region_attr(uint index) {
-  _region_attr.set_humongous_candidate(index, region_at(index)->rem_set()->is_tracked());
+  _region_attr.set_humongous_candidate(index);
 }
 
 void G1CollectedHeap::register_new_survivor_region_with_region_attr(HeapRegion* r) {

--- a/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionAttr.hpp
@@ -131,9 +131,11 @@ class G1HeapRegionAttrBiasedMappedArray : public G1BiasedMappedArray<G1HeapRegio
     get_ref_by_index(index)->set_new_survivor();
   }
 
-  void set_humongous_candidate(uintptr_t index, bool remset_is_tracked) {
+  void set_humongous_candidate(uintptr_t index) {
     assert(get_by_index(index).is_default(),
            "Region attributes at index " INTPTR_FORMAT " should be default but is %s", index, get_by_index(index).get_type_str());
+    // Humongous candidates must have complete remset.
+    const bool remset_is_tracked = true;
     set_by_index(index, G1HeapRegionAttr(G1HeapRegionAttr::HumongousCandidate, remset_is_tracked));
   }
 


### PR DESCRIPTION
Simple removing redundant method arg around humongous candidates.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315855](https://bugs.openjdk.org/browse/JDK-8315855): G1: Revise signature of set_humongous_candidate (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15617/head:pull/15617` \
`$ git checkout pull/15617`

Update a local copy of the PR: \
`$ git checkout pull/15617` \
`$ git pull https://git.openjdk.org/jdk.git pull/15617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15617`

View PR using the GUI difftool: \
`$ git pr show -t 15617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15617.diff">https://git.openjdk.org/jdk/pull/15617.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15617#issuecomment-1710031305)