### PR TITLE
8315940: ARM32: Move field resolution information out of the cpCache

### DIFF
--- a/src/hotspot/cpu/arm/interp_masm_arm.hpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.hpp
@@ -102,6 +102,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void load_resolved_klass_at_offset(Register Rcpool, Register Rindex, Register Rklass);
 
   void load_resolved_indy_entry(Register cache, Register index);
+  void load_field_entry(Register cache, Register index, int bcp_offset = 1);
 
   void pop_ptr(Register r);
   void pop_i(Register r = R0_tos);


### PR DESCRIPTION
Fix the ARM32 port after JDK-8301996. 

Testing: Tier-1 tests pass, tests in JDK-8301996 pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315940](https://bugs.openjdk.org/browse/JDK-8315940): ARM32: Move field resolution information out of the cpCache (**Bug** - P2)


### Reviewers
 * [Dmitry Samersoff](https://openjdk.org/census#dsamersoff) (@dsamersoff - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15645/head:pull/15645` \
`$ git checkout pull/15645`

Update a local copy of the PR: \
`$ git checkout pull/15645` \
`$ git pull https://git.openjdk.org/jdk.git pull/15645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15645`

View PR using the GUI difftool: \
`$ git pr show -t 15645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15645.diff">https://git.openjdk.org/jdk/pull/15645.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15645#issuecomment-1712178382)