### PR TITLE
8316031: SSLFlowDelegate should not log from synchronized block

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/SSLFlowDelegate.java
@@ -971,10 +971,12 @@ public class SSLFlowDelegate {
 
     boolean stopped;
 
-    private synchronized void normalStop() {
-        if (stopped)
-            return;
-        stopped = true;
+    private void normalStop() {
+        synchronized (this) {
+            if (stopped)
+                return;
+            stopped = true;
+        }
         reader.stop();
         writer.stop();
         // make sure the alpnCF is completed.

--- a/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
@@ -54,7 +54,7 @@ import static java.net.http.HttpClient.Version.HTTP_2;
  * @test
  * @summary Tests HttpClient usage when configured with a local address to bind
  *          to, when sending requests
- * @bug 8209137
+ * @bug 8209137 8316031
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  *
  * @build jdk.test.lib.net.SimpleSSLContext jdk.test.lib.net.IPSupport


### PR DESCRIPTION
The java/net/httpclient/HttpClientLocalAddrTest.java has been observed failing relatively frequently in timeout - and the log shows a Carrier thread being pinned.
Whether that's the root cause of the test failure is hard to say, but we should fix the code to avoid pinned threads. This is one path that had escaped my notice when I went through the HttpClient code before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316031](https://bugs.openjdk.org/browse/JDK-8316031): SSLFlowDelegate should not log from synchronized block (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15761/head:pull/15761` \
`$ git checkout pull/15761`

Update a local copy of the PR: \
`$ git checkout pull/15761` \
`$ git pull https://git.openjdk.org/jdk.git pull/15761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15761`

View PR using the GUI difftool: \
`$ git pr show -t 15761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15761.diff">https://git.openjdk.org/jdk/pull/15761.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15761#issuecomment-1721188316)