### PR TITLE
8315795: runtime/Safepoint/TestAbortVMOnSafepointTimeout.java fails after JDK-8305507

### DIFF
--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -68,7 +68,7 @@ public class TestAbortVMOnSafepointTimeout {
                 "-XX:+SafepointTimeout",
                 "-XX:+SafepointALot",
                 "-XX:+AbortVMOnSafepointTimeout",
-                "-XX:AbortVMOnSafepointTimeoutDelay=2500",
+                "-XX:AbortVMOnSafepointTimeoutDelay=10000",
                 "-XX:SafepointTimeoutDelay=50",
                 "-XX:GuaranteedSafepointInterval=1",
                 "-XX:-CreateCoredumpOnCrash",

--- a/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
+++ b/test/hotspot/jtreg/runtime/Safepoint/TestAbortVMOnSafepointTimeout.java
@@ -30,7 +30,7 @@ import jdk.test.whitebox.WhiteBox;
  * @test TestAbortVMOnSafepointTimeout
  * @summary Check if VM can kill thread which doesn't reach safepoint,
  *          test grace period before AbortVMOnSafepointTimeout kicks in
- * @bug 8219584 8227528
+ * @bug 8219584 8227528 8315795
  * @requires vm.flagless
  * @library /testlibrary /test/lib
  * @build jdk.test.whitebox.WhiteBox
@@ -68,7 +68,7 @@ public class TestAbortVMOnSafepointTimeout {
                 "-XX:+SafepointTimeout",
                 "-XX:+SafepointALot",
                 "-XX:+AbortVMOnSafepointTimeout",
-                "-XX:AbortVMOnSafepointTimeoutDelay=10000",
+                "-XX:AbortVMOnSafepointTimeoutDelay=10000", // Using 10 seconds instead of a smaller value for windows-debug
                 "-XX:SafepointTimeoutDelay=50",
                 "-XX:GuaranteedSafepointInterval=1",
                 "-XX:-CreateCoredumpOnCrash",


### PR DESCRIPTION
Please review this small fix to test TestAbortVMOnSafepointTimeout.java. With the current value of AbortVMOnSafepointTimeoutDelay we get cases where the spawned child VM exits with a safepoint timeout but without the main thread being able to print the PRE_STALL_TEXT text. I added a more detailed analysis in the bug comments.
To fix it I increased the value of AbortVMOnSafepointTimeoutDelay to be about twice as much as the longest time it could take to print the PRE_STALL_TEXT based on the measurements I have done in the failing Windows machines.
Without the fix I can reproduce the issue in about 10% of the runs running tier1_runtime. With the fix I run ~400 runs of tier1_runtime without failures.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315795](https://bugs.openjdk.org/browse/JDK-8315795): runtime/Safepoint/TestAbortVMOnSafepointTimeout.java fails after JDK-8305507 (**Bug** - P2)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15622/head:pull/15622` \
`$ git checkout pull/15622`

Update a local copy of the PR: \
`$ git checkout pull/15622` \
`$ git pull https://git.openjdk.org/jdk.git pull/15622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15622`

View PR using the GUI difftool: \
`$ git pr show -t 15622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15622.diff">https://git.openjdk.org/jdk/pull/15622.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15622#issuecomment-1710454251)