### PR TITLE
8316453: [JVMCI] Using Xcomp on jargraal must eagerly initialize JVMCI

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -699,6 +699,11 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
     // Initialize JVMCI eagerly when it is explicitly requested.
     // Or when JVMCILibDumpJNIConfig or JVMCIPrintProperties is enabled.
     force_JVMCI_initialization = EagerJVMCI || JVMCIPrintProperties || JVMCILibDumpJNIConfig;
+    if (!force_JVMCI_initialization && UseJVMCICompiler && !UseJVMCINativeLibrary && (!UseInterpreter || !BackgroundCompilation)) {
+      // Force initialization of jarjvmci otherwise requests for blocking
+      // compilations will not actually block until jarjvmci is initialized.
+      force_JVMCI_initialization = true;
+    }
     if (JVMCIPrintProperties || JVMCILibDumpJNIConfig) {
       // Both JVMCILibDumpJNIConfig and JVMCIPrintProperties exit the VM
       // so compilation should be disabled. This prevents dumping or


### PR DESCRIPTION
This PR fixes the behavior of jargraal under `-Xcomp` such that compilations of methods executed after VM startup are blocking compilations.

Note that this is different than https://bugs.openjdk.org/browse/JDK-8200230 in that compilations during VM startup (i.e. before main class) may be either skipped (VM not in yet state where JVMCI can be initialized) or non-blocking (JVMCI not yet initialized). That's fine as `-Xcomp`-based tests only have expectations on compilations of test classes being blocking.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316453](https://bugs.openjdk.org/browse/JDK-8316453): [JVMCI] Using Xcomp on jargraal must eagerly initialize JVMCI (**Bug** - P3)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15801/head:pull/15801` \
`$ git checkout pull/15801`

Update a local copy of the PR: \
`$ git checkout pull/15801` \
`$ git pull https://git.openjdk.org/jdk.git pull/15801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15801`

View PR using the GUI difftool: \
`$ git pr show -t 15801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15801.diff">https://git.openjdk.org/jdk/pull/15801.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15801#issuecomment-1725422690)