### PR TITLE
8315934: RISC-V: Disable conservative fences per vendor

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -99,6 +99,17 @@ void VM_Version::initialize() {
     }
   }
 
+  // Enable vendor specific features
+
+  if (mvendorid.enabled()) {
+    // Rivos
+    if (mvendorid.value() == RIVOS) {
+      if (FLAG_IS_DEFAULT(UseConservativeFence)) {
+        FLAG_SET_DEFAULT(UseConservativeFence, false);
+      }
+    }
+  }
+
   if (UseZic64b) {
     if (CacheLineSize != 64) {
       assert(!FLAG_IS_DEFAULT(CacheLineSize), "default cache line size should be 64 bytes");

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -40,6 +40,12 @@ class RiscvHwprobe;
 class VM_Version : public Abstract_VM_Version {
   friend RiscvHwprobe;
  private:
+
+  // JEDEC encoded as ((bank - 1) << 7) | (0x7f & JEDEC)
+  enum VendorId {
+    RIVOS = 0x6cf, // JEDEC: 0x4f, Bank: 14
+  };
+
   class RVFeatureValue {
     const char* const _pretty;
     const bool        _feature_string;

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -207,14 +207,11 @@ char* VM_Version::os_uarch_additional_features() {
 }
 
 void VM_Version::vendor_features() {
-  // JEDEC encoded as ((bank - 1) << 7) | (0x7f & JEDEC)
-  static constexpr int RIVOS_MVENDORID = 0x6cf; // JEDEC: 0x4f, Bank: 14
-
   if (!mvendorid.enabled()) {
     return;
   }
   switch (mvendorid.value()) {
-    case RIVOS_MVENDORID:
+    case RIVOS:
     rivos_features();
     break;
     default:


### PR DESCRIPTION
Conservative fences are not a requirement on some RISC-V hardware for correctness, but can bring a performance penalty. Let's make sure we disable them on a per-vendor basis, and keep them enabled for the default case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315934](https://bugs.openjdk.org/browse/JDK-8315934): RISC-V: Disable conservative fences per vendor (**Task** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15684/head:pull/15684` \
`$ git checkout pull/15684`

Update a local copy of the PR: \
`$ git checkout pull/15684` \
`$ git pull https://git.openjdk.org/jdk.git pull/15684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15684`

View PR using the GUI difftool: \
`$ git pr show -t 15684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15684.diff">https://git.openjdk.org/jdk/pull/15684.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15684#issuecomment-1715849626)