### PR TITLE
8316445: Mark com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java as vm.flagless

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -53,6 +53,7 @@ requires.extraPropDefns.vmOpts = \
 requires.properties= \
     sun.arch.data.model \
     java.runtime.name \
+    vm.flagless \
     vm.gc.G1 \
     vm.gc.Serial \
     vm.gc.Parallel \

--- a/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
+++ b/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
  * @test
  * @bug 8028994
  * @author Staffan Larsen
+ * @requires vm.flagless
  * @library /test/lib
  * @modules jdk.attach/sun.tools.attach
  *          jdk.management

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -689,15 +689,19 @@ public class VMProps implements Callable<Map<String, String>> {
         // check -X flags
         var ignoredXFlags = Set.of(
                 // default, yet still seen to be explicitly set
-                "mixed"
+                "mixed",
+                // -XmxmNNNm added by run-test framework for non-hotspot tests
+                "mx"
         );
         result &= allFlags.stream()
                           .filter(s -> s.startsWith("-X") && !s.startsWith("-XX:"))
                           // map to names:
-                              // remove -X
-                              .map(s -> s.substring(2))
-                              // remove :.* from flags with values
-                              .map(s -> s.contains(":") ? s.substring(0, s.indexOf(':')) : s)
+                          // remove -X
+                          .map(s -> s.substring(2))
+                          // remove :.* from flags with values
+                          .map(s -> s.contains(":") ? s.substring(0, s.indexOf(':')) : s)
+                          // remove size like 4G, 768m which might be set for non-hotspot tests
+                          .map(s -> s.replaceAll("(\\d+)[mMgGkK]", ""))
                           // skip known-to-be-there flags
                           .filter(s -> !ignoredXFlags.contains(s))
                           .findAny()


### PR DESCRIPTION
Test
com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
check how beans work with VM flags and ignore external flags.
It doesn't make sense to run it with external options so just mark it as flagless.
Tested with running tier1 and test with/without additional options.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316445](https://bugs.openjdk.org/browse/JDK-8316445): Mark com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java as vm.flagless (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [48fa3c66](https://git.openjdk.org/jdk/pull/15823/files/48fa3c667da00af6e7a1fcf94f641a01deedcd4a)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15823/head:pull/15823` \
`$ git checkout pull/15823`

Update a local copy of the PR: \
`$ git checkout pull/15823` \
`$ git pull https://git.openjdk.org/jdk.git pull/15823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15823`

View PR using the GUI difftool: \
`$ git pr show -t 15823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15823.diff">https://git.openjdk.org/jdk/pull/15823.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15823#issuecomment-1726193805)