### PR TITLE
JDK-8315042 NPE in PKCS7.parseOldSignedData

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS7.java
@@ -152,6 +152,10 @@ public class PKCS7 {
         ObjectIdentifier contentType = block.contentType;
         DerValue content = block.getContent();
 
+        if (content == null) {
+            throw new ParsingException("content is null");
+        }
+
         if (contentType.equals(ContentInfo.SIGNED_DATA_OID)) {
             parseSignedData(content);
         } else if (contentType.equals(ContentInfo.OLD_SIGNED_DATA_OID)) {

--- a/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedNPE.java
+++ b/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedNPE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedNPE.java
+++ b/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedNPE.java
@@ -35,24 +35,17 @@ import java.util.Base64;
 import jdk.test.lib.Utils;
 
 public class UnexpectedNPE {
-    static CertificateFactory cf = null ;
+    static CertificateFactory cf = null;
 
-    public static void main( String[] av ) {
+    public static void main(String[] av ) throws CertificateException,
+            NoSuchProviderException {
         byte[] encoded_1 = { 0x00, 0x00, 0x00, 0x00 };
         byte[] encoded_2 = { 0x30, 0x01, 0x00, 0x00 };
         byte[] encoded_3 = { 0x30, 0x01, 0x00 };
         byte[] encoded_4 = Base64.getDecoder().decode(
                 "MAsGCSqGSMP7TQEHAjI1Bgn///////8wCwUyAQ==");
 
-        if (cf == null) {
-            try {
-                cf = CertificateFactory.getInstance("X.509", "SUN");
-            } catch (CertificateException e) {
-                throw new SecurityException("Cannot get CertificateFactory");
-            } catch (NoSuchProviderException npe) {
-                throw new SecurityException("Cannot get CertificateFactory");
-            }
-        }
+        cf = CertificateFactory.getInstance("X.509", "SUN");
 
         run(encoded_1);
         run(encoded_2);
@@ -62,8 +55,10 @@ public class UnexpectedNPE {
 
     private static void run(byte[] buf) {
         Utils.runAndCheckException(
+                () -> cf.generateCRL(new ByteArrayInputStream(buf)),
+                CRLException.class);
+        Utils.runAndCheckException(
                 () -> cf.generateCRLs(new ByteArrayInputStream(buf)),
                 CRLException.class);
-        System.out.println("NPE checking passed");
     }
 }

--- a/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedNPE.java
+++ b/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedNPE.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 5052433 8315042
- * @summary NullPointerException for generateCRL and generateCRLs methods.
+ * @summary Verify that generateCRL and generateCRLs methods do not throw
+ *          NullPointerException. They should throw CRLException instead.
  * @library /test/lib
  */
 import java.security.NoSuchProviderException;

--- a/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedNPE.java
+++ b/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedNPE.java
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @library /test/lib
  * @bug 5052433 8315042
  * @summary NullPointerException for generateCRL and generateCRLs methods.
+ * @library /test/lib
  */
 import java.security.NoSuchProviderException;
 import java.security.cert.*;
@@ -35,26 +35,15 @@ import java.util.Base64;
 import jdk.test.lib.Utils;
 
 public class UnexpectedNPE {
-    CertificateFactory cf = null ;
-    private static final String in = "MAsGCSqGSMP7TQEHAjI1Bgn///////8wCwUyAQ==";
-
-    public UnexpectedNPE() {}
+    static CertificateFactory cf = null ;
 
     public static void main( String[] av ) {
         byte[] encoded_1 = { 0x00, 0x00, 0x00, 0x00 };
         byte[] encoded_2 = { 0x30, 0x01, 0x00, 0x00 };
         byte[] encoded_3 = { 0x30, 0x01, 0x00 };
-        byte[] decodedBytes = Base64.getDecoder().decode(in);
+        byte[] encoded_4 = Base64.getDecoder().decode(
+                "MAsGCSqGSMP7TQEHAjI1Bgn///////8wCwUyAQ==");
 
-        UnexpectedNPE unpe = new UnexpectedNPE() ;
-
-        unpe.run(encoded_1);
-        unpe.run(encoded_2);
-        unpe.run(encoded_3);
-        unpe.run(decodedBytes);
-    }
-
-    private void run(byte[] buf) {
         if (cf == null) {
             try {
                 cf = CertificateFactory.getInstance("X.509", "SUN");
@@ -65,9 +54,13 @@ public class UnexpectedNPE {
             }
         }
 
-        Utils.runAndCheckException(
-                () -> cf.generateCRL(new ByteArrayInputStream(buf)),
-                CRLException.class);
+        run(encoded_1);
+        run(encoded_2);
+        run(encoded_3);
+        run(encoded_4);
+    }
+
+    private static void run(byte[] buf) {
         Utils.runAndCheckException(
                 () -> cf.generateCRLs(new ByteArrayInputStream(buf)),
                 CRLException.class);


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8315042

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315042](https://bugs.openjdk.org/browse/JDK-8315042): NPE in PKCS7.parseOldSignedData (**Bug** - P3)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to [2fe7e47c](https://git.openjdk.org/jdk/pull/15844/files/2fe7e47c744c564356f2a31a2eb04b01871eb505)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15844/head:pull/15844` \
`$ git checkout pull/15844`

Update a local copy of the PR: \
`$ git checkout pull/15844` \
`$ git pull https://git.openjdk.org/jdk.git pull/15844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15844`

View PR using the GUI difftool: \
`$ git pr show -t 15844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15844.diff">https://git.openjdk.org/jdk/pull/15844.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15844#issuecomment-1727922839)