### PR TITLE
8316587: Use ArraysSupport.vectorizedHashCode in Utf8EntryImpl

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import java.lang.invoke.TypeDescriptor;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.classfile.Classfile;
 import jdk.internal.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.constantpool.ConstantDynamicEntry;
@@ -52,6 +54,8 @@ import jdk.internal.classfile.constantpool.PackageEntry;
 import jdk.internal.classfile.constantpool.PoolEntry;
 import jdk.internal.classfile.constantpool.StringEntry;
 import jdk.internal.classfile.constantpool.Utf8Entry;
+import jdk.internal.util.ArraysSupport;
+
 import java.lang.constant.ModuleDesc;
 import java.lang.constant.PackageDesc;
 
@@ -142,6 +146,8 @@ public abstract sealed class AbstractPoolEntry {
 
         enum State { RAW, BYTE, CHAR, STRING }
 
+        private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
         private State state;
         private final byte[] rawBytes; // null if initialized directly from a string
         private final int offset;
@@ -226,22 +232,9 @@ public abstract sealed class AbstractPoolEntry {
          * two-times-three-byte format instead.
          */
         private void inflate() {
-            int hash = 0;
-            boolean foundHigh = false;
-
-            int px = offset;
-            int utfend = px + rawLen;
-            while (px < utfend) {
-                int c = (int) rawBytes[px] & 0xff;
-                if (c > 127) {
-                    foundHigh = true;
-                    break;
-                }
-                hash = 31 * hash + c;
-                px++;
-            }
-
-            if (!foundHigh) {
+            int singleBytes = JLA.countPositives(rawBytes, offset, rawLen);
+            int hash = ArraysSupport.vectorizedHashCode(rawBytes, offset, singleBytes, 0, ArraysSupport.T_BOOLEAN);
+            if (singleBytes == rawLen) {
                 this.hash = hashString(hash);
                 charLen = rawLen;
                 state = State.BYTE;
@@ -250,10 +243,10 @@ public abstract sealed class AbstractPoolEntry {
                 char[] chararr = new char[rawLen];
                 int chararr_count = 0;
                 // Inflate prefix of bytes to characters
-                for (int i = offset; i < px; i++) {
-                    int c = (int) rawBytes[i] & 0xff;
-                    chararr[chararr_count++] = (char) c;
-                }
+                JLA.inflateBytesToChars(rawBytes, offset, chararr, 0, singleBytes);
+
+                int px = offset + singleBytes;
+                int utfend = offset + rawLen;
                 while (px < utfend) {
                     int c = (int) rawBytes[px] & 0xff;
                     switch (c >> 4) {
@@ -331,7 +324,7 @@ public abstract sealed class AbstractPoolEntry {
             if (state != State.STRING) {
                 stringValue = (chars != null)
                               ? new String(chars, 0, charLen)
-                              : new String(rawBytes, offset, charLen, StandardCharsets.UTF_8);
+                              : new String(rawBytes, offset, charLen, StandardCharsets.ISO_8859_1);
                 state = State.STRING;
             }
             return stringValue;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -241,7 +241,7 @@ public abstract sealed class AbstractPoolEntry {
             }
             else {
                 char[] chararr = new char[rawLen];
-                int chararr_count = 0;
+                int chararr_count = singleBytes;
                 // Inflate prefix of bytes to characters
                 JLA.inflateBytesToChars(rawBytes, offset, chararr, 0, singleBytes);
 

--- a/test/micro/org/openjdk/bench/jdk/classfile/ReadMetadata.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ReadMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,24 @@ public class ReadMetadata extends AbstractCorpusBenchmark {
         var cc = Classfile.of();
         for (byte[] bytes : classes) {
             bh.consume(cc.parse(bytes).thisClass().asInternalName());
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public void jdkReadMemberNames(Blackhole bh) {
+        var cc = Classfile.of();
+        for (byte[] bytes : classes) {
+            var cm = cc.parse(bytes);
+            bh.consume(cm.thisClass().asInternalName());
+            for (var f : cm.fields()) {
+                bh.consume(f.fieldName().stringValue());
+                bh.consume(f.fieldType().stringValue());
+            }
+            for (var m : cm.methods()) {
+                bh.consume(m.methodName().stringValue());
+                bh.consume(m.methodType().stringValue());
+            }
         }
     }
 


### PR DESCRIPTION
Like #12077, this uses JDK's internal utilities to speed up ASCII reading in Class files, where most identifiers, from conventions to attribute names, are ASCII. See the JBS issue for more in-depth explanations.

Before: (Master)
```
Benchmark                         Mode  Cnt    Score   Error  Units
ReadMetadata.jdkReadMemberNames  thrpt    4  167.623 ± 8.522  ops/s
```

After: (This patch, first revision)
```
Benchmark                         Mode  Cnt    Score   Error  Units
ReadMetadata.jdkReadMemberNames  thrpt    4  175.908 ± 4.766  ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316587](https://bugs.openjdk.org/browse/JDK-8316587): Use ArraysSupport.vectorizedHashCode in Utf8EntryImpl (**Enhancement** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15837/head:pull/15837` \
`$ git checkout pull/15837`

Update a local copy of the PR: \
`$ git checkout pull/15837` \
`$ git pull https://git.openjdk.org/jdk.git pull/15837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15837`

View PR using the GUI difftool: \
`$ git pr show -t 15837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15837.diff">https://git.openjdk.org/jdk/pull/15837.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15837#issuecomment-1727332377)