### PR TITLE
8316294: AIX: Build fopen system call fails on file _BUILD_LIBJDWP_objectfilenames.txt

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1167,9 +1167,7 @@ define SetupNativeCompilationBody
 
     # If we are building static library, 'AR' on macosx/aix may not support @-file.
     ifeq ($$($1_TYPE), STATIC_LIBRARY)
-      ifeq ($(call isTargetOs, macosx), true)
-        $1_LD_OBJ_ARG := `cat $$($1_OBJ_FILE_LIST)`
-      else ifeq ($(call isTargetOs, aix), true)
+      ifeq ($(call isTargetOs, macosx aix), true)
         $1_LD_OBJ_ARG := `cat $$($1_OBJ_FILE_LIST)`
       endif
     endif

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1165,9 +1165,11 @@ define SetupNativeCompilationBody
       $1_LD_OBJ_ARG := `cat $$($1_OBJ_FILE_LIST)`
     endif
 
-    # If we are building static library, 'AR' on macosx may not support @-file.
+    # If we are building static library, 'AR' on macosx/aix may not support @-file.
     ifeq ($$($1_TYPE), STATIC_LIBRARY)
       ifeq ($(call isTargetOs, macosx), true)
+        $1_LD_OBJ_ARG := `cat $$($1_OBJ_FILE_LIST)`
+      else ifeq ($(call isTargetOs, aix), true)
         $1_LD_OBJ_ARG := `cat $$($1_OBJ_FILE_LIST)`
       endif
     endif


### PR DESCRIPTION
While building openjdk on aix, we see this build-fail error:

The fopen system call failed on file
-f/home/.....etce4tcetc...../_BUILD_LIBJDWP_objectfilenames.txt

This change expands the fix for the similar issue on macosx, and prevents the fopen issue on aix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316294](https://bugs.openjdk.org/browse/JDK-8316294): AIX: Build fopen system call fails on file _BUILD_LIBJDWP_objectfilenames.txt (**Bug** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15743/head:pull/15743` \
`$ git checkout pull/15743`

Update a local copy of the PR: \
`$ git checkout pull/15743` \
`$ git pull https://git.openjdk.org/jdk.git pull/15743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15743`

View PR using the GUI difftool: \
`$ git pr show -t 15743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15743.diff">https://git.openjdk.org/jdk/pull/15743.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15743#issuecomment-1719539038)