### PR TITLE
8316417: ObjectMonitorIterator does not return the most recent monitor and is incorrect if no monitors exists

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectSynchronizer.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ObjectSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,8 +43,12 @@ public class ObjectSynchronizer {
   }
 
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
-    Type type = db.lookupType("ObjectSynchronizer");
-    inUseList = type.getAddressField("_in_use_list").getValue();
+    Type objectSynchronizerType = db.lookupType("ObjectSynchronizer");
+    Type monitorListType = db.lookupType("MonitorList");
+    // Static fields will be left in the default initialized state if the lookup fails
+    Address monitorListAddr = objectSynchronizerType.getField("_in_use_list").getStaticFieldAddress();
+    inUseListHead = monitorListType.getAddressField("_head").getAddress(monitorListAddr);
+    isSupported = true;
   }
 
   public long identityHashValueFor(Oop obj) {
@@ -70,7 +74,7 @@ public class ObjectSynchronizer {
   }
 
   public static Iterator objectMonitorIterator() {
-    if (inUseList != null) {
+    if (isSupported) {
       return new ObjectMonitorIterator();
     } else {
       return null;
@@ -83,21 +87,23 @@ public class ObjectSynchronizer {
     // are not returned by this Iterator.
 
     ObjectMonitorIterator() {
-      mon = new ObjectMonitor(inUseList);
+      mon = inUseListHead == null ? null : new ObjectMonitor(inUseListHead);
     }
 
     public boolean hasNext() {
-      return (mon.nextOM() != null);
+      return (mon != null);
     }
 
     public Object next() {
-      // advance to next entry
-      Address monAddr = mon.nextOM();
-      if (monAddr == null) {
+      ObjectMonitor ret = mon;
+      if (ret == null) {
         throw new NoSuchElementException();
       }
-      mon = new ObjectMonitor(monAddr);
-      return mon;
+      // advance to next entry
+      Address nextMon = mon.nextOM();
+      mon = nextMon == null ? null : new ObjectMonitor(nextMon);
+
+      return ret;
     }
 
     public void remove() {
@@ -107,6 +113,7 @@ public class ObjectSynchronizer {
     private ObjectMonitor mon;
   }
 
-  private static Address inUseList;
+  private static Address inUseListHead;
+  private static boolean isSupported;
 
 }

--- a/test/hotspot/jtreg/serviceability/sa/TestObjectMonitorIterate.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestObjectMonitorIterate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -82,6 +82,7 @@ public class TestObjectMonitorIterate {
              Long.toString(lingeredAppPid));
         SATestUtils.addPrivilegesIfNeeded(processBuilder);
         OutputAnalyzer SAOutput = ProcessTools.executeProcess(processBuilder);
+        SAOutput.shouldContain("SteadyStateLock");
         SAOutput.shouldHaveExitValue(0);
         System.out.println(SAOutput.getOutput());
     }

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -587,6 +587,7 @@ public class LingeredApp {
         }
     }
 
+    static class SteadyStateLock {};
 
     /**
      * This part is the application itself. First arg is optional "forceCrash".
@@ -616,7 +617,7 @@ public class LingeredApp {
         Path path = Paths.get(theLockFileName);
 
         try {
-            Object steadyStateObj = new Object();
+            Object steadyStateObj = new SteadyStateLock();
             synchronized(steadyStateObj) {
                 startSteadyStateThread(steadyStateObj);
                 if (forceCrash) {


### PR DESCRIPTION
ObjectMonitorIterator fails to return the most resent monitor added. It start with returning the `nextOM()` ObjectMonitor from the `_head` ObjectMonitor but fails to ever return the `_head` ObjectMonitor.
The current implementation can also not handle that the `_head` is nullptr (no monitors in the system) and returns a null ObjectMonitorIterator. Which is interpreted as `monitor list not supported, too old hotspot VM`.

Changed the iterator to keep return the current monitor (starts with `_head`) and decoupled `_head == nullptr` from the question if ObjectMonitorIterator is supported. 

Testing:
  * Passes all `serviceability/sa` tests
  * Currently running tier 1-3
  * Currently running GHA