### PR TITLE
8314909: tools/jpackage/windows/Win8282351Test.java fails with java.lang.AssertionError: Expected [0]. Actual [1618]:

### DIFF
--- a/test/jdk/tools/jpackage/TEST.properties
+++ b/test/jdk/tools/jpackage/TEST.properties
@@ -1,3 +1,12 @@
 keys=jpackagePlatformPackage
 requires.properties=jpackage.test.SQETest
 maxOutputSize=2000000
+
+# Run jpackage tests on windows platform sequentially.
+# Having "share" directory in the list affects tests on other platforms.
+# The better option would be:
+#   if (platfrom == windowws) {
+#     exclusiveAccess.dirs=share windows
+#   }
+# but conditionals are not supported by jtreg configuration files.
+exclusiveAccess.dirs=share windows


### PR DESCRIPTION
Run jpackage jtreg tests on Windows sequentially. Asynch execution of `msiexec.exe` that unpacks msi files doesn't work well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314909](https://bugs.openjdk.org/browse/JDK-8314909): tools/jpackage/windows/Win8282351Test.java fails with java.lang.AssertionError: Expected [0]. Actual [1618]: (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15766/head:pull/15766` \
`$ git checkout pull/15766`

Update a local copy of the PR: \
`$ git checkout pull/15766` \
`$ git pull https://git.openjdk.org/jdk.git pull/15766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15766`

View PR using the GUI difftool: \
`$ git pr show -t 15766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15766.diff">https://git.openjdk.org/jdk/pull/15766.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15766#issuecomment-1721496277)