### PR TITLE
8316660: (fs) Files.lines implementation can use MemorySegment for file mapping

### DIFF
--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -46,17 +46,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 /**
- * A file-based lines spliterator, leveraging a shared mapped byte buffer and
+ * A file-based lines spliterator, leveraging a shared mapped memory segment and
  * associated file channel, covering lines of a file for character encodings
  * where line feed characters can be easily identified from character encoded
  * bytes.
  *
  * <p>
- * When the root spliterator is first split a mapped byte buffer will be created
+ * When the root spliterator is first split a mapped memory segment will be created
  * over the file for its size that was observed when the stream was created.
- * Thus a mapped byte buffer is only required for parallel stream execution.
- * Sub-spliterators will share that mapped byte buffer.  Splitting will use the
- * mapped byte buffer to find the closest line feed characters(s) to the left or
+ * Thus a mapped memory segment is only required for parallel stream execution.
+ * Sub-spliterators will share that mapped memory segment.  Splitting will use the
+ * mapped memory segment to find the closest line feed characters(s) to the left or
  * right of the mid-point of covered range of bytes of the file.  If a line feed
  * is found then the spliterator is split with returned spliterator containing
  * the identified line feed characters(s) at the end of its covered range of

--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -93,10 +93,10 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
         this.fence = fence;
     }
 
-    private FileChannelLinesSpliterator(FileChannelLinesSpliterator parent,
+    private FileChannelLinesSpliterator(SharedState ss,
                                         int index,
                                         int fence) {
-        this.ss = parent.ss;
+        this.ss = ss;
         this.index = index;
         this.fence = fence;
     }
@@ -231,7 +231,7 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
 
             // The left spliterator will have the line-separator at the end
             return (mid > lo && mid < hi)
-                    ? new FileChannelLinesSpliterator(this, lo, index = mid)
+                    ? new FileChannelLinesSpliterator(ss, lo, index = mid)
                     : null;
         } finally {
             // Make sure the underlying `original` remains strongly referenced until the segment is fully used

--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -193,7 +193,7 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
         }
     }
 
-    private MemorySegment getMappedSegment() {
+    private MemorySegment mappedSegment() {
         try {
             return fc.map(FileChannel.MapMode.READ_ONLY, 0, fence, arena);
         } catch (IOException e) {
@@ -209,7 +209,7 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
 
         MemorySegment b;
         if ((b = buffer) == null) {
-            b = buffer = getMappedSegment();
+            b = buffer = mappedSegment();
             bufRefCount.set(1);
         }
 

--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -44,9 +44,6 @@ import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import jdk.internal.access.SharedSecrets;
-import jdk.internal.access.JavaNioAccess;
-
 /**
  * A file-based lines spliterator, leveraging a shared mapped byte buffer and
  * associated file channel, covering lines of a file for character encodings
@@ -196,7 +193,7 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
         }
     }
 
-    private MemorySegment getMappedByteBuffer() {
+    private MemorySegment getMappedSegment() {
         try {
             return fc.map(FileChannel.MapMode.READ_ONLY, 0, fence, arena);
         } catch (IOException e) {
@@ -212,7 +209,7 @@ final class FileChannelLinesSpliterator implements Spliterator<String> {
 
         MemorySegment b;
         if ((b = buffer) == null) {
-            b = buffer = getMappedByteBuffer();
+            b = buffer = getMappedSegment();
             bufRefCount.set(1);
         }
 

--- a/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileChannelLinesSpliterator.java
@@ -72,9 +72,9 @@ import java.util.function.Consumer;
 final class FileChannelLinesSpliterator implements Spliterator<String> {
 
     static final Set<Charset> SUPPORTED_CHARSETS = Set.of(
-            UTF_8.INSTANCE,
-            ISO_8859_1.INSTANCE,
-            US_ASCII.INSTANCE
+        UTF_8.INSTANCE,
+        ISO_8859_1.INSTANCE,
+        US_ASCII.INSTANCE
     );
 
     // This state is shared across all splits

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -4135,7 +4135,7 @@ public final class Files {
             // for a non-zero length file so disallow this case.
             if (length > 0 && length <= Integer.MAX_VALUE) {
                 FileChannelLinesSpliterator fcls =
-                    new FileChannelLinesSpliterator(fc, cs, 0, (int) length);
+                    new FileChannelLinesSpliterator(fc, cs,(int) length);
                 return StreamSupport.stream(fcls, false)
                         .onClose(Files.asUncheckedRunnable(fc))
                         .onClose(fcls::close);

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -4138,7 +4138,7 @@ public final class Files {
                     new FileChannelLinesSpliterator(fc, cs, 0, (int) length);
                 return StreamSupport.stream(fcls, false)
                         .onClose(Files.asUncheckedRunnable(fc))
-                        .onClose(() -> fcls.close());
+                        .onClose(fcls::close);
             }
         } catch (Error|RuntimeException|IOException e) {
             try {

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -4135,7 +4135,7 @@ public final class Files {
             // for a non-zero length file so disallow this case.
             if (length > 0 && length <= Integer.MAX_VALUE) {
                 FileChannelLinesSpliterator fcls =
-                    new FileChannelLinesSpliterator(fc, cs,(int) length);
+                    new FileChannelLinesSpliterator(fc, cs, (int)length);
                 return StreamSupport.stream(fcls, false)
                         .onClose(Files.asUncheckedRunnable(fc))
                         .onClose(fcls::close);

--- a/test/jdk/java/nio/file/FileChannelLinesSpliterator/Parallel.java
+++ b/test/jdk/java/nio/file/FileChannelLinesSpliterator/Parallel.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class Parallel {
 
-    // file used by most tests
+    // file used by the tests
     private Path tmpFile;
 
     @BeforeEach

--- a/test/jdk/java/nio/file/FileChannelLinesSpliterator/Parallel.java
+++ b/test/jdk/java/nio/file/FileChannelLinesSpliterator/Parallel.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @summary Unit test for checking parallel use of FileChannelLinesSpliterator
+ * @run junit Parallel
+ */
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Parallel {
+
+    // file used by most tests
+    private Path tmpFile;
+
+    @BeforeEach
+    void setup() throws IOException {
+        tmpFile = Files.createTempFile("text_file", null);
+        Files.write(tmpFile, genBytes(20_000), StandardOpenOption.CREATE);
+    }
+
+    @AfterEach
+    void cleanup() throws IOException {
+        Files.deleteIfExists(tmpFile);
+    }
+
+    @Test
+    void basicEquality() throws IOException {
+        List<String> expected;
+        List<String> actual;
+
+        try (var lines = Files.lines(tmpFile, StandardCharsets.UTF_8)) {
+            expected = lines.toList();
+        }
+
+        try (var lines = Files.lines(tmpFile, StandardCharsets.UTF_8)) {
+            actual = lines.parallel().toList();
+        }
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    /*
+     * The objective of this test is to ensure it is very likely the mapped
+     * memory region in the underlying Spliterator is released in a proper way.
+     *
+     * This works by creating parallel streams of various lengths and then
+     * , at the same time, invoking GC frequently (the mapped memory region can
+     * be freed both explicitly via the `Stream::close` method and via the GC).
+     */
+    void fuzzer() throws IOException {
+
+        AtomicBoolean ready = new AtomicBoolean();
+        Thread.ofPlatform().factory().newThread(() -> {
+            while (!ready.get()) {
+                System.gc();
+                // Hammer GC
+                LockSupport.parkNanos(1_000);
+            }
+        });
+
+        int elements;
+        try (var lines = Files.lines(tmpFile, StandardCharsets.UTF_8)) {
+            elements = Math.toIntExact(lines.count());
+        }
+
+        long cnt = 0;
+
+        for (int i = 0; i < 100; i++) {
+            // Properly close the Stream
+            try (var lines = Files.lines(tmpFile, StandardCharsets.UTF_8)) {
+                List<String> list = lines.parallel()
+                        .limit(((long) elements * i / 100))
+                        .toList();
+                cnt += list.size();
+            }
+
+            // Leave the Stream dangling
+            List<String> list = Files.lines(tmpFile, StandardCharsets.UTF_8)
+                    .parallel()
+                    .limit(((long) elements * i / 100))
+                    .toList();
+            cnt += list.size();
+        }
+
+        // Make the background thread exit
+        ready.set(true);
+        System.out.println(cnt);
+    }
+
+    /**
+     * Returns a byte[] of at least the given size with random content and
+     * with newlines at random places
+     */
+    private static byte[] genBytes(int size) {
+        Random rnd = new Random(42);
+        int maxLen = 127;
+        byte[] arr = new byte[size + maxLen + 2];
+        int c = 0;
+        while (c < size) {
+            int lineLen = rnd.nextInt(3, 127);
+            int end = c + lineLen;
+            for (; c < end; c++) {
+                arr[c] = 'a';
+            }
+            arr[c++] = '\r';
+            arr[c++] = '\n';
+        }
+        // No harm we might have one or more \0 at the end
+        return arr;
+    }
+
+}

--- a/test/jdk/java/nio/file/Files/LinesParallel.java
+++ b/test/jdk/java/nio/file/Files/LinesParallel.java
@@ -22,8 +22,8 @@
  */
 
 /* @test
- * @summary Unit test for checking parallel use of FileChannelLinesSpliterator
- * @run junit Parallel
+ * @summary Unit test for checking parallel use of Files::lines
+ * @run junit LinesParallel
  */
 
 import java.io.IOException;
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class Parallel {
+public class LinesParallel {
 
     // file used by the tests
     private Path tmpFile;
@@ -74,14 +74,14 @@ public class Parallel {
     }
 
     @Test
-    /*
-     * The objective of this test is to ensure it is very likely the mapped
-     * memory region in the underlying Spliterator is released in a proper way.
-     *
-     * This works by creating parallel streams of various lengths and then
-     * , at the same time, invoking GC frequently (the mapped memory region can
-     * be freed both explicitly via the `Stream::close` method and via the GC).
-     */
+        /*
+         * The objective of this test is to ensure it is very likely the mapped
+         * memory region in the underlying Spliterator is released in a proper way.
+         *
+         * This works by creating parallel streams of various lengths and then
+         * , at the same time, invoking GC frequently (the mapped memory region can
+         * be freed both explicitly via the `Stream::close` method and via the GC).
+         */
     void fuzzer() throws IOException {
 
         AtomicBoolean ready = new AtomicBoolean();


### PR DESCRIPTION
This PR proposes using a `MemorySegment` instead of a `ByteBuffer` in the `Files::lines` implementation (in the internal class `FileChannelLinesSpliterator`).

The old solution deterministically unmapped the `ByteBuffer` if closed. If not closed, the `ByteBuffer` would be GC:ed.

This proposal mimics the old behavior but may hold the mapped memory region slightly longer.

Tested and passed tier1, tier2, tier3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316660](https://bugs.openjdk.org/browse/JDK-8316660): (fs) Files.lines implementation can use MemorySegment for file mapping (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15814/head:pull/15814` \
`$ git checkout pull/15814`

Update a local copy of the PR: \
`$ git checkout pull/15814` \
`$ git pull https://git.openjdk.org/jdk.git pull/15814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15814`

View PR using the GUI difftool: \
`$ git pr show -t 15814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15814.diff">https://git.openjdk.org/jdk/pull/15814.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15814#issuecomment-1729328029)