### PR TITLE
8316658: serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java fails intermittently

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -133,7 +133,6 @@ serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
 serviceability/sa/ClhsdbDumpclass.java 8316342 generic-all
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
-serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java 8316658 generic-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -32,7 +32,7 @@
  * @modules java.instrument
  *          java.compiler
  * @run main RedefineClassHelper
- * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=12m  -XX:MaxMetaspaceSize=12m RedefineLeakThrowable
+ * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=24m  -XX:MaxMetaspaceSize=24m RedefineLeakThrowable
  */
 
 class Tester {
@@ -60,7 +60,7 @@ public class RedefineLeakThrowable {
 
 
     public static void main(String argv[]) throws Exception {
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < 1000; i++) {
             RedefineClassHelper.redefineClass(Tester.class, NEW_TESTER);
         }
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -32,7 +32,7 @@
  * @modules java.instrument
  *          java.compiler
  * @run main RedefineClassHelper
- * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=24m  -XX:MaxMetaspaceSize=24m RedefineLeakThrowable
+ * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=17m  -XX:MaxMetaspaceSize=17m RedefineLeakThrowable
  */
 
 class Tester {
@@ -60,7 +60,7 @@ public class RedefineLeakThrowable {
 
 
     public static void main(String argv[]) throws Exception {
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 700; i++) {
             RedefineClassHelper.redefineClass(Tester.class, NEW_TESTER);
         }
     }


### PR DESCRIPTION
increase Metaspace size and loop count to avoid OOME in nominal case

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8316658](https://bugs.openjdk.org/browse/JDK-8316658): serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java	fails intermittently (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [157ef53b](https://git.openjdk.org/jdk/pull/15882/files/157ef53b3d9ba19523ff035c523f5a855d6c7a2c)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15882/head:pull/15882` \
`$ git checkout pull/15882`

Update a local copy of the PR: \
`$ git checkout pull/15882` \
`$ git pull https://git.openjdk.org/jdk.git pull/15882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15882`

View PR using the GUI difftool: \
`$ git pr show -t 15882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15882.diff">https://git.openjdk.org/jdk/pull/15882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15882#issuecomment-1731336589)