### PR TITLE
JDK-8316595: Alpine build fails after JDK-8314021

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4373,7 +4373,11 @@ jlong os::Linux::fast_thread_cpu_time(clockid_t clockid) {
 // the number of bytes written to out_fd is returned if transfer was successful
 // otherwise, returns -1 that implies an error
 jlong os::Linux::sendfile(int out_fd, int in_fd, jlong* offset, jlong count) {
+#ifdef MUSL_LIBC
+  return ::sendfile(out_fd, in_fd, (off64_t*)offset, (size_t)count);
+#else
   return sendfile64(out_fd, in_fd, (off64_t*)offset, (size_t)count);
+#endif
 }
 
 // Determine if the vmid is the parent pid for a child in a PID namespace.

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4373,11 +4373,7 @@ jlong os::Linux::fast_thread_cpu_time(clockid_t clockid) {
 // the number of bytes written to out_fd is returned if transfer was successful
 // otherwise, returns -1 that implies an error
 jlong os::Linux::sendfile(int out_fd, int in_fd, jlong* offset, jlong count) {
-#ifdef MUSL_LIBC
-  return ::sendfile(out_fd, in_fd, (off64_t*)offset, (size_t)count);
-#else
-  return sendfile64(out_fd, in_fd, (off64_t*)offset, (size_t)count);
-#endif
+  return ::sendfile64(out_fd, in_fd, (off64_t*)offset, (size_t)count);
 }
 
 // Determine if the vmid is the parent pid for a child in a PID namespace.


### PR DESCRIPTION
[JDK-8314021](https://bugs.openjdk.org/browse/JDK-8314021) causes build errors on Linux Alpine/musl (Linux ALPINE 3.17.4 gcc12.2.1)

/linuxmuslx86_64/jdk/src/hotspot/os/linux/os_linux.cpp: In static member function 'static jlong os::Linux::sendfile(int, int, jlong*, jlong)':
/linuxmuslx86_64/jdk/src/hotspot/os/linux/os_linux.cpp:4375:7: error: infinite recursion detected [-Werror=infinite-recursion]
 4375 | jlong os::Linux::sendfile(int out_fd, int in_fd, jlong* offset, jlong count) {
      | ^~
/linuxmuslx86_64/jdk/src/hotspot/os/linux/os_linux.cpp:4376:20: note: recursive call
 4376 | return sendfile64(out_fd, in_fd, (off64_t*)offset, (size_t)count);

On Alpine Linux 3.17.4 we have just this definition for sendfile64 :
sys/sendfile.h:11:ssize_t sendfile(int, int, off_t *, size_t);
sys/sendfile.h:14:#define sendfile64 sendfile

So it would be better to use ::sendfile directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316595](https://bugs.openjdk.org/browse/JDK-8316595): Alpine build fails after JDK-8314021 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Yi Yang](https://openjdk.org/census#yyang) (@y1yang0 - Committer) ⚠️ Review applies to [b208bb98](https://git.openjdk.org/jdk/pull/15843/files/b208bb98a04578b5732ad9c731d899ec6fd650ae)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15843/head:pull/15843` \
`$ git checkout pull/15843`

Update a local copy of the PR: \
`$ git checkout pull/15843` \
`$ git pull https://git.openjdk.org/jdk.git pull/15843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15843`

View PR using the GUI difftool: \
`$ git pr show -t 15843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15843.diff">https://git.openjdk.org/jdk/pull/15843.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15843#issuecomment-1727893421)