### PR TITLE
8316654: remove edundant dmb after casal instruction

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2755,7 +2755,6 @@ void MacroAssembler::cmpxchgptr(Register oldv, Register newv, Register addr, Reg
     casal(Assembler::xword, oldv, newv, addr);
     cmp(tmp, oldv);
     br(Assembler::EQ, succeed);
-    membar(AnyAny);
   } else {
     Label retry_load, nope;
     prfm(Address(addr), PSTL1STRM);
@@ -2797,7 +2796,6 @@ void MacroAssembler::cmpxchgw(Register oldv, Register newv, Register addr, Regis
     casal(Assembler::word, oldv, newv, addr);
     cmp(tmp, oldv);
     br(Assembler::EQ, succeed);
-    membar(AnyAny);
   } else {
     Label retry_load, nope;
     prfm(Address(addr), PSTL1STRM);


### PR DESCRIPTION
Hi,all.
The `casal` means a CAS operate with both load-acquire and store-release semantics.It looks like the subsequent dmb is redundant. Can we remove it?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8316654](https://bugs.openjdk.org/browse/JDK-8316654)

### Issue
 * [JDK-8316654](https://bugs.openjdk.org/browse/JDK-8316654): Remove redundant dmb after casal instruction (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15856/head:pull/15856` \
`$ git checkout pull/15856`

Update a local copy of the PR: \
`$ git checkout pull/15856` \
`$ git pull https://git.openjdk.org/jdk.git pull/15856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15856`

View PR using the GUI difftool: \
`$ git pr show -t 15856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15856.diff">https://git.openjdk.org/jdk/pull/15856.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15856#issuecomment-1729221875)