### PR TITLE
8316182: RISC-V: SA stack walking code having trouble finding sender frame when invoking LambdaForms is involved

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
@@ -322,24 +322,17 @@ public class RISCV64Frame extends Frame {
   //------------------------------------------------------------------------------
   // frame::adjust_unextended_sp
   private void adjustUnextendedSP() {
-    // If we are returning to a compiled MethodHandle call site, the
-    // saved_fp will in fact be a saved value of the unextended SP.  The
-    // simplest way to tell whether we are returning to such a call site
-    // is as follows:
+    // Sites calling method handle intrinsics and lambda forms are
+    // treated as any other call site. Therefore, no special action is
+    // needed when we are returning to any of these call sites.
 
     CodeBlob cb = cb();
     NMethod senderNm = (cb == null) ? null : cb.asNMethodOrNull();
     if (senderNm != null) {
-      // If the sender PC is a deoptimization point, get the original
-      // PC.  For MethodHandle call site the unextended_sp is stored in
-      // saved_fp.
-      if (senderNm.isDeoptMhEntry(getPC())) {
-        raw_unextendedSP = getFP();
-      }
-      else if (senderNm.isDeoptEntry(getPC())) {
-      }
-      else if (senderNm.isMethodHandleReturn(getPC())) {
-        raw_unextendedSP = getFP();
+      // If the sender PC is a deoptimization point, get the original PC.
+      if (senderNm.isDeoptEntry(getPC()) ||
+          senderNm.isDeoptMhEntry(getPC())) {
+        // DEBUG_ONLY(verifyDeoptriginalPc(senderNm, raw_unextendedSp));
       }
     }
   }


### PR DESCRIPTION
Hi, please consider.
Inspired by [JDK-8313800](https://bugs.openjdk.org/browse/JDK-8313800). RISC-V also treats x8/fp as a callee-saved scratch register for some time, and it is freely used by C2-generated code. Therefore, any code in SA that uses getFP() in a compiled frame is very likely to come to grief.

Testing:
- [x] hotspot_serviceability
- [x] jdk_svc
- [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316182](https://bugs.openjdk.org/browse/JDK-8316182): RISC-V: SA stack walking code having trouble finding sender frame when invoking LambdaForms is involved (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15714/head:pull/15714` \
`$ git checkout pull/15714`

Update a local copy of the PR: \
`$ git checkout pull/15714` \
`$ git pull https://git.openjdk.org/jdk.git pull/15714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15714`

View PR using the GUI difftool: \
`$ git pr show -t 15714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15714.diff">https://git.openjdk.org/jdk/pull/15714.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15714#issuecomment-1717495132)