### PR TITLE
8315683: Parallelize java/util/concurrent/tck/JSR166TestCase.java

### DIFF
--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -43,7 +43,7 @@
  */
 
 /*
- * @test id=security-manager-allow
+ * @test id=security-manager
  * @summary Conformance testing variant of JSR-166 tck tests
  *          with java security manager set to allow.
  * @build *

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -35,7 +35,7 @@
  */
 
 /*
- * @test
+ * @test id=default
  * @summary JSR-166 tck tests, in a number of variations.
  *          The first is the conformance testing variant,
  *          while others also test implementation details.
@@ -43,11 +43,12 @@
  * @modules java.management
  * @run junit/othervm/timeout=1000 JSR166TestCase
  * @run junit/othervm/timeout=1000 -Djava.security.manager=allow JSR166TestCase
- * @run junit/othervm/timeout=1000
- *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
- *      --add-opens java.base/java.lang=ALL-UNNAMED
- *      -Djsr166.testImplementationDetails=true
- *      JSR166TestCase
+ */
+
+/*
+ * @test id=forkjoinpool-common-parallelism
+ * @build *
+ * @modules java.management
  * @run junit/othervm/timeout=1000
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
@@ -61,12 +62,24 @@
  *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -Djava.util.secureRandomSeed=true
  *      JSR166TestCase
+ */
+
+/*
+ * @test id=others
+ * @build *
+ * @modules java.management
+ * @run junit/othervm/timeout=1000
+ *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+ *      --add-opens java.base/java.lang=ALL-UNNAMED
+ *      -Djsr166.testImplementationDetails=true
+ *      JSR166TestCase
  * @run junit/othervm/timeout=1000/policy=tck.policy
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
  *      -Djsr166.testImplementationDetails=true
  *      JSR166TestCase
  */
+
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -36,9 +36,7 @@
 
 /*
  * @test id=default
- * @summary JSR-166 tck tests, in a number of variations.
- *          The first is the conformance testing variant,
- *          while others also test implementation details.
+ * @summary Conformance testing variant of JSR-166 tck tests.
  * @build *
  * @modules java.management
  * @run junit/othervm/timeout=1000 JSR166TestCase
@@ -47,6 +45,8 @@
 
 /*
  * @test id=forkjoinpool-common-parallelism
+ * @summary Test implementation details variant of JSR-166
+ *          tck tests with ForkJoinPool common parallelism.
  * @build *
  * @modules java.management
  * @run junit/othervm/timeout=1000
@@ -66,6 +66,9 @@
 
 /*
  * @test id=others
+ * @summary Remaining test implementation details variant of
+ *          JSR-166 tck tests apart from ForkJoinPool common
+ *          parallelism.
  * @build *
  * @modules java.management
  * @run junit/othervm/timeout=1000

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -40,6 +40,14 @@
  * @build *
  * @modules java.management
  * @run junit/othervm/timeout=1000 JSR166TestCase
+ */
+
+/*
+ * @test id=security-manager-allow
+ * @summary Conformance testing variant of JSR-166 tck tests
+ *          with java security manager set to allow.
+ * @build *
+ * @modules java.management
  * @run junit/othervm/timeout=1000 -Djava.security.manager=allow JSR166TestCase
  */
 

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -80,7 +80,6 @@
  *      JSR166TestCase
  */
 
-
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;


### PR DESCRIPTION
This test is running in tier1, and takes about 400 seconds to complete. Thus, it drags the execution time of tier1 on large machines. The commit includes changing the sequential run of test cases in java/util/concurrent/tck/JSR166TestCase.java to the best possible combination of parallelization to reduce the total runtime of the overall test and causing least possible change to user and system times. The below comparison shows existing and newer combinations of parallelizations:

* before                           : **200.64s user 20.94s system 204% cpu 1:48.47 total**
* fully parallel                  : **308.84s user 23.75s system 479% cpu 1:09.42 total**
* default-details-tck       : **244.69s user 22.03s system 314% cpu 1:24.94 total**
* default-fjp_details-others : **260.12s user 24.47s system 404% cpu 1:10.31 total**

Based on the comparison above, the fourth combination has a result very close to full parallelization and at the same time having the least deviation of system and user times among the newer combinations. Hence the commit includes the changes corresponding to the fourth combination.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315683](https://bugs.openjdk.org/browse/JDK-8315683): Parallelize java/util/concurrent/tck/JSR166TestCase.java (**Enhancement** - P4)


### Reviewers
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15619/head:pull/15619` \
`$ git checkout pull/15619`

Update a local copy of the PR: \
`$ git checkout pull/15619` \
`$ git pull https://git.openjdk.org/jdk.git pull/15619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15619`

View PR using the GUI difftool: \
`$ git pr show -t 15619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15619.diff">https://git.openjdk.org/jdk/pull/15619.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15619#issuecomment-1710211432)