### PR TITLE
8316627: JViewport Test headless failure

### DIFF
--- a/test/jdk/javax/swing/JViewport/bug4546474.java
+++ b/test/jdk/javax/swing/JViewport/bug4546474.java
@@ -28,8 +28,6 @@
  * @run main bug4546474
  */
 
-import java.awt.Dimension;
-
 import javax.swing.JPanel;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
@@ -41,7 +39,6 @@ public class bug4546474 {
 
     public static void main(String[] args) {
         JPanel panel = new JPanel();
-        panel.setPreferredSize(new Dimension(500, 500));
         scrollpane = new JScrollPane(panel,
                 JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
                 JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);

--- a/test/jdk/javax/swing/JViewport/bug4546474.java
+++ b/test/jdk/javax/swing/JViewport/bug4546474.java
@@ -35,7 +35,6 @@ import javax.swing.JScrollPane;
 public class bug4546474 {
     static JScrollPane scrollpane;
     static JScrollBar sbar;
-    static volatile boolean viewChanged;
 
     public static void main(String[] args) {
         JPanel panel = new JPanel();
@@ -44,11 +43,7 @@ public class bug4546474 {
                 JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
         sbar = scrollpane.getVerticalScrollBar();
 
-        sbar.addAdjustmentListener(e -> viewChanged = true);
         scrollpane.setViewportView(null);
-        if (!viewChanged) {
-            viewChanged = true;
-        }
 
         if (sbar.getVisibleAmount() > 0) {
             throw new RuntimeException("Vertical scrollbar is not " +

--- a/test/jdk/javax/swing/JViewport/bug4546474.java
+++ b/test/jdk/javax/swing/JViewport/bug4546474.java
@@ -25,6 +25,7 @@
  * @bug 4546474
  * @summary JScrollPane's always-visible scrollbars not updated when
  * viewport is replaced
+ * @key headful
  * @run main bug4546474
  */
 

--- a/test/jdk/javax/swing/JViewport/bug4546474.java
+++ b/test/jdk/javax/swing/JViewport/bug4546474.java
@@ -33,15 +33,12 @@ import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 
 public class bug4546474 {
-    static JScrollPane scrollpane;
-    static JScrollBar sbar;
-
     public static void main(String[] args) {
         JPanel panel = new JPanel();
-        scrollpane = new JScrollPane(panel,
+        JScrollPane scrollpane = new JScrollPane(panel,
                 JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
                 JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-        sbar = scrollpane.getVerticalScrollBar();
+        JScrollBar sbar = scrollpane.getVerticalScrollBar();
 
         scrollpane.setViewportView(null);
 

--- a/test/jdk/javax/swing/JViewport/bug4546474.java
+++ b/test/jdk/javax/swing/JViewport/bug4546474.java
@@ -25,50 +25,37 @@
  * @bug 4546474
  * @summary JScrollPane's always-visible scrollbars not updated when
  * viewport is replaced
- * @key headful
  * @run main bug4546474
  */
 
 import java.awt.Dimension;
-import java.awt.Robot;
 
 import javax.swing.JPanel;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
 
 public class bug4546474 {
     static JScrollPane scrollpane;
     static JScrollBar sbar;
     static volatile boolean viewChanged;
 
-    public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(() -> {
-            JPanel panel = new JPanel();
-            panel.setPreferredSize(new Dimension(500, 500));
-            scrollpane = new JScrollPane(panel,
-                    JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
-                    JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-            sbar = scrollpane.getVerticalScrollBar();
-        });
+    public static void main(String[] args) {
+        JPanel panel = new JPanel();
+        panel.setPreferredSize(new Dimension(500, 500));
+        scrollpane = new JScrollPane(panel,
+                JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        sbar = scrollpane.getVerticalScrollBar();
 
-        Robot robot = new Robot();
-        robot.delay(500);
-        SwingUtilities.invokeAndWait(() -> {
-            sbar.addAdjustmentListener(e -> viewChanged = true);
-            scrollpane.setViewportView(null);
-        });
-        robot.delay(500);
+        sbar.addAdjustmentListener(e -> viewChanged = true);
+        scrollpane.setViewportView(null);
         if (!viewChanged) {
             viewChanged = true;
         }
-        robot.delay(500);
 
-        SwingUtilities.invokeAndWait(() -> {
-            if (sbar.getVisibleAmount() > 0) {
-                throw new RuntimeException("Vertical scrollbar is not " +
-                        "updated when viewport is replaced");
-            }
-        });
+        if (sbar.getVisibleAmount() > 0) {
+            throw new RuntimeException("Vertical scrollbar is not " +
+                    "updated when viewport is replaced");
+        }
     }
 }


### PR DESCRIPTION
Converted test needs headful tag added to avoid failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316627](https://bugs.openjdk.org/browse/JDK-8316627): JViewport Test headless failure (**Bug** - P2)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [01358e68](https://git.openjdk.org/jdk/pull/15847/files/01358e68f2bc0aa6b8ac3a0b92552684830be842)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [cdc2cf88](https://git.openjdk.org/jdk/pull/15847/files/cdc2cf880b37e9c037716b541491cf725071bc56)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15847/head:pull/15847` \
`$ git checkout pull/15847`

Update a local copy of the PR: \
`$ git checkout pull/15847` \
`$ git pull https://git.openjdk.org/jdk.git pull/15847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15847`

View PR using the GUI difftool: \
`$ git pr show -t 15847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15847.diff">https://git.openjdk.org/jdk/pull/15847.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15847#issuecomment-1728442182)