### PR TITLE
8315970: Big-endian issues after JDK-8310929

### DIFF
--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1543,21 +1543,20 @@ final class StringUTF16 {
             q = i / 100;
             r = (q * 100) - i;
             i = q;
-
-            int packed = (int) StringLatin1.PACKED_DIGITS[r];
-            int inflated = ((packed & 0xFF00) << 8) | (packed & 0xFF);
-
             charPos -= 2;
-            ByteArrayLittleEndian.setInt(buf, charPos << 1, inflated);
+            ByteArrayLittleEndian.setInt(
+                    buf,
+                    charPos << 1,
+                    inflatePacked(r));
         }
 
         // We know there are at most two digits left at this point.
         if (i < -9) {
-            int packed = (int) StringLatin1.PACKED_DIGITS[-i];
-            int inflated = ((packed & 0xFF00) << 8) | (packed & 0xFF);
-
             charPos -= 2;
-            ByteArrayLittleEndian.setInt(buf, charPos << 1, inflated);
+            ByteArrayLittleEndian.setInt(
+                    buf,
+                    charPos << 1,
+                    inflatePacked(-i));
         } else {
             putChar(buf, --charPos, '0' - i);
         }
@@ -1590,12 +1589,11 @@ final class StringUTF16 {
         // Get 2 digits/iteration using longs until quotient fits into an int
         while (i <= Integer.MIN_VALUE) {
             q = i / 100;
-
-            int packed = (int) StringLatin1.PACKED_DIGITS[(int)((q * 100) - i)];
-            int inflated = ((packed & 0xFF00) << 8) | (packed & 0xFF);
-
             charPos -= 2;
-            ByteArrayLittleEndian.setInt(buf, charPos << 1, inflated);
+            ByteArrayLittleEndian.setInt(
+                    buf,
+                    charPos << 1,
+                    inflatePacked((int)((q * 100) - i)));
             i = q;
         }
 
@@ -1604,23 +1602,21 @@ final class StringUTF16 {
         int i2 = (int)i;
         while (i2 <= -100) {
             q2 = i2 / 100;
-
-            int packed = (int) StringLatin1.PACKED_DIGITS[(q2 * 100) - i2];
-            int inflated = ((packed & 0xFF00) << 8) | (packed & 0xFF);
-
             charPos -= 2;
-            ByteArrayLittleEndian.setInt(buf, charPos << 1, inflated);
+            ByteArrayLittleEndian.setInt(
+                    buf,
+                    charPos << 1,
+                    inflatePacked((q2 * 100) - i2));
             i2 = q2;
         }
 
         // We know there are at most two digits left at this point.
         if (i2 < -9) {
             charPos -= 2;
-
-            int packed = (int) StringLatin1.PACKED_DIGITS[-i2];
-            int inflated = ((packed & 0xFF00) << 8) | (packed & 0xFF);
-
-            ByteArrayLittleEndian.setInt(buf, charPos << 1, inflated);
+            ByteArrayLittleEndian.setInt(
+                    buf,
+                    charPos << 1,
+                    inflatePacked(-i2));
         } else {
             putChar(buf, --charPos, '0' - i2);
         }
@@ -1629,6 +1625,12 @@ final class StringUTF16 {
             putChar(buf, --charPos, '-');
         }
         return charPos;
+    }
+
+    private static int inflatePacked(int v) {
+        int packed = (int) StringLatin1.PACKED_DIGITS[v];
+        return ((packed & 0xFF) << HI_BYTE_SHIFT)
+                | ((packed & 0xFF00) << LO_BYTE_SHIFT);
     }
     // End of trusted methods.
 


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8310929

@TheRealMDoerr Feedback:

```
We're getting test failures on AIX:
compiler/intrinsics/Test8215792.java
compiler/intrinsics/string/TestStringIntrinsics.java
runtime/CompactStrings/TestMethodNames.java
runtime/StringIntrinsic/StringIndexOfChar.java
Is there a problem with Big Endian?
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315970](https://bugs.openjdk.org/browse/JDK-8315970): Big-endian issues after JDK-8310929 (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15652/head:pull/15652` \
`$ git checkout pull/15652`

Update a local copy of the PR: \
`$ git checkout pull/15652` \
`$ git pull https://git.openjdk.org/jdk.git pull/15652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15652`

View PR using the GUI difftool: \
`$ git pr show -t 15652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15652.diff">https://git.openjdk.org/jdk/pull/15652.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15652#issuecomment-1712898489)