### PR TITLE
8316190: Improve MemorySegment::toString

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -505,7 +505,11 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     public String toString() {
-        return "MemorySegment{ heapBase: " + heapBase() + " address: 0x" + Long.toHexString(address()) + " byteSize: " + length + " }";
+        return "MemorySegment{ " +
+                heapBase().map(hb -> "heapBase: " + hb + ", ").orElse("") +
+                "address: " + Utils.toHexString(address()) +
+                ", byteSize: " + length +
+                " }";
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -273,4 +273,9 @@ public final class Utils {
     public static boolean containsNullChars(String s) {
         return s.indexOf('\u0000') >= 0;
     }
+
+    public static String toHexString(long value) {
+        return "0x" + Long.toHexString(value);
+    }
+
 }

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -225,6 +225,21 @@ public class TestSegments {
         assertTrue(segment.isAccessibleBy(new Thread()) != isConfined);
     }
 
+    @Test(dataProvider = "segmentFactories")
+    public void testToString(Supplier<MemorySegment> segmentSupplier) {
+        var segment = segmentSupplier.get();
+        String s = segment.toString();
+        assertTrue(s.startsWith("MemorySegment{"));
+        assertTrue(s.contains("address: 0x"));
+        assertTrue(s.contains("byteSize: "));
+        if (segment.heapBase().isPresent()) {
+            assertTrue(s.contains("heapBase: ["));
+        } else {
+            assertFalse(s.contains("heapBase: "));
+        }
+        assertFalse(s.contains("Optional"));
+    }
+
     @DataProvider(name = "segmentFactories")
     public Object[][] segmentFactories() {
         List<Supplier<MemorySegment>> l = List.of(
@@ -233,7 +248,7 @@ public class TestSegments {
                 () -> MemorySegment.ofArray(new double[] { 1d, 2d, 3d, 4d} ),
                 () -> MemorySegment.ofArray(new float[] { 1.0f, 2.0f, 3.0f, 4.0f }),
                 () -> MemorySegment.ofArray(new int[] { 1, 2, 3, 4 }),
-                () -> MemorySegment.ofArray(new long[] { 1l, 2l, 3l, 4l } ),
+                () -> MemorySegment.ofArray(new long[] { 1L, 2L, 3L, 4L } ),
                 () -> MemorySegment.ofArray(new short[] { 1, 2, 3, 4 } ),
                 () -> Arena.ofAuto().allocate(4L, 1),
                 () -> Arena.ofAuto().allocate(4L, 8),


### PR DESCRIPTION
This PR proposes to improve the MemorySegment::toString to reduce cluttering and add missing comas.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316190](https://bugs.openjdk.org/browse/JDK-8316190): Improve MemorySegment::toString (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15740/head:pull/15740` \
`$ git checkout pull/15740`

Update a local copy of the PR: \
`$ git checkout pull/15740` \
`$ git pull https://git.openjdk.org/jdk.git pull/15740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15740`

View PR using the GUI difftool: \
`$ git pr show -t 15740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15740.diff">https://git.openjdk.org/jdk/pull/15740.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15740#issuecomment-1719327761)