### PR TITLE
JDK-8316123: ProblemList serviceability/dcmd/gc/RunFinalizationTest.java on AIX

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -121,7 +121,7 @@ serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
 serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generic-all
-serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
+serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64,aix-ppc64
 
 serviceability/sa/ClhsdbCDSCore.java 8267433 macosx-x64
 serviceability/sa/ClhsdbFindPC.java#xcomp-core 8267433 macosx-x64


### PR DESCRIPTION
we see the same timeout issues reported for e.g. Linux on AIX as well. So it should be problem-listed too on AIX.