### PR TITLE
8316440: LambdasInTwoArchives.java failed to find WhiteBox.class

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdasInTwoArchives.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/LambdasInTwoArchives.java
@@ -33,7 +33,7 @@
  * @requires vm.cds
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  *          /test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/test-classes
- * @build LambdasWithSameKey
+ * @build LambdasWithSameKey jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar lambdas_same_key.jar LambdasWithSameKey
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar WhiteBox.jar jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
Please review this simple test fix for adding build of `jdk.test.whitebox.WhiteBox`.

Passed tier1 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316440](https://bugs.openjdk.org/browse/JDK-8316440): LambdasInTwoArchives.java failed to find WhiteBox.class (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15805/head:pull/15805` \
`$ git checkout pull/15805`

Update a local copy of the PR: \
`$ git checkout pull/15805` \
`$ git pull https://git.openjdk.org/jdk.git pull/15805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15805`

View PR using the GUI difftool: \
`$ git pr show -t 15805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15805.diff">https://git.openjdk.org/jdk/pull/15805.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15805#issuecomment-1724613616)