### PR TITLE
8315883: Open source several Swing JToolbar tests

### DIFF
--- a/test/jdk/javax/swing/JToolBar/bug4138694.java
+++ b/test/jdk/javax/swing/JToolBar/bug4138694.java
@@ -30,7 +30,6 @@
  */
 
 import java.awt.event.ActionEvent;
-import java.lang.reflect.InvocationTargetException;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -39,19 +38,20 @@ import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
 
 public class bug4138694 {
+    public static final String exampleText = "Action";
+
     private static class MyAction extends AbstractAction {
         public void actionPerformed(ActionEvent e) {}
     }
 
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JToolBar jtb = new JToolBar();
             MyAction aa = new MyAction();
-            aa.putValue(Action.SHORT_DESCRIPTION, "Action");
+            aa.putValue(Action.SHORT_DESCRIPTION, exampleText);
             jtb.add(aa);
             JComponent c = (JComponent)jtb.getComponentAtIndex(0);
-            if (!c.getToolTipText().equals("Action")) {
+            if (!c.getToolTipText().equals(exampleText)) {
                 throw new RuntimeException("ToolTip not set automatically...");
             }
         });

--- a/test/jdk/javax/swing/JToolBar/bug4138694.java
+++ b/test/jdk/javax/swing/JToolBar/bug4138694.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4138694
+ * @summary When adding an Action object to a toolbar, the Action object's
+ * SHORT_DESCRIPTION property (if present) should be automatically used
+ * for toolTip text.
+ * @run main bug4138694
+ */
+
+import java.awt.event.ActionEvent;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JComponent;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+public class bug4138694 {
+    private static class MyAction extends AbstractAction {
+        public void actionPerformed(ActionEvent e) {}
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JToolBar jtb = new JToolBar();
+            MyAction aa = new MyAction();
+            aa.putValue(Action.SHORT_DESCRIPTION, "Action");
+            jtb.add(aa);
+            JComponent c = (JComponent)jtb.getComponentAtIndex(0);
+            if (!c.getToolTipText().equals("Action")) {
+                throw new RuntimeException("ToolTip not set automatically...");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4138694.java
+++ b/test/jdk/javax/swing/JToolBar/bug4138694.java
@@ -38,7 +38,7 @@ import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
 
 public class bug4138694 {
-    public static final String exampleText = "Action";
+    public static final String actionName = "Action";
 
     private static class MyAction extends AbstractAction {
         public void actionPerformed(ActionEvent e) {}
@@ -48,10 +48,10 @@ public class bug4138694 {
         SwingUtilities.invokeAndWait(() -> {
             JToolBar jtb = new JToolBar();
             MyAction aa = new MyAction();
-            aa.putValue(Action.SHORT_DESCRIPTION, exampleText);
+            aa.putValue(Action.SHORT_DESCRIPTION, actionName);
             jtb.add(aa);
             JComponent c = (JComponent)jtb.getComponentAtIndex(0);
-            if (!c.getToolTipText().equals(exampleText)) {
+            if (!c.getToolTipText().equals(actionName)) {
                 throw new RuntimeException("ToolTip not set automatically...");
             }
         });

--- a/test/jdk/javax/swing/JToolBar/bug4140421.java
+++ b/test/jdk/javax/swing/JToolBar/bug4140421.java
@@ -27,14 +27,11 @@
  * @run main bug4140421
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
 
 public class bug4140421 {
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JToolBar tb = new JToolBar("MyToolBar");
             if (!tb.getName().equals("MyToolBar")) {

--- a/test/jdk/javax/swing/JToolBar/bug4140421.java
+++ b/test/jdk/javax/swing/JToolBar/bug4140421.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4140421
+ * @summary Tests JToolBar set title correctly
+ * @run main bug4140421
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+public class bug4140421 {
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JToolBar tb = new JToolBar("MyToolBar");
+            if (!tb.getName().equals("MyToolBar")) {
+                throw new RuntimeException("Title of JToolBar set incorrectly...");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4196662.java
+++ b/test/jdk/javax/swing/JToolBar/bug4196662.java
@@ -27,15 +27,12 @@
  * @run main bug4196662
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.swing.JButton;
 import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
 
 public class bug4196662 {
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JToolBar tb = new JToolBar();
             tb.add(new JButton("Button1"));

--- a/test/jdk/javax/swing/JToolBar/bug4196662.java
+++ b/test/jdk/javax/swing/JToolBar/bug4196662.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4196662
+ * @summary JToolBar has remove(int) method.
+ * @run main bug4196662
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JButton;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+public class bug4196662 {
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JToolBar tb = new JToolBar();
+            tb.add(new JButton("Button1"));
+            JButton bt2 = new JButton("Button2");
+            tb.add(bt2);
+            tb.add(new JButton("Button3"));
+            tb.remove(1);
+            if (tb.getComponentCount() != 2 || tb.getComponent(1) == bt2) {
+                throw new RuntimeException("Component wasn't removed...");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4243930.java
+++ b/test/jdk/javax/swing/JToolBar/bug4243930.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4243930
+ * @summary Tests that JToolBar.remove() does not throw StackOverflowError
+ * @run main bug4243930
+ */
+
+import java.awt.event.ActionEvent;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+public class bug4243930 {
+
+/** Auxilliary class implementing Action
+ */
+    private static class NullAction extends AbstractAction {
+        public void actionPerformed(ActionEvent e){}
+    }
+
+    public static void main(String[] argv) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JToolBar tb = new JToolBar();
+            JButton test = tb.add(new NullAction());
+            tb.remove(test);
+        });
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4243930.java
+++ b/test/jdk/javax/swing/JToolBar/bug4243930.java
@@ -28,7 +28,6 @@
  */
 
 import java.awt.event.ActionEvent;
-import java.lang.reflect.InvocationTargetException;
 
 import javax.swing.AbstractAction;
 import javax.swing.JButton;
@@ -37,14 +36,11 @@ import javax.swing.SwingUtilities;
 
 public class bug4243930 {
 
-/** Auxilliary class implementing Action
- */
     private static class NullAction extends AbstractAction {
         public void actionPerformed(ActionEvent e){}
     }
 
-    public static void main(String[] argv) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JToolBar tb = new JToolBar();
             JButton test = tb.add(new NullAction());


### PR DESCRIPTION
These are the tests being converted:

javax/swing/JToolBar/4138694/bug4138694.java
javax/swing/JToolBar/4140421/bug4140421.java
javax/swing/JToolBar/4196662/bug4196662.java
javax/swing/JToolBar/4243930/bug4243930.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315883](https://bugs.openjdk.org/browse/JDK-8315883): Open source several Swing JToolbar tests (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [a8c8176c](https://git.openjdk.org/jdk/pull/15748/files/a8c8176c0c17739a131a8256cca2d3a427497a2a)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15748/head:pull/15748` \
`$ git checkout pull/15748`

Update a local copy of the PR: \
`$ git checkout pull/15748` \
`$ git pull https://git.openjdk.org/jdk.git pull/15748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15748`

View PR using the GUI difftool: \
`$ git pr show -t 15748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15748.diff">https://git.openjdk.org/jdk/pull/15748.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15748#issuecomment-1719804175)