### PR TITLE
8294158: HTML formatting for PassFailJFrame instructions

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -175,7 +175,8 @@ public class PassFailJFrame {
                           boolean enableScreenCapture) throws InterruptedException,
             InvocationTargetException {
         if (isEventDispatchThread()) {
-            createUI(title, instructions, testTimeOut, rows, columns, enableScreenCapture);
+            createUI(title, instructions, testTimeOut, rows, columns,
+                     enableScreenCapture);
         } else {
             invokeAndWait(() -> createUI(title, instructions, testTimeOut,
                     rows, columns, enableScreenCapture));

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -51,6 +51,7 @@ import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
+import javax.swing.JEditorPane;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -58,6 +59,9 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.Timer;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.StyleSheet;
 
 import static javax.swing.SwingUtilities.invokeAndWait;
 import static javax.swing.SwingUtilities.isEventDispatchThread;
@@ -81,8 +85,11 @@ public class PassFailJFrame {
     private static volatile boolean failed;
     private static volatile boolean timeout;
     private static volatile String testFailedReason;
+
     private static final AtomicInteger imgCounter = new AtomicInteger(0);
+
     private static JFrame frame;
+
     private static Robot robot;
 
     public enum Position {HORIZONTAL, VERTICAL, TOP_LEFT_CORNER}
@@ -168,8 +175,7 @@ public class PassFailJFrame {
                           boolean enableScreenCapture) throws InterruptedException,
             InvocationTargetException {
         if (isEventDispatchThread()) {
-            createUI(title, instructions, testTimeOut, rows, columns,
-                    enableScreenCapture);
+            createUI(title, instructions, testTimeOut, rows, columns, enableScreenCapture);
         } else {
             invokeAndWait(() -> createUI(title, instructions, testTimeOut,
                     rows, columns, enableScreenCapture));
@@ -187,9 +193,29 @@ public class PassFailJFrame {
                                  boolean enableScreenCapture) {
         frame = new JFrame(title);
         frame.setLayout(new BorderLayout());
-        JTextArea instructionsText = new JTextArea(instructions, rows, columns);
-        instructionsText.setEditable(false);
-        instructionsText.setLineWrap(true);
+
+        boolean isHTML = instructions.startsWith("<html>");
+        JTextComponent text =
+                isHTML ? new JEditorPane("text/html", instructions)
+                       : new JTextArea(instructions, rows, columns);
+        if (isHTML) {
+            text.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES,
+                                               Boolean.TRUE);
+            // Set preferred size as if it were JTextArea
+            text.setPreferredSize(
+                    new JTextArea(rows, columns).getPreferredSize());
+
+            HTMLEditorKit kit = (HTMLEditorKit) ((JEditorPane) text).getEditorKit();
+            StyleSheet styles = kit.getStyleSheet();
+            // Reduce the default margins
+            styles.addRule("ol, ul { margin-left-ltr: 20; margin-left-rtl: 20 }");
+            // Make the size of code blocks the same as other text
+            styles.addRule("code { font-size: inherit }");
+        } else {
+            ((JTextArea) text).setLineWrap(true);
+            ((JTextArea) text).setWrapStyleWord(true);
+        }
+        text.setEditable(false);
 
         long tTimeout = TimeUnit.MINUTES.toMillis(testTimeOut);
 
@@ -210,7 +236,7 @@ public class PassFailJFrame {
         });
         timer.start();
         frame.add(testTimeoutLabel, BorderLayout.NORTH);
-        frame.add(new JScrollPane(instructionsText), BorderLayout.CENTER);
+        frame.add(new JScrollPane(text), BorderLayout.CENTER);
 
         JButton btnPass = new JButton("Pass");
         btnPass.addActionListener((e) -> {

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -194,27 +194,9 @@ public class PassFailJFrame {
         frame = new JFrame(title);
         frame.setLayout(new BorderLayout());
 
-        boolean isHTML = instructions.startsWith("<html>");
-        JTextComponent text =
-                isHTML ? new JEditorPane("text/html", instructions)
-                       : new JTextArea(instructions, rows, columns);
-        if (isHTML) {
-            text.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES,
-                                               Boolean.TRUE);
-            // Set preferred size as if it were JTextArea
-            text.setPreferredSize(
-                    new JTextArea(rows, columns).getPreferredSize());
-
-            HTMLEditorKit kit = (HTMLEditorKit) ((JEditorPane) text).getEditorKit();
-            StyleSheet styles = kit.getStyleSheet();
-            // Reduce the default margins
-            styles.addRule("ol, ul { margin-left-ltr: 20; margin-left-rtl: 20 }");
-            // Make the size of code blocks the same as other text
-            styles.addRule("code { font-size: inherit }");
-        } else {
-            ((JTextArea) text).setLineWrap(true);
-            ((JTextArea) text).setWrapStyleWord(true);
-        }
+        JTextComponent text = instructions.startsWith("<html>")
+                              ? configureHTML(instructions, rows, columns)
+                              : configurePlainText(instructions, rows, columns);
         text.setEditable(false);
 
         long tTimeout = TimeUnit.MINUTES.toMillis(testTimeOut);
@@ -273,6 +255,32 @@ public class PassFailJFrame {
         frame.pack();
         frame.setLocationRelativeTo(null);
         windowList.add(frame);
+    }
+
+    private static JTextComponent configurePlainText(String instructions,
+                                                     int rows, int columns) {
+        JTextArea text = new JTextArea(instructions, rows, columns);
+        text.setLineWrap(true);
+        text.setWrapStyleWord(true);
+        return text;
+    }
+
+    private static JTextComponent configureHTML(String instructions,
+                                                int rows, int columns) {
+        JEditorPane text = new JEditorPane("text/html", instructions);
+        text.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES,
+                               Boolean.TRUE);
+        // Set preferred size as if it were JTextArea
+        text.setPreferredSize(new JTextArea(rows, columns).getPreferredSize());
+
+        HTMLEditorKit kit = (HTMLEditorKit) text.getEditorKit();
+        StyleSheet styles = kit.getStyleSheet();
+        // Reduce the default margins
+        styles.addRule("ol, ul { margin-left-ltr: 20; margin-left-rtl: 20 }");
+        // Make the size of code blocks the same as other text
+        styles.addRule("code { font-size: inherit }");
+
+        return text;
     }
 
     private static JComponent createCapturePanel() {

--- a/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,61 +74,48 @@ public class FileChooserSymLinkTest {
     static void initialize() throws InterruptedException, InvocationTargetException {
         //Initialize the components
         final String INSTRUCTIONS = """
-                <html><body>
                 Instructions to Test:
-                <ol>
-                <li>Open an elevated <i>Command Prompt</i>.
-                <li>Paste the following commands:
-                <pre><code>cd /d C:\\
+                1. Open an elevated Command Prompt.
+                2. Paste the following commands:
+                cd /d C:\\
                 mkdir FileChooserTest
                 cd FileChooserTest
                 mkdir target
-                mklink /d link target</code></pre>
+                mklink /d link target
 
-                <li>Navigate to <code>C:\\FileChooserTest</code> in
-                    the <code>JFileChooser</code>.
-                <li>Perform testing in single- and multi-selection modes:
-                    <ul style="margin-bottom: 0px">
-                    <li><strong>Single-selection:</strong>
-                        <ol>
-                            <li>Ensure <b>Enable multi-selection</b> is cleared
-                                (the default state).
-                            <li>Click <code>link</code> directory,
-                                the absolute path of the symbolic
-                                link should be displayed.<br>
-                                If it's <code>null</code>, click <b>Fail</b>.
-                            <li>Click <code>target</code> directory,
-                                its absolute path should be displayed.
-                        </ol>
-                    <li><strong>Multi-selection:</strong>
-                        <ol>
-                            <li>Select <b>Enable multi-selection</b>.
-                            <li>Click <code>link</code>,
-                            <li>Press <kbd>Ctrl</kbd> and
-                                then click <code>target</code>.
-                            <li>Both should be selected and
-                                their absolute paths should be displayed.
-                            <li>If <code>link</code> can't be selected or
-                                if its absolute path is <code>null</code>,
-                                click <b>Fail</b>.
-                        </ol>
-                    </ul>
-                    <p>If <code>link</code> can be selected in both
-                    single- and multi-selection modes, click <b>Pass</b>.</p>
-                <li>When done with testing, paste the following commands to
-                   remove the <code>FileChooserTest</code> directory:
-                <pre><code>cd \\
-                rmdir /s /q C:\\FileChooserTest</code></pre>
+                3. Navigate to C:\\FileChooserTest in the JFileChooser.
+                4. Use "Enable Multi-Selection" checkbox to enable/disable
+                   MultiSelection Mode
+                5. Single-selection:
+                   Click "link" directory, the absolute path of the symbolic
+                   link should be displayed. If it's null, click FAIL.
+                   Click "target" directory, its absolute path should be
+                   displayed.
+
+                   Enable multiple selection by clicking the checkbox.
+                   Multi-selection:
+                   Click "link", press Ctrl and then click "target".
+                   Both should be selected and their absolute paths should be
+                   displayed.
+
+                   If "link" can't be selected or if its absolute path is null,
+                   click FAIL.
+
+                   If "link" can be selected in both single- and multi-selection modes,
+                   click PASS.
+                6. When done with testing, paste the following commands to
+                   remove the 'FileChooserTest' directory:
+                cd \\
+                rmdir /s /q C:\\FileChooserTest
 
                 or use File Explorer to clean it up.
-                </ol>
                 """;
         frame = new JFrame("JFileChooser Symbolic Link test");
         panel = new JPanel(new BorderLayout());
         multiSelection = new JCheckBox("Enable Multi-Selection");
         pathList = new JTextArea(10, 50);
         jfc = new JFileChooser(new File("C:\\"));
-        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 35, 50);
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 35, 40);
 
         PassFailJFrame.addTestWindow(frame);
         PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);

--- a/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,33 +88,33 @@ public class FileChooserSymLinkTest {
                 <li>Navigate to <code>C:\\FileChooserTest</code> in
                     the <code>JFileChooser</code>.
                 <li>Perform testing in single- and multi-selection modes:
-                    <ul>
+                    <ul style="margin-bottom: 0px">
                     <li><strong>Single-selection:</strong>
-                    <ol>
-                        <li>Ensure <b>Enable multi-selection</b> is cleared
-                            (the default state).
-                        <li>Click <code>link</code> directory,
-                            the absolute path of the symbolic
-                            link should be displayed.<br>
-                            If it's <code>null</code>, click <b>Fail</b>.
-                        <li>Click <code>target</code> directory,
-                            its absolute path should be displayed.
-                    </ol>
+                        <ol>
+                            <li>Ensure <b>Enable multi-selection</b> is cleared
+                                (the default state).
+                            <li>Click <code>link</code> directory,
+                                the absolute path of the symbolic
+                                link should be displayed.<br>
+                                If it's <code>null</code>, click <b>Fail</b>.
+                            <li>Click <code>target</code> directory,
+                                its absolute path should be displayed.
+                        </ol>
                     <li><strong>Multi-selection:</strong>
-                    <ol>
-                        <li>Select <b>Enable multi-selection</b>.
-                        <li>Click <code>link</code>,
-                        <li>Press <kbd>Ctrl</kbd> and
-                            then click <code>target</code>.
-                        <li>Both should be selected and
-                            their absolute paths should be displayed.
-                        <li>If <code>link</code> can't be selected or
-                            if its absolute path is <code>null</code>,
-                            click <b>Fail</b>.
-                    </ol>
-                    If <code>link</code> can be selected in both
-                    single- and multi-selection modes, click <b>Pass</b>.
-                   </ul>
+                        <ol>
+                            <li>Select <b>Enable multi-selection</b>.
+                            <li>Click <code>link</code>,
+                            <li>Press <kbd>Ctrl</kbd> and
+                                then click <code>target</code>.
+                            <li>Both should be selected and
+                                their absolute paths should be displayed.
+                            <li>If <code>link</code> can't be selected or
+                                if its absolute path is <code>null</code>,
+                                click <b>Fail</b>.
+                        </ol>
+                    </ul>
+                    <p>If <code>link</code> can be selected in both
+                    single- and multi-selection modes, click <b>Pass</b>.</p>
                 <li>When done with testing, paste the following commands to
                    remove the <code>FileChooserTest</code> directory:
                 <pre><code>cd \\

--- a/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserSymLinkTest.java
@@ -74,48 +74,61 @@ public class FileChooserSymLinkTest {
     static void initialize() throws InterruptedException, InvocationTargetException {
         //Initialize the components
         final String INSTRUCTIONS = """
+                <html><body>
                 Instructions to Test:
-                1. Open an elevated Command Prompt.
-                2. Paste the following commands:
-                cd /d C:\\
+                <ol>
+                <li>Open an elevated <i>Command Prompt</i>.
+                <li>Paste the following commands:
+                <pre><code>cd /d C:\\
                 mkdir FileChooserTest
                 cd FileChooserTest
                 mkdir target
-                mklink /d link target
+                mklink /d link target</code></pre>
 
-                3. Navigate to C:\\FileChooserTest in the JFileChooser.
-                4. Use "Enable Multi-Selection" checkbox to enable/disable
-                   MultiSelection Mode
-                5. Single-selection:
-                   Click "link" directory, the absolute path of the symbolic
-                   link should be displayed. If it's null, click FAIL.
-                   Click "target" directory, its absolute path should be
-                   displayed.
-
-                   Enable multiple selection by clicking the checkbox.
-                   Multi-selection:
-                   Click "link", press Ctrl and then click "target".
-                   Both should be selected and their absolute paths should be
-                   displayed.
-
-                   If "link" can't be selected or if its absolute path is null,
-                   click FAIL.
-
-                   If "link" can be selected in both single- and multi-selection modes,
-                   click PASS.
-                6. When done with testing, paste the following commands to
-                   remove the 'FileChooserTest' directory:
-                cd \\
-                rmdir /s /q C:\\FileChooserTest
+                <li>Navigate to <code>C:\\FileChooserTest</code> in
+                    the <code>JFileChooser</code>.
+                <li>Perform testing in single- and multi-selection modes:
+                    <ul>
+                    <li><strong>Single-selection:</strong>
+                    <ol>
+                        <li>Ensure <b>Enable multi-selection</b> is cleared
+                            (the default state).
+                        <li>Click <code>link</code> directory,
+                            the absolute path of the symbolic
+                            link should be displayed.<br>
+                            If it's <code>null</code>, click <b>Fail</b>.
+                        <li>Click <code>target</code> directory,
+                            its absolute path should be displayed.
+                    </ol>
+                    <li><strong>Multi-selection:</strong>
+                    <ol>
+                        <li>Select <b>Enable multi-selection</b>.
+                        <li>Click <code>link</code>,
+                        <li>Press <kbd>Ctrl</kbd> and
+                            then click <code>target</code>.
+                        <li>Both should be selected and
+                            their absolute paths should be displayed.
+                        <li>If <code>link</code> can't be selected or
+                            if its absolute path is <code>null</code>,
+                            click <b>Fail</b>.
+                    </ol>
+                    If <code>link</code> can be selected in both
+                    single- and multi-selection modes, click <b>Pass</b>.
+                   </ul>
+                <li>When done with testing, paste the following commands to
+                   remove the <code>FileChooserTest</code> directory:
+                <pre><code>cd \\
+                rmdir /s /q C:\\FileChooserTest</code></pre>
 
                 or use File Explorer to clean it up.
+                </ol>
                 """;
         frame = new JFrame("JFileChooser Symbolic Link test");
         panel = new JPanel(new BorderLayout());
         multiSelection = new JCheckBox("Enable Multi-Selection");
         pathList = new JTextArea(10, 50);
         jfc = new JFileChooser(new File("C:\\"));
-        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 35, 40);
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 35, 50);
 
         PassFailJFrame.addTestWindow(frame);
         PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);


### PR DESCRIPTION
This enhancement provides HTML formatting for instructions in the manual test framework, `PassFailJFrame`.

Some tests could benefit from rich-formatted instructions, especially when the instructions are long.

See a sample usage in #15661.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294158](https://bugs.openjdk.org/browse/JDK-8294158): HTML formatting for PassFailJFrame instructions (**Enhancement** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15660/head:pull/15660` \
`$ git checkout pull/15660`

Update a local copy of the PR: \
`$ git checkout pull/15660` \
`$ git pull https://git.openjdk.org/jdk.git pull/15660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15660`

View PR using the GUI difftool: \
`$ git pr show -t 15660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15660.diff">https://git.openjdk.org/jdk/pull/15660.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15660#issuecomment-1713882843)