### PR TITLE
8299560: Assertion failed: currentQueryIndex >= 0 && currentQueryIndex < numberOfJavaProcessesAtInitialization

### DIFF
--- a/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/windows/native/libmanagement_ext/OperatingSystemImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -698,6 +698,8 @@ getProcessID() {
  * (in order to keep this index valid when the list resets from underneath,
  * ensure to call getCurrentQueryIndexForProcess() before every query involving
  * Process object instance data).
+ *
+ * Returns -1 on failure.
  */
 static int
 currentQueryIndexForProcess(void) {
@@ -775,8 +777,7 @@ static int
 getCurrentQueryIndexForProcess() {
     int currentQueryIndex = currentQueryIndexForProcess();
 
-    assert(currentQueryIndex >= 0 &&
-           currentQueryIndex < numberOfJavaProcessesAtInitialization);
+    assert(currentQueryIndex < numberOfJavaProcessesAtInitialization);
 
     return currentQueryIndex;
 }
@@ -1310,11 +1311,10 @@ perfGetProcessCPULoad() {
     }
 
     currentQueryIndex = getCurrentQueryIndexForProcess();
-
-    if (getPerformanceData(&processTotalCPULoad[currentQueryIndex].query,
-                           processTotalCPULoad[currentQueryIndex].counter,
-                           &cv,
-                           PDH_FMT_DOUBLE | PDH_FMT_NOCAP100) == 0) {
+    if (currentQueryIndex >= 0 && getPerformanceData(&processTotalCPULoad[currentQueryIndex].query,
+                                                     processTotalCPULoad[currentQueryIndex].counter,
+                                                     &cv,
+                                                     PDH_FMT_DOUBLE | PDH_FMT_NOCAP100) == 0) {
         double d = cv.doubleValue / cpuFactor;
         d = min(1, d);
         d = max(0, d);


### PR DESCRIPTION
This assert happens rarely, but is seen in testing a few times.

getCurrentQueryIndexForProcess comments that it can return -1, but it asserts that the value is >=0

If we let it return -1 for failure as its comment documents, the caller can handle the failure and not assert and end the JVM.  

Conversely, currentQueryIndexForProcess() clearly can return -1 on failure, so add the comment like we already have in getCurrentQueryIndexForProcess().

This assert is not reproducing on demand, but with this change I've done 50+ iterations of the test on windows-x64 and windows-x64-debug in mach5, and hundreds locally.

The test which has been seen to trigger the assert 
"test/jdk/com/sun/management/OperatingSystemMXBean/GetProcessCpuLoad.java" 
...checks the range of the load value returned, and is happy enough if -1 is the answer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299560](https://bugs.openjdk.org/browse/JDK-8299560): Assertion failed: currentQueryIndex &gt;= 0 &amp;&amp; currentQueryIndex &lt; numberOfJavaProcessesAtInitialization (**Bug** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15750/head:pull/15750` \
`$ git checkout pull/15750`

Update a local copy of the PR: \
`$ git checkout pull/15750` \
`$ git pull https://git.openjdk.org/jdk.git pull/15750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15750`

View PR using the GUI difftool: \
`$ git pr show -t 15750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15750.diff">https://git.openjdk.org/jdk/pull/15750.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15750#issuecomment-1720911447)