### PR TITLE
JDK-8316341: sun/security/pkcs11/PKCS11Test.java needs adjustment on Linux ppc64le Ubuntu 22

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -616,7 +616,10 @@ public abstract class PKCS11Test {
                 "/usr/lib/x86_64-linux-gnu/nss/",
                 "/usr/lib64/"});
         osMap.put("Linux-ppc64-64", new String[]{"/usr/lib64/"});
-        osMap.put("Linux-ppc64le-64", new String[]{"/usr/lib64/"});
+        osMap.put("Linux-ppc64le-64", new String[]{
+                 "/usr/lib/powerpc64le-linux-gnu/",
+                 "/usr/lib/powerpc64le-linux-gnu/nss/",
+                 "/usr/lib64/"});
         osMap.put("Linux-s390x-64", new String[]{"/usr/lib64/"});
         osMap.put("Windows-x86-32", new String[]{});
         osMap.put("Windows-amd64-64", new String[]{});


### PR DESCRIPTION
Currently sun/security/pkcs11/PKCS11Test.java needs adjustment on Linux ppc64le Ubuntu 22, it does not find the NSS libs because the new file system locations are not handled, unlike on Linux x86_64 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316341](https://bugs.openjdk.org/browse/JDK-8316341): sun/security/pkcs11/PKCS11Test.java needs adjustment on Linux ppc64le Ubuntu 22 (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15759/head:pull/15759` \
`$ git checkout pull/15759`

Update a local copy of the PR: \
`$ git checkout pull/15759` \
`$ git pull https://git.openjdk.org/jdk.git pull/15759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15759`

View PR using the GUI difftool: \
`$ git pr show -t 15759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15759.diff">https://git.openjdk.org/jdk/pull/15759.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15759#issuecomment-1720881689)