### PR TITLE
8316105: C2: Back to back Parse Predicates from different loops but with same deopt reason are wrongly grouped together

### DIFF
--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -110,7 +110,7 @@ ParsePredicateNode* ParsePredicateIterator::next() {
 
 #ifdef ASSERT
 // Check that the block has at most one Parse Predicate and that we only find Regular Predicate nodes (i.e. IfProj,
-// If, or RangeCheck nodes.
+// If, or RangeCheck nodes).
 void PredicateBlock::verify_block() {
   Node* next = _parse_predicate.entry(); // Skip unique Parse Predicate of this block if present
   while (next != _entry) {

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -77,7 +77,7 @@ Deoptimization::DeoptReason RuntimePredicate::uncommon_trap_reason(IfProjNode* i
 }
 
 bool RuntimePredicate::is_success_proj(Node* node, Deoptimization::DeoptReason deopt_reason) {
-  if (node->is_IfProj()) {
+  if (node->is_IfProj() && !node->in(0)->is_ParsePredicate()) {
     return deopt_reason == uncommon_trap_reason(node->as_IfProj());
   } else {
     return false;

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -270,11 +270,14 @@ class PredicateBlock : public StackObj {
   Node* _entry;
 
   static Node* skip_regular_predicates(Node* regular_predicate_proj, Deoptimization::DeoptReason deopt_reason);
+  DEBUG_ONLY(void verify_block();)
 
  public:
   PredicateBlock(Node* predicate_proj, Deoptimization::DeoptReason deopt_reason)
       : _parse_predicate(predicate_proj, deopt_reason),
-        _entry(skip_regular_predicates(_parse_predicate.entry(), deopt_reason)) {}
+        _entry(skip_regular_predicates(_parse_predicate.entry(), deopt_reason)) {
+    DEBUG_ONLY(verify_block();)
+  }
 
   // Returns the control input node into this Regular Predicate block. This is either:
   // - The control input to the first If node in the block representing a Runtime Predicate if there is at least one

--- a/test/hotspot/jtreg/compiler/predicates/TestBackToBackParsePredicates.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestBackToBackParsePredicates.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8316105
+ * @library /test/lib
+ * @summary Test that back to back Parse Predicates with same deopt reason are not grouped together
+ * @run main/othervm -Xbatch compiler.predicates.TestBackToBackParsePredicates
+ */
+
+package compiler.predicates;
+
+import jdk.test.lib.Asserts;
+
+public class TestBackToBackParsePredicates {
+    static long lFld;
+
+    public static void main(String[] strArr2) {
+        for (int i = -350; i <= 0; i++) {
+            lFld = 30;
+            test(i);
+            check();
+        }
+        lFld = 30;
+        test(1);
+        check();
+    }
+
+    // Inlined
+    static void foo() {
+        for (int i12 = 1; i12 < 5; i12++) { // Loop A
+            lFld += 1; // StoreL
+        }
+    }
+
+    static void test(int x) {
+        foo();
+
+        // After fully unrolling loop A and after next round of IGVN:
+        // We wrongly treat two back to back Loop Limit Check Parse Predicates as single Predicate Block. We therefore
+        // keep the Loop Parse Predicate of loop A:
+        //
+        // Loop Parse Predicate (of A)
+        // Loop Limit Check Parse Predicate (of A)  |
+        //    -> StoreL of lFld pinned here         | Wrongly treated as single Predicate Block
+        // Loop Limit Check Parse Predicate (of B)  |
+        for (int i = 7; i < 212; i++) { // Loop B
+            for (int j = 1; j < 80; j++) {
+                switch (x % 8) {
+                    case 0:
+                    case 2:
+                        break;
+                    case 6:
+                    case 7:
+                }
+            }
+        }
+    }
+
+    static void check() {
+        Asserts.assertEQ(34L, lFld);
+    }
+}


### PR DESCRIPTION
[JDK-8305636](https://bugs.openjdk.org/browse/JDK-8305636) wrongly refactored the code that groups predicates into Predicate Blocks which leads to a wrong execution when hitting a trap. 

**Background**

In general, when a loop X is folded and its Parse Predicates end up above loop Y, we can reuse the Parse Predicates from loop X to create Runtime Predicates with for loop Y. If such a Runtime Predicate of loop Y is false during runtime, we trap and jump back to the start of the folded loop X above. This is fine because we have not executed any side effects of loop X or between loop X and Y:

- **(i)** There are no other CFG nodes with possible side effects between loop X and Y. Otherwise, the Parse Predicates of loop X are not directly above loop Y and are removed by `eliminate_useless_parse_predicates()`.
- **(ii)** There can be no stores pinned at Parse Predicates (they are not hoisted out of a loop with range checks and invariant checks) except at the last one. This happens, for example, if loop X is fully unrolled and folded away in IGVN. A store is then no longer pinned at the folded `CountedLoopNode` but at the last Parse Predicate of loop X. If there are no other CFG nodes between loop X and Y, then the Parser Predicates from loop X end up just above loop Y. All Runtime Predicates created for loop Y with Parse Predicates from loop X will be executed before the pinned store at the last Parse Predicate (i.e. the loop entry).

**Problem**

In the test case, we have loop A that is fully unrolled and folded. Its Parse Predicates end up above loop B after IGVN. The only difference to the situation with loop X and Y in **(ii)** is that loop B still has a Loop Limit Check Parse Predicate:
![image](https://github.com/openjdk/jdk/assets/17833009/3089c174-0fb5-4154-b665-b57a5e6f0cb8)

- `40 Parse Predicate` and `51 Parse Predicate` are from loop A with the pinned `80 StoreL` from within the loop body of A (i.e. `lFld`).
- `107 Parse Predicate` is from loop B.

When eliminating useless Parse Predicates, we should remove the Parse Predicates of loop A, because **(i)** is violated: We have a CFG node (e.g. `107 Parse Predicate`). between the loop B and the Parse Predicates of loop A. This, however, does not happen due to a bug: We wrongly group the back to back Loop Limit Check Parse Predicates `107 Parse Predicate` and `51 Parse Predicate` together as single Predicate Block. As a result, we keep `51 Parse Predicate` and `40 Parse Predicate`.

**Manifestation of the Bug**

Keeping the Parse Predicates of loop A for now is not a problem, yet, in the test case. Even if we created a Runtime Predicate with `40 Parse Predicate` that traps at runtime, `80 StoreL` would not have been executed, yet.

The problem happens when unswitching loop B. We clone `40 Parse Predicate` to the slow (i.e. `403 Parse Predicate`) and fast loop (i.e. `400 Parse Predicate`) and kill the old Parse Predicates above the `If` that selects either the slow or fast loop (we don't clone Loop Limit Check Parse Predicates for counted loops because they will not be used anymore at this point).`80 StoreL` then ends up at `5 Parm`. This would still not result in a problem at runtime, yet. But now we additionally create a Hoisted Check Predicate `411 If` for an invariant check above the fast loop. We get the following graph:
![image](https://github.com/openjdk/jdk/assets/17833009/d83a4abe-1940-4a12-8cc2-d7da1065eed9)

At runtime, we execute `80 StoreL`, then hit the trap of `411 If`, jump back to the beginning of loop A and re-execute the store to `lFld`. We therefore observe a wrong value for `lFld` because we executed the store twice.

**Previous Fix for Known Loop Unswitching Problem Does not Apply here**

There is logic introduced by [JDK-8235984](https://bugs.openjdk.org/browse/JDK-8235984) which prevents loop unswitching completely if there are pinned nodes at the last Parse Predicate because we could end up executing such a pinned store before trapping with a Runtime Predicate:
https://github.com/openjdk/jdk/blob/3c743cfea00692d0b938cb1cbde936084eecf369/src/hotspot/share/opto/loopUnswitch.cpp#L206-L215

But since we can normally only have pinned stores at the last Parse Predicate, we do not bail out of loop unswitching (the pin is at the second last Parse Predicate) and we end up with the described wrong execution.

**Fix**

This all comes down to wrongly grouping the back to back Loop Limit Check Parse Predicates together which prevents the elimination of the Parse Predicates of loop A. The actual problem introduced with JDK-8305636 is that a Parse Predicate is wrongly detected as a Runtime Predicate. The fix is straight forward to exclude that case.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316105](https://bugs.openjdk.org/browse/JDK-8316105): C2: Back to back Parse Predicates from different loops but with same deopt reason are wrongly grouped together (**Bug** - P3)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [84cc0d5e](https://git.openjdk.org/jdk/pull/15764/files/84cc0d5ea07cdfaf8fa102e2f68661572e65779a)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [84cc0d5e](https://git.openjdk.org/jdk/pull/15764/files/84cc0d5ea07cdfaf8fa102e2f68661572e65779a)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15764/head:pull/15764` \
`$ git checkout pull/15764`

Update a local copy of the PR: \
`$ git checkout pull/15764` \
`$ git pull https://git.openjdk.org/jdk.git pull/15764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15764`

View PR using the GUI difftool: \
`$ git pr show -t 15764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15764.diff">https://git.openjdk.org/jdk/pull/15764.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15764#issuecomment-1721417968)