### PR TITLE
8316581

### DIFF
--- a/src/hotspot/share/oops/symbol.cpp
+++ b/src/hotspot/share/oops/symbol.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-
 #include "precompiled.hpp"
 #include "cds/metaspaceShared.hpp"
 #include "classfile/altHashing.hpp"
@@ -390,11 +389,10 @@ void Symbol::print() const { print_on(tty); }
 // The print_value functions are present in all builds, to support the
 // disassembler and error reporting.
 void Symbol::print_value_on(outputStream* st) const {
-  st->print("'");
-  for (int i = 0; i < utf8_length(); i++) {
-    st->print("%c", char_at(i));
-  }
-  st->print("'");
+  st->write("'", 1);
+  static_assert(sizeof(u1) == sizeof(char), "must be");
+  st->write((const char*)base(), utf8_length());
+  st->write("'", 1);
 }
 
 void Symbol::print_value() const { print_value_on(tty); }


### PR DESCRIPTION
Hi all,

  please review this (hopefully correct) optimization of `Symbol::print_value_on()`; investigation into class unloading time distribution showed that a lot of time is spent in the `UnloadingEventLog::log()` call (25+%, see CR).

The reason seems to be the use of `outputStream::print()` without any need for formatting.

This seems to decrease time spent in this logging by almost 10x.

Testing: hs_err output seems still be the same, GHA

Thanks,
  Thomas
