### PR TITLE
8315952: Open source several Swing JToolbar JTooltip JTree tests

### DIFF
--- a/test/jdk/javax/swing/JToolBar/bug4368050.java
+++ b/test/jdk/javax/swing/JToolBar/bug4368050.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4368050
+ * @summary Default toolbar layout manager should be serializable.
+ * @run main bug4368050
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import javax.swing.JToolBar;
+
+public class bug4368050 {
+    public static void main(String[] args) throws IOException,
+            ClassNotFoundException {
+        JToolBar toolBar = new JToolBar();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(toolBar);
+        byte[] buf = baos.toByteArray();
+        baos.close();
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(buf);
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        ois.readObject();
+        bais.close();
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4368050.java
+++ b/test/jdk/javax/swing/JToolBar/bug4368050.java
@@ -29,26 +29,23 @@
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import javax.swing.JToolBar;
 
 public class bug4368050 {
-    public static void main(String[] args) throws IOException,
-            ClassNotFoundException {
+    public static void main(String[] args) throws Exception {
         JToolBar toolBar = new JToolBar();
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ObjectOutputStream oos = new ObjectOutputStream(baos);
-        oos.writeObject(toolBar);
-        byte[] buf = baos.toByteArray();
-        baos.close();
-
-        ByteArrayInputStream bais = new ByteArrayInputStream(buf);
-        ObjectInputStream ois = new ObjectInputStream(bais);
-        ois.readObject();
-        bais.close();
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(toolBar);
+            byte[] buf = baos.toByteArray();
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(buf);
+                 ObjectInputStream ois = new ObjectInputStream(bais)) {
+                ois.readObject();
+            }
+        }
     }
 }

--- a/test/jdk/javax/swing/JToolBar/bug4465534.java
+++ b/test/jdk/javax/swing/JToolBar/bug4465534.java
@@ -27,15 +27,12 @@
  * @run main bug4465534
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.swing.JButton;
 import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
 
 public class bug4465534 {
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JToolBar toolbar = new JToolBar();
             JButton button = new JButton("text");

--- a/test/jdk/javax/swing/JToolBar/bug4465534.java
+++ b/test/jdk/javax/swing/JToolBar/bug4465534.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4465534
+ * @summary Tests adding borderless button to a toolbar
+ * @run main bug4465534
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JButton;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+public class bug4465534 {
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JToolBar toolbar = new JToolBar();
+            JButton button = new JButton("text");
+            button.setBorder(null);
+            toolbar.add(button);
+        });
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4700351.java
+++ b/test/jdk/javax/swing/JToolBar/bug4700351.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4700351
+ * @summary Checks if JToolBar keeps orientation when dragged off
+ * @key headful
+ * @run main bug4700351
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JFrame;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+import javax.swing.plaf.basic.BasicToolBarUI;
+
+public class bug4700351 {
+    static JFrame fr;
+    static JToolBar tb;
+    static BasicToolBarUI ui;
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            fr = new JFrame("bug4700351");
+            tb = new JToolBar();
+            tb.setOrientation(JToolBar.VERTICAL);
+            fr.add(tb);
+            ui = (javax.swing.plaf.basic.BasicToolBarUI) tb.getUI();
+            if (!ui.isFloating()) {
+                ui.setFloatingLocation(100, 100);
+                ui.setFloating(true, tb.getLocation());
+            }
+            if (tb.getOrientation() != JToolBar.VERTICAL) {
+                throw new RuntimeException("Error: toolbar's orientation " +
+                        "has changed");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4700351.java
+++ b/test/jdk/javax/swing/JToolBar/bug4700351.java
@@ -28,8 +28,6 @@
  * @run main bug4700351
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.swing.JFrame;
 import javax.swing.JToolBar;
 import javax.swing.SwingUtilities;
@@ -37,25 +35,30 @@ import javax.swing.plaf.basic.BasicToolBarUI;
 
 public class bug4700351 {
     static JFrame fr;
-    static JToolBar tb;
-    static BasicToolBarUI ui;
 
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
-        SwingUtilities.invokeAndWait(() -> {
-            fr = new JFrame("bug4700351");
-            tb = new JToolBar();
-            tb.setOrientation(JToolBar.VERTICAL);
-            fr.add(tb);
-            ui = (javax.swing.plaf.basic.BasicToolBarUI) tb.getUI();
-            if (!ui.isFloating()) {
-                ui.setFloatingLocation(100, 100);
-                ui.setFloating(true, tb.getLocation());
-            }
-            if (tb.getOrientation() != JToolBar.VERTICAL) {
-                throw new RuntimeException("Error: toolbar's orientation " +
-                        "has changed");
-            }
-        });
+    public static void main(String[] args) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("bug4700351");
+                JToolBar tb = new JToolBar();
+                tb.setOrientation(JToolBar.VERTICAL);
+                fr.add(tb);
+                BasicToolBarUI ui = (javax.swing.plaf.basic.BasicToolBarUI) tb.getUI();
+                if (!ui.isFloating()) {
+                    ui.setFloatingLocation(100, 100);
+                    ui.setFloating(true, tb.getLocation());
+                }
+                if (tb.getOrientation() != JToolBar.VERTICAL) {
+                    throw new RuntimeException("Error: toolbar's orientation " +
+                            "has changed");
+                }
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
     }
 }

--- a/test/jdk/javax/swing/JToolTip/bug4107843.java
+++ b/test/jdk/javax/swing/JToolTip/bug4107843.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4107843
+ * @summary ToolTipText for JTabbedPane.
+ * @run main bug4107843
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JButton;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+
+public class bug4107843 {
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JTabbedPane tp = new JTabbedPane();
+            tp.add("First", new JButton("Button1"));
+            tp.add("Second", new JButton("Button2"));
+            tp.setToolTipTextAt(0, "first button");
+            if (!tp.getToolTipTextAt(0).equals("first button")) {
+                throw new RuntimeException("ToolTipText doesn't set " +
+                        "as expected...");
+            }
+            tp.setToolTipTextAt(1, "second button");
+            if (!tp.getToolTipTextAt(1).equals("second button")) {
+                throw new RuntimeException("ToolTipText doesn't set " +
+                        "as expected...");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JToolTip/bug4107843.java
+++ b/test/jdk/javax/swing/JToolTip/bug4107843.java
@@ -27,27 +27,24 @@
  * @run main bug4107843
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.swing.JButton;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingUtilities;
 
 public class bug4107843 {
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JTabbedPane tp = new JTabbedPane();
             tp.add("First", new JButton("Button1"));
             tp.add("Second", new JButton("Button2"));
             tp.setToolTipTextAt(0, "first button");
             if (!tp.getToolTipTextAt(0).equals("first button")) {
-                throw new RuntimeException("ToolTipText doesn't set " +
+                throw new RuntimeException("ToolTipText isn't set " +
                         "as expected...");
             }
             tp.setToolTipTextAt(1, "second button");
             if (!tp.getToolTipTextAt(1).equals("second button")) {
-                throw new RuntimeException("ToolTipText doesn't set " +
+                throw new RuntimeException("ToolTipText isn't set " +
                         "as expected...");
             }
         });

--- a/test/jdk/javax/swing/JTree/bug4161685.java
+++ b/test/jdk/javax/swing/JTree/bug4161685.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4161685
+ * @summary JTree now has the public methods setAnchorSelectionPath,
+ * getAnchorSelectionPath, setLeadSelectionPath.
+ * @run main bug4161685
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.TreePath;
+
+public class bug4161685 {
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JTree tr = new JTree();
+            TreePath tp = tr.getPathForRow(2);
+            tr.setAnchorSelectionPath(tp);
+            if (tr.getAnchorSelectionPath() != tp) {
+                throw new RuntimeException("AnchorSelectionPath doesn't " +
+                        "set correctly...");
+            }
+            tr.setLeadSelectionPath(tp);
+            if (tr.getLeadSelectionPath() != tp) {
+                throw new RuntimeException("LeadSelectionPath doesn't " +
+                        "set correctly...");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JTree/bug4161685.java
+++ b/test/jdk/javax/swing/JTree/bug4161685.java
@@ -28,26 +28,23 @@
  * @run main bug4161685
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 import javax.swing.tree.TreePath;
 
 public class bug4161685 {
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JTree tr = new JTree();
             TreePath tp = tr.getPathForRow(2);
             tr.setAnchorSelectionPath(tp);
             if (tr.getAnchorSelectionPath() != tp) {
-                throw new RuntimeException("AnchorSelectionPath doesn't " +
+                throw new RuntimeException("AnchorSelectionPath isn't " +
                         "set correctly...");
             }
             tr.setLeadSelectionPath(tp);
             if (tr.getLeadSelectionPath() != tp) {
-                throw new RuntimeException("LeadSelectionPath doesn't " +
+                throw new RuntimeException("LeadSelectionPath isn't " +
                         "set correctly...");
             }
         });


### PR DESCRIPTION
These are the tests being converted:

javax/swing/JToolBar/4368050/bug4368050.java
javax/swing/JToolBar/4465534/bug4465534.java
javax/swing/JToolBar/4700351/bug4700351.java
javax/swing/JToolTip/4107843/bug4107843.java
javax/swing/JTree/4161685/bug4161685.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315952](https://bugs.openjdk.org/browse/JDK-8315952): Open source several Swing JToolbar JTooltip JTree tests (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15755/head:pull/15755` \
`$ git checkout pull/15755`

Update a local copy of the PR: \
`$ git checkout pull/15755` \
`$ git pull https://git.openjdk.org/jdk.git pull/15755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15755`

View PR using the GUI difftool: \
`$ git pr show -t 15755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15755.diff">https://git.openjdk.org/jdk/pull/15755.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15755#issuecomment-1720191227)