### PR TITLE
8315891: java/foreign/TestLinker.java failed with "error occurred while instantiating class TestLinker: null"

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
@@ -42,7 +42,7 @@ final class LibFallback {
                 new java.security.PrivilegedAction<>() {
                     public Boolean run() {
                         try {
-                            System.loadLibrary("jimage");
+                            System.loadLibrary("fallbackLinker");
                             init();
                             return true;
                         } catch (UnsatisfiedLinkError ule) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
@@ -36,14 +36,20 @@ final class LibFallback {
 
     static final boolean SUPPORTED = tryLoadLibrary();
 
+    @SuppressWarnings("removal")
     private static boolean tryLoadLibrary() {
-        try {
-            System.loadLibrary("fallbackLinker");
-        } catch (UnsatisfiedLinkError ule) {
-            return false;
-        }
-        init();
-        return true;
+        return java.security.AccessController.doPrivileged(
+                new java.security.PrivilegedAction<>() {
+                    public Boolean run() {
+                        try {
+                            System.loadLibrary("jimage");
+                            init();
+                            return true;
+                        } catch (UnsatisfiedLinkError ule) {
+                            return false;
+                        }
+                    }
+                });
     }
 
     static int defaultABI() { return NativeConstants.DEFAULT_ABI; }


### PR DESCRIPTION
This PR adds a privileged block surrounding the request to load the fallback linker library in LibFallback.
The lack of this block is causing test failures when platforms using the fallback linker are tested using a security manager.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315891](https://bugs.openjdk.org/browse/JDK-8315891): java/foreign/TestLinker.java failed with "error occurred while instantiating class TestLinker: null" (**Bug** - P4)


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15633/head:pull/15633` \
`$ git checkout pull/15633`

Update a local copy of the PR: \
`$ git checkout pull/15633` \
`$ git pull https://git.openjdk.org/jdk.git pull/15633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15633`

View PR using the GUI difftool: \
`$ git pr show -t 15633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15633.diff">https://git.openjdk.org/jdk/pull/15633.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15633#issuecomment-1711444840)