### PR TITLE
8316002: Remove unnecessary seen_dead_loader in ClassLoaderDataGraph::do_unloading

### DIFF
--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -494,7 +494,6 @@ bool ClassLoaderDataGraph::do_unloading() {
   assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
 
   ClassLoaderData* prev = nullptr;
-  bool seen_dead_loader = false;
   uint loaders_processed = 0;
   uint loaders_removed = 0;
 
@@ -505,7 +504,6 @@ bool ClassLoaderDataGraph::do_unloading() {
     } else {
       // Found dead CLD.
       loaders_removed++;
-      seen_dead_loader = true;
       data->unload();
 
       // Move dead CLD to unloading list.
@@ -523,7 +521,7 @@ bool ClassLoaderDataGraph::do_unloading() {
 
   log_debug(class, loader, data)("do_unloading: loaders processed %u, loaders removed %u", loaders_processed, loaders_removed);
 
-  return seen_dead_loader;
+  return loaders_removed != 0;
 }
 
 // There's at least one dead class loader.  Purge refererences of healthy module


### PR DESCRIPTION
Hi all,

  please review this removal of an unnecessary local variable which value can be derived at the end by existing ones.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316002](https://bugs.openjdk.org/browse/JDK-8316002): Remove unnecessary seen_dead_loader in ClassLoaderDataGraph::do_unloading (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15662/head:pull/15662` \
`$ git checkout pull/15662`

Update a local copy of the PR: \
`$ git checkout pull/15662` \
`$ git pull https://git.openjdk.org/jdk.git pull/15662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15662`

View PR using the GUI difftool: \
`$ git pr show -t 15662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15662.diff">https://git.openjdk.org/jdk/pull/15662.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15662#issuecomment-1713986363)