### PR TITLE
8316094: Problemlist compiler/rangechecks/TestRangeCheckHoistingScaledIV.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -51,6 +51,8 @@ compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
 compiler/loopopts/TestUnreachableInnerLoop.java 8288981 linux-s390x
 
+compiler/rangechecks/TestRangeCheckHoistingScaledIV.java 8315969 generic-all
+
 compiler/rtm/locking/TestRTMAbortRatio.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestRTMAbortThreshold.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestRTMAfterNonRTMDeopt.java 8183263 generic-x64,generic-i586


### PR DESCRIPTION
In order to reduce the noise in the JDK 22 CI, I'm problemlisting:

`compiler/rangechecks/TestRangeCheckHoistingScaledIV.java`

which fails regularly in tier6 and 7.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316094](https://bugs.openjdk.org/browse/JDK-8316094): Problemlist compiler/rangechecks/TestRangeCheckHoistingScaledIV.java (**Sub-task** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15679/head:pull/15679` \
`$ git checkout pull/15679`

Update a local copy of the PR: \
`$ git checkout pull/15679` \
`$ git pull https://git.openjdk.org/jdk.git pull/15679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15679`

View PR using the GUI difftool: \
`$ git pr show -t 15679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15679.diff">https://git.openjdk.org/jdk/pull/15679.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15679#issuecomment-1715224046)