### PR TITLE
8316711: SEGV in LoaderConstraintTable::find_loader_constraint after JDK-8310874

### DIFF
--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -448,6 +448,7 @@ InstanceKlass* LoaderConstraintTable::find_constrained_klass(Symbol* name,
 void LoaderConstraintTable::remove_failed_loaded_klass(InstanceKlass* klass,
                                                        ClassLoaderData* loader) {
 
+  MutexLocker ml(SystemDictionary_lock);
   Symbol* name = klass->name();
   LoaderConstraint *p = find_loader_constraint(name, loader);
   if (p != nullptr && p->klass() != nullptr && p->klass() == klass) {

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1524,12 +1524,10 @@ InstanceKlass* SystemDictionary::find_or_define_instance_class(Symbol* class_nam
     assert(defined_k != nullptr, "Should have a klass if there's no exception");
     k->class_loader_data()->add_to_deallocate_list(k);
   } else if (HAS_PENDING_EXCEPTION) {
+    // Remove this InstanceKlass from the LoaderConstraintTable if added.
+    LoaderConstraintTable::remove_failed_loaded_klass(k, class_loader_data(class_loader));
     assert(defined_k == nullptr, "Should not have a klass if there's an exception");
     k->class_loader_data()->add_to_deallocate_list(k);
-
-    // Also remove this InstanceKlass from the LoaderConstraintTable if added.
-    MutexLocker ml(SystemDictionary_lock);
-    LoaderConstraintTable::remove_failed_loaded_klass(k, class_loader_data(class_loader));
   }
   return defined_k;
 }


### PR DESCRIPTION
The new loader constraint code was putting the InstanceKlass on the deallocate list, then safepointing, then trying to find it in the LoaderConstraintTable.  In the crash, the InstanceKlass was deallocated before searching for it in the table.  The fix is to use the proper order.
Tested multiple runs with closed failing tests, and tier1-4 (1 test left)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316711](https://bugs.openjdk.org/browse/JDK-8316711): SEGV in LoaderConstraintTable::find_loader_constraint after JDK-8310874 (**Bug** - P3)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15891/head:pull/15891` \
`$ git checkout pull/15891`

Update a local copy of the PR: \
`$ git checkout pull/15891` \
`$ git pull https://git.openjdk.org/jdk.git pull/15891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15891`

View PR using the GUI difftool: \
`$ git pr show -t 15891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15891.diff">https://git.openjdk.org/jdk/pull/15891.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15891#issuecomment-1731746403)