### PR TITLE
8316057: javax/crypto/CryptoPermissions/InconsistentEntries.java fails on read-only JDK

### DIFF
--- a/test/jdk/javax/crypto/CryptoPermissions/InconsistentEntries.java
+++ b/test/jdk/javax/crypto/CryptoPermissions/InconsistentEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  */
 
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -57,12 +58,16 @@ public class InconsistentEntries {
 
     @BeforeTest
     public void setUp() throws IOException {
-        if (!POLICY_DIR.toFile().exists()) {
-            Files.createDirectory(POLICY_DIR);
-        }
+        try {
+            if (!POLICY_DIR.toFile().exists()) {
+                Files.createDirectory(POLICY_DIR);
+            }
 
-        targetFile = POLICY_DIR.resolve(POLICY_FILE.getFileName());
-        Files.copy(POLICY_FILE, targetFile, StandardCopyOption.REPLACE_EXISTING);
+            targetFile = POLICY_DIR.resolve(POLICY_FILE.getFileName());
+            Files.copy(POLICY_FILE, targetFile, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException ioe) {
+            throw new SkipException("probably insufficient privileges", ioe);
+        }
     }
 
     @AfterTest


### PR DESCRIPTION
I am not sure that it is a good thing to modify the JDK when many tests are executed in parallel. But for now, I updated the test, it will be skipped if the setup stage fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316057](https://bugs.openjdk.org/browse/JDK-8316057): javax/crypto/CryptoPermissions/InconsistentEntries.java fails on read-only JDK (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15674/head:pull/15674` \
`$ git checkout pull/15674`

Update a local copy of the PR: \
`$ git checkout pull/15674` \
`$ git pull https://git.openjdk.org/jdk.git pull/15674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15674`

View PR using the GUI difftool: \
`$ git pr show -t 15674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15674.diff">https://git.openjdk.org/jdk/pull/15674.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15674#issuecomment-1714755421)