### PR TITLE
8316178: Better diagnostic header for CodeBlobs

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -204,7 +204,8 @@ void RuntimeBlob::trace_new_stub(RuntimeBlob* stub, const char* name1, const cha
     if (PrintStubCode) {
       ttyLocker ttyl;
       tty->print_cr("- - - [BEGIN] - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
-      tty->print_cr("Decoding %s " INTPTR_FORMAT, stub_id, (intptr_t) stub);
+      tty->print_cr("Decoding %s " PTR_FORMAT " [" PTR_FORMAT ", " PTR_FORMAT "] (%d bytes)",
+                    stub_id, p2i(stub), p2i(stub->code_begin()), p2i(stub->code_end()), stub->code_size());
       Disassembler::decode(stub->code_begin(), stub->code_end(), tty
                            NOT_PRODUCT(COMMA &stub->asm_remarks()));
       if ((stub->oop_maps() != nullptr) && AbstractDisassembler::show_structs()) {


### PR DESCRIPTION
I realized that JMH perfasm misses some CodeBlobs, notably C1 RuntimeBlobs. While amending perfasm to capture those, I discovered the header printout for those blobs is not as convenient as for others. Notably, perfasm would like to know where the stub code ends.

```
# Good:
StubRoutines::sha512_implCompressMB [0x0000000117da2d80, 0x0000000117da3528] (1960 bytes)

# Bad:
Decoding RuntimeStub - _complete_monitor_locking_Java 0x0000000117e4fd10
```

After this change, we print this:

```
Decoding RuntimeStub - _complete_monitor_locking_Java 0x0000000114203110 [0x00000001142031c0, 0x0000000114203258] (152 bytes)
```

Note it still prints the (base) stub address. I think it is still useful for debugging. The brackets print the code size, because that is what the decoding block handles: the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316178](https://bugs.openjdk.org/browse/JDK-8316178): Better diagnostic header for CodeBlobs (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15708/head:pull/15708` \
`$ git checkout pull/15708`

Update a local copy of the PR: \
`$ git checkout pull/15708` \
`$ git pull https://git.openjdk.org/jdk.git pull/15708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15708`

View PR using the GUI difftool: \
`$ git pr show -t 15708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15708.diff">https://git.openjdk.org/jdk/pull/15708.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15708#issuecomment-1717395203)