### PR TITLE
8316436: ContinuationWrapper uses unhandled nullptr oop

### DIFF
--- a/src/hotspot/share/runtime/continuationWrapper.cpp
+++ b/src/hotspot/share/runtime/continuationWrapper.cpp
@@ -38,16 +38,12 @@
 #include "runtime/stackChunkFrameStream.inline.hpp"
 
 ContinuationWrapper::ContinuationWrapper(const RegisterMap* map)
-  : _thread(map->thread()),
-    _entry(Continuation::get_continuation_entry_for_continuation(_thread, map->stack_chunk()->cont())),
-    _continuation(map->stack_chunk()->cont())
-  {
-  assert(oopDesc::is_oop(_continuation),"Invalid cont: " INTPTR_FORMAT, p2i((void*)_continuation));
+  : ContinuationWrapper(map->thread(),
+                        Continuation::get_continuation_entry_for_continuation(_thread, map->stack_chunk()->cont()),
+                        map->stack_chunk()->cont()) {
   assert(_entry == nullptr || _continuation == _entry->cont_oop(map->thread()),
     "cont: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: " INTPTR_FORMAT,
     p2i( (oopDesc*)_continuation), p2i((oopDesc*)_entry->cont_oop(map->thread())), p2i(entrySP()));
-  disallow_safepoint();
-  read();
 }
 
 const frame ContinuationWrapper::last_frame() {

--- a/src/hotspot/share/runtime/continuationWrapper.cpp
+++ b/src/hotspot/share/runtime/continuationWrapper.cpp
@@ -39,7 +39,7 @@
 
 ContinuationWrapper::ContinuationWrapper(const RegisterMap* map)
   : ContinuationWrapper(map->thread(),
-                        Continuation::get_continuation_entry_for_continuation(_thread, map->stack_chunk()->cont()),
+                        Continuation::get_continuation_entry_for_continuation(map->thread(), map->stack_chunk()->cont()),
                         map->stack_chunk()->cont()) {
   assert(_entry == nullptr || _continuation == _entry->cont_oop(map->thread()),
     "cont: " INTPTR_FORMAT " entry: " INTPTR_FORMAT " entry_sp: " INTPTR_FORMAT,
@@ -92,4 +92,3 @@ bool ContinuationWrapper::chunk_invariant() const {
   return true;
 }
 #endif // ASSERT
-


### PR DESCRIPTION
The ZGC oop verification code in combination with CheckUnhandledOops finds an unhandled oop in ContinuationWrapper:

```
Test java/lang/Thread/virtual/stress/Skynet.java#ZGenerational with ' -XX:+CheckUnhandledOops' crashes with
#
# A fatal error has been detected by the Java Runtime Environment:
#
# Internal Error (src/hotspot/share/gc/z/zAddress.inline.hpp:296), pid=986260, tid=986296
# assert(!assert_on_failure) failed: Has low-order bits set: 0xfffffffffffffff1 

V [libjvm.so+0x1962fda] initialize_check_oop_function()::{lambda(oopDesc*)#1}::_FUN(oopDesc*)+0x5a (zAddress.inline.hpp:296)
V [libjvm.so+0xa6d484] ContinuationWrapper::~ContinuationWrapper()+0x24 (oopsHierarchy.hpp:89)
V [libjvm.so+0xa66c83] int freeze_internal<Config<(oop_kind)1, ZBarrierSet> >(JavaThread*, long*)+0x373 (continuationFreezeThaw.cpp:1584)
V [libjvm.so+0xa6711b] int freeze<Config<(oop_kind)1, ZBarrierSet> >(JavaThread*, long*)+0x5b (continuationFreezeThaw.cpp:272)
J 216 jdk.internal.vm.Continuation.doYield()I [java.base@22-internal](mailto:java.base@22-internal) (0 bytes) @ 0x00007f614c630875 [0x00007f614c630820+0x0000000000000055]
```

This is the scenario that triggers this bug:
1) ContinuationWrapper is created on the stack
2) We enter a JRT_BLOCK section
3) Call ContinuationWrapper::done()
4) Exit the JRT_BLOCK
5) ~ContinuationWrapper is called

(3) sets ContinuationWrapper::_continuation to nullptr
(4) hits a safepoint and sets ContinuationWrapper::_continuation to 0xfffffffffffffff1
(5) uses ContinuationWrapper::_continuation in `_continuation != nullptr`, which triggers ZGC's verification code that finds the broken oop.

So, this crashes with ZGC, but that's because ZGC finds a broken usage of _continuation. To show that this is still a problem with other GCs I added this assert:
```
diff --git a/src/hotspot/share/runtime/javaThread.hpp b/src/hotspot/share/runtime/javaThread.hpp
index 40205d324a6..80b60d0b7b8 100644
--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -258,7 +258,7 @@ class JavaThread: public Thread {
 
  public:
   void inc_no_safepoint_count() { _no_safepoint_count++; }
- void dec_no_safepoint_count() { _no_safepoint_count--; }
+ void dec_no_safepoint_count() { _no_safepoint_count--; assert(_no_safepoint_count >= 0, "Catch G1 in the act!"); }
 #endif // ASSERT
  public:
   // These functions check conditions before possibly going to a safepoint.
```

To catch the broken nullptr check in:
```
   void allow_safepoint() {
     #ifdef ASSERT
       // we could have already allowed safepoints in done
      if (_continuation != nullptr && _current_thread->is_Java_thread()) {
         JavaThread::cast(_current_thread)->dec_no_safepoint_count();
       }
     #endif
   }
```

The assert is triggered when I run the test with G1.

I propose that we fix this by stop setting _continuation to nullptr as a way to indicate cancellation of the ContinuationWrapper, and instead use a bool for that.

I made some slight changes to remove all the code duplication in the constructors so that I only had to initialize the new _done variable in one place.

I've tested this with the original reproducer + assert with both ZGC and G1. I'll run this through our internal CI pipeline as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316436](https://bugs.openjdk.org/browse/JDK-8316436): ContinuationWrapper uses unhandled nullptr oop (**Bug** - P3)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15810/head:pull/15810` \
`$ git checkout pull/15810`

Update a local copy of the PR: \
`$ git checkout pull/15810` \
`$ git pull https://git.openjdk.org/jdk.git pull/15810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15810`

View PR using the GUI difftool: \
`$ git pr show -t 15810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15810.diff">https://git.openjdk.org/jdk/pull/15810.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15810#issuecomment-1724932762)