### PR TITLE
8316326: ProblemList java/awt/Mouse/EnterExitEvents/DragWindowTest.java on macosx-all again

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -175,6 +175,7 @@ java/awt/Mixing/AWT_Mixing/JTextFieldOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonInGlassPaneOverlapping.java 8158801 windows-all
 java/awt/Mixing/AWT_Mixing/JToggleButtonOverlapping.java 8158801 windows-all
 java/awt/Mixing/NonOpaqueInternalFrame.java 7124549 macosx-all
+java/awt/Mouse/EnterExitEvents/DragWindowTest.java 8298823 macosx-all
 java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowRetaining.java 6829264 generic-all
 java/awt/datatransfer/DragImage/MultiResolutionDragImageTest.java 8080982 generic-all
 java/awt/datatransfer/SystemFlavorMap/AddFlavorTest.java 8079268 linux-all


### PR DESCRIPTION
java/awt/Mouse/EnterExitEvents/DragWindowTest.java was de-problemlisted wrongly under https://bugs.openjdk.org/browse/JDK-8315990.
This is creating lot of noise in our CI. Need to problemlist this test again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316326](https://bugs.openjdk.org/browse/JDK-8316326): ProblemList java/awt/Mouse/EnterExitEvents/DragWindowTest.java on macosx-all again (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15758/head:pull/15758` \
`$ git checkout pull/15758`

Update a local copy of the PR: \
`$ git checkout pull/15758` \
`$ git pull https://git.openjdk.org/jdk.git pull/15758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15758`

View PR using the GUI difftool: \
`$ git pr show -t 15758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15758.diff">https://git.openjdk.org/jdk/pull/15758.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15758#issuecomment-1720411183)