### PR TITLE
8315766: Parallelize gc/stress/TestStressIHOPMultiThread.java test

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,31 +24,63 @@
 package gc.stress;
 
  /*
- * @test TestStressIHOPMultiThread
+ * @test id=TestStressIHOPMultiThread1
  * @bug 8148397
  * @key stress
- * @summary Stress test for IHOP
+ * @summary Parallelized stress testcase 1 for IHOP
  * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx128m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=1m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread1.log
  *              -Dtimeout=2 -DheapUsageMinBound=30 -DheapUsageMaxBound=80
  *              -Dthreads=2 gc.stress.TestStressIHOPMultiThread
+ */
+
+/*
+ * @test id=TestStressIHOPMultiThread2
+ * @bug 8148397
+ * @key stress
+ * @summary Parallelized stress testcase 2 for IHOP
+ * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx256m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=2m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread2.log
  *              -Dtimeout=2 -DheapUsageMinBound=60 -DheapUsageMaxBound=90
  *              -Dthreads=3 gc.stress.TestStressIHOPMultiThread
+ */
+
+/*
+ * @test id=TestStressIHOPMultiThread3
+ * @bug 8148397
+ * @key stress
+ * @summary Parallelized stress testcase 3 for IHOP
+ * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx256m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=4m -XX:-G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread3.log
  *              -Dtimeout=2 -DheapUsageMinBound=40 -DheapUsageMaxBound=90
  *              -Dthreads=5 gc.stress.TestStressIHOPMultiThread
+ */
+
+/*
+ * @test id=TestStressIHOPMultiThread4
+ * @bug 8148397
+ * @key stress
+ * @summary Parallelized stress testcase 4 for IHOP
+ * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx128m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=8m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread4.log
  *              -Dtimeout=2 -DheapUsageMinBound=20 -DheapUsageMaxBound=90
  *              -Dthreads=10 gc.stress.TestStressIHOPMultiThread
+ */
+
+/*
+ * @test id=TestStressIHOPMultiThread5
+ * @bug 8148397
+ * @key stress
+ * @summary Parallelized stress testcase 5 for IHOP
+ * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx512m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+G1UseAdaptiveIHOP
  *              -Xlog:gc+ihop=debug,gc+ihop+ergo=debug,gc+ergo=debug:TestStressIHOPMultiThread5.log

--- a/test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressIHOPMultiThread.java
@@ -24,10 +24,10 @@
 package gc.stress;
 
  /*
- * @test id=TestStressIHOPMultiThread1
+ * @test
  * @bug 8148397
  * @key stress
- * @summary Parallelized stress testcase 1 for IHOP
+ * @summary Stress test for IHOP
  * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx128m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=1m -XX:+G1UseAdaptiveIHOP
@@ -37,10 +37,7 @@ package gc.stress;
  */
 
 /*
- * @test id=TestStressIHOPMultiThread2
- * @bug 8148397
- * @key stress
- * @summary Parallelized stress testcase 2 for IHOP
+ * @test
  * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx256m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=2m -XX:+G1UseAdaptiveIHOP
@@ -50,10 +47,7 @@ package gc.stress;
  */
 
 /*
- * @test id=TestStressIHOPMultiThread3
- * @bug 8148397
- * @key stress
- * @summary Parallelized stress testcase 3 for IHOP
+ * @test
  * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx256m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=4m -XX:-G1UseAdaptiveIHOP
@@ -63,10 +57,7 @@ package gc.stress;
  */
 
 /*
- * @test id=TestStressIHOPMultiThread4
- * @bug 8148397
- * @key stress
- * @summary Parallelized stress testcase 4 for IHOP
+ * @test
  * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx128m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=8m -XX:+G1UseAdaptiveIHOP
@@ -76,10 +67,7 @@ package gc.stress;
  */
 
 /*
- * @test id=TestStressIHOPMultiThread5
- * @bug 8148397
- * @key stress
- * @summary Parallelized stress testcase 5 for IHOP
+ * @test
  * @requires vm.gc.G1
  * @run main/othervm/timeout=200 -Xmx512m -XX:G1HeapWastePercent=0 -XX:G1MixedGCCountTarget=1
  *              -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:+G1UseAdaptiveIHOP


### PR DESCRIPTION
TestStressIHOPMultiThread takes about 10 minutes to run. This limits effective parallelism of tier4 testing on large machines. We can parallelize its `@run` configs to improve effective parallelism for tier4. With both fastdebug and release configuration runs, it has been found that the final testcase in the sequential run configuration takes the most amount of time. Because of that to parallel configurations were tried out, one with all 5 test cases parallelized and second with 3 sections of parallel runs: 1st with first 2 tests, 2nd with the next 2 tests and 3rd with the last test case. Below are the results in fast debug:
* before                       : **974.87s user 108.92s system 172% cpu 10:27.46 total**
* after_full-parallelization   : **796.79s user 88.73s system 343% cpu 4:17.51 total**
* after_partial-parallelization: **904.82s user 102.00s system 391% cpu 4:17.01 total**

From the reults we can see that even though partial and full parallelization has similar total running time, the user and system times and considerably better with full parallelization with repeated runs.

Below are the results with release mode:
* before                    : **1111.11s user 196.52s system 210% cpu 10:20.80 total**
* after_full-parallelization: **837.07s user 151.57s system 378% cpu 4:20.89 total**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8315766](https://bugs.openjdk.org/browse/JDK-8315766): Parallelize gc/stress/TestStressIHOPMultiThread.java test (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15710/head:pull/15710` \
`$ git checkout pull/15710`

Update a local copy of the PR: \
`$ git checkout pull/15710` \
`$ git pull https://git.openjdk.org/jdk.git pull/15710/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15710`

View PR using the GUI difftool: \
`$ git pr show -t 15710`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15710.diff">https://git.openjdk.org/jdk/pull/15710.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15710#issuecomment-1717438104)