### PR TITLE
Make immutable maps @ValueBased

### DIFF
--- a/src/java.base/share/classes/java/util/AbstractMap.java
+++ b/src/java.base/share/classes/java/util/AbstractMap.java
@@ -477,16 +477,20 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
      * @return {@code true} if the specified object is equal to this map
      */
     public boolean equals(Object o) {
-        if (o == this)
+        return equals(this, o);
+    }
+
+    static <K, V> boolean equals(Map<K, V> original, Object o) {
+        if (o == original)
             return true;
 
         if (!(o instanceof Map<?, ?> m))
             return false;
-        if (m.size() != size())
+        if (m.size() != original.size())
             return false;
 
         try {
-            for (Entry<K, V> e : entrySet()) {
+            for (Entry<K, V> e : original.entrySet()) {
                 K key = e.getKey();
                 V value = e.getValue();
                 if (value == null) {
@@ -542,7 +546,11 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
      * @return a string representation of this map
      */
     public String toString() {
-        Iterator<Entry<K,V>> i = entrySet().iterator();
+        return toString(this);
+    }
+
+    static <K, V> String toString(Map<K, V> map) {
+        Iterator<Entry<K,V>> i = map.entrySet().iterator();
         if (! i.hasNext())
             return "{}";
 
@@ -552,9 +560,9 @@ public abstract class AbstractMap<K,V> implements Map<K,V> {
             Entry<K,V> e = i.next();
             K key = e.getKey();
             V value = e.getValue();
-            sb.append(key   == this ? "(this Map)" : key);
+            sb.append(key   == map ? "(this Map)" : key);
             sb.append('=');
-            sb.append(value == this ? "(this Map)" : value);
+            sb.append(value == map ? "(this Map)" : value);
             if (! i.hasNext())
                 return sb.append('}').toString();
             sb.append(',').append(' ');

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -1287,7 +1287,7 @@ class ImmutableCollections {
             return size == 0;
         }
 
-        class MapNIterator implements Iterator<Map.Entry<K,V>> {
+        final class MapNIterator implements Iterator<Map.Entry<K,V>> {
 
             private int remaining;
 
@@ -1393,10 +1393,10 @@ class ImmutableCollections {
             return new AbstractSet<>() {
                 public Iterator<K> iterator() {
                     return new Iterator<>() {
-                        private final Iterator<Entry<K, V>> i = entrySet().iterator();
+                        private final Iterator<Entry<K, V>> i = new MapNIterator();
                         public boolean hasNext() { return i.hasNext(); }
                         public K next() { return i.next().getKey(); }
-                        public void remove() { i.remove(); }
+                        public void remove() { throw uoe(); }
                     };
                 }
                 public int size() { return MapN.this.size; }
@@ -1411,10 +1411,10 @@ class ImmutableCollections {
             return new AbstractCollection<>() {
                 public Iterator<V> iterator() {
                     return new Iterator<>() {
-                        private final Iterator<Entry<K,V>> i = entrySet().iterator();
+                        private final Iterator<Entry<K,V>> i = new MapNIterator();
                         public boolean hasNext() { return i.hasNext(); }
                         public V next() { return i.next().getValue(); }
-                        public void remove() { i.remove(); }
+                        public void remove() { throw uoe(); }
                     };
                 }
                 public int size() { return MapN.this.size;}

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -1106,7 +1106,7 @@ class ImmutableCollections {
 
         @Override
         public boolean equals(Object o) {
-            return AbstractMap.equals(this, 0);
+            return AbstractMap.equals(this, o);
         }
 
         @Override

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -1099,6 +1099,20 @@ class ImmutableCollections {
                     ? v
                     : defaultValue;
         }
+
+        protected Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return AbstractMap.equals(this, 0);
+        }
+
+        @Override
+        public String toString() {
+            return AbstractMap.toString(this);
+        }
     }
 
     @jdk.internal.ValueBased
@@ -1386,7 +1400,7 @@ class ImmutableCollections {
                     };
                 }
                 public int size() { return MapN.this.size; }
-                public boolean isEmpty() { return false; }
+                public boolean isEmpty() { return size() == 0; }
                 public void clear() { throw uoe(); }
                 public boolean contains(Object k) { return MapN.this.containsKey(k); }
             };


### PR DESCRIPTION
This PR outlines a solution for making the implementations of the immutable maps obtained via the `Map` factories `@ValueBased`. This is achieved by no longer extending `AbstractMap`.

A small compatibility issue with this is that now, not every JDK `Map` implementation can be cast to `AbstractMap`. On the other hand, the documentation for the `Map` factories states the maps are `@ValueBased` and `AbstractMap` is specified to cache certain values. From this, it follows that maps from the `Map` factories can only produce maps that _do not extend `AbstractMap`_ map and consequently, the cast is a programming error on the user part.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15887/head:pull/15887` \
`$ git checkout pull/15887`

Update a local copy of the PR: \
`$ git checkout pull/15887` \
`$ git pull https://git.openjdk.org/jdk.git pull/15887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15887`

View PR using the GUI difftool: \
`$ git pr show -t 15887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15887.diff">https://git.openjdk.org/jdk/pull/15887.diff</a>

</details>
