### PR TITLE
8316540: StoreReproducibilityTest fails on some locales 

### DIFF
--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -92,7 +92,7 @@ public class StoreReproducibilityTest {
         for (int i = 0; i < 5; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             storedFiles.add(tmpFile);
-            final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            final ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
@@ -134,7 +134,7 @@ public class StoreReproducibilityTest {
         for (int i = 0; i < 5; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             storedFiles.add(tmpFile);
-            final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            final ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
                     "-Djava.security.manager",
                     "-Djava.security.policy=" + policyFile,
@@ -178,7 +178,7 @@ public class StoreReproducibilityTest {
         for (int i = 0; i < 5; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             storedFiles.add(tmpFile);
-            final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            final ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
                     "-Djava.security.manager",
                     "-Djava.security.policy=" + policyFile,
@@ -208,7 +208,7 @@ public class StoreReproducibilityTest {
         for (int i = 0; i < 2; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             storedFiles.add(tmpFile);
-            final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            final ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
@@ -240,7 +240,7 @@ public class StoreReproducibilityTest {
     private static void testEmptySysPropValue() throws Exception {
         for (int i = 0; i < 2; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
-            final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            final ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=",
                     "-Duser.timezone=UTC",
                     StoreTest.class.getName(),
@@ -272,7 +272,7 @@ public class StoreReproducibilityTest {
         for (int i = 0; i < 2; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             storedFiles.add(tmpFile);
-            final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            final ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
@@ -301,7 +301,7 @@ public class StoreReproducibilityTest {
             for (int i = 0; i < 2; i++) {
                 final Path tmpFile = Files.createTempFile("8231640", ".props");
                 storedFiles.add(tmpFile);
-                final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+                final ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                         "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
                         StoreTest.class.getName(),
                         tmpFile.toString(),
@@ -343,7 +343,7 @@ public class StoreReproducibilityTest {
             for (int i = 0; i < 2; i++) {
                 final Path tmpFile = Files.createTempFile("8231640", ".props");
                 storedFiles.add(tmpFile);
-                final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+                final ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                         "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
                         StoreTest.class.getName(),
                         tmpFile.toString(),

--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ import java.util.TimeZone;
 /*
  * @test
  * @summary Tests that the Properties.store() APIs generate output that is reproducible
- * @bug 8231640 8282023
+ * @bug 8231640 8282023 8316540
  * @library /test/lib
  * @run driver StoreReproducibilityTest
  */
@@ -52,6 +52,7 @@ public class StoreReproducibilityTest {
 
     private static final String DATE_FORMAT_PATTERN = "EEE MMM dd HH:mm:ss zzz uuuu";
     private static final String SYS_PROP_JAVA_PROPERTIES_DATE = "java.properties.date";
+    private static final String SYS_PROP_UTC_TIMEZONE = "-Duser.timezone=UTC";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.ROOT)
             .withZone(ZoneOffset.UTC);
 
@@ -94,6 +95,7 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
+                    SYS_PROP_UTC_TIMEZONE,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -136,8 +138,9 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
+                    SYS_PROP_UTC_TIMEZONE,
                     "-Djava.security.manager",
-                    "-Djava.security.policy=" + policyFile.toString(),
+                    "-Djava.security.policy=" + policyFile,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -180,8 +183,9 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
+                    SYS_PROP_UTC_TIMEZONE,
                     "-Djava.security.manager",
-                    "-Djava.security.policy=" + policyFile.toString(),
+                    "-Djava.security.policy=" + policyFile,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -210,6 +214,7 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
+                    SYS_PROP_UTC_TIMEZONE,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -241,7 +246,8 @@ public class StoreReproducibilityTest {
         for (int i = 0; i < 2; i++) {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
-                    "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + "",
+                    "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=",
+                    SYS_PROP_UTC_TIMEZONE,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -273,6 +279,7 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
+                    SYS_PROP_UTC_TIMEZONE,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -302,6 +309,7 @@ public class StoreReproducibilityTest {
                 storedFiles.add(tmpFile);
                 final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                         "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
+                        SYS_PROP_UTC_TIMEZONE,
                         StoreTest.class.getName(),
                         tmpFile.toString(),
                         i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -344,6 +352,7 @@ public class StoreReproducibilityTest {
                 storedFiles.add(tmpFile);
                 final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                         "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
+                        SYS_PROP_UTC_TIMEZONE,
                         StoreTest.class.getName(),
                         tmpFile.toString(),
                         i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -440,7 +449,7 @@ public class StoreReproducibilityTest {
     private static String findNthComment(Path file, int commentIndex) throws IOException {
         List<String> comments = new ArrayList<>();
         try (final BufferedReader reader = Files.newBufferedReader(file)) {
-            String line = null;
+            String line;
             while ((line = reader.readLine()) != null) {
                 if (line.startsWith("#")) {
                     comments.add(line.substring(1));

--- a/test/jdk/java/util/Properties/StoreReproducibilityTest.java
+++ b/test/jdk/java/util/Properties/StoreReproducibilityTest.java
@@ -52,7 +52,6 @@ public class StoreReproducibilityTest {
 
     private static final String DATE_FORMAT_PATTERN = "EEE MMM dd HH:mm:ss zzz uuuu";
     private static final String SYS_PROP_JAVA_PROPERTIES_DATE = "java.properties.date";
-    private static final String SYS_PROP_UTC_TIMEZONE = "-Duser.timezone=UTC";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.ROOT)
             .withZone(ZoneOffset.UTC);
 
@@ -95,7 +94,6 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
-                    SYS_PROP_UTC_TIMEZONE,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -138,7 +136,6 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
-                    SYS_PROP_UTC_TIMEZONE,
                     "-Djava.security.manager",
                     "-Djava.security.policy=" + policyFile,
                     StoreTest.class.getName(),
@@ -183,7 +180,6 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
-                    SYS_PROP_UTC_TIMEZONE,
                     "-Djava.security.manager",
                     "-Djava.security.policy=" + policyFile,
                     StoreTest.class.getName(),
@@ -214,7 +210,6 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
-                    SYS_PROP_UTC_TIMEZONE,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -247,7 +242,7 @@ public class StoreReproducibilityTest {
             final Path tmpFile = Files.createTempFile("8231640", ".props");
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=",
-                    SYS_PROP_UTC_TIMEZONE,
+                    "-Duser.timezone=UTC",
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -279,7 +274,6 @@ public class StoreReproducibilityTest {
             storedFiles.add(tmpFile);
             final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                     "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
-                    SYS_PROP_UTC_TIMEZONE,
                     StoreTest.class.getName(),
                     tmpFile.toString(),
                     i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -309,7 +303,6 @@ public class StoreReproducibilityTest {
                 storedFiles.add(tmpFile);
                 final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                         "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
-                        SYS_PROP_UTC_TIMEZONE,
                         StoreTest.class.getName(),
                         tmpFile.toString(),
                         i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -352,7 +345,6 @@ public class StoreReproducibilityTest {
                 storedFiles.add(tmpFile);
                 final ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
                         "-D" + SYS_PROP_JAVA_PROPERTIES_DATE + "=" + sysPropVal,
-                        SYS_PROP_UTC_TIMEZONE,
                         StoreTest.class.getName(),
                         tmpFile.toString(),
                         i % 2 == 0 ? "--use-outputstream" : "--use-writer");
@@ -425,6 +417,9 @@ public class StoreReproducibilityTest {
      * Verifies that the date comment in the {@code destFile} can be parsed using the
      * "EEE MMM dd HH:mm:ss zzz uuuu" format and the time represented by it is {@link Date#after(Date) after}
      * the passed {@code date}
+     * The JVM runtime to invoke this method should set the time zone to UTC, i.e, specify
+     * "-Duser.timezone=UTC" at the command line. Otherwise, it will fail with some time
+     * zones that have ambiguous short names, such as "IST"
      */
     private static void assertCurrentDate(final Path destFile, final Date date) throws Exception {
         final String dateComment = findNthComment(destFile, 2);


### PR DESCRIPTION
Fixing a test case that fails in some time zones. Making sure the test is run in `UTC` zone will fix the issue. Confirmed the fix by manually setting machine's time zone to Europe/Dublin.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316540](https://bugs.openjdk.org/browse/JDK-8316540): StoreReproducibilityTest fails on some locales (**Bug** - P4)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [30b0af53](https://git.openjdk.org/jdk/pull/15829/files/30b0af5373a73a7ae6a55605be7dbb1c86debe67)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [30b0af53](https://git.openjdk.org/jdk/pull/15829/files/30b0af5373a73a7ae6a55605be7dbb1c86debe67)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15829/head:pull/15829` \
`$ git checkout pull/15829`

Update a local copy of the PR: \
`$ git checkout pull/15829` \
`$ git pull https://git.openjdk.org/jdk.git pull/15829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15829`

View PR using the GUI difftool: \
`$ git pr show -t 15829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15829.diff">https://git.openjdk.org/jdk/pull/15829.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15829#issuecomment-1726650764)