### PR TITLE
8316056: Open source several Swing JTree tests

### DIFF
--- a/test/jdk/javax/swing/JTree/bug4210432.java
+++ b/test/jdk/javax/swing/JTree/bug4210432.java
@@ -27,8 +27,6 @@
  * @run main bug4210432
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.swing.JPanel;
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
@@ -37,8 +35,7 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 
 public class bug4210432 {
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JPanel p = new JPanel();
             DefaultMutableTreeNode expansible =

--- a/test/jdk/javax/swing/JTree/bug4210432.java
+++ b/test/jdk/javax/swing/JTree/bug4210432.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4210432
+ * @summary Tests if JTree allows nodes not visible to be selected
+ * @run main bug4210432
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JPanel;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
+
+public class bug4210432 {
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JPanel p = new JPanel();
+            DefaultMutableTreeNode expansible =
+                    new DefaultMutableTreeNode("expansible");
+            DefaultMutableTreeNode unexpansible =
+                    new DefaultMutableTreeNode("unexpansible");
+            DefaultMutableTreeNode root = new DefaultMutableTreeNode("root");
+            DefaultMutableTreeNode subexpansible1 =
+                    new DefaultMutableTreeNode("sub-expansible 1");
+            DefaultMutableTreeNode subexpansible2 =
+                    new DefaultMutableTreeNode("sub-expansible 2");
+            DefaultMutableTreeNode subsubexpansible1 =
+                    new DefaultMutableTreeNode("sub-sub-expansible 1");
+            DefaultMutableTreeNode subsubexpansible2 =
+                    new DefaultMutableTreeNode("sub-sub-expansible 2");
+            expansible.add(subexpansible1);
+            expansible.add(subexpansible2);
+            subexpansible1.add(subsubexpansible1);
+            subexpansible1.add(subsubexpansible2);
+            root.add(expansible);
+            root.add(unexpansible);
+            DefaultTreeModel model = new DefaultTreeModel(root);
+            JTree t = new JTree(model);
+            Object[] tpa = {root, expansible, subexpansible1};
+            Object[] tpa2 = {root, expansible};
+            t.setExpandsSelectedPaths(false);
+            t.setSelectionPath(new TreePath(tpa));
+            p.add(t);
+            if (t.isExpanded(new TreePath(tpa2))) {
+                throw new RuntimeException("Test failed: JTree should not have " +
+                        "expanded path");
+            }
+            t.clearSelection();
+            t.setExpandsSelectedPaths(true);
+            t.setSelectionPath(new TreePath(tpa));
+            if (!t.isExpanded(new TreePath(tpa2))) {
+                throw new RuntimeException("Test failed: JTree should have " +
+                        "expanded path");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JTree/bug4213868.java
+++ b/test/jdk/javax/swing/JTree/bug4213868.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4213868
+ * @summary Tests if AccessibleJTreeNode.getAccessibleIndexInParent() returns
+ * correct value
+ * @run main bug4213868
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.accessibility.AccessibleContext;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+
+public class bug4213868 {
+    public static JTree createTree() {
+        DefaultMutableTreeNode root =
+                new DefaultMutableTreeNode(Integer.valueOf(0), true);
+        JTree tree = new JTree(root);
+        for (int i = 1; i < 10; i++) {
+            root.add(new DefaultMutableTreeNode(Integer.valueOf(i)));
+        }
+        return tree;
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            JTree parent = createTree();
+            AccessibleContext c = parent.getAccessibleContext()
+                    .getAccessibleChild(0).getAccessibleContext();
+            if (c.getAccessibleChild(1).getAccessibleContext()
+                    .getAccessibleIndexInParent() != 1) {
+                throw new RuntimeException("Test failed: " +
+                        "AccessibleJTreeNode.getAccessibleIndexInParent() " +
+                        "returns incorrect value");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JTree/bug4213868.java
+++ b/test/jdk/javax/swing/JTree/bug4213868.java
@@ -28,8 +28,6 @@
  * @run main bug4213868
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.accessibility.AccessibleContext;
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
@@ -38,22 +36,23 @@ import javax.swing.tree.DefaultMutableTreeNode;
 public class bug4213868 {
     public static JTree createTree() {
         DefaultMutableTreeNode root =
-                new DefaultMutableTreeNode(Integer.valueOf(0), true);
+                new DefaultMutableTreeNode(0, true);
         JTree tree = new JTree(root);
         for (int i = 1; i < 10; i++) {
-            root.add(new DefaultMutableTreeNode(Integer.valueOf(i)));
+            root.add(new DefaultMutableTreeNode(i));
         }
         return tree;
     }
 
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             JTree parent = createTree();
             AccessibleContext c = parent.getAccessibleContext()
-                    .getAccessibleChild(0).getAccessibleContext();
-            if (c.getAccessibleChild(1).getAccessibleContext()
-                    .getAccessibleIndexInParent() != 1) {
+                                        .getAccessibleChild(0)
+                                        .getAccessibleContext();
+            if (c.getAccessibleChild(1)
+                 .getAccessibleContext()
+                 .getAccessibleIndexInParent() != 1) {
                 throw new RuntimeException("Test failed: " +
                         "AccessibleJTreeNode.getAccessibleIndexInParent() " +
                         "returns incorrect value");

--- a/test/jdk/javax/swing/JTree/bug4224491.java
+++ b/test/jdk/javax/swing/JTree/bug4224491.java
@@ -28,8 +28,6 @@
  * @run main bug4224491
  */
 
-import java.lang.reflect.InvocationTargetException;
-
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -39,8 +37,7 @@ public class bug4224491 {
     private static boolean modelChanged = false;
     private static boolean invokesStopCellEditingChanged = false;
 
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
             DefaultMutableTreeNode root = new DefaultMutableTreeNode();
             JTree jt = new JTree(new DefaultTreeModel(root));

--- a/test/jdk/javax/swing/JTree/bug4224491.java
+++ b/test/jdk/javax/swing/JTree/bug4224491.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4224491
+ * @summary Tests if JTree's model & invokesStopCellEditing bound properties
+ * are working
+ * @run main bug4224491
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+
+public class bug4224491 {
+    private static boolean modelChanged = false;
+    private static boolean invokesStopCellEditingChanged = false;
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            DefaultMutableTreeNode root = new DefaultMutableTreeNode();
+            JTree jt = new JTree(new DefaultTreeModel(root));
+            jt.addPropertyChangeListener(evt -> {
+                if (evt.getPropertyName().equals("model")) {
+                    modelChanged = true;
+                }
+                if (evt.getPropertyName().equals("invokesStopCellEditing")) {
+                    invokesStopCellEditingChanged = true;
+                }
+            });
+            jt.setModel(new DefaultTreeModel(root));
+            jt.setInvokesStopCellEditing(true);
+            if (!(modelChanged && invokesStopCellEditingChanged)) {
+                throw new RuntimeException("Test failed: JTree's model " +
+                        "& invokesStopCellEditing bound properties " +
+                        "are not working");
+            }
+        });
+    }
+}

--- a/test/jdk/javax/swing/JTree/bug4237370.java
+++ b/test/jdk/javax/swing/JTree/bug4237370.java
@@ -53,7 +53,7 @@ public class bug4237370 {
             }
         }
 
-        public void treeExpanded (TreeExpansionEvent e) {
+        public void treeExpanded(TreeExpansionEvent e) {
             testRowCount();
         }
 

--- a/test/jdk/javax/swing/JTree/bug4237370.java
+++ b/test/jdk/javax/swing/JTree/bug4237370.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4237370
+ * @summary Tests that JTree calls TreeExpansionListener methods
+ *          after it has been updated due to expanded/collapsed event
+ * @run main bug4237370
+ */
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.event.TreeExpansionEvent;
+import javax.swing.event.TreeExpansionListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeModel;
+
+public class bug4237370 {
+    static class TestTree extends JTree implements TreeExpansionListener {
+        int[] testMap = {1, 2};
+        int testIndex = 0;
+
+        private void testRowCount() {
+            int rows = getRowCount();
+            if (rows != testMap[testIndex]) {
+                throw new RuntimeException("Bad row count: reported " + rows +
+                                " instead of " + testMap[testIndex]);
+            } else {
+                testIndex++;
+            }
+        }
+
+        public void treeExpanded (TreeExpansionEvent e) {
+            testRowCount();
+        }
+
+        public void treeCollapsed(TreeExpansionEvent e) {
+            testRowCount();
+        }
+
+        public TestTree() {
+            super((TreeModel)null);
+            DefaultMutableTreeNode top = new DefaultMutableTreeNode("Root");
+            top.add(new DefaultMutableTreeNode("Sub 1"));
+            setModel(new DefaultTreeModel(top));
+            addTreeExpansionListener(this);
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        SwingUtilities.invokeAndWait(() -> {
+            TestTree tree = new TestTree();
+            tree.collapseRow(0);
+            tree.expandRow(0);
+        });
+    }
+}

--- a/test/jdk/javax/swing/JTree/bug4662505.java
+++ b/test/jdk/javax/swing/JTree/bug4662505.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 4662505
+ * @summary IllegalArgumentException with empty JTree and key event
+ * @run main bug4662505
+ */
+
+import java.awt.event.KeyEvent;
+import java.util.Date;
+
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+
+public class bug4662505 {
+    static DummyTree tree;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            tree = new DummyTree();
+
+            try {
+                tree.doTest();
+            } catch (Exception e) {
+                throw new RuntimeException("Empty JTree shouldn't handle " +
+                        "first letter navigation", e);
+            }
+        });
+    }
+
+    static class DummyTree extends JTree {
+        public DummyTree() {
+            super(new Object[]{});
+        }
+
+        public void doTest() {
+            KeyEvent key = new KeyEvent(tree, KeyEvent.KEY_TYPED,
+                    new Date().getTime(), 0, KeyEvent.VK_UNDEFINED, 'a');
+            processKeyEvent(key);
+        }
+    }
+}


### PR DESCRIPTION
These are the tests being converted:

javax/swing/JTree/4210432/bug4210432.java
javax/swing/JTree/4213868/bug4213868.java
javax/swing/JTree/4224491/bug4224491.java
javax/swing/JTree/4237370/bug4237370.java
javax/swing/JTree/4662505/bug4662505.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316056](https://bugs.openjdk.org/browse/JDK-8316056): Open source several Swing JTree tests (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [a9bd7dcc](https://git.openjdk.org/jdk/pull/15756/files/a9bd7dcce39a6cad526806c80f203b0e89e4de0c)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15756/head:pull/15756` \
`$ git checkout pull/15756`

Update a local copy of the PR: \
`$ git checkout pull/15756` \
`$ git pull https://git.openjdk.org/jdk.git pull/15756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15756`

View PR using the GUI difftool: \
`$ git pr show -t 15756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15756.diff">https://git.openjdk.org/jdk/pull/15756.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15756#issuecomment-1720198709)