### PR TITLE
8315415: OutputAnalyzer.shouldMatchByLine() fails in some cases

### DIFF
--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -671,15 +671,15 @@ public final class OutputAnalyzer {
     /**
      * @see #shouldMatchByLine(String, String, String)
      */
-    public OutputAnalyzer shouldMatchByLineFrom(String from, String pattern) {
-        return shouldMatchByLine(from, null, pattern);
+    public OutputAnalyzer shouldMatchByLineFrom(String fromPattern, String pattern) {
+        return shouldMatchByLine(fromPattern, null, pattern);
     }
 
     /**
      * @see #shouldMatchByLine(String, String, String)
      */
-    public OutputAnalyzer shouldMatchByLineTo(String to, String pattern) {
-        return shouldMatchByLine(null, to, pattern);
+    public OutputAnalyzer shouldMatchByLineTo(String toPattern, String pattern) {
+        return shouldMatchByLine(null, toPattern, pattern);
     }
 
     /**
@@ -687,17 +687,17 @@ public final class OutputAnalyzer {
      * {@code pattern} line by line. The whole output could be matched or
      * just a subset of it.
      *
-     * @param from
-     *            The line (excluded) from where output will be matched.
-     *            Set {@code from} to null for matching from the first line.
-     * @param to
-     *            The line (excluded) until where output will be matched.
-     *            Set {@code to} to null for matching until the last line.
+     * @param fromPattern
+     *            The pattern of line (excluded) from where output will be matched.
+     *            Set {@code fromPattern} to null for matching from the first line.
+     * @param toPattern
+     *            The pattern of line (excluded) until where output will be matched.
+     *            Set {@code toPattern} to null for matching until the last line.
      * @param pattern
      *            Matching pattern
      */
-    public OutputAnalyzer shouldMatchByLine(String from, String to, String pattern) {
-        return shouldMatchByLine(getOutput(), from, to, pattern);
+    public OutputAnalyzer shouldMatchByLine(String fromPattern, String toPattern, String pattern) {
+        return shouldMatchByLine(getOutput(), fromPattern, toPattern, pattern);
     }
 
     /**
@@ -705,34 +705,34 @@ public final class OutputAnalyzer {
      * {@code pattern} line by line. The whole stdout could be matched or
      * just a subset of it.
      *
-     * @param from
-     *            The line (excluded) from where stdout will be matched.
-     *            Set {@code from} to null for matching from the first line.
-     * @param to
-     *            The line (excluded) until where stdout will be matched.
-     *            Set {@code to} to null for matching until the last line.
+     * @param fromPattern
+     *            The pattern of line (excluded) from where stdout will be matched.
+     *            Set {@code fromPattern} to null for matching from the first line.
+     * @param toPattern
+     *            The pattern of line (excluded) until where stdout will be matched.
+     *            Set {@code toPattern} to null for matching until the last line.
      * @param pattern
      *            Matching pattern
      */
-    public OutputAnalyzer stdoutShouldMatchByLine(String from, String to, String pattern) {
-        return shouldMatchByLine(getStdout(), from, to, pattern);
+    public OutputAnalyzer stdoutShouldMatchByLine(String fromPattern, String toPattern, String pattern) {
+        return shouldMatchByLine(getStdout(), fromPattern, toPattern, pattern);
     }
 
-    private OutputAnalyzer shouldMatchByLine(String buffer, String from, String to, String pattern) {
+    private OutputAnalyzer shouldMatchByLine(String buffer, String fromPattern, String toPattern, String pattern) {
         List<String> lines = asLines(buffer);
 
         int fromIndex = 0;
-        if (from != null) {
-            fromIndex = indexOf(lines, from, 0) + 1; // + 1 -> apply 'pattern' to lines after 'from' match
+        if (fromPattern != null) {
+            fromIndex = indexOf(lines, fromPattern, 0) + 1; // + 1 -> apply 'pattern' to lines after 'from' match
             Asserts.assertGreaterThan(fromIndex, 0,
-                    "The line/pattern '" + from + "' from where the output should match can not be found");
+                    "The line matched with pattern '" + fromPattern + "' from where the output should match can not be found");
         }
 
         int toIndex = lines.size();
-        if (to != null) {
-            toIndex = indexOf(lines, to, fromIndex);
+        if (toPattern != null) {
+            toIndex = indexOf(lines, toPattern, fromIndex);
             Asserts.assertGreaterThan(toIndex, fromIndex,
-                    "The line/pattern '" + to + "' until where the output should match can not be found");
+                    "The line matched with pattern '" + toPattern + "' until where the output should match can not be found");
         }
 
         List<String> subList = lines.subList(fromIndex, toIndex);


### PR DESCRIPTION
OutputAnalyzer.shouldMatchByLine(from, to, pattern) 
treat from and to parameters as patterns and not lines. So it might fail to compile them or work not as expected in some cases.

I grepped the usage of shouldMatchByLine and stdoutShouldMatchByLine and found that in most cases from/to are set to some regex patterns. So I just updated the names of variables and documentation to explicitly say that from/to are patterns.

See bugs for details. Tested with tier1 (mostly for validation scripts since no code changes.)