### PR TITLE
8316418: containers/docker/TestMemoryWithCgroupV1.java get OOM killed with Parallel GC

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -77,6 +77,7 @@ public class TestMemoryWithCgroupV1 {
         Common.logNewTestCase("Test print_container_info()");
 
         DockerRunOptions opts = Common.newOpts(imageName, "PrintContainerInfo").addJavaOpts("-XshowSettings:system");
+        opts.addDockerOpts("--cpus", "4"); // Avoid OOM kill on many-core systems
         opts.addDockerOpts("--memory", dockerMemLimit, "--memory-swappiness", "0", "--memory-swap", dockerSwapMemLimit);
         Common.addWhiteBoxOpts(opts);
 
@@ -104,6 +105,7 @@ public class TestMemoryWithCgroupV1 {
             String swappiness, String expectedSwap) throws Exception {
         Common.logNewTestCase("Check OperatingSystemMXBean");
         DockerRunOptions opts = Common.newOpts(imageName, "CheckOperatingSystemMXBean")
+                .addDockerOpts("--cpus", "4") // Avoid OOM kill on many-core systems
                 .addDockerOpts(
                         "--memory", memoryAllocation,
                         "--memory-swappiness", swappiness,


### PR DESCRIPTION
Please review this test fix to restrain the number of cores being used for the test. What matters for the test is the memory limit. The test verifies that a certain memory limit with swappiness set to 0 returns the memory limit (without swap). On some systems with many cores the memory limit might be too small for the number of threads the JVM creates with the set limit. I propose to make the number of cores the test is allowed to used to a fixed value: 4 (over the number of cores available on the system, which makes the test passing system dependent).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316418](https://bugs.openjdk.org/browse/JDK-8316418): containers/docker/TestMemoryWithCgroupV1.java get OOM killed with Parallel GC (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15840/head:pull/15840` \
`$ git checkout pull/15840`

Update a local copy of the PR: \
`$ git checkout pull/15840` \
`$ git pull https://git.openjdk.org/jdk.git pull/15840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15840`

View PR using the GUI difftool: \
`$ git pr show -t 15840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15840.diff">https://git.openjdk.org/jdk/pull/15840.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15840#issuecomment-1727598411)