### PR TITLE
JDK-8315946: DecimalFormat and CompactNumberFormat do allow U+FFFE and U+FFFF in the pattern

### DIFF
--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -169,11 +169,11 @@ import java.util.stream.Collectors;
  * <i>NegativePattern:</i>
  *        <i>Prefix<sub>optional</sub></i> <i>MinimumInteger</i> <i>Suffix<sub>optional</sub></i>
  * <i>Prefix:</i>
- *      Any Unicode characters except {@code U+FFFE}, {@code U+FFFF}, and
- *      {@linkplain DecimalFormat##special_pattern_character special characters}.
+ *      Any Unicode characters except the {@linkplain
+ *      DecimalFormat##special_pattern_character special characters}.
  * <i>Suffix:</i>
- *      Any Unicode characters except {@code U+FFFE}, {@code U+FFFF}, and
- *      {@linkplain DecimalFormat##special_pattern_character special characters}.
+ *      Any Unicode characters except the {@linkplain
+ *      DecimalFormat##special_pattern_character special characters}.
  * <i>MinimumInteger:</i>
  *      0
  *      0 <i>MinimumInteger</i>

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -169,10 +169,10 @@ import java.util.stream.Collectors;
  * <i>NegativePattern:</i>
  *        <i>Prefix<sub>optional</sub></i> <i>MinimumInteger</i> <i>Suffix<sub>optional</sub></i>
  * <i>Prefix:</i>
- *      Any Unicode characters except the {@linkplain
+ *      Any characters except the {@linkplain
  *      DecimalFormat##special_pattern_character special characters}.
  * <i>Suffix:</i>
- *      Any Unicode characters except the {@linkplain
+ *      Any characters except the {@linkplain
  *      DecimalFormat##special_pattern_character special characters}.
  * <i>MinimumInteger:</i>
  *      0

--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -170,10 +170,10 @@ import java.util.stream.Collectors;
  *        <i>Prefix<sub>optional</sub></i> <i>MinimumInteger</i> <i>Suffix<sub>optional</sub></i>
  * <i>Prefix:</i>
  *      Any characters except the {@linkplain
- *      DecimalFormat##special_pattern_character special characters}.
+ *      DecimalFormat##special_pattern_character special pattern characters}
  * <i>Suffix:</i>
  *      Any characters except the {@linkplain
- *      DecimalFormat##special_pattern_character special characters}.
+ *      DecimalFormat##special_pattern_character special pattern characters}
  * <i>MinimumInteger:</i>
  *      0
  *      0 <i>MinimumInteger</i>

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -105,9 +105,11 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * <i>NegativePattern:</i>
  *         <i>Prefix<sub>opt</sub></i> <i>Number</i> <i>Suffix<sub>opt</sub></i>
  * <i>Prefix:</i>
- *         Any characters except the special characters
+ *         Any characters except the {@linkplain ##special_pattern_character
+ *         special pattern characters}
  * <i>Suffix:</i>
- *         Any characters except the special characters
+ *         Any characters except the {@linkplain ##special_pattern_character
+ *         special pattern characters}
  * <i>Number:</i>
  *         <i>Integer</i> <i>Exponent<sub>opt</sub></i>
  *         <i>Integer</i> . <i>Fraction</i> <i>Exponent<sub>opt</sub></i>

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -105,9 +105,9 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * <i>NegativePattern:</i>
  *         <i>Prefix<sub>opt</sub></i> <i>Number</i> <i>Suffix<sub>opt</sub></i>
  * <i>Prefix:</i>
- *         any Unicode characters except {@code U+FFFE}, {@code U+FFFF}, and special characters
+ *         Any Unicode characters except the special characters
  * <i>Suffix:</i>
- *         any Unicode characters except {@code U+FFFE}, {@code U+FFFF}, and special characters
+ *         Any Unicode characters except the special characters
  * <i>Number:</i>
  *         <i>Integer</i> <i>Exponent<sub>opt</sub></i>
  *         <i>Integer</i> . <i>Fraction</i> <i>Exponent<sub>opt</sub></i>

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -105,9 +105,9 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * <i>NegativePattern:</i>
  *         <i>Prefix<sub>opt</sub></i> <i>Number</i> <i>Suffix<sub>opt</sub></i>
  * <i>Prefix:</i>
- *         Any Unicode characters except the special characters
+ *         Any characters except the special characters
  * <i>Suffix:</i>
- *         Any Unicode characters except the special characters
+ *         Any characters except the special characters
  * <i>Number:</i>
  *         <i>Integer</i> <i>Exponent<sub>opt</sub></i>
  *         <i>Integer</i> . <i>Fraction</i> <i>Exponent<sub>opt</sub></i>


### PR DESCRIPTION
Please review this change which adjusts the pattern syntax specification for the two classes to represent the actual behavior. That is, U+FFFE and U+FFFF are allowed in the suffix/prefix. (Additionally; 'Unicode' is dropped from the definitions, as a Java character is composed of Unicode code points).

See code below, no exception is thrown.

```
String uFFFE = "\uFFFE";
String uFFFF = "\uFFFF";
var a = new DecimalFormat("prefixStart"+uFFFE+"0.00"+uFFFF+"SuffixEnd");
a.format(1); // returns "prefixStart￾1.00￿SuffixEnd"
var b = new CompactNumberFormat(a.toPattern(), a.getDecimalFormatSymbols(), new String[] {""});
b.format(1); // returns "prefixStart￾1￿SuffixEnd"
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8315964](https://bugs.openjdk.org/browse/JDK-8315964) to be approved

### Issues
 * [JDK-8315946](https://bugs.openjdk.org/browse/JDK-8315946): DecimalFormat and CompactNumberFormat do allow U+FFFE and U+FFFF in the pattern (**Bug** - P4)
 * [JDK-8315964](https://bugs.openjdk.org/browse/JDK-8315964): DecimalFormat and CompactNumberFormat do allow U+FFFE and U+FFFF in the pattern (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15648/head:pull/15648` \
`$ git checkout pull/15648`

Update a local copy of the PR: \
`$ git checkout pull/15648` \
`$ git pull https://git.openjdk.org/jdk.git pull/15648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15648`

View PR using the GUI difftool: \
`$ git pr show -t 15648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15648.diff">https://git.openjdk.org/jdk/pull/15648.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15648#issuecomment-1712322144)