### PR TITLE
8316547: Use JUnit.dir jtreg property with jpackage JUnit tests

### DIFF
--- a/test/jdk/tools/jpackage/junit/TEST.properties
+++ b/test/jdk/tools/jpackage/junit/TEST.properties
@@ -1,0 +1,1 @@
+JUnit.dirs = .

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/AppImageFileTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/AppImageFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,12 +37,6 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.function.ThrowingRunnable;
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED AppImageFileTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.AppImageFileTest
- */
 public class AppImageFileTest {
 
     @Rule

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/ApplicationLayoutTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/ApplicationLayoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,6 @@ import org.junit.rules.TemporaryFolder;
 import static org.junit.Assert.assertTrue;
 
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED ApplicationLayoutTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.ApplicationLayoutTest
- */
 public class ApplicationLayoutTest {
 
     @Rule

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/CompareDottedVersionTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/CompareDottedVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import static org.junit.Assert.assertEquals;
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED CompareDottedVersionTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.CompareDottedVersionTest
- */
 @RunWith(Parameterized.class)
 public class CompareDottedVersionTest {
 

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/DeployParamsTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/DeployParamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,13 +32,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
-/*
- * @test
- * @summary Test for JDK-8211285
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED DeployParamsTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.DeployParamsTest
- */
 public class DeployParamsTest {
 
     @Rule

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/DottedVersionTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/DottedVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,12 +34,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED DottedVersionTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.DottedVersionTest
- */
 @RunWith(Parameterized.class)
 public class DottedVersionTest {
 

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/EnquoterTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/EnquoterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,6 @@ package jdk.jpackage.internal;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED EnquoterTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.EnquoterTest
- */
 public class EnquoterTest {
 
     @Test

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/InvalidDottedVersionTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/InvalidDottedVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED InvalidDottedVersionTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.InvalidDottedVersionTest
- */
 @RunWith(Parameterized.class)
 public class InvalidDottedVersionTest {
 

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/OverridableResourceTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/OverridableResourceTest.java
@@ -46,12 +46,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED OverridableResourceTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.OverridableResourceTest
- */
 public class OverridableResourceTest {
 
     @Rule

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/PathGroupTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/PathGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,12 +47,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED PathGroupTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.PathGroupTest
- */
 public class PathGroupTest {
 
     @Rule

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/PlatformVersionTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/PlatformVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,12 +37,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED PlatformVersionTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.PlatformVersionTest
- */
 @RunWith(Parameterized.class)
 public class PlatformVersionTest {
 

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/ToolValidatorTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/ToolValidatorTest.java
@@ -33,12 +33,6 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 
 
-/*
- * @test
- * @modules jdk.jpackage
- * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED ToolValidatorTest.java
- * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.ToolValidatorTest
- */
 public class ToolValidatorTest {
 
     @Test


### PR DESCRIPTION
Strip
```
/*
 * @test
 * @modules jdk.jpackage
 * @compile --patch-module jdk.jpackage=${test.src} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED AppImageFileTest.java
 * @run junit/othervm --patch-module jdk.jpackage=${test.classes} --add-reads jdk.jpackage=ALL-UNNAMED --add-exports jdk.jpackage/jdk.jpackage.internal=ALL-UNNAMED jdk.jpackage.internal.AppImageFileTest
 */
```
comment from jpackage JUnit tests and instruct jtreg to run them through `JUnit.dirs` property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316547](https://bugs.openjdk.org/browse/JDK-8316547): Use JUnit.dir jtreg property with jpackage JUnit tests (**Enhancement** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15826/head:pull/15826` \
`$ git checkout pull/15826`

Update a local copy of the PR: \
`$ git checkout pull/15826` \
`$ git pull https://git.openjdk.org/jdk.git pull/15826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15826`

View PR using the GUI difftool: \
`$ git pr show -t 15826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15826.diff">https://git.openjdk.org/jdk/pull/15826.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15826#issuecomment-1726416836)