### PR TITLE
8316468: os::write incorrectly handles partial write

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1439,7 +1439,7 @@ bool os::write(int fd, const void *buf, size_t nBytes) {
     if (res == OS_ERR) {
       return false;
     }
-    buf = (void *)((char *)buf + nBytes);
+    buf = (void *)((char *)buf + res);
     nBytes -= res;
   }
 


### PR DESCRIPTION
Hello,

Could anyone review this small but important fix?
This bug was introduced in bddf48380e658df630fecad5eda40106a24b6e1c, and regressed the fix for https://bugs.openjdk.org/browse/JDK-8303937.

-Man

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316468](https://bugs.openjdk.org/browse/JDK-8316468): os::write incorrectly handles partial write (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15808/head:pull/15808` \
`$ git checkout pull/15808`

Update a local copy of the PR: \
`$ git checkout pull/15808` \
`$ git pull https://git.openjdk.org/jdk.git pull/15808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15808`

View PR using the GUI difftool: \
`$ git pr show -t 15808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15808.diff">https://git.openjdk.org/jdk/pull/15808.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15808#issuecomment-1724721895)