### PR TITLE
8315954: getArgumentValues002.java fails on Graal

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -407,6 +407,8 @@ void OopMapCacheEntry::flush() {
 void InterpreterOopMap::resource_copy(OopMapCacheEntry* from) {
   assert(_resource_allocate_bit_mask,
     "Should not resource allocate the _bit_mask");
+  assert(from->has_valid_mask(),
+    "Cannot copy entry with an invalid mask");
 
   set_method(from->method());
   set_bci(from->bci());

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -194,14 +194,14 @@ InterpreterOopMap::~InterpreterOopMap() {
 bool InterpreterOopMap::is_empty() const {
   bool result = _method == nullptr;
   assert(_method != nullptr || (_bci == 0 &&
-    (_mask_size == 0 || _mask_size == USHRT_MAX) &&
+    (_mask_size == 0 || _mask_size == INT_MAX) &&
     _bit_mask[0] == 0), "Should be completely empty");
   return result;
 }
 
 void InterpreterOopMap::initialize() {
   _method    = nullptr;
-  _mask_size = USHRT_MAX;  // This value should cause a failure quickly
+  _mask_size = INT_MAX;  // This value should cause a failure quickly
   _bci       = 0;
   _expression_stack_size = 0;
   _num_oops  = 0;
@@ -612,7 +612,9 @@ void OopMapCache::compute_one_oop_map(const methodHandle& method, int bci, Inter
   OopMapCacheEntry* tmp = NEW_C_HEAP_OBJ(OopMapCacheEntry, mtClass);
   tmp->initialize();
   tmp->fill(method, bci);
-  entry->resource_copy(tmp);
+  if (tmp->has_valid_mask()) {
+    entry->resource_copy(tmp);
+  }
   tmp->flush();
   FREE_C_HEAP_OBJ(tmp);
 }

--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -194,14 +194,14 @@ InterpreterOopMap::~InterpreterOopMap() {
 bool InterpreterOopMap::is_empty() const {
   bool result = _method == nullptr;
   assert(_method != nullptr || (_bci == 0 &&
-    (_mask_size == 0 || _mask_size == INT_MAX) &&
+    (_mask_size == 0 || _mask_size == USHRT_MAX) &&
     _bit_mask[0] == 0), "Should be completely empty");
   return result;
 }
 
 void InterpreterOopMap::initialize() {
   _method    = nullptr;
-  _mask_size = INT_MAX;  // This value should cause a failure quickly
+  _mask_size = USHRT_MAX;  // This value should cause a failure quickly
   _bci       = 0;
   _expression_stack_size = 0;
   _num_oops  = 0;

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -84,7 +84,7 @@ class InterpreterOopMap: ResourceObj {
  private:
   Method*        _method;         // the method for which the mask is valid
   unsigned short _bci;            // the bci    for which the mask is valid
-  int            _mask_size;      // the mask size in bits
+  int            _mask_size;      // the mask size in bits (INT_MAX if invalid)
   int            _expression_stack_size; // the size of the expression stack in slots
 
  protected:
@@ -146,6 +146,8 @@ class InterpreterOopMap: ResourceObj {
 
   int expression_stack_size() const              { return _expression_stack_size; }
 
+  // Determines if a valid mask has been computed
+  bool has_valid_mask() const { return _mask_size != INT_MAX; }
 };
 
 class OopMapCache : public CHeapObj<mtClass> {

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -84,7 +84,7 @@ class InterpreterOopMap: ResourceObj {
  private:
   Method*        _method;         // the method for which the mask is valid
   unsigned short _bci;            // the bci    for which the mask is valid
-  int            _mask_size;      // the mask size in bits (INT_MAX if invalid)
+  int            _mask_size;      // the mask size in bits (USHRT_MAX if invalid)
   int            _expression_stack_size; // the size of the expression stack in slots
 
  protected:
@@ -147,7 +147,7 @@ class InterpreterOopMap: ResourceObj {
   int expression_stack_size() const              { return _expression_stack_size; }
 
   // Determines if a valid mask has been computed
-  bool has_valid_mask() const { return _mask_size != INT_MAX; }
+  bool has_valid_mask() const { return _mask_size != USHRT_MAX; }
 };
 
 class OopMapCache : public CHeapObj<mtClass> {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3076,7 +3076,7 @@ C2V_VMENTRY_0(jlong, getThreadLocalLong, (JNIEnv* env, jobject, jint id))
   }
 C2V_END
 
-C2V_VMENTRY(void, getLiveObjectLocalsAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(method),
+C2V_VMENTRY(void, getOopMapAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(method),
                  jint bci, jlongArray oop_map_handle))
   methodHandle method(THREAD, UNPACK_PAIR(Method, method));
   if (bci < 0 || bci >= method->code_size()) {
@@ -3092,8 +3092,8 @@ C2V_VMENTRY(void, getLiveObjectLocalsAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(me
     return;
   }
 
-  int nlocals = method->max_locals();
-  int nwords = ((nlocals - 1) / 64) + 1;
+  int nslots = method->max_locals() + method->max_stack();
+  int nwords = ((nslots - 1) / 64) + 1;
   JVMCIPrimitiveArray oop_map = JVMCIENV->wrap(oop_map_handle);
   int oop_map_len = JVMCIENV->get_length(oop_map);
   if (nwords > oop_map_len) {
@@ -3110,7 +3110,7 @@ C2V_VMENTRY(void, getLiveObjectLocalsAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(me
   }
 
   BitMapView oop_map_view = BitMapView((BitMap::bm_word_t*) oop_map_buf, nwords * BitsPerLong);
-  for (int i = 0; i < nlocals; i++) {
+  for (int i = 0; i < nslots; i++) {
     if (mask.is_oop(i)) {
       oop_map_view.set_bit(i);
     }
@@ -3275,7 +3275,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "registerCompilerPhase",                        CC "(" STRING ")I",                                                                   FN_PTR(registerCompilerPhase)},
   {CC "notifyCompilerPhaseEvent",                     CC "(JIII)V",                                                                         FN_PTR(notifyCompilerPhaseEvent)},
   {CC "notifyCompilerInliningEvent",                  CC "(I" HS_METHOD2 HS_METHOD2 "ZLjava/lang/String;I)V",                               FN_PTR(notifyCompilerInliningEvent)},
-  {CC "getLiveObjectLocalsAt",                        CC "(" HS_METHOD2 "I[J)V",                                                            FN_PTR(getLiveObjectLocalsAt)},
+  {CC "getOopMapAt",                                  CC "(" HS_METHOD2 "I[J)V",                                                            FN_PTR(getOopMapAt)},
 };
 
 int CompilerToVM::methods_count() {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3105,6 +3105,9 @@ C2V_VMENTRY(void, getLiveObjectLocalsAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(me
   if (oop_map_buf == nullptr) {
     JVMCI_THROW_MSG(InternalError, err_msg("could not allocate %d longs", nwords));
   }
+  for (int i = 0; i < nwords; i++) {
+    oop_map_buf[i] = 0L;
+  }
 
   BitMapView oop_map_view = BitMapView((BitMap::bm_word_t*) oop_map_buf, nwords * BitsPerLong);
   for (int i = 0; i < nlocals; i++) {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -35,6 +35,7 @@
 #include "compiler/oopMap.hpp"
 #include "interpreter/bytecodeStream.hpp"
 #include "interpreter/linkResolver.hpp"
+#include "interpreter/oopMapCache.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "jvmci/jvmciCodeInstaller.hpp"
 #include "jvmci/jvmciCompilerToVM.hpp"
@@ -2512,7 +2513,7 @@ C2V_VMENTRY_NULL(jlongArray, registerNativeMethods, (JNIEnv* env, jobject, jclas
   jlongArray info = (jlongArray) JNIHandles::make_local(THREAD, info_oop);
   runtime->init_JavaVM_info(info, JVMCI_CHECK_0);
   return info;
-}
+C2V_END
 
 C2V_VMENTRY_PREFIX(jboolean, isCurrentThreadAttached, (JNIEnv* env, jobject c2vm))
   if (thread == nullptr || thread->libjvmci_runtime() == nullptr) {
@@ -2777,7 +2778,7 @@ C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jbool
     return 0L;
   }
   return (jlong) PEER_JVMCIENV->make_global(result).as_jobject();
-}
+C2V_END
 
 C2V_VMENTRY_NULL(jobject, unhand, (JNIEnv* env, jobject, jlong obj_handle))
   requireJVMCINativeLibrary(JVMCI_CHECK_NULL);
@@ -2790,13 +2791,13 @@ C2V_VMENTRY_NULL(jobject, unhand, (JNIEnv* env, jobject, jlong obj_handle))
 
   JVMCIENV->destroy_global(global_handle_obj);
   return result;
-}
+C2V_END
 
 C2V_VMENTRY(void, updateHotSpotNmethod, (JNIEnv* env, jobject, jobject code_handle))
   JVMCIObject code = JVMCIENV->wrap(code_handle);
   // Execute this operation for the side effect of updating the InstalledCode state
   JVMCIENV->get_nmethod(code);
-}
+C2V_END
 
 C2V_VMENTRY_NULL(jbyteArray, getCode, (JNIEnv* env, jobject, jobject code_handle))
   JVMCIObject code = JVMCIENV->wrap(code_handle);
@@ -2812,7 +2813,7 @@ C2V_VMENTRY_NULL(jbyteArray, getCode, (JNIEnv* env, jobject, jobject code_handle
   JVMCIPrimitiveArray result = JVMCIENV->new_byteArray(code_size, JVMCI_CHECK_NULL);
   JVMCIENV->copy_bytes_from(code_bytes, result, 0, code_size);
   return JVMCIENV->get_jbyteArray(result);
-}
+C2V_END
 
 C2V_VMENTRY_NULL(jobject, asReflectionExecutable, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
   requireInHotSpot("asReflectionExecutable", JVMCI_CHECK_NULL);
@@ -2828,7 +2829,7 @@ C2V_VMENTRY_NULL(jobject, asReflectionExecutable, (JNIEnv* env, jobject, ARGUMEN
     executable = Reflection::new_method(m, false, CHECK_NULL);
   }
   return JNIHandles::make_local(THREAD, executable);
-}
+C2V_END
 
 static InstanceKlass* check_field(Klass* klass, jint index, JVMCI_TRAPS) {
   if (!klass->is_instance_klass()) {
@@ -2850,7 +2851,7 @@ C2V_VMENTRY_NULL(jobject, asReflectionField, (JNIEnv* env, jobject, ARGUMENT_PAI
   fieldDescriptor fd(iklass, index);
   oop reflected = Reflection::new_field(&fd, CHECK_NULL);
   return JNIHandles::make_local(THREAD, reflected);
-}
+C2V_END
 
 static jbyteArray get_encoded_annotation_data(InstanceKlass* holder, AnnotationArray* annotations_array, bool for_class,
                                               jint filter_length, jlong filter_klass_pointers,
@@ -2964,7 +2965,7 @@ C2V_VMENTRY_NULL(jobjectArray, getFailedSpeculations, (JNIEnv* env, jobject, jlo
     JVMCIENV->put_object_at(result, result_index++, entry);
   }
   return JVMCIENV->get_jobjectArray(result);
-}
+C2V_END
 
 C2V_VMENTRY_0(jlong, getFailedSpeculationsAddress, (JNIEnv* env, jobject, ARGUMENT_PAIR(method)))
   methodHandle method(THREAD, UNPACK_PAIR(Method, method));
@@ -2975,11 +2976,11 @@ C2V_VMENTRY_0(jlong, getFailedSpeculationsAddress, (JNIEnv* env, jobject, ARGUME
     method->set_method_data(method_data);
   }
   return (jlong) method_data->get_failed_speculations_address();
-}
+C2V_END
 
 C2V_VMENTRY(void, releaseFailedSpeculations, (JNIEnv* env, jobject, jlong failed_speculations_address))
   FailedSpeculation::free_failed_speculations((FailedSpeculation**)(address) failed_speculations_address);
-}
+C2V_END
 
 C2V_VMENTRY_0(jboolean, addFailedSpeculation, (JNIEnv* env, jobject, jlong failed_speculations_address, jbyteArray speculation_obj))
   JVMCIPrimitiveArray speculation_handle = JVMCIENV->wrap(speculation_obj);
@@ -2987,7 +2988,7 @@ C2V_VMENTRY_0(jboolean, addFailedSpeculation, (JNIEnv* env, jobject, jlong faile
   char* speculation = NEW_RESOURCE_ARRAY(char, speculation_len);
   JVMCIENV->copy_bytes_to(speculation_handle, (jbyte*) speculation, 0, speculation_len);
   return FailedSpeculation::add_failed_speculation(nullptr, (FailedSpeculation**)(address) failed_speculations_address, (address) speculation, speculation_len);
-}
+C2V_END
 
 C2V_VMENTRY(void, callSystemExit, (JNIEnv* env, jobject, jint status))
   JavaValue result(T_VOID);
@@ -2999,11 +3000,11 @@ C2V_VMENTRY(void, callSystemExit, (JNIEnv* env, jobject, jint status))
                        vmSymbols::int_void_signature(),
                        &jargs,
                        CHECK);
-}
+C2V_END
 
 C2V_VMENTRY_0(jlong, ticksNow, (JNIEnv* env, jobject))
   return CompilerEvent::ticksNow();
-}
+C2V_END
 
 C2V_VMENTRY_0(jint, registerCompilerPhase, (JNIEnv* env, jobject, jstring jphase_name))
 #if INCLUDE_JFR
@@ -3013,14 +3014,14 @@ C2V_VMENTRY_0(jint, registerCompilerPhase, (JNIEnv* env, jobject, jstring jphase
 #else
   return -1;
 #endif // !INCLUDE_JFR
-}
+C2V_END
 
 C2V_VMENTRY(void, notifyCompilerPhaseEvent, (JNIEnv* env, jobject, jlong startTime, jint phase, jint compileId, jint level))
   EventCompilerPhase event;
   if (event.should_commit()) {
     CompilerEvent::PhaseEvent::post(event, startTime, phase, compileId, level);
   }
-}
+C2V_END
 
 C2V_VMENTRY(void, notifyCompilerInliningEvent, (JNIEnv* env, jobject, jint compileId, ARGUMENT_PAIR(caller), ARGUMENT_PAIR(callee), jboolean succeeded, jstring jmessage, jint bci))
   EventCompilerInlining event;
@@ -3030,7 +3031,7 @@ C2V_VMENTRY(void, notifyCompilerInliningEvent, (JNIEnv* env, jobject, jint compi
     JVMCIObject message = JVMCIENV->wrap(jmessage);
     CompilerEvent::InlineEvent::post(event, compileId, caller, callee, succeeded, JVMCIENV->as_utf8_string(message), bci);
   }
-}
+C2V_END
 
 C2V_VMENTRY(void, setThreadLocalObject, (JNIEnv* env, jobject, jint id, jobject value))
   requireInHotSpot("setThreadLocalObject", JVMCI_CHECK);
@@ -3040,7 +3041,7 @@ C2V_VMENTRY(void, setThreadLocalObject, (JNIEnv* env, jobject, jint id, jobject 
   }
   THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
             err_msg("%d is not a valid thread local id", id));
-}
+C2V_END
 
 C2V_VMENTRY_NULL(jobject, getThreadLocalObject, (JNIEnv* env, jobject, jint id))
   requireInHotSpot("getThreadLocalObject", JVMCI_CHECK_NULL);
@@ -3049,7 +3050,7 @@ C2V_VMENTRY_NULL(jobject, getThreadLocalObject, (JNIEnv* env, jobject, jint id))
   }
   THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(),
               err_msg("%d is not a valid thread local id", id));
-}
+C2V_END
 
 C2V_VMENTRY(void, setThreadLocalLong, (JNIEnv* env, jobject, jint id, jlong value))
   requireInHotSpot("setThreadLocalLong", JVMCI_CHECK);
@@ -3061,7 +3062,7 @@ C2V_VMENTRY(void, setThreadLocalLong, (JNIEnv* env, jobject, jint id, jlong valu
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               err_msg("%d is not a valid thread local id", id));
   }
-}
+C2V_END
 
 C2V_VMENTRY_0(jlong, getThreadLocalLong, (JNIEnv* env, jobject, jint id))
   requireInHotSpot("getThreadLocalLong", JVMCI_CHECK_0);
@@ -3073,7 +3074,36 @@ C2V_VMENTRY_0(jlong, getThreadLocalLong, (JNIEnv* env, jobject, jint id))
     THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(),
                 err_msg("%d is not a valid thread local id", id));
   }
-}
+C2V_END
+
+C2V_VMENTRY_0(jlong, getLiveObjectLocalsAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(method),
+                 jint bci, jlong buffer))
+  methodHandle method(THREAD, UNPACK_PAIR(Method, method));
+  if (bci < 0 || bci >= method->code_size()) {
+    JVMCI_THROW_MSG_0(IllegalArgumentException,
+                err_msg("bci %d is out of bounds [0 .. %d)", bci, method->code_size()));
+  }
+  InterpreterOopMap mask;
+  OopMapCache::compute_one_oop_map(method, bci, &mask);
+  if (!mask.has_valid_mask()) {
+    JVMCI_THROW_MSG_0(IllegalArgumentException, err_msg("bci %d is not valid", bci));
+  }
+  int nlocals = method->max_locals();
+  jlong liveness = 0L;
+  // stringStream st;
+  // st.print("BitMap[%s@%d, nlocals:%d]:", method->name_and_sig_as_C_string(), bci, nlocals);
+  BitMapView bm = BitMapView((BitMap::bm_word_t*) (nlocals <= 64 ? (jlong) &liveness : buffer), nlocals);
+  for (int i = 0; i < nlocals ; i++ ) {
+    if (mask.is_oop(i)) {
+      bm.set_bit(i);
+      // st.print(" %d", i);
+    }
+  }
+  // st.print(" [liveness: 0x" JULONG_FORMAT_X "]", (julong) liveness);
+  // tty->print_raw_cr(st.as_string());
+  // tty->flush();
+  return liveness;
+C2V_END
 
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &(c2v_ ## f))
@@ -3232,6 +3262,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "registerCompilerPhase",                        CC "(" STRING ")I",                                                                   FN_PTR(registerCompilerPhase)},
   {CC "notifyCompilerPhaseEvent",                     CC "(JIII)V",                                                                         FN_PTR(notifyCompilerPhaseEvent)},
   {CC "notifyCompilerInliningEvent",                  CC "(I" HS_METHOD2 HS_METHOD2 "ZLjava/lang/String;I)V",                               FN_PTR(notifyCompilerInliningEvent)},
+  {CC "getLiveObjectLocalsAt",                        CC "(" HS_METHOD2 "IJ)J",                                                             FN_PTR(getLiveObjectLocalsAt)},
 };
 
 int CompilerToVM::methods_count() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1475,16 +1475,11 @@ final class CompilerToVM {
     }
 
     /**
-     * Computes which local variables in {@code method} contain live object values
-     * at the instruction denoted by {@code bci}. This is the "oop map" used
-     * by the garbage collector.
-     *
-     * @param oopMap array in which the oop map is returned
-     * @see HotSpotResolvedJavaMethodImpl#getLiveObjectLocalsAt
+     * @see HotSpotResolvedJavaMethod#getOopMapAt
      */
-    void getLiveObjectLocalsAt(HotSpotResolvedJavaMethodImpl method, int bci, long[] oopMap) {
-        getLiveObjectLocalsAt(method, method.getMethodPointer(), bci, oopMap);
+    void getOopMapAt(HotSpotResolvedJavaMethodImpl method, int bci, long[] oopMap) {
+        getOopMapAt(method, method.getMethodPointer(), bci, oopMap);
     }
 
-    native void getLiveObjectLocalsAt(HotSpotResolvedJavaMethodImpl method, long methodPointer, int bci, long[] oopMap);
+    native void getOopMapAt(HotSpotResolvedJavaMethodImpl method, long methodPointer, int bci, long[] oopMap);
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1473,4 +1473,11 @@ final class CompilerToVM {
             }
         }
     }
+
+
+    long getLiveObjectLocalsAt(HotSpotResolvedJavaMethodImpl method, int bci, long buffer) {
+        return getLiveObjectLocalsAt(method, method.getMethodPointer(), bci, buffer);
+    }
+
+    native long getLiveObjectLocalsAt(HotSpotResolvedJavaMethodImpl method, long methodPointer, int bci, long buffer);
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1474,10 +1474,17 @@ final class CompilerToVM {
         }
     }
 
-
-    long getLiveObjectLocalsAt(HotSpotResolvedJavaMethodImpl method, int bci, long buffer) {
-        return getLiveObjectLocalsAt(method, method.getMethodPointer(), bci, buffer);
+    /**
+     * Computes which local variables in {@code method} contain live object values
+     * at the instruction denoted by {@code bci}. This is the "oop map" used
+     * by the garbage collector.
+     *
+     * @param oopMap array in which the oop map is returned
+     * @see HotSpotResolvedJavaMethodImpl#getLiveObjectLocalsAt
+     */
+    void getLiveObjectLocalsAt(HotSpotResolvedJavaMethodImpl method, int bci, long[] oopMap) {
+        getLiveObjectLocalsAt(method, method.getMethodPointer(), bci, oopMap);
     }
 
-    native long getLiveObjectLocalsAt(HotSpotResolvedJavaMethodImpl method, long methodPointer, int bci, long buffer);
+    native void getLiveObjectLocalsAt(HotSpotResolvedJavaMethodImpl method, long methodPointer, int bci, long[] oopMap);
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethod.java
@@ -23,6 +23,7 @@
 package jdk.vm.ci.hotspot;
 
 import java.lang.reflect.Modifier;
+import java.util.BitSet;
 
 import jdk.vm.ci.meta.JavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
@@ -127,4 +128,17 @@ public interface HotSpotResolvedJavaMethod extends ResolvedJavaMethod {
     boolean hasCodeAtLevel(int entryBCI, int level);
 
     int methodIdnum();
+
+
+    /**
+     * Computes which local variables contain live object values
+     * at the instruction denoted by {@code bci}. This is the "oop map" used
+     * by the garbage collector.
+     *
+     * @param bci the index of an instruction in this method's bytecodes
+     * @return the computed oop map
+     * @throws IllegalArgumentException if this method has no bytecode or
+     *         {@code bci} is not the index of a bytecode instruction
+     */
+    BitSet getLiveObjectLocalsAt(int bci);
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethod.java
@@ -131,14 +131,15 @@ public interface HotSpotResolvedJavaMethod extends ResolvedJavaMethod {
 
 
     /**
-     * Computes which local variables contain live object values
-     * at the instruction denoted by {@code bci}. This is the "oop map" used
-     * by the garbage collector.
+     * Computes which local variables and operand stack slots in {@code method} contain
+     * live object values at the instruction denoted by {@code bci}. This is the "oop map"
+     * used by the garbage collector for interpreter frames.
      *
      * @param bci the index of an instruction in this method's bytecodes
-     * @return the computed oop map
+     * @return the computed oop map. The first {@link #getMaxLocals} bits are for
+     *         the local variables, the remaining bits are for the stack slots.
      * @throws IllegalArgumentException if this method has no bytecode or
      *         {@code bci} is not the index of a bytecode instruction
      */
-    BitSet getLiveObjectLocalsAt(int bci);
+    BitSet getOopMapAt(int bci);
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -770,13 +770,13 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
     }
 
     @Override
-    public BitSet getLiveObjectLocalsAt(int bci) {
+    public BitSet getOopMapAt(int bci) {
         if (getCodeSize() == 0) {
             throw new IllegalArgumentException("has no bytecode");
         }
-        int nwords = ((getMaxLocals() - 1) / 64) + 1;
+        int nwords = ((getMaxLocals() + getMaxStackSize() - 1) / 64) + 1;
         long[] oopMap = new long[nwords];
-        compilerToVM().getLiveObjectLocalsAt(this, bci, oopMap);
+        compilerToVM().getOopMapAt(this, bci, oopMap);
         return BitSet.valueOf(oopMap);
     }
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -34,14 +34,12 @@ import static jdk.vm.ci.hotspot.UnsafeAccess.UNSAFE;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.BitSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.VMSupport;
 import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.Option;
@@ -771,43 +769,14 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
         return VMSupport.decodeAnnotations(encoded, AnnotationDataDecoder.INSTANCE);
     }
 
-    /*
-     * BitSets are packed into arrays of "words."  Currently a word is
-     * a long, which consists of 64 bits, requiring 6 address bits.
-     * The choice of word size is determined purely by performance concerns.
-     */
-    private static final int ADDRESS_BITS_PER_WORD = 6;
-    private static final int BITS_PER_WORD = 1 << ADDRESS_BITS_PER_WORD;
-    private static final int BIT_INDEX_MASK = BITS_PER_WORD - 1;
-
-    private static int wordIndex(int bitIndex) {
-        return bitIndex >> ADDRESS_BITS_PER_WORD;
-    }
-
     @Override
-    public long getLiveObjectLocalsAt(int bci, BitSet bigOopMap) {
-        int locals = getMaxLocals();
-        if (locals == 0) {
-            throw new IllegalArgumentException("cannot compute oop map for method with no local variables");
+    public BitSet getLiveObjectLocalsAt(int bci) {
+        if (getCodeSize() == 0) {
+            throw new IllegalArgumentException("has no bytecode");
         }
-        if (locals > 64) {
-            int nwords = ((locals - 1) / 64) + 1;
-            Unsafe unsafe = UnsafeAccess.UNSAFE;
-            long buffer = unsafe.allocateMemory(nwords);
-            try {
-                compilerToVM().getLiveObjectLocalsAt(this, bci, buffer);
-                long liveness[] = new long[nwords];
-                for (int i = 0; i < nwords; i++) {
-                    liveness[i] = unsafe.getLong(buffer + i);
-                }
-                bigOopMap.or(BitSet.valueOf(liveness));
-            } finally {
-                unsafe.freeMemory(buffer);
-            }
-            return 0;
-        } else {
-            return compilerToVM().getLiveObjectLocalsAt(this, bci, 0);
-        }
+        int nwords = ((getMaxLocals() - 1) / 64) + 1;
+        long[] oopMap = new long[nwords];
+        compilerToVM().getLiveObjectLocalsAt(this, bci, oopMap);
+        return BitSet.valueOf(oopMap);
     }
-
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaMethod.java
@@ -470,28 +470,4 @@ public interface ResolvedJavaMethod extends JavaMethod, InvokeTarget, ModifiersP
      * responsibility to ensure the same speculation log is used throughout a compilation.
      */
     SpeculationLog getSpeculationLog();
-
-    /**
-     * Computes which local variables contain live object values
-     * at the instruction denoted by {@code bci}. This is the "oop map" used
-     * by the garbage collector.
-     *
-     * If {@link #getMaxLocals()} {@code <= 64}, then the oop map is encoded
-     * in the return value. Otherwise, it is copied into {@code bigOopMap}.
-     *
-     * @param bci the index of an instruction in this method's bytecodes
-     * @param bigOopMap the bit set in which the oop map is returned for
-     *         methods whose max number of local variables is {@code > 64}. It's up
-     *         to the caller to ensure this bit set is large enough and initially has
-     *         all bits set to 0.
-     * @return the oop map for methods with 64 or less max locals otherwise 0
-     * @throws NullPointerException if {@link #getMaxLocals()} {@code > 64 && bigOopMap == null}
-     * @throws IllegalArgumentException if {@link #getMaxLocals()} {@code == 0} or if
-     *         {@code bci} is not the index of a bytecode instruction
-     * @throws UnsupportedOperationException if local variable liveness is not provided
-     *         by the current JVMCI runtime
-     */
-    default long getLiveObjectLocalsAt(int bci, BitSet bigOopMap) {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaMethod.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.BitSet;
 
 /**
  * Represents a resolved Java method. Methods, like fields and types, are resolved through
@@ -469,4 +470,28 @@ public interface ResolvedJavaMethod extends JavaMethod, InvokeTarget, ModifiersP
      * responsibility to ensure the same speculation log is used throughout a compilation.
      */
     SpeculationLog getSpeculationLog();
+
+    /**
+     * Computes which local variables contain live object values
+     * at the instruction denoted by {@code bci}. This is the "oop map" used
+     * by the garbage collector.
+     *
+     * If {@link #getMaxLocals()} {@code <= 64}, then the oop map is encoded
+     * in the return value. Otherwise, it is copied into {@code bigOopMap}.
+     *
+     * @param bci the index of an instruction in this method's bytecodes
+     * @param bigOopMap the bit set in which the oop map is returned for
+     *         methods whose max number of local variables is {@code > 64}. It's up
+     *         to the caller to ensure this bit set is large enough and initially has
+     *         all bits set to 0.
+     * @return the oop map for methods with 64 or less max locals otherwise 0
+     * @throws NullPointerException if {@link #getMaxLocals()} {@code > 64 && bigOopMap == null}
+     * @throws IllegalArgumentException if {@link #getMaxLocals()} {@code == 0} or if
+     *         {@code bci} is not the index of a bytecode instruction
+     * @throws UnsupportedOperationException if local variable liveness is not provided
+     *         by the current JVMCI runtime
+     */
+    default long getLiveObjectLocalsAt(int bci, BitSet bigOopMap) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaMethod.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaMethod.java
@@ -35,6 +35,7 @@
  * @modules jdk.internal.vm.ci/jdk.vm.ci.meta
  *          jdk.internal.vm.ci/jdk.vm.ci.runtime
  *          jdk.internal.vm.ci/jdk.vm.ci.common
+ *          jdk.internal.vm.ci/jdk.vm.ci.hotspot
  *          java.base/jdk.internal.classfile
  *          java.base/jdk.internal.classfile.attribute
  *          java.base/jdk.internal.classfile.constantpool
@@ -103,6 +104,7 @@ import jdk.vm.ci.runtime.test.TestResolvedJavaMethod.AnnotationDataTest.Annotati
 import jdk.vm.ci.runtime.test.TestResolvedJavaMethod.AnnotationDataTest.Annotation2;
 import jdk.vm.ci.runtime.test.TestResolvedJavaMethod.AnnotationDataTest.Annotation3;
 import jdk.vm.ci.runtime.test.TestResolvedJavaMethod.AnnotationDataTest.NumbersDE;
+import jdk.vm.ci.hotspot.HotSpotResolvedJavaMethod;
 
 /**
  * Tests for {@link ResolvedJavaMethod}.
@@ -607,85 +609,35 @@ public class TestResolvedJavaMethod extends MethodUniverse {
     }
 
     public static void methodWithManyArgs(
-        Object o1, int i1,
-        Object o2, int i2,
-        Object o3, int i3,
-        Object o4, int i4,
-        Object o5, int i5,
-        Object o6, int i6,
-        Object o7, int i7,
-        Object o8, int i8,
-        Object o9, int i9,
-        Object o10, int i10,
-        Object o11, int i11,
-        Object o12, int i12,
-        Object o13, int i13,
-        Object o14, int i14,
-        Object o15, int i15,
-        Object o16, int i16,
-        Object o17, int i17,
-        Object o18, int i18,
-        Object o19, int i19,
-        Object o20, int i20,
-        Object o21, int i21,
-        Object o22, int i22,
-        Object o23, int i23,
-        Object o24, int i24,
-        Object o25, int i25,
-        Object o26, int i26,
-        Object o27, int i27,
-        Object o28, int i28,
-        Object o29, int i29,
-        Object o30, int i30,
-        Object o31, int i31,
-        Object o32, int i32,
-        Object o33, int i33,
-        Object o34, int i34,
-        Object o35, int i35,
-        Object o36, int i36,
-        Object o37, int i37,
-        Object o38, int i38,
-        Object o39, int i39,
-        Object o40, int i40,
-        Object o41, int i41,
-        Object o42, int i42,
-        Object o43, int i43,
-        Object o44, int i44,
-        Object o45, int i45,
-        Object o46, int i46,
-        Object o47, int i47,
-        Object o48, int i48,
-        Object o49, int i49,
-        Object o50, int i50,
-        Object o51, int i51,
-        Object o52, int i52,
-        Object o53, int i53,
-        Object o54, int i54,
-        Object o55, int i55,
-        Object o56, int i56,
-        Object o57, int i57,
-        Object o58, int i58,
-        Object o59, int i59) {
-            System.out.println("" + o1 + i1);
-            System.out.println("" + o2 + i2);
-            System.out.println("" + o3 + i3);
-            System.out.println("" + o4 + i4);
-            System.out.println("" + o5 + i5);
-            System.out.println("" + o6 + i6);
-            System.out.println("" + o7 + i7);
-            System.out.println("" + o8 + i8);
-            System.out.println("" + o9 + i9);
-            System.out.println("" + o10 + i10);
-            System.out.println("" + o11 + i11);
-            System.out.println("" + o12 + i12);
-            System.out.println("" + o13 + i13);
-            System.out.println("" + o14 + i14);
-            System.out.println("" + o15 + i15);
-            System.out.println("" + o16 + i16);
-            System.out.println("" + o17 + i17);
-            System.out.println("" + o58 + i58);
-            System.out.println("" + o59 + i59);
+        Object   o0, int   i1, int  i2,  int   i3, int   i4, int   i5, int   i6, int  i7,
+           int   i8, int   i9, int  i10, int  i11, int  i12, int  i13, int  i14, int  i15,
+           int  i16, int  i17, int  i18, int  i19, int  i20, int  i21, int  i22, int  i23,
+           int  i24, int  i25, int  i26, int  i27, int  i28, int  i29, int  i30, int  i31,
+           int  i32, int  i33, int  i34, int  i35, int  i36, int  i37, int  i38, int  i39,
+           int  i40, int  i41, int  i42, int  i43, int  i44, int  i45, int  i46, int  i47,
+           int  i48, int  i49, int  i50, int  i51, int  i52, int  i53, int  i54, int  i55,
+           int  i56, int  i57, int  i58, int  i59, int  i60, int  i61, int  i62, int  i63,
+        Object  o64, int  i65, int  i66, int  i67, int  i68, int  i69, int  i70, int  i71,
+           int  i72, int  i73, int  i74, int  i75, int  i76, int  i77, int  i78, int  i79,
+           int  i80, int  i81, int  i82, int  i83, int  i84, int  i85, int  i86, int  i87,
+           int  i88, int  i89, int  i90, int  i91, int  i92, int  i93, int  i94, int  i95,
+           int  i96, int  i97, int  i98, int  i99, int i100, int i101, int i102, int i103,
+           int i104, int i105, int i106, int i107, int i108, int i109, int i110, int i111,
+           int i112, int i113, int i114, int i115, int i116, int i117, int i118, int i119,
+           int i120, int i121, int i122, int i123, int i124, int i125, int i126, int i127,
+        Object o128)
+    {
+        o0.hashCode();
+        o64.hashCode();
+        if (o128 != null) {
+            Object t1 = "tmp val";
+            t1.hashCode();
+        } else {
+            int t1 = 42 + i1;
+            String.valueOf(t1);
         }
+        o128.hashCode();
+    }
 
     private static Map<String, ResolvedJavaMethod> buildMethodMap(ResolvedJavaType type) {
         Map<String, ResolvedJavaMethod> methodMap = new HashMap<>();
@@ -716,6 +668,9 @@ public class TestResolvedJavaMethod extends MethodUniverse {
         // Add this class so that methodWithManyArgs is processed
         allClasses.add(getClass());
 
+        boolean[] processedMethodWithManyArgs = {false};
+        final boolean debug = false;
+
         for (Class<?> c : allClasses) {
             if (c.isArray() || c.isPrimitive() || c.isHidden()) {
                 continue;
@@ -726,34 +681,33 @@ public class TestResolvedJavaMethod extends MethodUniverse {
             for (MethodModel cm : cf.methods()) {
                 cm.findAttribute(Attributes.CODE).ifPresent(codeAttr -> {
                     String key = cm.methodName().stringValue() + ":" + cm.methodType().stringValue();
-                    ResolvedJavaMethod m = Objects.requireNonNull(methodMap.get(key));
+                    HotSpotResolvedJavaMethod m = (HotSpotResolvedJavaMethod) Objects.requireNonNull(methodMap.get(key));
                     int maxLocals = m.getMaxLocals();
-
-                    // Requesting an oop map for a method with 0 locals must throw an exception
-                    if (maxLocals == 0) {
-                        try {
-                            m.getLiveObjectLocalsAt(0, null);
-                            throw new AssertionError("expected exception for method %s with no locals".formatted(m.format("%H.%n(%p)")));
-                        } catch(IllegalArgumentException e) {
-                            return;
-                        }
-                    }
 
                     int bci = 0;
                     for (CodeElement i : codeAttr.elementList()) {
                         if (i instanceof Instruction ins) {
-                            BitSet bigOopMap = maxLocals <= 64 ? null : new BitSet(maxLocals);
-                            long oopMap = m.getLiveObjectLocalsAt(bci, bigOopMap);
-                            if (maxLocals > 64) {
-                                Assert.assertEquals(m.toString(), oopMap, 0L);
-                                Assert.assertNotEquals(m.toString(), bigOopMap.cardinality(), 0);
+                            BitSet oopMap = m.getLiveObjectLocalsAt(bci);
+                            if (c == getClass() && m.getName().equals("methodWithManyArgs")) {
+                                if (debug) {
+                                    System.out.printf("%s@%d [%d]: %s%n", m.getName(), bci, maxLocals, oopMap);
+                                    System.out.printf("%s@%d [%d]: %s%n", m.getName(), bci, maxLocals, ins);
+                                }
+                                // Assumes stability of javac output
+                                String where = "methodWithManyArgs@" + bci;
+                                if (bci >= 21 && bci <= 27) {
+                                    Assert.assertEquals(where, "{0, 64, 128, 129}", oopMap.toString());
+                                } else {
+                                    Assert.assertEquals(where, "{0, 64, 128}", oopMap.toString());
+                                }
+                                processedMethodWithManyArgs[0] = true;
                             }
 
                             // Requesting an oop map at an invalid BCI must throw an exception
                             if (ins.sizeInBytes() > 1) {
                                 try {
-                                    m.getLiveObjectLocalsAt(bci + 1, bigOopMap);
-                                    throw new AssertionError("expected exception for illegal bci %d in %s".formatted(bci + 1, m.format("%H.%n(%p)")));
+                                    oopMap = m.getLiveObjectLocalsAt(bci + 1);
+                                    throw new AssertionError("expected exception for illegal bci %d in %s: %s".formatted(bci + 1, m.format("%H.%n(%p)"), oopMap));
                                 } catch(IllegalArgumentException e) {
                                     // expected
                                 }
@@ -764,6 +718,8 @@ public class TestResolvedJavaMethod extends MethodUniverse {
                 });
             }
         }
+
+        Assert.assertTrue(processedMethodWithManyArgs[0]);
     }
 
     private Method findTestMethod(Method apiMethod) {


### PR DESCRIPTION
This PR adds `HotSpotResolvedJavaMethod.getOopMapAt` to get the oop map for a method at a given BCI. This is required to do correct clearing of oops at OSR entry points.

As part of this addition, I needed to be able to detect requests for oop maps at invalid BCIs. For this, I added `InterpreterOopMap::has_valid_mask()`. When an oop map computation is requested for an invalid BCI, this method returns false.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315954](https://bugs.openjdk.org/browse/JDK-8315954): getArgumentValues002.java fails on Graal (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [c6c6c0d8](https://git.openjdk.org/jdk/pull/15705/files/c6c6c0d83ab8f12496ea114b1874093b92850c1c)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15705/head:pull/15705` \
`$ git checkout pull/15705`

Update a local copy of the PR: \
`$ git checkout pull/15705` \
`$ git pull https://git.openjdk.org/jdk.git pull/15705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15705`

View PR using the GUI difftool: \
`$ git pr show -t 15705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15705.diff">https://git.openjdk.org/jdk/pull/15705.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15705#issuecomment-1717321726)