### PR TITLE
8315971: ProblemList containers/docker/TestMemoryAwareness.java on linux-all

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -108,7 +108,7 @@ runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
-containers/docker/TestMemoryAwareness.java 8303470 linux-x64
+containers/docker/TestMemoryAwareness.java 8303470 linux-all
 
 #############################################################################
 


### PR DESCRIPTION
An existed record for TestMemoryAwareness test in the ProblemList is updated to cover linux-all, the related [bug](https://bugs.openjdk.org/browse/JDK-8303470) is not x64 specific.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315971](https://bugs.openjdk.org/browse/JDK-8315971): ProblemList containers/docker/TestMemoryAwareness.java on linux-all (**Sub-task** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15653/head:pull/15653` \
`$ git checkout pull/15653`

Update a local copy of the PR: \
`$ git checkout pull/15653` \
`$ git pull https://git.openjdk.org/jdk.git pull/15653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15653`

View PR using the GUI difftool: \
`$ git pr show -t 15653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15653.diff">https://git.openjdk.org/jdk/pull/15653.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15653#issuecomment-1713177869)