### PR TITLE
8316228: jcmd tests are broken by 8314828

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/HelpTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
  * @test
  * @summary Test of diagnostic command help (tests all DCMD executors)
  * @library /test/lib
+ *          /vmTestbase
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/InvalidCommandTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
  * @test
  * @summary Test of invalid diagnostic command (tests all DCMD executors)
  * @library /test/lib
+ *          /vmTestbase
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.compiler

--- a/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/framework/VMVersionTest.java
@@ -43,6 +43,7 @@ import org.testng.annotations.Test;
  *          java.management
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @library /test/lib
+ *          /vmTestbase
  * @requires vm.flagless
  * @run testng/othervm -XX:+UsePerfData VMVersionTest
  */


### PR DESCRIPTION
The fix 8314828 removed dependency to /vmTestbase and tests started failing.
Verified by running tests and submitting tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316228](https://bugs.openjdk.org/browse/JDK-8316228): jcmd tests are broken by 8314828 (**Bug** - P1)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15731/head:pull/15731` \
`$ git checkout pull/15731`

Update a local copy of the PR: \
`$ git checkout pull/15731` \
`$ git pull https://git.openjdk.org/jdk.git pull/15731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15731`

View PR using the GUI difftool: \
`$ git pr show -t 15731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15731.diff">https://git.openjdk.org/jdk/pull/15731.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15731#issuecomment-1718464661)