### PR TITLE
8315692: Parallelize gc/stress/TestStressRSetCoarsening.java test

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressRSetCoarsening.java
@@ -27,14 +27,13 @@ import java.util.concurrent.TimeoutException;
 import jdk.test.whitebox.WhiteBox;
 
 /*
- * @test TestStressRSetCoarsening.java
+ * @test
  * @key stress
  * @bug 8146984 8147087
+ * @summary Stress G1 Remembered Set by creating a lot of cross region links
  * @requires vm.gc.G1
  * @requires os.maxMemory > 3G
  * @requires vm.opt.MaxGCPauseMillis == "null"
- *
- * @summary Stress G1 Remembered Set by creating a lot of cross region links
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
@@ -43,22 +42,77 @@ import jdk.test.whitebox.WhiteBox;
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
  *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  1  0 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
  *     -Xmx500m -XX:G1HeapRegionSize=8m gc.stress.TestStressRSetCoarsening  1 10 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
  *     -Xmx500m -XX:G1HeapRegionSize=32m gc.stress.TestStressRSetCoarsening 42 10 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
  *     -Xmx500m -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening  2 0 300
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000
  *     -Xmx1G -XX:G1HeapRegionSize=1m gc.stress.TestStressRSetCoarsening 500 0  1800
+ */
+
+/*
+ * @test
+ * @requires vm.gc.G1
+ * @requires os.maxMemory > 3G
+ * @requires vm.opt.MaxGCPauseMillis == "null"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=1800
  *     -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:+UseG1GC -Xlog:gc* -XX:MaxGCPauseMillis=1000


### PR DESCRIPTION
Looking at tier4 tests, gc/stress tests take lots of time per test. For example TestStressRSetCoarsening takes about 33 minutes to runin fastdebug mode in macos arm cpu. This limits effective parallelism of tier4 testing on large machines. We can parallelize its `@run` configs to improve effective parallelism for tier4. Below are some of the observation from before any change, partial parallelization and full parallelization:

* before_release                        : **585.70s user 23.80s system 106% cpu 9:32.16 total**
* before_fastdebug                   : **2033.77s user 30.04s system 105% cpu 32:43.10 total**
* fully-parallelized_fastdebug  : **2246.94s user 36.97s system 135% cpu 28:07.24 total**
* fully-parallelized_release       : **463.52s user 31.54s system 234% cpu 3:31.19 total**
* partially-parallelized_release : **461.15s user 20.88s system 257% cpu 3:06.91 total**

Even though partial parallelization shows better results it has anomaly 33%-50% of the time where the run results are same as before_release. I have runn each of the above combinations multiple times to establish a consistency and fully parallel gives us the most benefit in terms of total time without deviating too much on user and system times.