### PR TITLE
Optimization of String.format

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/StringFormat.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringFormat.java
@@ -49,8 +49,18 @@ public class StringFormat {
     public int i = 17;
 
     @Benchmark
+    public String intFormat() {
+        return "%d".formatted(i);
+    }
+
+    @Benchmark
     public String int02Format() {
         return "%02d".formatted(i);
+    }
+
+    @Benchmark
+    public String longFormat() {
+        return "%d".formatted((long) i);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/StringFormat.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringFormat.java
@@ -49,6 +49,11 @@ public class StringFormat {
     public int i = 17;
 
     @Benchmark
+    public String int02Format() {
+        return "%02d".formatted(i);
+    }
+
+    @Benchmark
     public String stringFormat() {
         return "%s".formatted(s);
     }


### PR DESCRIPTION
@cl4es made performance optimizations for the simple specifiers of String.format in PR #2830. Based on the same idea, I continued to make improvements. I made patterns like %2d %02d also be optimized.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15774/head:pull/15774` \
`$ git checkout pull/15774`

Update a local copy of the PR: \
`$ git checkout pull/15774` \
`$ git pull https://git.openjdk.org/jdk.git pull/15774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15774`

View PR using the GUI difftool: \
`$ git pr show -t 15774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15774.diff">https://git.openjdk.org/jdk/pull/15774.diff</a>

</details>
