### PR TITLE
8316514: Better diagnostic header for VtableStub

### DIFF
--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -230,8 +230,9 @@ address VtableStubs::find_stub(bool is_vtable_stub, int vtable_index) {
 
       enter(is_vtable_stub, vtable_index, s);
       if (PrintAdapterHandlers) {
-        tty->print_cr("Decoding VtableStub %s[%d]@" INTX_FORMAT,
-                      is_vtable_stub? "vtbl": "itbl", vtable_index, p2i(VtableStub::receiver_location()));
+        tty->print_cr("Decoding VtableStub %s[%d]@" INTX_FORMAT " [" PTR_FORMAT ", " PTR_FORMAT "] (" SIZE_FORMAT " bytes)",
+                      is_vtable_stub? "vtbl": "itbl", vtable_index, p2i(VtableStub::receiver_location()),
+                      p2i(s->code_begin()), p2i(s->code_end()), pointer_delta(s->code_end(), s->code_begin(), 1));
         Disassembler::decode(s->code_begin(), s->code_end());
       }
       // Notify JVMTI about this stub. The event will be recorded by the enclosing

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -230,7 +230,7 @@ address VtableStubs::find_stub(bool is_vtable_stub, int vtable_index) {
 
       enter(is_vtable_stub, vtable_index, s);
       if (PrintAdapterHandlers) {
-        tty->print_cr("Decoding VtableStub %s[%d]@" INTX_FORMAT " [" PTR_FORMAT ", " PTR_FORMAT "] (" SIZE_FORMAT " bytes)",
+        tty->print_cr("Decoding VtableStub %s[%d]@" PTR_FORMAT " [" PTR_FORMAT ", " PTR_FORMAT "] (" SIZE_FORMAT " bytes)",
                       is_vtable_stub? "vtbl": "itbl", vtable_index, p2i(VtableStub::receiver_location()),
                       p2i(s->code_begin()), p2i(s->code_end()), pointer_delta(s->code_end(), s->code_begin(), 1));
         Disassembler::decode(s->code_begin(), s->code_end());


### PR DESCRIPTION
Similar to [JDK-8316178](https://bugs.openjdk.org/browse/JDK-8316178), but for VtableStubs. JMH perfasm would like to know where the stub code ends.

Printout before this fix:

```
Decoding VtableStub vtbl[5]@281473683415027
--------------------------------------------------------------------------------
  0x0000ffff9bf22320:   ldr     w16, [x1, #8]
  0x0000ffff9bf22324:   movk    x16, #0x98, lsl #32
  0x0000ffff9bf22328:   ldr     x12, [x16, #496]
  0x0000ffff9bf2232c:   ldr     x8, [x12, #64]
  0x0000ffff9bf22330:   br      x8
  0x0000ffff9bf22334:   udf     #0
```

Printout after this fix:

```
--------------------------------------------------------------------------------
Decoding VtableStub vtbl[5]@281473592893427 [0x0000ffff97f22320, 0x0000ffff97f22338] (24 bytes)
--------------------------------------------------------------------------------
  0x0000ffff97f22320:   ldr     w16, [x1, #8]
  0x0000ffff97f22324:   eor     x16, x16, #0x3800000000
  0x0000ffff97f22328:   ldr     x12, [x16, #496]
  0x0000ffff97f2232c:   ldr     x8, [x12, #64]
  0x0000ffff97f22330:   br      x8
  0x0000ffff97f22334:   udf     #0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316514](https://bugs.openjdk.org/browse/JDK-8316514): Better diagnostic header for VtableStub (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [78d28bc4](https://git.openjdk.org/jdk/pull/15816/files/78d28bc43289ad572437963e7e739e4738b106dc)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15816/head:pull/15816` \
`$ git checkout pull/15816`

Update a local copy of the PR: \
`$ git checkout pull/15816` \
`$ git pull https://git.openjdk.org/jdk.git pull/15816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15816`

View PR using the GUI difftool: \
`$ git pr show -t 15816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15816.diff">https://git.openjdk.org/jdk/pull/15816.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15816#issuecomment-1725220143)