### PR TITLE
8316148: Remove sun/tools/jhsdb/JStackStressTest.java from problem list

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -731,8 +731,6 @@ sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aa
 sun/tools/jstat/jstatLineCounts3.sh                             8268211 linux-aarch64
 sun/tools/jstat/jstatLineCounts4.sh                             8268211 linux-aarch64
 
-sun/tools/jhsdb/JStackStressTest.java                           8276210 linux-aarch64
-
 ############################################################################
 
 # jdk_other


### PR DESCRIPTION
[JDK-8276210](https://bugs.openjdk.org/browse/JDK-8276210) no longer seems to be reproducing, even before [JDK-8313800](https://bugs.openjdk.org/browse/JDK-8313800) was just pushed. I'm not sure what may have fixed it, but even if the bug was potentially still there, it has likely been fixed by [JDK-8313800](https://bugs.openjdk.org/browse/JDK-8313800). `sun/tools/jhsdb/JStackStressTest.java` should be removed from the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316148](https://bugs.openjdk.org/browse/JDK-8316148): Remove sun/tools/jhsdb/JStackStressTest.java from problem list (**Sub-task** - P5)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15697/head:pull/15697` \
`$ git checkout pull/15697`

Update a local copy of the PR: \
`$ git checkout pull/15697` \
`$ git pull https://git.openjdk.org/jdk.git pull/15697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15697`

View PR using the GUI difftool: \
`$ git pr show -t 15697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15697.diff">https://git.openjdk.org/jdk/pull/15697.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15697#issuecomment-1716691321)