### PR TITLE
8315880: change LockingMode default from LM_LEGACY to LM_LIGHTWEIGHT

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1986,11 +1986,11 @@ const int ObjectAlignmentInBytes = 8;
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
                                                                             \
-  product(int, LockingMode, LM_LEGACY,                                      \
+  product(int, LockingMode, LM_LIGHTWEIGHT,                                 \
           "Select locking mode: "                                           \
           "0: monitors only (LM_MONITOR), "                                 \
-          "1: monitors & legacy stack-locking (LM_LEGACY, default), "       \
-          "2: monitors & new lightweight locking (LM_LIGHTWEIGHT)")         \
+          "1: monitors & legacy stack-locking (LM_LEGACY), "                \
+          "2: monitors & new lightweight locking (LM_LIGHTWEIGHT, default)") \
           range(0, 2)                                                       \
                                                                             \
   product(uint, TrimNativeHeapInterval, 0, EXPERIMENTAL,                    \


### PR DESCRIPTION
Change the default of LockingMode to LM_LIGHTWEIGHT from LM_LEGACY.

This fix has been tested with 3 Mach5 Tier[1-8] runs and a 4th is in process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8315881](https://bugs.openjdk.org/browse/JDK-8315881) to be approved

### Issues
 * [JDK-8315880](https://bugs.openjdk.org/browse/JDK-8315880): Change LockingMode default from LM_LEGACY to LM_LIGHTWEIGHT (**Enhancement** - P4)
 * [JDK-8315881](https://bugs.openjdk.org/browse/JDK-8315881): Change LockingMode default from LM_LEGACY to LM_LIGHTWEIGHT (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15797/head:pull/15797` \
`$ git checkout pull/15797`

Update a local copy of the PR: \
`$ git checkout pull/15797` \
`$ git pull https://git.openjdk.org/jdk.git pull/15797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15797`

View PR using the GUI difftool: \
`$ git pr show -t 15797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15797.diff">https://git.openjdk.org/jdk/pull/15797.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15797#issuecomment-1724403296)