### PR TITLE
8316383: NullPointerException in AbstractSAXParser after JDK-8306632

### DIFF
--- a/src/java.xml/share/classes/jdk/xml/internal/Utils.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/Utils.java
@@ -26,11 +26,38 @@
 package jdk.xml.internal;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 /**
  * General utility. Use JdkXmlUtils for XML processing related functions.
  */
 public class Utils {
+    // The debug flag
+    private static boolean debug = false;
+
+    /*
+     * The {@systemProperty jaxp.debug} property is supported by JAXP factories
+     * and used to print out information related to the configuration of factories
+     * and processors
+    */
+    static {
+        try {
+            String val = SecuritySupport.getSystemProperty("jaxp.debug");
+            // Allow simply setting the prop to turn on debug
+            debug = val != null && !"false".equals(val);
+        }
+        catch (SecurityException se) {
+            debug = false;
+        }
+    }
+
+    // print out debug information if jaxp.debug is enabled
+    public static void dPrint(Supplier<String> msgGen) {
+        if (debug) {
+            System.err.println("JAXP: " + msgGen.get());
+        }
+    }
+
     /**
      * Creates a new array with copies of the original array and additional items
      * appended to the end of it.

--- a/src/java.xml/share/classes/jdk/xml/internal/Utils.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/Utils.java
@@ -39,7 +39,7 @@ public class Utils {
      * The {@systemProperty jaxp.debug} property is supported by JAXP factories
      * and used to print out information related to the configuration of factories
      * and processors
-    */
+     */
     static {
         try {
             String val = SecuritySupport.getSystemProperty("jaxp.debug");

--- a/test/jaxp/javax/xml/jaxp/unittest/sax/XMLReaderTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/sax/XMLReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,11 +33,13 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderAdapter;
+import org.xml.sax.helpers.XMLReaderFactory;
 
 /*
  * @test
- * @bug 8158246
+ * @bug 8158246 8316383
  * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
  * @run testng/othervm -DrunSecMngr=true -Djava.security.manager=allow sax.XMLReaderTest
  * @run testng/othervm sax.XMLReaderTest
@@ -68,5 +70,16 @@ public class XMLReaderTest {
                             .getXMLReader().getClass().getName();
         setSystemProperty(SAX_PROPNAME, className + "nosuch");
         XMLReaderAdapter adapter = new XMLReaderAdapter();
+    }
+
+    /*
+     * @bug 8316383
+     * Verifies that the XMLReader is initialized properly when it's created
+     * with XMLReaderFactory.
+     */
+    @Test
+    public void testCreateXMLReaderWithXMLReaderFactory() throws SAXException, ParserConfigurationException {
+        XMLReader reader = XMLReaderFactory.createXMLReader();
+        reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
     }
 }


### PR DESCRIPTION
Fix a NPE. The DTD patch (JDK-8306632) moved initialization to factories, for example, for SAXParser, the SecurityManagers are created in the SAXParserFactory impl and passed on to instances of SAXParsers. The (deprecated) XMLReaderFactory however, instantiates SAXParsers directly, thus without initializing the SecurityManagers. This patch checks the condition and creates them if they have not already been constructed.

Test: XML tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316383](https://bugs.openjdk.org/browse/JDK-8316383): NullPointerException in AbstractSAXParser after JDK-8306632 (**Bug** - P2)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [5c414425](https://git.openjdk.org/jdk/pull/15828/files/5c41442527754429f025bae464e2bccffc47f91c)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [5c414425](https://git.openjdk.org/jdk/pull/15828/files/5c41442527754429f025bae464e2bccffc47f91c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15828/head:pull/15828` \
`$ git checkout pull/15828`

Update a local copy of the PR: \
`$ git checkout pull/15828` \
`$ git pull https://git.openjdk.org/jdk.git pull/15828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15828`

View PR using the GUI difftool: \
`$ git pr show -t 15828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15828.diff">https://git.openjdk.org/jdk/pull/15828.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15828#issuecomment-1726492926)