### PR TITLE
8316285: Opensource JButton manual tests

### DIFF
--- a/test/jdk/javax/swing/JButton/bug4234034.java
+++ b/test/jdk/javax/swing/JButton/bug4234034.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4234034
+ * @summary Tests
+ * @key headful
+ * @run main bug4234034
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4234034 {
+    static JFrame frame;
+    static JButton button;
+    static Robot robot;
+
+    public static void main(String args[]) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                    frame = new JFrame("bug4323121");
+                    button = new JButton("Press tab, then Ctrl+F1");
+                    button.setToolTipText("Tooltip for button");
+                    frame.getContentPane().add(button);
+                    frame.pack();
+                    frame.setSize(250, 200);
+                    frame.setLocationRelativeTo(null);
+                    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_F1);
+            robot.keyRelease(KeyEvent.VK_F1);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JButton/bug4323121.java
+++ b/test/jdk/javax/swing/JButton/bug4323121.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4323121
+ * @summary Tests whether any button that extends JButton always
+            returns true for isArmed()
+ * @key headful
+ * @run main bug4323121
+ */
+
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4323121 {
+
+    static JFrame frame;
+    static testButton button;
+    static Robot robot;
+    static volatile Point pt;
+    static volatile int buttonW;
+    static volatile int buttonH;
+    static volatile boolean failed = false;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4323121");
+                button = new testButton("gotcha");
+                frame.getContentPane().add(button);
+                frame.pack();
+                frame.setSize(250, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                pt = button.getLocationOnScreen();
+                buttonW = button.getSize().width;
+                buttonH = button.getSize().height;
+            });
+            robot.mouseMove(pt.x + buttonW / 2, pt.y + buttonH / 2);
+
+            if (failed) {
+                throw new RuntimeException("Any created button returns " +
+                                    "true for isArmed()");
+            }
+        } finally {
+                SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    static class testButton extends JButton implements MouseMotionListener, MouseListener {
+        public testButton(String label) {
+            super(label);
+            addMouseMotionListener(this);
+            addMouseListener(this);
+        }
+
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+        }
+
+        protected void paintBorder(Graphics g) {
+        }
+
+        public void mousePressed(MouseEvent e) {
+        }
+
+        public void mouseDragged(MouseEvent e) {
+        }
+
+        public void mouseMoved(MouseEvent e) {
+        }
+
+        public void mouseReleased(MouseEvent e) {
+        }
+
+        public void mouseEntered(MouseEvent e) {
+            if (getModel().isArmed()) {
+                failed = true;
+            }
+        }
+
+        public void mouseExited(MouseEvent e) {
+        }
+
+        public void mouseClicked(MouseEvent e) {
+        }
+    }
+}

--- a/test/jdk/javax/swing/JButton/bug4490179.java
+++ b/test/jdk/javax/swing/JButton/bug4490179.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002, 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4490179
+ * @summary Tests that JButton only responds to left mouse clicks.
+ * @key headful
+ * @run main bug4490179
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4490179 {
+    static JFrame frame;
+    static JButton button;
+    static Robot robot;
+    static volatile Point pt;
+    static volatile int buttonW;
+    static volatile int buttonH;
+    static volatile boolean passed = true;
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4490179");
+                button = new JButton("Button");
+                frame.getContentPane().add(button);
+                button.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        passed = false;
+                    }
+                });
+                frame.pack();
+                frame.setSize(250, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                pt = button.getLocationOnScreen();
+                buttonW = button.getSize().width;
+                buttonH = button.getSize().height;
+            });
+
+            robot.mouseMove(pt.x + buttonW / 2, pt.y + buttonH / 2);
+            robot.delay(100);
+            robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+
+            if (!passed) {
+                throw new RuntimeException("Test Failed");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JFormattedTextField/bug4741926.java
+++ b/test/jdk/javax/swing/JFormattedTextField/bug4741926.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4741926
+ * @summary JFormattedTextField/JSpinner always consumes certain key events
+ * @key headful
+ * @run main bug4741926
+ */
+
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.util.Date;
+import javax.swing.AbstractAction;
+import javax.swing.InputMap;
+import javax.swing.JComponent;
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
+public class bug4741926 {
+
+    static MyFormattedTextField ftf;
+    static JFrame fr;
+    static Robot robot;
+    static volatile boolean passed_enter = false;
+    static volatile boolean passed_escape = false;
+    static volatile boolean ftfFocused = false;
+    static volatile boolean keyProcessed = false;
+
+    public static void main(String[] args) throws Exception {
+
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("Test");
+                ftf = new MyFormattedTextField();
+                ftf.setValue("JFormattedTextField");
+                JPanel p = (JPanel) fr.getContentPane();
+                p.add(ftf);
+                ftf.addFocusListener(new FocusAdapter() {
+                    public void focusGained(FocusEvent e) {
+                        ftfFocused = true;
+                    }
+                });
+                InputMap map = p.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+
+                map.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+                        "enter-action");
+                p.getActionMap().put("enter-action", new AbstractAction() {
+                    public void actionPerformed(ActionEvent e) {
+                        passed_enter = true;
+                        keyProcessed = true;
+                    }
+                });
+                map.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+                        "escape-action");
+                p.getActionMap().put("escape-action", new AbstractAction() {
+                    public void actionPerformed(ActionEvent e) {
+                        passed_escape = true;
+                        keyProcessed = true;
+                    }
+                });
+                fr.pack();
+                fr.setLocationRelativeTo(null);
+                fr.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            test();
+            if (!(passed_enter && passed_escape)) {
+                throw new RuntimeException("JFormattedTextField consume " +
+                        "Enter/Escape key event");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    public static void test() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            ftf.requestFocus();
+        });
+        robot.delay(500);
+        doTest(KeyEvent.VK_ENTER);
+        doTest(KeyEvent.VK_ESCAPE);
+    }
+
+    static void doTest(int keyCode) throws InterruptedException {
+        keyProcessed = false;
+        KeyEvent key = new KeyEvent(ftf, KeyEvent.KEY_PRESSED,
+                                    new Date().getTime(), 0,
+                                    keyCode,
+                                    KeyEvent.CHAR_UNDEFINED);
+        ftf.processKey(key);
+    }
+
+    static class MyFormattedTextField extends JFormattedTextField {
+        public void processKey(KeyEvent e) {
+            processKeyEvent(e);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JFormattedTextField/bug4863121.java
+++ b/test/jdk/javax/swing/JFormattedTextField/bug4863121.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4863121
+ * @summary JFormattedTextField's NotifyAction should invoke invalidEdit if
+   commit fails
+ * @key headful
+ * @run main bug4863121
+ */
+
+import java.awt.Robot;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.text.Format;
+import java.text.DecimalFormat;
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4863121 {
+
+    static TestFormattedTextField ftf;
+    static JFrame fr;
+    static Robot robot;
+
+    private static volatile boolean focused = false;
+    private static volatile boolean passed = false;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeAndWait(() -> {
+                fr = new JFrame("Test");
+                ftf = new TestFormattedTextField(new DecimalFormat("####"));
+                ftf.setText("q");
+                fr.getContentPane().add(ftf);
+
+                ftf.addFocusListener(new FocusAdapter() {
+                    public void focusGained(FocusEvent e) {
+                        focused = true;
+                    }
+                });
+                fr.pack();
+                fr.setLocationRelativeTo(null);
+                fr.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                ftf.requestFocus();
+            });
+            robot.waitForIdle();
+            robot.delay(500);
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+            if (!passed) {
+                throw new RuntimeException("JFormattedTextField's NotifyAction " +
+                        "should invoke invalidEdit if commit fails");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (fr != null) {
+                    fr.dispose();
+                }
+            });
+        }
+    }
+
+    public static class TestFormattedTextField extends JFormattedTextField {
+        public TestFormattedTextField(Format f) {
+            super(f);
+        }
+        protected void invalidEdit() {
+            passed = true;
+        }
+    }
+}

--- a/test/jdk/javax/swing/JFormattedTextField/bug4886538.java
+++ b/test/jdk/javax/swing/JFormattedTextField/bug4886538.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4886538
+ * @summary JFormattedTextField not returning correct value (class)
+ * @run main bug4886538
+ */
+
+import javax.swing.JFormattedTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.text.DefaultFormatterFactory;
+
+public class bug4886538 {
+
+    public static void main(String[] args) throws Exception {
+        // test default display formatter
+        TestFormattedTextField field = new TestFormattedTextField(0.0);
+        field.setFormatter(((DefaultFormatterFactory) field.
+                getFormatterFactory()).getDisplayFormatter());
+        field.setText("10");
+        field.commitEdit();
+
+        Object dblValue = field.getValue();
+        if (!(dblValue instanceof Double)) {
+            throw new RuntimeException("The JFormattedTextField's value " +
+                    "should be instanceof Double");
+        }
+
+        // test default editor formatter
+        field = new TestFormattedTextField(0.0);
+        field.setFormatter(((DefaultFormatterFactory) field.
+                getFormatterFactory()).getEditFormatter());
+        field.setText("10");
+        field.commitEdit();
+
+        dblValue = field.getValue();
+        if (!(dblValue instanceof Double)) {
+            throw new RuntimeException("The JFormattedTextField's value " +
+                    "should be instanceof Double");
+        }
+
+    }
+
+    static class TestFormattedTextField extends JFormattedTextField {
+        public TestFormattedTextField(Object value) {
+            super(value);
+        }
+        public void setFormatter(JFormattedTextField.AbstractFormatter formatter) {
+            super.setFormatter(formatter);
+        }
+    }
+
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug4123919.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4123919.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4123919
+ * @requires (os.family == "windows")
+ * @summary JPopupMenu.isPopupTrigger() under a different L&F.
+ * @key headful
+ * @run main bug4123919
+ */
+
+import javax.swing.JLabel;
+import javax.swing.JPopupMenu;
+import javax.swing.UIManager;
+import javax.swing.SwingUtilities;
+import java.awt.event.MouseEvent;
+import java.util.Date;
+
+public class bug4123919 {
+
+    public static void main(String[] args) throws Exception {
+        JPopupMenu popup = new JPopupMenu("Test");
+        JLabel lb = new JLabel();
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+        SwingUtilities.updateComponentTreeUI(lb);
+        SwingUtilities.updateComponentTreeUI(popup);
+        if (!popup.isPopupTrigger(new MouseEvent(lb, MouseEvent.MOUSE_PRESSED,
+                (new Date()).getTime(), MouseEvent.BUTTON3_MASK, 10, 10, 1, true))) {
+            throw new RuntimeException("JPopupMenu.isPopupTrigger() fails on" +
+                    " MotifLookAndFeel when mouse pressed...");
+        }
+        if (popup.isPopupTrigger(new MouseEvent(lb, MouseEvent.MOUSE_RELEASED,
+                (new Date()).getTime(), MouseEvent.BUTTON3_MASK, 10, 10, 1, true))) {
+            throw new RuntimeException("JPopupMenu.isPopupTrigger() fails on" +
+                    " MotifLookAndFeel when mouse released...");
+        }
+
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        SwingUtilities.updateComponentTreeUI(lb);
+        SwingUtilities.updateComponentTreeUI(popup);
+
+        if (popup.isPopupTrigger(new MouseEvent(lb, MouseEvent.MOUSE_PRESSED,
+                (new Date()).getTime(), MouseEvent.BUTTON3_MASK, 10, 10, 1, true))) {
+            throw new RuntimeException("JPopupMenu.isPopupTrigger() fails on" +
+                    " WindowsLookAndFeel when mouse pressed...");
+        }
+        if (!popup.isPopupTrigger(new MouseEvent(lb, MouseEvent.MOUSE_RELEASED,
+                (new Date()).getTime(), MouseEvent.BUTTON3_MASK, 10, 10, 1, true))) {
+            throw new RuntimeException("JPopupMenu.isPopupTrigger() fails on" +
+                    " WindowsLookAndFeel when mouse released...");
+        }
+    }
+}

--- a/test/jdk/javax/swing/JPopupMenu/bug4197019.java
+++ b/test/jdk/javax/swing/JPopupMenu/bug4197019.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4197019
+ * @key headful
+ * @run main bug4197019
+ */
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Polygon;
+import java.awt.event.ActionEvent;
+
+import javax.swing.Action;
+import javax.swing.AbstractAction;
+import javax.swing.Icon;
+import javax.swing.JMenuItem;
+import javax.swing.JMenu;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+
+public class bug4197019 {
+    static volatile JMenuItem mi1;
+    static volatile JMenuItem mi2;
+    static volatile Icon i2;
+    static volatile boolean isPassed = false;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JMenu fileMenu = new JMenu("File");
+            JPopupMenu p = new JPopupMenu();
+            Icon i = new ArrowIcon();
+            Action a = new TestAction("Test", i);
+            mi1 = fileMenu.add(a);
+            mi2 = p.add(a);
+
+            i2 = new SquareIcon();
+            a.putValue(Action.SMALL_ICON, i2);
+
+            isPassed = (mi2.getIcon() != i2) || (mi1.getIcon() != i2) ||
+                    (mi1.getIcon() != mi2.getIcon());
+        });
+        if (isPassed) {
+            throw new RuntimeException("Failed bug test 4197019");
+        }
+    }
+
+    private static class TestAction extends AbstractAction {
+        public TestAction(String s, Icon i) {
+            super(s,i);
+        }
+        public void actionPerformed(ActionEvent e) {
+
+        }
+    }
+
+    private static class ArrowIcon implements Icon {
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            Polygon p = new Polygon();
+            p.addPoint(x, y);
+            p.addPoint(x+getIconWidth(), y+getIconHeight()/2);
+            p.addPoint(x, y+getIconHeight());
+            g.fillPolygon(p);
+
+        }
+        public int getIconWidth() { return 4; }
+        public int getIconHeight() { return 8; }
+    } // End class MenuArrowIcon
+
+    private static class SquareIcon implements Icon {
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            g.setColor(Color.red);
+            g.fill3DRect(x,y,4,8,true);
+        }
+        public int getIconWidth() { return 8; }
+        public int getIconHeight() { return 8; }
+    } // End class MenuArrowIcon
+
+}


### PR DESCRIPTION
Few closed JButton swing manual test converted to automated and open sourced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316285](https://bugs.openjdk.org/browse/JDK-8316285): Opensource JButton manual tests (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15831/head:pull/15831` \
`$ git checkout pull/15831`

Update a local copy of the PR: \
`$ git checkout pull/15831` \
`$ git pull https://git.openjdk.org/jdk.git pull/15831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15831`

View PR using the GUI difftool: \
`$ git pr show -t 15831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15831.diff">https://git.openjdk.org/jdk/pull/15831.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15831#issuecomment-1726830496)