### PR TITLE
8315986: [macos14] javax/swing/JMenuItem/4654927/bug4654927.java: component must be showing on the screen to determine its location

### DIFF
--- a/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -76,7 +76,6 @@ public class bug4654927 {
             robot.waitForIdle();
             robot.delay(250);
 
-            System.out.println("MenuItem LocationOnScreen " + menuItem.getLocationOnScreen());
             Point itemLocation = Util.getCenterPoint(menuItem);
             System.out.println("MenuItem Location " + itemLocation);
             robot.mouseMove(itemLocation.x, itemLocation.y);

--- a/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -68,15 +68,18 @@ public class bug4654927 {
             robot.delay(1000);
 
             // test mouse press
-            Point point = Util.getCenterPoint(menu);
-            robot.mouseMove(point.x, point.y);
+            Point menuLocation = Util.getCenterPoint(menu);
+            System.out.println("Menu Location " + menuLocation);
+            robot.mouseMove(menuLocation.x, menuLocation.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
             robot.delay(250);
 
-            point = Util.getCenterPoint(menuItem);
-            robot.mouseMove(point.x, point.y);
+            System.out.println("MenuItem LocationOnScreen " + menuItem.getLocationOnScreen());
+            Point itemLocation = Util.getCenterPoint(menuItem);
+            System.out.println("MenuItem Location " + itemLocation);
+            robot.mouseMove(itemLocation.x, itemLocation.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
@@ -86,40 +89,18 @@ public class bug4654927 {
                 throw new RuntimeException("Popup is unexpectedly closed");
             }
 
-            // test mouse drag
-            point = Util.getCenterPoint(menu);
-            robot.mouseMove(point.x, point.y);
-            robot.delay(250);
-            Point menuLocation = Util.invokeOnEDT(new Callable<Point>() {
-
-                @Override
-                public Point call() throws Exception {
-                    System.out.println("Menu Location: " + menu.getLocationOnScreen());
-                    return menu.getLocationOnScreen();
-                }
-            });
-
-            Point itemLocation = Util.invokeOnEDT(new Callable<Point>() {
-
-                @Override
-                public Point call() throws Exception {
-                    System.out.println("MenuItem Location: " + menuItem.getLocationOnScreen());
-                    return menuItem.getLocationOnScreen();
-                }
-            });
-
-            int x0 = menuLocation.x + 10;
-            int y0 = menuLocation.y + 10;
-            int x1 = itemLocation.x + 10;
-            int y1 = itemLocation.y + 10;
-
             // close menu
+            robot.mouseMove(menuLocation.x, menuLocation.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(250);
 
+            // test mouse drag
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-            Util.glide(robot, x0, y0, x1, y1);
+            robot.delay(250);
+            Util.glide(robot, menuLocation.x, menuLocation.y,
+                              itemLocation.x, itemLocation.y);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
@@ -165,3 +146,4 @@ public class bug4654927 {
         frame.setVisible(true);
     }
 }
+

--- a/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -89,7 +89,7 @@ public class bug4654927 {
             // test mouse drag
             point = Util.getCenterPoint(menu);
             robot.mouseMove(point.x, point.y);
-	    robot.delay(250);
+            robot.delay(250);
             Point menuLocation = Util.invokeOnEDT(new Callable<Point>() {
 
                 @Override

--- a/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,15 +26,20 @@
  * @key headful
  * @bug 4654927
  * @summary Clicking on Greyed Menuitems closes the Menubar Dropdown
- * @author Alexander Potochkin
  * @library ../../regtesthelpers
  * @build Util
  * @run main bug4654927
  */
 
-import javax.swing.*;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
-import java.awt.*;
+import java.awt.Point;
+import java.awt.Robot;
 import java.awt.event.InputEvent;
 import java.util.concurrent.Callable;
 
@@ -48,34 +53,33 @@ public class bug4654927 {
         try {
             String systemLAF = UIManager.getSystemLookAndFeelClassName();
             // the test is not applicable to Motif L&F
-            if(systemLAF.endsWith("MotifLookAndFeel")){
+            if (systemLAF.endsWith("MotifLookAndFeel")){
                 return;
             }
 
             UIManager.setLookAndFeel(systemLAF);
             Robot robot = new Robot();
-            robot.setAutoDelay(10);
+            robot.setAutoDelay(100);
 
-            SwingUtilities.invokeAndWait(new Runnable() {
+            SwingUtilities.invokeAndWait(() -> createAndShowUI());
 
-                public void run() {
-                    createAndShowUI();
-                }
-            });
             robot.waitForIdle();
+            robot.delay(1000);	    
 
             // test mouse press
             Point point = Util.getCenterPoint(menu);
             robot.mouseMove(point.x, point.y);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(250);
 
             point = Util.getCenterPoint(menuItem);
             robot.mouseMove(point.x, point.y);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+            robot.delay(250);
 
             if (!isMenuItemShowing()) {
                 throw new RuntimeException("Popup is unexpectedly closed");
@@ -106,20 +110,24 @@ public class bug4654927 {
             int y1 = itemLocation.y + 10;
 
             // close menu
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
-            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             Util.glide(robot, x0, y0, x1, y1);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
 
             if (!isMenuItemShowing()) {
                 throw new RuntimeException("Popup is unexpectedly closed");
             }
         } finally {
-            if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 
@@ -151,6 +159,5 @@ public class bug4654927 {
         frame.setSize(200, 200);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
-
     }
 }

--- a/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -53,7 +53,7 @@ public class bug4654927 {
         try {
             String systemLAF = UIManager.getSystemLookAndFeelClassName();
             // the test is not applicable to Motif L&F
-            if (systemLAF.endsWith("MotifLookAndFeel")){
+            if (systemLAF.endsWith("MotifLookAndFeel")) {
                 return;
             }
 
@@ -89,11 +89,12 @@ public class bug4654927 {
             // test mouse drag
             point = Util.getCenterPoint(menu);
             robot.mouseMove(point.x, point.y);
+	    robot.delay(250);
             Point menuLocation = Util.invokeOnEDT(new Callable<Point>() {
 
                 @Override
                 public Point call() throws Exception {
-                    System.out.println("Menu Location: "+ menu.getLocationOnScreen());
+                    System.out.println("Menu Location: " + menu.getLocationOnScreen());
                     return menu.getLocationOnScreen();
                 }
             });
@@ -102,7 +103,7 @@ public class bug4654927 {
 
                 @Override
                 public Point call() throws Exception {
-                    System.out.println("MenuItem Location: "+ menuItem.getLocationOnScreen());
+                    System.out.println("MenuItem Location: " + menuItem.getLocationOnScreen());
                     return menuItem.getLocationOnScreen();
                 }
             });

--- a/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -59,6 +59,7 @@ public class bug4654927 {
 
             UIManager.setLookAndFeel(systemLAF);
             Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
             robot.setAutoDelay(100);
 
             SwingUtilities.invokeAndWait(() -> createAndShowUI());
@@ -92,6 +93,7 @@ public class bug4654927 {
 
                 @Override
                 public Point call() throws Exception {
+                    System.out.println("Menu Location: "+ menu.getLocationOnScreen());
                     return menu.getLocationOnScreen();
                 }
             });
@@ -100,6 +102,7 @@ public class bug4654927 {
 
                 @Override
                 public Point call() throws Exception {
+                    System.out.println("MenuItem Location: "+ menuItem.getLocationOnScreen());
                     return menuItem.getLocationOnScreen();
                 }
             });

--- a/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
+++ b/test/jdk/javax/swing/JMenuItem/4654927/bug4654927.java
@@ -64,7 +64,7 @@ public class bug4654927 {
             SwingUtilities.invokeAndWait(() -> createAndShowUI());
 
             robot.waitForIdle();
-            robot.delay(1000);	    
+            robot.delay(1000);
 
             // test mouse press
             Point point = Util.getCenterPoint(menu);


### PR DESCRIPTION
Test was run without waiting for UI to be made visible leading to IllegalComponentStateException.
Used robot.delay consistent with other headful tests to made the test wait after UI is created and shown.

Test passed in several iterations in all platforms. Link in JBS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315986](https://bugs.openjdk.org/browse/JDK-8315986): [macos14] javax/swing/JMenuItem/4654927/bug4654927.java: component must be showing on the screen to determine its location (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) ⚠️ Review applies to [b5861ef5](https://git.openjdk.org/jdk/pull/15677/files/b5861ef552671cec58a96c6fd07538f19550f4e0)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [b5861ef5](https://git.openjdk.org/jdk/pull/15677/files/b5861ef552671cec58a96c6fd07538f19550f4e0)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [268b995b](https://git.openjdk.org/jdk/pull/15677/files/268b995b42a1ea918a06c9fa6eb7d3f08893ea22)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15677/head:pull/15677` \
`$ git checkout pull/15677`

Update a local copy of the PR: \
`$ git checkout pull/15677` \
`$ git pull https://git.openjdk.org/jdk.git pull/15677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15677`

View PR using the GUI difftool: \
`$ git pr show -t 15677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15677.diff">https://git.openjdk.org/jdk/pull/15677.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15677#issuecomment-1714963762)