### PR TITLE
JDK-8315897: some PrivilegedActions missing in JDK code for getting properties

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
+++ b/src/java.desktop/share/classes/sun/awt/FontConfiguration.java
@@ -130,9 +130,12 @@ public abstract class FontConfiguration {
      * default uses the system properties os.name and os.version;
      * subclasses may override.
      */
+    @SuppressWarnings("removal")
     protected void setOsNameAndVersion() {
-        osName = System.getProperty("os.name");
-        osVersion = System.getProperty("os.version");
+        osName = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("os.name"));
+        osVersion = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("os.version"));
     }
 
     private void setEncoding() {

--- a/src/java.management/share/classes/sun/management/VMManagementImpl.java
+++ b/src/java.management/share/classes/sun/management/VMManagementImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,29 +151,53 @@ class VMManagementImpl implements VMManagement {
     private native int getProcessId();
 
     public String   getVmName() {
-        return System.getProperty("java.vm.name");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("java.vm.name"));
+        return sh;
     }
 
     public String   getVmVendor() {
-        return System.getProperty("java.vm.vendor");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("java.vm.vendor"));
+        return sh;
     }
     public String   getVmVersion() {
-        return System.getProperty("java.vm.version");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("java.vm.version"));
+        return sh;
     }
     public String   getVmSpecName()  {
-        return System.getProperty("java.vm.specification.name");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("java.vm.specification.name"));
+        return sh;
     }
     public String   getVmSpecVendor() {
-        return System.getProperty("java.vm.specification.vendor");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("java.vm.specification.vendor"));
+        return sh;
     }
     public String   getVmSpecVersion() {
-        return System.getProperty("java.vm.specification.version");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("java.vm.specification.version"));
+        return sh;
     }
     public String   getClassPath() {
-        return System.getProperty("java.class.path");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("java.class.path"));
+        return sh;
     }
     public String   getLibraryPath()  {
-        return System.getProperty("java.library.path");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("java.library.path"));
+        return sh;
     }
 
     public String   getBootClassPath( ) {
@@ -204,13 +228,9 @@ class VMManagementImpl implements VMManagement {
     // Compilation Subsystem
     public String   getCompilerName() {
         @SuppressWarnings("removal")
-        String name =  AccessController.doPrivileged(
-            new PrivilegedAction<>() {
-                public String run() {
-                    return System.getProperty("sun.management.compiler");
-                }
-            });
-        return name;
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("sun.management.compiler"));
+        return sh;
     }
     public native long getTotalCompileTime();
 
@@ -222,13 +242,22 @@ class VMManagementImpl implements VMManagement {
 
     // Operating System
     public String getOsName() {
-        return System.getProperty("os.name");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("os.name"));
+        return sh;
     }
     public String getOsArch() {
-        return System.getProperty("os.arch");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("os.arch"));
+        return sh;
     }
     public String getOsVersion() {
-        return System.getProperty("os.version");
+        @SuppressWarnings("removal")
+        String sh = AccessController.doPrivileged(
+          (PrivilegedAction<String>)()->System.getProperty("os.version"));
+        return sh;
     }
 
     // Hotspot-specific runtime support


### PR DESCRIPTION
There are some remaining places in 'general' JDK code (= code not related to e.g. a specific tool) getting properties like :

osName = System.getProperty(os.name)

https://github.com/openjdk/jdk/blob/master/src/java.management/share/classes/sun/management/VMManagementImpl.java#L225

https://github.com/openjdk/jdk/blob/master/src/java.desktop/share/classes/sun/awt/FontConfiguration.java#L134

Those should be a PrivilegedAction .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315897](https://bugs.openjdk.org/browse/JDK-8315897): some PrivilegedActions missing in JDK code for getting properties (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15629/head:pull/15629` \
`$ git checkout pull/15629`

Update a local copy of the PR: \
`$ git checkout pull/15629` \
`$ git pull https://git.openjdk.org/jdk.git pull/15629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15629`

View PR using the GUI difftool: \
`$ git pr show -t 15629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15629.diff">https://git.openjdk.org/jdk/pull/15629.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15629#issuecomment-1711288605)