### PR TITLE
8316187: Modernize examples in StringTokenizer and {Date,Number}Format

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -85,8 +85,8 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * <blockquote>
  * {@snippet lang=java :
  * DateFormat df = DateFormat.getDateInstance();
- * for (int i = 0; i < myDate.length; ++i) {
- *     output.println(df.format(myDate[i]) + "; ");
+ * for (Date myDate : dates) {
+ *     output.println(df.format(myDate) + "; ");
  * }
  * }
  * </blockquote>

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -82,8 +82,8 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * <blockquote>
  * {@snippet lang=java :
  * NumberFormat nf = NumberFormat.getInstance();
- * for (int i = 0; i < myNumber.length; ++i) {
- *     output.println(nf.format(myNumber[i]) + "; ");
+ * for (var myNumber : numbers) {
+ *     output.println(nf.format(myNumber) + "; ");
  * }
  * }
  * </blockquote>

--- a/src/java.base/share/classes/java/util/StringTokenizer.java
+++ b/src/java.base/share/classes/java/util/StringTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,8 +83,8 @@ import java.lang.*;
  * method can be used to break up a string into its basic tokens:
  * <blockquote><pre>
  *     String[] result = "this is a test".split("\\s");
- *     for (int x=0; x&lt;result.length; x++)
- *         System.out.println(result[x]);
+ *     for (String r : result)
+ *         System.out.println(r);
  * </pre></blockquote>
  * <p>
  * prints the following output:


### PR DESCRIPTION
This modernizes an example to use the extended for-statement introduced in JDK 1.5.

I understand that StringTokenizer is a legacy class. But legacy or not, a class shouldn't promote older constructs when newer fit better. Especially when advising on preferred alternatives to itself.

That said, I wouldn't go as far as to use `var` anywhere in that example: JDK 10, which introduced `var`, might still be relatively new to some. Nor would I inline the call to `String.split` in the for-statement to dispense with the `String[] result` variable: I reckon it's good for a reader unfamiliar with `String.split` to see the type it returns.

Perhaps one additional thing to ponder is this: we could either add `@see` to point to `String.split` or make the whole example a `@snippet`, which `@link`s code to the definition of `String.split`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316187](https://bugs.openjdk.org/browse/JDK-8316187): Modernize examples in StringTokenizer and {Date,Number}Format (**Bug** - P5)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15716/head:pull/15716` \
`$ git checkout pull/15716`

Update a local copy of the PR: \
`$ git checkout pull/15716` \
`$ git pull https://git.openjdk.org/jdk.git pull/15716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15716`

View PR using the GUI difftool: \
`$ git pr show -t 15716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15716.diff">https://git.openjdk.org/jdk/pull/15716.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15716#issuecomment-1717561806)