### PR TITLE
8316357: Serial: Remove unused GenCollectedHeap::space_containing

### DIFF
--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -842,16 +842,6 @@ void GenCollectedHeap::object_iterate(ObjectClosure* cl) {
   _old_gen->object_iterate(cl);
 }
 
-Space* GenCollectedHeap::space_containing(const void* addr) const {
-  Space* res = _young_gen->space_containing(addr);
-  if (res != nullptr) {
-    return res;
-  }
-  res = _old_gen->space_containing(addr);
-  assert(res != nullptr, "Could not find containing space");
-  return res;
-}
-
 HeapWord* GenCollectedHeap::block_start(const void* addr) const {
   assert(is_in_reserved(addr), "block_start of address outside of heap");
   if (_young_gen->is_in_reserved(addr)) {

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -197,7 +197,6 @@ public:
   // Iteration functions.
   void oop_iterate(OopIterateClosure* cl);
   void object_iterate(ObjectClosure* cl) override;
-  Space* space_containing(const void* addr) const;
 
   // A CollectedHeap is divided into a dense sequence of "blocks"; that is,
   // each address in the (reserved) heap is a member of exactly

--- a/src/hotspot/share/gc/shared/generation.cpp
+++ b/src/hotspot/share/gc/shared/generation.cpp
@@ -172,13 +172,6 @@ oop Generation::promote(oop obj, size_t obj_size) {
   return new_obj;
 }
 
-Space* Generation::space_containing(const void* p) const {
-  GenerationIsInReservedClosure blk(p);
-  // Cast away const
-  ((Generation*)this)->space_iterate(&blk);
-  return blk.sp;
-}
-
 // Some of these are mediocre general implementations.  Should be
 // overridden to get better performance.
 

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -176,10 +176,6 @@ class Generation: public CHeapObj<mtGC> {
     return _reserved.contains(p);
   }
 
-  // If some space in the generation contains the given "addr", return a
-  // pointer to that space, else return "null".
-  virtual Space* space_containing(const void* addr) const;
-
   // Iteration - do not use for time critical operations
   virtual void space_iterate(SpaceClosure* blk, bool usedOnly = false) = 0;
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316357](https://bugs.openjdk.org/browse/JDK-8316357): Serial: Remove unused GenCollectedHeap::space_containing (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15760/head:pull/15760` \
`$ git checkout pull/15760`

Update a local copy of the PR: \
`$ git checkout pull/15760` \
`$ git pull https://git.openjdk.org/jdk.git pull/15760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15760`

View PR using the GUI difftool: \
`$ git pr show -t 15760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15760.diff">https://git.openjdk.org/jdk/pull/15760.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15760#issuecomment-1721158912)