### PR TITLE
8315988: Parallel: Make TestAggressiveHeap use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java
+++ b/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class TestAggressiveHeap {
         " *bool +UseParallelGC *= *true +\\{product\\} *\\{command line\\}";
 
     private static void testFlag() throws Exception {
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+        ProcessBuilder pb = GCArguments.createTestJvm(
             option, heapSizeOption, "-XX:+PrintFlagsFinal", "-version");
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
Make TestAggressiveHeap use createTestJvm (so that the test forwards VM/JAVA_OPTIONS). The TestAggressiveHeap flag implicitly turns on the parallel gc, thus  `@requires vm.gc.Parallel`. 

Tested with:
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java JTREG="JAVA_OPTIONS=-XX:+UseParallelGC"` (PASS 1)
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java JTREG="JAVA_OPTIONS=-XX:+UseSerialGC"` (PASS 0)
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestAggressiveHeap.java`(PASS 1)

Started hs_tier1, hs_tier2 to see that we do not propagate conflicting flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315988](https://bugs.openjdk.org/browse/JDK-8315988): Parallel: Make TestAggressiveHeap use createTestJvm (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15657/head:pull/15657` \
`$ git checkout pull/15657`

Update a local copy of the PR: \
`$ git checkout pull/15657` \
`$ git pull https://git.openjdk.org/jdk.git pull/15657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15657`

View PR using the GUI difftool: \
`$ git pr show -t 15657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15657.diff">https://git.openjdk.org/jdk/pull/15657.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15657#issuecomment-1713749716)