### PR TITLE
8301247: JPackage app-image exe launches multiple exe's in JDK 17+

### DIFF
--- a/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
+++ b/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
@@ -34,6 +34,7 @@
 #include "Dll.h"
 #include "WinApp.h"
 #include "Toolbox.h"
+#include "Executor.h"
 #include "FileUtils.h"
 #include "PackageFile.h"
 #include "UniqueHandle.h"
@@ -180,29 +181,29 @@ void launchApp() {
 
         jvm = std::unique_ptr<Jvm>();
 
-        STARTUPINFOW si;
-        ZeroMemory(&si, sizeof(si));
-        si.cb = sizeof(si);
-
-        PROCESS_INFORMATION pi;
-        ZeroMemory(&pi, sizeof(pi));
-
-        if (!CreateProcessW(launcherPath.c_str(), GetCommandLineW(),
-                NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
-            JP_THROW(SysError(tstrings::any() << "CreateProcessW() failed",
-                                                            CreateProcessW));
+        UniqueHandle jobHandle(CreateJobObject(NULL, NULL));
+        if (jobHandle.get() == NULL) {
+            JP_THROW(SysError(tstrings::any() << "CreateJobObject() failed",
+                                                            CreateJobObject));
+        }
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInfo = { };
+        jobInfo.BasicLimitInformation.LimitFlags =
+                                          JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if (!SetInformationJobObject(jobHandle.get(),
+                JobObjectExtendedLimitInformation, &jobInfo, sizeof(jobInfo))) {
+            JP_THROW(SysError(tstrings::any() <<
+                                            "SetInformationJobObject() failed",
+                                                    SetInformationJobObject));
         }
 
-        WaitForSingleObject(pi.hProcess, INFINITE);
+        Executor exec(launcherPath);
+        exec.visible(true).withJobObject(jobHandle.get()).suspended(true).inherit(true);
+        const auto args = SysInfo::getCommandArgs();
+        std::for_each(args.begin(), args.end(), [&exec] (const tstring& arg) {
+            exec.arg(arg);
+        });
 
-        UniqueHandle childProcessHandle(pi.hProcess);
-        UniqueHandle childThreadHandle(pi.hThread);
-
-        DWORD exitCode;
-        if (!GetExitCodeProcess(pi.hProcess, &exitCode)) {
-            JP_THROW(SysError(tstrings::any() << "GetExitCodeProcess() failed",
-                                                        GetExitCodeProcess));
-        }
+        DWORD exitCode = static_cast<DWORD>(exec.execAndWaitForExit());
 
         exit(exitCode);
         return;

--- a/src/jdk.jpackage/windows/native/common/Executor.h
+++ b/src/jdk.jpackage/windows/native/common/Executor.h
@@ -33,7 +33,7 @@
 class Executor {
 public:
     explicit Executor(const std::wstring& appPath=std::wstring()) {
-        app(appPath).visible(false);
+        app(appPath).visible(false).suspended(false).withJobObject(NULL).inherit(false);
     }
 
     /**
@@ -66,6 +66,30 @@ public:
     }
 
     /**
+     * Controls if the process should inherit handles.
+     */
+    Executor& inherit(bool v) {
+        theInherit = v;
+        return *this;
+    }
+
+    /**
+     * Controls if the process should be started suspended.
+     */
+    Executor& suspended(bool v) {
+        theSuspended = v;
+        return *this;
+    }
+
+    /**
+     * Use the given job object with started process.
+     */
+    Executor& withJobObject(HANDLE v) {
+        jobHandle = v;
+        return *this;
+    }
+
+    /**
      * Starts application process and blocks waiting when the started
      * process terminates.
      * Returns process exit code.
@@ -74,9 +98,12 @@ public:
     int execAndWaitForExit() const;
 
 private:
-    UniqueHandle startProcess() const;
+    UniqueHandle startProcess(UniqueHandle* threadHandle=0) const;
 
     bool theVisible;
+    bool theInherit;
+    bool theSuspended;
+    HANDLE jobHandle;
     tstring_array argsArray;
     std::wstring appPath;
 };

--- a/test/jdk/tools/jpackage/windows/Win8301247Test.java
+++ b/test/jdk/tools/jpackage/windows/Win8301247Test.java
@@ -59,14 +59,14 @@ public class Win8301247Test {
     public void test() throws IOException, InterruptedException {
         JPackageCommand cmd = JPackageCommand.helloAppImage();
 
-        if (!cmd.canRunLauncher("Not running the test")) {
-            return;
-        }
-
         // Launch the app in a way it doesn't exit to let us trap app laucnher
         // processes in the process list
         cmd.addArguments("--java-options", "-Djpackage.test.noexit=true");
         cmd.executeAndAssertImageCreated();
+
+        if (!cmd.canRunLauncher("Not running the test")) {
+            return;
+        }
 
         try ( // Launch the app in a separate thread
                 ExecutorService exec = Executors.newSingleThreadExecutor()) {

--- a/test/jdk/tools/jpackage/windows/Win8301247Test.java
+++ b/test/jdk/tools/jpackage/windows/Win8301247Test.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import jdk.jpackage.test.JPackageCommand;
+import jdk.jpackage.test.Annotations.Test;
+import jdk.jpackage.test.Executor;
+import jdk.jpackage.test.HelloApp;
+import jdk.jpackage.test.TKit;
+
+/**
+ * Test that terminating of the parent app launcher process automatically
+ * terminates child app launcher process.
+ */
+
+/*
+ * @test
+ * @summary Test case for JDK-8301247
+ * @library ../helpers
+ * @build jdk.jpackage.test.*
+ * @build Win8301247Test
+ * @requires (os.family == "windows")
+ * @modules jdk.jpackage/jdk.jpackage.internal
+ * @run main/othervm/timeout=360 -Xmx512m  jdk.jpackage.test.Main
+ *  --jpt-run=Win8301247Test
+ */
+public class Win8301247Test {
+
+    @Test
+    public void test() throws IOException, InterruptedException {
+        JPackageCommand cmd = JPackageCommand.helloAppImage();
+
+        if (!cmd.canRunLauncher("Not running the test")) {
+            return;
+        }
+
+        // Launch the app in a way it doesn't exit to let us trap app laucnher
+        // processes in the process list
+        cmd.addArguments("--java-options", "-Djpackage.test.noexit=true");
+        cmd.executeAndAssertImageCreated();
+
+        try ( // Launch the app in a separate thread
+                ExecutorService exec = Executors.newSingleThreadExecutor()) {
+            exec.execute(() -> {
+                HelloApp.executeLauncher(cmd);
+            });
+
+            // Wait a bit to let the app start
+            Thread.sleep(Duration.ofSeconds(10));
+
+            // Get PID of the main app launcher process
+            final long pid = findMainAppLauncherPID(cmd, 2).get();
+
+            // Kill the main app launcher process
+            Executor.of("taskkill", "/F", "/PID", Long.toString(pid)).
+                    dumpOutput(true).execute();
+
+            // Wait a bit and check if child app launcher process is still running (it must NOT)
+            Thread.sleep(Duration.ofSeconds(5));
+
+            findMainAppLauncherPID(cmd, 0);
+        }
+    }
+
+    private static Optional<Long> findMainAppLauncherPID(JPackageCommand cmd,
+            int expectedCount) {
+        // Get the list of PIDs and PPIDs of app launcher processes.
+        // wmic process where (name = "foo.exe") get ProcessID,ParentProcessID
+        List<String> output = Executor.of("wmic", "process", "where", "(name",
+                "=",
+                "\"" + cmd.appLauncherPath().getFileName().toString() + "\"",
+                ")", "get", "ProcessID,ParentProcessID").dumpOutput(true).
+                saveOutput().executeAndGetOutput();
+
+        if (expectedCount == 0) {
+            TKit.assertEquals("No Instance(s) Available.", output.getFirst().
+                    trim(), "Check no app launcher processes found running");
+            return Optional.empty();
+        }
+
+        String[] headers = Stream.of(output.getFirst().split("\\s+", 2)).map(
+                String::trim).map(String::toLowerCase).toArray(String[]::new);
+        Pattern pattern;
+        if (headers[0].equals("parentprocessid") && headers[1].equals(
+                "processid")) {
+            pattern = Pattern.compile("^(?<ppid>\\d+)\\s+(?<pid>\\d+)\\s+$");
+        } else if (headers[1].equals("parentprocessid") && headers[0].equals(
+                "processid")) {
+            pattern = Pattern.compile("^(?<pid>\\d+)\\s+(?<ppid>\\d+)\\s+$");
+        } else {
+            throw new RuntimeException(
+                    "Unrecognizable output of \'wmic process\' command");
+        }
+
+        List<long[]> processes = output.stream().skip(1).map(line -> {
+            Matcher m = pattern.matcher(line);
+            long[] pids = null;
+            if (m.matches()) {
+                pids = new long[]{Long.parseLong(m.group("pid")), Long.
+                    parseLong(m.group("ppid"))};
+            }
+            return pids;
+        }).filter(Objects::nonNull).toList();
+
+        TKit.assertEquals(expectedCount, processes.size(), String.format(
+                "Check [%d] app launcher processes found running", expectedCount));
+
+        switch (expectedCount) {
+            case 2 -> {
+                if (processes.get(0)[0] == processes.get(1)[1]) {
+                    return Optional.of(processes.get(0)[0]);
+                } else if (processes.get(1)[0] == processes.get(0)[1]) {
+                    return Optional.of(processes.get(1)[0]);
+                } else {
+                    throw new RuntimeException(
+                            "App launcher processes unrelated");
+                }
+            }
+            default ->
+                throw new IllegalArgumentException();
+        }
+    }
+}


### PR DESCRIPTION
On Windows, restart app launcher in a way that when the parent app launcher process terminates, the child app launcher process is automatically terminated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301247](https://bugs.openjdk.org/browse/JDK-8301247): JPackage app-image exe launches multiple exe's in JDK 17+ (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15690/head:pull/15690` \
`$ git checkout pull/15690`

Update a local copy of the PR: \
`$ git checkout pull/15690` \
`$ git pull https://git.openjdk.org/jdk.git pull/15690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15690`

View PR using the GUI difftool: \
`$ git pr show -t 15690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15690.diff">https://git.openjdk.org/jdk/pull/15690.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15690#issuecomment-1716335623)