### PR TITLE
8316532: Native library copying in BuildMicrobenchmark.gmk cause dups on macOS

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -155,10 +155,10 @@ $(eval $(call SetupTestFilesCompilation, BUILD_MICROBENCHMARK_LIBRARIES, \
 
 # Setup copy of native dependencies to image output dir
 $(eval $(call SetupCopyFiles, COPY_MICROBENCHMARK_NATIVE, \
-    SRC := $(MICROBENCHMARK_NATIVE_OUTPUT), \
+    SRC := $(MICROBENCHMARK_NATIVE_OUTPUT)/lib, \
     DEST := $(MICROBENCHMARK_IMAGE_DIR)/native, \
-    FILES := $(BUILD_MICROBENCHMARK_LIBRARIES), \
-    FLATTEN := true, \
+    FILES := $(filter $(MICROBENCHMARK_NATIVE_OUTPUT)/lib/%, \
+        $(BUILD_MICROBENCHMARK_LIBRARIES)), \
 ))
 
 all: $(MICROBENCHMARK_JAR) $(BUILD_MICROBENCHMARK_LIBRARIES) $(COPY_MICROBENCHMARK_NATIVE)


### PR DESCRIPTION
After [JDK-8253620](https://bugs.openjdk.org/browse/JDK-8253620), BuildMicrobenchmark.gmk has started printing warnings about overriding targets on macos. This is caused by a CopyFiles using the `FLATTEN` option in combination with debug symbols on macos having the same filename as the dylib itself.

In this fix, I'm changing the CopyFiles to no longer flatten the file structure. I'm also filtering the list of files to be copied to only include files from the native output `lib` dir. This avoids having any files from the support dir (e.g. dependency *.d files) from being copied into the test image. The resulting native directory in the test-image ends up having all native libraries in it, with debug symbols in their respective *.dSYM sub-directories, as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316532](https://bugs.openjdk.org/browse/JDK-8316532): Native library copying in BuildMicrobenchmark.gmk cause dups on macOS (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15824/head:pull/15824` \
`$ git checkout pull/15824`

Update a local copy of the PR: \
`$ git checkout pull/15824` \
`$ git pull https://git.openjdk.org/jdk.git pull/15824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15824`

View PR using the GUI difftool: \
`$ git pr show -t 15824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15824.diff">https://git.openjdk.org/jdk/pull/15824.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15824#issuecomment-1726244597)