### PR TITLE
8315932: runtime/InvocationTests spend a lot of time on dependency verification

### DIFF
--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
@@ -72,6 +72,7 @@ public class invocationC1Tests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M",
             "-Xcomp", "-XX:TieredStopAtLevel=1",
+            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
             whichTests, "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationOldCHATests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationOldCHATests.java
@@ -69,6 +69,7 @@ public class invocationOldCHATests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M",
             "-Xcomp", "-XX:+UnlockDiagnosticVMOptions", "-XX:-UseVtableBasedCHA",
+            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
             whichTests, "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
@@ -75,6 +75,7 @@ public class invokeinterfaceTests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M", option,
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
+            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "invokeinterface.Generator", "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         try {

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
@@ -72,6 +72,7 @@ public class invokespecialTests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M", option,
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
+            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "invokespecial.Generator", "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         try {

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
@@ -72,6 +72,7 @@ public class invokevirtualTests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M", option,
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
+            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "invokevirtual.Generator", "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         try {


### PR DESCRIPTION
Looking at performance of `runtime/InvocationTests` that run in `hotspot:tier3`, I notice that in `-Xcomp` tests, we are spending considerable time verifying nmethod dependencies, due to large number of generated classes. Normally, we would just add `-XX:-VerifyDependencies` to test that generates lots of classes, but I think this test actually wants to verify dependencies as part of the end-to-end invocation checks.

So, I think we can still mitigate the impact of dependency verification by making class unloading more frequent, so that stale classes would get unloaded often, and thus stop being considered by verification code as potential dependencies. One way is to trim down the metaspace size. (Maybe @tstuefe knows a better way to do this.)

Example improvements:

```
$ time CONF=linux-x86_64-server-fastdebug make test TEST=runtime/InvocationTests/

# Before
 4303.87s user 94.13s system 465% cpu 15:45.09 total

# After
 2860.52s user 116.86s system 680% cpu 7:17.80 total

# (for the reference, disabling verification completely with -XX:-VerifyDependencies)
 2284.49s user 84.64s system 605% cpu 6:31.30 total
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315932](https://bugs.openjdk.org/browse/JDK-8315932): runtime/InvocationTests spend a lot of time on dependency verification (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15637/head:pull/15637` \
`$ git checkout pull/15637`

Update a local copy of the PR: \
`$ git checkout pull/15637` \
`$ git pull https://git.openjdk.org/jdk.git pull/15637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15637`

View PR using the GUI difftool: \
`$ git pr show -t 15637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15637.diff">https://git.openjdk.org/jdk/pull/15637.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15637#issuecomment-1711651313)