### PR TITLE
8311823: JFR: Uninitialized EventEmitter::_thread_id field

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.hpp
@@ -44,7 +44,6 @@ class EventEmitter : public CHeapObj<mtTracing> {
   const JfrTicks& _end_time;
   Thread* _thread;
   JfrThreadLocal* _jfr_thread_local;
-  traceid _thread_id;
 
   EventEmitter(const JfrTicks& start_time, const JfrTicks& end_time);
   ~EventEmitter();


### PR DESCRIPTION
[JDK-8311823](https://bugs.openjdk.org/browse/JDK-8311823)

Remove Uninitialized EventEmitter::_thread_id field from src/hotspot/share/jfr/leakprofiler/checkpoint/eventEmitter.hpp

GHA tests pass

Additional testing:
make test TEST=jdk/jfr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311823](https://bugs.openjdk.org/browse/JDK-8311823): JFR: Uninitialized EventEmitter::_thread_id field (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15893/head:pull/15893` \
`$ git checkout pull/15893`

Update a local copy of the PR: \
`$ git checkout pull/15893` \
`$ git pull https://git.openjdk.org/jdk.git pull/15893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15893`

View PR using the GUI difftool: \
`$ git pr show -t 15893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15893.diff">https://git.openjdk.org/jdk/pull/15893.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15893#issuecomment-1732027729)