### PR TITLE
8320400: Make fields final in 'jdk.internal.util.xml.impl' package

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/Parser.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/Parser.java
@@ -53,8 +53,8 @@ public abstract class Parser {
      * The end of stream character.
      */
     public static final char EOS = 0xffff;
-    private Pair mNoNS; // there is no namespace
-    private Pair mXml;  // the xml namespace
+    private final Pair mNoNS; // there is no namespace
+    private final Pair mXml;  // the xml namespace
     private Map<String, Input> mEnt;  // the entities look up table
     private Map<String, Input> mPEnt; // the parameter entities look up table
     protected boolean mIsSAlone;     // xml decl standalone flag
@@ -541,11 +541,11 @@ public abstract class Parser {
                         bkch();
                         name = name(mIsNSAware);
                         wsskip();
-                        st = 1;  // read 'PUPLIC' or 'SYSTEM'
+                        st = 1;  // read 'PUBLIC' or 'SYSTEM'
                     }
                     break;
 
-                case 1:     // read 'PUPLIC' or 'SYSTEM'
+                case 1:     // read 'PUBLIC' or 'SYSTEM'
                     switch (chtyp(ch)) {
                         case 'A':
                             bkch();
@@ -1338,7 +1338,7 @@ public abstract class Parser {
      * declared in DTD (attribute declaration had been read); 0x2 - attribute's
      * default value is used.</p>
      *
-     * @param att An object which reprecents current attribute.
+     * @param att An object which represents current attribute.
      * @exception Exception is parser specific exception form panic method.
      * @exception IOException
      */
@@ -1869,7 +1869,7 @@ public abstract class Parser {
      * character before quoted string and read the following string as not an
      * attribute ('-'), 'c' - CDATA, 'i' - non CDATA, ' ' - no normalization;
      * '-' - not an attribute value; 'd' - in DTD context.
-     * @return The content of the quoted strign as a string.
+     * @return The content of the quoted string as a string.
      * @exception Exception is parser specific exception form panic method.
      * @exception IOException
      */
@@ -2745,7 +2745,7 @@ public abstract class Parser {
 
     /**
      * Recognizes the built-in entities <i>lt</i>, <i>gt</i>, <i>amp</i>,
-     * <i>apos</i>, <i>quot</i>. The initial state is 0x100. Any state belowe
+     * <i>apos</i>, <i>quot</i>. The initial state is 0x100. Any state below
      * 0x100 is a built-in entity replacement character.
      *
      * @param ch the next character of an entity name.
@@ -3357,7 +3357,7 @@ public abstract class Parser {
     /**
      * Puts back the last read character.
      *
-     * This method <strong>MUST NOT</strong> be called more then once after each
+     * This method <strong>MUST NOT</strong> be called more than once after each
      * call of {@link #getch getch} method.
      */
     protected void bkch()
@@ -3394,7 +3394,7 @@ public abstract class Parser {
     }
 
     /**
-     * Provedes an instance of a pair.
+     * Provides an instance of a pair.
      *
      * @param next The reference to a next pair.
      * @return An instance of a pair.

--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/ParserSAX.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/ParserSAX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,10 +61,10 @@ final class ParserSAX
     public static final String FEATURE_PREF =
             "http://xml.org/sax/features/namespace-prefixes";
     //          SAX feature flags
-    private boolean mFNamespaces;
-    private boolean mFPrefixes;
+    private final boolean mFNamespaces;
+    private final boolean mFPrefixes;
     //          SAX handlers
-    private DefaultHandler mHand;      // the default handler
+    private final DefaultHandler mHand;      // the default handler
     private ContentHandler mHandCont;  // the content handler
     private DTDHandler mHandDtd;   // the DTD handler
     private ErrorHandler mHandErr;   // the error handler
@@ -291,11 +291,11 @@ final class ParserSAX
      * application before it is passed to the parser.</p>
      *
      * @param systemId The system identifier (URI).
-     * @exception org.xml.sax.SAXException Any SAX exception, possibly wrapping
+     * @exception SAXException Any SAX exception, possibly wrapping
      * another exception.
-     * @exception java.io.IOException An IO exception from the parser, possibly
+     * @exception IOException An IO exception from the parser, possibly
      * from a byte stream or character stream supplied by the application.
-     * @see #parse(org.xml.sax.InputSource)
+     * @see #parse(InputSource)
      */
     public void parse(String systemId) throws IOException, SAXException {
         parse(new InputSource(systemId));
@@ -321,9 +321,9 @@ final class ParserSAX
      * should throw an exception.</p>
      *
      * @param is The input source for the top-level of the XML document.
-     * @exception org.xml.sax.SAXException Any SAX exception, possibly wrapping
+     * @exception SAXException Any SAX exception, possibly wrapping
      * another exception.
-     * @exception java.io.IOException An IO exception from the parser, possibly
+     * @exception IOException An IO exception from the parser, possibly
      * from a byte stream or character stream supplied by the application.
      * @see org.xml.sax.InputSource
      * @see #parse(java.lang.String)
@@ -350,8 +350,8 @@ final class ParserSAX
     }
 
     /**
-     * Parse the content of the given {@link java.io.InputStream} instance as
-     * XML using the specified {@link org.xml.sax.helpers.DefaultHandler}.
+     * Parse the content of the given {@link InputStream} instance as
+     * XML using the specified {@link DefaultHandler}.
      *
      * @param src InputStream containing the content to be parsed.
      * @param handler The SAX DefaultHandler to use.
@@ -371,8 +371,8 @@ final class ParserSAX
     }
 
     /**
-     * Parse the content given {@link org.xml.sax.InputSource} as XML using the
-     * specified {@link org.xml.sax.helpers.DefaultHandler}.
+     * Parse the content given {@link InputSource} as XML using the
+     * specified {@link DefaultHandler}.
      *
      * @param is The InputSource containing the content to be parsed.
      * @param handler The SAX DefaultHandler to use.

--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/ReaderUTF16.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/ReaderUTF16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,8 @@ import java.io.IOException;
  */
 public class ReaderUTF16 extends Reader {
 
-    private InputStream is;
-    private char bo;
+    private final InputStream is;
+    private final char bo;
 
     /**
      * Constructor.

--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/ReaderUTF8.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/ReaderUTF8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import java.io.UnsupportedEncodingException;
  */
 public class ReaderUTF8 extends Reader {
 
-    private InputStream is;
+    private final InputStream is;
 
     /**
      * Constructor.

--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/SAXParserImpl.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/SAXParserImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import jdk.internal.util.xml.SAXParser;
 
 public class SAXParserImpl extends SAXParser {
 
-    private ParserSAX parser;
+    private final ParserSAX parser;
 
     public SAXParserImpl() {
         super();
@@ -79,9 +79,9 @@ public class SAXParserImpl extends SAXParser {
     }
 
     /**
-     * Parse the content of the given {@link java.io.InputStream}
+     * Parse the content of the given {@link InputStream}
      * instance as XML using the specified
-     * {@link org.xml.sax.helpers.DefaultHandler}.
+     * {@link DefaultHandler}.
      *
      * @param src InputStream containing the content to be parsed.
      * @param handler The SAX DefaultHandler to use.
@@ -98,9 +98,9 @@ public class SAXParserImpl extends SAXParser {
     }
 
     /**
-     * Parse the content given {@link org.xml.sax.InputSource}
+     * Parse the content given {@link InputSource}
      * as XML using the specified
-     * {@link org.xml.sax.helpers.DefaultHandler}.
+     * {@link DefaultHandler}.
      *
      * @param is The InputSource containing the content to be parsed.
      * @param handler The SAX DefaultHandler to use.

--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/XMLStreamWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/XMLStreamWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class XMLStreamWriterImpl implements XMLStreamWriter {
     private int _state = 0;
     private Element _currentEle;
     private XMLWriter _writer;
-    private Charset _charset;
+    private final Charset _charset;
     /**
      * This flag can be used to turn escaping off for content. It does
      * not apply to attribute content.
@@ -75,7 +75,7 @@ public class XMLStreamWriterImpl implements XMLStreamWriter {
     //pretty print by default
     private boolean _doIndent = true;
     //The system line separator for writing out line breaks.
-    private char[] _lineSep = System.lineSeparator().toCharArray();
+    private final char[] _lineSep = System.lineSeparator().toCharArray();
 
     public XMLStreamWriterImpl(OutputStream os) throws XMLStreamException {
         this(os, XMLStreamWriter.DEFAULT_CHARSET);

--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/XMLWriter.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/XMLWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import jdk.internal.util.xml.XMLStreamException;
  */
 public class XMLWriter {
 
-    private Writer _writer;
+    private final Writer _writer;
     /**
      * In some cases, this charset encoder is used to determine if a char is
      * encodable by underlying writer. For example, an 8-bit char from the


### PR DESCRIPTION
A few classes in `jdk.internal.util.xml.impl` package have non-final fields which could easily be marked `final`.

Also fixed a few typos and incorrect javadoc links.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320400](https://bugs.openjdk.org/browse/JDK-8320400): Make fields final in 'jdk.internal.util.xml.impl' package (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15691/head:pull/15691` \
`$ git checkout pull/15691`

Update a local copy of the PR: \
`$ git checkout pull/15691` \
`$ git pull https://git.openjdk.org/jdk.git pull/15691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15691`

View PR using the GUI difftool: \
`$ git pr show -t 15691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15691.diff">https://git.openjdk.org/jdk/pull/15691.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15691#issuecomment-1818898577)