### PR TITLE
8316415: Parallelize sun/security/rsa/SignedObjectChain.java subtests

### DIFF
--- a/test/jdk/sun/security/rsa/SignedObjectChain.java
+++ b/test/jdk/sun/security/rsa/SignedObjectChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,16 +22,95 @@
  */
 
 /*
- * @test
+ * @test id=MD2withRSA
  * @bug 8050374 8146293
  * @library /test/lib
  * @build jdk.test.lib.SigTestUtil
  * @compile ../../../java/security/SignedObject/Chain.java
- * @run main SignedObjectChain
+ * @run main/othervm -DSigAlg=MD2withRSA SignedObjectChain
+ * @summary Verify a chain of signed objects
+ */
+
+/*
+ * @test id=MD5withRSA
+ * @bug 8050374 8146293
+ * @library /test/lib
+ * @build jdk.test.lib.SigTestUtil
+ * @compile ../../../java/security/SignedObject/Chain.java
+ * @run main/othervm -DSigAlg=MD5withRSA SignedObjectChain
+ * @summary Verify a chain of signed objects
+ */
+
+/*
+ * @test id=SHA1withRSA
+ * @bug 8050374 8146293
+ * @library /test/lib
+ * @build jdk.test.lib.SigTestUtil
+ * @compile ../../../java/security/SignedObject/Chain.java
+ * @run main/othervm -DSigAlg=SHA1withRSA SignedObjectChain
+ * @summary Verify a chain of signed objects
+ */
+
+/*
+ * @test id=SHA224withRSA
+ * @bug 8050374 8146293
+ * @library /test/lib
+ * @build jdk.test.lib.SigTestUtil
+ * @compile ../../../java/security/SignedObject/Chain.java
+ * @run main/othervm -DSigAlg=SHA224withRSA SignedObjectChain
+ * @summary Verify a chain of signed objects
+ */
+
+/*
+ * @test id=SHA256withRSA
+ * @bug 8050374 8146293
+ * @library /test/lib
+ * @build jdk.test.lib.SigTestUtil
+ * @compile ../../../java/security/SignedObject/Chain.java
+ * @run main/othervm -DSigAlg=SHA256withRSA SignedObjectChain
+ * @summary Verify a chain of signed objects
+ */
+
+/*
+ * @test id=SHA384withRSA
+ * @bug 8050374 8146293
+ * @library /test/lib
+ * @build jdk.test.lib.SigTestUtil
+ * @compile ../../../java/security/SignedObject/Chain.java
+ * @run main/othervm -DSigAlg=SHA384withRSA SignedObjectChain
+ * @summary Verify a chain of signed objects
+ */
+
+/*
+ * @test id=SHA512withRSA
+ * @bug 8050374 8146293
+ * @library /test/lib
+ * @build jdk.test.lib.SigTestUtil
+ * @compile ../../../java/security/SignedObject/Chain.java
+ * @run main/othervm -DSigAlg=SHA512withRSA SignedObjectChain
+ * @summary Verify a chain of signed objects
+ */
+
+/*
+ * @test id=SHA512_224withRSA
+ * @bug 8050374 8146293
+ * @library /test/lib
+ * @build jdk.test.lib.SigTestUtil
+ * @compile ../../../java/security/SignedObject/Chain.java
+ * @run main/othervm -DSigAlg=SHA512_224withRSA SignedObjectChain
+ * @summary Verify a chain of signed objects
+ */
+
+/*
+ * @test id=SHA512_256withRSA
+ * @bug 8050374 8146293
+ * @library /test/lib
+ * @build jdk.test.lib.SigTestUtil
+ * @compile ../../../java/security/SignedObject/Chain.java
+ * @run main/othervm -DSigAlg=SHA512_256withRSA SignedObjectChain
  * @summary Verify a chain of signed objects
  */
 public class SignedObjectChain {
-
     private static class Test extends Chain.Test {
 
         public Test(Chain.SigAlg sigAlg) {
@@ -39,21 +118,9 @@ public class SignedObjectChain {
         }
     }
 
-    private static final Test[] tests = {
-        new Test(Chain.SigAlg.MD2withRSA),
-        new Test(Chain.SigAlg.MD5withRSA),
-        new Test(Chain.SigAlg.SHA1withRSA),
-        new Test(Chain.SigAlg.SHA224withRSA),
-        new Test(Chain.SigAlg.SHA256withRSA),
-        new Test(Chain.SigAlg.SHA384withRSA),
-        new Test(Chain.SigAlg.SHA512withRSA),
-        new Test(Chain.SigAlg.SHA512_224withRSA),
-        new Test(Chain.SigAlg.SHA512_256withRSA),
-    };
 
     public static void main(String argv[]) {
-        boolean resutl = java.util.Arrays.stream(tests).allMatch(
-                (test) -> Chain.runTest(test));
+        boolean resutl = Chain.runTest(new Test(Chain.SigAlg.valueOf(System.getProperty("SigAlg"))));
 
         if(resutl) {
             System.out.println("All tests passed");

--- a/test/jdk/sun/security/rsa/SignedObjectChain.java
+++ b/test/jdk/sun/security/rsa/SignedObjectChain.java
@@ -55,7 +55,7 @@ public class SignedObjectChain {
     public static void main(String argv[]) {
         boolean result = Arrays.stream(tests).parallel().allMatch(Chain::runTest);
 
-        if(result) {
+        if (result) {
             System.out.println("All tests passed");
         } else {
             throw new RuntimeException("Some tests failed");

--- a/test/jdk/sun/security/rsa/SignedObjectChain.java
+++ b/test/jdk/sun/security/rsa/SignedObjectChain.java
@@ -62,4 +62,3 @@ public class SignedObjectChain {
         }
     }
 }
-

--- a/test/jdk/sun/security/rsa/SignedObjectChain.java
+++ b/test/jdk/sun/security/rsa/SignedObjectChain.java
@@ -21,93 +21,15 @@
  * questions.
  */
 
-/*
- * @test id=MD2withRSA
- * @bug 8050374 8146293
- * @library /test/lib
- * @build jdk.test.lib.SigTestUtil
- * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=MD2withRSA SignedObjectChain
- * @summary Verify a chain of signed objects
- */
+import java.util.Arrays;
 
 /*
- * @test id=MD5withRSA
+ * @test
  * @bug 8050374 8146293
  * @library /test/lib
  * @build jdk.test.lib.SigTestUtil
  * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=MD5withRSA SignedObjectChain
- * @summary Verify a chain of signed objects
- */
-
-/*
- * @test id=SHA1withRSA
- * @bug 8050374 8146293
- * @library /test/lib
- * @build jdk.test.lib.SigTestUtil
- * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=SHA1withRSA SignedObjectChain
- * @summary Verify a chain of signed objects
- */
-
-/*
- * @test id=SHA224withRSA
- * @bug 8050374 8146293
- * @library /test/lib
- * @build jdk.test.lib.SigTestUtil
- * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=SHA224withRSA SignedObjectChain
- * @summary Verify a chain of signed objects
- */
-
-/*
- * @test id=SHA256withRSA
- * @bug 8050374 8146293
- * @library /test/lib
- * @build jdk.test.lib.SigTestUtil
- * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=SHA256withRSA SignedObjectChain
- * @summary Verify a chain of signed objects
- */
-
-/*
- * @test id=SHA384withRSA
- * @bug 8050374 8146293
- * @library /test/lib
- * @build jdk.test.lib.SigTestUtil
- * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=SHA384withRSA SignedObjectChain
- * @summary Verify a chain of signed objects
- */
-
-/*
- * @test id=SHA512withRSA
- * @bug 8050374 8146293
- * @library /test/lib
- * @build jdk.test.lib.SigTestUtil
- * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=SHA512withRSA SignedObjectChain
- * @summary Verify a chain of signed objects
- */
-
-/*
- * @test id=SHA512_224withRSA
- * @bug 8050374 8146293
- * @library /test/lib
- * @build jdk.test.lib.SigTestUtil
- * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=SHA512_224withRSA SignedObjectChain
- * @summary Verify a chain of signed objects
- */
-
-/*
- * @test id=SHA512_256withRSA
- * @bug 8050374 8146293
- * @library /test/lib
- * @build jdk.test.lib.SigTestUtil
- * @compile ../../../java/security/SignedObject/Chain.java
- * @run main/othervm -DSigAlg=SHA512_256withRSA SignedObjectChain
+ * @run main SignedObjectChain
  * @summary Verify a chain of signed objects
  */
 public class SignedObjectChain {
@@ -118,14 +40,26 @@ public class SignedObjectChain {
         }
     }
 
+    private static final Test[] tests = {
+        new Test(Chain.SigAlg.MD2withRSA),
+        new Test(Chain.SigAlg.MD5withRSA),
+        new Test(Chain.SigAlg.SHA1withRSA),
+        new Test(Chain.SigAlg.SHA224withRSA),
+        new Test(Chain.SigAlg.SHA256withRSA),
+        new Test(Chain.SigAlg.SHA384withRSA),
+        new Test(Chain.SigAlg.SHA512withRSA),
+        new Test(Chain.SigAlg.SHA512_224withRSA),
+        new Test(Chain.SigAlg.SHA512_256withRSA),
+    };
 
     public static void main(String argv[]) {
-        boolean resutl = Chain.runTest(new Test(Chain.SigAlg.valueOf(System.getProperty("SigAlg"))));
+        boolean result = Arrays.stream(tests).parallel().allMatch(Chain::runTest);
 
-        if(resutl) {
+        if(result) {
             System.out.println("All tests passed");
         } else {
             throw new RuntimeException("Some tests failed");
         }
     }
 }
+


### PR DESCRIPTION
sun/security/rsa/SignedObjectChain.java is very slow when run with C1, I suspect because some crypto intrinsics are only implemented in C2. Commit contains changes made to parallelize it.

Comparison of before and after parallelization:
time make test TEST=jdk/sun/security/rsa/SignedObjectChain.java TEST_VM_OPTS="-XX:+UseParallelGC -XX:TieredStopAtLevel=1"
before:   270.72s user 4.88s system 108% cpu 4:14.43 total
after:   410.76s user 7.50s system 555% cpu 1:15.23 total
after second commit:   375.46s user 4.59s system 539% cpu 1:10.41 total

time make test TEST=jdk/sun/security/rsa/SignedObjectChain.java TEST_VM_OPTS="-XX:+UseParallelGC"
before:   63.67s user 4.67s system 161% cpu 42.424 total
after:   130.36s user 7.47s system 585% cpu 23.526 total
after second commit:   67.31s user 4.48s system 417% cpu 17.183 total

time make test TEST=jdk/sun/security/rsa/SignedObjectChain.java TEST_VM_OPTS="-XX:+UseShenandoahGC -XX:TieredStopAtLevel=1"
before:   281.99s user 5.54s system 108% cpu 4:24.09 total
after:   386.98s user 8.62s system 496% cpu 1:19.73 total
after second commit:   413.51s user 5.08s system 613% cpu 1:08.25 total

time make test TEST=jdk/sun/security/rsa/SignedObjectChain.java TEST_VM_OPTS="-XX:+UseShenandoahGC"
before:   65.86s user 5.05s system 156% cpu 45.215 total
after:   135.90s user 7.66s system 585% cpu 24.502 total
after second commit:   83.25s user 4.82s system 469% cpu 18.741 total

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8316415](https://bugs.openjdk.org/browse/JDK-8316415): Parallelize sun/security/rsa/SignedObjectChain.java subtests (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**) ⚠️ Review applies to [0040ba31](https://git.openjdk.org/jdk/pull/15860/files/0040ba31e681fbf5e59a0655a7bd7721e101c4f4)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to [0040ba31](https://git.openjdk.org/jdk/pull/15860/files/0040ba31e681fbf5e59a0655a7bd7721e101c4f4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15860/head:pull/15860` \
`$ git checkout pull/15860`

Update a local copy of the PR: \
`$ git checkout pull/15860` \
`$ git pull https://git.openjdk.org/jdk.git pull/15860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15860`

View PR using the GUI difftool: \
`$ git pr show -t 15860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15860.diff">https://git.openjdk.org/jdk/pull/15860.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15860#issuecomment-1729507337)