### PR TITLE
8315931: RISC-V: xxxMaxVectorTestsSmokeTest fails when using RVV

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -2900,11 +2900,9 @@ instruct vmask_gen_I(vRegMask dst, iRegI src) %{
   format %{ "vmask_gen_I $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vmclr_m(as_VectorRegister($dst$$reg));
-    __ vsetvli(t0, $src$$Register, sew);
-    __ vmset_m(as_VectorRegister($dst$$reg));
+    __ vid_v(as_VectorRegister($dst$$reg));
+    __ vmsltu_vx(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), $src$$Register);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2914,26 +2912,30 @@ instruct vmask_gen_L(vRegMask dst, iRegL src) %{
   format %{ "vmask_gen_L $dst, $src" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vmclr_m(as_VectorRegister($dst$$reg));
-    __ vsetvli(t0, $src$$Register, sew);
-    __ vmset_m(as_VectorRegister($dst$$reg));
+    __ vid_v(as_VectorRegister($dst$$reg));
+    __ vmsltu_vx(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), $src$$Register);
   %}
   ins_pipe(pipe_slow);
 %}
 
 instruct vmask_gen_imm(vRegMask dst, immL con) %{
+  predicate(n->in(1)->get_long() <= 16 ||
+            n->in(1)->get_long() == Matcher::vector_length(n));
   match(Set dst (VectorMaskGen con));
   format %{ "vmask_gen_imm $dst, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    if ($con$$constant != Matcher::vector_length(this)) {
-      __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    if ((uint)($con$$constant) == 0) {
       __ vmclr_m(as_VectorRegister($dst$$reg));
+    } else if ((uint)($con$$constant) == Matcher::vector_length(this)) {
+      __ vmset_m(as_VectorRegister($dst$$reg));
+    } else {
+      assert((uint)($con$$constant) < Matcher::vector_length(this), "unsupported input lane_cnt");
+      __ vid_v(as_VectorRegister($dst$$reg));
+      __ vmsleu_vi(as_VectorRegister($dst$$reg), as_VectorRegister($dst$$reg), (uint)($con$$constant) - 1);
     }
-    __ vsetvli_helper(bt, (uint)($con$$constant));
-    __ vmset_m(as_VectorRegister($dst$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -3497,18 +3499,16 @@ instruct extractD(fRegD dst, vReg src, immI idx, vReg tmp)
 
 // ------------------------------ Compress/Expand Operations -------------------
 
-instruct mcompress(vRegMask dst, vRegMask src, iRegLNoSp tmp) %{
+instruct mcompress(vRegMask dst, vRegMask src, vReg tmp) %{
   match(Set dst (CompressM src));
-  effect(TEMP_DEF dst, TEMP tmp);
+  effect(TEMP tmp);
   format %{ "mcompress $dst, $src\t# KILL $tmp" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vmclr_m(as_VectorRegister($dst$$reg));
-    __ vcpop_m($tmp$$Register, as_VectorRegister($src$$reg));
-    __ vsetvli(t0, $tmp$$Register, sew);
-    __ vmset_m(as_VectorRegister($dst$$reg));
+    __ vid_v(as_VectorRegister($tmp$$reg));
+    __ vcpop_m(t0, as_VectorRegister($src$$reg));
+    __ vmsltu_vx(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), t0);
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
Hi, This patch fixes an error when qemu enabled the parameter rvv_ta_all_1s=true. The cause for the error is that the number of set lanes here may be smaller than Matcher::vector_length(this), then this vector width is not set correctly. this in turn causes the width of the returned vector length to be less than the expected length. together with these two options for QEMU, this resulted in the use of unintended vector element values.

https://github.com/openjdk/jdk/blob/94800781eae192d3e82f5635d4aad165f11eabc1/src/hotspot/cpu/riscv/riscv_v.ad#L3510
### Testing:
qemu with UseRVV:
- [x] test/jdk/jdk/incubator/vector (fastdebug)

qemu with rvv_ma_all_1s=true,rvv_ta_all_1s=true and UseRVV:
- [x] Tier1 tests (release)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)
- [x] test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315931](https://bugs.openjdk.org/browse/JDK-8315931): RISC-V: xxxMaxVectorTestsSmokeTest fails when using RVV (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Dingli Zhang](https://openjdk.org/census#dzhang) (@DingliZhang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15680/head:pull/15680` \
`$ git checkout pull/15680`

Update a local copy of the PR: \
`$ git checkout pull/15680` \
`$ git pull https://git.openjdk.org/jdk.git pull/15680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15680`

View PR using the GUI difftool: \
`$ git pr show -t 15680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15680.diff">https://git.openjdk.org/jdk/pull/15680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15680#issuecomment-1715525794)