### PR TITLE
8314829: serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java ignores vm flags

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -30,6 +30,7 @@
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8276539   generic-all
 serviceability/sa/CDSJMapClstats.java                         8276539   generic-all
 serviceability/sa/ClhsdbJhisto.java                           8276539   generic-all
+serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java      8276539   generic-all
 
 serviceability/sa/ClhsdbFindPC.java#xcomp-core                8284045   generic-all
 serviceability/sa/TestJmapCore.java                           8268283,8270202   linux-aarch64,linux-x64,macosx-aarch64

--- a/test/hotspot/jtreg/serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java
+++ b/test/hotspot/jtreg/serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class JMapHProfLargeHeapTest {
     private static void testHProfFileFormat(String vmArgs, long heapSize,
             String expectedFormat) throws Exception, IOException,
             InterruptedException, FileNotFoundException {
-        ProcessBuilder procBuilder = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder procBuilder = ProcessTools.createTestJvm(
                 "--add-exports=java.management/sun.management=ALL-UNNAMED", vmArgs, "JMapHProfLargeHeapProc", String.valueOf(heapSize));
         procBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
         Process largeHeapProc = procBuilder.start();


### PR DESCRIPTION
The test is updated to start the target VM with tested flags additionally to heap size.