### PR TITLE
8316098: Revise signature of numa_get_leaf_groups

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1911,7 +1911,7 @@ int os::numa_get_group_id() {
   return 0;
 }
 
-size_t os::numa_get_leaf_groups(int *ids, size_t size) {
+size_t os::numa_get_leaf_groups(uint *ids, size_t size) {
   if (size > 0) {
     ids[0] = 0;
     return 1;

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1627,7 +1627,7 @@ int os::numa_get_group_id() {
   return 0;
 }
 
-size_t os::numa_get_leaf_groups(int *ids, size_t size) {
+size_t os::numa_get_leaf_groups(uint *ids, size_t size) {
   if (size > 0) {
     ids[0] = 0;
     return 1;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2958,7 +2958,7 @@ int os::Linux::get_existing_num_nodes() {
   return num_nodes;
 }
 
-size_t os::numa_get_leaf_groups(int *ids, size_t size) {
+size_t os::numa_get_leaf_groups(uint *ids, size_t size) {
   int highest_node_number = Linux::numa_max_node();
   size_t i = 0;
 
@@ -2967,8 +2967,8 @@ size_t os::numa_get_leaf_groups(int *ids, size_t size) {
   // node number. If the nodes have been bound explicitly using numactl membind,
   // then allocate memory from those nodes only.
   for (int node = 0; node <= highest_node_number; node++) {
-    if (Linux::is_node_in_bound_nodes((unsigned int)node)) {
-      ids[i++] = node;
+    if (Linux::is_node_in_bound_nodes(node)) {
+      ids[i++] = checked_cast<uint>(node);
     }
   }
   return i;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3825,7 +3825,7 @@ void os::numa_make_local(char *addr, size_t bytes, int lgrp_hint)    { }
 bool os::numa_topology_changed()                       { return false; }
 size_t os::numa_get_groups_num()                       { return MAX2(numa_node_list_holder.get_count(), 1); }
 int os::numa_get_group_id()                            { return 0; }
-size_t os::numa_get_leaf_groups(int *ids, size_t size) {
+size_t os::numa_get_leaf_groups(uint *ids, size_t size) {
   if (numa_node_list_holder.get_count() == 0 && size > 0) {
     // Provide an answer for UMA systems
     ids[0] = 0;
@@ -3834,7 +3834,8 @@ size_t os::numa_get_leaf_groups(int *ids, size_t size) {
     // check for size bigger than actual groups_num
     size = MIN2(size, numa_get_groups_num());
     for (int i = 0; i < (int)size; i++) {
-      ids[i] = numa_node_list_holder.get_node_list_entry(i);
+      int node_id = numa_node_list_holder.get_node_list_entry(i);
+      ids[i] = checked_cast<uint>(node_id);
     }
     return size;
   }

--- a/src/hotspot/share/gc/g1/g1NUMA.cpp
+++ b/src/hotspot/share/gc/g1/g1NUMA.cpp
@@ -98,7 +98,7 @@ void G1NUMA::initialize(bool use_numa) {
 
   // Create an array of active node ids.
   _node_ids = NEW_C_HEAP_ARRAY(uint, num_node_ids, mtGC);
-  _num_active_node_ids = checked_cast<uint>(os::numa_get_leaf_groups(reinterpret_cast<int*>(_node_ids), num_node_ids));
+  _num_active_node_ids = checked_cast<uint>(os::numa_get_leaf_groups(_node_ids, num_node_ids));
 
   uint max_node_id = 0;
   for (uint i = 0; i < _num_active_node_ids; i++) {

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -55,7 +55,7 @@ MutableNUMASpace::MutableNUMASpace(size_t alignment) : MutableSpace(alignment), 
 
   size_t lgrp_limit = os::numa_get_groups_num();
   uint *lgrp_ids = NEW_C_HEAP_ARRAY(uint, lgrp_limit, mtGC);
-  size_t lgrp_num = os::numa_get_leaf_groups(reinterpret_cast<int*>(lgrp_ids), lgrp_limit);
+  size_t lgrp_num = os::numa_get_leaf_groups(lgrp_ids, lgrp_limit);
   assert(lgrp_num > 0, "There should be at least one locality group");
 
   lgrp_spaces()->reserve(checked_cast<int>(lgrp_num));

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -512,7 +512,7 @@ class os: AllStatic {
   static void   numa_make_local(char *addr, size_t bytes, int lgrp_hint);
   static void   numa_make_global(char *addr, size_t bytes);
   static size_t numa_get_groups_num();
-  static size_t numa_get_leaf_groups(int *ids, size_t size);
+  static size_t numa_get_leaf_groups(uint *ids, size_t size);
   static bool   numa_topology_changed();
   static int    numa_get_group_id();
   static int    numa_get_group_id_for_address(const void* address);


### PR DESCRIPTION
Simple refactoring to better reflect NUMA node id is non-negative using unsigned type.

More cleanup can possibly be done to avoid the use of `checked_cast` in `os_windows.cpp`, but since the NUMA code in Windows is unreachable (JDK-8244065), I went to for the smallest diff there in order to avoid adding more untested code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316098](https://bugs.openjdk.org/browse/JDK-8316098): Revise signature of numa_get_leaf_groups (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15786/head:pull/15786` \
`$ git checkout pull/15786`

Update a local copy of the PR: \
`$ git checkout pull/15786` \
`$ git pull https://git.openjdk.org/jdk.git pull/15786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15786`

View PR using the GUI difftool: \
`$ git pr show -t 15786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15786.diff">https://git.openjdk.org/jdk/pull/15786.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15786#issuecomment-1723312310)