### PR TITLE
8316159: Update BoxLayout sample image for crisper edges

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/doc-files/BoxLayout-1.svg
+++ b/src/java.desktop/share/classes/javax/swing/doc-files/BoxLayout-1.svg
@@ -46,18 +46,18 @@
         }
     ]]></style>
 
-    <rect x="8" y="8"
+    <rect x="8.5" y="8.5"
           width="144" height="144"/>
     <text x="16" y="24" class="left">P1</text>
     <g id="leftBox">
-        <rect x="16" y="28"
+        <rect x="16.5" y="28.5"
               width="56" height="116"/>
 
-        <rect x="24" y="36"
+        <rect x="24.5" y="36.5"
               width="40" height="28"/>
-        <rect x="24" y="72"
+        <rect x="24.5" y="72.5"
               width="40" height="28"/>
-        <rect x="24" y="108"
+        <rect x="24.5" y="108.5"
               width="40" height="28"/>
     </g>
 


### PR DESCRIPTION
**Problem**

On a standard display with the scale of 100%, the BoxLayout sample has blurred edges.

It is the result of how SVG is rendered: the strokes fall between the pixel grid, therefore a 1-pixel wide stroke is blurred between the previous and the following pixels with 50% of colour on each pixel. It doesn't look as good.

**Fix**

Move all rectangles half a pixel to make edges crisp. The edges of the rectangles look crisp in 100% and 200%.

For more information see answers to the following questions on Stack Overflow:

- [Why is my SVG line blurry or 2px in height when I specified 1px?](https://stackoverflow.com/a/34229584/572834)
- [Avoiding lines between adjacent SVG rectangles](https://stackoverflow.com/a/23376793/572834)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316159](https://bugs.openjdk.org/browse/JDK-8316159): Update BoxLayout sample image for crisper edges (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15703/head:pull/15703` \
`$ git checkout pull/15703`

Update a local copy of the PR: \
`$ git checkout pull/15703` \
`$ git pull https://git.openjdk.org/jdk.git pull/15703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15703`

View PR using the GUI difftool: \
`$ git pr show -t 15703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15703.diff">https://git.openjdk.org/jdk/pull/15703.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15703#issuecomment-1717269616)