### PR TITLE
8304956: Update KeyStore.getDefaultType​() specification to return pkcs12 as fallback

### DIFF
--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -205,7 +205,7 @@ public class KeyStore {
      * the default keystore type.
      * In the Security properties file, the default keystore type is given as:
      * <pre>
-     * keystore.type=jks
+     * keystore.type=pkcs12
      * </pre>
      */
     private static final String KEYSTORE_TYPE = "keystore.type";

--- a/src/java.base/share/classes/java/security/KeyStore.java
+++ b/src/java.base/share/classes/java/security/KeyStore.java
@@ -971,8 +971,7 @@ public class KeyStore {
     /**
      * Returns the default keystore type as specified by the
      * {@code keystore.type} security property, or the string
-     * {@literal "jks"} (acronym for {@literal "Java keystore"})
-     * if no such property exists.
+     * {@literal "pkcs12"} if no such property exists.
      *
      * <p>The default keystore type can be used by applications that do not
      * want to use a hard-coded keystore type when calling one of the
@@ -983,7 +982,7 @@ public class KeyStore {
      * {@code keystore.type} security property to the desired keystore type.
      *
      * @return the default keystore type as specified by the
-     * {@code keystore.type} security property, or the string {@literal "jks"}
+     * {@code keystore.type} security property, or the string {@literal "pkcs12"}
      * if no such property exists.
      * @see java.security.Security security properties
      */
@@ -992,7 +991,7 @@ public class KeyStore {
         String kstype = AccessController.doPrivileged((PrivilegedAction<String>) () ->
             Security.getProperty(KEYSTORE_TYPE));
         if (kstype == null) {
-            kstype = "jks";
+            kstype = "pkcs12";
         }
         return kstype;
     }

--- a/test/jdk/java/security/KeyStore/PKCS12/CheckNullDefault.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/CheckNullDefault.java
@@ -29,7 +29,7 @@ import static java.lang.System.out;
  * @summary Set keystore.type as null and check that
  * KeyStore.getDefaultType() returns pkcs12
  * @run main/othervm
- *  -Djava.security.properties=${test.src}/java.security CheckDefaults
+ *  -Djava.security.properties==${test.src}/java.security CheckDefaults
  */
 public class CheckNullDefault {
     public static void main(String[] args) {

--- a/test/jdk/java/security/KeyStore/PKCS12/CheckNullDefault.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/CheckNullDefault.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.security.KeyStore;
+import static java.lang.System.out;
+
+/**
+ * @test
+ * @bug 8304956
+ * @summary Set up keystore.type as null and check that
+ * KeyStore.getDefaultType() value is related to property value. Expect a full
+ * match the value 'keystore.type' and the value of the
+ * KeyStore.getDefaultType()
+ * @run main/othervm CheckDefaults
+ *  -Djava.security.properties=./java.security
+ */
+public class CheckNullDefault {
+    private static final String DEFAULT_KEY_STORE_TYPE = "pkcs12";
+    private void runTest(String[] args) {
+        if (!KeyStore.getDefaultType().
+            equalsIgnoreCase(DEFAULT_KEY_STORE_TYPE)) {
+            throw new RuntimeException(String.format("Default keystore type "
+                    + "Expected '%s' . Actual: '%s' ", DEFAULT_KEY_STORE_TYPE,
+                KeyStore.getDefaultType()));
+        }
+        out.println("Test Passed");
+    }
+
+    public static void main(String[] args) {
+        CheckNullDefault checkDefaultsTest = new CheckNullDefault();
+        checkDefaultsTest.runTest(args);
+    }
+}

--- a/test/jdk/java/security/KeyStore/PKCS12/CheckNullDefault.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/CheckNullDefault.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -30,23 +28,17 @@ import static java.lang.System.out;
  * @bug 8304956
  * @summary Set keystore.type as null and check that
  * KeyStore.getDefaultType() returns pkcs12
- * @run main/othervm CheckDefaults
- *  -Djava.security.properties=./java.security
+ * @run main/othervm
+ *  -Djava.security.properties=${test.src}/java.security CheckDefaults
  */
 public class CheckNullDefault {
-    private static final String DEFAULT_KEY_STORE_TYPE = "pkcs12";
-    private void runTest(String[] args) {
+    public static void main(String[] args) {
         if (!KeyStore.getDefaultType().
-                equalsIgnoreCase(DEFAULT_KEY_STORE_TYPE)) {
+            equalsIgnoreCase("pkcs12")) {
             throw new RuntimeException(String.format("Default keystore type "
-                    + "Expected '%s' . Actual: '%s' ", DEFAULT_KEY_STORE_TYPE,
-                    KeyStore.getDefaultType()));
+                    + "Expected '%s' . Actual: '%s' ", "pkcs12",
+                KeyStore.getDefaultType()));
         }
         out.println("Test Passed");
-    }
-
-    public static void main(String[] args) {
-        CheckNullDefault checkDefaultsTest = new CheckNullDefault();
-        checkDefaultsTest.runTest(args);
     }
 }

--- a/test/jdk/java/security/KeyStore/PKCS12/CheckNullDefault.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/CheckNullDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,8 @@ import static java.lang.System.out;
 /**
  * @test
  * @bug 8304956
- * @summary Set up keystore.type as null and check that
- * KeyStore.getDefaultType() value is related to property value. Expect a full
- * match the value 'keystore.type' and the value of the
- * KeyStore.getDefaultType()
+ * @summary Set keystore.type as null and check that
+ * KeyStore.getDefaultType() returns pkcs12
  * @run main/othervm CheckDefaults
  *  -Djava.security.properties=./java.security
  */
@@ -39,10 +37,10 @@ public class CheckNullDefault {
     private static final String DEFAULT_KEY_STORE_TYPE = "pkcs12";
     private void runTest(String[] args) {
         if (!KeyStore.getDefaultType().
-            equalsIgnoreCase(DEFAULT_KEY_STORE_TYPE)) {
+                equalsIgnoreCase(DEFAULT_KEY_STORE_TYPE)) {
             throw new RuntimeException(String.format("Default keystore type "
                     + "Expected '%s' . Actual: '%s' ", DEFAULT_KEY_STORE_TYPE,
-                KeyStore.getDefaultType()));
+                    KeyStore.getDefaultType()));
         }
         out.println("Test Passed");
     }

--- a/test/jdk/java/security/KeyStore/PKCS12/java.security
+++ b/test/jdk/java/security/KeyStore/PKCS12/java.security
@@ -1,0 +1,2 @@
+# override keystore.type property and make it not exist
+#keystore.type=

--- a/test/jdk/java/security/KeyStore/PKCS12/java.security
+++ b/test/jdk/java/security/KeyStore/PKCS12/java.security
@@ -1,2 +1,2 @@
-# override keystore.type property and make it not exist
+# do not set keystore.type property, so default value will be used
 #keystore.type=


### PR DESCRIPTION
Replaced "jks" with "pkcs12" in both the spec and fallback for `KeyStore.getDefaultType()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8316043](https://bugs.openjdk.org/browse/JDK-8316043) to be approved

### Issues
 * [JDK-8304956](https://bugs.openjdk.org/browse/JDK-8304956): Update KeyStore.getDefaultType​() specification to return pkcs12 as fallback (**Bug** - P4)
 * [JDK-8316043](https://bugs.openjdk.org/browse/JDK-8316043): Update KeyStore.getDefaultType​() specification to return pkcs12 as fallback (**CSR**)


### Reviewers
 * @Findoboutme32 (no known openjdk.org user name / role) ⚠️ Review applies to [74573641](https://git.openjdk.org/jdk/pull/15625/files/74573641c164eaadce74a1a0ee5f80a9dbb7ab32)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer) ⚠️ Review applies to [26978443](https://git.openjdk.org/jdk/pull/15625/files/26978443e5e2464891098f2e3330a0be54e7d8b6)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15625/head:pull/15625` \
`$ git checkout pull/15625`

Update a local copy of the PR: \
`$ git checkout pull/15625` \
`$ git pull https://git.openjdk.org/jdk.git pull/15625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15625`

View PR using the GUI difftool: \
`$ git pr show -t 15625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15625.diff">https://git.openjdk.org/jdk/pull/15625.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15625#issuecomment-1710590392)