### PR TITLE
8316695: ProblemList serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -133,6 +133,7 @@ serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
 serviceability/sa/ClhsdbDumpclass.java 8316342 generic-all
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
+serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java 8316658 generic-all
 
 #############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
on all platforms. It's a new test and we already have 8 failure sightings in the JDK22 CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316695](https://bugs.openjdk.org/browse/JDK-8316695): ProblemList serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java (**Sub-task** - P3)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15870/head:pull/15870` \
`$ git checkout pull/15870`

Update a local copy of the PR: \
`$ git checkout pull/15870` \
`$ git pull https://git.openjdk.org/jdk.git pull/15870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15870`

View PR using the GUI difftool: \
`$ git pr show -t 15870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15870.diff">https://git.openjdk.org/jdk/pull/15870.diff</a>

</details>
