### PR TITLE
JDK-8316546: Backout JDK-8315932: runtime/InvocationTests spend a lot of time on dependency verification

### DIFF
--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationC1Tests.java
@@ -72,7 +72,6 @@ public class invocationC1Tests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M",
             "-Xcomp", "-XX:TieredStopAtLevel=1",
-            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
             whichTests, "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/InvocationTests/invocationOldCHATests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invocationOldCHATests.java
@@ -69,7 +69,6 @@ public class invocationOldCHATests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M",
             "-Xcomp", "-XX:+UnlockDiagnosticVMOptions", "-XX:-UseVtableBasedCHA",
-            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
             whichTests, "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokeinterfaceTests.java
@@ -75,7 +75,6 @@ public class invokeinterfaceTests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M", option,
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
-            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "invokeinterface.Generator", "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         try {

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokespecialTests.java
@@ -72,7 +72,6 @@ public class invokespecialTests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M", option,
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
-            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "invokespecial.Generator", "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         try {

--- a/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/invokevirtualTests.java
@@ -72,7 +72,6 @@ public class invokevirtualTests {
                            ", class file version: " + classFileVersion);
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xmx128M", option,
             "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
-            "-XX:MetaspaceSize=128K", "-XX:MaxMetaspaceSize=4M",
             "invokevirtual.Generator", "--classfile_version=" + classFileVersion);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         try {


### PR DESCRIPTION
There is an evidence that at least AIX runs into problems with this. We can redo the patch in more reliable manner. 
This cleanly reverts commit ca3fe7b3fd9c4d08ac7a40d9bd36149ce3d71d9b.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316546](https://bugs.openjdk.org/browse/JDK-8316546): Backout JDK-8315932: runtime/InvocationTests spend a lot of time on dependency verification (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15822/head:pull/15822` \
`$ git checkout pull/15822`

Update a local copy of the PR: \
`$ git checkout pull/15822` \
`$ git pull https://git.openjdk.org/jdk.git pull/15822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15822`

View PR using the GUI difftool: \
`$ git pr show -t 15822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15822.diff">https://git.openjdk.org/jdk/pull/15822.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15822#issuecomment-1726167614)