### PR TITLE
8316669: ImmutableOopMapSet destructor not called

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -174,8 +174,11 @@ void RuntimeBlob::free(RuntimeBlob* blob) {
 }
 
 void CodeBlob::flush() {
-  FREE_C_HEAP_ARRAY(unsigned char, _oop_maps);
-  _oop_maps = nullptr;
+  if (_oop_maps != nullptr) {
+    _oop_maps->~ImmutableOopMapSet();
+    FREE_C_HEAP_ARRAY(unsigned char, _oop_maps);
+    _oop_maps = nullptr;
+  }
   NOT_PRODUCT(_asm_remarks.clear());
   NOT_PRODUCT(_dbg_strings.clear());
 }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -175,8 +175,7 @@ void RuntimeBlob::free(RuntimeBlob* blob) {
 
 void CodeBlob::flush() {
   if (_oop_maps != nullptr) {
-    _oop_maps->~ImmutableOopMapSet();
-    FREE_C_HEAP_ARRAY(unsigned char, _oop_maps);
+    delete _oop_maps;
     _oop_maps = nullptr;
   }
   NOT_PRODUCT(_asm_remarks.clear());
@@ -192,7 +191,6 @@ void CodeBlob::set_oop_maps(OopMapSet* p) {
     _oop_maps = nullptr;
   }
 }
-
 
 void RuntimeBlob::trace_new_stub(RuntimeBlob* stub, const char* name1, const char* name2) {
   // Do not hold the CodeCache lock during name formatting.

--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -871,6 +871,9 @@ ImmutableOopMapSet* ImmutableOopMapSet::build_from(const OopMapSet* oopmap_set) 
   return builder.build();
 }
 
+void ImmutableOopMapSet::operator delete(void* p) {
+  FREE_C_HEAP_ARRAY(unsigned char, p);
+}
 
 //------------------------------DerivedPointerTable---------------------------
 

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -336,6 +336,7 @@ private:
 
 public:
   ImmutableOopMapSet(const OopMapSet* oopmap_set, int size) : _count(oopmap_set->size()), _size(size) {}
+  ~ImmutableOopMapSet() = default;
 
   ImmutableOopMap* oopmap_at_offset(int offset) const {
     assert(offset >= 0 && offset < _size, "must be within boundaries");

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -335,6 +335,8 @@ private:
   address data() const { return (address) this + sizeof(*this) + sizeof(ImmutableOopMapPair) * _count; }
 
 public:
+  void operator delete(void* p);
+
   ImmutableOopMapSet(const OopMapSet* oopmap_set, int size) : _count(oopmap_set->size()), _size(size) {}
   ~ImmutableOopMapSet() = default;
 


### PR DESCRIPTION
Hi all,

  please review this addition to call the destructor of `ImmutableOopMapSet` before its memory is deleted. There is no functional problem as the destructor is empty, but it is surprising to free new'ed objects without calling its destructor.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316669](https://bugs.openjdk.org/browse/JDK-8316669): ImmutableOopMapSet destructor not called (**Enhancement** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15862/head:pull/15862` \
`$ git checkout pull/15862`

Update a local copy of the PR: \
`$ git checkout pull/15862` \
`$ git pull https://git.openjdk.org/jdk.git pull/15862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15862`

View PR using the GUI difftool: \
`$ git pr show -t 15862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15862.diff">https://git.openjdk.org/jdk/pull/15862.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15862#issuecomment-1729873078)