### PR TITLE
8316420: Serial: Remove unused GenCollectedHeap::oop_iterate

### DIFF
--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -832,11 +832,6 @@ bool GenCollectedHeap::is_in_partial_collection(const void* p) {
 }
 #endif
 
-void GenCollectedHeap::oop_iterate(OopIterateClosure* cl) {
-  _young_gen->oop_iterate(cl);
-  _old_gen->oop_iterate(cl);
-}
-
 void GenCollectedHeap::object_iterate(ObjectClosure* cl) {
   _young_gen->object_iterate(cl);
   _old_gen->object_iterate(cl);

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -195,7 +195,6 @@ public:
   void prune_scavengable_nmethods();
 
   // Iteration functions.
-  void oop_iterate(OopIterateClosure* cl);
   void object_iterate(ObjectClosure* cl) override;
 
   // A CollectedHeap is divided into a dense sequence of "blocks"; that is,

--- a/src/hotspot/share/gc/shared/generation.cpp
+++ b/src/hotspot/share/gc/shared/generation.cpp
@@ -233,21 +233,6 @@ bool Generation::block_is_obj(const HeapWord* p) const {
   return blk.is_obj;
 }
 
-class GenerationOopIterateClosure : public SpaceClosure {
- public:
-  OopIterateClosure* _cl;
-  virtual void do_space(Space* s) {
-    s->oop_iterate(_cl);
-  }
-  GenerationOopIterateClosure(OopIterateClosure* cl) :
-    _cl(cl) {}
-};
-
-void Generation::oop_iterate(OopIterateClosure* cl) {
-  GenerationOopIterateClosure blk(cl);
-  space_iterate(&blk);
-}
-
 class GenerationObjIterateClosure : public SpaceClosure {
  private:
   ObjectClosure* _cl;

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -322,10 +322,6 @@ class Generation: public CHeapObj<mtGC> {
 
   // Iteration.
 
-  // Iterate over all the ref-containing fields of all objects in the
-  // generation, calling "cl.do_oop" on each.
-  virtual void oop_iterate(OopIterateClosure* cl);
-
   // Iterate over all objects in the generation, calling "cl.do_object" on
   // each.
   virtual void object_iterate(ObjectClosure* cl);

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -518,24 +518,9 @@ void ContiguousSpace::verify() const {
   }
 }
 
-void Space::oop_iterate(OopIterateClosure* blk) {
-  ObjectToOopClosure blk2(blk);
-  object_iterate(&blk2);
-}
-
 bool Space::obj_is_alive(const HeapWord* p) const {
   assert (block_is_obj(p), "The address should point to an object");
   return true;
-}
-
-void ContiguousSpace::oop_iterate(OopIterateClosure* blk) {
-  if (is_empty()) return;
-  HeapWord* obj_addr = bottom();
-  HeapWord* t = top();
-  // Could call objects iterate, but this is easier.
-  while (obj_addr < t) {
-    obj_addr += cast_to_oop(obj_addr)->oop_iterate_size(blk);
-  }
 }
 
 void ContiguousSpace::object_iterate(ObjectClosure* blk) {

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -163,11 +163,6 @@ class Space: public CHeapObj<mtGC> {
   virtual size_t used() const = 0;
   virtual size_t free() const = 0;
 
-  // Iterate over all the ref-containing fields of all objects in the
-  // space, calling "cl.do_oop" on each.  Fields in objects allocated by
-  // applications of the closure are not included in the iteration.
-  virtual void oop_iterate(OopIterateClosure* cl);
-
   // Iterate over all objects in the space, calling "cl.do_object" on
   // each.  Objects allocated by applications of the closure are not
   // included in the iteration.
@@ -443,8 +438,6 @@ private:
   HeapWord* allocate(size_t word_size) override;
   HeapWord* par_allocate(size_t word_size) override;
 
-  // Iteration
-  void oop_iterate(OopIterateClosure* cl) override;
   void object_iterate(ObjectClosure* blk) override;
 
   // Compaction support

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -438,6 +438,7 @@ private:
   HeapWord* allocate(size_t word_size) override;
   HeapWord* par_allocate(size_t word_size) override;
 
+  // Iteration
   void object_iterate(ObjectClosure* blk) override;
 
   // Compaction support


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316420](https://bugs.openjdk.org/browse/JDK-8316420): Serial: Remove unused GenCollectedHeap::oop_iterate (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [8da225cb](https://git.openjdk.org/jdk/pull/15785/files/8da225cb97f601e7c1d2ecd1dfdbc40bcea994ff)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15785/head:pull/15785` \
`$ git checkout pull/15785`

Update a local copy of the PR: \
`$ git checkout pull/15785` \
`$ git pull https://git.openjdk.org/jdk.git pull/15785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15785`

View PR using the GUI difftool: \
`$ git pr show -t 15785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15785.diff">https://git.openjdk.org/jdk/pull/15785.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15785#issuecomment-1723251191)