### PR TITLE
8316557: Make fields final in 'sun.util' package

### DIFF
--- a/src/java.base/share/classes/sun/util/PreHashedMap.java
+++ b/src/java.base/share/classes/sun/util/PreHashedMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,7 @@ public abstract class PreHashedMap<V>
 
                     public Map.Entry<String,V> next() {
                         return new Map.Entry<String,V>() {
-                            String k = i.next();
+                            final String k = i.next();
                             public String getKey() { return k; }
                             public V getValue() { return get(k); }
                             public int hashCode() {

--- a/src/java.base/share/classes/sun/util/PropertyResourceBundleCharset.java
+++ b/src/java.base/share/classes/sun/util/PropertyResourceBundleCharset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 /**
@@ -45,15 +44,11 @@ import java.util.Objects;
  */
 public class PropertyResourceBundleCharset extends Charset {
 
-    private boolean strictUTF8 = false;
+    private final boolean strictUTF8;
 
     public PropertyResourceBundleCharset(boolean strictUTF8) {
-        this(PropertyResourceBundleCharset.class.getCanonicalName(), null);
+        super(PropertyResourceBundleCharset.class.getCanonicalName(), null);
         this.strictUTF8 = strictUTF8;
-    }
-
-    public PropertyResourceBundleCharset(String canonicalName, String[] aliases) {
-        super(canonicalName, aliases);
     }
 
     @Override
@@ -73,7 +68,7 @@ public class PropertyResourceBundleCharset extends Charset {
 
     private final class PropertiesFileDecoder extends CharsetDecoder {
 
-        private CharsetDecoder cdUTF_8 = UTF_8.INSTANCE.newDecoder()
+        private final CharsetDecoder cdUTF_8 = UTF_8.INSTANCE.newDecoder()
                                 .onMalformedInput(CodingErrorAction.REPORT)
                                 .onUnmappableCharacter(CodingErrorAction.REPORT);
         private CharsetDecoder cdISO_8859_1 = null;

--- a/src/java.base/share/classes/sun/util/ResourceBundleEnumeration.java
+++ b/src/java.base/share/classes/sun/util/ResourceBundleEnumeration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,9 @@ import java.util.Set;
  */
 public class ResourceBundleEnumeration implements Enumeration<String> {
 
-    Set<String> set;
-    Iterator<String> iterator;
-    Enumeration<String> enumeration; // may remain null
+    private final Set<String> set;
+    private final Iterator<String> iterator;
+    private final Enumeration<String> enumeration; // may remain null
 
     /**
      * Constructs a resource bundle enumeration.

--- a/src/java.base/share/classes/sun/util/calendar/LocalGregorianCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/LocalGregorianCalendar.java
@@ -60,8 +60,8 @@ public class LocalGregorianCalendar extends BaseCalendar {
         return true;
     }
 
-    private String name;
-    private Era[] eras;
+    private final String name;
+    private final Era[] eras;
 
     public static class Date extends BaseCalendar.Date {
 

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -210,7 +210,7 @@ public final class ZoneInfoFile {
 
     private static String versionId;
     private static final Map<String, ZoneInfo> zones = new ConcurrentHashMap<>();
-    private static Map<String, String> aliases = new HashMap<>();
+    private static final Map<String, String> aliases = new HashMap<>();
 
     private static byte[][] ruleArray;
     private static String[] regions;
@@ -219,7 +219,7 @@ public final class ZoneInfoFile {
     // Flag for supporting JDK backward compatible IDs, such as "EST".
     private static final boolean USE_OLDMAPPING;
 
-    private static String[][] oldMappings = new String[][] {
+    private static final String[][] oldMappings = new String[][] {
         { "ACT", "Australia/Darwin" },
         { "AET", "Australia/Sydney" },
         { "AGT", "America/Argentina/Buenos_Aires" },

--- a/src/java.base/share/classes/sun/util/cldr/CLDRCalendarDataProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRCalendarDataProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,12 @@ package sun.util.cldr;
 
 import static sun.util.locale.provider.LocaleProviderAdapter.Type;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Locale;
 import java.util.Set;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import sun.util.locale.provider.LocaleProviderAdapter;
-import sun.util.locale.provider.LocaleResources;
 import sun.util.locale.provider.CalendarDataProviderImpl;
 import sun.util.locale.provider.CalendarDataUtility;
 
@@ -47,8 +45,8 @@ import sun.util.locale.provider.CalendarDataUtility;
  */
 public class CLDRCalendarDataProviderImpl extends CalendarDataProviderImpl {
 
-    private static Map<String, Integer> firstDay = new ConcurrentHashMap<>();
-    private static Map<String, Integer> minDays = new ConcurrentHashMap<>();
+    private static final Map<String, Integer> firstDay = new ConcurrentHashMap<>();
+    private static final Map<String, Integer> minDays = new ConcurrentHashMap<>();
 
     public CLDRCalendarDataProviderImpl(Type type, Set<String> langtags) {
         super(type, langtags);

--- a/src/java.base/share/classes/sun/util/cldr/CLDRCalendarDataProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRCalendarDataProviderImpl.java
@@ -45,7 +45,7 @@ import sun.util.locale.provider.CalendarDataUtility;
  */
 public class CLDRCalendarDataProviderImpl extends CalendarDataProviderImpl {
 
-    private static final Map<String, Integer> firstDays = new ConcurrentHashMap<>();
+    private static final Map<String, Integer> firstDay = new ConcurrentHashMap<>();
     private static final Map<String, Integer> minDays = new ConcurrentHashMap<>();
 
     public CLDRCalendarDataProviderImpl(Type type, Set<String> langtags) {
@@ -74,7 +74,7 @@ public class CLDRCalendarDataProviderImpl extends CalendarDataProviderImpl {
      */
     private static int findValue(String key, Locale locale) {
         Map<String, Integer> map = CalendarDataUtility.FIRST_DAY_OF_WEEK.equals(key) ?
-            firstDays : minDays;
+            firstDay : minDays;
         String region = locale.getCountry();
 
         if (region.isEmpty()) {

--- a/src/java.base/share/classes/sun/util/cldr/CLDRCalendarDataProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRCalendarDataProviderImpl.java
@@ -45,7 +45,7 @@ import sun.util.locale.provider.CalendarDataUtility;
  */
 public class CLDRCalendarDataProviderImpl extends CalendarDataProviderImpl {
 
-    private static final Map<String, Integer> firstDay = new ConcurrentHashMap<>();
+    private static final Map<String, Integer> firstDays = new ConcurrentHashMap<>();
     private static final Map<String, Integer> minDays = new ConcurrentHashMap<>();
 
     public CLDRCalendarDataProviderImpl(Type type, Set<String> langtags) {
@@ -74,7 +74,7 @@ public class CLDRCalendarDataProviderImpl extends CalendarDataProviderImpl {
      */
     private static int findValue(String key, Locale locale) {
         Map<String, Integer> map = CalendarDataUtility.FIRST_DAY_OF_WEEK.equals(key) ?
-            firstDay : minDays;
+            firstDays : minDays;
         String region = locale.getCountry();
 
         if (region.isEmpty()) {

--- a/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
     private final LocaleDataMetaInfo nonBaseMetaInfo;
 
     // parent locales map
-    private static volatile Map<Locale, Locale> parentLocalesMap;
+    private static final Map<Locale, Locale> parentLocalesMap;
     // cache to hold  locale to locale mapping for language aliases.
     private static final Map<Locale, Locale> langAliasesCache;
     // cache the available locales

--- a/src/java.base/share/classes/sun/util/locale/LocaleObjectCache.java
+++ b/src/java.base/share/classes/sun/util/locale/LocaleObjectCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public abstract class LocaleObjectCache<K, V> {
     }
 
     private static class CacheEntry<K, V> extends SoftReference<V> {
-        private K key;
+        private final K key;
 
         CacheEntry(K key, V value, ReferenceQueue<V> queue) {
             super(value, queue);

--- a/src/java.base/share/classes/sun/util/locale/LocaleSyntaxException.java
+++ b/src/java.base/share/classes/sun/util/locale/LocaleSyntaxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ public class LocaleSyntaxException extends Exception {
     @java.io.Serial
     private static final long serialVersionUID = 1L;
 
-    private int index = -1;
+    private final int index;
 
     public LocaleSyntaxException(String msg) {
         this(msg, 0);

--- a/src/java.base/share/classes/sun/util/locale/StringTokenIterator.java
+++ b/src/java.base/share/classes/sun/util/locale/StringTokenIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,9 @@
 package sun.util.locale;
 
 public class StringTokenIterator {
-    private String text;
-    private String dlms;        // null if a single char delimiter
-    private char delimiterChar; // delimiter if a single char delimiter
+    private final String text;
+    private final String dlms;        // null if a single char delimiter
+    private final char delimiterChar; // delimiter if a single char delimiter
 
     private String token;
     private int start;
@@ -44,7 +44,9 @@ public class StringTokenIterator {
         this.text = text;
         if (dlms.length() == 1) {
             delimiterChar = dlms.charAt(0);
+            this.dlms = null;
         } else {
+            delimiterChar = 0;
             this.dlms = dlms;
         }
         setStart(0);
@@ -96,12 +98,6 @@ public class StringTokenIterator {
         end = nextDelimiter(start);
         token = text.substring(start, end);
         done = false;
-        return this;
-    }
-
-    public StringTokenIterator setText(String text) {
-        this.text = text;
-        setStart(0);
         return this;
     }
 


### PR DESCRIPTION
A few classes in `sun.util` package have non-final fields which could easily be marked `final`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316557](https://bugs.openjdk.org/browse/JDK-8316557): Make fields final in 'sun.util' package (**Enhancement** - P5)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15736/head:pull/15736` \
`$ git checkout pull/15736`

Update a local copy of the PR: \
`$ git checkout pull/15736` \
`$ git pull https://git.openjdk.org/jdk.git pull/15736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15736`

View PR using the GUI difftool: \
`$ git pr show -t 15736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15736.diff">https://git.openjdk.org/jdk/pull/15736.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15736#issuecomment-1726415232)