### PR TITLE
8313865: Always true condition in sun.nio.cs.CharsetMapping#readINDEXC2B

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/CharsetMapping.java
+++ b/src/java.base/share/classes/sun/nio/cs/CharsetMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,7 @@
 package sun.nio.cs;
 
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.*;
 import java.security.*;
 
@@ -244,7 +239,7 @@ public class CharsetMapping {
     void readINDEXC2B() {
         char[] map = readCharArray();
         for (int i = map.length - 1; i >= 0; i--) {
-            if (c2b == null && map[i] != -1) {
+            if (c2b == null) {
                 c2b = new char[map[i] + 256];
                 Arrays.fill(c2b, (char)UNMAPPABLE_ENCODING);
                 break;


### PR DESCRIPTION
Simple clean-up for removing an unnecessary condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313865](https://bugs.openjdk.org/browse/JDK-8313865): Always true condition in sun.nio.cs.CharsetMapping#readINDEXC2B (**Bug** - P5)


### Reviewers
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15672/head:pull/15672` \
`$ git checkout pull/15672`

Update a local copy of the PR: \
`$ git checkout pull/15672` \
`$ git pull https://git.openjdk.org/jdk.git pull/15672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15672`

View PR using the GUI difftool: \
`$ git pr show -t 15672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15672.diff">https://git.openjdk.org/jdk/pull/15672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15672#issuecomment-1714670005)