### PR TITLE
8316513: Serial: Remove unused invalidate_remembered_set

### DIFF
--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -143,12 +143,6 @@ void TenuredGeneration::shrink(size_t bytes) {
                       name(), old_mem_size/K, new_mem_size/K);
 }
 
-// Objects in this generation may have moved, invalidate this
-// generation's cards.
-void TenuredGeneration::invalidate_remembered_set() {
-  _rs->invalidate(used_region());
-}
-
 void TenuredGeneration::compute_new_size_inner() {
   assert(_shrink_factor <= 100, "invalid shrink factor");
   size_t current_shrink_factor = _shrink_factor;

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -85,8 +85,6 @@ class TenuredGeneration: public Generation {
  public:
   virtual void compute_new_size();
 
-  virtual void invalidate_remembered_set();
-
   // Grow generation with specified size (returns false if unable to grow)
   bool grow_by(size_t bytes);
   // Grow generation to reserved size.

--- a/src/hotspot/share/gc/shared/generation.hpp
+++ b/src/hotspot/share/gc/shared/generation.hpp
@@ -326,10 +326,6 @@ class Generation: public CHeapObj<mtGC> {
   // each.
   virtual void object_iterate(ObjectClosure* cl);
 
-  // Inform a generation that some of its objects have moved.  [e.g. The
-  // generation's spaces were compacted, invalidating the card table.]
-  virtual void invalidate_remembered_set() { }
-
   // Block abstraction.
 
   // Returns the address of the start of the "block" that contains the


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316513](https://bugs.openjdk.org/browse/JDK-8316513): Serial: Remove unused invalidate_remembered_set (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15813/head:pull/15813` \
`$ git checkout pull/15813`

Update a local copy of the PR: \
`$ git checkout pull/15813` \
`$ git pull https://git.openjdk.org/jdk.git pull/15813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15813`

View PR using the GUI difftool: \
`$ git pr show -t 15813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15813.diff">https://git.openjdk.org/jdk/pull/15813.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15813#issuecomment-1725104625)