### PR TITLE
8315942: Sort platform enums and definitions after JDK-8304913 follow-ups

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -41,20 +41,20 @@ public enum Architecture {
      * An unknown architecture not specifically named.
      * The addrSize and ByteOrder values are those of the current architecture.
      */
-    OTHER(is64bit() ? 64 : 32, ByteOrder.nativeOrder()),
-    X64(64, ByteOrder.LITTLE_ENDIAN),  // Represents AMD64 and X86_64
-    X86(32, ByteOrder.LITTLE_ENDIAN),
     AARCH64(64, ByteOrder.LITTLE_ENDIAN),
     ARM(32, ByteOrder.LITTLE_ENDIAN),
-    RISCV64(64, ByteOrder.LITTLE_ENDIAN),
     LOONGARCH64(64, ByteOrder.LITTLE_ENDIAN),
-    S390(64, ByteOrder.BIG_ENDIAN),
+    MIPSEL(32, ByteOrder.LITTLE_ENDIAN),
+    MIPS64EL(64, ByteOrder.LITTLE_ENDIAN),
+    OTHER(is64bit() ? 64 : 32, ByteOrder.nativeOrder()),
     PPC(32, ByteOrder.BIG_ENDIAN),
     PPC64(64, ByteOrder.BIG_ENDIAN),
     PPC64LE(64, ByteOrder.LITTLE_ENDIAN),
-    MIPSEL(32, ByteOrder.LITTLE_ENDIAN),
-    MIPS64EL(64, ByteOrder.LITTLE_ENDIAN),
+    RISCV64(64, ByteOrder.LITTLE_ENDIAN),
+    S390(64, ByteOrder.BIG_ENDIAN),
     SPARCV9(64, ByteOrder.BIG_ENDIAN),
+    X86(32, ByteOrder.LITTLE_ENDIAN),
+    X64(64, ByteOrder.LITTLE_ENDIAN),  // Represents AMD64 and X86_64
     ;
 
     private final int addrSize;

--- a/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
+++ b/src/java.base/share/classes/jdk/internal/util/PlatformProps.java.template
@@ -52,17 +52,18 @@ class PlatformProps {
     // Precomputed booleans for each Architecture, shared with jdk.internal.util.Architecture
     // The variables are named to match the Architecture value names, and
     // the values chosen to match the build values.
-    static final boolean TARGET_ARCH_IS_X64     = "@@OPENJDK_TARGET_CPU@@" == "x64";
-    static final boolean TARGET_ARCH_IS_X86     = "@@OPENJDK_TARGET_CPU@@" == "x86";
     static final boolean TARGET_ARCH_IS_AARCH64 = "@@OPENJDK_TARGET_CPU@@" == "aarch64";
     static final boolean TARGET_ARCH_IS_ARM     = "@@OPENJDK_TARGET_CPU@@" == "arm";
-    static final boolean TARGET_ARCH_IS_RISCV64 = "@@OPENJDK_TARGET_CPU@@" == "riscv64";
     static final boolean TARGET_ARCH_IS_LOONGARCH64 = "@@OPENJDK_TARGET_CPU@@" == "loongarch64";
-    static final boolean TARGET_ARCH_IS_S390    = "@@OPENJDK_TARGET_CPU@@" == "s390";
+    static final boolean TARGET_ARCH_IS_MIPSEL  = "@@OPENJDK_TARGET_CPU@@" == "mipsel";
+    static final boolean TARGET_ARCH_IS_MIPS64EL= "@@OPENJDK_TARGET_CPU@@" == "mips64el";
     static final boolean TARGET_ARCH_IS_PPC     = "@@OPENJDK_TARGET_CPU@@" == "ppc";
     static final boolean TARGET_ARCH_IS_PPC64   = "@@OPENJDK_TARGET_CPU@@" == "ppc64";
     static final boolean TARGET_ARCH_IS_PPC64LE = "@@OPENJDK_TARGET_CPU@@" == "ppc64le";
-    static final boolean TARGET_ARCH_IS_MIPSEL  = "@@OPENJDK_TARGET_CPU@@" == "mipsel";
-    static final boolean TARGET_ARCH_IS_MIPS64EL= "@@OPENJDK_TARGET_CPU@@" == "mips64el";
+    static final boolean TARGET_ARCH_IS_RISCV64 = "@@OPENJDK_TARGET_CPU@@" == "riscv64";
+    static final boolean TARGET_ARCH_IS_S390    = "@@OPENJDK_TARGET_CPU@@" == "s390";
     static final boolean TARGET_ARCH_IS_SPARCV9 = "@@OPENJDK_TARGET_CPU@@" == "sparcv9";
+    static final boolean TARGET_ARCH_IS_X86     = "@@OPENJDK_TARGET_CPU@@" == "x86";
+    static final boolean TARGET_ARCH_IS_X64     = "@@OPENJDK_TARGET_CPU@@" == "x64";
+
 }

--- a/test/jdk/jdk/internal/util/ArchTest.java
+++ b/test/jdk/jdk/internal/util/ArchTest.java
@@ -30,17 +30,17 @@ import jdk.internal.misc.Unsafe;
 
 import static jdk.internal.util.Architecture.AARCH64;
 import static jdk.internal.util.Architecture.ARM;
+import static jdk.internal.util.Architecture.LOONGARCH64;
+import static jdk.internal.util.Architecture.MIPSEL;
+import static jdk.internal.util.Architecture.MIPS64EL;
 import static jdk.internal.util.Architecture.PPC;
 import static jdk.internal.util.Architecture.PPC64;
 import static jdk.internal.util.Architecture.PPC64LE;
 import static jdk.internal.util.Architecture.RISCV64;
-import static jdk.internal.util.Architecture.LOONGARCH64;
 import static jdk.internal.util.Architecture.S390;
+import static jdk.internal.util.Architecture.SPARCV9;
 import static jdk.internal.util.Architecture.X64;
 import static jdk.internal.util.Architecture.X86;
-import static jdk.internal.util.Architecture.MIPSEL;
-import static jdk.internal.util.Architecture.MIPS64EL;
-import static jdk.internal.util.Architecture.SPARCV9;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
@RogerRiggs asked for this. The moves are mechanical, so nothing should be lost. Tell me if other things need to be sorted as well.

I would wait a little to see if there are any more JDK-8304913 followups.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315942](https://bugs.openjdk.org/browse/JDK-8315942): Sort platform enums and definitions after JDK-8304913 follow-ups (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15640/head:pull/15640` \
`$ git checkout pull/15640`

Update a local copy of the PR: \
`$ git checkout pull/15640` \
`$ git pull https://git.openjdk.org/jdk.git pull/15640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15640`

View PR using the GUI difftool: \
`$ git pr show -t 15640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15640.diff">https://git.openjdk.org/jdk/pull/15640.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15640#issuecomment-1711861749)