### PR TITLE
JDK-8316411: compiler/compilercontrol/TestConflictInlineCommands.java fails intermittent with force inline by CompileCommand missing

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
@@ -52,6 +52,7 @@ public class TestConflictInlineCommands {
         analyzer.shouldNotContain("force inline by CompileCommand");
 
         pb = ProcessTools.createJavaProcessBuilder(
+                "-Xbatch",
                 "-XX:CompileCommand=dontinline,*TestConflictInlineCommands::*caller",
                 "-XX:CompileCommand=inline,*TestConflictInlineCommands::caller",
                 "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*Launcher::main",
@@ -77,6 +78,9 @@ public class TestConflictInlineCommands {
                     sum += caller(i, 0);
                 }
             }
+            System.out.println("sum is:" + sum);
+            System.out.flush();
+            System.err.flush();
         }
     }
 }


### PR DESCRIPTION
We run sometimes into this error (especially on some virtualized windows machines) :

java.lang.RuntimeException: 'force inline by CompileCommand' missing from stdout/stderr
at jdk.test.lib.process.OutputAnalyzer.shouldContain(OutputAnalyzer.java:221)
at compiler.compilercontrol.TestConflictInlineCommands.main(TestConflictInlineCommands.java:63)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
at java.base/java.lang.Thread.run(Thread.java:1570)

Maybe we do not reach the "force inline" action of the JIT so the output is missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316411](https://bugs.openjdk.org/browse/JDK-8316411): compiler/compilercontrol/TestConflictInlineCommands.java fails intermittent with force inline by CompileCommand missing (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15783/head:pull/15783` \
`$ git checkout pull/15783`

Update a local copy of the PR: \
`$ git checkout pull/15783` \
`$ git pull https://git.openjdk.org/jdk.git pull/15783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15783`

View PR using the GUI difftool: \
`$ git pr show -t 15783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15783.diff">https://git.openjdk.org/jdk/pull/15783.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15783#issuecomment-1723167858)