### PR TITLE
8316295: Serial: Remove empty Generation::promotion_failure_occurred

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -846,8 +846,6 @@ void DefNewGeneration::collect(bool   full,
     from()->set_next_compaction_space(to());
     heap->set_incremental_collection_failed();
 
-    // Inform the next generation that a promotion failure occurred.
-    _old_gen->promotion_failure_occurred();
     _gc_tracer->report_promotion_failed(_promotion_failed_info);
 
     // Reset the PromotionFailureALot counters.

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -142,12 +142,6 @@ class Generation: public CHeapObj<mtGC> {
   // might be attempted in the worst case.
   virtual bool promotion_attempt_is_safe(size_t max_promotion_in_bytes) const;
 
-  // For a non-young generation, this interface can be used to inform a
-  // generation that a promotion attempt into that generation failed.
-  // Typically used to enable diagnostic output for post-mortem analysis,
-  // but other uses of the interface are not ruled out.
-  virtual void promotion_failure_occurred() { /* does nothing */ }
-
   // Return an estimate of the maximum allocation that could be performed
   // in the generation without triggering any collection or expansion
   // activity.  It is "unsafe" because no locks are taken; the result


### PR DESCRIPTION
Trivial removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316295](https://bugs.openjdk.org/browse/JDK-8316295): Serial: Remove empty Generation::promotion_failure_occurred (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15744/head:pull/15744` \
`$ git checkout pull/15744`

Update a local copy of the PR: \
`$ git checkout pull/15744` \
`$ git pull https://git.openjdk.org/jdk.git pull/15744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15744`

View PR using the GUI difftool: \
`$ git pr show -t 15744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15744.diff">https://git.openjdk.org/jdk/pull/15744.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15744#issuecomment-1719552973)