### PR TITLE
8316306: Open source and convert manual Swing test

### DIFF
--- a/test/jdk/javax/swing/JToolBar/bug4203039.java
+++ b/test/jdk/javax/swing/JToolBar/bug4203039.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-
 import java.awt.BorderLayout;
 
 import javax.swing.JComponent;

--- a/test/jdk/javax/swing/JToolBar/bug4203039.java
+++ b/test/jdk/javax/swing/JToolBar/bug4203039.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import java.awt.BorderLayout;
+
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 4203039
+ * @summary JToolBar needs a way to limit docking to a particular orientation
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4203039
+ */
+
+public class bug4203039 {
+    private static final String instructionsText = "This test is used to " +
+            "verify that application-installed\ncomponents prevent the " +
+            "toolbar from docking in\nthose locations.\n\nThis test has " +
+            "installed components on the SOUTH\nand EAST, so verify the " +
+            "toolbar cannot dock in those\nlocations but can dock on the " +
+            "NORTH and WEST";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("bug4203039 Instructions")
+                .instructions(instructionsText)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(30)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame("bug4203039");
+            frame.setSize(300, 200);
+
+            JToolBar toolbar = new JToolBar();
+            JLabel label = new JLabel("This is the toolbar");
+            toolbar.add(label);
+
+            frame.add(toolbar, BorderLayout.NORTH);
+
+            frame.add(new JComponent(){}, BorderLayout.SOUTH);
+            frame.add(new JComponent(){}, BorderLayout.EAST);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.HORIZONTAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}

--- a/test/jdk/javax/swing/JToolBar/bug4203039.java
+++ b/test/jdk/javax/swing/JToolBar/bug4203039.java
@@ -34,7 +34,7 @@ import javax.swing.SwingUtilities;
  * @test
  * @bug 4203039
  * @summary JToolBar needs a way to limit docking to a particular orientation
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual bug4203039
  */

--- a/test/jdk/javax/swing/JToolBar/bug4203039.java
+++ b/test/jdk/javax/swing/JToolBar/bug4203039.java
@@ -39,12 +39,14 @@ import javax.swing.SwingUtilities;
  */
 
 public class bug4203039 {
-    private static final String instructionsText = "This test is used to " +
-            "verify that application-installed\ncomponents prevent the " +
-            "toolbar from docking in\nthose locations.\n\nThis test has " +
-            "installed components on the SOUTH\nand EAST, so verify the " +
-            "toolbar cannot dock in those\nlocations but can dock on the " +
-            "NORTH and WEST";
+    private static final String instructionsText = """
+            This test is used to verify that application-installed
+            components prevent the toolbar from docking in
+            those locations.
+
+            This test has installed components on the SOUTH
+            and EAST, so verify the toolbar cannot dock in those
+            locations but can dock on the NORTH and WEST""";
 
     public static void main(String[] args) throws Exception {
         PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
@@ -52,7 +54,7 @@ public class bug4203039 {
                 .instructions(instructionsText)
                 .testTimeOut(5)
                 .rows(10)
-                .columns(30)
+                .columns(35)
                 .build();
 
         SwingUtilities.invokeAndWait(() -> {


### PR DESCRIPTION
This is to convert and open source test: javax/swing/JToolBar/4203039/bug4203039.java 

This manual test now uses PassFailJFrame to handle the display for the instructions text as well as the pass/fail buttons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316306](https://bugs.openjdk.org/browse/JDK-8316306): Open source and convert manual Swing test (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15806/head:pull/15806` \
`$ git checkout pull/15806`

Update a local copy of the PR: \
`$ git checkout pull/15806` \
`$ git pull https://git.openjdk.org/jdk.git pull/15806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15806`

View PR using the GUI difftool: \
`$ git pr show -t 15806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15806.diff">https://git.openjdk.org/jdk/pull/15806.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15806#issuecomment-1724650189)