### PR TITLE
8316060: test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java may fail if heap is huge

### DIFF
--- a/test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8297977
  * @summary Test that throwing OOM from reflected method gets InvocationTargetException
- * @run main/othervm/timeout=150 ReflectOutOfMemoryError
+ * @run main/othervm -Xmx128m ReflectOutOfMemoryError
  */
 import java.lang.reflect.*;
 


### PR DESCRIPTION
The test tries to generate the OOM by filling the whole heap, unfortunately it may fail if the heap is large than 25G. If the heap is around 15-20G the test is quite slow.

The current patch is kind of modified version of the next [fix](https://github.com/openjdk/jdk/pull/14070/files#r1199632388), but instead of increasing timeout it minimize the amount of memory used by the heap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316060](https://bugs.openjdk.org/browse/JDK-8316060): test/hotspot/jtreg/runtime/reflect/ReflectOutOfMemoryError.java may fail if heap is huge (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15676/head:pull/15676` \
`$ git checkout pull/15676`

Update a local copy of the PR: \
`$ git checkout pull/15676` \
`$ git pull https://git.openjdk.org/jdk.git pull/15676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15676`

View PR using the GUI difftool: \
`$ git pr show -t 15676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15676.diff">https://git.openjdk.org/jdk/pull/15676.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15676#issuecomment-1716391109)