### PR TITLE
8314029: Add file name parameter to Compiler.perfmap

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1800,12 +1800,6 @@ void CodeCache::log_state(outputStream* st) {
 }
 
 #ifdef LINUX
-CodeCache::DefaultPerfMapFile::DefaultPerfMapFile() {
-  // Perf expects to find the map file at /tmp/perf-<pid>.map.
-  // It is used as the default file name.
-  jio_snprintf(_name, sizeof(_name), "/tmp/perf-%d.map", os::current_process_id());
-}
-
 void CodeCache::write_perf_map(const char* filename) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
@@ -1826,6 +1820,14 @@ void CodeCache::write_perf_map(const char* filename) {
                 (intptr_t)cb->code_begin(), (intptr_t)cb->code_size(),
                 method_name);
   }
+}
+
+void CodeCache::write_default_perf_map() {
+  // Perf expects to find the map file at /tmp/perf-<pid>.map.
+  // It is used as the default file name.
+  char fname[32];
+  jio_snprintf(fname, sizeof(fname), "/tmp/perf-%d.map", os::current_process_id());
+  write_perf_map(fname);
 }
 #endif // LINUX
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1803,6 +1803,14 @@ void CodeCache::log_state(outputStream* st) {
 void CodeCache::write_perf_map(const char* filename) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
+  // Perf expects to find the map file at /tmp/perf-<pid>.map
+  // if the file name is not specified.
+  char fname[32];
+  if (filename == nullptr) {
+    jio_snprintf(fname, sizeof(fname), "/tmp/perf-%d.map", os::current_process_id());
+    filename = fname;
+  }
+
   fileStream fs(filename, "w");
   if (!fs.is_open()) {
     log_warning(codecache)("Failed to create %s for perf map", filename);
@@ -1820,14 +1828,6 @@ void CodeCache::write_perf_map(const char* filename) {
                 (intptr_t)cb->code_begin(), (intptr_t)cb->code_size(),
                 method_name);
   }
-}
-
-void CodeCache::write_default_perf_map() {
-  // Perf expects to find the map file at /tmp/perf-<pid>.map.
-  // It is used as the default file name.
-  char fname[32];
-  jio_snprintf(fname, sizeof(fname), "/tmp/perf-%d.map", os::current_process_id());
-  write_perf_map(fname);
 }
 #endif // LINUX
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1802,6 +1802,7 @@ void CodeCache::log_state(outputStream* st) {
 #ifdef LINUX
 CodeCache::DefaultPerfMapFile::DefaultPerfMapFile() {
   // Perf expects to find the map file at /tmp/perf-<pid>.map.
+  // It is used as the default file name.
   jio_snprintf(_name, sizeof(_name), "/tmp/perf-%d.map", os::current_process_id());
 }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1804,11 +1804,12 @@ void CodeCache::write_perf_map(const char* filename) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
   // Perf expects to find the map file at /tmp/perf-<pid>.map.
-  char fname[32];
+  // Write to filename if specified.
+  char fname[MAXPATHLEN];
   if (filename == nullptr) {
     jio_snprintf(fname, sizeof(fname), "/tmp/perf-%d.map", os::current_process_id());
   } else {
-    jio_snprintf(fname, sizeof(fname), filename, os::current_process_id());
+    jio_snprintf(fname, sizeof(fname), "%s", filename);
   }
 
   fileStream fs(fname, "w");

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1800,12 +1800,16 @@ void CodeCache::log_state(outputStream* st) {
 }
 
 #ifdef LINUX
-void CodeCache::write_perf_map() {
+void CodeCache::write_perf_map(const char* filename) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
   // Perf expects to find the map file at /tmp/perf-<pid>.map.
   char fname[32];
-  jio_snprintf(fname, sizeof(fname), "/tmp/perf-%d.map", os::current_process_id());
+  if (filename == nullptr) {
+    jio_snprintf(fname, sizeof(fname), "/tmp/perf-%d.map", os::current_process_id());
+  } else {
+    jio_snprintf(fname, sizeof(fname), filename, os::current_process_id());
+  }
 
   fileStream fs(fname, "w");
   if (!fs.is_open()) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1805,12 +1805,12 @@ CodeCache::DefaultPerfMapFile::DefaultPerfMapFile() {
   jio_snprintf(_name, sizeof(_name), "/tmp/perf-%d.map", os::current_process_id());
 }
 
-void CodeCache::write_perf_map(const char* fname) {
+void CodeCache::write_perf_map(const char* filename) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
-  fileStream fs(fname, "w");
+  fileStream fs(filename, "w");
   if (!fs.is_open()) {
-    log_warning(codecache)("Failed to create %s for perf map", fname);
+    log_warning(codecache)("Failed to create %s for perf map", filename);
     return;
   }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1800,17 +1800,13 @@ void CodeCache::log_state(outputStream* st) {
 }
 
 #ifdef LINUX
-void CodeCache::write_perf_map(const char* filename) {
-  MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-
+CodeCache::DefaultPerfMapFile::DefaultPerfMapFile() {
   // Perf expects to find the map file at /tmp/perf-<pid>.map.
-  // Write to filename if specified.
-  char fname[MAXPATHLEN];
-  if (filename == nullptr) {
-    jio_snprintf(fname, sizeof(fname), "/tmp/perf-%d.map", os::current_process_id());
-  } else {
-    jio_snprintf(fname, sizeof(fname), "%s", filename);
-  }
+  jio_snprintf(_name, sizeof(_name), "/tmp/perf-%d.map", os::current_process_id());
+}
+
+void CodeCache::write_perf_map(const char* fname) {
+  MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
   fileStream fs(fname, "w");
   if (!fs.is_open()) {

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -231,8 +231,7 @@ class CodeCache : AllStatic {
   static void print_trace(const char* event, CodeBlob* cb, int size = 0) PRODUCT_RETURN;
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
   static void log_state(outputStream* st);
-  LINUX_ONLY(static void write_perf_map(const char* filename);)
-  LINUX_ONLY(static void write_default_perf_map();)
+  LINUX_ONLY(static void write_perf_map(const char* filename = nullptr);)
   static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
   static void report_codemem_full(CodeBlobType code_blob_type, bool print);
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -223,13 +223,6 @@ class CodeCache : AllStatic {
   static void release_exception_cache(ExceptionCache* entry);
   static void purge_exception_caches();
 
-  LINUX_ONLY(class DefaultPerfMapFile {
-    char _name[32];
-  public:
-    DefaultPerfMapFile();
-    const char* name() const  { return _name; }
-  };)
-
   // Printing/debugging
   static void print();                           // prints summary
   static void print_internals();
@@ -239,6 +232,7 @@ class CodeCache : AllStatic {
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
   static void log_state(outputStream* st);
   LINUX_ONLY(static void write_perf_map(const char* filename);)
+  LINUX_ONLY(static void write_default_perf_map();)
   static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
   static void report_codemem_full(CodeBlobType code_blob_type, bool print);
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -231,7 +231,7 @@ class CodeCache : AllStatic {
   static void print_trace(const char* event, CodeBlob* cb, int size = 0) PRODUCT_RETURN;
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
   static void log_state(outputStream* st);
-  LINUX_ONLY(static void write_perf_map();)
+  LINUX_ONLY(static void write_perf_map(const char* filename = nullptr);)
   static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
   static void report_codemem_full(CodeBlobType code_blob_type, bool print);
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -223,6 +223,13 @@ class CodeCache : AllStatic {
   static void release_exception_cache(ExceptionCache* entry);
   static void purge_exception_caches();
 
+  LINUX_ONLY(class DefaultPerfMapFile {
+    char _name[32];
+  public:
+    DefaultPerfMapFile();
+    const char* name() const  { return _name; }
+  };)
+
   // Printing/debugging
   static void print();                           // prints summary
   static void print_internals();
@@ -231,7 +238,7 @@ class CodeCache : AllStatic {
   static void print_trace(const char* event, CodeBlob* cb, int size = 0) PRODUCT_RETURN;
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
   static void log_state(outputStream* st);
-  LINUX_ONLY(static void write_perf_map(const char* filename = nullptr);)
+  LINUX_ONLY(static void write_perf_map(const char* filename);)
   static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
   static void report_codemem_full(CodeBlobType code_blob_type, bool print);
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -503,7 +503,7 @@ void before_exit(JavaThread* thread, bool halt) {
 
 #ifdef LINUX
   if (DumpPerfMapAtExit) {
-    CodeCache::write_default_perf_map();
+    CodeCache::write_perf_map();
   }
 #endif
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -503,8 +503,7 @@ void before_exit(JavaThread* thread, bool halt) {
 
 #ifdef LINUX
   if (DumpPerfMapAtExit) {
-    CodeCache::DefaultPerfMapFile file;
-    CodeCache::write_perf_map(file.name());
+    CodeCache::write_default_perf_map();
   }
 #endif
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -503,7 +503,8 @@ void before_exit(JavaThread* thread, bool halt) {
 
 #ifdef LINUX
   if (DumpPerfMapAtExit) {
-    CodeCache::write_perf_map();
+    CodeCache::DefaultPerfMapFile file;
+    CodeCache::write_perf_map(file.name());
   }
 #endif
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -853,8 +853,7 @@ void PerfMapDCmd::execute(DCmdSource source, TRAPS) {
   if (_filename.value() != nullptr) {
     CodeCache::write_perf_map(_filename.value());
   } else {
-    CodeCache::DefaultPerfMapFile file;
-    CodeCache::write_perf_map(file.name());
+    CodeCache::write_default_perf_map();
   }
 }
 #endif // LINUX

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -846,7 +846,7 @@ PerfMapDCmd::PerfMapDCmd(outputStream* output, bool heap) :
              DCmdWithParser(output, heap),
   _filename("filename", "Name of the map file", "STRING", false)
 {
-  _dcmdparser.add_dcmd_option(&_filename);
+  _dcmdparser.add_dcmd_argument(&_filename);
 }
 
 void PerfMapDCmd::execute(DCmdSource source, TRAPS) {

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -850,11 +850,7 @@ PerfMapDCmd::PerfMapDCmd(outputStream* output, bool heap) :
 }
 
 void PerfMapDCmd::execute(DCmdSource source, TRAPS) {
-  if (_filename.value() != nullptr) {
-    CodeCache::write_perf_map(_filename.value());
-  } else {
-    CodeCache::write_default_perf_map();
-  }
+  CodeCache::write_perf_map(_filename.value());
 }
 #endif // LINUX
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -844,7 +844,7 @@ void CodeCacheDCmd::execute(DCmdSource source, TRAPS) {
 #ifdef LINUX
 PerfMapDCmd::PerfMapDCmd(outputStream* output, bool heap) :
              DCmdWithParser(output, heap),
-  _filename("-f", "Name of the file", "STRING", false)
+  _filename("filename", "Name of the map file", "STRING", false)
 {
   _dcmdparser.add_dcmd_option(&_filename);
 }

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -842,8 +842,15 @@ void CodeCacheDCmd::execute(DCmdSource source, TRAPS) {
 }
 
 #ifdef LINUX
+PerfMapDCmd::PerfMapDCmd(outputStream* output, bool heap) :
+             DCmdWithParser(output, heap),
+  _filename("-f", "Name of the file", "STRING", false)
+{
+  _dcmdparser.add_dcmd_option(&_filename);
+}
+
 void PerfMapDCmd::execute(DCmdSource source, TRAPS) {
-  CodeCache::write_perf_map();
+  CodeCache::write_perf_map(_filename.value());
 }
 #endif // LINUX
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -850,7 +850,12 @@ PerfMapDCmd::PerfMapDCmd(outputStream* output, bool heap) :
 }
 
 void PerfMapDCmd::execute(DCmdSource source, TRAPS) {
-  CodeCache::write_perf_map(_filename.value());
+  if (_filename.value() != nullptr) {
+    CodeCache::write_perf_map(_filename.value());
+  } else {
+    CodeCache::DefaultPerfMapFile file;
+    CodeCache::write_perf_map(file.name());
+  }
 }
 #endif // LINUX
 

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -577,9 +577,12 @@ public:
 };
 
 #ifdef LINUX
-class PerfMapDCmd : public DCmd {
+class PerfMapDCmd : public DCmdWithParser {
+protected:
+  DCmdArgument<char*> _filename;
 public:
-  PerfMapDCmd(outputStream* output, bool heap) : DCmd(output, heap) {}
+  static int num_arguments() { return 1; }
+  PerfMapDCmd(outputStream* output, bool heap);
   static const char* name() {
     return "Compiler.perfmap";
   }

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -178,21 +178,11 @@ Prints all compiled methods in code cache that are alive.
 Impact: Medium
 .RE
 .TP
-\f[V]Compiler.perfmap\f[R] [\f[I]options\f[R]] (Linux only)
+\f[V]Compiler.perfmap\f[R] (Linux only)
 Write map file for Linux perf tool.
 .RS
 .PP
 Impact: Low
-.PP
-\f[B]Note:\f[R]
-.PP
-The \f[I]options\f[R] must be specified using either \f[I]key\f[R] or
-\f[I]key\f[R]\f[V]=\f[R]\f[I]value\f[R] syntax.
-.PP
-\f[I]options\f[R]:
-.IP \[bu] 2
-\f[V]filename\f[R]: (Optional) Name of the map file (STRING, no default
-value)
 .RE
 .TP
 \f[V]Compiler.queue\f[R]

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -178,11 +178,21 @@ Prints all compiled methods in code cache that are alive.
 Impact: Medium
 .RE
 .TP
-\f[V]Compiler.perfmap\f[R] (Linux only)
+\f[V]Compiler.perfmap\f[R] [\f[I]arguments\f[R]] (Linux only)
 Write map file for Linux perf tool.
 .RS
 .PP
 Impact: Low
+.PP
+\f[I]arguments\f[R]:
+.IP \[bu] 2
+\f[V]filename\f[R]: (Optional) Name of the map file (STRING, no default
+value)
+.PP
+If \f[V]filename\f[R] is not specified, a default file name is chosen
+using the pid of the target JVM process.
+For example, if the pid is \f[V]12345\f[R], then the default
+\f[V]filename\f[R] will be \f[V]/tmp/perf-12345.map\f[R].
 .RE
 .TP
 \f[V]Compiler.queue\f[R]

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -178,11 +178,21 @@ Prints all compiled methods in code cache that are alive.
 Impact: Medium
 .RE
 .TP
-\f[V]Compiler.perfmap\f[R] (Linux only)
+\f[V]Compiler.perfmap\f[R] [\f[I]options\f[R]] (Linux only)
 Write map file for Linux perf tool.
 .RS
 .PP
 Impact: Low
+.PP
+\f[B]Note:\f[R]
+.PP
+The \f[I]options\f[R] must be specified using either \f[I]key\f[R] or
+\f[I]key\f[R]\f[V]=\f[R]\f[I]value\f[R] syntax.
+.PP
+\f[I]options\f[R]:
+.IP \[bu] 2
+\f[V]filename\f[R]: (Optional) Name of the map file (STRING, no default
+value)
 .RE
 .TP
 \f[V]Compiler.queue\f[R]

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -92,6 +92,6 @@ public class PerfMapTest {
         do {
             path = Paths.get(String.format("%s/%s.map", test_dir, UUID.randomUUID().toString()));
         } while(Files.exists(path));
-        run(new JMXExecutor(), "Compiler.perfmap filename=" + path.toString(), path);
+        run(new JMXExecutor(), "Compiler.perfmap " + path.toString(), path);
     }
 }

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -79,12 +79,16 @@ public class PerfMapTest {
     }
 
     @Test
-    public void jmx() {
+    public void defaultMapFile() {
         final long pid = ProcessHandle.current().pid();
-        Path path = Paths.get(String.format("/tmp/perf-%d.map", pid));
+        final Path path = Paths.get(String.format("/tmp/perf-%d.map", pid));
         run(new JMXExecutor(), "Compiler.perfmap", path);
+    }
 
+    @Test
+    public void specifiedMapFile() {
         String test_dir = System.getProperty("test.dir", ".");
+        Path path = null;
         do {
             path = Paths.get(String.format("%s/%s.map", test_dir, UUID.randomUUID().toString()));
         } while(Files.exists(path));


### PR DESCRIPTION
`jcmd Compiler.perfmap` uses the hard-coded file name for a perf map: `/tmp/perf-%d.map`. This change adds an optional argument for specifying a file name.

`jcmd PID help Compiler.perfmap` shows the following usage.

```
Compiler.perfmap
Write map file for Linux perf tool.

Impact: Low

Syntax : Compiler.perfmap  [<filename>]

Arguments:
        filename : [optional] Name of the map file (STRING, no default value)
```

The following section of man page is also updated. (`man -l src/jdk.jcmd/share/man/jcmd.1`)

```
       Compiler.perfmap [arguments] (Linux only)
              Write map file for Linux perf tool.

              Impact: Low

              arguments:

              · filename: (Optional) Name of the map file (STRING, no default value)

              If filename is not specified, a default file name is chosen using the pid of the target JVM process.  For example, if the pid is 12345,  then
              the default filename will be /tmp/perf-12345.map.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8314029](https://bugs.openjdk.org/browse/JDK-8314029): Add file name parameter to Compiler.perfmap (**Enhancement** - P5)
 * [JDK-8316922](https://bugs.openjdk.org/browse/JDK-8316922): Add file name parameter to Compiler.perfmap (**CSR**) (Withdrawn)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [dbe223c5](https://git.openjdk.org/jdk/pull/15871/files/dbe223c55cd698c9d24398481e003e4fb5b823d2)
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15871/head:pull/15871` \
`$ git checkout pull/15871`

Update a local copy of the PR: \
`$ git checkout pull/15871` \
`$ git pull https://git.openjdk.org/jdk.git pull/15871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15871`

View PR using the GUI difftool: \
`$ git pr show -t 15871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15871.diff">https://git.openjdk.org/jdk/pull/15871.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15871#issuecomment-1730296249)