### PR TITLE
8315938: Deprecate for removal Unsafe methods that have standard APIs for many releases

### DIFF
--- a/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
+++ b/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1089,7 +1089,10 @@ public final class Unsafe {
      * so when calling from native code.
      *
      * @param thread the thread to unpark.
+     *
+     * @deprecated Use {@link java.util.concurrent.locks.LockSupport#unpark(Thread)} instead.
      */
+    @Deprecated(since="22", forRemoval=true)
     @ForceInline
     public void unpark(Object thread) {
         theInternalUnsafe.unpark(thread);
@@ -1105,7 +1108,11 @@ public final class Unsafe {
      * "reason"). Note: This operation is in the Unsafe class only
      * because {@code unpark} is, so it would be strange to place it
      * elsewhere.
+     *
+     * @deprecated Use {@link java.util.concurrent.locks.LockSupport#parkNanos(long)} or
+     * {@link java.util.concurrent.locks.LockSupport#parkUntil(long)} instead.
      */
+    @Deprecated(since="22", forRemoval=true)
     @ForceInline
     public void park(boolean isAbsolute, long time) {
         theInternalUnsafe.park(isAbsolute, time);
@@ -1125,7 +1132,11 @@ public final class Unsafe {
      *
      * @return the number of samples actually retrieved; or -1
      *         if the load average is unobtainable.
+     *
+     * @deprecated Use {@link java.lang.management.OperatingSystemMXBean#getSystemLoadAverage()}
+     * instead.
      */
+    @Deprecated(since="22", forRemoval=true)
     @ForceInline
     public int getLoadAverage(double[] loadavg, int nelems) {
         return theInternalUnsafe.getLoadAverage(loadavg, nelems);
@@ -1214,7 +1225,6 @@ public final class Unsafe {
         return theInternalUnsafe.getAndSetReference(o, offset, newValue);
     }
 
-
     /**
      * Ensures that loads before the fence will not be reordered with loads and
      * stores after the fence; a "LoadLoad plus LoadStore barrier".
@@ -1225,8 +1235,11 @@ public final class Unsafe {
      * A pure LoadLoad fence is not provided, since the addition of LoadStore
      * is almost always desired, and most current hardware instructions that
      * provide a LoadLoad barrier also provide a LoadStore barrier for free.
+     *
+     * @deprecated Use {@link java.lang.invoke.VarHandle#acquireFence()} instead.
      * @since 1.8
      */
+    @Deprecated(since="22", forRemoval=true)
     @ForceInline
     public void loadFence() {
         theInternalUnsafe.loadFence();
@@ -1242,8 +1255,11 @@ public final class Unsafe {
      * A pure StoreStore fence is not provided, since the addition of LoadStore
      * is almost always desired, and most current hardware instructions that
      * provide a StoreStore barrier also provide a LoadStore barrier for free.
+     *
+     * @deprecated Use {@link java.lang.invoke.VarHandle#releaseFence()} instead.
      * @since 1.8
      */
+    @Deprecated(since="22", forRemoval=true)
     @ForceInline
     public void storeFence() {
         theInternalUnsafe.storeFence();
@@ -1256,8 +1272,11 @@ public final class Unsafe {
      * barrier.
      *
      * Corresponds to C11 atomic_thread_fence(memory_order_seq_cst).
+     *
+     * @deprecated Use {@link java.lang.invoke.VarHandle#fullFence()} instead.
      * @since 1.8
      */
+    @Deprecated(since="22", forRemoval=true)
     @ForceInline
     public void fullFence() {
         theInternalUnsafe.fullFence();


### PR DESCRIPTION
There are several methods defined by sun.misc.Unsafe that have standard API equivalents for many years and releases. The change proposed here is to deprecate, for removal, the park, unpark, getLoadAverage, loadFence, storeFence, and fullFence methods. Code using these methods should move to LockSupport.park/unpark (Java 5), OperatingSystemMXBean.getSystemLoadAverage (Java 6), and VarHandles xxxFence methods (Java 9).

The following is a summary of a search of 175973022 classes in 484751 artifacts to get a sense of the usage of these methods.

- 1290 usages of Unsafe.park. 1195 are libraries that have re-packaged some version of ForkJoinPool, maybe from the jsr166 repo, maybe an older JDK release. In the remaining, only Ehcache stands out with 29 matches. It seems to be one usage but the library seems to copied/shaded into other artifacts.

- 1322 usages of Unsafe.unpark. 1243 are re-packaged ForkJoinPool. 29 occurrences are Encache, again one usage but the library seems to copied/shaded into other artifacts.

- 22 usages of Unsafe.getLoadAverage. Most of these are one usage in many published versions of Apache HBase.

- 339 usages of Unsafe.loadFence, 1057 usages of Unsafe.storeFence, 517 usages of Unsafe.fullFence. A handful of these are libraries with copies of j.u.concurrent, the rest seem to be high performance libraries that support older JDK releases or just haven't been updated to use VarHandles yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8315953](https://bugs.openjdk.org/browse/JDK-8315953) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8315938](https://bugs.openjdk.org/browse/JDK-8315938): Deprecate for removal Unsafe methods that have standard APIs for many releases (**Enhancement** - P4)
 * [JDK-8315953](https://bugs.openjdk.org/browse/JDK-8315953): Deprecate for removal Unsafe methods that have standard APIs for many releases (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15641/head:pull/15641` \
`$ git checkout pull/15641`

Update a local copy of the PR: \
`$ git checkout pull/15641` \
`$ git pull https://git.openjdk.org/jdk.git pull/15641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15641`

View PR using the GUI difftool: \
`$ git pr show -t 15641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15641.diff">https://git.openjdk.org/jdk/pull/15641.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15641#issuecomment-1712103190)