### PR TITLE
8315960: test/jdk/java/io/File/TempDirDoesNotExist.java leaves test files behind

### DIFF
--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -35,7 +35,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,30 +49,37 @@ public class TempDirDoesNotExist {
 
     private static final String USER_DIR = System.getProperty("user.home");
 
+    //
+    // This class is spawned to test combinations of parameters.
+    //
     public static void main(String... args) throws IOException {
         for (String arg : args) {
-            if (arg.equals("io")) {
-                File file = null;
-                try {
-                    file = File.createTempFile("prefix", ".suffix");
-                } catch (Exception e) {
-                    e.printStackTrace();
-                } finally {
-                    if (file != null && file.exists())
-                        file.delete();
+            switch (arg) {
+                case "io" -> {
+                    File file = null;
+                    try {
+                        file = File.createTempFile("prefix", ".suffix");
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        if (file != null && file.exists())
+                            file.delete();
+                    }
                 }
-            } else if (arg.equals("nio")) {
+                case "nio" -> {
                 Path path = null;
-                try {
-                    path = Files.createTempFile("prefix", ".suffix");
-                } catch (Exception e) {
-                    e.printStackTrace();
-                } finally {
-                    if (path != null)
-                        Files.deleteIfExists(path);
+                    try {
+                        path = Files.createTempFile("prefix", ".suffix");
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    } finally {
+                        if (path != null)
+                            Files.deleteIfExists(path);
+                    }
                 }
-            } else {
-                throw new RuntimeException("unknown case: " + arg);
+                default -> {
+                    throw new RuntimeException("unknown case: " + arg);
+                }
             }
         }
     }
@@ -84,87 +90,60 @@ public class TempDirDoesNotExist {
     }
 
     public static Stream<Arguments> existingProvider() {
-        List<Arguments> list = new ArrayList<Arguments>();
-
-        // invalid custom java.io.tmpdir
-        Arguments args = Arguments.of(0, WARNING,
+        return Stream.of(Arguments.of(0, WARNING,
                                       new String[] {
                                           "-Djava.io.tmpdir=" +
                                           tempDir(),
                                           "TempDirDoesNotExist", "io"
-                                      });
-        list.add(args);
-        args = Arguments.of(0, WARNING,
+                                      }),
+                         Arguments.of(0, WARNING,
                             new String[] {
                                 "-Djava.io.tmpdir=" + tempDir(),
                                 "TempDirDoesNotExist", "nio"
-                            });
-        list.add(args);
-
-        // test with security manager
-        args = Arguments.of(0, WARNING,
+                            }),
+                         Arguments.of(0, WARNING,
                             new String[] {
                                 "-Djava.io.tmpdir=" + tempDir()
                                 + " -Djava.security.manager",
                                 "TempDirDoesNotExist", "io"
-                            });
-        list.add(args);
-        args = Arguments.of(0, WARNING,
+                            }),
+                         Arguments.of(0, WARNING,
                             new String[] {
                                 "-Djava.io.tmpdir=" + tempDir()
                                 + " -Djava.security.manager",
                                 "TempDirDoesNotExist", "nio"
-                            });
-        list.add(args);
-
-        return list.stream();
+                            }));
     }
 
     public static Stream<Arguments> nonexistentProvider() {
-        List<Arguments> list = new ArrayList<Arguments>();
-
-        // standard test with default setting for java.io.tmpdir
-        Arguments args = Arguments.of(0, WARNING,
+        return Stream.of(Arguments.of(0, WARNING,
                                       new String[] {
                                           "TempDirDoesNotExist",
                                           "io"
-                                      });
-        list.add(args);
-        args = Arguments.of(0, WARNING,
-                            new String[] {
-                                "TempDirDoesNotExist", "nio"
-                            });
-        list.add(args);
-
-        // valid custom java.io.tmpdir
-        args = Arguments.of(0, WARNING,
-                            new String[] {
-                                "-Djava.io.tmpdir=" + USER_DIR,
-                                "TempDirDoesNotExist", "io"
-                            });
-        list.add(args);
-        args = Arguments.of(0, WARNING,
-                            new String[] {
-                                "-Djava.io.tmpdir=" + USER_DIR,
-                                "TempDirDoesNotExist", "nio"
-                            });
-        list.add(args);
-
-        return list.stream();
+                                      }),
+                         Arguments.of(0, WARNING,
+                                      new String[] {
+                                          "TempDirDoesNotExist", "nio"
+                                      }),
+                         Arguments.of(0, WARNING,
+                                      new String[] {
+                                          "-Djava.io.tmpdir=" + USER_DIR,
+                                          "TempDirDoesNotExist", "io"
+                                      }),
+                         Arguments.of(0, WARNING,
+                                      new String[] {
+                                          "-Djava.io.tmpdir=" + USER_DIR,
+                                          "TempDirDoesNotExist", "nio"
+                                      }));
     }
 
     public static Stream<Arguments> counterProvider() {
-        List<Arguments> list = new ArrayList<Arguments>();
-
         // standard test with default setting for java.io.tmpdir
-        Arguments args = Arguments.of(0,
+        return Stream.of(Arguments.of(0,
                                       new String[] {
                                           "-Djava.io.tmpdir=" + tempDir(),
                                           "TempDirDoesNotExist", "io", "nio"
-                                      });
-        list.add(args);
-
-        return list.stream();
+                                      }));
     }
 
     @ParameterizedTest

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -99,22 +99,22 @@ public class TempDirDoesNotExist {
                                           "TempDirDoesNotExist", "io"
                                       }),
                          Arguments.of(0, WARNING,
-                            new String[] {
-                                "-Djava.io.tmpdir=" + tempDir(),
-                                "TempDirDoesNotExist", "nio"
-                            }),
+                                      new String[] {
+                                          "-Djava.io.tmpdir=" + tempDir(),
+                                          "TempDirDoesNotExist", "nio"
+                                      }),
                          Arguments.of(0, WARNING,
-                            new String[] {
-                                "-Djava.io.tmpdir=" + tempDir()
-                                + " -Djava.security.manager",
-                                "TempDirDoesNotExist", "io"
-                            }),
+                                      new String[] {
+                                          "-Djava.io.tmpdir=" + tempDir()
+                                          + " -Djava.security.manager",
+                                          "TempDirDoesNotExist", "io"
+                                      }),
                          Arguments.of(0, WARNING,
-                            new String[] {
-                                "-Djava.io.tmpdir=" + tempDir()
-                                + " -Djava.security.manager",
-                                "TempDirDoesNotExist", "nio"
-                            }));
+                                      new String[] {
+                                          "-Djava.io.tmpdir=" + tempDir()
+                                          + " -Djava.security.manager",
+                                          "TempDirDoesNotExist", "nio"
+                                      }));
     }
 
     public static Stream<Arguments> noTempDirSource() {

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@
  * @summary Produce warning when user specified java.io.tmpdir directory doesn't exist
  */
 
-import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -47,16 +47,24 @@ public class TempDirDoesNotExist {
 
         for (String arg : args) {
             if (arg.equals("io")) {
+                File file = null;
                 try {
-                    File.createTempFile("prefix", ".suffix");
+                    file = File.createTempFile("prefix", ".suffix");
                 } catch (Exception e) {
                     e.printStackTrace();
+                } finally {
+                    if (file != null && file.exists())
+                        file.delete();
                 }
             } else if (arg.equals("nio")) {
+                Path path = null;
                 try {
-                    Files.createTempFile("prefix", ".suffix");
+                    path = Files.createTempFile("prefix", ".suffix");
                 } catch (Exception e) {
                     e.printStackTrace();
+                } finally {
+                    if (path != null)
+                        Files.deleteIfExists(path);
                 }
             } else {
                 throw new Exception("unknown case: " + arg);

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TempDirDoesNotExist {
     final static String WARNING = "WARNING: java.io.tmpdir directory does not exist";
@@ -138,14 +139,12 @@ public class TempDirDoesNotExist {
     @MethodSource("counterSource")
     public void messageCounter(List<String> options) throws Exception {
         OutputAnalyzer originalOutput = ProcessTools.executeTestJvm(options);
-        List<String> list = originalOutput.asLines().stream().filter(line
-                -> line.equalsIgnoreCase(WARNING)).toList();
-        if (list.size() != 1)
-            throw new RuntimeException("counter of messages is not one, but " +
-                                       list.size() + "\n" +
-                                       originalOutput.asLines().toString());
+        long count = originalOutput.asLines().stream().filter(
+                line -> line.equalsIgnoreCase(WARNING)).count();
+        assertEquals(1, count,
+                     "counter of messages is not one, but " + count +
+                     "\n" + originalOutput.asLines().toString());
         int exitValue = originalOutput.getExitValue();
-        if (exitValue != 0)
-            throw new RuntimeException("non-zero exit value " + exitValue);
+        assertEquals(0, exitValue);
     }
 }

--- a/test/jdk/java/io/File/TempDirDoesNotExist.java
+++ b/test/jdk/java/io/File/TempDirDoesNotExist.java
@@ -49,9 +49,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class TempDirDoesNotExist {
     final static String WARNING = "WARNING: java.io.tmpdir directory does not exist";
 
-    static String userDir;
-    static String timeStamp;
-    static String tempDir;
+    private static final String USER_DIR = System.getProperty("user.home");
 
     public static void main(String... args) throws IOException {
         for (String arg : args) {
@@ -81,11 +79,9 @@ public class TempDirDoesNotExist {
         }
     }
 
-    @BeforeAll
-    public static void beforeAll() throws IOException {
-        userDir = System.getProperty("user.home");
-        timeStamp = System.currentTimeMillis() + "";
-        tempDir = Path.of(userDir,"non-existing-", timeStamp).toString();
+    private static String tempDir() {
+        String timeStamp = String.valueOf(System.currentTimeMillis());
+        return Path.of(USER_DIR, "non-existing-", timeStamp).toString();
     }
 
     public static Stream<Arguments> existingProvider() {
@@ -95,13 +91,13 @@ public class TempDirDoesNotExist {
         Arguments args = Arguments.of(0, WARNING,
                                       new String[] {
                                           "-Djava.io.tmpdir=" +
-                                          tempDir,
+                                          tempDir(),
                                           "TempDirDoesNotExist", "io"
                                       });
         list.add(args);
         args = Arguments.of(0, WARNING,
                             new String[] {
-                                "-Djava.io.tmpdir=" + tempDir,
+                                "-Djava.io.tmpdir=" + tempDir(),
                                 "TempDirDoesNotExist", "nio"
                             });
         list.add(args);
@@ -109,14 +105,14 @@ public class TempDirDoesNotExist {
         // test with security manager
         args = Arguments.of(0, WARNING,
                             new String[] {
-                                "-Djava.io.tmpdir=" + tempDir
+                                "-Djava.io.tmpdir=" + tempDir()
                                 + " -Djava.security.manager",
                                 "TempDirDoesNotExist", "io"
                             });
         list.add(args);
         args = Arguments.of(0, WARNING,
                             new String[] {
-                                "-Djava.io.tmpdir=" + tempDir
+                                "-Djava.io.tmpdir=" + tempDir()
                                 + " -Djava.security.manager",
                                 "TempDirDoesNotExist", "nio"
                             });
@@ -144,13 +140,13 @@ public class TempDirDoesNotExist {
         // valid custom java.io.tmpdir
         args = Arguments.of(0, WARNING,
                             new String[] {
-                                "-Djava.io.tmpdir=" + userDir,
+                                "-Djava.io.tmpdir=" + USER_DIR,
                                 "TempDirDoesNotExist", "io"
                             });
         list.add(args);
         args = Arguments.of(0, WARNING,
                             new String[] {
-                                "-Djava.io.tmpdir=" + userDir,
+                                "-Djava.io.tmpdir=" + USER_DIR,
                                 "TempDirDoesNotExist", "nio"
                             });
         list.add(args);
@@ -164,7 +160,7 @@ public class TempDirDoesNotExist {
         // standard test with default setting for java.io.tmpdir
         Arguments args = Arguments.of(0,
                                       new String[] {
-                                          "-Djava.io.tmpdir=" + tempDir,
+                                          "-Djava.io.tmpdir=" + tempDir(),
                                           "TempDirDoesNotExist", "io", "nio"
                                       });
         list.add(args);


### PR DESCRIPTION
Add a `finally` block to delete the created files. Convert the test to JUnit 5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315960](https://bugs.openjdk.org/browse/JDK-8315960): test/jdk/java/io/File/TempDirDoesNotExist.java leaves test files behind (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15757/head:pull/15757` \
`$ git checkout pull/15757`

Update a local copy of the PR: \
`$ git checkout pull/15757` \
`$ git pull https://git.openjdk.org/jdk.git pull/15757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15757`

View PR using the GUI difftool: \
`$ git pr show -t 15757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15757.diff">https://git.openjdk.org/jdk/pull/15757.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15757#issuecomment-1720212079)