### PR TITLE
8316235: Optimization for DateTimeFormatter::format

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -829,15 +829,20 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
 
     void appendDigit3(int i) {
         ensureCapacityInternal(count + 3);
-        int v = DecimalDigits.digitTriple(i);
+
+        int div = i / 100;
+        int rem = i - div * 100;
+        byte c0 = (byte) ('0' + div);
+        short c12 = DecimalDigits.digitPair(i - div * 100);
+
         if (isLatin1()) {
-            ByteArrayLittleEndian.setShort(value, count, (short) (v >> 8));
-            value[count + 2] = (byte) (v >> 24);
+            value[count] = c0;
+            ByteArrayLittleEndian.setShort(value, count + 1, c12);
         } else {
-            StringUTF16.putChar(value, count, (byte) (v >> 8));
-            StringUTF16.putChar(value, count + 1, (byte) (v >> 16));
-            StringUTF16.putChar(value, count + 2, (byte) (v >> 24));
+            StringUTF16.putChar(value, count, c0);
+            StringUTF16.putPair(value, count + 1, c12);
         }
+
         count += 3;
     }
 

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1612,7 +1612,7 @@ final class StringUTF16 {
         return charPos;
     }
 
-    private static void putPair(byte[] buf, int charPos, int v) {
+    static void putPair(byte[] buf, int charPos, int v) {
         int packed = (int) DecimalDigits.digitPair(v);
         putChar(buf, charPos, packed & 0xFF);
         putChar(buf, charPos + 1, packed >> 8);

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2544,6 +2544,14 @@ public final class System {
                 return sb.prepend(lengthCoder, buf);
             }
 
+            public void appendDigit2(StringBuilder sb, int i) {
+                sb.appendDigit2(i);
+            }
+
+            public void appendDigit3(StringBuilder sb, int i) {
+                sb.appendDigit3(i);
+            }
+
             public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
                 return String.join(prefix, suffix, delimiter, elements, size);
             }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -797,11 +797,7 @@ public final class DateTimeFormatter {
     public static final DateTimeFormatter ISO_LOCAL_DATE;
     static {
         ISO_LOCAL_DATE = new DateTimeFormatterBuilder()
-                .appendValue(YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
-                .appendLiteral('-')
-                .appendValue(MONTH_OF_YEAR, 2)
-                .appendLiteral('-')
-                .appendValue(DAY_OF_MONTH, 2)
+                .appendLocalDate()
                 .toFormatter(ResolverStyle.STRICT, IsoChronology.INSTANCE);
     }
 
@@ -896,14 +892,7 @@ public final class DateTimeFormatter {
     public static final DateTimeFormatter ISO_LOCAL_TIME;
     static {
         ISO_LOCAL_TIME = new DateTimeFormatterBuilder()
-                .appendValue(HOUR_OF_DAY, 2)
-                .appendLiteral(':')
-                .appendValue(MINUTE_OF_HOUR, 2)
-                .optionalStart()
-                .appendLiteral(':')
-                .appendValue(SECOND_OF_MINUTE, 2)
-                .optionalStart()
-                .appendFraction(NANO_OF_SECOND, 0, 9, true)
+                .appendLocalTime()
                 .toFormatter(ResolverStyle.STRICT, null);
     }
 

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2656,9 +2656,6 @@ public final class DateTimeFormatterBuilder {
                 time = ((OffsetDateTime) temporal).toLocalTime();
             } else if (temporal instanceof OffsetTime) {
                 time = ((OffsetTime) temporal).toLocalTime();
-            } else if (temporal instanceof Instant) {
-                Instant instant = (Instant) temporal;
-                time = LocalTime.ofInstant(instant, ZoneId.systemDefault());
             } else {
                 return super.format(context, buf);
             }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2675,7 +2675,7 @@ public final class DateTimeFormatterBuilder {
     /**
      * Composite printer and parser.
      */
-    static class CompositePrinterParser implements DateTimePrinterParser {
+    static sealed class CompositePrinterParser implements DateTimePrinterParser {
         private final DateTimePrinterParser[] printerParsers;
         private final boolean optional;
 

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2454,8 +2454,6 @@ public final class DateTimeFormatterBuilder {
         int printerParsersSize = printerParsers.size();
         if (DateCompositePrinterParser.accept(printerParsers)) {
             pp = new DateCompositePrinterParser(printerParsers, false);
-        } else if (TimeCompositePrinterParser.accept(printerParsers)) {
-            pp = new TimeCompositePrinterParser(printerParsers, false);
         }
 
         if (pp == null) {
@@ -2593,102 +2591,6 @@ public final class DateTimeFormatterBuilder {
 
             if (date != null) {
                 formatDate(buf, literal, date);
-                return true;
-            }
-
-            return super.format(context, buf);
-        }
-    }
-
-    static final class TimeCompositePrinterParser extends CompositePrinterParser {
-        final char literal;
-        final int fractionalDigits;
-        private TimeCompositePrinterParser(List<DateTimePrinterParser> printerParsers, boolean optional) {
-            super(printerParsers, optional);
-            literal = ((CharLiteralPrinterParser) printerParsers.get(1)).literal;
-            CompositePrinterParser p3 = (CompositePrinterParser) printerParsers.get(3);
-            CompositePrinterParser s2 = (CompositePrinterParser) p3.printerParsers[2];
-            NanosPrinterParser n = (NanosPrinterParser) s2.printerParsers[0];
-            if (n.minWidth == 0 && n.maxWidth == 9) {
-                fractionalDigits = -2;
-            } else {
-                fractionalDigits = n.minWidth;
-            }
-        }
-
-        static boolean accept(List<DateTimePrinterParser> printerParsers) {
-            if (printerParsers.size() != 4) {
-                return false;
-            }
-
-            if (printerParsers.get(0) instanceof NumberPrinterParser
-                    && printerParsers.get(1) instanceof CharLiteralPrinterParser
-                    && printerParsers.get(2) instanceof NumberPrinterParser
-                    && printerParsers.get(3) instanceof CompositePrinterParser
-            ) {
-                NumberPrinterParser p0 = (NumberPrinterParser) printerParsers.get(0);
-                CharLiteralPrinterParser p1 = (CharLiteralPrinterParser) printerParsers.get(1);
-                NumberPrinterParser p2 = (NumberPrinterParser) printerParsers.get(2);
-                CompositePrinterParser p3 = (CompositePrinterParser) printerParsers.get(3);
-
-                if (p0.field == ChronoField.HOUR_OF_DAY
-                        && p0.signStyle == SignStyle.NOT_NEGATIVE
-                        && p0.minWidth == 2
-                        && p0.maxWidth == 2
-                        && p0.subsequentWidth == 0
-                        && p2.field == ChronoField.MINUTE_OF_HOUR
-                        && p2.signStyle == SignStyle.NOT_NEGATIVE
-                        && p2.minWidth == 2
-                        && p2.maxWidth == 2
-                        && p2.subsequentWidth == 0
-                        && p3.printerParsers.length == 3
-                        && p3.printerParsers[0] instanceof CharLiteralPrinterParser
-                        && p3.printerParsers[1] instanceof NumberPrinterParser
-                        && p3.printerParsers[2] instanceof CompositePrinterParser
-                ) {
-                    CharLiteralPrinterParser s0 = (CharLiteralPrinterParser) p3.printerParsers[0];
-                    NumberPrinterParser s1 = (NumberPrinterParser) p3.printerParsers[1];
-                    CompositePrinterParser s2 = (CompositePrinterParser) p3.printerParsers[2];
-                    if (s1.field == ChronoField.SECOND_OF_MINUTE
-                            && s0.literal == p1.literal
-                            && s1.minWidth == 2
-                            && s1.maxWidth == 2
-                            && s1.subsequentWidth == 0
-                            && s2.printerParsers.length == 1
-                            && s2.printerParsers[0] instanceof NanosPrinterParser
-                    ) {
-                        NanosPrinterParser n = (NanosPrinterParser) s2.printerParsers[0];
-                        if (n.decimalPoint
-                                && n.field == ChronoField.NANO_OF_SECOND
-                                && n.signStyle == SignStyle.NOT_NEGATIVE
-                                && n.subsequentWidth == 0
-                                && ((n.minWidth == 0 && n.maxWidth == 9) || n.minWidth == n.maxWidth)
-                        ) {
-                            return true;
-                        }
-                    }
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public boolean format(DateTimePrintContext context, StringBuilder buf) {
-            TemporalAccessor temporal = context.getTemporal();
-
-            LocalTime time = null;
-            if (temporal instanceof LocalDateTime) {
-                time = ((LocalDateTime) temporal).toLocalTime();
-            } else if (temporal instanceof LocalTime) {
-                time = (LocalTime) temporal;
-            } else if (temporal instanceof ZonedDateTime) {
-                time = ((ZonedDateTime) temporal).toLocalTime();
-            } else if (temporal instanceof OffsetDateTime) {
-                time = ((OffsetDateTime) temporal).toLocalTime();
-            }
-
-            if (time != null) {
-                formatTime(buf, -2, time);
                 return true;
             }
 

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2643,23 +2643,13 @@ public final class DateTimeFormatterBuilder {
         public boolean format(DateTimePrintContext context, StringBuilder buf) {
             TemporalAccessor temporal = context.getTemporal();
 
-            boolean utc = true;
             LocalTime time;
             switch (temporal) {
                 case LocalTime lt -> time = lt;
                 case LocalDateTime ldt -> time = ldt.toLocalTime();
-                case ZonedDateTime zdt -> {
-                    time = zdt.toLocalTime();
-                    utc = false;
-                }
-                case OffsetDateTime odt -> {
-                    time = odt.toLocalTime();
-                    utc = false;
-                }
-                case OffsetTime ot -> {
-                    time = ot.toLocalTime();
-                    utc = false;
-                }
+                case ZonedDateTime zdt -> time = zdt.toLocalTime();
+                case OffsetDateTime odt -> time = odt.toLocalTime();
+                case OffsetTime ot -> time = ot.toLocalTime();
                 default -> {
                     return super.format(context, buf);
                 }
@@ -2676,9 +2666,6 @@ public final class DateTimeFormatterBuilder {
                 }
             }
 
-            if (utc) {
-                buf.append('Z');
-            }
             return true;
         }
     }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -82,6 +82,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.chrono.ChronoLocalDate;
@@ -121,6 +123,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
+
 import sun.text.spi.JavaTimeDateTimePatternProvider;
 import sun.util.locale.provider.CalendarDataUtility;
 import sun.util.locale.provider.LocaleProviderAdapter;
@@ -159,7 +164,28 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * @since 1.8
  */
 public final class DateTimeFormatterBuilder {
+    /**
+     * Hours per day.
+     */
+    static final int HOURS_PER_DAY = 24;
+    /**
+     * Minutes per hour.
+     */
+    static final int MINUTES_PER_HOUR = 60;
+    /**
+     * Seconds per minute.
+     */
+    static final int SECONDS_PER_MINUTE = 60;
+    /**
+     * Seconds per hour.
+     */
+    static final int SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+    /**
+     * Seconds per day.
+     */
+    static final int SECONDS_PER_DAY = SECONDS_PER_HOUR * HOURS_PER_DAY;
 
+    private static final JavaLangAccess jla = SharedSecrets.getJavaLangAccess();
     /**
      * Query for a time-zone that is region-only.
      */
@@ -2422,7 +2448,20 @@ public final class DateTimeFormatterBuilder {
         while (active.parent != null) {
             optionalEnd();
         }
-        CompositePrinterParser pp = new CompositePrinterParser(printerParsers, false);
+
+        CompositePrinterParser pp = null;
+
+        int printerParsersSize = printerParsers.size();
+        if (DateCompositePrinterParser.accept(printerParsers)) {
+            pp = new DateCompositePrinterParser(printerParsers, false);
+        } else if (TimeCompositePrinterParser.accept(printerParsers)) {
+            pp = new TimeCompositePrinterParser(printerParsers, false);
+        }
+
+        if (pp == null) {
+            pp = new CompositePrinterParser(printerParsers, false);
+        }
+
         return new DateTimeFormatter(pp, locale, DecimalStyle.STANDARD,
                 resolverStyle, null, chrono, null);
     }
@@ -2488,15 +2527,184 @@ public final class DateTimeFormatterBuilder {
         int parse(DateTimeParseContext context, CharSequence text, int position);
     }
 
+    static final class DateCompositePrinterParser extends CompositePrinterParser {
+        private final char literal;
+        private DateCompositePrinterParser(List<DateTimePrinterParser> printerParsers, boolean optional) {
+            super(printerParsers, optional);
+            literal = ((CharLiteralPrinterParser) printerParsers.get(1)).literal;
+        }
+
+        static boolean accept(List<DateTimePrinterParser> printerParsers) {
+            int printerParsersSize = printerParsers.size();
+            if (printerParsersSize != 5) {
+                return false;
+            }
+
+            if (printerParsers.get(0) instanceof NumberPrinterParser
+                    && printerParsers.get(1) instanceof CharLiteralPrinterParser
+                    && printerParsers.get(2) instanceof NumberPrinterParser
+                    && printerParsers.get(3) instanceof CharLiteralPrinterParser
+                    && printerParsers.get(4) instanceof NumberPrinterParser
+            ) {
+                NumberPrinterParser p0 = (NumberPrinterParser) printerParsers.get(0);
+                CharLiteralPrinterParser p1 = (CharLiteralPrinterParser) printerParsers.get(1);
+                NumberPrinterParser p2 = (NumberPrinterParser) printerParsers.get(2);
+                CharLiteralPrinterParser p3 = (CharLiteralPrinterParser) printerParsers.get(3);
+                NumberPrinterParser p4 = (NumberPrinterParser) printerParsers.get(4);
+                if (p0.field == ChronoField.YEAR
+                        && p1.literal == p3.literal
+                        && p0.signStyle == SignStyle.EXCEEDS_PAD
+                        && p0.minWidth == 4
+                        && p0.maxWidth == 10
+                        && p0.subsequentWidth == 0
+                        && p2.field == ChronoField.MONTH_OF_YEAR
+                        && p2.signStyle == SignStyle.NOT_NEGATIVE
+                        && p2.minWidth == 2
+                        && p2.maxWidth == 2
+                        && p4.subsequentWidth == 0
+                        && p4.field == ChronoField.DAY_OF_MONTH
+                        && p4.signStyle == SignStyle.NOT_NEGATIVE
+                        && p4.minWidth == 2
+                        && p4.maxWidth == 2
+                        && p4.subsequentWidth == 0
+                ) {
+                    return true;
+                }
+            }
+
+
+            return false;
+        }
+
+        @Override
+        public boolean format(DateTimePrintContext context, StringBuilder buf) {
+            TemporalAccessor temporal = context.getTemporal();
+
+            LocalDate date = null;
+            if (temporal instanceof LocalDateTime) {
+                date = ((LocalDateTime) temporal).toLocalDate();
+            } else if (temporal instanceof LocalDate) {
+                date = (LocalDate) temporal;
+            } else if (temporal instanceof ZonedDateTime) {
+                date = ((ZonedDateTime) temporal).toLocalDate();
+            } else if (temporal instanceof OffsetDateTime) {
+                date = ((OffsetDateTime) temporal).toLocalDate();
+            }
+
+            if (date != null) {
+                formatDate(buf, literal, date);
+                return true;
+            }
+
+            return super.format(context, buf);
+        }
+    }
+
+    static final class TimeCompositePrinterParser extends CompositePrinterParser {
+        final char literal;
+        final int fractionalDigits;
+        private TimeCompositePrinterParser(List<DateTimePrinterParser> printerParsers, boolean optional) {
+            super(printerParsers, optional);
+            literal = ((CharLiteralPrinterParser) printerParsers.get(1)).literal;
+            CompositePrinterParser p3 = (CompositePrinterParser) printerParsers.get(3);
+            CompositePrinterParser s2 = (CompositePrinterParser) p3.printerParsers[2];
+            NanosPrinterParser n = (NanosPrinterParser) s2.printerParsers[0];
+            if (n.minWidth == 0 && n.maxWidth == 9) {
+                fractionalDigits = -2;
+            } else {
+                fractionalDigits = n.minWidth;
+            }
+        }
+
+        static boolean accept(List<DateTimePrinterParser> printerParsers) {
+            if (printerParsers.size() != 4) {
+                return false;
+            }
+
+            if (printerParsers.get(0) instanceof NumberPrinterParser
+                    && printerParsers.get(1) instanceof CharLiteralPrinterParser
+                    && printerParsers.get(2) instanceof NumberPrinterParser
+                    && printerParsers.get(3) instanceof CompositePrinterParser
+            ) {
+                NumberPrinterParser p0 = (NumberPrinterParser) printerParsers.get(0);
+                CharLiteralPrinterParser p1 = (CharLiteralPrinterParser) printerParsers.get(1);
+                NumberPrinterParser p2 = (NumberPrinterParser) printerParsers.get(2);
+                CompositePrinterParser p3 = (CompositePrinterParser) printerParsers.get(3);
+
+                if (p0.field == ChronoField.HOUR_OF_DAY
+                        && p0.signStyle == SignStyle.NOT_NEGATIVE
+                        && p0.minWidth == 2
+                        && p0.maxWidth == 2
+                        && p0.subsequentWidth == 0
+                        && p2.field == ChronoField.MINUTE_OF_HOUR
+                        && p2.signStyle == SignStyle.NOT_NEGATIVE
+                        && p2.minWidth == 2
+                        && p2.maxWidth == 2
+                        && p2.subsequentWidth == 0
+                        && p3.printerParsers.length == 3
+                        && p3.printerParsers[0] instanceof CharLiteralPrinterParser
+                        && p3.printerParsers[1] instanceof NumberPrinterParser
+                        && p3.printerParsers[2] instanceof CompositePrinterParser
+                ) {
+                    CharLiteralPrinterParser s0 = (CharLiteralPrinterParser) p3.printerParsers[0];
+                    NumberPrinterParser s1 = (NumberPrinterParser) p3.printerParsers[1];
+                    CompositePrinterParser s2 = (CompositePrinterParser) p3.printerParsers[2];
+                    if (s1.field == ChronoField.SECOND_OF_MINUTE
+                            && s0.literal == p1.literal
+                            && s1.minWidth == 2
+                            && s1.maxWidth == 2
+                            && s1.subsequentWidth == 0
+                            && s2.printerParsers.length == 1
+                            && s2.printerParsers[0] instanceof NanosPrinterParser
+                    ) {
+                        NanosPrinterParser n = (NanosPrinterParser) s2.printerParsers[0];
+                        if (n.decimalPoint
+                                && n.field == ChronoField.NANO_OF_SECOND
+                                && n.signStyle == SignStyle.NOT_NEGATIVE
+                                && n.subsequentWidth == 0
+                                && ((n.minWidth == 0 && n.maxWidth == 9) || n.minWidth == n.maxWidth)
+                        ) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean format(DateTimePrintContext context, StringBuilder buf) {
+            TemporalAccessor temporal = context.getTemporal();
+
+            LocalTime time = null;
+            if (temporal instanceof LocalDateTime) {
+                time = ((LocalDateTime) temporal).toLocalTime();
+            } else if (temporal instanceof LocalTime) {
+                time = (LocalTime) temporal;
+            } else if (temporal instanceof ZonedDateTime) {
+                time = ((ZonedDateTime) temporal).toLocalTime();
+            } else if (temporal instanceof OffsetDateTime) {
+                time = ((OffsetDateTime) temporal).toLocalTime();
+            }
+
+            if (time != null) {
+                formatTime(buf, -2, time);
+                return true;
+            }
+
+            return super.format(context, buf);
+        }
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Composite printer and parser.
      */
-    static final class CompositePrinterParser implements DateTimePrinterParser {
+    static class CompositePrinterParser implements DateTimePrinterParser {
         private final DateTimePrinterParser[] printerParsers;
         private final boolean optional;
 
-        private CompositePrinterParser(List<DateTimePrinterParser> printerParsers, boolean optional) {
+        CompositePrinterParser(List<DateTimePrinterParser> printerParsers, boolean optional) {
             this(printerParsers.toArray(new DateTimePrinterParser[0]), optional);
         }
 
@@ -2830,7 +3038,7 @@ public final class DateTimeFormatterBuilder {
         final TemporalField field;
         final int minWidth;
         final int maxWidth;
-        private final SignStyle signStyle;
+        final SignStyle signStyle;
         final int subsequentWidth;
 
         /**
@@ -3276,7 +3484,7 @@ public final class DateTimeFormatterBuilder {
      * Prints and parses a NANO_OF_SECOND field with optional padding.
      */
     static final class NanosPrinterParser extends NumberPrinterParser {
-        private final boolean decimalPoint;
+        final boolean decimalPoint;
 
         /**
          * Constructor.
@@ -3793,6 +4001,129 @@ public final class DateTimeFormatterBuilder {
         }
     }
 
+    static void formatDate(StringBuilder buf, char literal, LocalDate date) {
+        int year = date.getYear();
+        int yearAbs = Math.abs(year);
+        if (yearAbs < 1000) {
+            if (year < 0) {
+                buf.append('-');
+            }
+            int y01 = yearAbs / 100;
+            int y23 = yearAbs - y01 * 100;
+
+            jla.appendDigit2(buf, y01);
+            jla.appendDigit2(buf, y23);
+        } else {
+            if (year > 9999) {
+                buf.append('+');
+            }
+
+            buf.append(year);
+        }
+        buf.append(literal);
+        jla.appendDigit2(buf, date.getMonthValue());
+        buf.append(literal);
+        jla.appendDigit2(buf, date.getDayOfMonth());
+    }
+
+    static void formatTime(StringBuilder buf, int fractionalDigits, LocalTime time) {
+        jla.appendDigit2(buf, time.getHour());
+        buf.append(':');
+        jla.appendDigit2(buf, time.getMinute());
+        buf.append(':');
+        jla.appendDigit2(buf, time.getSecond());
+
+        int nano = time.getNano();
+        if (fractionalDigits < 0) {
+            formatNano(buf, nano);
+        } else {
+            formatNano(buf, fractionalDigits, nano);
+        }
+    }
+
+    static void formatNano(StringBuilder buf, int nano) {
+        if (nano == 0) {
+            return;
+        }
+
+        int div = nano / 1000;
+        int div2 = div / 1000;
+
+        buf.append('.');
+        jla.appendDigit3(buf, div2);
+
+        int rem1 = nano - div * 1000;
+        int rem2 = div - div2 * 1000;
+
+        if (rem1 == 0 && rem2 == 0) {
+            return;
+        }
+
+        jla.appendDigit3(buf, rem2);
+        if (rem1 == 0) {
+            return;
+        }
+        jla.appendDigit3(buf, rem1);
+    }
+
+    static void formatNano(StringBuilder buf, int fractionalDigits, int nano) {
+        if (fractionalDigits == 0) {
+            return;
+        }
+
+        buf.append('.');
+
+        int div = nano / 1000;
+        int div2 = div / 1000;
+
+        if (fractionalDigits == 1) {
+            buf.append((char) ('0' + (div2 / 100)));
+            return;
+        }
+
+        if (fractionalDigits == 2) {
+            jla.appendDigit2(buf, div2 / 10);
+            return;
+        }
+
+        jla.appendDigit3(buf, div2);
+
+        if (fractionalDigits == 3) {
+            return;
+        }
+
+        int rem1 = nano - div * 1000;
+        int rem2 = div - div2 * 1000;
+
+        if (fractionalDigits == 4) {
+            buf.append((char) ('0' + (rem2 / 100)));
+            return;
+        }
+
+        if (fractionalDigits == 5) {
+            jla.appendDigit2(buf, rem2 / 10);
+            return;
+        }
+
+        jla.appendDigit3(buf, rem2);
+
+        if (fractionalDigits == 6) {
+            return;
+        }
+
+        if (fractionalDigits == 7) {
+            buf.append((char) ('0' + (rem1 / 100)));
+            return;
+        }
+
+        if (fractionalDigits == 8) {
+            jla.appendDigit2(buf, rem1 / 10);
+            return;
+        }
+
+        jla.appendDigit3(buf, rem1);
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Prints or parses an ISO-8601 instant.
@@ -3811,65 +4142,20 @@ public final class DateTimeFormatterBuilder {
 
         @Override
         public boolean format(DateTimePrintContext context, StringBuilder buf) {
-            // use INSTANT_SECONDS, thus this code is not bound by Instant.MAX
-            Long inSecs = context.getValue(INSTANT_SECONDS);
-            Long inNanos = null;
-            if (context.getTemporal().isSupported(NANO_OF_SECOND)) {
-                inNanos = context.getTemporal().getLong(NANO_OF_SECOND);
-            }
-            if (inSecs == null) {
-                return false;
-            }
-            long inSec = inSecs;
-            int inNano = NANO_OF_SECOND.checkValidIntValue(inNanos != null ? inNanos : 0);
-            // format mostly using LocalDateTime.toString
-            if (inSec >= -SECONDS_0000_TO_1970) {
-                // current era
-                long zeroSecs = inSec - SECONDS_PER_10000_YEARS + SECONDS_0000_TO_1970;
-                long hi = Math.floorDiv(zeroSecs, SECONDS_PER_10000_YEARS) + 1;
-                long lo = Math.floorMod(zeroSecs, SECONDS_PER_10000_YEARS);
-                LocalDateTime ldt = LocalDateTime.ofEpochSecond(lo - SECONDS_0000_TO_1970, 0, ZoneOffset.UTC);
-                if (hi > 0) {
-                    buf.append('+').append(hi);
-                }
-                buf.append(ldt);
-                if (ldt.getSecond() == 0) {
-                    buf.append(":00");
-                }
-            } else {
-                // before current era
-                long zeroSecs = inSec + SECONDS_0000_TO_1970;
-                long hi = zeroSecs / SECONDS_PER_10000_YEARS;
-                long lo = zeroSecs % SECONDS_PER_10000_YEARS;
-                LocalDateTime ldt = LocalDateTime.ofEpochSecond(lo - SECONDS_0000_TO_1970, 0, ZoneOffset.UTC);
-                int pos = buf.length();
-                buf.append(ldt);
-                if (ldt.getSecond() == 0) {
-                    buf.append(":00");
-                }
-                if (hi < 0) {
-                    if (ldt.getYear() == -10_000) {
-                        buf.replace(pos, pos + 2, Long.toString(hi - 1));
-                    } else if (lo == 0) {
-                        buf.insert(pos, hi);
-                    } else {
-                        buf.insert(pos + 1, Math.abs(hi));
-                    }
-                }
-            }
-            // add fraction
-            if ((fractionalDigits < 0 && inNano > 0) || fractionalDigits > 0) {
-                buf.append('.');
-                int div = 100_000_000;
-                for (int i = 0; ((fractionalDigits == -1 && inNano > 0) ||
-                                    (fractionalDigits == -2 && (inNano > 0 || (i % 3) != 0)) ||
-                                    i < fractionalDigits); i++) {
-                    int digit = inNano / div;
-                    buf.append((char) (digit + '0'));
-                    inNano = inNano - (digit * div);
-                    div = div / 10;
-                }
-            }
+            Instant instant = (Instant) context.getTemporal();
+            long seconds = instant.getEpochSecond();
+            int nano = instant.getNano();
+
+            LocalDate date = LocalDate.ofEpochDay(
+                    Math.floorDiv(seconds, SECONDS_PER_DAY));
+
+            formatDate(buf, '-', date);
+            buf.append('T');
+
+            LocalTime time = LocalTime.ofSecondOfDay(
+                    Math.floorMod(seconds, SECONDS_PER_DAY));
+
+            formatTime(buf, fractionalDigits, time);
             buf.append('Z');
             return true;
         }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2581,16 +2581,14 @@ public final class DateTimeFormatterBuilder {
             TemporalAccessor temporal = context.getTemporal();
 
             LocalDate date;
-            if (temporal instanceof LocalDateTime) {
-                date = ((LocalDateTime) temporal).toLocalDate();
-            } else if (temporal instanceof LocalDate) {
-                date = (LocalDate) temporal;
-            } else if (temporal instanceof ZonedDateTime) {
-                date = ((ZonedDateTime) temporal).toLocalDate();
-            } else if (temporal instanceof OffsetDateTime) {
-                date = ((OffsetDateTime) temporal).toLocalDate();
-            } else {
-                return super.format(context, buf);
+            switch (temporal) {
+                case LocalDate localDate -> date = localDate;
+                case LocalDateTime ldt -> date = ldt.toLocalDate();
+                case ZonedDateTime zdt -> date = zdt.toLocalDate();
+                case OffsetDateTime odt -> date = odt.toLocalDate();
+                default -> {
+                    return super.format(context, buf);
+                }
             }
 
             formatDate(buf, date);
@@ -2646,18 +2644,15 @@ public final class DateTimeFormatterBuilder {
             TemporalAccessor temporal = context.getTemporal();
 
             LocalTime time;
-            if (temporal instanceof LocalTime) {
-                time = (LocalTime) temporal;
-            } else if (temporal instanceof LocalDateTime) {
-                time = ((LocalDateTime) temporal).toLocalTime();
-            } else if (temporal instanceof ZonedDateTime) {
-                time = ((ZonedDateTime) temporal).toLocalTime();
-            } else if (temporal instanceof OffsetDateTime) {
-                time = ((OffsetDateTime) temporal).toLocalTime();
-            } else if (temporal instanceof OffsetTime) {
-                time = ((OffsetTime) temporal).toLocalTime();
-            } else {
-                return super.format(context, buf);
+            switch (temporal) {
+                case LocalTime lt -> time = lt;
+                case LocalDateTime ldt -> time = ldt.toLocalTime();
+                case ZonedDateTime zdt -> time = zdt.toLocalTime();
+                case OffsetDateTime odt -> time = odt.toLocalTime();
+                case OffsetTime ot -> time = ot.toLocalTime();
+                default -> {
+                    return super.format(context, buf);
+                }
             }
 
             formatTime(buf, time);

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -1957,6 +1957,10 @@ public final class DateTimeFormatterBuilder {
                 return appendLocalDate()
                         .appendLiteral('T')
                         .appendLocalTime(false, 0, 0);
+            case "yyyy-MM-dd HH:mm:ss.SSS":
+                return appendLocalDate()
+                        .appendLiteral(' ')
+                        .appendLocalTime(false, 3, 3);
             case "yyyy-MM-dd'T'HH:mm:ss.SSS":
                 return appendLocalDate()
                         .appendLiteral('T')

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2643,13 +2643,23 @@ public final class DateTimeFormatterBuilder {
         public boolean format(DateTimePrintContext context, StringBuilder buf) {
             TemporalAccessor temporal = context.getTemporal();
 
+            boolean utc = true;
             LocalTime time;
             switch (temporal) {
                 case LocalTime lt -> time = lt;
                 case LocalDateTime ldt -> time = ldt.toLocalTime();
-                case ZonedDateTime zdt -> time = zdt.toLocalTime();
-                case OffsetDateTime odt -> time = odt.toLocalTime();
-                case OffsetTime ot -> time = ot.toLocalTime();
+                case ZonedDateTime zdt -> {
+                    time = zdt.toLocalTime();
+                    utc = false;
+                }
+                case OffsetDateTime odt -> {
+                    time = odt.toLocalTime();
+                    utc = false;
+                }
+                case OffsetTime ot -> {
+                    time = ot.toLocalTime();
+                    utc = false;
+                }
                 default -> {
                     return super.format(context, buf);
                 }
@@ -2666,7 +2676,9 @@ public final class DateTimeFormatterBuilder {
                 }
             }
 
-            buf.append('Z');
+            if (utc) {
+                buf.append('Z');
+            }
             return true;
         }
     }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -434,6 +434,10 @@ public interface JavaLangAccess {
     @PreviewFeature(feature=PreviewFeature.Feature.STRING_TEMPLATES)
    long stringBuilderConcatPrepend(long lengthCoder, byte[] buf, StringBuilder sb);
 
+   void appendDigit2(StringBuilder sb, int i);
+
+   void appendDigit3(StringBuilder sb, int i);
+
     /**
      * Join strings
      */

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -70,21 +70,6 @@ public final class DecimalDigits implements Digits {
             0x3039, 0x3139, 0x3239, 0x3339, 0x3439, 0x3539, 0x3639, 0x3739, 0x3839, 0x3939
     };
 
-    @Stable
-    private static final int[] DIGITS_K;
-
-    static {
-        int[] digits_k = new int[1000];
-        for (int i = 0; i < 1000; i++) {
-            int c0 = i < 10 ? 2 : i < 100 ? 1 : 0;
-            int c1 = (i / 100) + '0';
-            int c2 = ((i / 10) % 10) + '0';
-            int c3 = i % 10 + '0';
-            digits_k[i] = c0 + (c1 << 8) + (c2 << 16) + (c3 << 24);
-        }
-        DIGITS_K = digits_k;
-    }
-
     /**
      * Singleton instance of DecimalDigits.
      */
@@ -171,14 +156,5 @@ public final class DecimalDigits implements Digits {
      */
     public static short digitPair(int i) {
         return DIGITS[i];
-    }
-
-    /**
-     * For values from 0 to 999 return a short encoding a triple of ASCII-encoded digit characters in little-endian
-     * @param i value to convert
-     * @return a short encoding a triple of ASCII-encoded digit characters
-     */
-    public static int digitTriple(int i) {
-        return DIGITS_K[i];
     }
 }

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -70,6 +70,21 @@ public final class DecimalDigits implements Digits {
             0x3039, 0x3139, 0x3239, 0x3339, 0x3439, 0x3539, 0x3639, 0x3739, 0x3839, 0x3939
     };
 
+    @Stable
+    private static final int[] DIGITS_K;
+
+    static {
+        int[] digits_k = new int[1000];
+        for (int i = 0; i < 1000; i++) {
+            int c0 = i < 10 ? 2 : i < 100 ? 1 : 0;
+            int c1 = (i / 100) + '0';
+            int c2 = ((i / 10) % 10) + '0';
+            int c3 = i % 10 + '0';
+            digits_k[i] = c0 + (c1 << 8) + (c2 << 16) + (c3 << 24);
+        }
+        DIGITS_K = digits_k;
+    }
+
     /**
      * Singleton instance of DecimalDigits.
      */
@@ -156,5 +171,14 @@ public final class DecimalDigits implements Digits {
      */
     public static short digitPair(int i) {
         return DIGITS[i];
+    }
+
+    /**
+     * For values from 0 to 999 return a short encoding a triple of ASCII-encoded digit characters in little-endian
+     * @param i value to convert
+     * @return a short encoding a triple of ASCII-encoded digit characters
+     */
+    public static int digitTriple(int i) {
+        return DIGITS_K[i];
     }
 }


### PR DESCRIPTION
In many scenarios, DateTimeFormatter::format is a slower operation.  

For example, the following business scenarios
1. The json library gson/jackson/[fastjson2](https://github.com/alibaba/fastjson2) formats Instant/LocalDate/LocalTime/LocalDateTime/ZonedDateTim into strings.
2. In data integration scenarios, for projects like  [datax](https://github.com/alibaba/datax)/[canal](https://github.com/alibaba/canal), if the input type is Date/Instant and the output type is String, formatting is required.

This PR provides format performance optimization for commonly used date patterns.
```
ISO_INSTANT
ISO_LOCAL_TIME
ISO_LOCAL_DATE
ISO_LOCAL_DATETIME
HH:mm:ss
HH:mm:ss.SSS
yyyy-MM-dd
yyyy-MM-dd HH:mm:ss
yyyy-MM-dd'T'HH:mm:ss
yyyy-MM-dd HH:mm:ss.SSS
yyyy-MM-dd'T'HH:mm:ss.SSS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316235](https://bugs.openjdk.org/browse/JDK-8316235): Optimization for DateTimeFormatter::format (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15722/head:pull/15722` \
`$ git checkout pull/15722`

Update a local copy of the PR: \
`$ git checkout pull/15722` \
`$ git pull https://git.openjdk.org/jdk.git pull/15722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15722`

View PR using the GUI difftool: \
`$ git pr show -t 15722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15722.diff">https://git.openjdk.org/jdk/pull/15722.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15722#issuecomment-1718650068)