### PR TITLE
8316698: build failure caused by JDK-8316456

### DIFF
--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -522,7 +522,7 @@ jint StackWalk::fetchNextBatch(Handle stackStream, jint mode, jlong magic,
 
   log_debug(stackwalk)("StackWalk::fetchNextBatch last_batch_count %d buffer_size %d existing_stream "
                        PTR_FORMAT " start %d", last_batch_count,
-                       buffer_size, p2i(existing_stream), start_index, frames_array->length());
+                       buffer_size, p2i(existing_stream), start_index);
   int end_index = start_index;
   if (buffer_size <= start_index) {
     return 0;        // No operation.


### PR DESCRIPTION
JDK-8316456 causes hotspot build to fail due to an extra argument passed to log_debug.   Trivial fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316698](https://bugs.openjdk.org/browse/JDK-8316698): build failure caused by JDK-8316456 (**Bug** - P1)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15876/head:pull/15876` \
`$ git checkout pull/15876`

Update a local copy of the PR: \
`$ git checkout pull/15876` \
`$ git pull https://git.openjdk.org/jdk.git pull/15876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15876`

View PR using the GUI difftool: \
`$ git pr show -t 15876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15876.diff">https://git.openjdk.org/jdk/pull/15876.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15876#issuecomment-1730494575)