### PR TITLE
8316361: C2: assert(!failure) failed: Missed optimization opportunity in PhaseIterGVN with -XX:VerifyIterativeGVN=10

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2282,6 +2282,8 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
     // can edit it's inputs directly.  Hammer in the new limit for the
     // minimum-trip guard.
     assert(opaq->outcnt() == 1, "");
+    // Notify limit -> opaq -> CmpI, it may constant fold.
+    _igvn.add_users_to_worklist(opaq->in(1));
     _igvn.replace_input_of(opaq, 1, new_limit);
   }
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestNotifyOpaqueZeroTripGuardToCmpI.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestNotifyOpaqueZeroTripGuardToCmpI.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8316361
+ * @summary Test that if input to OpaqueZeroTripGuard changes, we notify down to CmpI.
+ * @run main/othervm -Xcomp -XX:+IgnoreUnrecognizedVMOptions -XX:VerifyIterativeGVN=10
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.TestNotifyOpaqueZeroTripGuardToCmpI::test
+ *                   compiler.loopopts.TestNotifyOpaqueZeroTripGuardToCmpI
+ */
+package compiler.loopopts;
+
+public class TestNotifyOpaqueZeroTripGuardToCmpI {
+    static int x, y;
+
+    public static void main(String[] strArr) {
+        test();
+    }
+
+    static void test() {
+        for (int i = 6; i < 43; i++) {
+            for (int j = i; j < 11; j++) {
+                x = y;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This seems to be related to [JDK-8298176](https://bugs.openjdk.org/browse/JDK-8298176) / https://github.com/openjdk/jdk20/pull/65
This change allows `OpaqueZeroTripGuard -> CmpI` to fold in some cases. We have also added code to notify the `CmpI` during IGVN, so it can potentially change its type/constant fold:
https://github.com/openjdk/jdk/blob/a0a09d56ba4fc6133b423ad29d86fc99dd6dc19b/src/hotspot/share/opto/phaseX.cpp#L1681-L1687

However, when we hack the input to the `opaq` node, we must call `_igvn.add_users_to_worklist` to trigger this notification. I added this missing part.

Running Tier1-6 and stress testing... passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316361](https://bugs.openjdk.org/browse/JDK-8316361): C2: assert(!failure) failed: Missed optimization opportunity in PhaseIterGVN with -XX:VerifyIterativeGVN=10 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15886/head:pull/15886` \
`$ git checkout pull/15886`

Update a local copy of the PR: \
`$ git checkout pull/15886` \
`$ git pull https://git.openjdk.org/jdk.git pull/15886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15886`

View PR using the GUI difftool: \
`$ git pr show -t 15886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15886.diff">https://git.openjdk.org/jdk/pull/15886.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15886#issuecomment-1731394147)