### PR TITLE
JDK-8315464: Uncouple AllClassesIndexWriter from IndexBuilder

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -28,6 +28,7 @@ package jdk.javadoc.internal.doclets.formats.html;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.lang.model.element.TypeElement;
 
@@ -39,8 +40,6 @@ import jdk.javadoc.internal.doclets.formats.html.markup.HtmlTree;
 import jdk.javadoc.internal.doclets.formats.html.Navigation.PageMode;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
-import jdk.javadoc.internal.doclets.toolkit.util.IndexBuilder;
-import jdk.javadoc.internal.doclets.toolkit.util.IndexItem;
 import jdk.javadoc.internal.doclets.toolkit.util.Utils.ElementFlag;
 
 /**
@@ -49,24 +48,18 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils.ElementFlag;
 public class AllClassesIndexWriter extends HtmlDocletWriter {
 
     /**
-     * Index of all the classes.
-     */
-    protected IndexBuilder indexBuilder;
-
-    /**
      * Construct AllClassesIndexWriter object. Also initializes the indexBuilder variable in this
      * class.
      *
      * @param configuration The current configuration
-     * @param indexBuilder Unicode based Index from {@link IndexBuilder}
      */
-    public AllClassesIndexWriter(HtmlConfiguration configuration, IndexBuilder indexBuilder) {
+    public AllClassesIndexWriter(HtmlConfiguration configuration) {
         super(configuration, DocPaths.ALLCLASSES_INDEX);
-        this.indexBuilder = indexBuilder;
     }
 
     @Override
     public void buildPage() throws DocFileIOException {
+        messages.notice("doclet.Building_Index_For_All_Classes");
         String label = resources.getText("doclet.All_Classes_And_Interfaces");
         Content allClassesContent = new ContentBuilder();
         addContents(allClassesContent);
@@ -97,13 +90,9 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
                 .addTab(contents.records, utils::isRecord)
                 .addTab(contents.exceptionClasses, utils::isThrowable)
                 .addTab(contents.annotationTypes, utils::isAnnotationInterface);
-        for (Character unicode : indexBuilder.getFirstCharacters()) {
-            for (IndexItem indexItem : indexBuilder.getItems(unicode)) {
-                TypeElement typeElement = (TypeElement) indexItem.getElement();
-                if (typeElement != null && utils.isCoreClass(typeElement)) {
-                    addTableRow(table, typeElement);
-                }
-            }
+        Set<TypeElement> typeElements = getTypeElements();
+        for (TypeElement typeElement : typeElements) {
+            addTableRow(table, typeElement);
         }
         Content titleContent = contents.allClassesAndInterfacesLabel;
         var pHeading = HtmlTree.HEADING_TITLE(Headings.PAGE_TITLE_HEADING,
@@ -113,6 +102,24 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
         if (!table.isEmpty()) {
             target.add(table);
         }
+    }
+
+    private Set<TypeElement> getTypeElements()  {
+        Set<TypeElement> classes = new TreeSet<>(utils.comparators.allClassesComparator());
+        boolean noDeprecated = options.noDeprecated();
+        Set<TypeElement> includedTypes = configuration.getIncludedTypeElements();
+        for (TypeElement typeElement : includedTypes) {
+            if (utils.hasHiddenTag(typeElement) || !utils.isCoreClass(typeElement)) {
+                continue;
+            }
+            if (noDeprecated
+                    && (utils.isDeprecated(typeElement)
+                    || utils.isDeprecated(utils.containingPackage(typeElement)))) {
+                continue;
+            }
+            classes.add(typeElement);
+        }
+        return classes;
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AllClassesIndexWriter.java
@@ -104,7 +104,7 @@ public class AllClassesIndexWriter extends HtmlDocletWriter {
         }
     }
 
-    private Set<TypeElement> getTypeElements()  {
+    private Set<TypeElement> getTypeElements() {
         Set<TypeElement> classes = new TreeSet<>(utils.comparators.allClassesComparator());
         boolean noDeprecated = options.noDeprecated();
         Set<TypeElement> includedTypes = configuration.getIncludedTypeElements();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstantsSummaryWriter.java
@@ -475,8 +475,8 @@ public class ConstantsSummaryWriter extends HtmlDocletWriter {
         content.add(bodyContents);
         printHtmlDocument(null, "summary of constants", content);
 
-        if (hasConstants && configuration.mainIndex != null) {
-            configuration.mainIndex.add(IndexItem.of(IndexItem.Category.TAGS,
+        if (hasConstants && configuration.indexBuilder != null) {
+            configuration.indexBuilder.add(IndexItem.of(IndexItem.Category.TAGS,
                     resources.getText("doclet.Constants_Summary"), path));
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ExternalSpecsWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ExternalSpecsWriter.java
@@ -86,8 +86,8 @@ public class ExternalSpecsWriter extends HtmlDocletWriter {
      */
     @Override
     public void buildPage() throws DocFileIOException {
-        boolean hasExternalSpecs = configuration.mainIndex != null
-                && !configuration.mainIndex.getItems(DocTree.Kind.SPEC).isEmpty();
+        boolean hasExternalSpecs = configuration.indexBuilder != null
+                && !configuration.indexBuilder.getItems(DocTree.Kind.SPEC).isEmpty();
         if (!hasExternalSpecs) {
             return;
         }
@@ -110,15 +110,15 @@ public class ExternalSpecsWriter extends HtmlDocletWriter {
                 .setFooter(getFooter()));
         printHtmlDocument(null, "external specifications", body);
 
-        if (configuration.mainIndex != null) {
-            configuration.mainIndex.add(IndexItem.of(IndexItem.Category.TAGS, title, path));
+        if (configuration.indexBuilder != null) {
+            configuration.indexBuilder.add(IndexItem.of(IndexItem.Category.TAGS, title, path));
         }
     }
 
     protected void checkUniqueItems() {
         Map<String, Map<String, List<IndexItem>>> itemsByURL = new HashMap<>();
         Map<String, Map<String, List<IndexItem>>> itemsByTitle = new HashMap<>();
-        for (IndexItem ii : configuration.mainIndex.getItems(DocTree.Kind.SPEC)) {
+        for (IndexItem ii : configuration.indexBuilder.getItems(DocTree.Kind.SPEC)) {
             if (ii.getDocTree() instanceof SpecTree st) {
                 String url = st.getURL().toString();
                 String title = ii.getLabel(); // normalized form of  st.getTitle()
@@ -230,7 +230,7 @@ public class ExternalSpecsWriter extends HtmlDocletWriter {
     }
 
     private Map<String, List<IndexItem>> groupExternalSpecs() {
-        return configuration.mainIndex.getItems(DocTree.Kind.SPEC).stream()
+        return configuration.indexBuilder.getItems(DocTree.Kind.SPEC).stream()
                 .collect(groupingBy(IndexItem::getLabel, () -> new TreeMap<>(getTitleComparator()), toList()));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -112,7 +112,7 @@ public class HtmlConfiguration extends BaseConfiguration {
      * 2. items for elements are added in bulk before generating the index files
      * 3. additional items are added as needed
      */
-    public HtmlIndexBuilder mainIndex;
+    public HtmlIndexBuilder indexBuilder;
 
     /**
      * The collection of deprecated items, if any, to be displayed on the deprecated-list page,
@@ -307,7 +307,7 @@ public class HtmlConfiguration extends BaseConfiguration {
             }
         }
         if (options.createIndex()) {
-            mainIndex = new HtmlIndexBuilder(this);
+            indexBuilder = new HtmlIndexBuilder(this);
         }
         docPaths = new DocPaths(utils);
         setCreateOverview();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -59,7 +59,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocFile;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFileIOException;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
-import jdk.javadoc.internal.doclets.toolkit.util.IndexBuilder;
 import jdk.javadoc.internal.doclets.toolkit.util.NewAPIBuilder;
 import jdk.javadoc.internal.doclets.toolkit.util.PreviewAPIListBuilder;
 import jdk.javadoc.internal.doclets.toolkit.util.ResourceIOException;
@@ -273,16 +272,14 @@ public class HtmlDoclet extends AbstractDoclet {
             }
             writerFactory.newSystemPropertiesWriter().buildPage();
 
-            configuration.mainIndex.addElements();
-            IndexBuilder allClassesIndex = new IndexBuilder(configuration, nodeprecated, true);
-            allClassesIndex.addElements();
+            configuration.indexBuilder.addElements();
 
-            writerFactory.newAllClassesIndexWriter(allClassesIndex).buildPage();
+            writerFactory.newAllClassesIndexWriter().buildPage();
             if (!configuration.packages.isEmpty()) {
                 writerFactory.newAllPackagesIndexWriter().buildPage();
             }
 
-            configuration.mainIndex.createSearchIndexFiles();
+            configuration.indexBuilder.createSearchIndexFiles();
             IndexWriter.generate(configuration);
             writerFactory.newSearchWriter().buildPage();
         }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1470,13 +1470,13 @@ public abstract class HtmlDocletWriter {
             attrs.add("id=\"").add(htmlId.name()).add("\"");
         }
         // Generate index item
-        if (!headingContent.isEmpty() && configuration.mainIndex != null) {
+        if (!headingContent.isEmpty() && configuration.indexBuilder != null) {
             String tagText = headingContent.replaceAll("\\s+", " ");
             IndexItem item = IndexItem.of(element, node, tagText,
                     getTagletWriterInstance(context).getHolderName(element),
                     resources.getText("doclet.Section"),
                     new DocLink(path, id));
-            configuration.mainIndex.add(item);
+            configuration.indexBuilder.add(item);
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIndexBuilder.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIndexBuilder.java
@@ -42,7 +42,6 @@ import jdk.javadoc.internal.doclets.toolkit.util.DocPath;
 import jdk.javadoc.internal.doclets.toolkit.util.DocPaths;
 import jdk.javadoc.internal.doclets.toolkit.util.IndexBuilder;
 import jdk.javadoc.internal.doclets.toolkit.util.IndexItem;
-import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
 /**
  * Extensions to {@code IndexBuilder} to fill in remaining fields
@@ -51,10 +50,8 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils;
  * JavaScript files.
  */
 public class HtmlIndexBuilder extends IndexBuilder {
-    private final HtmlConfiguration configuration;
 
     private final Resources resources;
-    private final Utils utils;
     private final HtmlIds htmlIds;
 
     /**
@@ -63,11 +60,9 @@ public class HtmlIndexBuilder extends IndexBuilder {
      * @param configuration the current configuration of the doclet
      */
     HtmlIndexBuilder(HtmlConfiguration configuration) {
-        super(configuration, configuration.getOptions().noDeprecated());
-        this.configuration = configuration;
-        resources = configuration.docResources;
-        utils = configuration.utils;
-        htmlIds = configuration.htmlIds;
+        super(configuration);
+        this.resources = configuration.docResources;
+        this.htmlIds = configuration.htmlIds;
     }
 
     /**
@@ -79,15 +74,12 @@ public class HtmlIndexBuilder extends IndexBuilder {
     @Override
     public void addElements() {
         super.addElements();
-        if (classesOnly) {
-            return;
-        }
 
         Map<String,Integer> duplicateLabelCheck = new HashMap<>();
         for (Character ch : getFirstCharacters()) {
             for (IndexItem item : getItems(ch)) {
                 duplicateLabelCheck.compute(item.getFullyQualifiedLabel(utils),
-                                            (k, v) -> v == null ? 1 : v + 1);
+                        (k, v) -> v == null ? 1 : v + 1);
             }
         }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexWriter.java
@@ -79,7 +79,7 @@ public class IndexWriter extends HtmlDocletWriter {
      */
     public static void generate(HtmlConfiguration configuration) throws DocletException {
         var writerFactory = configuration.getWriterFactory();
-        IndexBuilder mainIndex = configuration.mainIndex;
+        IndexBuilder mainIndex = configuration.indexBuilder;
         List<Character> firstCharacters = mainIndex.getFirstCharacters();
         if (configuration.getOptions().splitIndex()) {
             ListIterator<Character> iter = firstCharacters.listIterator();
@@ -104,7 +104,7 @@ public class IndexWriter extends HtmlDocletWriter {
     protected IndexWriter(HtmlConfiguration configuration, DocPath path,
                           List<Character> allFirstCharacters, List<Character> displayFirstCharacters) {
         super(configuration, path);
-        this.mainIndex = configuration.mainIndex;
+        this.mainIndex = configuration.indexBuilder;
         this.splitIndex = configuration.getOptions().splitIndex();
         this.allFirstCharacters = allFirstCharacters;
         this.displayFirstCharacters = displayFirstCharacters;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SerializedFormWriter.java
@@ -696,8 +696,8 @@ public class SerializedFormWriter extends SubWriterHolderWriter {
         source.add(bodyContents);
         printHtmlDocument(null, "serialized forms", source);
 
-        if (configuration.mainIndex != null) {
-            configuration.mainIndex.add(IndexItem.of(IndexItem.Category.TAGS,
+        if (configuration.indexBuilder != null) {
+            configuration.indexBuilder.add(IndexItem.of(IndexItem.Category.TAGS,
                     resources.getText("doclet.Serialized_Form"), path));
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SystemPropertiesWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/SystemPropertiesWriter.java
@@ -73,8 +73,8 @@ public class SystemPropertiesWriter extends HtmlDocletWriter {
 
     @Override
     public void buildPage() throws DocFileIOException {
-        boolean hasSystemProperties = configuration.mainIndex != null
-                && !configuration.mainIndex.getItems(DocTree.Kind.SYSTEM_PROPERTY).isEmpty();
+        boolean hasSystemProperties = configuration.indexBuilder != null
+                && !configuration.indexBuilder.getItems(DocTree.Kind.SYSTEM_PROPERTY).isEmpty();
         if (!hasSystemProperties) {
             return;
         }
@@ -95,8 +95,8 @@ public class SystemPropertiesWriter extends HtmlDocletWriter {
                 .setFooter(getFooter()));
         printHtmlDocument(null, "system properties", body);
 
-        if (configuration.mainIndex != null) {
-            configuration.mainIndex.add(IndexItem.of(IndexItem.Category.TAGS, title, path));
+        if (configuration.indexBuilder != null) {
+            configuration.indexBuilder.add(IndexItem.of(IndexItem.Category.TAGS, title, path));
         }
     }
 
@@ -127,7 +127,7 @@ public class SystemPropertiesWriter extends HtmlDocletWriter {
     }
 
     private Map<String, List<IndexItem>> groupSystemProperties() {
-        return configuration.mainIndex.getItems(DocTree.Kind.SYSTEM_PROPERTY).stream()
+        return configuration.indexBuilder.getItems(DocTree.Kind.SYSTEM_PROPERTY).stream()
                 .collect(groupingBy(IndexItem::getLabel, TreeMap::new, Collectors.toCollection(ArrayList::new)));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/WriterFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/WriterFactory.java
@@ -103,8 +103,8 @@ public class WriterFactory {
     /**
      * {@return a new writer for the list of "all classes"}
      */
-    public HtmlDocletWriter newAllClassesIndexWriter(IndexBuilder indexBuilder) {
-        return new AllClassesIndexWriter(configuration, indexBuilder);
+    public HtmlDocletWriter newAllClassesIndexWriter() {
+        return new AllClassesIndexWriter(configuration);
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
@@ -379,7 +379,7 @@ public class TagletWriter {
                 String holder = getHolderName(element);
                 IndexItem item = IndexItem.of(element, tree, tagText, holder, desc,
                         new DocLink(htmlWriter.path, id.name()));
-                configuration.mainIndex.add(item);
+                configuration.indexBuilder.add(item);
             }
         }
         return result;


### PR DESCRIPTION
My original intention with this cleanup was to keep using `[Html]IndexBuilder' for both the "All Classes" and the main index, but just improve separation of code and naming of classes. However, I then discovered two things:

 - The "All Classes" page is so simple to build that it doesn't justify using a complex builder class. In fact, moving the necessary functionality from `IndexBuilder` to `AllClassesIndexWriter` just added about a dozen lines of code to the latter, while making `IndexBuilder` much simpler by removing its dual purpose.
 - The separation of code between `toolkit.util.IndexBuilder` and `formats.html.HtmlIndexBuilder`, although seemingly random at first sight, actually reflects the usage of functionality provided by the respective packages. Although with a single output format the separation between these packages is not as important as it used to be, it is still nice to keep things separated.

Based on these two findings, I decided to pull the "All Classes" code into "AllClassesIndexWriter", but maintain the implementation of `[Html]IndexBuilder` across the two classes/packages. Although the base `IndexBuilder` class is technically able to function on its own without the HTML-specific enhancements, I made the class abstract in order to point out that the HTML enhancements in `HtmlIndexBuilder` are actually essential for our us.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315464](https://bugs.openjdk.org/browse/JDK-8315464): Uncouple AllClassesIndexWriter from IndexBuilder (**Task** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15746/head:pull/15746` \
`$ git checkout pull/15746`

Update a local copy of the PR: \
`$ git checkout pull/15746` \
`$ git pull https://git.openjdk.org/jdk.git pull/15746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15746`

View PR using the GUI difftool: \
`$ git pr show -t 15746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15746.diff">https://git.openjdk.org/jdk/pull/15746.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15746#issuecomment-1719773603)