### PR TITLE
8316273: JDK-8315818 broke JVMCIPrintProperties on libgraal

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -591,7 +591,7 @@ void register_jfr_phasetype_serializer(CompilerType compiler_type) {
 // CompileBroker::compilation_init
 //
 // Initialize the Compilation object
-void CompileBroker::compilation_init_phase1(JavaThread* THREAD) {
+void CompileBroker::compilation_init(JavaThread* THREAD) {
   // No need to initialize compilation system if we do not use it.
   if (!UseCompiler) {
     return;
@@ -750,11 +750,7 @@ void CompileBroker::compilation_init_phase1(JavaThread* THREAD) {
                                           (jlong)CompileBroker::no_compile,
                                           CHECK);
   }
-}
 
-// Completes compiler initialization. Compilation requests submitted
-// prior to this will be silently ignored.
-void CompileBroker::compilation_init_phase2() {
   _initialized = true;
 }
 

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -291,8 +291,7 @@ public:
     CompileQueue *q = compile_queue(comp_level);
     return q != nullptr ? q->size() : 0;
   }
-  static void compilation_init_phase1(JavaThread* THREAD);
-  static void compilation_init_phase2();
+  static void compilation_init(JavaThread* THREAD);
   static void init_compiler_thread_log();
   static nmethod* compile_method(const methodHandle& method,
                                  int osr_bci,

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -708,8 +708,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   }
 #endif
   if (init_compilation) {
-    CompileBroker::compilation_init_phase1(CHECK_JNI_ERR);
-    CompileBroker::compilation_init_phase2();
+    CompileBroker::compilation_init(CHECK_JNI_ERR);
   }
 #endif
 

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -692,16 +692,25 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
   // initialize compiler(s)
 #if defined(COMPILER1) || COMPILER2_OR_JVMCI
+  bool init_compilation = true;
 #if INCLUDE_JVMCI
   bool force_JVMCI_initialization = false;
   if (EnableJVMCI) {
     // Initialize JVMCI eagerly when it is explicitly requested.
     // Or when JVMCILibDumpJNIConfig or JVMCIPrintProperties is enabled.
     force_JVMCI_initialization = EagerJVMCI || JVMCIPrintProperties || JVMCILibDumpJNIConfig;
+    if (JVMCIPrintProperties || JVMCILibDumpJNIConfig) {
+      // Both JVMCILibDumpJNIConfig and JVMCIPrintProperties exit the VM
+      // so compilation should be disabled. This prevents dumping or
+      // printing from happening more than once.
+      init_compilation = false;
+    }
   }
 #endif
-  CompileBroker::compilation_init_phase1(CHECK_JNI_ERR);
-  CompileBroker::compilation_init_phase2();
+  if (init_compilation) {
+    CompileBroker::compilation_init_phase1(CHECK_JNI_ERR);
+    CompileBroker::compilation_init_phase2();
+  }
 #endif
 
   // Start string deduplication thread if requested.

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -564,7 +564,7 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
             }
             Option.printProperties(vmLogStream);
             compilerFactory.printProperties(vmLogStream);
-            System.exit(0);
+            exitHotSpot(0);
         }
 
         if (Option.PrintConfig.getBoolean()) {


### PR DESCRIPTION
This PR prevents the possibility for `JVMCIPrintProperties` to emit output more than once. That possibility was introduced by [JDK-8315818](https://bugs.openjdk.org/browse/JDK-8315818) by allowing JVMCI initialization to happen earlier on a compiler thread that races with the main thread in terms of JVMCI initialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316273](https://bugs.openjdk.org/browse/JDK-8316273): JDK-8315818 broke JVMCIPrintProperties on libgraal (**Bug** - P5)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15739/head:pull/15739` \
`$ git checkout pull/15739`

Update a local copy of the PR: \
`$ git checkout pull/15739` \
`$ git pull https://git.openjdk.org/jdk.git pull/15739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15739`

View PR using the GUI difftool: \
`$ git pr show -t 15739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15739.diff">https://git.openjdk.org/jdk/pull/15739.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15739#issuecomment-1719317254)