### PR TITLE
8316743: RISC-V: Change UseVectorizedMismatchIntrinsic option result to warning

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
@@ -801,7 +801,7 @@ void LIRGenerator::do_FmaIntrinsic(Intrinsic* x) {
 }
 
 void LIRGenerator::do_vectorizedMismatch(Intrinsic* x) {
-  fatal("vectorizedMismatch intrinsic is not implemented on this platform");
+  ShouldNotReachHere();
 }
 
 // _i2l, _i2f, _i2d, _l2i, _l2f, _l2d, _f2i, _f2l, _f2d, _d2i, _d2l, _d2f

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -171,6 +171,11 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseCRC32CIntrinsics, false);
   }
 
+  if (UseVectorizedMismatchIntrinsic) {
+    warning("VectorizedMismatch intrinsic is not available on this CPU.");
+    FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
+  }
+
   if (FLAG_IS_DEFAULT(UseMD5Intrinsics)) {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, true);
   }


### PR DESCRIPTION
Please review this small change for UseVectorizedMismatchIntrinsic option.
On RISC-V we do not have VectorizedMismatch intrinsic, so `void LIRGenerator::do_vectorizedMismatch(Intrinsic* x)` prodeuces fatal error when this option turned on.
Other similar options (like -XX:+UseCRC32Intrinsics) produces only warning: https://github.com/openjdk/jdk/blob/c90d63105ca774c047d5f5a4348aa657efc57953/src/hotspot/cpu/riscv/vm_version_riscv.cpp#L150-L183
Also, on platforms, where VectorizedMismatch unimplemented to we got warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316743](https://bugs.openjdk.org/browse/JDK-8316743): RISC-V: Change UseVectorizedMismatchIntrinsic option result to warning (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * @M4ximumPizza (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15890/head:pull/15890` \
`$ git checkout pull/15890`

Update a local copy of the PR: \
`$ git checkout pull/15890` \
`$ git pull https://git.openjdk.org/jdk.git pull/15890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15890`

View PR using the GUI difftool: \
`$ git pr show -t 15890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15890.diff">https://git.openjdk.org/jdk/pull/15890.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15890#issuecomment-1731516264)