### PR TITLE
8316199: Remove sun/tools/jstatd/TestJstatd* tests from problemlist for Windows.

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -722,9 +722,7 @@ java/util/concurrent/ExecutorService/CloseTest.java             8288899 macosx-a
 
 # svc_tools
 
-sun/tools/jstatd/TestJstatdDefaults.java                        8081569 windows-all
 sun/tools/jstatd/TestJstatdRmiPort.java                         8251259,8293577 generic-all
-sun/tools/jstatd/TestJstatdServer.java                          8081569 windows-all
 
 sun/tools/jstat/jstatLineCounts1.sh                             8268211 linux-aarch64
 sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aarch64


### PR DESCRIPTION
Original failure in 8081569 is a long time ago, and not reproducing.
Other failures recorded there may be different problems, some of them are port related which are helped by other changes since these tests were problemlisted.

This problemlist entry should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316199](https://bugs.openjdk.org/browse/JDK-8316199): Remove sun/tools/jstatd/TestJstatd* tests from problemlist for Windows. (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15719/head:pull/15719` \
`$ git checkout pull/15719`

Update a local copy of the PR: \
`$ git checkout pull/15719` \
`$ git pull https://git.openjdk.org/jdk.git pull/15719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15719`

View PR using the GUI difftool: \
`$ git pr show -t 15719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15719.diff">https://git.openjdk.org/jdk/pull/15719.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15719#issuecomment-1717773584)