### PR TITLE
8314612: TestUnorderedReduction.java fails with -XX:MaxVectorSize=32 and -XX:+AlignVector

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -4275,6 +4275,12 @@ void PhaseIdealLoop::move_unordered_reduction_out_of_loop(IdealLoopTree* loop) {
         break; // Chain traversal fails.
       }
 
+      assert(current->vect_type() != nullptr, "must have vector type");
+      if (current->vect_type() != last_ur->vect_type()) {
+        // Reductions do not have the same vector type (length and element type).
+        break; // Chain traversal fails.
+      }
+
       // Expect single use of UnorderedReduction, except for last_ur.
       if (current == last_ur) {
         // Expect all uses to be outside the loop, except phi.

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
@@ -25,6 +25,7 @@
  * @test id=Vanilla-Unaligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReduction Vanilla-Unaligned
  */
@@ -33,6 +34,7 @@
  * @test id=Vanilla-Aligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReduction Vanilla-Aligned
  */
@@ -41,6 +43,7 @@
  * @test id=MaxVectorSize16-Unaligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReduction MaxVectorSize16-Unaligned
  */
@@ -49,6 +52,7 @@
  * @test id=MaxVectorSize32-Aligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
+ * @requires vm.compiler2.enabled
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestUnorderedReduction MaxVectorSize32-Aligned
  */

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReduction.java
@@ -22,35 +22,35 @@
  */
 
 /**
- * @test id=vanilla-U
+ * @test id=Vanilla-Unaligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
  * @library /test/lib /
- * @run driver compiler.loopopts.superword.TestUnorderedReduction vanilla-U
+ * @run driver compiler.loopopts.superword.TestUnorderedReduction Vanilla-Unaligned
  */
 
 /**
- * @test id=vanilla-A
+ * @test id=Vanilla-Aligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
  * @library /test/lib /
- * @run driver compiler.loopopts.superword.TestUnorderedReduction vanilla-A
+ * @run driver compiler.loopopts.superword.TestUnorderedReduction Vanilla-Aligned
  */
 
 /**
- * @test id=v016-U
+ * @test id=MaxVectorSize16-Unaligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
  * @library /test/lib /
- * @run driver compiler.loopopts.superword.TestUnorderedReduction v016-U
+ * @run driver compiler.loopopts.superword.TestUnorderedReduction MaxVectorSize16-Unaligned
  */
 
 /**
- * @test id=v032-A
+ * @test id=MaxVectorSize32-Aligned
  * @bug 8302652 8314612
  * @summary Special test cases for PhaseIdealLoop::move_unordered_reduction_out_of_loop
  * @library /test/lib /
- * @run driver compiler.loopopts.superword.TestUnorderedReduction v032-A
+ * @run driver compiler.loopopts.superword.TestUnorderedReduction MaxVectorSize32-Aligned
  */
 
 package compiler.loopopts.superword;
@@ -71,10 +71,10 @@ public class TestUnorderedReduction {
         }
 
         switch (args[0]) {
-            case "vanilla-U" -> { framework.addFlags("-XX:-AlignVector"); }
-            case "vanilla-A" -> { framework.addFlags("-XX:+AlignVector"); }
-            case "v016-U"    -> { framework.addFlags("-XX:MaxVectorSize=16"); }
-            case "v032-A"    -> { framework.addFlags("-XX:MaxVectorSize=32", "-XX:+AlignVector"); }
+            case "Vanilla-Unaligned"         -> { framework.addFlags("-XX:-AlignVector"); }
+            case "Vanilla-Aligned"           -> { framework.addFlags("-XX:+AlignVector"); }
+            case "MaxVectorSize16-Unaligned" -> { framework.addFlags("-XX:-AlignVector", "-XX:MaxVectorSize=16"); }
+            case "MaxVectorSize32-Aligned"   -> { framework.addFlags("-XX:+AlignVector", "-XX:MaxVectorSize=32"); }
             default -> { throw new RuntimeException("Test argument not recognized: " + args[0]); }
         }
         framework.start();


### PR DESCRIPTION
**Problem**

There is a case where `PhaseIdealLoop::move_unordered_reduction_out_of_loop` gets a chain of `UnorderedReduction` which have differing vector lengths. But this can lead to wrong results, as some elements now get dropped or "hallucinated".

Details:
`-XX:+AlingVector` creates alignment boundaries over which no pack can go. Effectively, it cuts the packs at the alignment boundaries. This can create unexpected series of packs with lengths `[4, 8, 4]`, rather than `[8, 8]`.

**Solution**

We need to check that all `UnorderedReduction` have the same `vect_type()`. That ensures all have the same length and element type.

**Testing**

I converted the old test into scenario `v016-U`, and added scenario `v032-A` (fails without the patch). Also, I added some vanilla scenarios, just to ensure the test cases can be run with other flag combinations. The IR tests are targeted at scenario `v016-U`.

Tests: tier1-6, stress-testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314612](https://bugs.openjdk.org/browse/JDK-8314612): TestUnorderedReduction.java fails with -XX:MaxVectorSize=32 and -XX:+AlignVector (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15654/head:pull/15654` \
`$ git checkout pull/15654`

Update a local copy of the PR: \
`$ git checkout pull/15654` \
`$ git pull https://git.openjdk.org/jdk.git pull/15654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15654`

View PR using the GUI difftool: \
`$ git pr show -t 15654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15654.diff">https://git.openjdk.org/jdk/pull/15654.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15654#issuecomment-1713701229)