### PR TITLE
8316433: net.dll should delay load winhttp.dll

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -52,7 +52,8 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBNET, \
     DISABLED_WARNINGS_microsoft_ResolverConfigurationImpl.c := 4996, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \
-    LDFLAGS_windows := -delayload:secur32.dll -delayload:iphlpapi.dll, \
+    LDFLAGS_windows := -delayload:secur32.dll -delayload:iphlpapi.dll \
+        -delayload:winhttp.dll, \
     LIBS_unix := -ljvm -ljava, \
     LIBS_linux := $(LIBDL), \
     LIBS_aix := $(LIBDL),\

--- a/test/jdk/java/net/ProxySelector/SystemProxies.java
+++ b/test/jdk/java/net/ProxySelector/SystemProxies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6912868 8170868 8316433
+ * @bug 6912868 8170868
  * @summary Basic test to provide some coverage of system proxy code. Will
  * always pass. Should be run manually for specific systems to inspect output.
  * @run main/othervm -Djava.net.useSystemProxies=true SystemProxies

--- a/test/jdk/java/net/ProxySelector/SystemProxies.java
+++ b/test/jdk/java/net/ProxySelector/SystemProxies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6912868 8170868
+ * @bug 6912868 8170868 8316433
  * @summary Basic test to provide some coverage of system proxy code. Will
  * always pass. Should be run manually for specific systems to inspect output.
  * @run main/othervm -Djava.net.useSystemProxies=true SystemProxies


### PR DESCRIPTION
WinHTTP functions are only used when an application:
- uses DefaultProxySelector to resolve proxies, and
- is run with -Djava.net.useSystemProxies=true

In all other cases, loading winhttp.dll is a waste of resources.

Verified that:
- existing tier1 and tier2 tests still pass
- the same system proxies are returned with and without this patch
- WinHTTP is not loaded unless DefaultProxySelector is used

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316433](https://bugs.openjdk.org/browse/JDK-8316433): net.dll should delay load winhttp.dll (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15793/head:pull/15793` \
`$ git checkout pull/15793`

Update a local copy of the PR: \
`$ git checkout pull/15793` \
`$ git pull https://git.openjdk.org/jdk.git pull/15793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15793`

View PR using the GUI difftool: \
`$ git pr show -t 15793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15793.diff">https://git.openjdk.org/jdk/pull/15793.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15793#issuecomment-1724215414)