### PR TITLE
8315944: SunJCE provider should not zeroize the deserialized key values

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
@@ -151,11 +151,9 @@ final class DESKey implements SecretKey {
          throws java.io.IOException, ClassNotFoundException
     {
         s.defaultReadObject();
-        byte[] temp = key;
-        key = temp.clone();
-        Arrays.fill(temp, (byte)0x00);
+        key = key.clone();
         // Use the cleaner to zero the key when no longer referenced
-        final byte[] k = this.key;
+        final byte[] k = key;
         CleanerFactory.cleaner().register(this,
                 () -> java.util.Arrays.fill(k, (byte)0x00));
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeKey.java
@@ -152,11 +152,9 @@ final class DESedeKey implements SecretKey {
          throws java.io.IOException, ClassNotFoundException
     {
         s.defaultReadObject();
-        byte[] temp = key;
-        this.key = temp.clone();
-        java.util.Arrays.fill(temp, (byte)0x00);
+        key = key.clone();
         // Use the cleaner to zero the key when no longer referenced
-        final byte[] k = this.key;
+        final byte[] k = key;
         CleanerFactory.cleaner().register(this,
                 () -> java.util.Arrays.fill(k, (byte)0x00));
     }

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
@@ -170,11 +170,9 @@ final class PBEKey implements SecretKey {
          throws java.io.IOException, ClassNotFoundException
     {
         s.defaultReadObject();
-        byte[] temp = key;
-        key = temp.clone();
-        Arrays.fill(temp, (byte)0x00);
+        key = key.clone();
         // Use cleaner to zero the key when no longer referenced
-        final byte[] k = this.key;
+        final byte[] k = key;
         cleanable = CleanerFactory.cleaner().register(this,
                 () -> java.util.Arrays.fill(k, (byte)0x00));
     }


### PR DESCRIPTION
This PR reverts part of the changes under JDK-8312306 which zero-out the deserialized key bytes after an internal copy has been made. If considering the deserialized key bytes as input arguments, such cleaning action may be too aggressive. Thus, on second thought, I am reverting to earlier behavior. No regression test since the changes are trivial.

Thanks!
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315944](https://bugs.openjdk.org/browse/JDK-8315944): SunJCE provider should not zeroize the deserialized key values (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15848/head:pull/15848` \
`$ git checkout pull/15848`

Update a local copy of the PR: \
`$ git checkout pull/15848` \
`$ git pull https://git.openjdk.org/jdk.git pull/15848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15848`

View PR using the GUI difftool: \
`$ git pr show -t 15848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15848.diff">https://git.openjdk.org/jdk/pull/15848.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15848#issuecomment-1728487581)