### PR TITLE
8316412: javax/print tests fail without printer set up

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/ExceptionTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/print/PrinterJob/ExceptionTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/ExceptionTest.java
@@ -26,11 +26,13 @@
  * @key printer
  * @bug 6467557
  * @summary No exception should be thrown.
+ * @library /test/lib
  * @run main ExceptionTest
  */
 
 import java.awt.*;
 import java.awt.print.*;
+import jtreg.SkippedException;
 
 public class ExceptionTest {
 private TextCanvas c;
@@ -50,7 +52,7 @@ public ExceptionTest() {
            pj.print();
         } catch (PrinterException pe) {
             if (!(pe.getCause() instanceof IndexOutOfBoundsException)) {
-              throw new RuntimeException("initCause of Exception not thrown");
+              throw new SkippedException("initCause of Exception not thrown");
             }
         }
     }

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
@@ -50,12 +50,12 @@ public class NullClipARGB implements Printable {
             pj.setPrintable(new NullClipARGB());
             pj.print();
             } catch (Exception ex) {
-            throw new RuntimeException(ex);
+             throw new RuntimeException(ex);
         }
     }
 
     public int print(Graphics g, PageFormat pf, int pageIndex)
-                throws PrinterException{
+               throws PrinterException{
 
         if (pageIndex != 0) {
             return NO_SUCH_PAGE;

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
@@ -32,27 +32,30 @@
 import java.awt.*;
 import java.awt.image.*;
 import java.awt.print.*;
+import javax.print.DocFlavor;
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
 import jtreg.SkippedException;
 
 public class NullClipARGB implements Printable {
 
     public static void main( String[] args ) {
+        PrintService[] svc = PrintServiceLookup.lookupPrintServices(DocFlavor.SERVICE_FORMATTED.PRINTABLE, null);
+        if (svc.length == 0) {
+            throw new SkippedException("Printer is required for this test.  TEST ABORTED");
+        }
 
         try {
             PrinterJob pj = PrinterJob.getPrinterJob();
             pj.setPrintable(new NullClipARGB());
             pj.print();
         } catch (Exception ex) {
-            if (ex instanceof PrinterException) {
-                throw new SkippedException("Printer is required for this test.  TEST ABORTED");
-            } else {
-                throw new RuntimeException(ex);
-            }
+            throw new RuntimeException(ex);
         }
     }
 
     public int print(Graphics g, PageFormat pf, int pageIndex)
-               throws PrinterException{
+            throws PrinterException{
 
         if (pageIndex != 0) {
             return NO_SUCH_PAGE;
@@ -65,7 +68,7 @@ public class NullClipARGB implements Printable {
         g2.setColor( Color.BLACK );
         g2.drawString("This text should be visible through the image", 0, 20);
         BufferedImage bi = new BufferedImage(100, 100,
-                                              BufferedImage.TYPE_INT_ARGB );
+                BufferedImage.TYPE_INT_ARGB );
         Graphics ig = bi.createGraphics();
         ig.setColor( new Color( 192, 192, 192, 80 ) );
         ig.fillRect( 0, 0, 100, 100 );

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
@@ -49,13 +49,13 @@ public class NullClipARGB implements Printable {
             PrinterJob pj = PrinterJob.getPrinterJob();
             pj.setPrintable(new NullClipARGB());
             pj.print();
-        } catch (Exception ex) {
+            } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
     }
 
     public int print(Graphics g, PageFormat pf, int pageIndex)
-            throws PrinterException{
+                throws PrinterException{
 
         if (pageIndex != 0) {
             return NO_SUCH_PAGE;
@@ -68,7 +68,7 @@ public class NullClipARGB implements Printable {
         g2.setColor( Color.BLACK );
         g2.drawString("This text should be visible through the image", 0, 20);
         BufferedImage bi = new BufferedImage(100, 100,
-                BufferedImage.TYPE_INT_ARGB );
+                                              BufferedImage.TYPE_INT_ARGB );
         Graphics ig = bi.createGraphics();
         ig.setColor( new Color( 192, 192, 192, 80 ) );
         ig.fillRect( 0, 0, 100, 100 );

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
@@ -26,11 +26,13 @@
  * @key printer
  * @bug 8061392
  * @summary Test no NPE when printing transparency with null clip.
+ * @library /test/lib
  */
 
 import java.awt.*;
 import java.awt.image.*;
 import java.awt.print.*;
+import jtreg.SkippedException;
 
 public class NullClipARGB implements Printable {
 
@@ -40,8 +42,12 @@ public class NullClipARGB implements Printable {
             PrinterJob pj = PrinterJob.getPrinterJob();
             pj.setPrintable(new NullClipARGB());
             pj.print();
-            } catch (Exception ex) {
-             throw new RuntimeException(ex);
+        } catch (Exception ex) {
+            if (ex instanceof PrinterException) {
+                throw new SkippedException("Printer is required for this test.  TEST ABORTED");
+            } else {
+                throw new RuntimeException(ex);
+            }
         }
     }
 

--- a/test/jdk/java/awt/print/PrinterJob/PrtException.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrtException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/print/PrinterJob/PrtException.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrtException.java
@@ -26,12 +26,14 @@
  * @key printer
  * @bug 4429544
  * @summary This test should not throw a printer exception. Test has been modified to correspond with the behavior of 1.5 and above.
+ * @library /test/lib
  * @run main PrtException
  */
 
 import java.awt.*;
 import java.awt.print.*;
 import javax.print.*;
+import jtreg.SkippedException;
 
 public class PrtException implements Printable {
     PrinterJob pj;
@@ -44,7 +46,7 @@ public class PrtException implements Printable {
             if (defService == null) {
                 svc = PrintServiceLookup.lookupPrintServices(DocFlavor.SERVICE_FORMATTED.PRINTABLE, null);
                 if (svc.length == 0) {
-                    throw new RuntimeException("Printer is required for this test.  TEST ABORTED");
+                    throw new SkippedException("Printer is required for this test.  TEST ABORTED");
                 }
                 defService = svc[0];
             }

--- a/test/jdk/javax/print/CheckDupFlavor.java
+++ b/test/jdk/javax/print/CheckDupFlavor.java
@@ -31,6 +31,8 @@
  */
 
 import javax.print.*;
+import javax.print.attribute.*;
+import javax.print.attribute.standard.*;
 import java.util.ArrayList;
 import jtreg.SkippedException;
 

--- a/test/jdk/javax/print/CheckDupFlavor.java
+++ b/test/jdk/javax/print/CheckDupFlavor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/print/CheckDupFlavor.java
+++ b/test/jdk/javax/print/CheckDupFlavor.java
@@ -26,14 +26,13 @@
  * @key printer
  * @bug 4996318 6731937
  * @summary  There should be no duplicates returned by getSupportedDocFlavors.
+ * @library /test/lib
  * @run main CheckDupFlavor
  */
 
 import javax.print.*;
-import javax.print.attribute.*;
-import javax.print.attribute.standard.*;
 import java.util.ArrayList;
-
+import jtreg.SkippedException;
 
 public class CheckDupFlavor {
     public static void main(String[] args){
@@ -42,7 +41,7 @@ public class CheckDupFlavor {
         if (defService == null) {
             pservice = PrintServiceLookup.lookupPrintServices(null, null);
             if (pservice.length == 0) {
-                throw new RuntimeException("No printer found.  TEST ABORTED");
+                throw new SkippedException("No printer found.  TEST ABORTED");
             }
             defService = pservice[0];
         }

--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -26,6 +26,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
+import javax.print.attribute.AttributeSet;
+import javax.print.attribute.HashAttributeSet;
+import javax.print.attribute.standard.PrinterName;
 import jtreg.SkippedException;
 
 /*

--- a/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
+++ b/test/jdk/javax/print/PrintServiceLookup/CountPrintServices.java
@@ -22,18 +22,18 @@
  */
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
-import javax.print.attribute.AttributeSet;
-import javax.print.attribute.HashAttributeSet;
-import javax.print.attribute.standard.PrinterName;
+import jtreg.SkippedException;
 
 /*
  * @test
  * @bug 8032693
  * @key printer
  * @summary Test that lpstat and JDK agree whether there are printers.
+ * @library /test/lib
  */
 public class CountPrintServices {
 
@@ -51,7 +51,13 @@ public class CountPrintServices {
        return;
     }
     String[] lpcmd = { "lpstat", "-a" };
-    Process proc = Runtime.getRuntime().exec(lpcmd);
+    Process proc;
+    try {
+        proc = Runtime.getRuntime().exec(lpcmd);
+    } catch (IOException e) {
+        e.printStackTrace();
+        throw new SkippedException("lpstat not found but is required for this test.  TEST ABORTED");
+    }
     proc.waitFor();
     InputStreamReader ir = new InputStreamReader(proc.getInputStream());
     BufferedReader br = new BufferedReader(ir);

--- a/test/jdk/javax/print/attribute/AttributeTest.java
+++ b/test/jdk/javax/print/attribute/AttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/print/attribute/AttributeTest.java
+++ b/test/jdk/javax/print/attribute/AttributeTest.java
@@ -26,12 +26,13 @@
  * @key printer
  * @bug 6387255
  * @summary  Tests conflict of Media values returned by isAttrValueSupported and getSupportedAttrValues.  No runtime exception should be thrown.
+ * @library /test/lib
  * @run main AttributeTest
  */
 
 import javax.print.*;
 import javax.print.attribute.standard.*;
-import javax.print.attribute.*;
+import jtreg.SkippedException;
 
 public class AttributeTest {
 
@@ -40,7 +41,7 @@ public class AttributeTest {
                 PrintService service[] = PrintServiceLookup.lookupPrintServices(null, null);
 
                 if (service.length == 0) {
-                        throw new RuntimeException("No printer found.  TEST ABORTED");
+                        throw new SkippedException("No printer found.  TEST ABORTED");
                 }
 
                 for (int x = 0; x < service.length; x ++) {

--- a/test/jdk/javax/print/attribute/AttributeTest.java
+++ b/test/jdk/javax/print/attribute/AttributeTest.java
@@ -32,6 +32,7 @@
 
 import javax.print.*;
 import javax.print.attribute.standard.*;
+import javax.print.attribute.*;
 import jtreg.SkippedException;
 
 public class AttributeTest {

--- a/test/jdk/javax/print/attribute/GetCopiesSupported.java
+++ b/test/jdk/javax/print/attribute/GetCopiesSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/print/attribute/GetCopiesSupported.java
+++ b/test/jdk/javax/print/attribute/GetCopiesSupported.java
@@ -26,12 +26,13 @@
  * @key printer
  * @bug 4463280
  * @summary No ClassCastException should occur.
+ * @library /test/lib
  * @run main GetCopiesSupported
  */
 
 import javax.print.*;
-import javax.print.attribute.*;
 import javax.print.attribute.standard.*;
+import jtreg.SkippedException;
 
 public class GetCopiesSupported {
 
@@ -41,7 +42,7 @@ public class GetCopiesSupported {
         if (service == null) {
              pservice = PrintServiceLookup.lookupPrintServices(null, null);
             if (pservice.length == 0) {
-                    throw new RuntimeException("No printer found.  TEST ABORTED");
+                    throw new SkippedException("No printer found.  TEST ABORTED");
             }
             service = pservice[0];
         }

--- a/test/jdk/javax/print/attribute/GetCopiesSupported.java
+++ b/test/jdk/javax/print/attribute/GetCopiesSupported.java
@@ -31,6 +31,7 @@
  */
 
 import javax.print.*;
+import javax.print.attribute.*;
 import javax.print.attribute.standard.*;
 import jtreg.SkippedException;
 

--- a/test/jdk/javax/print/attribute/SidesPageRangesTest.java
+++ b/test/jdk/javax/print/attribute/SidesPageRangesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/print/attribute/SidesPageRangesTest.java
+++ b/test/jdk/javax/print/attribute/SidesPageRangesTest.java
@@ -30,8 +30,13 @@
  * @run main SidesPageRangesTest
  */
 
+import java.awt.*;
 import javax.print.*;
 import javax.print.attribute.standard.*;
+import javax.print.attribute.*;
+import java.io.*;
+import java.util.Locale;
+import java.net.URL;
 import jtreg.SkippedException;
 
 public class SidesPageRangesTest {

--- a/test/jdk/javax/print/attribute/SidesPageRangesTest.java
+++ b/test/jdk/javax/print/attribute/SidesPageRangesTest.java
@@ -26,16 +26,13 @@
  * @key printer
  * @bug 4903366
  * @summary No crash should occur.
+ * @library /test/lib
  * @run main SidesPageRangesTest
  */
 
-import java.awt.*;
 import javax.print.*;
 import javax.print.attribute.standard.*;
-import javax.print.attribute.*;
-import java.io.*;
-import java.util.Locale;
-import java.net.URL;
+import jtreg.SkippedException;
 
 public class SidesPageRangesTest {
         /**
@@ -56,7 +53,7 @@ public class SidesPageRangesTest {
                 if (defService == null) {
                     pservice = PrintServiceLookup.lookupPrintServices(null, null);
                     if (pservice.length == 0) {
-                        throw new RuntimeException("Printer is required for this test.  TEST ABORTED");
+                        throw new SkippedException("Printer is required for this test.  TEST ABORTED");
                     }
                     defService = pservice[0];
                 }

--- a/test/jdk/javax/print/attribute/SupportedPrintableAreas.java
+++ b/test/jdk/javax/print/attribute/SupportedPrintableAreas.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/print/attribute/SupportedPrintableAreas.java
+++ b/test/jdk/javax/print/attribute/SupportedPrintableAreas.java
@@ -32,6 +32,7 @@
 
 
 import javax.print.*;
+import javax.print.event.*;
 import javax.print.attribute.*;
 import javax.print.attribute.standard.*;
 import jtreg.SkippedException;

--- a/test/jdk/javax/print/attribute/SupportedPrintableAreas.java
+++ b/test/jdk/javax/print/attribute/SupportedPrintableAreas.java
@@ -26,14 +26,15 @@
  * @key printer
  * @bug 4762773 6289206 6324049 6362765
  * @summary Tests that get non-null return list of printable areas.
+ * @library /test/lib
  * @run main SupportedPrintableAreas
  */
 
 
 import javax.print.*;
-import javax.print.event.*;
 import javax.print.attribute.*;
 import javax.print.attribute.standard.*;
+import jtreg.SkippedException;
 
 public class SupportedPrintableAreas {
 
@@ -43,7 +44,7 @@ public class SupportedPrintableAreas {
      if (printer == null) {
          svc = PrintServiceLookup.lookupPrintServices(DocFlavor.SERVICE_FORMATTED.PRINTABLE, null);
          if (svc.length == 0) {
-             throw new RuntimeException("Printer is required for this test.  TEST ABORTED");
+             throw new SkippedException("Printer is required for this test.  TEST ABORTED");
          }
          printer = svc[0];
      }


### PR DESCRIPTION
For NullClipARGB we are throwing SkippedException only if instance of caught exception is PrinterException. All other exceptions are considered unrelated to printer configuration.

For CountPrintServices we want to throw SkippedException in the case when lpstat is not installed, where an IOException is caught in that case.

For ExceptionTest we want to throw SkippedException for all PrinterExceptions which were not caused by IndexOutOfBoundsException.

For rest of the tests if PrintService was not created instead RuntimeException we are throwing now SkippedException.

Tested on environment without printer installed.
Test are passing with skipped exception as expected.

Passed: java/awt/print/PrinterJob/ExceptionTest.java
Passed: java/awt/print/PrinterJob/ImagePrinting/NullClipARGB.java
Passed: java/awt/print/PrinterJob/PrtException.java
Passed: javax/print/attribute/AttributeTest.java
Passed: javax/print/attribute/GetCopiesSupported.java
Passed: javax/print/attribute/SidesPageRangesTest.java
Passed: javax/print/attribute/SupportedPrintableAreas.java
Passed: javax/print/PrintServiceLookup/CountPrintServices.java
Passed: javax/print/CheckDupFlavor.java

Additionally unused imports have been removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8316412](https://bugs.openjdk.org/browse/JDK-8316412): javax/print tests fail without printer set up (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15821/head:pull/15821` \
`$ git checkout pull/15821`

Update a local copy of the PR: \
`$ git checkout pull/15821` \
`$ git pull https://git.openjdk.org/jdk.git pull/15821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15821`

View PR using the GUI difftool: \
`$ git pr show -t 15821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15821.diff">https://git.openjdk.org/jdk/pull/15821.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15821#issuecomment-1728103439)