### PR TITLE
8316319: Generational ZGC: The SoftMaxHeapSize might be wrong when CDS decreases the MaxHeapSize

### DIFF
--- a/src/hotspot/share/gc/x/xArguments.cpp
+++ b/src/hotspot/share/gc/x/xArguments.cpp
@@ -37,6 +37,10 @@ void XArguments::initialize_alignments() {
   HeapAlignment = SpaceAlignment;
 }
 
+void XArguments::initialize_heap_flags_and_sizes() {
+  // Nothing extra to do
+}
+
 void XArguments::initialize() {
   // Check mark stack size
   const size_t mark_stack_space_limit = XAddressSpaceLimit::mark_stack();

--- a/src/hotspot/share/gc/x/xArguments.hpp
+++ b/src/hotspot/share/gc/x/xArguments.hpp
@@ -31,6 +31,7 @@ class CollectedHeap;
 class XArguments : AllStatic {
 public:
   static void initialize_alignments();
+  static void initialize_heap_flags_and_sizes();
   static void initialize();
   static size_t heap_virtual_to_physical_ratio();
   static CollectedHeap* create_heap();

--- a/src/hotspot/share/gc/z/shared/zSharedArguments.cpp
+++ b/src/hotspot/share/gc/z/shared/zSharedArguments.cpp
@@ -38,6 +38,16 @@ void ZSharedArguments::initialize_alignments() {
   }
 }
 
+void ZSharedArguments::initialize_heap_flags_and_sizes() {
+  GCArguments::initialize_heap_flags_and_sizes();
+
+  if (ZGenerational) {
+    ZArguments::initialize_heap_flags_and_sizes();
+  } else {
+    XArguments::initialize_heap_flags_and_sizes();
+  }
+}
+
 void ZSharedArguments::initialize() {
   GCArguments::initialize();
 

--- a/src/hotspot/share/gc/z/shared/zSharedArguments.hpp
+++ b/src/hotspot/share/gc/z/shared/zSharedArguments.hpp
@@ -31,6 +31,7 @@ class CollectedHeap;
 class ZSharedArguments : public GCArguments {
 private:
   virtual void initialize_alignments();
+  virtual void initialize_heap_flags_and_sizes();
 
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment();

--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -37,6 +37,19 @@ void ZArguments::initialize_alignments() {
   HeapAlignment = SpaceAlignment;
 }
 
+void ZArguments::initialize_heap_flags_and_sizes() {
+  if (!FLAG_IS_CMDLINE(MaxHeapSize) &&
+      !FLAG_IS_CMDLINE(MaxRAMFraction) &&
+      !FLAG_IS_CMDLINE(MaxRAMPercentage) &&
+      !FLAG_IS_CMDLINE(SoftMaxHeapSize)) {
+    // We are really just guessing how much memory the program needs.
+    // When that is the case, we don't want the soft and hard limits to be the same
+    // as it can cause flakyness in the number of GC threads used, in order to keep
+    // to a random number we just pulled out of thin air.
+    FLAG_SET_ERGO(SoftMaxHeapSize, MaxHeapSize * 90 / 100);
+  }
+}
+
 void ZArguments::select_max_gc_threads() {
   // Select number of parallel threads
   if (FLAG_IS_DEFAULT(ParallelGCThreads)) {
@@ -124,16 +137,6 @@ void ZArguments::initialize() {
   // Backwards compatible alias for ZCollectionIntervalMajor
   if (!FLAG_IS_DEFAULT(ZCollectionInterval)) {
     FLAG_SET_ERGO_IF_DEFAULT(ZCollectionIntervalMajor, ZCollectionInterval);
-  }
-
-  if (!FLAG_IS_CMDLINE(MaxHeapSize) &&
-      !FLAG_IS_CMDLINE(MaxRAMFraction) &&
-      !FLAG_IS_CMDLINE(MaxRAMPercentage)) {
-    // We are really just guessing how much memory the program needs.
-    // When that is the case, we don't want the soft and hard limits to be the same
-    // as it can cause flakyness in the number of GC threads used, in order to keep
-    // to a random number we just pulled out of thin air.
-    FLAG_SET_ERGO_IF_DEFAULT(SoftMaxHeapSize, MaxHeapSize * 90 / 100);
   }
 
   if (FLAG_IS_DEFAULT(ZFragmentationLimit)) {

--- a/src/hotspot/share/gc/z/zArguments.hpp
+++ b/src/hotspot/share/gc/z/zArguments.hpp
@@ -34,6 +34,7 @@ private:
 
 public:
   static void initialize_alignments();
+  static void initialize_heap_flags_and_sizes();
   static void initialize();
   static size_t heap_virtual_to_physical_ratio();
   static CollectedHeap* create_heap();


### PR DESCRIPTION
Generational ZGC sets SoftMaxHeapSize to 90% of the MaxHeapSize if the user has not specified the maximum heap size with any of the available flags. Unfortunately, this break when CDS later on decreases the MaxHeapSize.

I propose that we solve this by moving the code that sets the SoftMaxHeapSize to the point after CDS and the GC has done its final tweaks to the MaxHeapSize.

This can be easily reproduced just by running:
java -XX:+UseZGC -XX:+ZGenerational -Xshare:dump -Xlog:gc+init -version

This wasn't caught in testing because our test infrastructure uses MaxRamPercentage to set the maximum heap size. I've manually verified that the patch fixes the issue and that SoftMaxHeapSize is set as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316319](https://bugs.openjdk.org/browse/JDK-8316319): Generational ZGC: The SoftMaxHeapSize might be wrong when CDS decreases the MaxHeapSize (**Bug** - P3)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15841/head:pull/15841` \
`$ git checkout pull/15841`

Update a local copy of the PR: \
`$ git checkout pull/15841` \
`$ git pull https://git.openjdk.org/jdk.git pull/15841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15841`

View PR using the GUI difftool: \
`$ git pr show -t 15841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15841.diff">https://git.openjdk.org/jdk/pull/15841.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15841#issuecomment-1727657976)