### PR TITLE
8316670: Remove effectively unused nmethodBucket::_count

### DIFF
--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -70,21 +70,19 @@ void DependencyContext::init() {
 void DependencyContext::mark_dependent_nmethods(DeoptimizationScope* deopt_scope, DepChange& changes) {
   for (nmethodBucket* b = dependencies_not_unloading(); b != nullptr; b = b->next_not_unloading()) {
     nmethod* nm = b->get_nmethod();
-    if (b->count() > 0) {
-      if (nm->is_marked_for_deoptimization()) {
-        deopt_scope->dependent(nm);
-      } else if (nm->check_dependency_on(changes)) {
-        LogTarget(Info, dependencies) lt;
-        if (lt.is_enabled()) {
-          ResourceMark rm;
-          LogStream ls(&lt);
-          ls.print_cr("Marked for deoptimization");
-          changes.print_on(&ls);
-          nm->print_on(&ls);
-          nm->print_dependencies_on(&ls);
-        }
-        deopt_scope->mark(nm, !changes.is_call_site_change());
+    if (nm->is_marked_for_deoptimization()) {
+      deopt_scope->dependent(nm);
+    } else if (nm->check_dependency_on(changes)) {
+      LogTarget(Info, dependencies) lt;
+      if (lt.is_enabled()) {
+        ResourceMark rm;
+        LogStream ls(&lt);
+        ls.print_cr("Marked for deoptimization");
+        changes.print_on(&ls);
+        nm->print_on(&ls);
+        nm->print_dependencies_on(&ls);
       }
+      deopt_scope->mark(nm, !changes.is_call_site_change());
     }
   }
 }
@@ -99,7 +97,6 @@ void DependencyContext::add_dependent_nmethod(nmethod* nm) {
   assert_lock_strong(CodeCache_lock);
   for (nmethodBucket* b = dependencies_not_unloading(); b != nullptr; b = b->next_not_unloading()) {
     if (nm == b->get_nmethod()) {
-      b->increment();
       return;
     }
   }
@@ -194,11 +191,9 @@ void DependencyContext::remove_and_mark_for_deoptimization_all_dependents(Deopti
   set_dependencies(nullptr);
   while (b != nullptr) {
     nmethod* nm = b->get_nmethod();
-    if (b->count() > 0) {
-      // Also count already (concurrently) marked nmethods to make sure
-      // deoptimization is triggered before execution in this thread continues.
-      deopt_scope->mark(nm);
-    }
+    // Also count already (concurrently) marked nmethods to make sure
+    // deoptimization is triggered before execution in this thread continues.
+    deopt_scope->mark(nm);
     b = release_and_get_next_not_unloading(b);
   }
 }
@@ -208,7 +203,7 @@ void DependencyContext::print_dependent_nmethods(bool verbose) {
   int idx = 0;
   for (nmethodBucket* b = dependencies_not_unloading(); b != nullptr; b = b->next_not_unloading()) {
     nmethod* nm = b->get_nmethod();
-    tty->print("[%d] count=%d { ", idx++, b->count());
+    tty->print("[%d] { ", idx++);
     if (!verbose) {
       nm->print_on(tty, "nmethod");
       tty->print_cr(" } ");
@@ -224,18 +219,10 @@ void DependencyContext::print_dependent_nmethods(bool verbose) {
 bool DependencyContext::is_dependent_nmethod(nmethod* nm) {
   for (nmethodBucket* b = dependencies_not_unloading(); b != nullptr; b = b->next_not_unloading()) {
     if (nm == b->get_nmethod()) {
-#ifdef ASSERT
-      int count = b->count();
-      assert(count >= 0, "count shouldn't be negative: %d", count);
-#endif
       return true;
     }
   }
   return false;
-}
-
-int nmethodBucket::decrement() {
-  return Atomic::sub(&_count, 1);
 }
 
 // We use a monotonically increasing epoch counter to track the last epoch a given

--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -89,9 +89,6 @@ void DependencyContext::mark_dependent_nmethods(DeoptimizationScope* deopt_scope
 
 //
 // Add an nmethod to the dependency context.
-// It's possible that an nmethod has multiple dependencies on a klass
-// so a count is kept for each bucket to guarantee that creation and
-// deletion of dependencies is consistent.
 //
 void DependencyContext::add_dependent_nmethod(nmethod* nm) {
   assert_lock_strong(CodeCache_lock);

--- a/src/hotspot/share/code/dependencyContext.hpp
+++ b/src/hotspot/share/code/dependencyContext.hpp
@@ -39,27 +39,19 @@ class DepChange;
 // nmethodBucket is used to record dependent nmethods for
 // deoptimization.  nmethod dependencies are actually <klass, method>
 // pairs but we really only care about the klass part for purposes of
-// finding nmethods which might need to be deoptimized.  Instead of
-// recording the method, a count of how many times a particular nmethod
-// was recorded is kept.  This ensures that any recording errors are
-// noticed since an nmethod should be removed as many times are it's
-// added.
+// finding nmethods which might need to be deoptimized.
 //
 class nmethodBucket: public CHeapObj<mtClass> {
   friend class VMStructs;
  private:
   nmethod*       _nmethod;
-  volatile int   _count;
   nmethodBucket* volatile _next;
   nmethodBucket* volatile _purge_list_next;
 
  public:
   nmethodBucket(nmethod* nmethod, nmethodBucket* next) :
-    _nmethod(nmethod), _count(1), _next(next), _purge_list_next(nullptr) {}
+    _nmethod(nmethod), _next(next), _purge_list_next(nullptr) {}
 
-  int count()                                { return _count; }
-  int increment()                            { _count += 1; return _count; }
-  int decrement();
   nmethodBucket* next();
   nmethodBucket* next_not_unloading();
   void set_next(nmethodBucket* b);


### PR DESCRIPTION
Hi all,

  please review this removal of effectively dead code: `nmethodBucket::_count` is effectively dead code because as it's intended to be used as a refcount to check for mismatched add/remove calls, for some time now the remove-call has been removed, making the count obsolete.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316670](https://bugs.openjdk.org/browse/JDK-8316670): Remove effectively unused nmethodBucket::_count (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [f31f7c1f](https://git.openjdk.org/jdk/pull/15863/files/f31f7c1f1c7cdac980b27011159235c39cfd7b9e)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15863/head:pull/15863` \
`$ git checkout pull/15863`

Update a local copy of the PR: \
`$ git checkout pull/15863` \
`$ git pull https://git.openjdk.org/jdk.git pull/15863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15863`

View PR using the GUI difftool: \
`$ git pr show -t 15863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15863.diff">https://git.openjdk.org/jdk/pull/15863.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15863#issuecomment-1729872904)