### PR TITLE
8315871: Opensource five more Swing regression tests

### DIFF
--- a/test/jdk/javax/swing/AncestorNotifier/4817630/bug4817630.java
+++ b/test/jdk/javax/swing/AncestorNotifier/4817630/bug4817630.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ *  @test
+ *  @bug 4817630
+ *  @summary AncestorEvent ancestorAdded thrown at JFrame creation, not at show()
+ *  @key headful
+ *  @run main bug4817630
+ */
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
+import java.lang.reflect.InvocationTargetException;
+
+
+public class bug4817630 {
+
+    JFrame fr;
+
+    volatile boolean ancestorAdded = false;
+    volatile boolean passed = true;
+
+    public void init() {
+        fr = new JFrame("bug4817630");
+        JLabel label = new JLabel("Label");
+
+        label.addAncestorListener(new AncestorListener() {
+                public void ancestorAdded(AncestorEvent e) {
+                    if (!fr.isVisible()) {
+                        setPassed(false);
+                    }
+                    synchronized (bug4817630.this) {
+                        ancestorAdded = true;
+                        bug4817630.this.notifyAll();
+                    }
+                }
+                public void ancestorRemoved(AncestorEvent e) {
+                }
+                public void ancestorMoved(AncestorEvent e) {
+                }
+            });
+
+        fr.setLocationRelativeTo(null);
+        fr.getContentPane().add(label);
+        fr.pack();
+        fr.setVisible(true);
+    }
+
+    public void start() {
+        try {
+            synchronized (bug4817630.this) {
+                while (!ancestorAdded) {
+                    bug4817630.this.wait();
+                }
+            }
+        } catch(Exception e) {
+            throw new RuntimeException("Test failed because of "
+                    + e.getLocalizedMessage());
+        }
+    }
+
+    public void destroy() {
+        if (!isPassed()) {
+            throw new RuntimeException("ancestorAdded() method shouldn't be "
+                    + "called before the frame is shown.");
+        }
+        if (fr != null) {
+            fr.setVisible(false);
+            fr.dispose();
+        }
+    }
+
+    synchronized void setPassed(boolean passed) {
+        this.passed = passed;
+    }
+
+    synchronized boolean isPassed() {
+        return passed;
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        bug4817630 test = new bug4817630();
+        try {
+            SwingUtilities.invokeAndWait(test::init);
+            test.start();
+        } finally {
+            test.destroy();
+        }
+    }
+}

--- a/test/jdk/javax/swing/AncestorNotifier/4817630/bug4817630.java
+++ b/test/jdk/javax/swing/AncestorNotifier/4817630/bug4817630.java
@@ -77,7 +77,7 @@ public class bug4817630 {
                     bug4817630.this.wait();
                 }
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException("Test failed because of "
                     + e.getLocalizedMessage());
         }

--- a/test/jdk/javax/swing/AncestorNotifier/4817630/bug4817630.java
+++ b/test/jdk/javax/swing/AncestorNotifier/4817630/bug4817630.java
@@ -29,13 +29,12 @@
  *  @run main bug4817630
  */
 
+import java.lang.reflect.InvocationTargetException;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.AncestorEvent;
 import javax.swing.event.AncestorListener;
-import java.lang.reflect.InvocationTargetException;
-
 
 public class bug4817630 {
 
@@ -77,20 +76,20 @@ public class bug4817630 {
                     bug4817630.this.wait();
                 }
             }
-        } catch (Exception e) {
+        } catch(Exception e) {
             throw new RuntimeException("Test failed because of "
                     + e.getLocalizedMessage());
         }
     }
 
     public void destroy() {
-        if (!isPassed()) {
-            throw new RuntimeException("ancestorAdded() method shouldn't be "
-                    + "called before the frame is shown.");
-        }
         if (fr != null) {
             fr.setVisible(false);
             fr.dispose();
+        }
+        if (!isPassed()) {
+            throw new RuntimeException("ancestorAdded() method shouldn't be "
+                    + "called before the frame is shown.");
         }
     }
 
@@ -109,7 +108,7 @@ public class bug4817630 {
             SwingUtilities.invokeAndWait(test::init);
             test.start();
         } finally {
-            test.destroy();
+            SwingUtilities.invokeAndWait(test::destroy);
         }
     }
 }

--- a/test/jdk/javax/swing/BoxLayout/4191948/bug4191948.java
+++ b/test/jdk/javax/swing/BoxLayout/4191948/bug4191948.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4191948
+ * @summary BoxLayout doesn't ignore invisible components
+ * @key headful
+ * @run main bug4191948
+ */
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.lang.reflect.InvocationTargetException;
+
+public class bug4191948 {
+    JFrame frame;
+    JPanel p;
+    JButton foo1;
+    JButton foo2;
+    JButton foo3;
+
+    public void init() {
+        frame = new JFrame("bug4191948");
+        p = new JPanel();
+        p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
+        foo1 = (JButton)p.add(new JButton("Foo1"));
+        foo2 = (JButton)p.add(new JButton("Foo2"));
+        foo3 = (JButton)p.add(new JButton("Foo3"));
+
+        foo2.setVisible(false);
+        frame.setLocationRelativeTo(null);
+        frame.setLayout(new BorderLayout());
+        frame.add(p, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    public void start() {
+        try {
+            int totalWidth = p.getPreferredSize().width;
+            int foo1Width = foo1.getPreferredSize().width;
+            int foo2Width = foo2.getPreferredSize().width;
+            int foo3Width = foo3.getPreferredSize().width;
+            if (totalWidth >= (foo1Width + foo2Width + foo3Width)) {
+                throw new RuntimeException("Panel is too wide");
+            }
+        } finally {
+            if (frame != null) {
+                frame.setVisible(false);
+                frame.dispose();
+            }
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        bug4191948 test = new bug4191948();
+        SwingUtilities.invokeAndWait(test::init);
+        SwingUtilities.invokeAndWait(test::start);
+    }
+}

--- a/test/jdk/javax/swing/BoxLayout/4191948/bug4191948.java
+++ b/test/jdk/javax/swing/BoxLayout/4191948/bug4191948.java
@@ -29,13 +29,13 @@
  * @run main bug4191948
  */
 
+import java.awt.BorderLayout;
+import java.lang.reflect.InvocationTargetException;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
-import java.awt.BorderLayout;
-import java.lang.reflect.InvocationTargetException;
 
 public class bug4191948 {
     JFrame frame;

--- a/test/jdk/javax/swing/ComponentInputMap/4248723/bug4248723.java
+++ b/test/jdk/javax/swing/ComponentInputMap/4248723/bug4248723.java
@@ -28,9 +28,6 @@
  * @run main bug4248723
  */
 
-import javax.swing.ComponentInputMap;
-import javax.swing.JButton;
-import javax.swing.KeyStroke;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.ByteArrayInputStream;
@@ -38,6 +35,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import javax.swing.ComponentInputMap;
+import javax.swing.JButton;
+import javax.swing.KeyStroke;
 
 public class bug4248723 {
     public static Object serializeAndDeserialize(Object toWrite)
@@ -62,8 +62,8 @@ public class bug4248723 {
                 KeyEvent.VK_B, InputEvent.CTRL_DOWN_MASK), "A");
         try {
             cim = (ComponentInputMap)serializeAndDeserialize(cim);
-        } catch (ClassNotFoundException e) {
-        } catch (IOException e) {
+        } catch (ClassNotFoundException|IOException ignore) {
+            // Should not cause test to fail so silently ignore these
         }
     }
 }

--- a/test/jdk/javax/swing/ComponentInputMap/4248723/bug4248723.java
+++ b/test/jdk/javax/swing/ComponentInputMap/4248723/bug4248723.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4248723
+ * @summary Tests that ComponentInputMap doesn't throw NPE when deserializing
+ * @run main bug4248723
+ */
+
+import javax.swing.ComponentInputMap;
+import javax.swing.JButton;
+import javax.swing.KeyStroke;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class bug4248723 {
+    public static Object serializeAndDeserialize(Object toWrite)
+            throws ClassNotFoundException, IOException {
+        ByteArrayOutputStream ostream = new ByteArrayOutputStream();
+        ObjectOutputStream p = new ObjectOutputStream(ostream);
+        p.writeObject(toWrite);
+        p.flush();
+        byte[] data = ostream.toByteArray();
+        ostream.close();
+
+        ByteArrayInputStream istream = new ByteArrayInputStream(data);
+        ObjectInputStream q = new ObjectInputStream(istream);
+        Object retValue = q.readObject();
+        istream.close();
+        return retValue;
+    }
+
+    public static void main(String[] argv) {
+        ComponentInputMap cim = new ComponentInputMap(new JButton());
+        cim.put(KeyStroke.getKeyStroke(
+                KeyEvent.VK_B, InputEvent.CTRL_DOWN_MASK), "A");
+        try {
+            cim = (ComponentInputMap)serializeAndDeserialize(cim);
+        } catch (ClassNotFoundException e) {
+        } catch (IOException e) {
+        }
+    }
+}

--- a/test/jdk/javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
+++ b/test/jdk/javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4297953
+ * @summary Tests that DefaultBoundedRangeModel doesn't zero out the
+ *          extent value when maximum changes
+ * @run main bug4297953
+ */
+
+import javax.swing.JScrollBar;
+
+public class bug4297953 {
+    public static void main(String[] args)  {
+        JScrollBar sb = new JScrollBar(JScrollBar.HORIZONTAL, 90, 10, 0, 100);
+        sb.setMaximum(80);
+        if (sb.getVisibleAmount() != 10) {
+            throw new RuntimeException("Failed: extent is " + sb.getVisibleAmount());
+        }
+    }
+}

--- a/test/jdk/javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
+++ b/test/jdk/javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
@@ -32,7 +32,7 @@
 import javax.swing.JScrollBar;
 
 public class bug4297953 {
-    public static void main(String[] args)  {
+    public static void main(String[] args) {
         JScrollBar sb = new JScrollBar(JScrollBar.HORIZONTAL, 90, 10, 0, 100);
         sb.setMaximum(80);
         if (sb.getVisibleAmount() != 10) {

--- a/test/jdk/javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
+++ b/test/jdk/javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
@@ -32,7 +32,7 @@
 import javax.swing.JScrollBar;
 
 public class bug4297953 {
-    public static void main(String[] args) {
+    public static void main(String[] args)  {
         JScrollBar sb = new JScrollBar(JScrollBar.HORIZONTAL, 90, 10, 0, 100);
         sb.setMaximum(80);
         if (sb.getVisibleAmount() != 10) {

--- a/test/jdk/javax/swing/DefaultButtonModel/4097723/bug4097723.java
+++ b/test/jdk/javax/swing/DefaultButtonModel/4097723/bug4097723.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4097723
+ * @summary Tests that method DefaultButtonModel.getGroup() exists
+ * @run main bug4097723
+ */
+
+import javax.swing.ButtonGroup;
+import javax.swing.DefaultButtonModel;
+
+public class bug4097723 {
+    public static void main(String[] argv) {
+        DefaultButtonModel dbm = new DefaultButtonModel();
+        ButtonGroup group = new ButtonGroup();
+        dbm.setGroup(group);
+        ButtonGroup g = dbm.getGroup();
+        if (g != group) {
+            throw new RuntimeException("Failure: getGroup() returned wrong thing");
+        }
+    }
+}


### PR DESCRIPTION
Clean up and move to open source five tests.
javax/swing/AncestorNotifier/4817630/bug4817630.java
javax/swing/BoxLayout/4191948/bug4191948.java
javax/swing/ComponentInputMap/4248723/bug4248723.java
javax/swing/DefaultBoundedRangeModel/4297953/bug4297953.java
javax/swing/DefaultButtonModel/4097723/bug4097723.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315871](https://bugs.openjdk.org/browse/JDK-8315871): Opensource five more Swing regression tests (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) ⚠️ Review applies to [d9d32378](https://git.openjdk.org/jdk/pull/15702/files/d9d3237871176539e96f7a00055256f49f0ca38f)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15702/head:pull/15702` \
`$ git checkout pull/15702`

Update a local copy of the PR: \
`$ git checkout pull/15702` \
`$ git pull https://git.openjdk.org/jdk.git pull/15702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15702`

View PR using the GUI difftool: \
`$ git pr show -t 15702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15702.diff">https://git.openjdk.org/jdk/pull/15702.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15702#issuecomment-1717222866)