### PR TITLE
8316648: jrt-fs.jar classes not reproducible between standard and bootcycle builds

### DIFF
--- a/make/JrtfsJar.gmk
+++ b/make/JrtfsJar.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,10 @@ JIMAGE_PKGS := \
     jdk/internal/jrtfs \
     #
 
+# Compile jrt-fs.jar with the interim compiler, as it
+# ends up in the image, this will ensure reproducible classes
 $(eval $(call SetupJavaCompilation, BUILD_JRTFS, \
-    COMPILER := bootjdk, \
+    COMPILER := interim, \
     DISABLED_WARNINGS := options, \
     TARGET_RELEASE := $(TARGET_RELEASE_JDK8), \
     SRC := $(TOPDIR)/src/java.base/share/classes, \


### PR DESCRIPTION
jrt-fs.jar classes are currently compiled with the BootJDK being used, this has a couple of issues:
- The classes are not reproducible between a standard and bootcycle build image, since the first is compiled by jdk-N-1 and the later jdk-N
- The jrt-fs classes in a standard product image are compiled by the BootJDK (typically jdk-N-1), which means from a "secure dev" perspective they are not compiled with the latest and greatest compiler with all the latest vulnerability fixes. 

The jrt-fs classes are required to be built targeting jdk-8 compatible, there is no reason they cannot be compiled with the jdk-N "interim" compiler as part of the standard build.
This then makes the jrt-fs classes reproducible regardless of which bootjdk is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316648](https://bugs.openjdk.org/browse/JDK-8316648): jrt-fs.jar classes not reproducible between standard and bootcycle builds (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15888/head:pull/15888` \
`$ git checkout pull/15888`

Update a local copy of the PR: \
`$ git checkout pull/15888` \
`$ git pull https://git.openjdk.org/jdk.git pull/15888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15888`

View PR using the GUI difftool: \
`$ git pr show -t 15888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15888.diff">https://git.openjdk.org/jdk/pull/15888.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15888#issuecomment-1731353905)