### PR TITLE
8316160: Remove sun.misc.Unsafe.{shouldBeInitialized,ensureClassInitialized}

### DIFF
--- a/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
+++ b/src/jdk.unsupported/share/classes/sun/misc/Unsafe.java
@@ -728,42 +728,6 @@ public final class Unsafe {
     }
 
     /**
-     * Detects if the given class may need to be initialized. This is often
-     * needed in conjunction with obtaining the static field base of a
-     * class.
-     *
-     * @deprecated No replacement API for this method.  As multiple threads
-     * may be trying to initialize the same class or interface at the same time.
-     * The only reliable result returned by this method is {@code false}
-     * indicating that the given class has been initialized.  Instead, simply
-     * call {@link java.lang.invoke.MethodHandles.Lookup#ensureInitialized(Class)}
-     * that does nothing if the given class has already been initialized.
-     * This method is subject to removal in a future version of JDK.
-     *
-     * @return false only if a call to {@code ensureClassInitialized} would have no effect
-     *
-     */
-    @Deprecated(since = "15", forRemoval = true)
-    @ForceInline
-    public boolean shouldBeInitialized(Class<?> c) {
-        return theInternalUnsafe.shouldBeInitialized(c);
-    }
-
-    /**
-     * Ensures the given class has been initialized. This is often
-     * needed in conjunction with obtaining the static field base of a
-     * class.
-     *
-     * @deprecated Use the {@link java.lang.invoke.MethodHandles.Lookup#ensureInitialized(Class)}
-     * method instead.  This method is subject to removal in a future version of JDK.
-     */
-    @Deprecated(since = "15", forRemoval = true)
-    @ForceInline
-    public void ensureClassInitialized(Class<?> c) {
-        theInternalUnsafe.ensureClassInitialized(c);
-    }
-
-    /**
      * Reports the offset of the first element in the storage allocation of a
      * given array class.  If {@link #arrayIndexScale} returns a non-zero value
      * for the same class, you may use that scale factor, together with this


### PR DESCRIPTION
Unsafe.{shouldBeInitialized,ensureClassInitialized} are deprecated for removal since JDK 15. It's time to remove them. Lookup.ensureInitialized(Class) was added in Java 15 as a standard API to ensure that an accessible class is initialized. 

A search of 175973022 classes in 484751 artifacts found:
- 23 usages of Unsafe.shouldBeInitialized, of which 8 are unique
- 121 usages of Unsafe.ensureClassInitialized, of which 31 are unique

Not a lot of usage, many of the usages seem to be code compiled to older releases.