### PR TITLE
JDK-8269393: store/load order not preserved when handling memory pool due to weakly ordered memory architecture of aarch64

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -574,7 +574,6 @@ CodeBlob* CodeCache::allocate(int size, CodeBlobType code_blob_type, bool handle
       }
       return nullptr;
     }
-    OrderAccess::storestore();
     if (PrintCodeCacheExtension) {
       ResourceMark rm;
       if (_nmethod_heaps->length() >= 1) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -574,6 +574,7 @@ CodeBlob* CodeCache::allocate(int size, CodeBlobType code_blob_type, bool handle
       }
       return nullptr;
     }
+    OrderAccess::storestore();
     if (PrintCodeCacheExtension) {
       ResourceMark rm;
       if (_nmethod_heaps->length() >= 1) {

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -178,13 +178,9 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 }
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
-  size_t used;
-  size_t committed;
-  {
-    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    used = used_in_bytes();
-    committed = _codeHeap->capacity();
-  }
+  OrderAccess::loadload();
+  size_t used = used_in_bytes();
+  size_t committed = _codeHeap->capacity();
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);
 
   return MemoryUsage(initial_size(), used, committed, maxSize);

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -178,7 +178,7 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 }
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
-  size_t used = used_in_bytes();
+  size_t used      = used_in_bytes();
   OrderAccess::loadload();
   size_t committed = _codeHeap->capacity();
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -178,9 +178,13 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 }
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
-  OrderAccess::loadload();
-  size_t used = used_in_bytes();
-  size_t committed = _codeHeap->capacity();
+  size_t used;
+  size_t committed;
+  {
+    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    used = used_in_bytes();
+    committed = _codeHeap->capacity();
+  }
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);
 
   return MemoryUsage(initial_size(), used, committed, maxSize);

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -178,8 +178,8 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 }
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
-  size_t used = used_in_bytes();
   OrderAccess::loadload();
+  size_t used = used_in_bytes();
   size_t committed = _codeHeap->capacity();
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);
 

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -178,8 +178,8 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 }
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
-  OrderAccess::loadload();
   size_t used = used_in_bytes();
+  OrderAccess::loadload();
   size_t committed = _codeHeap->capacity();
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);
 

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -178,8 +178,13 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 }
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
-  size_t used      = used_in_bytes();
-  size_t committed = _codeHeap->capacity();
+  size_t used;
+  size_t committed;
+  {
+    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+    used = used_in_bytes();
+    committed = _codeHeap->capacity();
+  }
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);
 
   return MemoryUsage(initial_size(), used, committed, maxSize);

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -178,7 +178,7 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 }
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
-  size_t used      = used_in_bytes();
+  size_t used = used_in_bytes();
   OrderAccess::loadload();
   size_t committed = _codeHeap->capacity();
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);


### PR DESCRIPTION
# Issue
An intermittent _Memory Pool not found_ error has been noticed when running  a few tests (_vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java_, _vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java_) on _macosx\_aarch64_ (production build) with non-segmented code cache.

## Origin
The issue originates from the fact that aarch64 architecture is a weakly ordered memory architecture, i.e. it _permits the observation and completion of memory accesses in a different order from the program order_.

More precisely: while calling `CodeHeapPool::get_memory_usage`, the `used` and `committed` variables are retrieved
https://github.com/openjdk/jdk/blob/138542de7889e8002df0e15a79e31d824c6a0473/src/hotspot/share/services/memoryPool.cpp#L181-L182
and these are computed based on different variables saved in memory in `CodeCache::allocate` (during `heap->allocate` and `heap->expand_by` to be precise) .https://github.com/openjdk/jdk/blob/138542de7889e8002df0e15a79e31d824c6a0473/src/hotspot/share/code/codeCache.cpp#L535-L537
The problem happens when first `heap->expand_by` gets called (which _increases_ `committed`) and then `heap->allocate` gets called in a second loop pass (which _increases_ `used`). Although stores in `CodeCache::allocate` happen in the this order, when reading from memory in `CodeHeapPool::get_memory_usage` it can happen that `used` has the newly computed value, while `committed` is still "old" (because of ARM’s weak memory order). This is a problem, since `committed` must be > than `used`.

# Solution

To avoid this situation we must assure that values used to calculate `committed` are actually saved before the values used to calculate `used` and that the opposite be true for reading. To enforce this we acquire a `CodeCache_lock` while reading `used` and `committed` in `CodeHeapPool::get_memory_usage` (which should actually be the convention when accessing CodeCache data).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269393](https://bugs.openjdk.org/browse/JDK-8269393): store/load order not preserved when handling memory pool due to weakly ordered memory architecture of aarch64 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15819/head:pull/15819` \
`$ git checkout pull/15819`

Update a local copy of the PR: \
`$ git checkout pull/15819` \
`$ git pull https://git.openjdk.org/jdk.git pull/15819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15819`

View PR using the GUI difftool: \
`$ git pr show -t 15819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15819.diff">https://git.openjdk.org/jdk/pull/15819.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15819#issuecomment-1741006500)