### PR TITLE
8316050: Use hexadecimal encoding in MemorySegment::toString

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -505,7 +505,7 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     public String toString() {
-        return "MemorySegment{ heapBase: " + heapBase() + " address: 0x" + Long.toHexString(address()) + " limit: " + length + " }";
+        return "MemorySegment{ heapBase: " + heapBase() + " address: 0x" + Long.toHexString(address()) + " byteSize: " + length + " }";
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -505,7 +505,7 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     public String toString() {
-        return "MemorySegment{ heapBase: " + heapBase() + " address:" + address() + " limit: " + length + " }";
+        return "MemorySegment{ heapBase: " + heapBase() + " address: 0x" + Long.toHexString(address()) + " limit: " + length + " }";
     }
 
     @Override


### PR DESCRIPTION
This PR proposes to use hexadecimal representation for a memory segment address rather than a decimal one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316050](https://bugs.openjdk.org/browse/JDK-8316050): Use hexadecimal encoding in MemorySegment::toString (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [ed5c76c9](https://git.openjdk.org/jdk/pull/15670/files/ed5c76c916364b157844c6b43191208c837b6397)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [ed5c76c9](https://git.openjdk.org/jdk/pull/15670/files/ed5c76c916364b157844c6b43191208c837b6397)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15670/head:pull/15670` \
`$ git checkout pull/15670`

Update a local copy of the PR: \
`$ git checkout pull/15670` \
`$ git pull https://git.openjdk.org/jdk.git pull/15670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15670`

View PR using the GUI difftool: \
`$ git pr show -t 15670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15670.diff">https://git.openjdk.org/jdk/pull/15670.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15670#issuecomment-1714602175)