### PR TITLE
8316144: Remove unused field jdk.internal.util.xml.impl.XMLStreamWriterImpl.Element._Depth

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/xml/impl/XMLStreamWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/util/xml/impl/XMLStreamWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -603,10 +603,6 @@ public class XMLStreamWriterImpl implements XMLStreamWriter {
          * the parent element
          */
         protected Element _parent;
-        /**
-         * The size of the stack.
-         */
-        protected short _Depth;
         /**
          * indicate if an element is an empty one
          */


### PR DESCRIPTION
A field `short _Depth` in the `jdk.internal.util.xml.impl.XMLStreamWriterImpl.Element` class is unused and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316144](https://bugs.openjdk.org/browse/JDK-8316144): Remove unused field jdk.internal.util.xml.impl.XMLStreamWriterImpl.Element._Depth (**Enhancement** - P5)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15692/head:pull/15692` \
`$ git checkout pull/15692`

Update a local copy of the PR: \
`$ git checkout pull/15692` \
`$ git pull https://git.openjdk.org/jdk.git pull/15692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15692`

View PR using the GUI difftool: \
`$ git pr show -t 15692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15692.diff">https://git.openjdk.org/jdk/pull/15692.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15692#issuecomment-1716359164)