### PR TITLE
8315863: [GHA] Update checkout action to use v4

### DIFF
--- a/.github/actions/get-gtest/action.yml
+++ b/.github/actions/get-gtest/action.yml
@@ -40,7 +40,7 @@ runs:
         var: GTEST_VERSION
 
     - name: 'Checkout GTest source'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: google/googletest
         ref: 'v${{ steps.version.outputs.value }}'

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -47,7 +47,7 @@ runs:
         key: jtreg-${{ steps.version.outputs.value }}
 
     - name: 'Checkout the JTReg source'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: openjdk/jtreg
         ref: jtreg-${{ steps.version.outputs.value }}

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Get the BootJDK'
         id: bootjdk

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Get the BootJDK'
         id: bootjdk

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Get the BootJDK'
         id: bootjdk

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Get MSYS2'
         uses: ./.github/actions/get-msys2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - name: 'Checkout the JDK source'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Get MSYS2'
         uses: ./.github/actions/get-msys2


### PR DESCRIPTION
Please review this change to update all workflows to use `actions/checkout@v4`.

Find the associated release notes here: https://github.com/actions/checkout/releases/tag/v4.0.0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315863](https://bugs.openjdk.org/browse/JDK-8315863): [GHA] Update checkout action to use v4 (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15620/head:pull/15620` \
`$ git checkout pull/15620`

Update a local copy of the PR: \
`$ git checkout pull/15620` \
`$ git pull https://git.openjdk.org/jdk.git pull/15620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15620`

View PR using the GUI difftool: \
`$ git pr show -t 15620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15620.diff">https://git.openjdk.org/jdk/pull/15620.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15620#issuecomment-1710322572)