### PR TITLE
8315933: Serial: Remove empty Generation::ensure_parsability

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -328,7 +328,7 @@ class CollectedHeap : public CHeapObj<mtGC> {
   // super::ensure_parsability so that the non-generational
   // part of the work gets done. See implementation of
   // CollectedHeap::ensure_parsability and, for instance,
-  // that of GenCollectedHeap::ensure_parsability().
+  // that of ParallelScavengeHeap::ensure_parsability().
   // The argument "retire_tlabs" controls whether existing TLABs
   // are merely filled or also retired, thus preventing further
   // allocation from them and necessitating allocation of new TLABs.

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -1069,16 +1069,3 @@ void GenCollectedHeap::record_gen_tops_before_GC() {
   }
 }
 #endif  // not PRODUCT
-
-class GenEnsureParsabilityClosure: public GenCollectedHeap::GenClosure {
- public:
-  void do_generation(Generation* gen) {
-    gen->ensure_parsability();
-  }
-};
-
-void GenCollectedHeap::ensure_parsability(bool retire_tlabs) {
-  CollectedHeap::ensure_parsability(retire_tlabs);
-  GenEnsureParsabilityClosure ep_cl;
-  generation_iterate(&ep_cl, false);
-}

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -228,9 +228,6 @@ public:
                               size_t requested_size,
                               size_t* actual_size) override;
 
-  // Ensure parsability
-  void ensure_parsability(bool retire_tlabs) override;
-
   // Total number of full collections completed.
   unsigned int total_full_collections_completed() {
     assert(_full_collections_completed <= _total_full_collections,

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -291,10 +291,6 @@ class Generation: public CHeapObj<mtGC> {
   // Save the high water marks for the used space in a generation.
   virtual void record_spaces_top() {}
 
-  // Some generations may need to be "fixed-up" after some allocation
-  // activity to make them parsable again. The default is to do nothing.
-  virtual void ensure_parsability() {}
-
   // Generations may keep statistics about collection. This method
   // updates those statistics. current_generation is the generation
   // that was most recently collected. This allows the generation to


### PR DESCRIPTION
Simple removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315933](https://bugs.openjdk.org/browse/JDK-8315933): Serial: Remove empty Generation::ensure_parsability (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [43e8b49e](https://git.openjdk.org/jdk/pull/15636/files/43e8b49e0b4365cdf81b280e1437616627f84124)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to [43e8b49e](https://git.openjdk.org/jdk/pull/15636/files/43e8b49e0b4365cdf81b280e1437616627f84124)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15636/head:pull/15636` \
`$ git checkout pull/15636`

Update a local copy of the PR: \
`$ git checkout pull/15636` \
`$ git pull https://git.openjdk.org/jdk.git pull/15636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15636`

View PR using the GUI difftool: \
`$ git pr show -t 15636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15636.diff">https://git.openjdk.org/jdk/pull/15636.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15636#issuecomment-1711597529)