### PR TITLE
8316285: Opensource JButton manual tests

### DIFF
--- a/test/jdk/javax/swing/JButton/bug4234034.java
+++ b/test/jdk/javax/swing/JButton/bug4234034.java
@@ -38,7 +38,6 @@ import javax.swing.SwingUtilities;
 public class bug4234034 {
     static JFrame frame;
     static JButton button;
-    static Robot robot;
 
     public static void main(String args[]) throws Exception {
         Robot robot = new Robot();

--- a/test/jdk/javax/swing/JButton/bug4234034.java
+++ b/test/jdk/javax/swing/JButton/bug4234034.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4234034
+ * @summary Tests
+ * @key headful
+ * @run main bug4234034
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4234034 {
+    static JFrame frame;
+    static JButton button;
+    static Robot robot;
+
+    public static void main(String args[]) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                    frame = new JFrame("bug4323121");
+                    button = new JButton("Press tab, then Ctrl+F1");
+                    button.setToolTipText("Tooltip for button");
+                    frame.getContentPane().add(button);
+                    frame.pack();
+                    frame.setSize(250, 200);
+                    frame.setLocationRelativeTo(null);
+                    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                    frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            robot.keyPress(KeyEvent.VK_TAB);
+            robot.keyRelease(KeyEvent.VK_TAB);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_F1);
+            robot.keyRelease(KeyEvent.VK_F1);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}

--- a/test/jdk/javax/swing/JButton/bug4234034.java
+++ b/test/jdk/javax/swing/JButton/bug4234034.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 4234034
- * @summary Tests
+ * @summary Tests NullPointerException when ToolTip invoked via keyboard
  * @key headful
  * @run main bug4234034
  */
@@ -44,15 +44,14 @@ public class bug4234034 {
         robot.setAutoDelay(100);
         try {
             SwingUtilities.invokeAndWait(() -> {
-                    frame = new JFrame("bug4323121");
-                    button = new JButton("Press tab, then Ctrl+F1");
-                    button.setToolTipText("Tooltip for button");
-                    frame.getContentPane().add(button);
-                    frame.pack();
-                    frame.setSize(250, 200);
-                    frame.setLocationRelativeTo(null);
-                    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-                    frame.setVisible(true);
+                frame = new JFrame("bug4323121");
+                button = new JButton("Press tab, then Ctrl+F1");
+                button.setToolTipText("Tooltip for button");
+                frame.getContentPane().add(button);
+                frame.pack();
+                frame.setLocationRelativeTo(null);
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                frame.setVisible(true);
             });
             robot.waitForIdle();
             robot.delay(1000);

--- a/test/jdk/javax/swing/JButton/bug4323121.java
+++ b/test/jdk/javax/swing/JButton/bug4323121.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,6 @@ public class bug4323121 {
                 button = new testButton("gotcha");
                 frame.getContentPane().add(button);
                 frame.pack();
-                frame.setSize(250, 200);
                 frame.setLocationRelativeTo(null);
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                 frame.setVisible(true);
@@ -71,7 +70,7 @@ public class bug4323121 {
                 buttonH = button.getSize().height;
             });
             robot.mouseMove(pt.x + buttonW / 2, pt.y + buttonH / 2);
-
+            robot.waitForIdle();
             if (failed) {
                 throw new RuntimeException("Any created button returns " +
                                     "true for isArmed()");

--- a/test/jdk/javax/swing/JButton/bug4323121.java
+++ b/test/jdk/javax/swing/JButton/bug4323121.java
@@ -44,7 +44,6 @@ public class bug4323121 {
 
     static JFrame frame;
     static testButton button;
-    static Robot robot;
     static volatile Point pt;
     static volatile int buttonW;
     static volatile int buttonH;

--- a/test/jdk/javax/swing/JButton/bug4323121.java
+++ b/test/jdk/javax/swing/JButton/bug4323121.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2000, 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4323121
+ * @summary Tests whether any button that extends JButton always
+            returns true for isArmed()
+ * @key headful
+ * @run main bug4323121
+ */
+
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4323121 {
+
+    static JFrame frame;
+    static testButton button;
+    static Robot robot;
+    static volatile Point pt;
+    static volatile int buttonW;
+    static volatile int buttonH;
+    static volatile boolean failed = false;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4323121");
+                button = new testButton("gotcha");
+                frame.getContentPane().add(button);
+                frame.pack();
+                frame.setSize(250, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                pt = button.getLocationOnScreen();
+                buttonW = button.getSize().width;
+                buttonH = button.getSize().height;
+            });
+            robot.mouseMove(pt.x + buttonW / 2, pt.y + buttonH / 2);
+
+            if (failed) {
+                throw new RuntimeException("Any created button returns " +
+                                    "true for isArmed()");
+            }
+        } finally {
+                SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    static class testButton extends JButton implements MouseMotionListener, MouseListener {
+        public testButton(String label) {
+            super(label);
+            addMouseMotionListener(this);
+            addMouseListener(this);
+        }
+
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+        }
+
+        protected void paintBorder(Graphics g) {
+        }
+
+        public void mousePressed(MouseEvent e) {
+        }
+
+        public void mouseDragged(MouseEvent e) {
+        }
+
+        public void mouseMoved(MouseEvent e) {
+        }
+
+        public void mouseReleased(MouseEvent e) {
+        }
+
+        public void mouseEntered(MouseEvent e) {
+            if (getModel().isArmed()) {
+                failed = true;
+            }
+        }
+
+        public void mouseExited(MouseEvent e) {
+        }
+
+        public void mouseClicked(MouseEvent e) {
+        }
+    }
+}

--- a/test/jdk/javax/swing/JButton/bug4490179.java
+++ b/test/jdk/javax/swing/JButton/bug4490179.java
@@ -41,7 +41,6 @@ import javax.swing.SwingUtilities;
 public class bug4490179 {
     static JFrame frame;
     static JButton button;
-    static Robot robot;
     static volatile Point pt;
     static volatile int buttonW;
     static volatile int buttonH;

--- a/test/jdk/javax/swing/JButton/bug4490179.java
+++ b/test/jdk/javax/swing/JButton/bug4490179.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ public class bug4490179 {
     static volatile int buttonW;
     static volatile int buttonH;
     static volatile boolean passed = true;
+
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
         robot.setAutoDelay(100);
@@ -59,7 +60,6 @@ public class bug4490179 {
                     }
                 });
                 frame.pack();
-                frame.setSize(250, 200);
                 frame.setLocationRelativeTo(null);
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                 frame.setVisible(true);
@@ -73,7 +73,7 @@ public class bug4490179 {
             });
 
             robot.mouseMove(pt.x + buttonW / 2, pt.y + buttonH / 2);
-            robot.delay(100);
+            robot.waitForIdle();
             robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
 

--- a/test/jdk/javax/swing/JButton/bug4490179.java
+++ b/test/jdk/javax/swing/JButton/bug4490179.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002, 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4490179
+ * @summary Tests that JButton only responds to left mouse clicks.
+ * @key headful
+ * @run main bug4490179
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+public class bug4490179 {
+    static JFrame frame;
+    static JButton button;
+    static Robot robot;
+    static volatile Point pt;
+    static volatile int buttonW;
+    static volatile int buttonH;
+    static volatile boolean passed = true;
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame("bug4490179");
+                button = new JButton("Button");
+                frame.getContentPane().add(button);
+                button.addActionListener(new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        passed = false;
+                    }
+                });
+                frame.pack();
+                frame.setSize(250, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                frame.setVisible(true);
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            SwingUtilities.invokeAndWait(() -> {
+                pt = button.getLocationOnScreen();
+                buttonW = button.getSize().width;
+                buttonH = button.getSize().height;
+            });
+
+            robot.mouseMove(pt.x + buttonW / 2, pt.y + buttonH / 2);
+            robot.delay(100);
+            robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
+
+            if (!passed) {
+                throw new RuntimeException("Test Failed");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Few closed JButton swing manual test converted to automated and open sourced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316285](https://bugs.openjdk.org/browse/JDK-8316285): Opensource JButton manual tests (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15835/head:pull/15835` \
`$ git checkout pull/15835`

Update a local copy of the PR: \
`$ git checkout pull/15835` \
`$ git pull https://git.openjdk.org/jdk.git pull/15835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15835`

View PR using the GUI difftool: \
`$ git pr show -t 15835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15835.diff">https://git.openjdk.org/jdk/pull/15835.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15835#issuecomment-1727002785)