### PR TITLE
JDK-8313804: JDWP support for -Djava.net.preferIPv6Addresses=system

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -745,9 +745,9 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
     // Binding to IN6ADDR_ANY allows to serve both IPv4 and IPv6 connections,
     // but binding to mapped INADDR_ANY (::ffff:0.0.0.0) allows to serve IPv4
     // connections only. Make sure that IN6ADDR_ANY is preferred over
-    // mapped INADDR_ANY if preferredAddressFamily is AF_INET6 or not set.
+    // mapped INADDR_ANY if preferIPv4Stack is false.
 
-    if (preferredAddressFamily != AF_INET) {
+    if (!allowOnlyIPv4) {
         inet_pton(AF_INET6, "::ffff:0.0.0.0", &mappedAny);
 
         if (isEqualIPv6Addr(listenAddr, mappedAny)) {

--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -1309,7 +1309,7 @@ static int readBooleanSysProp(int *result, int trueValue, int falseValue,
  * Reads java.net.preferIPv6Addresses system value, sets preferredAddressFamily to
  *  - AF_INET6 if the property is "true";
  *  - AF_INET if the property is "false".
- *  - 0 if the property is "false".
+ *  - AF_UNSPEC if the property is "system".
  * Doesn't change preferredAddressFamily if the property is not set or failed to read.
  */
 static int readPreferIPv6Addresses(JNIEnv* jniEnv,
@@ -1335,7 +1335,7 @@ static int readPreferIPv6Addresses(JNIEnv* jniEnv,
         } else if (strcmp(theValue, "false") == 0) {
             preferredAddressFamily = AF_INET;
         } else if (strcmp(theValue, "system") == 0) {
-            preferredAddressFamily = 0;
+            preferredAddressFamily = AF_UNSPEC;
         }
         (*jniEnv)->ReleaseStringUTFChars(jniEnv, value, theValue);
     }

--- a/test/jdk/com/sun/jdi/JdwpNetProps.java
+++ b/test/jdk/com/sun/jdi/JdwpNetProps.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 /*
  * @test
- * @bug 8184770
+ * @bug 8184770 8313804
  * @summary Tests that JDWP agent honors jdk net properties
  * @library /test/lib
  *
@@ -67,19 +67,26 @@ public class JdwpNetProps {
             new ListenTest("localhost", ipv4Address)
                     .preferIPv4Stack(false)
                     .run(TestResult.Success);
+            new ListenTest("localhost", ipv4Address)
+                    .preferIPv4Stack(true)
+                    .preferIPv6Addresses("system")
+                    .run(TestResult.Success);
             if (ipv6Address != null) {
                 // - only IPv4, so connection prom IPv6 should fail
                 new ListenTest("localhost", ipv6Address)
                         .preferIPv4Stack(true)
-                        .preferIPv6Addresses(true)
+                        .preferIPv6Addresses("true")
                         .run(TestResult.AttachFailed);
                 // - listen on IPv4
                 new ListenTest("localhost", ipv6Address)
-                        .preferIPv6Addresses(false)
+                        .preferIPv6Addresses("false")
                         .run(TestResult.AttachFailed);
                 // - listen on IPv6
                 new ListenTest("localhost", ipv6Address)
-                        .preferIPv6Addresses(true)
+                        .preferIPv6Addresses("true")
+                        .run(TestResult.Success);
+                new ListenTest("localhost", ipv6Address)
+                        .preferIPv6Addresses("system")
                         .run(TestResult.Success);
             }
         } else {
@@ -100,7 +107,7 @@ public class JdwpNetProps {
         private final String listenAddress;
         private final InetAddress connectAddress;
         private Boolean preferIPv4Stack;
-        private Boolean preferIPv6Addresses;
+        private String preferIPv6Addresses;
         public ListenTest(String listenAddress, InetAddress connectAddress) {
             this.listenAddress = listenAddress;
             this.connectAddress = connectAddress;
@@ -109,7 +116,7 @@ public class JdwpNetProps {
             preferIPv4Stack = value;
             return this;
         }
-        public ListenTest preferIPv6Addresses(Boolean value) {
+        public ListenTest preferIPv6Addresses(String value) {
             preferIPv6Addresses = value;
             return this;
         }
@@ -120,7 +127,7 @@ public class JdwpNetProps {
                 options.add("-Djava.net.preferIPv4Stack=" + preferIPv4Stack.toString());
             }
             if (preferIPv6Addresses != null) {
-                options.add("-Djava.net.preferIPv6Addresses=" + preferIPv6Addresses.toString());
+                options.add("-Djava.net.preferIPv6Addresses=" + preferIPv6Addresses);
             }
             log("Starting listening debuggee at " + listenAddress
                     + (expectedResult == TestResult.ListenFailed ? ": expected to fail" : ""));

--- a/test/jdk/com/sun/jdi/JdwpNetProps.java
+++ b/test/jdk/com/sun/jdi/JdwpNetProps.java
@@ -72,7 +72,7 @@ public class JdwpNetProps {
                     .preferIPv6Addresses("system")
                     .run(TestResult.Success);
             if (ipv6Address != null) {
-                // - only IPv4, so connection prom IPv6 should fail
+                // - only IPv4, so connection from IPv6 should fail
                 new ListenTest("localhost", ipv6Address)
                         .preferIPv4Stack(true)
                         .preferIPv6Addresses("true")

--- a/test/jdk/com/sun/jdi/JdwpNetProps.java
+++ b/test/jdk/com/sun/jdi/JdwpNetProps.java
@@ -83,14 +83,6 @@ public class JdwpNetProps {
             new ListenTest("localhost", ipv4Address)
                     .preferIPv4Stack(false)
                     .run(TestResult.Success);
-            new ListenTest("localhost", ipv4Address)
-                    .preferIPv4Stack(false)
-                    .preferIPv6Addresses("true")
-                    .run(TestResult.AttachFailed);
-            new ListenTest("localhost", ipv4Address)
-                    .preferIPv4Stack(false)
-                    .preferIPv6Addresses("system")
-                    .run(systemPrefersIPv6 ? TestResult.AttachFailed : TestResult.Success);
             if (ipv6Address != null) {
                 // - only IPv4, so connection from IPv6 should fail
                 new ListenTest("localhost", ipv6Address)
@@ -115,8 +107,22 @@ public class JdwpNetProps {
                 new ListenTest("localhost", ipv6Address)
                         .preferIPv6Addresses("system")
                         .run(systemPrefersIPv6 ? TestResult.Success : TestResult.AttachFailed);
+                // - listen on IPv6, connect from IPv4
+                new ListenTest("localhost", ipv4Address)
+                        .preferIPv4Stack(false)
+                        .preferIPv6Addresses("true")
+                        .run(TestResult.AttachFailed);
+                // - listen on system preference, connect from IPv4
+                new ListenTest("localhost", ipv4Address)
+                        .preferIPv4Stack(false)
+                        .preferIPv6Addresses("system")
+                        .run(systemPrefersIPv6 ? TestResult.AttachFailed : TestResult.Success);
             }
         } else {
+            if (!systemPrefersIPv6) {
+                throw new AssertionError("The system is IPv6-only, but systemPrefersIPv6 was unexpectedly false");
+            }
+
             // IPv6-only system - expected to fail on IPv4 address
             new ListenTest("localhost", ipv6Address)
                     .preferIPv4Stack(true)
@@ -130,10 +136,10 @@ public class JdwpNetProps {
                     .preferIPv6Addresses("true")
                     .run(TestResult.ListenFailed);
             new ListenTest("localhost", ipv6Address)
-                    .run(TestResult.ListenFailed);
+                    .run(TestResult.Success);
             new ListenTest("localhost", ipv6Address)
                     .preferIPv6Addresses("system")
-                    .run(systemPrefersIPv6 ? TestResult.Success : TestResult.AttachFailed);
+                    .run(TestResult.Success);
             new ListenTest("localhost", ipv6Address)
                     .preferIPv6Addresses("true")
                     .run(TestResult.Success);


### PR DESCRIPTION
Please consider this fix for [JDK-8313804](https://bugs.openjdk.org/browse/JDK-8313804), which adds support to JDWP for `-Djava.net.preferIPv6Addresses=system`. Previously it only handled `-Djava.net.preferIPv6Addresses=true` and `-Djava.net.preferIPv6Addresses=false`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313804](https://bugs.openjdk.org/browse/JDK-8313804): JDWP support for -Djava.net.preferIPv6Addresses=system (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15796/head:pull/15796` \
`$ git checkout pull/15796`

Update a local copy of the PR: \
`$ git checkout pull/15796` \
`$ git pull https://git.openjdk.org/jdk.git pull/15796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15796`

View PR using the GUI difftool: \
`$ git pr show -t 15796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15796.diff">https://git.openjdk.org/jdk/pull/15796.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15796#issuecomment-1724340179)