### PR TITLE
8316421: libjava should load shell32.dll eagerly

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -64,7 +64,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
     LDFLAGS_macosx := -L$(SUPPORT_OUTPUTDIR)/native/$(MODULE)/, \
-    LDFLAGS_windows := -delayload:shell32.dll, \
     LIBS_unix := -ljvm, \
     LIBS_linux := $(LIBDL), \
     LIBS_aix := $(LIBDL) $(LIBM),\
@@ -72,7 +71,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
         -framework Foundation \
         -framework SystemConfiguration, \
     LIBS_windows := jvm.lib \
-        shell32.lib delayimp.lib \
+        shell32.lib \
         advapi32.lib version.lib, \
 ))
 

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -71,7 +71,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
         -framework Foundation \
         -framework SystemConfiguration, \
     LIBS_windows := jvm.lib \
-        shell32.lib \
+        shell32.lib ole32.lib \
         advapi32.lib version.lib, \
 ))
 

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -40,10 +40,6 @@
 #include "locale_str.h"
 #include "java_props.h"
 
-#ifndef VER_PLATFORM_WIN32_WINDOWS
-#define VER_PLATFORM_WIN32_WINDOWS 1
-#endif
-
 #ifndef PROCESSOR_ARCHITECTURE_AMD64
 #define PROCESSOR_ARCHITECTURE_AMD64 9
 #endif

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -216,23 +216,15 @@ getHomeFromShell32()
         HRESULT hr;
 
         /*
-         * SHELL32 DLL is delay load DLL and we can use the trick with
-         * __try/__except block.
+         * For Windows Vista and later (or patched MS OS) we need to use
+         * [SHGetKnownFolderPath] call to avoid MAX_PATH length limitation.
+         * Shell32.dll (version 6.0.6000 or later)
          */
-        __try {
-            /*
-             * For Windows Vista and later (or patched MS OS) we need to use
-             * [SHGetKnownFolderPath] call to avoid MAX_PATH length limitation.
-             * Shell32.dll (version 6.0.6000 or later)
-             */
-            hr = SHGetKnownFolderPath(&FOLDERID_Profile, KF_FLAG_DONT_VERIFY, NULL, &u_path);
-        } __except(EXCEPTION_EXECUTE_HANDLER) {
-            /* Exception: no [SHGetKnownFolderPath] entry */
-            hr = E_FAIL;
-        }
+        hr = SHGetKnownFolderPath(&FOLDERID_Profile, KF_FLAG_DONT_VERIFY, NULL, &u_path);
 
         if (FAILED(hr)) {
             WCHAR path[MAX_PATH+1];
+            CoTaskMemFree(u_path);
 
             /* fallback solution for WinXP and Windows 2000 */
             hr = SHGetFolderPathW(NULL, CSIDL_FLAG_DONT_VERIFY | CSIDL_PROFILE, NULL, SHGFP_TYPE_CURRENT, path);

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -209,9 +209,8 @@ getHomeFromShell32()
      */
     static WCHAR *u_path = NULL;
     if (u_path == NULL) {
-        HRESULT hr;
         WCHAR *tmpPath = NULL;
-        hr = SHGetKnownFolderPath(&FOLDERID_Profile, KF_FLAG_DONT_VERIFY, NULL, &tmpPath);
+        HRESULT hr = SHGetKnownFolderPath(&FOLDERID_Profile, KF_FLAG_DONT_VERIFY, NULL, &tmpPath);
 
         if (FAILED(hr)) {
             CoTaskMemFree(tmpPath);

--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -214,30 +214,13 @@ getHomeFromShell32()
     static WCHAR *u_path = NULL;
     if (u_path == NULL) {
         HRESULT hr;
-
-        /*
-         * For Windows Vista and later (or patched MS OS) we need to use
-         * [SHGetKnownFolderPath] call to avoid MAX_PATH length limitation.
-         * Shell32.dll (version 6.0.6000 or later)
-         */
-        hr = SHGetKnownFolderPath(&FOLDERID_Profile, KF_FLAG_DONT_VERIFY, NULL, &u_path);
+        WCHAR *tmpPath = NULL;
+        hr = SHGetKnownFolderPath(&FOLDERID_Profile, KF_FLAG_DONT_VERIFY, NULL, &tmpPath);
 
         if (FAILED(hr)) {
-            WCHAR path[MAX_PATH+1];
-            CoTaskMemFree(u_path);
-
-            /* fallback solution for WinXP and Windows 2000 */
-            hr = SHGetFolderPathW(NULL, CSIDL_FLAG_DONT_VERIFY | CSIDL_PROFILE, NULL, SHGFP_TYPE_CURRENT, path);
-            if (FAILED(hr)) {
-                /* we can't find the shell folder. */
-                u_path = NULL;
-            } else {
-                /* Just to be sure about the path length until Windows Vista approach.
-                 * [S_FALSE] could not be returned due to [CSIDL_FLAG_DONT_VERIFY] flag and UNICODE version.
-                 */
-                path[MAX_PATH] = 0;
-                u_path = _wcsdup(path);
-            }
+            CoTaskMemFree(tmpPath);
+        } else {
+            u_path = tmpPath;
         }
     }
     return u_path;


### PR DESCRIPTION
Please review this patch that makes java.dll load shell32.dll earlier. Delay-loading requires some additional code (delayimp.lib), and offers no benefits since we always load shell32 during JVM startup.

Other than removing the delayload clause, the patch also cleans up the `getHomeFromShell32` method:
- the WinXP code path is removed. The documentation states that [the older function just calls the new one with translated parameters](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetfolderpatha).
- `CoTaskMemFree` is now called if `SHGetKnownFolderPath` fails. This is suggested by the documentation, but probably never needed in practice.

This change shouldn't have any observable effect on behavior on any of the supported operating systems. It reduced the size of java.dll by 2KB on my machine.
No new tests. Existing tier1-2 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316421](https://bugs.openjdk.org/browse/JDK-8316421): libjava should load shell32.dll eagerly (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [1fa01288](https://git.openjdk.org/jdk/pull/15789/files/1fa012885ae50f649d6038db3562b930adb9df2f)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer) ⚠️ Review applies to [1fa01288](https://git.openjdk.org/jdk/pull/15789/files/1fa012885ae50f649d6038db3562b930adb9df2f)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15789/head:pull/15789` \
`$ git checkout pull/15789`

Update a local copy of the PR: \
`$ git checkout pull/15789` \
`$ git pull https://git.openjdk.org/jdk.git pull/15789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15789`

View PR using the GUI difftool: \
`$ git pr show -t 15789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15789.diff">https://git.openjdk.org/jdk/pull/15789.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15789#issuecomment-1723649038)