### PR TITLE
8316206: Test StretchedFontTest.java fails for Baekmuk font

### DIFF
--- a/test/jdk/java/awt/font/FontScaling/StretchedFontTest.java
+++ b/test/jdk/java/awt/font/FontScaling/StretchedFontTest.java
@@ -26,6 +26,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.font.FontRenderContext;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -61,15 +62,19 @@ public final class StretchedFontTest {
             new Color(0x7F000000, true)
     };
 
+    /** Locale for getting font names. */
+    private static final Locale ENGLISH_LOCALE = Locale.ENGLISH;
+
     private static final AffineTransform STRETCH_TRANSFORM =
             AffineTransform.getScaleInstance(2.0, 1.0);
 
     public static void main(String[] args) {
         List<String> errors =
                 Arrays.stream(getLocalGraphicsEnvironment()
-                              .getAvailableFontFamilyNames(Locale.ENGLISH))
+                              .getAvailableFontFamilyNames(ENGLISH_LOCALE))
                       .map(family -> new Font(family, Font.PLAIN, FONT_SIZE))
                       .filter(font -> font.canDisplay(TEXT.codePointAt(0)))
+                      .filter(font -> !isBrokenFont(font))
                       .map(font -> font.deriveFont(STRETCH_TRANSFORM))
                       .flatMap(StretchedFontTest::testFont)
                       .filter(Objects::nonNull)
@@ -80,6 +85,26 @@ public final class StretchedFontTest {
             throw new Error(errors.size() + " failure(s) found;"
                             + " the first one: " + errors.get(0));
         }
+    }
+
+    /**
+     * Checks whether the font renders the glyph in {@code TEXT} and
+     * returns {@code true} if the glyph isn't rendered.
+     *
+     * @param font the font to test
+     * @return {@code true} if the visual bounds of {@code TEXT} are empty, and
+     *         {@code false} otherwise
+     */
+    private static boolean isBrokenFont(final Font font) {
+        final boolean empty =
+                font.createGlyphVector(new FontRenderContext(null, false, false),
+                                       TEXT)
+                    .getVisualBounds()
+                    .isEmpty();
+        if (empty) {
+            System.err.println("Broken font: " + font.getFontName(ENGLISH_LOCALE));
+        }
+        return empty;
     }
 
     /**
@@ -145,7 +170,7 @@ public final class StretchedFontTest {
         if (verifyImage(image)) {
             return null;
         }
-        String fontName = font.getFontName(Locale.ENGLISH);
+        String fontName = font.getFontName(ENGLISH_LOCALE);
         String hintValue = getHintString(hint);
         String hexColor = String.format("0x%08x", foreground.getRGB());
         saveImage(image, fontName + "-" + hintValue + "-" + hexColor);
@@ -158,58 +183,27 @@ public final class StretchedFontTest {
      * If the right half of the image contains only pixels of the background
      * color, the hieroglyph isn't stretched correctly
      * &mdash; it's a failure.
-     * <p>
-     * If the left half of the image contains only pixels of the background
-     * color, the glyph isn't rendered at all, such a font is ignored as if
-     * it were a success.
      *
      * @param image the image to verify
-     * @return {@code true} if the hieroglyph is stretched correctly, or
-     *                      if there's no glyph in the image; or<br>
-     *         {@code false} if the right half of the image contains only
+     * @return {@code true} if the hieroglyph is stretched correctly; or
+     *         {@code false} if right half of the image contains only
      *         background-colored pixels, which means the hieroglyph isn't
      *         stretched.
      */
     private static boolean verifyImage(final BufferedImage image) {
         final int width = image.getWidth();
-
-        // Some fonts map the character to zero-width glyph.
-        // Verify the glyph is rendered on the left side of the image.
-        if (!verifyImage(image, 0, width / 2)) {
-            // Ignore the broken font
-            return true;
-        }
-
-        // There's a glyph on the left side of the image,
-        // Verify it is stretched, i.e. it is present on the right side
-        return verifyImage(image, width / 2, width);
-    }
-
-    /**
-     * Verifies a portion of the rendered image of the hieroglyph.
-     * It returns {@code true} if it finds pixels of a different color
-     * from the background.
-     *
-     * @param image the image to verify
-     * @param startX the starting <i>x</i> coordinate
-     * @param endX the limit for the <i>x</i> coordinate
-     * @return {@code true} if there are non-background color pixels, and
-     *         {@code false} otherwise
-     */
-    private static boolean verifyImage(final BufferedImage image,
-                                       final int startX,
-                                       final int endX) {
         final int height = image.getHeight();
-        for (int x = startX; x < endX; x++) {
+        for (int x = width / 2; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 if (image.getRGB(x, y) != BACKGROUND.getRGB()) {
-                    // Any other color but background means there's a glyph
+                    // Any other color but background means the glyph is stretched
                     return true;
                 }
             }
         }
 
-        // There's no glyph in the tested part of the image
+        // The right side of the image is filled with the background color only,
+        // the glyph isn't stretched.
         return false;
     }
 

--- a/test/jdk/java/awt/font/FontScaling/StretchedFontTest.java
+++ b/test/jdk/java/awt/font/FontScaling/StretchedFontTest.java
@@ -158,27 +158,58 @@ public final class StretchedFontTest {
      * If the right half of the image contains only pixels of the background
      * color, the hieroglyph isn't stretched correctly
      * &mdash; it's a failure.
+     * <p>
+     * If the left half of the image contains only pixels of the background
+     * color, the glyph isn't rendered at all, such a font is ignored as if
+     * it were a success.
      *
      * @param image the image to verify
-     * @return {@code true} if the hieroglyph is stretched correctly; or
-     *         {@code false} if right half of the image contains only
+     * @return {@code true} if the hieroglyph is stretched correctly, or
+     *                      if there's no glyph in the image; or<br>
+     *         {@code false} if the right half of the image contains only
      *         background-colored pixels, which means the hieroglyph isn't
      *         stretched.
      */
     private static boolean verifyImage(final BufferedImage image) {
         final int width = image.getWidth();
+
+        // Some fonts map the character to zero-width glyph.
+        // Verify the glyph is rendered on the left side of the image.
+        if (!verifyImage(image, 0, width / 2)) {
+            // Ignore the broken font
+            return true;
+        }
+
+        // There's a glyph on the left side of the image,
+        // Verify it is stretched, i.e. it is present on the right side
+        return verifyImage(image, width / 2, width);
+    }
+
+    /**
+     * Verifies a portion of the rendered image of the hieroglyph.
+     * It returns {@code true} if it finds pixels of a different color
+     * from the background.
+     *
+     * @param image the image to verify
+     * @param startX the starting <i>x</i> coordinate
+     * @param endX the limit for the <i>x</i> coordinate
+     * @return {@code true} if there are non-background color pixels, and
+     *         {@code false} otherwise
+     */
+    private static boolean verifyImage(final BufferedImage image,
+                                       final int startX,
+                                       final int endX) {
         final int height = image.getHeight();
-        for (int x = width / 2; x < width; x++) {
+        for (int x = startX; x < endX; x++) {
             for (int y = 0; y < height; y++) {
                 if (image.getRGB(x, y) != BACKGROUND.getRGB()) {
-                    // Any other color but background means the glyph is stretched
+                    // Any other color but background means there's a glyph
                     return true;
                 }
             }
         }
 
-        // The right side of the image is filled with the background color only,
-        // the glyph isn't stretched.
+        // There's no glyph in the tested part of the image
         return false;
     }
 


### PR DESCRIPTION
**Root cause**

The _Baekmuk Headline_ font maps `\u6f22` (漢) to glyph id 16950 which has zero length.

The test fails if the right half of the image with the rendered glyph contains only pixels of background colour. In this case, the left half of the image is also blank. It's somewhat false positive because of the broken font.

**Fix**

Ignore fonts which don't render the glyph correctly. If the left half of the image contains pixels of the background colour only, it is expected that the right half also contains background-coloured pixels only.

The updated test does not fail with the _Baekmuk Headline_ font. It still detects the original problem and fails on builds without the fix for [JDK-8312555](https://bugs.openjdk.org/browse/JDK-8312555).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316206](https://bugs.openjdk.org/browse/JDK-8316206): Test StretchedFontTest.java fails for Baekmuk font (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to [6c866aea](https://git.openjdk.org/jdk/pull/15818/files/6c866aeacc294bd74a1c78a2796078c5ce4e1055)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15818/head:pull/15818` \
`$ git checkout pull/15818`

Update a local copy of the PR: \
`$ git checkout pull/15818` \
`$ git pull https://git.openjdk.org/jdk.git pull/15818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15818`

View PR using the GUI difftool: \
`$ git pr show -t 15818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15818.diff">https://git.openjdk.org/jdk/pull/15818.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15818#issuecomment-1725621642)