### PR TITLE
8316400: Exclude jdk/jfr/event/runtime/TestResidentSetSizeEvent.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -747,6 +747,7 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 # jdk_jfr
 
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-all
+jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all


### PR DESCRIPTION
While folks are working on finding a solution for test jdk/jfr/event/runtime/TestResidentSetSizeEvent.java on AIX, it should be excluded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316400](https://bugs.openjdk.org/browse/JDK-8316400): Exclude jdk/jfr/event/runtime/TestResidentSetSizeEvent.java on AIX (**Sub-task** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15778/head:pull/15778` \
`$ git checkout pull/15778`

Update a local copy of the PR: \
`$ git checkout pull/15778` \
`$ git pull https://git.openjdk.org/jdk.git pull/15778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15778`

View PR using the GUI difftool: \
`$ git pr show -t 15778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15778.diff">https://git.openjdk.org/jdk/pull/15778.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15778#issuecomment-1722584196)