### PR TITLE
8316207: Fix typos in java.io.StreamTokenizer

### DIFF
--- a/src/java.base/share/classes/java/io/StreamTokenizer.java
+++ b/src/java.base/share/classes/java/io/StreamTokenizer.java
@@ -115,7 +115,7 @@ public class StreamTokenizer {
      *     has been reached.
      * </ul>
      * <p>
-     * The initial value of this field is -4.
+     * The initial value of this field is {@value TT_NOTHING}.
      *
      * @see     java.io.StreamTokenizer#eolIsSignificant(boolean)
      * @see     java.io.StreamTokenizer#nextToken()
@@ -344,7 +344,7 @@ public class StreamTokenizer {
     }
 
     /**
-     * Specified that the character argument starts a single-line
+     * Specifies that the character argument starts a single-line
      * comment. All characters from the comment character to the end of
      * the line are ignored by this stream tokenizer.
      *
@@ -478,7 +478,7 @@ public class StreamTokenizer {
      * If the flag argument is {@code true}, then the value in the
      * {@code sval} field is lowercased whenever a word token is
      * returned (the {@code ttype} field has the
-     * value {@code TT_WORD} by the {@code nextToken} method
+     * value {@code TT_WORD}) by the {@code nextToken} method
      * of this tokenizer.
      * <p>
      * If the flag argument is {@code false}, then the
@@ -755,7 +755,7 @@ public class StreamTokenizer {
     }
 
     /**
-     * Return the current line number.
+     * Returns the current line number.
      *
      * @return  the current line number of this stream tokenizer.
      */


### PR DESCRIPTION
This is a simple PR to fix a few typos in the doc comments of java.io.StreamTokenizer. When reviewing it, please double-check my proposal for L481. For this, you should ideally read the complete comment to the `lowerCaseMode` method. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316207](https://bugs.openjdk.org/browse/JDK-8316207): Fix typos in java.io.StreamTokenizer (**Bug** - P5)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15723/head:pull/15723` \
`$ git checkout pull/15723`

Update a local copy of the PR: \
`$ git checkout pull/15723` \
`$ git pull https://git.openjdk.org/jdk.git pull/15723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15723`

View PR using the GUI difftool: \
`$ git pr show -t 15723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15723.diff">https://git.openjdk.org/jdk/pull/15723.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15723#issuecomment-1717897902)