### PR TITLE
8315684: Parallelize sun/security/util/math/TestIntegerModuloP.java

### DIFF
--- a/test/jdk/sun/security/util/math/TestIntegerModuloP.java
+++ b/test/jdk/sun/security/util/math/TestIntegerModuloP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,6 @@
  * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.Curve448OrderField 56 12
  */
-
 
 import sun.security.util.math.*;
 import sun.security.util.math.intpoly.*;

--- a/test/jdk/sun/security/util/math/TestIntegerModuloP.java
+++ b/test/jdk/sun/security/util/math/TestIntegerModuloP.java
@@ -22,23 +22,84 @@
  */
 
 /*
- * @test
+ * @test id=IntegerPolynomial25519
  * @bug 8181594 8208648
  * @summary Test proper operation of integer field arithmetic
  * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
  * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.IntegerPolynomial25519 32 0
+ */
+
+ /*
+ * @test id=IntegerPolynomial448
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.IntegerPolynomial448 56 1
+ */
+
+ /*
+ * @test id=IntegerPolynomial1305
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.IntegerPolynomial1305 16 2
+ */
+
+ /*
+ * @test id=IntegerPolynomialP256
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.IntegerPolynomialP256 32 5
+ */
+
+ /*
+ * @test id=IntegerPolynomialP384
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.IntegerPolynomialP384 48 6
+ */
+
+ /*
+ * @test id=IntegerPolynomialP521
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.IntegerPolynomialP521 66 7
+ */
+
+ /*
+ * @test id=P256OrderField
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.P256OrderField 32 8
+ */
+
+ /*
+ * @test id=P384OrderField
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.P384OrderField 48 9
+ */
+
+ /*
+ * @test id=P521OrderField
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.P521OrderField 66 10
+ */
+
+ /*
+ * @test id=Curve25519OrderField
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.Curve25519OrderField 32 11
+ */
+
+ /*
+ * @test id=Curve448OrderField
+ * @modules java.base/sun.security.util java.base/sun.security.util.math java.base/sun.security.util.math.intpoly
+ * @build BigIntegerModuloP
  * @run main TestIntegerModuloP sun.security.util.math.intpoly.Curve448OrderField 56 12
  */
+
 
 import sun.security.util.math.*;
 import sun.security.util.math.intpoly.*;


### PR DESCRIPTION
sun/security/util/math/TestIntegerModuloP.java runs in tier2 and takes about 600 seconds to run. Thus, it drags the execution time of tier2 on large machines. We can split the run configurations a bit so that test is more parallel. 

TestIntegerModuloP.java current run time: **235.02s user 6.60s system 119% cpu 3:22.69 total**
TestIntegerModuloP.java parallelized run time: **328.75s user 14.57s system 755% cpu 45.467 total**

This change splits TestIntegerModuloP.java's previously serialized test into 11 separate tests that run in parallel.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8315684](https://bugs.openjdk.org/browse/JDK-8315684): Parallelize sun/security/util/math/TestIntegerModuloP.java (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15618/head:pull/15618` \
`$ git checkout pull/15618`

Update a local copy of the PR: \
`$ git checkout pull/15618` \
`$ git pull https://git.openjdk.org/jdk.git pull/15618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15618`

View PR using the GUI difftool: \
`$ git pr show -t 15618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15618.diff">https://git.openjdk.org/jdk/pull/15618.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15618#issuecomment-1718332106)