### PR TITLE
8316461: Fix: make test outputs TEST SUCCESS after unsuccessful exit

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -862,7 +862,7 @@ define SetupRunJtregTestBody
 
   $$(eval $$(call SetupRunJtregTestCustom, $1))
 
-  clean-workdir-$1:
+  clean-outputdirs-$1:
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
 	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
@@ -910,7 +910,7 @@ define SetupRunJtregTestBody
         done
   endif
 
-  run-test-$1: pre-run-test clean-workdir-$1
+  run-test-$1: pre-run-test clean-outputdirs-$1
 	$$(call LogWarn)
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR) \
@@ -947,9 +947,9 @@ define SetupRunJtregTestBody
 	  $$(eval $1_TOTAL := 1) \
 	)
 
-  $1: run-test-$1 parse-test-$1 clean-workdir-$1
+  $1: run-test-$1 parse-test-$1 clean-outputdirs-$1
 
-  TARGETS += $1 run-test-$1 parse-test-$1 clean-workdir-$1
+  TARGETS += $1 run-test-$1 parse-test-$1 clean-outputdirs-$1
   TEST_TARGETS += parse-test-$1
 
 endef

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -864,6 +864,7 @@ define SetupRunJtregTestBody
 
   clean-workdir-$1:
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)
+	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
   $1_COMMAND_LINE := \
       $$(JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \


### PR DESCRIPTION
`make test` outputs `TEST SUCCESS` after unsuccessful exit of JVM. One example is bad VM flags.

I now have a reproducer for something that has puzzled me before (and most of my co-workers I think):

// first test uses -XX:+UseG1GC second and third uses -XX:+UseG1GCC (sic)
`make clean run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='JAVA_OPTIONS=-XX:+UseG1GC'` -> OK
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='JAVA_OPTIONS=-XX:+UseG1GCC'` -> OK
`rm -rf test-results/jtreg_open_test_hotspot_jtreg_gc_arguments_TestCompressedClassFlags_java`
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='JAVA_OPTIONS=-XX:+UseG1GCC'` -> FAIL

The problem is that the success of the first test run seems to be cached and the second test-run seems to reuse the result of the first run.

This seems to fix the problem:
```
diff --git a/make/RunTests.gmk b/make/RunTests.gmk
index 25dcdbb083d..489c3f839f8 100644
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -864,6 +864,7 @@ define SetupRunJtregTestBody

   clean-workdir-$1:
        $$(RM) -r $$($1_TEST_SUPPORT_DIR)
+ $$(RM) -r $$($1_TEST_RESULTS_DIR)

   $1_COMMAND_LINE := \
       $$(JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
``` 
I have started tier 1-5 testing, but they are not completed yet. I would also like to know if this change cooperates nicely with RETRY_COUNT and REPEAT_COUNT. To me, it seems they both should be able to be more or less stateless, i.e. they ought to be able to quit on failure or success without a mutating directory, but It would be good if I could get that confirmed (because I have a hard time understanding the make files).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316461](https://bugs.openjdk.org/browse/JDK-8316461): Fix: make test outputs TEST SUCCESS after unsuccessful exit (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15820/head:pull/15820` \
`$ git checkout pull/15820`

Update a local copy of the PR: \
`$ git checkout pull/15820` \
`$ git pull https://git.openjdk.org/jdk.git pull/15820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15820`

View PR using the GUI difftool: \
`$ git pr show -t 15820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15820.diff">https://git.openjdk.org/jdk/pull/15820.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15820#issuecomment-1725800920)