### PR TITLE
8316130: Incorrect control in LibraryCallKit::inline_native_notify_jvmti_funcs

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -2890,6 +2890,7 @@ bool LibraryCallKit::inline_native_notify_jvmti_funcs(address funcAddr, const ch
   if (!DoJVMTIVirtualThreadTransitions) {
     return true;
   }
+  Node* vt_oop = _gvn.transform(must_be_not_null(argument(0), true)); // VirtualThread this argument
   IdealKit ideal(this);
 
   Node* ONE = ideal.ConI(1);
@@ -2898,11 +2899,9 @@ bool LibraryCallKit::inline_native_notify_jvmti_funcs(address funcAddr, const ch
   Node* notify_jvmti_enabled = ideal.load(ideal.ctrl(), addr, TypeInt::BOOL, T_BOOLEAN, Compile::AliasIdxRaw);
 
   ideal.if_then(notify_jvmti_enabled, BoolTest::eq, ONE); {
+    sync_kit(ideal);
     // if notifyJvmti enabled then make a call to the given SharedRuntime function
     const TypeFunc* tf = OptoRuntime::notify_jvmti_vthread_Type();
-    Node* vt_oop = _gvn.transform(must_be_not_null(argument(0), true)); // VirtualThread this argument
-
-    sync_kit(ideal);
     make_runtime_call(RC_NO_LEAF, tf, funcAddr, funcName, TypePtr::BOTTOM, vt_oop, hide);
     ideal.sync_kit(this);
   } ideal.else_(); {


### PR DESCRIPTION
We hit an assert during loop opts because the control input fed into `must_be_not_null` in `LibraryCallKit::inline_native_notify_jvmti_funcs` is wrong. The problem is that control is obtained from the `GraphKit` while it's been updated via the `IdealKit`. I simply moved the `must_be_not_null` out of the if branch and to before `IdealKit` creation, similar to what we do for other intrinsics.

The original reproducer requires JFR and changes to core libraries (see JBS for details) and I was not able to extract a standalone reproducer. I don't think it's worth it because the required core libraries changes will be integrated separately and then the existing test will trigger the issue (with JFR).

Thanks,
Tobias