### PR TITLE
JDK-8316629: j.text.DateFormatSymbols setZoneStrings() exception is unhelpful

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -612,7 +612,8 @@ public class DateFormatSymbols implements Serializable, Cloneable {
         for (int i = 0; i < newZoneStrings.length; ++i) {
             int len = newZoneStrings[i].length;
             if (len < 5) {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(String.format(
+                        "Row %s of the input array does not have a length of at least 5", i));
             }
             aCopy[i] = Arrays.copyOf(newZoneStrings[i], len);
         }


### PR DESCRIPTION
Please review this PR, which updates the exception message for java.text.DateFormatSymbols.setZoneStrings

`setZoneStrings()` takes a multi dimensional array as input. If any row does not have a length of at least 5, an _IllegalArgumentException_ is thrown. The exception should indicate why it was thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316629](https://bugs.openjdk.org/browse/JDK-8316629): j.text.DateFormatSymbols setZoneStrings() exception is unhelpful (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15849/head:pull/15849` \
`$ git checkout pull/15849`

Update a local copy of the PR: \
`$ git checkout pull/15849` \
`$ git pull https://git.openjdk.org/jdk.git pull/15849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15849`

View PR using the GUI difftool: \
`$ git pr show -t 15849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15849.diff">https://git.openjdk.org/jdk/pull/15849.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15849#issuecomment-1728498889)