### PR TITLE
8316428: G1: Nmethod count statistics only count last code root set iterated

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -829,6 +829,8 @@ public:
     _rem_set_opt_trim_partially_time() { }
 
   bool do_heap_region(HeapRegion* r) {
+    uint const region_idx = r->hrm_index();
+
     // The individual references for the optional remembered set are per-worker, so we
     // always need to scan them.
     if (r->has_index_in_opt_cset()) {

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -829,8 +829,6 @@ public:
     _rem_set_opt_trim_partially_time() { }
 
   bool do_heap_region(HeapRegion* r) {
-    uint const region_idx = r->hrm_index();
-
     // The individual references for the optional remembered set are per-worker, so we
     // always need to scan them.
     if (r->has_index_in_opt_cset()) {
@@ -849,7 +847,7 @@ public:
       // Scan the code root list attached to the current region
       r->code_roots_do(&cl);
 
-      _code_roots_scanned = cl.count();
+      _code_roots_scanned += cl.count();
 
       event.commit(GCId::current(), _worker_id, G1GCPhaseTimes::phase_name(_code_roots_phase));
     }


### PR DESCRIPTION
Hi all,

  please review this small fix to nmethod code root counting where currently only the last code root set scanned counts.

Testing: gha

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316428](https://bugs.openjdk.org/browse/JDK-8316428): G1: Nmethod count statistics only count last code root set iterated (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [846e310d](https://git.openjdk.org/jdk/pull/15790/files/846e310d717c64cc3d6cddb42c6be6c63f9b0d36)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [846e310d](https://git.openjdk.org/jdk/pull/15790/files/846e310d717c64cc3d6cddb42c6be6c63f9b0d36)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15790/head:pull/15790` \
`$ git checkout pull/15790`

Update a local copy of the PR: \
`$ git checkout pull/15790` \
`$ git pull https://git.openjdk.org/jdk.git pull/15790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15790`

View PR using the GUI difftool: \
`$ git pr show -t 15790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15790.diff">https://git.openjdk.org/jdk/pull/15790.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15790#issuecomment-1723666940)