### PR TITLE
JDK-8316688: Widen allowable error bound of Math.hypot

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -2755,7 +2755,7 @@ public final class Math {
      * <li> If both arguments are zero, the result is positive zero.
      * </ul>
      *
-     * <p>The computed result must be within 1 ulp of the exact
+     * <p>The computed result must be within 1.5 ulps of the exact
      * result.  If one parameter is held constant, the results must be
      * semi-monotonic in the other parameter.
      *


### PR DESCRIPTION
The Math.hypot method claims its error bound is one ulp.

The paper

"Accuracy of Mathematical Functions in Single, Double, Double
Extended, and Quadruple Precision"
Brian Gladman, Vincenzo Innocente and Paul Zimmermann
September 21, 2023
https://members.loria.fr/PZimmermann/papers/accuracy.pdf

lists a known worst-case error of 1.21 ulps for hypot for the "OpenLibm" math library, which is a derivative of FDLIBM.

The specification of Math.hypot should be updated to acknowledge the wider error bound. I changed the allowable error bound to 1.5 ulps is give a bit of cushion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8316690](https://bugs.openjdk.org/browse/JDK-8316690) to be approved

### Issues
 * [JDK-8316688](https://bugs.openjdk.org/browse/JDK-8316688): Widen allowable error bound of Math.hypot (**Bug** - P4)
 * [JDK-8316690](https://bugs.openjdk.org/browse/JDK-8316690): Widen allowable error bound of Math.hypot (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15868/head:pull/15868` \
`$ git checkout pull/15868`

Update a local copy of the PR: \
`$ git checkout pull/15868` \
`$ git pull https://git.openjdk.org/jdk.git pull/15868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15868`

View PR using the GUI difftool: \
`$ git pr show -t 15868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15868.diff">https://git.openjdk.org/jdk/pull/15868.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15868#issuecomment-1730170614)