### PR TITLE
8315948: JDK-8315818 broke Xcomp on libgraal

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1229,6 +1229,7 @@ void CompileBroker::compile_method_base(const methodHandle& method,
         blocking = false;
       }
 
+      // In libjvmci, JVMCI initialization should not deadlock with other threads
       if (!UseJVMCINativeLibrary) {
         // Don't allow blocking compiles if inside a class initializer or while performing class loading
         vframeStream vfst(JavaThread::cast(thread));
@@ -1246,8 +1247,6 @@ void CompileBroker::compile_method_base(const methodHandle& method,
         if (!JVMCI::is_compiler_initialized() && compiler(comp_level)->is_jvmci()) {
           blocking = false;
         }
-      } else {
-        // In libjvmci, JVMCI initialization should not deadlock with other threads
       }
 
       // Don't allow blocking compilation requests if we are in JVMCIRuntime::shutdown

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1240,12 +1240,14 @@ void CompileBroker::compile_method_base(const methodHandle& method,
             break;
           }
         }
-      }
 
-      // Don't allow blocking compilation requests to JVMCI
-      // if JVMCI itself is not yet initialized
-      if (!JVMCI::is_compiler_initialized() && compiler(comp_level)->is_jvmci()) {
-        blocking = false;
+        // Don't allow blocking compilation requests to JVMCI
+        // if JVMCI itself is not yet initialized
+        if (!JVMCI::is_compiler_initialized() && compiler(comp_level)->is_jvmci()) {
+          blocking = false;
+        }
+      } else {
+        // In libjvmci, JVMCI initialization should not deadlock with other threads
       }
 
       // Don't allow blocking compilation requests if we are in JVMCIRuntime::shutdown


### PR DESCRIPTION
This PR fixes a regression caused by [JDK-8315818](https://bugs.openjdk.org/browse/JDK-8315818). Libgraal must not unblock a thread waiting on a blocking compilation, even if libgraal itself is not yet initialized. Initialization of libgraal is not prone to the same initialization deadlocks that jargraal can cause.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315948](https://bugs.openjdk.org/browse/JDK-8315948): JDK-8315818 broke Xcomp on libgraal (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [5c50d5e8](https://git.openjdk.org/jdk/pull/15643/files/5c50d5e82c860587f146e6a1524e20c95df43c95)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15643/head:pull/15643` \
`$ git checkout pull/15643`

Update a local copy of the PR: \
`$ git checkout pull/15643` \
`$ git pull https://git.openjdk.org/jdk.git pull/15643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15643`

View PR using the GUI difftool: \
`$ git pr show -t 15643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15643.diff">https://git.openjdk.org/jdk/pull/15643.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15643#issuecomment-1712075896)