### PR TITLE
8315588: JShell does not accept underscore from JEP 443 even with --enable-preview

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
@@ -190,7 +190,7 @@ class CompletenessAnalyzer {
         EOF(TokenKind.EOF, 0),  //
         ERROR(TokenKind.ERROR, XERRO),  //
         IDENTIFIER(TokenKind.IDENTIFIER, XEXPR1|XDECL1|XTERM),  //
-        UNDERSCORE(TokenKind.UNDERSCORE, XERRO),  //  _
+        UNDERSCORE(TokenKind.UNDERSCORE, XDECL1),  //  _
         CLASS(TokenKind.CLASS, XEXPR|XDECL1|XBRACESNEEDED),  //  class decl (MAPPED: DOTCLASS)
         MONKEYS_AT(TokenKind.MONKEYS_AT, XEXPR|XDECL1),  //  @
         IMPORT(TokenKind.IMPORT, XDECL1|XSTART),  //  import -- consider declaration


### PR DESCRIPTION
The current status is that we get an `UNKNOWN` status for those incomplete snippets that involve underscore declaring local variables or patterns. Those should have been classified as `DEFINITELY_INCOMPLETE`. This process takes place in `SourceCodeAnalysisImpl` and `CompletenessAnalyzer` and the processing that takes place regarded `_` as a location of kind `XERR0`. It would be correct now to classify it with `XDECL1`”.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315588](https://bugs.openjdk.org/browse/JDK-8315588): JShell does not accept underscore from JEP 443 even with --enable-preview (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15765/head:pull/15765` \
`$ git checkout pull/15765`

Update a local copy of the PR: \
`$ git checkout pull/15765` \
`$ git pull https://git.openjdk.org/jdk.git pull/15765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15765`

View PR using the GUI difftool: \
`$ git pr show -t 15765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15765.diff">https://git.openjdk.org/jdk/pull/15765.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15765#issuecomment-1721493807)