### PR TITLE
8316387: Exclude more failing multicast tests on AIX after JDK-8315651

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -535,15 +535,21 @@ javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java 
 
 # jdk_net
 
-java/net/MulticastSocket/NoLoopbackPackets.java                 7122846,8308807 macosx-all,aix-ppc64
-java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 macosx-all,aix-ppc64
+java/net/DatagramSocket/DatagramSocketExample.java              8308807 aix-ppc64
+java/net/DatagramSocket/DatagramSocketMulticasting.java         8308807 aix-ppc64
 
+java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
+java/net/MulticastSocket/IPMulticastIF.java                     8308807 aix-ppc64
+java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc64
+java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc64
+java/net/MulticastSocket/NoLoopbackPackets.java                 7122846,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
+java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
+java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 macosx-all,aix-ppc64
+java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
-
-java/net/MulticastSocket/B6427403.java                          8308807 aix-ppc64
-java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 
 ############################################################################
 
@@ -551,10 +557,9 @@ java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc6
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
+java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
-
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64
-
 java/nio/channels/DatagramChannel/Unref.java                    8233437 generic-all
 
 java/nio/file/Path/ToRealPath.java                              8315273 windows-all


### PR DESCRIPTION
[JDK-8315651](https://bugs.openjdk.org/browse/JDK-8315651) has removed a facility to hide errors of the type that is described in [JDK-8308807](https://bugs.openjdk.org/browse/JDK-8308807) from the test scaffolding.

Now we see more multicast tests failing on AIX and we should exclude them with reference to [JDK-8308807](https://bugs.openjdk.org/browse/JDK-8308807).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316387](https://bugs.openjdk.org/browse/JDK-8316387): Exclude more failing multicast tests on AIX after JDK-8315651 (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15770/head:pull/15770` \
`$ git checkout pull/15770`

Update a local copy of the PR: \
`$ git checkout pull/15770` \
`$ git pull https://git.openjdk.org/jdk.git pull/15770/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15770`

View PR using the GUI difftool: \
`$ git pr show -t 15770`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15770.diff">https://git.openjdk.org/jdk/pull/15770.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15770#issuecomment-1721896947)