### PR TITLE
8316399: Exclude java/net/MulticastSocket/Promiscuous.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -544,6 +544,7 @@ java/net/MulticastSocket/JoinLeave.java                         8308807 aix-ppc6
 java/net/MulticastSocket/MulticastAddresses.java                8308807 aix-ppc64
 java/net/MulticastSocket/NoLoopbackPackets.java                 7122846,8308807 macosx-all,aix-ppc64
 java/net/MulticastSocket/NoSetNetworkInterface.java             8308807 aix-ppc64
+java/net/MulticastSocket/Promiscuous.java                       8308807 aix-ppc64
 java/net/MulticastSocket/SetGetNetworkInterfaceTest.java        8308807 aix-ppc64
 java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 macosx-all,aix-ppc64
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64


### PR DESCRIPTION
Test java/net/MulticastSocket/Promiscuous.java shows the symptoms of [JDK-8308807](https://bugs.openjdk.org/browse/JDK-8308807) as well and was forgotten to be excluded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316399](https://bugs.openjdk.org/browse/JDK-8316399): Exclude java/net/MulticastSocket/Promiscuous.java on AIX (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15777/head:pull/15777` \
`$ git checkout pull/15777`

Update a local copy of the PR: \
`$ git checkout pull/15777` \
`$ git pull https://git.openjdk.org/jdk.git pull/15777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15777`

View PR using the GUI difftool: \
`$ git pr show -t 15777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15777.diff">https://git.openjdk.org/jdk/pull/15777.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15777#issuecomment-1722580550)