### PR TITLE
8316001: GC: Make TestArrayAllocatorMallocLimit use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
+++ b/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class TestArrayAllocatorMallocLimit {
   private static final String printFlagsFinalPattern = " *size_t *" + flagName + " *:?= *(\\d+) *\\{experimental\\} *";
 
   public static void testDefaultValue()  throws Exception {
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createTestJvm(
       "-XX:+UnlockExperimentalVMOptions", "-XX:+PrintFlagsFinal", "-version");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());


### PR DESCRIPTION
Make TestArrayAllocatorMallocLimit use createTestJvm (so that the test forwards VM/JAVA_OPTIONS). It seems there is no problem to propagate `-XX:+UnlockExperimentalVMOptions`.

Tested with:
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java` (PASS 1)
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestArrayAllocatorMallocLimit.java JTREG="JAVA_OPTIONS=-XX:+UnlockExperimentalVMOptions"` (PASS 1)

Started hs_tier1-5 to see that we do not propagate conflicting flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316001](https://bugs.openjdk.org/browse/JDK-8316001): GC: Make TestArrayAllocatorMallocLimit use createTestJvm (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15659/head:pull/15659` \
`$ git checkout pull/15659`

Update a local copy of the PR: \
`$ git checkout pull/15659` \
`$ git pull https://git.openjdk.org/jdk.git pull/15659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15659`

View PR using the GUI difftool: \
`$ git pr show -t 15659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15659.diff">https://git.openjdk.org/jdk/pull/15659.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15659#issuecomment-1713814401)