### PR TITLE
8316661: CompilerThread leaks CodeBlob memory when dynamically stopping compiler thread in non-product

### DIFF
--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -128,11 +128,13 @@ protected:
            int frame_size, OopMapSet* oop_maps,
            bool caller_must_gc_arguments, bool compiled = false);
 
+  void operator delete(void* p) { }
+
 public:
   // Only used by unit test.
   CodeBlob() : _type(compiler_none) {}
 
-  ~CodeBlob() {
+  virtual ~CodeBlob() {
     assert(_oop_maps == nullptr, "Not flushed");
   }
 
@@ -404,10 +406,6 @@ class BufferBlob: public RuntimeBlob {
   BufferBlob(const char* name, int size);
   BufferBlob(const char* name, int size, CodeBuffer* cb);
 
-  // This ordinary operator delete is needed even though not used, so the
-  // below two-argument operator delete will be treated as a placement
-  // delete rather than an ordinary sized delete; see C++14 3.7.4.2/p2.
-  void operator delete(void* p);
   void* operator new(size_t s, unsigned size) throw();
 
  public:
@@ -492,10 +490,6 @@ class RuntimeStub: public RuntimeBlob {
     bool        caller_must_gc_arguments
   );
 
-  // This ordinary operator delete is needed even though not used, so the
-  // below two-argument operator delete will be treated as a placement
-  // delete rather than an ordinary sized delete; see C++14 3.7.4.2/p2.
-  void operator delete(void* p);
   void* operator new(size_t s, unsigned size) throw();
 
  public:
@@ -532,10 +526,6 @@ class SingletonBlob: public RuntimeBlob {
   friend class VMStructs;
 
  protected:
-  // This ordinary operator delete is needed even though not used, so the
-  // below two-argument operator delete will be treated as a placement
-  // delete rather than an ordinary sized delete; see C++14 3.7.4.2/p2.
-  void operator delete(void* p);
   void* operator new(size_t s, unsigned size) throw();
 
  public:
@@ -750,10 +740,6 @@ class UpcallStub: public RuntimeBlob {
                      intptr_t exception_handler_offset,
                      jobject receiver, ByteSize frame_data_offset);
 
-  // This ordinary operator delete is needed even though not used, so the
-  // below two-argument operator delete will be treated as a placement
-  // delete rather than an ordinary sized delete; see C++14 3.7.4.2/p2.
-  void operator delete(void* p);
   void* operator new(size_t s, unsigned size) throw();
 
   struct FrameData {

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -119,11 +119,6 @@ protected:
 #ifndef PRODUCT
   AsmRemarks _asm_remarks;
   DbgStrings _dbg_strings;
-
- ~CodeBlob() {
-    _asm_remarks.clear();
-    _dbg_strings.clear();
-  }
 #endif // not PRODUCT
 
   CodeBlob(const char* name, CompilerType type, const CodeBlobLayout& layout, int frame_complete_offset,
@@ -132,9 +127,14 @@ protected:
   CodeBlob(const char* name, CompilerType type, const CodeBlobLayout& layout, CodeBuffer* cb, int frame_complete_offset,
            int frame_size, OopMapSet* oop_maps,
            bool caller_must_gc_arguments, bool compiled = false);
+
 public:
   // Only used by unit test.
   CodeBlob() : _type(compiler_none) {}
+
+  ~CodeBlob() {
+    assert(_oop_maps == nullptr, "Not flushed");
+  }
 
   // Returns the space needed for CodeBlob
   static unsigned int allocation_size(CodeBuffer* cb, int header_size);

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -472,10 +472,10 @@ CodeHeap* CodeCache::get_code_heap_containing(void* start) {
   return nullptr;
 }
 
-CodeHeap* CodeCache::get_code_heap(const CodeBlob* cb) {
+CodeHeap* CodeCache::get_code_heap(const void* cb) {
   assert(cb != nullptr, "CodeBlob is null");
   FOR_ALL_HEAPS(heap) {
-    if ((*heap)->contains_blob(cb)) {
+    if ((*heap)->contains(cb)) {
       return *heap;
     }
   }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -604,6 +604,7 @@ void CodeCache::free(CodeBlob* cb) {
     heap->set_adapter_count(heap->adapter_count() - 1);
   }
 
+  cb->~CodeBlob();
   // Get heap for given CodeBlob and deallocate
   get_code_heap(cb)->deallocate(cb);
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -117,7 +117,7 @@ class CodeCache : AllStatic {
   // Creates a new heap with the given name and size, containing CodeBlobs of the given type
   static void add_heap(ReservedSpace rs, const char* name, CodeBlobType code_blob_type);
   static CodeHeap* get_code_heap_containing(void* p);         // Returns the CodeHeap containing the given pointer, or nullptr
-  static CodeHeap* get_code_heap(const CodeBlob* cb);         // Returns the CodeHeap for the given CodeBlob
+  static CodeHeap* get_code_heap(const void* cb);             // Returns the CodeHeap for the given CodeBlob
   static CodeHeap* get_code_heap(CodeBlobType code_blob_type);         // Returns the CodeHeap for the given CodeBlobType
   // Returns the name of the VM option to set the size of the corresponding CodeHeap
   static const char* get_code_heap_flag_name(CodeBlobType code_blob_type);
@@ -397,10 +397,10 @@ template <class T, class Filter, bool is_relaxed> class CodeBlobIterator : publi
     // If set to nullptr, initialized by first call to next()
     _code_blob = nm;
     if (nm != nullptr) {
-      while(!(*_heap)->contains_blob(_code_blob)) {
+      while(!(*_heap)->contains(_code_blob)) {
         ++_heap;
       }
-      assert((*_heap)->contains_blob(_code_blob), "match not found");
+      assert((*_heap)->contains(_code_blob), "match not found");
     }
   }
 

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -252,6 +252,8 @@ class CompileBroker: AllStatic {
   static bool wait_for_jvmci_completion(JVMCICompiler* comp, CompileTask* task, JavaThread* thread);
 #endif
 
+  static void free_buffer_blob_if_allocated(CompilerThread* thread);
+
   static void invoke_compiler_on_method(CompileTask* task);
   static void handle_compile_error(CompilerThread* thread, CompileTask* task, ciEnv* ci_env,
                                    int compilable, const char* failure_reason);

--- a/src/hotspot/share/memory/heap.hpp
+++ b/src/hotspot/share/memory/heap.hpp
@@ -171,9 +171,6 @@ class CodeHeap : public CHeapObj<mtCode> {
 
   // Containment means "contained in committed space".
   bool contains(const void* p) const             { return low() <= p && p < high(); }
-  bool contains_blob(const CodeBlob* blob) const {
-    return contains((void*)blob);
-  }
 
   void* find_start(void* p)     const;   // returns the block containing p or null
   CodeBlob* find_blob(void* start) const;


### PR DESCRIPTION
Hi all,

  please review this change to fix a memory leak I found when having `CodeCache::free` call the destructor of `CodeBlob`: when adding the latter, one gets assertion failures that the native memory that `_asm_remarks` and `_dbg_strings` members were not deallocated properly when
* stopping a compiler thread due to dynamic compiler thread policy
* shutting down the compiler runtime

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316661](https://bugs.openjdk.org/browse/JDK-8316661): CompilerThread leaks CodeBlob memory when dynamically stopping compiler thread in non-product (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15858/head:pull/15858` \
`$ git checkout pull/15858`

Update a local copy of the PR: \
`$ git checkout pull/15858` \
`$ git pull https://git.openjdk.org/jdk.git pull/15858/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15858`

View PR using the GUI difftool: \
`$ git pr show -t 15858`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15858.diff">https://git.openjdk.org/jdk/pull/15858.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15858#issuecomment-1729872734)