### PR TITLE
8316735: Print LockStack in hs_err files

### DIFF
--- a/src/hotspot/share/runtime/lockStack.cpp
+++ b/src/hotspot/share/runtime/lockStack.cpp
@@ -77,3 +77,15 @@ void LockStack::verify(const char* msg) const {
   }
 }
 #endif
+
+void LockStack::print_on(outputStream* st) {
+  for (int i = to_index(_top); (--i) >= 0;) {
+    st->print("LockStack[%d]: ", i);
+    oop o = _base[i];
+    if (oopDesc::is_oop(o)) {
+      o->print_on(st);
+    } else {
+      st->print_cr("not an oop: " PTR_FORMAT, p2i(o));
+    }
+  }
+}

--- a/src/hotspot/share/runtime/lockStack.hpp
+++ b/src/hotspot/share/runtime/lockStack.hpp
@@ -30,8 +30,9 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/sizes.hpp"
 
-class Thread;
+class JavaThread;
 class OopClosure;
+class outputStream;
 
 class LockStack {
   friend class VMStructs;
@@ -91,6 +92,8 @@ public:
   // GC support
   inline void oops_do(OopClosure* cl);
 
+  // Printing
+  void print_on(outputStream* st);
 };
 
 #endif // SHARE_RUNTIME_LOCKSTACK_HPP

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1167,6 +1167,10 @@ void VMError::report(outputStream* st, bool _verbose) {
       st->cr();
     }
 
+  STEP_IF("printing fast locked objects", _verbose && _thread != nullptr && _thread->is_Java_thread() && LockingMode == LM_LIGHTWEIGHT);
+    st->print_cr("Objects fast locked by this thread (top to bottom):");
+    JavaThread::cast(_thread)->lock_stack().print_on(st);
+
   STEP_IF("printing process", _verbose)
     st->cr();
     st->print_cr("---------------  P R O C E S S  ---------------");

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1100,6 +1100,11 @@ void VMError::report(outputStream* st, bool _verbose) {
     print_stack_location(st, _context, continuation);
     st->cr();
 
+  STEP_IF("printing lock stack", _verbose && _thread != nullptr && _thread->is_Java_thread() && LockingMode == LM_LIGHTWEIGHT);
+    st->print_cr("Lock stack of current Java thread (top to bottom):");
+    JavaThread::cast(_thread)->lock_stack().print_on(st);
+    st->cr();
+
   STEP_IF("printing code blobs if possible", _verbose)
     const int printed_capacity = max_error_log_print_code;
     address printed[printed_capacity];
@@ -1166,10 +1171,6 @@ void VMError::report(outputStream* st, bool _verbose) {
       callback->call(st);
       st->cr();
     }
-
-  STEP_IF("printing fast locked objects", _verbose && _thread != nullptr && _thread->is_Java_thread() && LockingMode == LM_LIGHTWEIGHT);
-    st->print_cr("Objects fast locked by this thread (top to bottom):");
-    JavaThread::cast(_thread)->lock_stack().print_on(st);
 
   STEP_IF("printing process", _verbose)
     st->cr();


### PR DESCRIPTION
Example output:
```
Lock stack of current Java thread (top to bottom):
LockStack[1]: nsk.share.jdi.EventHandler 
{0x00000000bcc28198} - klass: 'nsk/share/jdi/EventHandler'
 - ---- fields (total size 5 words):
 - private volatile 'wasInterrupted' 'Z' @12  false (0x00)
 - private 'debuggee' 'Lnsk/share/jdi/Debugee;' @16  a 'nsk/share/jdi/LocalLaunchedDebugee'{0x00000000bcc08c18} (0xbcc08c18)
 - private 'log' 'Lnsk/share/Log;' @20  a 'nsk/share/Log'{0x00000000bcc08cb0} (0xbcc08cb0)
 - private 'vm' 'Lcom/sun/jdi/VirtualMachine;' @24  a 'com/sun/tools/jdi/VirtualMachineImpl'{0x00000000bccb3d60} (0xbccb3d60)
 - private 'requestManager' 'Lcom/sun/jdi/request/EventRequestManager;' @28  a 'com/sun/tools/jdi/EventRequestManagerImpl'{0x00000000bccb56f8} (0xbccb56f8)
 - private 'listenThread' 'Ljava/lang/Thread;' @32  a 'java/lang/Thread'{0x00000000bcc280e8} (0xbcc280e8)
LockStack[0]: java.util.Collections$SynchronizedRandomAccessList 
{0x00000000bcb163e8} - klass: 'java/util/Collections$SynchronizedRandomAccessList'
 - ---- fields (total size 3 words):
 - final 'c' 'Ljava/util/Collection;' @12  a 'java/util/Vector'{0x00000000bcb16400} (0xbcb16400)
 - final 'mutex' 'Ljava/lang/Object;' @16  a 'java/util/Collections$SynchronizedRandomAccessList'{0x00000000bcb163e8} (0xbcb163e8)
 - final 'list' 'Ljava/util/List;' @20  a 'java/util/Vector'{0x00000000bcb16400} (0xbcb16400)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316735](https://bugs.openjdk.org/browse/JDK-8316735): Print LockStack in hs_err files (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15884/head:pull/15884` \
`$ git checkout pull/15884`

Update a local copy of the PR: \
`$ git checkout pull/15884` \
`$ git pull https://git.openjdk.org/jdk.git pull/15884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15884`

View PR using the GUI difftool: \
`$ git pr show -t 15884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15884.diff">https://git.openjdk.org/jdk/pull/15884.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15884#issuecomment-1731142950)