### PR TITLE
8316448: do not load jdk.internal.vm.ci automatically if UseJVMCINativeLibrary is true

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1880,7 +1880,10 @@ bool Arguments::check_vm_args_consistency() {
   if (status && EnableJVMCI) {
     PropertyList_unique_add(&_system_properties, "jdk.internal.vm.ci.enabled", "true",
         AddProperty, UnwriteableProperty, InternalProperty);
-    if (ClassLoader::is_module_observable("jdk.internal.vm.ci")) {
+    if (UseJVMCINativeLibrary) {
+      // When using libjvmci, do not automatically add jdk.internal.vm.ci to the
+      // root module graph. It must be done explicitly with --add-modules.
+    } else if (ClassLoader::is_module_observable("jdk.internal.vm.ci")) {
       if (!create_numbered_module_property("jdk.module.addmods", "jdk.internal.vm.ci", addmods_count++)) {
         return false;
       }


### PR DESCRIPTION
A consequence of [JDK-8266329](https://bugs.openjdk.org/browse/JDK-8266329) is that -Xcomp on libgraal does a lot more class loading and therefore a lot more compilation during VM startup than C2.

The reason is that EnableJVMCI automatically adds the jdk.internal.vm.ci module which disables the CDS archived full module graph (FMG). Without FMG, a lot of core JDK classes must be loaded instead being read from the archive.

This PR disables the automatic loading of `jdk.internal.vm.ci` when `UseJVMCINativeLibrary` is true. In local measurements, this reduces `-Xcomp` executions of an empty Java main program on a fastdebug build of libgraal from 38 secs to 9 secs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8316448](https://bugs.openjdk.org/browse/JDK-8316448)

### Issue
 * [JDK-8316448](https://bugs.openjdk.org/browse/JDK-8316448): [JVMCI] Do not load jdk.internal.vm.ci automatically if UseJVMCINativeLibrary is true (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15798/head:pull/15798` \
`$ git checkout pull/15798`

Update a local copy of the PR: \
`$ git checkout pull/15798` \
`$ git pull https://git.openjdk.org/jdk.git pull/15798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15798`

View PR using the GUI difftool: \
`$ git pr show -t 15798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15798.diff">https://git.openjdk.org/jdk/pull/15798.diff</a>

</details>
