### PR TITLE
8310823: Materialize CDS archived objects with regular GC allocation

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -32,6 +32,7 @@
 #include "cds/metaspaceShared.hpp"
 #include "cds/regeneratedClasses.hpp"
 #include "classfile/classLoaderDataShared.hpp"
+#include "classfile/javaClasses.hpp"
 #include "classfile/symbolTable.hpp"
 #include "classfile/systemDictionaryShared.hpp"
 #include "classfile/vmClasses.hpp"
@@ -46,6 +47,7 @@
 #include "oops/objArrayOop.inline.hpp"
 #include "oops/oopHandle.inline.hpp"
 #include "runtime/arguments.hpp"
+#include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/globals_extension.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/sharedRuntime.hpp"
@@ -964,7 +966,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
       SourceObjInfo* src_info = src_objs->at(i);
       address src = src_info->source_addr();
       address dest = src_info->buffered_addr();
-      log_data(last_obj_base, dest, last_obj_base + buffer_to_runtime_delta());
+      log_as_hex(last_obj_base, dest, last_obj_base + buffer_to_runtime_delta());
       address runtime_dest = dest + buffer_to_runtime_delta();
       int bytes = src_info->size_in_bytes();
 
@@ -1006,12 +1008,12 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
       last_obj_end  = dest + bytes;
     }
 
-    log_data(last_obj_base, last_obj_end, last_obj_base + buffer_to_runtime_delta());
+    log_as_hex(last_obj_base, last_obj_end, last_obj_base + buffer_to_runtime_delta());
     if (last_obj_end < region_end) {
       log_debug(cds, map)(PTR_FORMAT ": @@ Misc data " SIZE_FORMAT " bytes",
                           p2i(last_obj_end + buffer_to_runtime_delta()),
                           size_t(region_end - last_obj_end));
-      log_data(last_obj_end, region_end, last_obj_end + buffer_to_runtime_delta());
+      log_as_hex(last_obj_end, region_end, last_obj_end + buffer_to_runtime_delta());
     }
   }
 
@@ -1037,44 +1039,162 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
     MemRegion r = heap_info->buffer_region();
     address start = address(r.start());
     address end = address(r.end());
-    log_region("heap", start, end, to_requested(start));
+    log_region("heap", start, end, ArchiveHeapWriter::buffered_addr_to_requested_addr(start));
+
+    LogStreamHandle(Info, cds, map) st;
 
     while (start < end) {
       size_t byte_size;
-      oop original_oop = ArchiveHeapWriter::buffered_addr_to_source_obj(start);
-      if (original_oop != nullptr) {
-        ResourceMark rm;
-        log_info(cds, map)(PTR_FORMAT ": @@ Object %s",
-                           p2i(to_requested(start)), original_oop->klass()->external_name());
-        byte_size = original_oop->size() * BytesPerWord;
+      oop source_oop = ArchiveHeapWriter::buffered_addr_to_source_obj(start);
+      address requested_start = ArchiveHeapWriter::buffered_addr_to_requested_addr(start);
+      st.print(PTR_FORMAT ": @@ Object ", p2i(requested_start));
+
+      if (source_oop != nullptr) {
+        // This is a regular oop that got archived.
+        print_oop_with_requested_addr_cr(&st, source_oop, false);
+        byte_size = source_oop->size() * BytesPerWord;
       } else if (start == ArchiveHeapWriter::buffered_heap_roots_addr()) {
-        // HeapShared::roots() is copied specially so it doesn't exist in
-        // HeapShared::OriginalObjectTable. See HeapShared::copy_roots().
-        log_info(cds, map)(PTR_FORMAT ": @@ Object HeapShared::roots (ObjArray)",
-                           p2i(to_requested(start)));
+        // HeapShared::roots() is copied specially, so it doesn't exist in
+        // ArchiveHeapWriter::BufferOffsetToSourceObjectTable.
+        // See ArchiveHeapWriter::copy_roots_to_buffer().
+        st.print_cr("HeapShared::roots[%d]", HeapShared::pending_roots()->length());
         byte_size = ArchiveHeapWriter::heap_roots_word_size() * BytesPerWord;
+      } else if ((byte_size = ArchiveHeapWriter::get_filler_size_at(start)) > 0) {
+        // We have a filler oop, which also does not exist in BufferOffsetToSourceObjectTable.
+        st.print_cr("filler " SIZE_FORMAT " bytes", byte_size);
       } else {
-        // We have reached the end of the region, but have some unused space
-        // at the end.
-        log_info(cds, map)(PTR_FORMAT ": @@ Unused heap space " SIZE_FORMAT " bytes",
-                           p2i(to_requested(start)), size_t(end - start));
-        log_data(start, end, to_requested(start), /*is_heap=*/true);
-        break;
+        ShouldNotReachHere();
       }
+
       address oop_end = start + byte_size;
-      log_data(start, oop_end, to_requested(start), /*is_heap=*/true);
+      log_as_hex(start, oop_end, requested_start, /*is_heap=*/true);
+
+      if (source_oop != nullptr) {
+        log_oop_details(heap_info, source_oop);
+      } else if (start == ArchiveHeapWriter::buffered_heap_roots_addr()) {
+        log_heap_roots();
+      }
       start = oop_end;
     }
   }
 
-  static address to_requested(address p) {
-    return ArchiveHeapWriter::buffered_addr_to_requested_addr(p);
+  // ArchivedFieldPrinter is used to print the fields of archived objects. We can't
+  // use _source_obj->print_on(), because we want to print the oop fields
+  // in _source_obj with their requested addresses using print_oop_with_requested_addr_cr().
+  class ArchivedFieldPrinter : public FieldClosure {
+    ArchiveHeapInfo* _heap_info;
+    outputStream* _st;
+    oop _source_obj;
+  public:
+    ArchivedFieldPrinter(ArchiveHeapInfo* heap_info, outputStream* st, oop src_obj) :
+      _heap_info(heap_info), _st(st), _source_obj(src_obj) {}
+    void do_field(fieldDescriptor* fd) {
+      _st->print(" - ");
+      BasicType ft = fd->field_type();
+      switch (ft) {
+      case T_ARRAY:
+      case T_OBJECT:
+        fd->print_on(_st); // print just the name and offset
+        print_oop_with_requested_addr_cr(_st, _source_obj->obj_field(fd->offset()));
+        break;
+      default:
+        if (ArchiveHeapWriter::is_marked_as_native_pointer(_heap_info, _source_obj, fd->offset())) {
+          LP64_ONLY(assert(ft == T_LONG, "must be"));
+          NOT_LP64 (assert(ft == T_INT, "must be"));
+
+          // We have a field that looks like an integer, but it's actually a pointer to a MetaspaceObj.
+          address source_native_ptr = (address)
+            LP64_ONLY(_source_obj->long_field(fd->offset()))
+            NOT_LP64( _source_obj->int_field (fd->offset()));
+          ArchiveBuilder* builder = ArchiveBuilder::current();
+
+          // The value of the native pointer at runtime.
+          address requested_native_ptr = builder->to_requested(builder->get_buffered_addr(source_native_ptr));
+
+          // The address of _source_obj at runtime
+          oop requested_obj = ArchiveHeapWriter::source_obj_to_requested_obj(_source_obj);
+          // The address of this field in the requested space
+          address requested_field_addr = cast_from_oop<address>(requested_obj) + fd->offset();
+
+          fd->print_on(_st);
+          _st->print_cr(PTR_FORMAT " (marked metadata pointer @" PTR_FORMAT " )",
+                        p2i(requested_native_ptr), p2i(requested_field_addr));
+        } else {
+          fd->print_on_for(_st, _source_obj); // name, offset, value
+          _st->cr();
+        }
+      }
+    }
+  };
+
+  // Print the fields of instanceOops, or the elements of arrayOops
+  static void log_oop_details(ArchiveHeapInfo* heap_info, oop source_oop) {
+    LogStreamHandle(Trace, cds, map, oops) st;
+    if (st.is_enabled()) {
+      Klass* source_klass = source_oop->klass();
+      ArchiveBuilder* builder = ArchiveBuilder::current();
+      Klass* requested_klass = builder->to_requested(builder->get_buffered_addr(source_klass));
+
+      st.print(" - klass: ");
+      source_klass->print_value_on(&st);
+      st.print(" " PTR_FORMAT, p2i(requested_klass));
+      st.cr();
+
+      if (source_oop->is_typeArray()) {
+        TypeArrayKlass::cast(source_klass)->oop_print_elements_on(typeArrayOop(source_oop), &st);
+      } else if (source_oop->is_objArray()) {
+        objArrayOop source_obj_array = objArrayOop(source_oop);
+        for (int i = 0; i < source_obj_array->length(); i++) {
+          st.print(" -%4d: ", i);
+          print_oop_with_requested_addr_cr(&st, source_obj_array->obj_at(i));
+        }
+      } else {
+        st.print_cr(" - ---- fields (total size " SIZE_FORMAT " words):", source_oop->size());
+        ArchivedFieldPrinter print_field(heap_info, &st, source_oop);
+        InstanceKlass::cast(source_klass)->print_nonstatic_fields(&print_field);
+      }
+    }
   }
-#endif
+
+  static void log_heap_roots() {
+    LogStreamHandle(Trace, cds, map, oops) st;
+    if (st.is_enabled()) {
+      for (int i = 0; i < HeapShared::pending_roots()->length(); i++) {
+        st.print("roots[%4d]: ", i);
+        print_oop_with_requested_addr_cr(&st, HeapShared::pending_roots()->at(i));
+      }
+    }
+  }
+
+  // The output looks like this. The first number is the requested address. The second number is
+  // the narrowOop version of the requested address.
+  //     0x00000007ffc7e840 (0xfff8fd08) java.lang.Class
+  //     0x00000007ffc000f8 (0xfff8001f) [B length: 11
+  static void print_oop_with_requested_addr_cr(outputStream* st, oop source_oop, bool print_addr = true) {
+    if (source_oop == nullptr) {
+      st->print_cr("null");
+    } else {
+      ResourceMark rm;
+      oop requested_obj = ArchiveHeapWriter::source_obj_to_requested_obj(source_oop);
+      if (print_addr) {
+        st->print(PTR_FORMAT " ", p2i(requested_obj));
+      }
+      if (UseCompressedOops) {
+        st->print("(0x%08x) ", CompressedOops::narrow_oop_value(requested_obj));
+      }
+      if (source_oop->is_array()) {
+        int array_len = arrayOop(source_oop)->length();
+        st->print_cr("%s length: %d", source_oop->klass()->external_name(), array_len);
+      } else {
+        st->print_cr("%s", source_oop->klass()->external_name());
+      }
+    }
+  }
+#endif // INCLUDE_CDS_JAVA_HEAP
 
   // Log all the data [base...top). Pretend that the base address
   // will be mapped to requested_base at run-time.
-  static void log_data(address base, address top, address requested_base, bool is_heap = false) {
+  static void log_as_hex(address base, address top, address requested_base, bool is_heap = false) {
     assert(top >= base, "must be");
 
     LogStreamHandle(Trace, cds, map) lsh;
@@ -1106,7 +1226,7 @@ public:
     address header_end = header + mapinfo->header()->header_size();
     log_region("header", header, header_end, 0);
     log_header(mapinfo);
-    log_data(header, header_end, 0);
+    log_as_hex(header, header_end, 0);
 
     DumpRegion* rw_region = &builder->_rw_region;
     DumpRegion* ro_region = &builder->_ro_region;
@@ -1116,7 +1236,7 @@ public:
 
     address bitmap_end = address(bitmap + bitmap_size_in_bytes);
     log_region("bitmap", address(bitmap), bitmap_end, 0);
-    log_data((address)bitmap, bitmap_end, 0);
+    log_as_hex((address)bitmap, bitmap_end, 0);
 
 #if INCLUDE_CDS_JAVA_HEAP
     if (heap_info->is_used()) {

--- a/src/hotspot/share/cds/archiveHeapLoader.hpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.hpp
@@ -26,6 +26,7 @@
 #define SHARE_CDS_ARCHIVEHEAPLOADER_HPP
 
 #include "cds/filemap.hpp"
+#include "cds/cds_globals.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "memory/allocation.hpp"
 #include "memory/allStatic.hpp"
@@ -50,6 +51,9 @@ public:
 
   // Can this VM map archived heap region? Currently only G1+compressed{oops,cp}
   static bool can_map() {
+    if (NewArchiveHeapLoading) {
+      return false;
+    }
     CDS_JAVA_HEAP_ONLY(return (UseG1GC && UseCompressedClassPointers);)
     NOT_CDS_JAVA_HEAP(return false;)
   }
@@ -147,9 +151,12 @@ private:
 
   class PatchLoadedRegionPointers;
 
+  static void new_fixup_region(TRAPS);
 public:
 
   static bool load_heap_region(FileMapInfo* mapinfo);
+  static bool new_load_heap_region(FileMapInfo* mapinfo);
+  static void newcode_set_roots(narrowOop n);
   static void assert_in_loaded_heap(uintptr_t o) {
     assert(is_in_loaded_heap(o), "must be");
   }

--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -64,12 +64,19 @@ GrowableArrayCHeap<oop, mtClassShared>* ArchiveHeapWriter::_source_objs;
 ArchiveHeapWriter::BufferOffsetToSourceObjectTable*
   ArchiveHeapWriter::_buffer_offset_to_source_obj_table = nullptr;
 
+
+typedef ResourceHashtable<address, size_t,
+      127, // prime number
+      AnyObj::C_HEAP,
+      mtClassShared> FillersTable;
+static FillersTable* _fillers;
+
 void ArchiveHeapWriter::init() {
   if (HeapShared::can_write()) {
     Universe::heap()->collect(GCCause::_java_lang_system_gc);
 
     _buffer_offset_to_source_obj_table = new BufferOffsetToSourceObjectTable();
-
+    _fillers = new FillersTable();
     _requested_bottom = nullptr;
     _requested_top = nullptr;
 
@@ -255,7 +262,7 @@ int ArchiveHeapWriter::filler_array_length(size_t fill_bytes) {
   return -1;
 }
 
-void ArchiveHeapWriter::init_filler_array_at_buffer_top(int array_length, size_t fill_bytes) {
+HeapWord* ArchiveHeapWriter::init_filler_array_at_buffer_top(int array_length, size_t fill_bytes) {
   assert(UseCompressedClassPointers, "Archived heap only supported for compressed klasses");
   Klass* oak = Universe::objectArrayKlassObj(); // already relocated to point to archived klass
   HeapWord* mem = offset_to_buffered_address<HeapWord*>(_buffer_used);
@@ -264,6 +271,7 @@ void ArchiveHeapWriter::init_filler_array_at_buffer_top(int array_length, size_t
   narrowKlass nk = ArchiveBuilder::current()->get_requested_narrow_klass(oak);
   cast_to_oop(mem)->set_narrow_klass(nk);
   arrayOopDesc::set_length(mem, array_length);
+  return mem;
 }
 
 void ArchiveHeapWriter::maybe_fill_gc_region_gap(size_t required_byte_size) {
@@ -293,9 +301,19 @@ void ArchiveHeapWriter::maybe_fill_gc_region_gap(size_t required_byte_size) {
     int array_length = filler_array_length(fill_bytes);
     log_info(cds, heap)("Inserting filler obj array of %d elements (" SIZE_FORMAT " bytes total) @ buffer offset " SIZE_FORMAT,
                         array_length, fill_bytes, _buffer_used);
-    init_filler_array_at_buffer_top(array_length, fill_bytes);
-
+    HeapWord* filler = init_filler_array_at_buffer_top(array_length, fill_bytes);
     _buffer_used = filler_end;
+    _fillers->put((address)filler, fill_bytes);
+  }
+}
+
+size_t ArchiveHeapWriter::get_filler_size_at(address buffered_addr) {
+  size_t* p = _fillers->get(buffered_addr);
+  if (p != nullptr) {
+    assert(*p > 0, "filler must be larger than zero bytes");
+    return *p;
+  } else {
+    return 0; // buffered_addr is not a filler
   }
 }
 
@@ -512,6 +530,20 @@ void ArchiveHeapWriter::mark_native_pointer(oop src_obj, int field_offset) {
     info._field_offset = field_offset;
     _native_pointers->append(info);
   }
+}
+
+// Do we have a jlong/jint field that's actually a pointer to a MetaspaceObj?
+bool ArchiveHeapWriter::is_marked_as_native_pointer(ArchiveHeapInfo* heap_info, oop src_obj, int field_offset) {
+  HeapShared::CachedOopInfo* p = HeapShared::archived_object_cache()->get(src_obj);
+  assert(p != nullptr, "must be");
+
+  // requested_field_addr = the address of this field in the requested space
+  oop requested_obj = requested_obj_from_buffer_offset(p->buffer_offset());
+  Metadata** requested_field_addr = (Metadata**)(cast_from_oop<address>(requested_obj) + field_offset);
+  assert((Metadata**)_requested_bottom <= requested_field_addr && requested_field_addr < (Metadata**) _requested_top, "range check");
+
+  BitMap::idx_t idx = requested_field_addr - (Metadata**) _requested_bottom;
+  return idx < heap_info->ptrmap()->size() && heap_info->ptrmap()->at(idx);
 }
 
 void ArchiveHeapWriter::compute_ptrmap(ArchiveHeapInfo* heap_info) {

--- a/src/hotspot/share/cds/archiveHeapWriter.hpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.hpp
@@ -188,7 +188,7 @@ private:
   static void maybe_fill_gc_region_gap(size_t required_byte_size);
   static size_t filler_array_byte_size(int length);
   static int filler_array_length(size_t fill_bytes);
-  static void init_filler_array_at_buffer_top(int array_length, size_t fill_bytes);
+  static HeapWord* init_filler_array_at_buffer_top(int array_length, size_t fill_bytes);
 
   static void set_requested_address(ArchiveHeapInfo* info);
   static void relocate_embedded_oops(GrowableArrayCHeap<oop, mtClassShared>* roots, ArchiveHeapInfo* info);
@@ -225,8 +225,10 @@ public:
   static size_t heap_roots_word_size() {
     return _heap_roots_word_size;
   }
+  static size_t get_filler_size_at(address buffered_addr);
 
   static void mark_native_pointer(oop src_obj, int offset);
+  static bool is_marked_as_native_pointer(ArchiveHeapInfo* heap_info, oop src_obj, int field_offset);
   static oop source_obj_to_requested_obj(oop src_obj);
   static oop buffered_addr_to_source_obj(address buffered_addr);
   static address buffered_addr_to_requested_addr(address buffered_addr);

--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -67,6 +67,13 @@
   product(bool, AllowArchivingWithJavaAgent, false, DIAGNOSTIC,             \
           "Allow Java agent to be run with CDS dumping")                    \
                                                                             \
+  product(bool, NewArchiveHeapLoading, false,                               \
+          "(Investigation) Load each object in the archived heap "          \
+          "individually")                                                   \
+                                                                            \
+  product(bool, NahlRawAlloc, true,                                         \
+          "Use CollectedHeap::mem_allocate() to allocate uninited heap mem")\
+                                                                            \
   develop(ccstr, ArchiveHeapTestClass, nullptr,                             \
           "For JVM internal testing only. The static field named "          \
           "\"archivedObjects\" of the specified class is stored in the "    \

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2190,7 +2190,7 @@ char* FileMapInfo::new_map_heap(size_t& size) {
   }
 
   char* base = os::map_memory(_fd, _full_path, r->file_offset(),
-                              nullptr, byte_size, /*read_only*/true, /*allow_exec*/false);
+                              nullptr, byte_size, /*read_only*/false, /*allow_exec*/false);
   size = heap_word_size(byte_size);
   return base;
 }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -288,6 +288,8 @@ void FileMapHeader::print(outputStream* st) {
   st->print_cr("- requested_base_address:         " INTPTR_FORMAT, p2i(_requested_base_address));
   st->print_cr("- mapped_base_address:            " INTPTR_FORMAT, p2i(_mapped_base_address));
   st->print_cr("- heap_roots_offset:              " SIZE_FORMAT, _heap_roots_offset);
+  st->print_cr("- heap_first_quick_reloc:         " SIZE_FORMAT, _heap_first_quick_reloc);
+  st->print_cr("- heap_first_slow_reloc:          " SIZE_FORMAT, _heap_first_slow_reloc);
   st->print_cr("- allow_archiving_with_java_agent:%d", _allow_archiving_with_java_agent);
   st->print_cr("- use_optimized_module_handling:  %d", _use_optimized_module_handling);
   st->print_cr("- use_full_module_graph           %d", _use_full_module_graph);
@@ -1624,6 +1626,8 @@ size_t FileMapInfo::write_heap_region(ArchiveHeapInfo* heap_info) {
   size_t buffer_size = heap_info->buffer_byte_size();
   write_region(MetaspaceShared::hp, buffer_start, buffer_size, false, false);
   header()->set_heap_roots_offset(heap_info->heap_roots_offset());
+  header()->set_heap_first_quick_reloc(heap_info->first_quick_reloc());
+  header()->set_heap_first_slow_reloc(heap_info->first_slow_reloc());
   return buffer_size;
 }
 

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -568,6 +568,8 @@ public:
   address heap_region_requested_address() NOT_CDS_JAVA_HEAP_RETURN_(nullptr);
   narrowOop encoded_heap_region_dumptime_address();
 
+  char* new_map_heap(size_t& size);
+
 private:
 
 #if INCLUDE_JVMTI

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -232,6 +232,9 @@ private:
   size_t _ptrmap_size_in_bits;          // Size of pointer relocation bitmap
   size_t _heap_roots_offset;            // Offset of the HeapShared::roots() object, from the bottom
                                         // of the archived heap objects, in bytes.
+  size_t _heap_first_quick_reloc;       // The first object in the archive that has relocatable oop fields.
+  size_t _heap_first_slow_reloc;        // The first object in the archive that has relocatable oop fields that point
+                                        // to a lower address.
   char* from_mapped_offset(size_t offset) const {
     return mapped_base_address() + offset;
   }
@@ -272,6 +275,8 @@ public:
   bool compressed_oops()                   const { return _compressed_oops; }
   bool compressed_class_pointers()         const { return _compressed_class_ptrs; }
   size_t heap_roots_offset()               const { return _heap_roots_offset; }
+  size_t heap_first_quick_reloc()          const { return _heap_first_quick_reloc;}
+  size_t heap_first_slow_reloc()           const { return _heap_first_slow_reloc;}
   // FIXME: These should really return int
   jshort max_used_path_index()             const { return _max_used_path_index; }
   jshort app_module_paths_start_index()    const { return _app_module_paths_start_index; }
@@ -284,6 +289,8 @@ public:
   void set_ptrmap_size_in_bits(size_t s)         { _ptrmap_size_in_bits = s; }
   void set_mapped_base_address(char* p)          { _mapped_base_address = p; }
   void set_heap_roots_offset(size_t n)           { _heap_roots_offset = n; }
+  void set_heap_first_quick_reloc(size_t n)      { _heap_first_quick_reloc = n; }
+  void set_heap_first_slow_reloc(size_t n)       { _heap_first_slow_reloc = n; }
   void copy_base_archive_name(const char* name);
 
   void set_shared_path_table(SharedPathTable table) {
@@ -380,7 +387,9 @@ public:
   int     narrow_oop_shift()   const { return header()->narrow_oop_shift(); }
   uintx   max_heap_size()      const { return header()->max_heap_size(); }
   size_t  heap_roots_offset()  const { return header()->heap_roots_offset(); }
-  size_t  core_region_alignment() const { return header()->core_region_alignment(); }
+  size_t  heap_first_quick_reloc() const { return header()->heap_first_quick_reloc(); }
+  size_t  heap_first_slow_reloc()  const { return header()->heap_first_slow_reloc(); }
+  size_t  core_region_alignment()  const { return header()->core_region_alignment(); }
 
   CompressedOops::Mode narrow_oop_mode()      const { return header()->narrow_oop_mode(); }
   jshort app_module_paths_start_index()       const { return header()->app_module_paths_start_index(); }

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -381,6 +381,7 @@ private:
   // Dump-time only. Returns the index of the root, which can be used at run time to read
   // the root using get_root(index, ...).
   static int append_root(oop obj);
+  static GrowableArrayCHeap<oop, mtClassShared>* pending_roots() { return _pending_roots; }
 
   // Dump-time and runtime
   static objArrayOop roots();

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -182,18 +182,24 @@ public:
   }
 
   class CachedOopInfo {
-    // See "TEMP notes: What are these?" in archiveHeapWriter.hpp
+    // Used by CDSHeapVerifier.
     oop _orig_referrer;
 
     // The location of this object inside ArchiveHeapWriter::_buffer
     size_t _buffer_offset;
+
+    // One or more fields in this object are pointing to MetaspaceObj
+    bool _has_native_pointers;
   public:
     CachedOopInfo(oop orig_referrer)
       : _orig_referrer(orig_referrer),
-        _buffer_offset(0) {}
+        _buffer_offset(0),
+        _has_native_pointers(false) {}
     oop orig_referrer()             const { return _orig_referrer;   }
     void set_buffer_offset(size_t offset) { _buffer_offset = offset; }
     size_t buffer_offset()          const { return _buffer_offset;   }
+    bool has_native_pointers()      const { return _has_native_pointers; }
+    void set_has_native_pointers()        { _has_native_pointers = true; }
   };
 
 private:
@@ -363,6 +369,7 @@ private:
   // Scratch objects for archiving Klass::java_mirror()
   static void set_scratch_java_mirror(Klass* k, oop mirror);
   static void remove_scratch_objects(Klass* k);
+  static void set_has_native_pointers(oop obj);
 
   // We use the HeapShared::roots() array to make sure that objects stored in the
   // archived heap region are not prematurely collected. These roots include:

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1459,9 +1459,8 @@ void MetaspaceShared::initialize_shared_spaces() {
   //CDS_JAVA_HEAP_ONLY(Universe::update_archived_basic_type_mirrors());
 
   // Close the mapinfo file
-  static_mapinfo->close();
-
   if (!NewArchiveHeapLoading) {
+    static_mapinfo->close();
     static_mapinfo->unmap_region(MetaspaceShared::bm);
   }
 

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1456,12 +1456,14 @@ void MetaspaceShared::initialize_shared_spaces() {
   static_mapinfo->patch_heap_embedded_pointers();
   ArchiveHeapLoader::finish_initialization();
 
-  CDS_JAVA_HEAP_ONLY(Universe::update_archived_basic_type_mirrors());
+  //CDS_JAVA_HEAP_ONLY(Universe::update_archived_basic_type_mirrors());
 
   // Close the mapinfo file
   static_mapinfo->close();
 
-  static_mapinfo->unmap_region(MetaspaceShared::bm);
+  if (!NewArchiveHeapLoading) {
+    static_mapinfo->unmap_region(MetaspaceShared::bm);
+  }
 
   FileMapInfo *dynamic_mapinfo = FileMapInfo::dynamic_info();
   if (dynamic_mapinfo != nullptr) {

--- a/src/hotspot/share/classfile/vmClasses.cpp
+++ b/src/hotspot/share/classfile/vmClasses.cpp
@@ -143,6 +143,7 @@ void vmClasses::resolve_all(TRAPS) {
     // call. No mirror objects are accessed/restored in the above call.
     // Mirrors are restored after java.lang.Class is loaded.
     ArchiveHeapLoader::fixup_region();
+    CDS_JAVA_HEAP_ONLY(Universe::update_archived_basic_type_mirrors());
 
     // Initialize the constant pool for the Object_class
     assert(Object_klass()->is_shared(), "must be");

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -98,7 +98,7 @@ class CollectedHeap : public CHeapObj<mtGC> {
   friend class DisableIsGCActiveMark; // Disable current IsGCActiveMark
   friend class MemAllocator;
   friend class ParallelObjectIterator;
-
+  friend class NewQuickLoader;
  private:
   GCHeapLog* _gc_heap_log;
 

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -70,7 +70,7 @@ class MemAllocator::Allocation: StackObj {
 public:
   Allocation(const MemAllocator& allocator, oop* obj_ptr)
     : _allocator(allocator),
-      _thread(JavaThread::current()),
+      _thread((JavaThread*)allocator._thread),
       _obj_ptr(obj_ptr),
       _overhead_limit_exceeded(false),
       _allocated_outside_tlab(false),

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -510,6 +510,11 @@ protected:
     DEBUG_ONLY(set_allocation_type(res, RESOURCE_AREA);)
     return res;
   }
+  void* operator new(size_t size, Thread* thread) {
+    address res = (address)resource_allocate_bytes(thread, size);
+    DEBUG_ONLY(set_allocation_type(res, RESOURCE_AREA);)
+    return res;
+  }
   void* operator new(size_t size, const std::nothrow_t& nothrow_constant) throw() {
     address res = (address)resource_allocate_bytes(size, AllocFailStrategy::RETURN_NULL);
     DEBUG_ONLY(if (res != nullptr) set_allocation_type(res, RESOURCE_AREA);)

--- a/src/hotspot/share/oops/typeArrayKlass.cpp
+++ b/src/hotspot/share/oops/typeArrayKlass.cpp
@@ -276,8 +276,6 @@ void TypeArrayKlass::print_value_on(outputStream* st) const {
   st->print("}");
 }
 
-#ifndef PRODUCT
-
 static void print_boolean_array(typeArrayOop ta, int print_len, outputStream* st) {
   for (int index = 0; index < print_len; index++) {
     st->print_cr(" - %3d: %s", index, (ta->bool_at(index) == 0) ? "false" : "true");
@@ -341,7 +339,10 @@ static void print_long_array(typeArrayOop ta, int print_len, outputStream* st) {
 
 void TypeArrayKlass::oop_print_on(oop obj, outputStream* st) {
   ArrayKlass::oop_print_on(obj, st);
-  typeArrayOop ta = typeArrayOop(obj);
+  oop_print_elements_on(typeArrayOop(obj), st);
+}
+
+void TypeArrayKlass::oop_print_elements_on(typeArrayOop ta, outputStream* st) {
   int print_len = MIN2((intx) ta->length(), MaxElementPrintSize);
   switch (element_type()) {
     case T_BOOLEAN: print_boolean_array(ta, print_len, st); break;
@@ -359,8 +360,6 @@ void TypeArrayKlass::oop_print_on(oop obj, outputStream* st) {
     st->print_cr(" - <%d more elements, increase MaxElementPrintSize to print>", remaining);
   }
 }
-
-#endif // PRODUCT
 
 const char* TypeArrayKlass::internal_name() const {
   return Klass::external_name();

--- a/src/hotspot/share/oops/typeArrayKlass.hpp
+++ b/src/hotspot/share/oops/typeArrayKlass.hpp
@@ -123,10 +123,8 @@ class TypeArrayKlass : public ArrayKlass {
 
  public:
   // Printing
-#ifndef PRODUCT
   void oop_print_on(oop obj, outputStream* st);
-#endif
-
+  void oop_print_elements_on(typeArrayOop ta, outputStream* st);
   void print_on(outputStream* st) const;
   void print_value_on(outputStream* st) const;
 

--- a/src/hotspot/share/utilities/resourceHash.hpp
+++ b/src/hotspot/share/utilities/resourceHash.hpp
@@ -166,7 +166,7 @@ class ResourceHashtableBase : public STORAGE {
   * @return: true:  if a new item is added
   *          false: if the item already existed and the value is updated
   */
-  bool put(K const& key, V const& value) {
+  bool put(K const& key, V const& value, Thread* thread = nullptr) {
     unsigned hv = HASH(key);
     Node** ptr = lookup_node(hv, key);
     if (*ptr != nullptr) {
@@ -176,7 +176,11 @@ class ResourceHashtableBase : public STORAGE {
       if (ALLOC_TYPE == AnyObj::C_HEAP) {
         *ptr = new (MEM_TYPE) Node(hv, key, value);
       } else {
-        *ptr = new Node(hv, key, value);
+        if (thread == nullptr) {
+          *ptr = new Node(hv, key, value);
+        } else {
+          *ptr = new (thread) Node(hv, key, value);
+        }
       }
       _number_of_entries ++;
       return true;

--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -80,7 +80,7 @@ public class DeterministicDump {
         String mapName = logName + ".map";
         CDSOptions opts = (new CDSOptions())
             .addPrefix("-Xlog:cds=debug")
-            .addPrefix("-Xlog:cds+map=trace:file=" + mapName + ":none:filesize=0")
+            .addPrefix("-Xlog:cds+map*=trace:file=" + mapName + ":none:filesize=0")
             .setArchiveName(archiveName)
             .addSuffix(args)
             .addSuffix(more);


### PR DESCRIPTION
This is a draft. No plans to integrate yet.

See https://bugs.openjdk.org/browse/JDK-8310823

And also discussions in a related PR https://github.com/openjdk/jdk/pull/14520

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8310823](https://bugs.openjdk.org/browse/JDK-8310823): Materialize CDS archived objects with regular GC allocation (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15730/head:pull/15730` \
`$ git checkout pull/15730`

Update a local copy of the PR: \
`$ git checkout pull/15730` \
`$ git pull https://git.openjdk.org/jdk.git pull/15730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15730`

View PR using the GUI difftool: \
`$ git pr show -t 15730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15730.diff">https://git.openjdk.org/jdk/pull/15730.diff</a>

</details>
