### PR TITLE
8316229: Enhance class initialization logging

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -772,18 +772,39 @@ void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
 
   // Another thread is linking this class, wait.
   while (is_being_linked() && !is_init_thread(current)) {
+    if (log_is_enabled(Debug, class, init)) {
+      ResourceMark rm(current);
+      log_debug(class, init)("Thread %s waiting for linking of %s by thread %s",
+                             current->name(), external_name(), init_thread_name());
+    }
     ml.wait();
   }
 
   // This thread is recursively linking this class, continue
   if (is_being_linked() && is_init_thread(current)) {
+    if (log_is_enabled(Debug, class, init)) {
+      ResourceMark rm(current);
+      log_debug(class, init)("Thread %s recursively linking %s",
+                             current->name(), external_name());
+    }
     return;
   }
 
   // If this class wasn't linked already, set state to being_linked
   if (!is_linked()) {
+    if (log_is_enabled(Debug, class, init)) {
+      ResourceMark rm(current);
+      log_debug(class, init)("Thread %s linking %s",
+                             current->name(), external_name());
+    }
     set_init_state(being_linked);
     set_init_thread(current);
+  } else {
+    if (log_is_enabled(Debug, class, init)) {
+      ResourceMark rm(current);
+      log_debug(class, init)("Thread %s found %s already linked",
+                             current->name(), external_name());
+      }
   }
 }
 
@@ -1061,10 +1082,16 @@ void InstanceKlass::initialize_impl(TRAPS) {
   // refer to the JVM book page 47 for description of steps
   // Step 1
   {
-    MonitorLocker ml(THREAD, _init_monitor);
+    MonitorLocker ml(jt, _init_monitor);
 
     // Step 2
     while (is_being_initialized() && !is_init_thread(jt)) {
+      if (log_is_enabled(Debug, class, init)) {
+        ResourceMark rm(jt);
+        log_debug(class, init)("Thread %s waiting for initialization of %s by thread %s",
+                               jt->name(), external_name(), init_thread_name());
+      }
+
       wait = true;
       jt->set_class_to_be_initialized(this);
       ml.wait();
@@ -1073,24 +1100,44 @@ void InstanceKlass::initialize_impl(TRAPS) {
 
     // Step 3
     if (is_being_initialized() && is_init_thread(jt)) {
+      if (log_is_enabled(Debug, class, init)) {
+        ResourceMark rm(jt);
+        log_debug(class, init)("Thread %s recursively initializing %s",
+                               jt->name(), external_name());
+      }
       DTRACE_CLASSINIT_PROBE_WAIT(recursive, -1, wait);
       return;
     }
 
     // Step 4
     if (is_initialized()) {
+      if (log_is_enabled(Debug, class, init)) {
+        ResourceMark rm(jt);
+        log_debug(class, init)("Thread %s found %s already initialized",
+                               jt->name(), external_name());
+      }
       DTRACE_CLASSINIT_PROBE_WAIT(concurrent, -1, wait);
       return;
     }
 
     // Step 5
     if (is_in_error_state()) {
+      if (log_is_enabled(Debug, class, init)) {
+        ResourceMark rm(jt);
+        log_debug(class, init)("Thread %s found %s is in error state",
+                               jt->name(), external_name());
+      }
       throw_error = true;
     } else {
 
       // Step 6
       set_init_state(being_initialized);
       set_init_thread(jt);
+      if (log_is_enabled(Debug, class, init)) {
+        ResourceMark rm(jt);
+        log_debug(class, init)("Thread %s is initializing %s",
+                               jt->name(), external_name());
+      }
     }
   }
 
@@ -1564,7 +1611,9 @@ void InstanceKlass::call_class_initializer(TRAPS) {
     LogStream ls(lt);
     ls.print("%d Initializing ", call_class_initializer_counter++);
     name()->print_value_on(&ls);
-    ls.print_cr("%s (" PTR_FORMAT ")", h_method() == nullptr ? "(no method)" : "", p2i(this));
+    ls.print_cr("%s (" PTR_FORMAT ") by thread %s",
+                h_method() == nullptr ? "(no method)" : "", p2i(this),
+                THREAD->name());
   }
   if (h_method() != nullptr) {
     JavaCallArguments args; // No arguments
@@ -4427,4 +4476,3 @@ void ClassHierarchyIterator::next() {
   _current = _current->next_sibling();
   return; // visit next sibling subclass
 }
-

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -776,7 +776,7 @@ void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
   while (is_being_linked() && !is_init_thread(current)) {
     if (debug_logging_enabled) {
       ResourceMark rm(current);
-      log_debug(class, init)("Thread %s waiting for linking of %s by thread %s",
+      log_debug(class, init)("Thread \"%s\" waiting for linking of %s by thread \"%s\"",
                              current->name(), external_name(), init_thread_name());
     }
     ml.wait();
@@ -786,7 +786,7 @@ void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
   if (is_being_linked() && is_init_thread(current)) {
     if (debug_logging_enabled) {
       ResourceMark rm(current);
-      log_debug(class, init)("Thread %s recursively linking %s",
+      log_debug(class, init)("Thread \"%s\" recursively linking %s",
                              current->name(), external_name());
     }
     return;
@@ -796,7 +796,7 @@ void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
   if (!is_linked()) {
     if (debug_logging_enabled) {
       ResourceMark rm(current);
-      log_debug(class, init)("Thread %s linking %s",
+      log_debug(class, init)("Thread \"%s\" linking %s",
                              current->name(), external_name());
     }
     set_init_state(being_linked);
@@ -804,7 +804,7 @@ void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
   } else {
     if (debug_logging_enabled) {
       ResourceMark rm(current);
-      log_debug(class, init)("Thread %s found %s already linked",
+      log_debug(class, init)("Thread \"%s\" found %s already linked",
                              current->name(), external_name());
       }
   }
@@ -1092,7 +1092,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
     while (is_being_initialized() && !is_init_thread(jt)) {
       if (debug_logging_enabled) {
         ResourceMark rm(jt);
-        log_debug(class, init)("Thread %s waiting for initialization of %s by thread %s",
+        log_debug(class, init)("Thread \"%s\" waiting for initialization of %s by thread \"%s\"",
                                jt->name(), external_name(), init_thread_name());
       }
 
@@ -1106,7 +1106,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
     if (is_being_initialized() && is_init_thread(jt)) {
       if (debug_logging_enabled) {
         ResourceMark rm(jt);
-        log_debug(class, init)("Thread %s recursively initializing %s",
+        log_debug(class, init)("Thread \"%s\" recursively initializing %s",
                                jt->name(), external_name());
       }
       DTRACE_CLASSINIT_PROBE_WAIT(recursive, -1, wait);
@@ -1117,7 +1117,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
     if (is_initialized()) {
       if (debug_logging_enabled) {
         ResourceMark rm(jt);
-        log_debug(class, init)("Thread %s found %s already initialized",
+        log_debug(class, init)("Thread \"%s\" found %s already initialized",
                                jt->name(), external_name());
       }
       DTRACE_CLASSINIT_PROBE_WAIT(concurrent, -1, wait);
@@ -1128,7 +1128,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
     if (is_in_error_state()) {
       if (debug_logging_enabled) {
         ResourceMark rm(jt);
-        log_debug(class, init)("Thread %s found %s is in error state",
+        log_debug(class, init)("Thread \"%s\" found %s is in error state",
                                jt->name(), external_name());
       }
       throw_error = true;
@@ -1139,7 +1139,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
       set_init_thread(jt);
       if (debug_logging_enabled) {
         ResourceMark rm(jt);
-        log_debug(class, init)("Thread %s is initializing %s",
+        log_debug(class, init)("Thread \"%s\" is initializing %s",
                                jt->name(), external_name());
       }
     }
@@ -1615,7 +1615,7 @@ void InstanceKlass::call_class_initializer(TRAPS) {
     LogStream ls(lt);
     ls.print("%d Initializing ", call_class_initializer_counter++);
     name()->print_value_on(&ls);
-    ls.print_cr("%s (" PTR_FORMAT ") by thread %s",
+    ls.print_cr("%s (" PTR_FORMAT ") by thread \"%s\"",
                 h_method() == nullptr ? "(no method)" : "", p2i(this),
                 THREAD->name());
   }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -770,9 +770,11 @@ void InstanceKlass::link_class(TRAPS) {
 void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
   MonitorLocker ml(current, _init_monitor);
 
+  bool debug_logging_enabled = log_is_enabled(Debug, class, init);
+
   // Another thread is linking this class, wait.
   while (is_being_linked() && !is_init_thread(current)) {
-    if (log_is_enabled(Debug, class, init)) {
+    if (debug_logging_enabled) {
       ResourceMark rm(current);
       log_debug(class, init)("Thread %s waiting for linking of %s by thread %s",
                              current->name(), external_name(), init_thread_name());
@@ -782,7 +784,7 @@ void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
 
   // This thread is recursively linking this class, continue
   if (is_being_linked() && is_init_thread(current)) {
-    if (log_is_enabled(Debug, class, init)) {
+    if (debug_logging_enabled) {
       ResourceMark rm(current);
       log_debug(class, init)("Thread %s recursively linking %s",
                              current->name(), external_name());
@@ -792,7 +794,7 @@ void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
 
   // If this class wasn't linked already, set state to being_linked
   if (!is_linked()) {
-    if (log_is_enabled(Debug, class, init)) {
+    if (debug_logging_enabled) {
       ResourceMark rm(current);
       log_debug(class, init)("Thread %s linking %s",
                              current->name(), external_name());
@@ -800,7 +802,7 @@ void InstanceKlass::check_link_state_and_wait(JavaThread* current) {
     set_init_state(being_linked);
     set_init_thread(current);
   } else {
-    if (log_is_enabled(Debug, class, init)) {
+    if (debug_logging_enabled) {
       ResourceMark rm(current);
       log_debug(class, init)("Thread %s found %s already linked",
                              current->name(), external_name());
@@ -1079,6 +1081,8 @@ void InstanceKlass::initialize_impl(TRAPS) {
 
   JavaThread* jt = THREAD;
 
+  bool debug_logging_enabled = log_is_enabled(Debug, class, init);
+
   // refer to the JVM book page 47 for description of steps
   // Step 1
   {
@@ -1086,7 +1090,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
 
     // Step 2
     while (is_being_initialized() && !is_init_thread(jt)) {
-      if (log_is_enabled(Debug, class, init)) {
+      if (debug_logging_enabled) {
         ResourceMark rm(jt);
         log_debug(class, init)("Thread %s waiting for initialization of %s by thread %s",
                                jt->name(), external_name(), init_thread_name());
@@ -1100,7 +1104,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
 
     // Step 3
     if (is_being_initialized() && is_init_thread(jt)) {
-      if (log_is_enabled(Debug, class, init)) {
+      if (debug_logging_enabled) {
         ResourceMark rm(jt);
         log_debug(class, init)("Thread %s recursively initializing %s",
                                jt->name(), external_name());
@@ -1111,7 +1115,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
 
     // Step 4
     if (is_initialized()) {
-      if (log_is_enabled(Debug, class, init)) {
+      if (debug_logging_enabled) {
         ResourceMark rm(jt);
         log_debug(class, init)("Thread %s found %s already initialized",
                                jt->name(), external_name());
@@ -1122,7 +1126,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
 
     // Step 5
     if (is_in_error_state()) {
-      if (log_is_enabled(Debug, class, init)) {
+      if (debug_logging_enabled) {
         ResourceMark rm(jt);
         log_debug(class, init)("Thread %s found %s is in error state",
                                jt->name(), external_name());
@@ -1133,7 +1137,7 @@ void InstanceKlass::initialize_impl(TRAPS) {
       // Step 6
       set_init_state(being_initialized);
       set_init_thread(jt);
-      if (log_is_enabled(Debug, class, init)) {
+      if (debug_logging_enabled) {
         ResourceMark rm(jt);
         log_debug(class, init)("Thread %s is initializing %s",
                                jt->name(), external_name());

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -495,6 +495,14 @@ public:
   static void check_prohibited_package(Symbol* class_name,
                                        ClassLoaderData* loader_data,
                                        TRAPS);
+
+  JavaThread* init_thread()  { return Atomic::load(&_init_thread); }
+  // We can safely access the name as long as we hold the _init_monitor.
+  const char* init_thread_name() {
+    assert(_init_monitor->owned_by_self(), " Must hold _init_monitor here");
+    return init_thread()->name_raw();
+  }
+
  public:
   // initialization state
   bool is_loaded() const                   { return init_state() >= loaded; }
@@ -504,7 +512,7 @@ public:
   bool is_not_initialized() const          { return init_state() <  being_initialized; }
   bool is_being_initialized() const        { return init_state() == being_initialized; }
   bool is_in_error_state() const           { return init_state() == initialization_error; }
-  bool is_init_thread(JavaThread *thread)  { return thread == Atomic::load(&_init_thread); }
+  bool is_init_thread(JavaThread *thread)  { return thread == init_thread(); }
   ClassState  init_state() const           { return Atomic::load(&_init_state); }
   const char* init_state_name() const;
   bool is_rewritten() const                { return _misc_flags.rewritten(); }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -499,7 +499,7 @@ public:
   JavaThread* init_thread()  { return Atomic::load(&_init_thread); }
   // We can safely access the name as long as we hold the _init_monitor.
   const char* init_thread_name() {
-    assert(_init_monitor->owned_by_self(), " Must hold _init_monitor here");
+    assert(_init_monitor->owned_by_self(), "Must hold _init_monitor here");
     return init_thread()->name_raw();
   }
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1588,6 +1588,13 @@ const char* JavaThread::name() const  {
   return Thread::name();
 }
 
+// Like name() but doesn't include the protection check. This must only be
+// called when it is known to be safe, even though the protection check can't tell
+// that e.g. when this thread is the init_thread() - see instanceKlass.cpp.
+const char* JavaThread::name_raw() const  {
+  return get_thread_name_string();
+}
+
 // Returns a non-null representation of this thread's name, or a suitable
 // descriptive string if there is no set name.
 const char* JavaThread::get_thread_name_string(char* buf, int buflen) const {

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -900,6 +900,7 @@ private:
 
   // Misc. operations
   const char* name() const;
+  const char* name_raw() const;
   const char* type_name() const { return "JavaThread"; }
   static const char* name_for(oop thread_obj);
 


### PR DESCRIPTION
This change adds some additional debug logging to the class linking and initialization process. It was useful in diagnosing the deadlock described by:

https://bugs.openjdk.org/browse/JDK-8316469

See the example output in JBS issue.

The changes are mostly uncontroversial but I needed to expose a way to access the init thread's name, which can't use the regular `name()` method as the safety check doesn't recognise the calling context as being safe.

Testing:
 - manual examination of logging output
 - ran the only test that enables class+init logging: runtime/logging/ClassInitializationTest.java (no change as expected)
 - tiers1-3 sanity

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316229](https://bugs.openjdk.org/browse/JDK-8316229): Enhance class initialization logging (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15809/head:pull/15809` \
`$ git checkout pull/15809`

Update a local copy of the PR: \
`$ git checkout pull/15809` \
`$ git pull https://git.openjdk.org/jdk.git pull/15809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15809`

View PR using the GUI difftool: \
`$ git pr show -t 15809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15809.diff">https://git.openjdk.org/jdk/pull/15809.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15809#issuecomment-1724914512)