### PR TITLE
[PATCH] Remove unused method matchDSTString from SimpleDateFormat

### DIFF
--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -1710,17 +1710,6 @@ public class SimpleDateFormat extends DateFormat {
         return -1;
     }
 
-    private boolean matchDSTString(String text, int start, int zoneIndex, int standardIndex,
-                                   String[][] zoneStrings) {
-        int index = standardIndex + 2;
-        String zoneName  = zoneStrings[zoneIndex][index];
-        if (text.regionMatches(true, start,
-                               zoneName, 0, zoneName.length())) {
-            return true;
-        }
-        return false;
-    }
-
     /**
      * find time zone 'text' matched zoneStrings and set to internal
      * calendar.
@@ -2520,7 +2509,7 @@ public class SimpleDateFormat extends DateFormat {
                 hasFollowingMinusSign = false;
 
                 int separatorIndex = numberPattern.indexOf(';');
-                // If the negative subpattern is not absent, we have to analayze
+                // If the negative subpattern is not absent, we have to analyze
                 // it in order to check if it has a following minus sign.
                 if (separatorIndex > -1) {
                     int minusIndex = numberPattern.indexOf('-', separatorIndex);


### PR DESCRIPTION
Remove unused method `java.text.SimpleDateFormat.matchDSTString`
It was added under [JDK-4267450](https://bugs.openjdk.java.net/browse/JDK-4267450) but wasn't used - d950166573199f6b5d5de26b7a1f03cd41434924

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15729/head:pull/15729` \
`$ git checkout pull/15729`

Update a local copy of the PR: \
`$ git checkout pull/15729` \
`$ git pull https://git.openjdk.org/jdk.git pull/15729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15729`

View PR using the GUI difftool: \
`$ git pr show -t 15729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15729.diff">https://git.openjdk.org/jdk/pull/15729.diff</a>

</details>
