### PR TITLE
8316021: Serial: Remove unused Generation::post_compact

### DIFF
--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -311,7 +311,6 @@ class Generation: public CHeapObj<mtGC> {
   virtual void adjust_pointers();
   // Mark sweep support phase4
   virtual void compact();
-  virtual void post_compact() { ShouldNotReachHere(); }
 #endif
 
   // Accessing "marks".


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316021](https://bugs.openjdk.org/browse/JDK-8316021): Serial: Remove unused Generation::post_compact (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15663/head:pull/15663` \
`$ git checkout pull/15663`

Update a local copy of the PR: \
`$ git checkout pull/15663` \
`$ git pull https://git.openjdk.org/jdk.git pull/15663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15663`

View PR using the GUI difftool: \
`$ git pr show -t 15663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15663.diff">https://git.openjdk.org/jdk/pull/15663.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15663#issuecomment-1714092885)