### PR TITLE
8315920: C2: "control input must dominate current control" assert failure

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1918,6 +1918,8 @@ Node *PhaseIdealLoop::insert_post_loop(IdealLoopTree* loop, Node_List& old_new,
   post_head->set_normal_loop();
   post_head->set_post_loop(main_head);
 
+  main_exit = outer_main_end->proj_out(false);
+
   // Reduce the post-loop trip count.
   CountedLoopEndNode* post_end = old_new[main_end->_idx]->as_CountedLoopEnd();
   post_end->_prob = PROB_FAIR;

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1543,7 +1543,7 @@ private:
   Node *find_use_block( Node *use, Node *def, Node *old_false, Node *new_false, Node *old_true, Node *new_true );
   void handle_use( Node *use, Node *def, small_cache *cache, Node *region_dom, Node *new_false, Node *new_true, Node *old_false, Node *old_true );
   bool split_up( Node *n, Node *blk1, Node *blk2 );
-  void sink_use( Node *use, Node *post_loop );
+
   Node* place_outside_loop(Node* useblock, IdealLoopTree* loop) const;
   Node* try_move_store_before_loop(Node* n, Node *n_ctrl);
   void try_move_store_after_loop(Node* n);

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2064,17 +2064,6 @@ CmpNode*PhaseIdealLoop::clone_bool(PhiNode* phi) {
   return (CmpNode*)cmp;
 }
 
-//------------------------------sink_use---------------------------------------
-// If 'use' was in the loop-exit block, it now needs to be sunk
-// below the post-loop merge point.
-void PhaseIdealLoop::sink_use( Node *use, Node *post_loop ) {
-  if (!use->is_CFG() && get_ctrl(use) == post_loop->in(2)) {
-    set_ctrl(use, post_loop);
-    for (DUIterator j = use->outs(); use->has_out(j); j++)
-      sink_use(use->out(j), post_loop);
-  }
-}
-
 void PhaseIdealLoop::clone_loop_handle_data_uses(Node* old, Node_List &old_new,
                                                  IdealLoopTree* loop, IdealLoopTree* outer_loop,
                                                  Node_List*& split_if_set, Node_List*& split_bool_set,
@@ -2141,7 +2130,7 @@ void PhaseIdealLoop::clone_loop_handle_data_uses(Node* old, Node_List &old_new,
       while( use->in(idx) != old ) idx++;
       Node *prev = use->is_CFG() ? use : get_ctrl(use);
       assert(!loop->is_member(get_loop(prev)) && !outer_loop->is_member(get_loop(prev)), "" );
-      Node *cfg = prev->_idx >= new_counter
+      Node *cfg = (prev->_idx >= new_counter && prev->is_Region())
         ? prev->in(2)
         : idom(prev);
       if( use->is_Phi() )     // Phi use is in prior block
@@ -2165,7 +2154,7 @@ void PhaseIdealLoop::clone_loop_handle_data_uses(Node* old, Node_List &old_new,
 
       while(!outer_loop->is_member(get_loop(cfg))) {
         prev = cfg;
-        cfg = cfg->_idx >= new_counter ? cfg->in(2) : idom(cfg);
+        cfg = (cfg->_idx >= new_counter && cfg->is_Region()) ? cfg->in(2) : idom(cfg);
       }
       // If the use occurs after merging several exits from the loop, then
       // old value must have dominated all those exits.  Since the same old
@@ -2223,10 +2212,6 @@ void PhaseIdealLoop::clone_loop_handle_data_uses(Node* old, Node_List &old_new,
         if( hit )             // Go ahead and re-hash for hits.
           _igvn.replace_node( use, hit );
       }
-
-      // If 'use' was in the loop-exit block, it now needs to be sunk
-      // below the post-loop merge point.
-      sink_use( use, prev );
     }
   }
 }
@@ -2593,8 +2578,6 @@ void PhaseIdealLoop::fix_ctrl_uses(const Node_List& body, const IdealLoopTree* l
         // We need a Region to merge the exit from the peeled body and the
         // exit from the old loop body.
         RegionNode *r = new RegionNode(3);
-        // Map the old use to the new merge point
-        old_new.map( use->_idx, r );
         uint dd_r = MIN2(dom_depth(newuse), dom_depth(use));
         assert(dd_r >= dom_depth(dom_lca(newuse, use)), "" );
 
@@ -2630,12 +2613,18 @@ void PhaseIdealLoop::fix_ctrl_uses(const Node_List& body, const IdealLoopTree* l
           l -= uses_found;    // we deleted 1 or more copies of this edge
         }
 
+        assert(use->is_Proj(), "loop exit should be projections");
+        Node* use_clone = use->clone();
+        register_control(use_clone, use_loop, idom(use), dom_depth(use));
         // Now finish up 'r'
         r->set_req(1, newuse);
-        r->set_req(2,    use);
+        r->set_req(2,    use_clone);
         _igvn.register_new_node_with_optimizer(r);
         set_loop(r, use_loop);
         set_idom(r, (side_by_side_idom == nullptr) ? newuse->in(0) : side_by_side_idom, dd_r);
+        lazy_replace(use, r);
+        // Map the (cloned) old use to the new merge point
+        old_new.map( use_clone->_idx, r );
       } // End of if a loop-exit test
     }
   }

--- a/test/hotspot/jtreg/compiler/loopopts/TestBadControlAfterPreMainPost.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestBadControlAfterPreMainPost.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8315920
+ * @summary C2: "control input must dominate current control" assert failure
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseLoopPredicate -XX:-DoEscapeAnalysis TestBadControlAfterPreMainPost
+ */
+
+public class TestBadControlAfterPreMainPost {
+    private static volatile int volatileField;
+
+    public static void main(String[] args) {
+        int[] array2 = new int[100];
+        for (int i = 0; i < 20_000; i++) {
+            test(1, array2);
+        }
+    }
+
+    private static int test(int j, int[] array2) {
+        int[] array = new int[10];
+        array[j] = 42;
+        float f = 1;
+        for (int i = 0; i < 100; i++) {
+            for (int k = 0; k < 10; k++) {
+            }
+            f = f * 2;
+        }
+        int v = array[0];
+        int i = 0;
+        do {
+            synchronized (new Object()) {
+            }
+            array2[i + v] = 42;
+            i++;
+        } while (i < 100);
+        return (int)f;
+    }
+}


### PR DESCRIPTION
The assert fires during range check eliminationin code that was added
recently. It catches a bug that's been going unnoticed. The `array[0]`
load of the test case ends up on the exit of the loop above it. After
pre/main/post loops are created for this loop (the inner loop is
optimized out), the load is at a region merging control from the just
created pre/main/post loops but its control (as returned by
`PhaseIdealLoop::get_ctrl()`) is not updated by pre/main/post loops
creation code so it's still the exit projection of one of the
loops. This causes the assert to fire (the load has bad control) when
RC runs next in the same loop opts pass.

The current logic for pre/main/post loops creation does update the
control of nodes on an exit projection but only if the node is
referenced from some other node in the loop body.

I think a similar bug with a node assigned control at the exit but not
pinned is likely to exist. So I doubt simply going over nodes pinned
at exits during pre/main/post and updating their control is good
enough. What I propose instead is to `lazy_replace()` the projection
by the region so that, for all nodes that are assigned the exit as
control, `get_ctrl()` will then return the region. It's not entirely
straightforward to implement because the `lazy_replace()` mechanism
assumes the control being replaced is dead which is not the case
here. That's why in the patch the exit projection is cloned so the
existing one is dead and can be used in `lazy_replace()`. This also
makes the calls to `sink_use()` redundant.

