### PR TITLE
8267509: Improve IllegalAccessException message to include the cause of the exception

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1719,7 +1719,7 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
         try {
             return this.withVarargs(true);
         } catch (IllegalArgumentException ex) {
-            throw new IllegalAccessException("cannot make variable arity: " + this + " because " + ex.getMessage());
+            throw new IllegalAccessException("cannot make variable arity: " + member + " because " + ex.getMessage());
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1719,7 +1719,8 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
         try {
             return this.withVarargs(true);
         } catch (IllegalArgumentException ex) {
-            throw new IllegalAccessException("cannot make variable arity: " + member + " because " + ex.getMessage());
+            throw new IllegalAccessException("cannot make variable arity: " + member +
+                    " does not have a trailing array parameter");
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1719,7 +1719,7 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
         try {
             return this.withVarargs(true);
         } catch (IllegalArgumentException ex) {
-            throw member.makeAccessException("cannot make variable arity", null);
+            throw new IllegalAccessException("cannot make variable arity: " + this + " because " + ex.getMessage());
         }
     }
 


### PR DESCRIPTION
This PR improves IllegalAccessException message thrown by `Lookup::findXXX` APIs if the method's variable arity modifier bit is set and `asVarargsCollector` fails.  It will include the exception message thrown by asVarargsCollector`.

The exception message looks like this:
```
java.lang.IllegalAccessException: cannot make variable arity: MyClass.m(Object[],int)void/invokeStatic does not have a trailing array parameter
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8267509](https://bugs.openjdk.org/browse/JDK-8267509): Improve IllegalAccessException message to include the cause of the exception (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15698/head:pull/15698` \
`$ git checkout pull/15698`

Update a local copy of the PR: \
`$ git checkout pull/15698` \
`$ git pull https://git.openjdk.org/jdk.git pull/15698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15698`

View PR using the GUI difftool: \
`$ git pr show -t 15698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15698.diff">https://git.openjdk.org/jdk/pull/15698.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15698#issuecomment-1716793438)