### PR TITLE
8316147: Remove serviceability/sa/TestJhsdbJstackMixed.java from -Xcomp problem list

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -38,8 +38,6 @@ vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 lin
 
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8303168 linux-x64
 
-serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
-
 serviceability/sa/ClhsdbInspect.java 8283578 windows-x64
 
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 windows-x64


### PR DESCRIPTION
[JDK-8248675](https://bugs.openjdk.org/browse/JDK-8248675) no longer seems to be reproducing, even before [JDK-8313800](https://bugs.openjdk.org/browse/JDK-8313800) was just pushed. I'm not sure what may have fixed it, but even if the bug was potentially still there, it has likely been fixed by [JDK-8313800](https://bugs.openjdk.org/browse/JDK-8313800). `serviceability/sa/TestJhsdbJstackMixed.java` should be removed from the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316147](https://bugs.openjdk.org/browse/JDK-8316147): Remove serviceability/sa/TestJhsdbJstackMixed.java from -Xcomp problem list (**Sub-task** - P5)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15696/head:pull/15696` \
`$ git checkout pull/15696`

Update a local copy of the PR: \
`$ git checkout pull/15696` \
`$ git pull https://git.openjdk.org/jdk.git pull/15696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15696`

View PR using the GUI difftool: \
`$ git pr show -t 15696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15696.diff">https://git.openjdk.org/jdk/pull/15696.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15696#issuecomment-1716688516)