### PR TITLE
8315770: serviceability/sa/TestJmapCoreMetaspace.java should run with -XX:-VerifyDependencies

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJmapCore.java
@@ -73,6 +73,7 @@ public class TestJmapCore {
     static void test(String type) throws Throwable {
         ProcessBuilder pb = ProcessTools.createTestJvm("-XX:+CreateCoredumpOnCrash",
                 "-Xmx512m", "-XX:MaxMetaspaceSize=64m", "-XX:+CrashOnOutOfMemoryError",
+                "-XX:-VerifyDependencies", "-XX:+IgnoreUnrecognizedVMOptions",
                 CoreUtils.getAlwaysPretouchArg(true),
                 TestJmapCore.class.getName(), type);
 


### PR DESCRIPTION
8315770: serviceability/sa/TestJmapCoreMetaspace.java should run with -XX:-VerifyDependencies

serviceability/sa/TestJmapCoreMetaspace.java runs in hotspot:tier2, and takes about 330 seconds out of 670 seconds of the entire run on x86_64 fastdebug. The tier2 completion usually waits on it. Profiling shows we are spending time during classloading, checking dependencies. Since we load lots of classes, we do it many times, and each time the cost grows linearly to the number of classes. Some other tests that target metaspace explicitly disable `VerifyDependencies` to avoid this.

The commit includes adding "-XX:-VerifyDependencies" along with "-XX:+IgnoreUnrecognizedVMOptions" in TestJmapCore.java to make sure that release builds work with the test, as VerifyDependencies is a develop option and not available in release builds. The changes in the commit is resulting in considerable improvement for the test in fastdebug mode as can be seen below:

* before: **130.41s user 14.11s system 118% cpu 2:01.85 total**
* after: **27.52s user 13.64s system 213% cpu 19.249 total**