### PR TITLE
8312126: NullPointerException in CertStore.getCRLs after 8297955

### DIFF
--- a/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
+++ b/src/java.naming/share/classes/sun/security/provider/certpath/ldap/LDAPCertStoreImpl.java
@@ -779,9 +779,13 @@ final class LDAPCertStoreImpl {
                 } catch (IllegalArgumentException e) {
                     continue;
                 }
-            } else {
+            } else if (nameObject instanceof String) {
                 issuerName = (String)nameObject;
+            } else {
+                throw new CertStoreException(
+                    "unrecognized issuerName: must be String or byte[]");
             }
+
             // If all we want is CA certs, try to get the (probably shorter) ARL
             Collection<X509CRL> entryCRLs = Collections.emptySet();
             if (certChecking == null || certChecking.getBasicConstraints() != -1) {


### PR DESCRIPTION
Please review this fix for a regression in the LDAP CertStore implementation where a null CRL issuerName in an X509CRLSelector should be treated as a CertStoreException instead of a NullPointerException.

A new test has been added but requires internal infrastructure so will only be in the closed.