### PR TITLE
8189088: Add intrusive doubly-linked list utility

### DIFF
--- a/src/hotspot/share/utilities/intrusiveList.cpp
+++ b/src/hotspot/share/utilities/intrusiveList.cpp
@@ -54,20 +54,20 @@ IntrusiveListImpl::~IntrusiveListImpl() {
 
 #ifdef ASSERT
 
-const IntrusiveListImpl* IntrusiveListImpl::entry_list(const Entry* entry) {
+const IntrusiveListImpl* IntrusiveListImpl::entry_list(const Entry& entry) {
   // Ensure consistency.
-  if (entry->_list == nullptr) {
-    assert(entry->_next == nullptr, "invariant");
-    assert(entry->_prev == nullptr, "invariant");
+  if (entry._list == nullptr) {
+    assert(entry._next == nullptr, "invariant");
+    assert(entry._prev == nullptr, "invariant");
   } else {
-    assert(entry->_next != nullptr, "invariant");
-    assert(entry->_prev != nullptr, "invariant");
+    assert(entry._next != nullptr, "invariant");
+    assert(entry._prev != nullptr, "invariant");
   }
-  return entry->_list;
+  return entry._list;
 }
 
-void IntrusiveListImpl::set_entry_list(const Entry* entry, IntrusiveListImpl* list) {
-  entry->_list = list;
+void IntrusiveListImpl::set_entry_list(const Entry& entry, IntrusiveListImpl* list) {
+  entry._list = list;
 }
 
 #endif // ASSERT

--- a/src/hotspot/share/utilities/intrusiveList.cpp
+++ b/src/hotspot/share/utilities/intrusiveList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,47 +27,41 @@
 #include "utilities/intrusiveList.hpp"
 #include "utilities/macros.hpp"
 
-IntrusiveListEntry::IntrusiveListEntry() :
-  _prev(NULL),
-  _next(NULL)
 #ifdef ASSERT
-  , _list(NULL)
-#endif
-{ }
-
 IntrusiveListEntry::~IntrusiveListEntry() {
-  assert(_list == NULL, "deleting list entry while in list");
-  assert(_prev == NULL, "invariant");
-  assert(_next == NULL, "invariant");
+  assert(_list == nullptr, "deleting list entry while in list");
+  assert(_prev == nullptr, "invariant");
+  assert(_next == nullptr, "invariant");
 }
+#endif // ASSERT
 
-IntrusiveListImpl::IntrusiveListImpl() : _root() {
-  _root._prev = tag_entry(&_root);
-  _root._next = tag_entry(&_root);
+IntrusiveListImpl::IntrusiveListImpl() {
+  _root._prev = add_tag_to_root_entry(&_root);
+  _root._next = add_tag_to_root_entry(&_root);
   DEBUG_ONLY(_root._list = this;)
 }
 
-IntrusiveListImpl::~IntrusiveListImpl() {
-  assert(is_tagged_entry(_root._prev), "deleting non-empty list");
-  assert(is_tagged_entry(_root._next), "deleting non-empty list");
 #ifdef ASSERT
+IntrusiveListImpl::~IntrusiveListImpl() {
+  assert(is_tagged_root_entry(_root._prev), "deleting non-empty list");
+  assert(is_tagged_root_entry(_root._next), "deleting non-empty list");
   // Clear _root's information before running its asserting destructor.
-  _root._prev = NULL;
-  _root._next = NULL;
-  _root._list = NULL;
-#endif
+  _root._prev = nullptr;
+  _root._next = nullptr;
+  _root._list = nullptr;
 }
+#endif // ASSERT
 
 #ifdef ASSERT
 
 const IntrusiveListImpl* IntrusiveListImpl::entry_list(const Entry* entry) {
   // Ensure consistency.
-  if (entry->_list == NULL) {
-    assert(entry->_next == NULL, "invariant");
-    assert(entry->_prev == NULL, "invariant");
+  if (entry->_list == nullptr) {
+    assert(entry->_next == nullptr, "invariant");
+    assert(entry->_prev == nullptr, "invariant");
   } else {
-    assert(entry->_next != NULL, "invariant");
-    assert(entry->_prev != NULL, "invariant");
+    assert(entry->_next != nullptr, "invariant");
+    assert(entry->_prev != nullptr, "invariant");
   }
   return entry->_list;
 }

--- a/src/hotspot/share/utilities/intrusiveList.cpp
+++ b/src/hotspot/share/utilities/intrusiveList.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/intrusiveList.hpp"
+#include "utilities/macros.hpp"
+
+IntrusiveListEntry::IntrusiveListEntry() :
+  _prev(NULL),
+  _next(NULL)
+#ifdef ASSERT
+  , _list(NULL)
+#endif
+{ }
+
+IntrusiveListEntry::~IntrusiveListEntry() {
+  assert(_list == NULL, "deleting list entry while in list");
+  assert(_prev == NULL, "invariant");
+  assert(_next == NULL, "invariant");
+}
+
+IntrusiveListImpl::IntrusiveListImpl() : _root() {
+  _root._prev = tag_entry(&_root);
+  _root._next = tag_entry(&_root);
+  DEBUG_ONLY(_root._list = this;)
+}
+
+IntrusiveListImpl::~IntrusiveListImpl() {
+  assert(is_tagged_entry(_root._prev), "deleting non-empty list");
+  assert(is_tagged_entry(_root._next), "deleting non-empty list");
+#ifdef ASSERT
+  // Clear _root's information before running its asserting destructor.
+  _root._prev = NULL;
+  _root._next = NULL;
+  _root._list = NULL;
+#endif
+}
+
+#ifdef ASSERT
+
+const IntrusiveListImpl* IntrusiveListImpl::entry_list(const Entry* entry) {
+  // Ensure consistency.
+  if (entry->_list == NULL) {
+    assert(entry->_next == NULL, "invariant");
+    assert(entry->_prev == NULL, "invariant");
+  } else {
+    assert(entry->_next != NULL, "invariant");
+    assert(entry->_prev != NULL, "invariant");
+  }
+  return entry->_list;
+}
+
+void IntrusiveListImpl::set_entry_list(const Entry* entry, IntrusiveListImpl* list) {
+  entry->_list = list;
+}
+
+#endif // ASSERT

--- a/src/hotspot/share/utilities/intrusiveList.hpp
+++ b/src/hotspot/share/utilities/intrusiveList.hpp
@@ -62,18 +62,18 @@ class IntrusiveListImpl;
  * in the list, the actual type of such objects may be more specific
  * than the list's element type.
  *
- * \tparam T is the class of the elements in the list.  Must be a possibly
+ * * T is the class of the elements in the list.  Must be a possibly
  * const-qualified class type.
  *
- * \tparam entry_member is a pointer to class member referring to the
+ * * entry_member is a pointer to class member referring to the
  * IntrusiveListEntry subobject of T used by this list.
  *
- * \tparam has_size determines whether the list has a size()
+ * * has_size determines whether the list has a size()
  * operation, returning the number of elements in the list.  If the
  * operation is present, it has constant-time complexity.  The default
  * is to not provide a constant-time size() operation.
  *
- * \tparam Base is the base class for the list.  This is typically
+ * * Base is the base class for the list.  This is typically
  * used to specify the allocation class.  The default is void, indicating
  * no allocation class for the list.
  *
@@ -86,11 +86,11 @@ class IntrusiveListImpl;
  * added to a list whose value type is not const-qualified, as that would be
  * an implicit casting away of the const qualifier.
  *
- * Some operations that remove elements from a list take a
- * <code>disposer</code> argument.  This is a function or function object that
- * will be called with one argument, a const reference to a removed element.
- * This function should "dispose" of the argument object when called, such as
- * by deleting the object.  The result of the call is ignored.
+ * Some operations that remove elements from a list take a disposer argument.
+ * This is a function or function object that will be called with one
+ * argument, a const reference to a removed element.  This function should
+ * "dispose" of the argument object when called, such as by deleting the
+ * object.  The result of the call is ignored.
  *
  * Usage of IntrusiveList involves defining an element class which
  * contains a IntrusiveListEntry member, and using a corresponding
@@ -119,7 +119,7 @@ class IntrusiveListImpl;
  *   ...
  * public:
  *   ...
- *   using MyList = IntrusiveList<MyClass, &_entry>;
+ *   using MyList = IntrusiveList<MyClass, &MyClass::_entry>;
  *   ...
  * };
  *

--- a/src/hotspot/share/utilities/intrusiveList.hpp
+++ b/src/hotspot/share/utilities/intrusiveList.hpp
@@ -980,34 +980,6 @@ public:
   const_reference back() const { return *rbegin(); }
 
   /**
-   * Returns a [const_]reference to the n'th element of the list.
-   *
-   * precondition: n < length()
-   * complexity: O(length())
-   */
-  reference operator[](size_type n) {
-    return nth_element(begin(), end(), n);
-  }
-
-  const_reference operator[](size_type n) const {
-    return nth_element(cbegin(), cend(), n);
-  }
-
-private:
-
-  // Implementation of operator[].
-  template<typename Iterator>
-  static typename Iterator::reference
-  nth_element(Iterator it, Iterator end, size_type n) {
-    for (size_type index = 0; true; ++it, ++index) {
-      assert(it != end, "index out of bounds: %ju", uintmax_t(n));
-      if (index == n) return *it;
-    }
-  }
-
-public:
-
-  /**
    * Returns a [const_]iterator referring to the first element of the
    * list, or end-of-list if the list is empty.
    *

--- a/src/hotspot/share/utilities/intrusiveList.hpp
+++ b/src/hotspot/share/utilities/intrusiveList.hpp
@@ -105,7 +105,6 @@ using IntrusiveListEntryAccessor =
  * contains a IntrusiveListEntry member, and using a corresponding
  * specialization of the IntrusiveList class, e.g.
  *
- * <code>
  * class MyClass {
  *   ...
  *   IntrusiveListEntry _entry;
@@ -121,12 +120,10 @@ using IntrusiveListEntryAccessor =
  *   ...
  *   IntrusiveList<MyClass, &MyClass::get_entry> mylist;
  *   ... use mylist ...
- * </code>
  *
  * Alternatively, the scope of the entry accessor can be limited, with a
  * type alias of a list specialization providing access, e.g.
  *
- * <code>
  * class MyClass {
  *   ...
  *   IntrusiveListEntry _entry;
@@ -143,7 +140,6 @@ using IntrusiveListEntryAccessor =
  *   ...
  *   MyClass::MyList mylist;
  *   ... use mylist ...
- * </code>
  */
 template<typename T,
          IntrusiveListEntryAccessor<T> entry_accessor,

--- a/src/hotspot/share/utilities/intrusiveList.hpp
+++ b/src/hotspot/share/utilities/intrusiveList.hpp
@@ -158,6 +158,13 @@ public:
 
   NONCOPYABLE(IntrusiveListEntry);
 
+  /** Test whether this entry is attached to some list. */
+  bool is_attached() const {
+    bool result = (_prev != nullptr);
+    assert(result == (_next != nullptr), "inconsistent entry");
+    return result;
+  }
+
 private:
   // _prev and _next are the links between elements / root entries in
   // an associated list.  The values of these members are type-erased

--- a/src/hotspot/share/utilities/intrusiveList.hpp
+++ b/src/hotspot/share/utilities/intrusiveList.hpp
@@ -1,0 +1,1346 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_VM_UTILITIES_INTRUSIVELIST_HPP
+#define SHARE_VM_UTILITIES_INTRUSIVELIST_HPP
+
+#include "memory/allocation.hpp"
+#include "metaprogramming/conditional.hpp"
+#include "metaprogramming/enableIf.hpp"
+#include "metaprogramming/integralConstant.hpp"
+#include "metaprogramming/isSame.hpp"
+#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/macros.hpp"
+
+class IntrusiveListEntry;
+class IntrusiveListImpl;
+
+/**
+ * The IntrusiveList class template provides a doubly-linked list in
+ * which the links between elements are embedded directly into objects
+ * contained in the list.  As a result, there are no copies involved
+ * when inserting objects into the list or referencing list objects,
+ * and removing an object from a list need not involve destroying the
+ * object.
+ *
+ * To be used in a IntrusiveList, an object must have a
+ * IntrusiveListEntry member.  An IntrusiveList is associated with the
+ * class of its elements and the entry member.
+ *
+ * An object can be in multiple lists at the same time, so long as
+ * each list uses a different entry member.  That is, the class of the
+ * object must have multiple IntrusiveListEntry members, one for each
+ * list the object is simultaneously an element.
+ *
+ * The API for IntrusiveList is modelled on the containers provided by
+ * the C++ standard library.  In particular, iteration over the
+ * elements is provided via iterator classes.
+ *
+ * IntrusiveLists support polymorphic elements.  Because the objects
+ * in a list are externally managed, rather than being embedded values
+ * in the list, the actual type of such objects may be more specific
+ * than the list's element type.
+ *
+ * \tparam T is the class of the elements in the list.
+ *
+ * \tparam entry_member is a pointer to class member referring to the
+ * IntrusiveListEntry subobject of T used by this list.
+ *
+ * \tparam has_size determines whether the list has a size()
+ * operation, returning the number of elements in the list.  If the
+ * operation is present, it has constant-time complexity.  The default
+ * is to not provide a constant-time size() operation.
+ *
+ * \tparam Base is the base class for the list.  This is typically
+ * used to specify the allocation class, and defaults to _ValueObj.
+ *
+ * Usage of IntrusiveList involves defining an element class which
+ * contains a IntrusiveListEntry member, and using a corresponding
+ * specialization of the IntrusiveList class, e.g.
+ *
+ * <code>
+ * class MyClass {
+ * public:
+ *   ...
+ *   IntrusiveListEntry _entry;
+ *   ...
+ * };
+ *
+ *   ...
+ *   IntrusiveList<MyClass, &MyClass::_entry> mylist;
+ *   ... use mylist ...
+ * </code>
+ *
+ * Alternatively, the scope of the entry member can be limited, with a
+ * typedef of a list specialization providing access, e.g.
+ *
+ * <code>
+ * class MyClass {
+ *   ...
+ *   IntrusiveListEntry _entry;
+ *   ...
+ * public:
+ *   ...
+ *   typedef IntrusiveList<MyClass, &_entry> MyList;
+ *   ...
+ * };
+ *
+ *   ...
+ *   MyClass::MyList mylist;
+ *   ... use mylist ...
+ * </code>
+ */
+template<typename T,
+         IntrusiveListEntry T::*entry_member,
+         bool has_size = false,
+         typename Base = _ValueObj>
+class IntrusiveList;
+
+/**
+ * A class with an IntrusiveListEntry member can be used as an element
+ * of a corresponding specialization of IntrusiveList.
+ */
+class IntrusiveListEntry VALUE_OBJ_CLASS_SPEC {
+  friend class IntrusiveListImpl;
+
+public:
+  IntrusiveListEntry();
+  ~IntrusiveListEntry();
+
+private:
+  // _prev and _next are the links between elements / entries in an
+  // associated list.  The values of these members are type-erased
+  // void*.  The IntrusiveListImpl::IteratorOperations class is used
+  // to encode, decode, and manipulate the type-erased values.
+  //
+  // Members are mutable and we deal exclusively with pointers to
+  // const to make const_references and const_iterators easier to use;
+  // an object being const doesn't prevent modifying its list state.
+  mutable const void* _prev;
+  mutable const void* _next;
+  // The list containing this entry, if any.
+  // Debug-only, for use in validity checks.
+  DEBUG_ONLY(mutable IntrusiveListImpl* _list;)
+
+  // Noncopyable.
+  IntrusiveListEntry(const IntrusiveListEntry&);
+  IntrusiveListEntry& operator=(const IntrusiveListEntry&);
+};
+
+class IntrusiveListImpl VALUE_OBJ_CLASS_SPEC {
+  typedef IntrusiveListEntry Entry;
+
+  // Nothing for clients to see here, everything is private.  Only
+  // the IntrusiveList class template has access, via friendship.
+  template<typename T, Entry T::*, bool, typename> friend class IntrusiveList;
+
+  typedef size_t size_type;
+  typedef ptrdiff_t difference_type;
+
+  Entry _root;
+
+  IntrusiveListImpl();
+  ~IntrusiveListImpl();
+
+  // Noncopyable
+  IntrusiveListImpl(const IntrusiveListImpl&);
+  IntrusiveListImpl& operator=(const IntrusiveListImpl&);
+
+  // Tag manipulation for encoded void*; see IteratorOperations.
+  static const uintptr_t tag_alignment = 2;
+
+  static bool is_tagged_entry(const void* ptr) {
+    return !is_aligned(ptr, tag_alignment);
+  }
+
+  static const void* tag_entry(const Entry* entry) {
+    const void* untagged = entry;
+    assert(is_aligned(untagged, tag_alignment), "must be");
+    return static_cast<const char*>(untagged) + 1;
+  }
+
+  static const Entry* untag_entry(const void* ptr) {
+    assert(is_tagged_entry(ptr), "precondition");
+    const void* untagged = static_cast<const char*>(ptr) - 1;
+    assert(is_aligned(untagged, tag_alignment), "must be");
+    return static_cast<const Entry*>(untagged);
+  }
+
+  const Entry* root_entry() const { return &_root; }
+
+  static void detach(const Entry* entry) {
+    // TODO: Consider making the clearing of next & prev DEBUG_ONLY.
+    // Any operation that will care is a precondition violation, which
+    // we only check in debug builds.
+    entry->_prev = NULL;
+    entry->_next = NULL;
+    DEBUG_ONLY(entry->_list = NULL;)
+  }
+
+  // Support for optional constant-time size() operation.
+  // Can't be private: C++03 11.4/2; fixed in C++11.
+public:
+  template<bool has_size, typename Base> class SizeBase;
+private:
+
+  // Conversion from T* to Entry*, along with relevant typedefs.  A
+  // corresponding specialization is used directly by IntrusiveList,
+  // and by the list's iterators.
+  template<typename T, Entry T::*entry_member>
+  struct ListTraits : public AllStatic {
+    typedef IntrusiveListImpl::size_type size_type;
+    typedef IntrusiveListImpl::difference_type difference_type;
+    typedef T value_type;
+    typedef value_type* pointer;
+    typedef const value_type* const_pointer;
+    typedef value_type& reference;
+    typedef const value_type& const_reference;
+
+    static const Entry* get_entry(const_reference value) {
+      return &(value.*entry_member);
+    }
+  };
+
+  // Stand-in for std::distance.
+  template<typename Iterator>
+  static difference_type distance(Iterator from, Iterator to) {
+    difference_type result = 0;
+    for ( ; from != to; ++result, ++from) {}
+    return result;
+  }
+
+  // Iterator support.  IntrusiveList defines its iterator types as
+  // specializations of this class.
+  template<typename T,
+           Entry T::*entry_member,
+           bool is_forward,
+           bool is_const>
+  class IteratorImpl;
+
+  // Iterator support.  Provides (static) functions for manipulating
+  // iterators.  These are used to implement iterators and list
+  // operations related to iterators, but are not part of the public
+  // API for iterators.
+  template<typename Iterator> class IteratorOperations;
+
+  // Metafunction for determining the mutable variant of Iterator.
+  template<typename Iterator> struct MutableIterator;
+
+  // Metafunction for determining whether L is an IntrusiveList type
+  // compatible with T and entry_member.
+  template<typename T, Entry T::*entry_member, typename L>
+  struct IsCompatibleList;
+
+  // Used as the ConvertibleFrom for IteratorImpl instantiations that
+  // don't support implicit conversions.
+  class Inaccessible {};
+
+#ifdef ASSERT
+  // Get entry's containing list; NULL if entry not in a list.
+  static const IntrusiveListImpl* entry_list(const Entry* entry);
+  // Set entry's containing list; list may be NULL.
+  static void set_entry_list(const Entry* entry, IntrusiveListImpl* list);
+#endif // ASSERT
+};
+
+// Base class for IntrusiveList, with specializations either providing
+// or not providing constant-time size.  Base is the next base class
+// in the superclass list.
+
+template<bool has_size, typename Base>
+class IntrusiveListImpl::SizeBase : public Base {
+protected:
+  SizeBase() {}
+  ~SizeBase() {}
+
+  size_type* size_ptr() { return NULL; }
+  void adjust_size(difference_type n) {}
+};
+
+template<typename Base>
+class IntrusiveListImpl::SizeBase<true, Base> : public Base {
+public:
+  size_type size() const { return _size; }
+
+protected:
+  SizeBase() : _size(0) {}
+  ~SizeBase() {}
+
+  size_type* size_ptr() { return &_size; }
+  void adjust_size(difference_type n) { _size += n; }
+
+private:
+  size_type _size;
+};
+
+template<typename T,
+         IntrusiveListEntry T::*entry_member,
+         bool is_forward,
+         bool is_const>
+struct IntrusiveListImpl::MutableIterator<
+  IntrusiveListImpl::IteratorImpl<T, entry_member, is_forward, is_const> >
+  : public AllStatic
+{
+  typedef IteratorImpl<T, entry_member, is_forward, false> type;
+};
+
+template<typename T, IntrusiveListEntry T::*entry_member, typename L>
+struct IntrusiveListImpl::IsCompatibleList : public FalseType {};
+
+template<typename T,
+         IntrusiveListEntry T::*entry_member,
+         bool has_size,
+         typename Base>
+struct IntrusiveListImpl::IsCompatibleList<
+  T, entry_member, IntrusiveList<T, entry_member, has_size, Base> >
+  : public TrueType
+{};
+
+// The IteratorOperations class provides operations for encoding,
+// decoding, and manipulating type-erased void* values representing
+// objects in a list.  The encoded void* provides a discriminated
+// union of the following:
+//
+// - T*: a pointer to a list element.
+// - IntrusiveListEntry*: a pointer to a list's root entry.
+// - NULL: a pointer to no object.
+//
+// IntrusiveListEntry uses such encoded values to refer to the next or
+// previous object in a list, e.g. to represent the links between
+// objects.
+//
+// IteratorImpl uses such encoded values to refer to the object that
+// represents the iterator.  A singular iterator is represented by an
+// encoded NULL.  A dereferenceable iterator is represented by an
+// encoded pointer to a list element.  An encoded list root entry is
+// used to represent either an end-of-list or before-the-beginning
+// iterator, depending on context.
+//
+// The encoding of these values uses a tagged void pointer scheme.
+// NULL represents itself.  A list element (T*) is distinguished from
+// a IntrusiveListEntry* via the low address bit.  If the low bit is
+// set, the value is a IntrusiveListEntry*; specifically, it is one
+// byte past the pointer to the entry.  Otherwise, it is a list
+// element.  [This requires all value types and IntrusiveListEntry to
+// have an alignment of at least 2.]
+//
+// IteratorOperations also provides a suite of operations for
+// manipulating iterators and list elements, making use of that
+// encoding.  This allows the implementation of iterators and lists to
+// be written in terms of these higher level operations, without
+// needing to deal with the underlying encoding directly.
+template<typename Iterator>
+class IntrusiveListImpl::IteratorOperations : AllStatic {
+  typedef IntrusiveListImpl Impl;
+  typedef typename Iterator::ListTraits ListTraits;
+  typedef typename ListTraits::const_reference const_reference;
+
+  static const bool is_forward = Iterator::is_forward;
+
+  static const void* make_raw_value(const_reference value) {
+    return &value;
+  }
+
+  static const void* make_raw_value(const Entry* entry) {
+    return tag_entry(entry);
+  }
+
+  static const Entry* resolve_to_entry(Iterator i) {
+    assert_not_singular(i);
+    return is_entry(i) ? untag_entry(raw_value(i)) : ListTraits::get_entry(dereference(i));
+  }
+
+  static Iterator next(Iterator i) {
+    return Iterator(resolve_to_entry(i)->_next);
+  }
+
+  static Iterator prev(Iterator i) {
+    return Iterator(resolve_to_entry(i)->_prev);
+  }
+
+  static Iterator next(const_reference value) {
+    return Iterator(ListTraits::get_entry(value)->_next);
+  }
+
+  static Iterator prev(const_reference value) {
+    return Iterator(ListTraits::get_entry(value)->_prev);
+  }
+
+  static void attach_impl(const_reference prev, Iterator next) {
+    ListTraits::get_entry(prev)->_next = raw_value(next);
+    resolve_to_entry(next)->_prev = make_raw_value(prev);
+  }
+
+  static void attach_impl(Iterator prev, const_reference next) {
+    resolve_to_entry(prev)->_next = make_raw_value(next);
+    ListTraits::get_entry(next)->_prev = raw_value(prev);
+  }
+
+  static void iter_attach_impl(Iterator prev, Iterator next) {
+    resolve_to_entry(prev)->_next = raw_value(next);
+    resolve_to_entry(next)->_prev = raw_value(prev);
+  }
+
+public:
+  static const void* raw_value(Iterator i) { return i._raw_value; }
+
+  static bool is_singular(Iterator i) { return raw_value(i) == NULL; }
+  static bool is_entry(Iterator i) { return is_tagged_entry(raw_value(i)); }
+
+  static const_reference dereference(Iterator i) {
+    assert_not_singular(i);
+    assert(!is_entry(i), "dereference end-of-list iterator");
+    return *static_cast<typename ListTraits::const_pointer>(raw_value(i));
+  }
+
+  // Get the predecessor / successor (according to the iterator's
+  // direction) of the argument.  Reference arguments are preferred;
+  // the iterator form should only be used when the iterator is not
+  // already known to be dereferenceable.  (The iterator form of
+  // successor is not provided; for an iterator to have a successor,
+  // the iterator must be dereferenceable.)
+
+  static Iterator successor(const_reference value) {
+    return is_forward ? next(value) : prev(value);
+  }
+
+  static Iterator predecessor(const_reference value) {
+    return is_forward ? prev(value) : next(value);
+  }
+
+  static Iterator iter_predecessor(Iterator i) {
+    return is_forward ? prev(i) : next(i);
+  }
+
+  // Attach pred to succ such that, after the operation,
+  // predecessor(succ) == pred.  A reference argument is required when
+  // it is not already in the list, since iterator_to is invalid in
+  // that situation.  Reference arguments are preferred; an iterator
+  // argument should only be used when it is not already known to be
+  // dereferenceable.  That is, the first argument should only be an
+  // iterator if it might be a before-the-beginning (pseudo)iterator.
+  // Similarly, the second argument should only be an iterator if it
+  // might be an end-of-list iterator.  (The two-reference case is not
+  // provided because that form is never needed.)
+
+  // Mixed reference / iterator attachment.
+  // C++11: PredType&& and SuccType&& ?
+  template<typename PredType, typename SuccType>
+  static void attach(const PredType& pred, const SuccType& succ) {
+    is_forward ? attach_impl(pred, succ) : attach_impl(succ, pred);
+  }
+
+  // Iterator to iterator attachment.
+  static void iter_attach(Iterator pred, Iterator succ) {
+    is_forward ? iter_attach_impl(pred, succ) : iter_attach_impl(succ, pred);
+  }
+
+  template<typename Iterator2>
+  static Iterator make_iterator(Iterator2 i) {
+    return Iterator(IteratorOperations<Iterator2>::raw_value(i));
+  }
+
+  static Iterator make_iterator_to(const_reference value) {
+    return Iterator(make_raw_value(value));
+  }
+
+  static Iterator make_begin_iterator(const Impl& impl) {
+    const Entry* entry = impl.root_entry();
+    return Iterator(is_forward ? entry->_next : entry->_prev);
+  }
+
+  static Iterator make_end_iterator(const Impl& impl) {
+    return Iterator(make_raw_value(impl.root_entry()));
+  }
+
+  // Support for iterator copy conversion and copy assignment from
+  // ConvertibleFrom.  The Inaccessible overload is only declared; it
+  // can never be called.  If ConvertibleFrom is *not* Inaccessible,
+  // then the template overload is the best (and only) match.
+
+  static const void* raw_value_for_conversion(const Inaccessible&);
+
+  template<typename Iterator2>
+  static const void* raw_value_for_conversion(Iterator2 i) {
+    return IteratorOperations<Iterator2>::raw_value(i);
+  }
+
+  static void assert_not_singular(Iterator i) {
+    assert(!is_singular(i), "singular iterator");
+  }
+
+  static void assert_is_in_some_list(Iterator i) {
+    assert_not_singular(i);
+    assert(list_ptr(i) != NULL,
+           "Invalid iterator " PTR_FORMAT, p2i(raw_value(i)));
+  }
+
+#ifdef ASSERT
+
+  static const Impl* list_ptr(Iterator i) {
+    return entry_list(resolve_to_entry(i));
+  }
+
+#endif // ASSERT
+};
+
+/**
+ * Bi-directional constant (e.g. not output) iterator for iterating
+ * over the elements of an IntrusiveList.  The IntrusiveList class
+ * uses specializations of this class as its iterator types.
+ */
+template<typename T,
+         IntrusiveListEntry T::*entry_member,
+         bool is_forward_,
+         bool is_const_>
+class IntrusiveListImpl::IteratorImpl VALUE_OBJ_CLASS_SPEC {
+  friend class IntrusiveListImpl;
+
+  static const bool is_forward = is_forward_;
+  static const bool is_const = is_const_;
+
+  typedef IntrusiveListImpl Impl;
+  typedef Impl::ListTraits<T, entry_member> ListTraits;
+  typedef Impl::IteratorOperations<IteratorImpl> IOps;
+
+  // A const iterator type supports implicit conversion from the
+  // corresponding non-const iterator type.  For non-const iterators,
+  // use Inaccessible as the ConvertibleFrom type, to simplify
+  // overload definitions.
+  typedef typename Conditional<is_const,
+                               IteratorImpl<T, entry_member, is_forward, false>,
+                               Impl::Inaccessible>::type ConvertibleFrom;
+
+public:
+  /** Type of an iterator's value. */
+  typedef typename ListTraits::value_type value_type;
+
+  /** Type of a reference to an iterator's value. */
+  typedef typename Conditional<is_const,
+                               typename ListTraits::const_reference,
+                               typename ListTraits::reference>::type reference;
+
+  /** Type of a pointer to an iterator's value. */
+  typedef typename Conditional<is_const,
+                               typename ListTraits::const_pointer,
+                               typename ListTraits::pointer>::type pointer;
+
+  /** Type for distance between iterators. */
+  typedef typename ListTraits::difference_type difference_type;
+
+  // TODO: We don't have access to <iterator>, so we can't provide the
+  // iterator_category type.  Maybe someday...
+  // typedef std::bidirectional_iterator_tag iterator_category;
+
+  /** Construct a singular iterator. */
+  IteratorImpl() : _raw_value(NULL) {}
+
+  // Default destructor, copy constructor, copy assign.
+
+  // Implicit conversion from ConvertibleFrom.
+  // If ConvertibleFrom is Inaccessible, this can't actually be called.
+  IteratorImpl(const ConvertibleFrom& other) :
+    _raw_value(IOps::raw_value_for_conversion(other))
+  {}
+
+  /**
+   * Return a reference to the iterator's value.
+   *
+   * precondition: this is dereferenceable.
+   * complexity: constant.
+   */
+  reference operator*() const {
+    return const_cast<reference>(IOps::dereference(*this));
+  }
+
+  /**
+   * Return a pointer to the iterator's value.
+   *
+   * precondition: this is dereferenceable.
+   * complexity: constant.
+   */
+  pointer operator->() const {
+    return &this->operator*();
+  }
+
+  /**
+   * Change this iterator to refer to the successor element (per the
+   * iterator's direction) in the list, or to the end of the list.
+   * Return a reference to this iterator.
+   *
+   * precondition: this is dereferenceable.
+   * postcondition: this is dereferenceable or end-of-list.
+   * complexity: constant.
+   */
+  IteratorImpl& operator++() {
+    IOps::assert_is_in_some_list(*this);
+    *this = IOps::successor(this->operator*());
+    return *this;
+  }
+
+  /**
+   * Make a copy of this iterator, then change this iterator to refer
+   * to the successor element (per the iterator's direction) in the
+   * list, or to the end of the list.  Return the copy.
+   *
+   * precondition: this is dereferenceable.
+   * postcondition: this is dereferenceable or end-of-list.
+   * complexity: constant.
+   */
+  IteratorImpl operator++(int) {
+    IteratorImpl result = *this;
+    this->operator++();
+    return result;
+  }
+
+  /**
+   * Change this iterator to refer to the preceeding element (per the
+   * iterator's direction) in the list.  Return a reference to this
+   * iterator.
+   *
+   * precondition: There exists an iterator i such that ++i equals this.
+   * postcondition: this is dereferenceable.
+   * complexity: constant.
+   */
+  IteratorImpl& operator--() {
+    IOps::assert_is_in_some_list(*this);
+    *this = IOps::iter_predecessor(*this);
+    // Must not have been (r)begin iterator.
+    assert(!IOps::is_entry(*this), "iterator decrement underflow");
+    return *this;
+  }
+
+  /**
+   * Make a copy of this iterator, then change this iterator to refer
+   * to the preceeding element (per the iterator's direction) in the
+   * list.  Return the copy.
+   *
+   * precondition: There exists an iterator i such that ++i equals this.
+   * postcondition: this is dereferenceable.
+   * complexity: constant.
+   */
+  IteratorImpl operator--(int) {
+    IteratorImpl result = *this;
+    this->operator--();
+    return result;
+  }
+
+  /**
+   * Return true if this and other refer to the same element of a list,
+   * or both refer to end-of-list.
+   *
+   * precondition: this and other are both dereferenceable or end-of-list.
+   * precondition: this and other must be iterators for the same list.
+   * complexity: constant.
+   */
+  bool operator==(const IteratorImpl& other) const {
+    IOps::assert_is_in_some_list(*this);
+    IOps::assert_is_in_some_list(other);
+    assert(IOps::list_ptr(*this) == IOps::list_ptr(other),
+           "comparing iterators from different lists");
+    return IOps::raw_value(*this) == IOps::raw_value(other);
+  }
+
+  /**
+   * Return true if this and other are not ==.
+   *
+   * precondition: this and other are both dereferenceable or end-of-list.
+   * precondition: this and other must be iterators for the same list.
+   * complexity: constant.
+   */
+  bool operator!=(const IteratorImpl& other) const {
+    return !(*this == other);
+  }
+
+  // Comparisons with Inaccessible, to simplify the definitions below
+  // for ConvertibleFrom OP IteratorImpl.  Only declared, since can't
+  // be called.
+  bool operator==(const Impl::Inaccessible&) const;
+  bool operator!=(const Impl::Inaccessible&) const;
+
+  // Add ConvertibleFrom OP IteratorImpl overloads, because these are
+  // not handled by the corresponding member function plus implicit
+  // conversions.  For example, const_iterator == iterator is handled
+  // by const_iterator::operator==(const_iterator) plus implicit
+  // conversion of iterator to const_iterator.  But we need an
+  // additional overload to handle iterator == const_iterator.
+
+  friend bool operator==(const ConvertibleFrom& lhs, const IteratorImpl& rhs) {
+    return rhs == lhs;
+  }
+
+  friend bool operator!=(const ConvertibleFrom& lhs, const IteratorImpl& rhs) {
+    return rhs != lhs;
+  }
+
+private:
+  // An iterator refers to either an object in the list, the root
+  // entry of the list, or NULL if singular.  See IteratorOperations
+  // for details of the encoding.
+  const void* _raw_value;
+
+  // Allow explicit construction from an encoded const void* raw
+  // value.  But require exactly that type, disallowing any implicit
+  // conversions.  Without that restriction, certain kinds of usage
+  // errors become both more likely and harder to diagnose the
+  // resulting compilation errors.  [The remaining diagnostic
+  // difficulties could be eliminated by making RawValue a non-public
+  // class for carrying the encoded void* to iterator construction.]
+  template<typename RawValue>
+  explicit IteratorImpl(RawValue raw_value,
+                        typename EnableIf<IsSame<RawValue, const void*>::value>::type* = NULL)
+    : _raw_value(raw_value)
+  {}
+};
+
+template<typename T,
+         IntrusiveListEntry T::*entry_member,
+         bool has_size_,
+         typename Base>
+class IntrusiveList : public IntrusiveListImpl::SizeBase<has_size_, Base> {
+  // Give access to other instantiations, for splice().
+  template<typename U, IntrusiveListEntry U::*, bool, typename>
+  friend class IntrusiveList;
+
+  typedef IntrusiveListEntry Entry;
+  typedef IntrusiveListImpl Impl;
+  typedef Impl::ListTraits<T, entry_member> ListTraits;
+  typedef Impl::SizeBase<has_size_, Base> Super;
+
+public:
+  /** Flag indicating presence of a constant-time size() operation. */
+  static const bool has_size = has_size_;
+
+  /** Type of the size of the list. */
+  typedef typename ListTraits::size_type size_type;
+
+  /** The difference type for iterators. */
+  typedef typename ListTraits::difference_type difference_type;
+
+  /** Type of list elements. */
+  typedef typename ListTraits::value_type value_type;
+
+  /** Type of a pointer to a list element. */
+  typedef typename ListTraits::pointer pointer;
+
+  /** Type of a const pointer to a list element. */
+  typedef typename ListTraits::const_pointer const_pointer;
+
+  /** Type of a reference to a list element. */
+  typedef typename ListTraits::reference reference;
+
+  /** Type of a const reference to a list element. */
+  typedef typename ListTraits::const_reference const_reference;
+
+  /** Forward iterator type allowing modification of elements. */
+  typedef Impl::IteratorImpl<T,                 // element type
+                             entry_member,      // pointer to entry member of T
+                             true,              // is_forward
+                             false>             // is_const
+  iterator;
+
+  /** Forward iterator type disallowing modification of elements. */
+  typedef Impl::IteratorImpl<T,                 // element type
+                             entry_member,      // pointer to entry member of T
+                             true,              // is_forward
+                             true>              // is_const
+  const_iterator;
+
+  /** Reverse iterator type allowing modification of elements. */
+  typedef Impl::IteratorImpl<T,                 // element type
+                             entry_member,      // pointer to entry member of T
+                             false,             // is_forward
+                             false>             // is_const
+  reverse_iterator;
+
+  /** Reverse iterator type disallowing modification of elements. */
+  typedef Impl::IteratorImpl<T,                 // element type
+                             entry_member,      // pointer to entry member of T
+                             false,             // is_forward
+                             true>              // is_const
+  const_reverse_iterator;
+
+  /**
+   * Inserts value at the front of the list.  Does not affect the
+   * validity of iterators or element references for this list.
+   *
+   * precondition: value must not already be in a list using the same entry.
+   * complexity: constant.
+   */
+  void push_front(const_reference value) {
+    insert(begin(), value);
+  }
+
+  /**
+   * Inserts value at the back of the list.  Does not affect the
+   * validity of iterators or element references for this list.
+   *
+   * precondition: value must not already be in a list using the same entry.
+   * complexity: constant.
+   */
+  void push_back(const_reference value) {
+    insert(end(), value);
+  }
+
+  /**
+   * Removes the front element from the list, and applies the
+   * disposer, if any, to the removed element.  The list may not be in
+   * a consistent state when the disposer is called.  Invalidates
+   * iterators for the removed element.
+   *
+   * precondition: !empty()
+   * complexity: constant.
+   */
+  void pop_front() {
+    pop_front_and_dispose(NopDisposer());
+  }
+
+  template<typename Disposer>
+  void pop_front_and_dispose(Disposer disposer) {
+    erase_and_dispose(begin(), disposer);
+  }
+
+  /**
+   * Removes the back element from the list, and applies the disposer,
+   * if any, to the removed element.  The list may not be in a
+   * consistent state when the disposer is called.  Invalidates
+   * iterators for the removed element.
+   *
+   * precondition: !empty()
+   * complexity: constant.
+   */
+  void pop_back() {
+    pop_back_and_dispose(NopDisposer());
+  }
+
+  template<typename Disposer>
+  void pop_back_and_dispose(Disposer disposer) {
+    erase_and_dispose(rbegin(), disposer);
+  }
+
+  /**
+   * Returns a [const_]reference to the front element of the list.
+   *
+   * precondition: !empty()
+   * complexity: constant.
+   */
+  reference front() { return *begin(); }
+  const_reference front() const { return *begin(); }
+
+  /**
+   * Returns a [const_]reference to the back element of the list.
+   *
+   * precondition: !empty()
+   * complexity: constant.
+   */
+  reference back() { return *rbegin(); }
+  const_reference back() const { return *rbegin(); }
+
+  /**
+   * Returns a [const_]iterator referring to the first element of the
+   * list, or end-of-list if the list is empty.
+   *
+   * complexity: constant.
+   */
+  iterator begin() {
+    return Impl::IteratorOperations<iterator>::make_begin_iterator(_impl);
+  }
+
+  const_iterator begin() const {
+    return cbegin();
+  }
+
+  const_iterator cbegin() const {
+    return Impl::IteratorOperations<const_iterator>::make_begin_iterator(_impl);
+  }
+
+  /**
+   * Returns a [const_]iterator referring to the end-of-list.
+   *
+   * complexity: constant.
+   */
+  iterator end() {
+    return Impl::IteratorOperations<iterator>::make_end_iterator(_impl);
+  }
+
+  const_iterator end() const {
+    return cend();
+  }
+
+  const_iterator cend() const {
+    return Impl::IteratorOperations<const_iterator>::make_end_iterator(_impl);
+  }
+
+  /**
+   * Returns a [const_]reverse_iterator referring to the last element
+   * of the list, or end-of-reversed-list if the list is empty.
+   *
+   * complexity: constant.
+   */
+  reverse_iterator rbegin() {
+    return Impl::IteratorOperations<reverse_iterator>::make_begin_iterator(_impl);
+  }
+
+  const_reverse_iterator rbegin() const {
+    return crbegin();
+  }
+
+  const_reverse_iterator crbegin() const {
+    return Impl::IteratorOperations<const_reverse_iterator>::make_begin_iterator(_impl);
+  }
+
+  /**
+   * Returns a [const_]reverse_iterator referring to the
+   * end-of-reversed-list.
+   *
+   * complexity: constant.
+   */
+  reverse_iterator rend() {
+    return Impl::IteratorOperations<reverse_iterator>::make_end_iterator(_impl);
+  }
+
+  const_reverse_iterator rend() const {
+    return crend();
+  }
+
+  const_reverse_iterator crend() const {
+    return Impl::IteratorOperations<const_reverse_iterator>::make_end_iterator(_impl);
+  }
+
+  /**
+   * Returns true if list contains no elements.
+   *
+   * complexity: constant.
+   */
+  bool empty() const {
+    return cbegin() == cend();
+  }
+
+  /**
+   * Returns the number of elements in the list.
+   *
+   * complexity: O(length())
+   */
+  size_type length() const {
+    return Impl::distance(cbegin(), cend());
+  }
+
+  /**
+   * Removes the element referred to by i from the list, then applies
+   * the disposer, if any, to the removed element.  The list may not
+   * be in a consistent state when the disposer is called.  Returns an
+   * iterator for the successor of i.  Invalidates iterators referring
+   * to the removed element.
+   *
+   * precondition: i must be a valid iterator for the list.
+   * precondition: i is not end-of-list.
+   * complexity: constant.
+   */
+  iterator erase(const_iterator i) {
+    return erase_and_dispose(i, NopDisposer());
+  }
+
+  reverse_iterator erase(const_reverse_iterator i) {
+    return erase_and_dispose(i, NopDisposer());
+  }
+
+  template<typename Disposer>
+  iterator erase_and_dispose(const_iterator i, Disposer disposer) {
+    return erase_one_and_dispose(i, disposer);
+  }
+
+  template<typename Disposer>
+  reverse_iterator erase_and_dispose(const_reverse_iterator i, Disposer disposer) {
+    return erase_one_and_dispose(i, disposer);
+  }
+
+private:
+
+  // C++11: typename Result = MutableIterator...
+  template<typename Iterator, typename Disposer>
+  typename Impl::MutableIterator<Iterator>::type
+  erase_one_and_dispose(Iterator i, Disposer disposer) {
+    typedef Impl::IteratorOperations<Iterator> IOps;
+    assert_is_iterator(i);
+    const_reference value = *i++;
+    IOps::iter_attach(IOps::predecessor(value), i);
+    detach(value);
+    disposer(value);
+    return make_iterator<typename Impl::MutableIterator<Iterator>::type>(i);
+  }
+
+public:
+
+  /**
+   * Removes the elements in the range designated by from and to.
+   * Applies the disposer, if any, to each removed element.  The list
+   * may not be in a consistent state when the disposer is called.
+   * Returns an iterator referring to the end of the removed range.
+   * Invalidates iterators referring to the removed elements.
+   *
+   * precondition: from and to must be valid iterators for the list.
+   * precondition: from does not follow to in the list.
+   * complexity: O(number of elements removed)
+   */
+  iterator erase(const_iterator from, const_iterator to) {
+    return erase_and_dispose(from, to, NopDisposer());
+  }
+
+  reverse_iterator erase(const_reverse_iterator from, const_reverse_iterator to) {
+    return erase_and_dispose(from, to, NopDisposer());
+  }
+
+  template<typename Disposer>
+  iterator erase_and_dispose(const_iterator from, const_iterator to, Disposer disposer) {
+    return erase_range_and_dispose(from, to, disposer);
+  }
+
+  template<typename Disposer>
+  reverse_iterator erase_and_dispose(const_reverse_iterator from,
+                                     const_reverse_iterator to,
+                                     Disposer disposer) {
+    return erase_range_and_dispose(from, to, disposer);
+  }
+
+private:
+
+  // C++11: typename Result = MutableIterator...
+  template<typename Iterator, typename Disposer>
+  typename Impl::MutableIterator<Iterator>::type
+  erase_range_and_dispose(Iterator from, Iterator to, Disposer disposer) {
+    typedef Impl::IteratorOperations<Iterator> IOps;
+    assert_is_iterator(from);
+    assert_is_iterator(to);
+    if (from != to) {
+      IOps::iter_attach(IOps::predecessor(*from), to);
+      do {
+        const_reference value = *from++;
+        detach(value);
+        disposer(value);
+      } while (from != to);
+    }
+    return make_iterator<typename Impl::MutableIterator<Iterator>::type>(to);
+  }
+
+public:
+
+  /**
+   * Removes all of the elements from the list.  Applies the disposer,
+   * if any, to each element as it is removed.  The list may not be in
+   * a consistent state when the disposer is called.  Invalidates all
+   * non-end-of-list iterators for this list.
+   *
+   * postcondition: empty()
+   * complexity: O(length())
+   */
+  void clear() {
+    erase(begin(), end());
+  }
+
+  template<typename Disposer>
+  void clear_and_dispose(Disposer disposer) {
+    erase_and_dispose(begin(), end(), disposer);
+  }
+
+  /**
+   * Inserts value into the list before pos.  Returns an iterator
+   * referring to the newly inserted value.  Does not invalidate any
+   * iterators.
+   *
+   * precondition: pos must be a valid iterator for the list.
+   * precondition: value must not already be in a list using the same entry.
+   * postcondition: ++result == pos
+   * complexity: constant.
+   */
+  iterator insert(const_iterator pos, const_reference value) {
+    return insert_impl(pos, value);
+  }
+
+  reverse_iterator insert(const_reverse_iterator pos, const_reference value) {
+    return insert_impl(pos, value);
+  }
+
+private:
+
+  // C++11: typename Result = MutableIterator...
+  template<typename Iterator>
+  typename Impl::MutableIterator<Iterator>::type
+  insert_impl(Iterator pos, const_reference value) {
+    assert(Impl::entry_list(ListTraits::get_entry(value)) == NULL, "precondition");
+    assert_is_iterator(pos);
+    typedef Impl::IteratorOperations<Iterator> IOps;
+    IOps::attach(IOps::iter_predecessor(pos), value);
+    IOps::attach(value, pos);
+    DEBUG_ONLY(set_list(value, &_impl);)
+    adjust_size(1);
+    return make_iterator_to<typename Impl::MutableIterator<Iterator>::type>(value);
+  }
+
+public:
+
+  /**
+   * Transfers the elements of from_list in the range designated by
+   * from and to to this list, inserted before pos.  Returns an
+   * iterator referring to the head of the spliced in range.  Does
+   * not invalidate any iterators.
+   *
+   * precondition: pos must be a valid iterator for this list.
+   * precondition: from and to must be valid iterators for from_list.
+   * precondition: from does not follow to.
+   * precondition: pos is not in the range to transfer, i.e. if
+   * this == from_list then either from follows pos or to does not
+   * follow pos.
+   *
+   * postcondition: iterators referring to elements in the transferred range
+   * are valid iterators for this list rather than from_list.
+   *
+   * complexity: constant if either (a) this == &from_list, (b) neither
+   * this nor from_list has a constant-time size() operation, or (c)
+   * from_list has a constant-time size() operation and is being
+   * transferred in its entirety; otherwise O(number of elements
+   * transferred).
+   */
+  template<typename FromList>
+  typename EnableIf<Impl::IsCompatibleList<T, entry_member, FromList>::value,
+                    iterator>::type
+  splice(const_iterator pos,
+         FromList& from_list,
+         const_iterator from,
+         const_iterator to) {
+    // preparation for supporting reverse iterators too.
+    typedef const_iterator Iterator;
+    typedef typename Impl::MutableIterator<Iterator>::type Result;
+    typedef Impl::IteratorOperations<Iterator> IOps;
+
+    assert_is_iterator(pos);
+    from_list.assert_is_iterator(from);
+    from_list.assert_is_iterator(to);
+
+    if (from == to) {
+      // Done if empty range.
+      return make_iterator<Result>(pos);
+    } else if (is_same_list(from_list) && (pos == to)) {
+      // Done if already in desired position.
+      return make_iterator_to<Result>(*from);
+    }
+
+    // Adjust sizes if needed.  Only need adjustment if different
+    // lists and at least one of the lists has a constant-time size.
+    if ((has_size || from_list.has_size) && !is_same_list(from_list)) {
+      difference_type transferring;
+      if (from_list.has_size &&
+          (from == from_list.cbegin()) &&
+          (to == from_list.cend())) {
+        // If from_list has constant-time size() and we're transferring
+        // all of it, we can use that size value to avoid counting the
+        // number of elements being transferred.
+        transferring = *from_list.size_ptr();
+      } else {
+        // Count the number of elements being transferred.
+        transferring = Impl::distance(from, to);
+      }
+      from_list.adjust_size(-transferring);
+      adjust_size(transferring);
+    }
+
+#ifdef ASSERT
+    // Transfer elements to this list, and verify pos not in [from, to).
+    if (is_same_list(from_list)) {
+      for (Iterator i = from; i != to; ++i) {
+        assert(i != pos, "splice range includes destination");
+      }
+    } else {
+      for (Iterator i = from; i != to; ++i) {
+        set_list(*i, &_impl);
+      }
+    }
+#endif // ASSERT
+
+    Iterator to_pred = --Iterator(to); // Fetch before clobbered
+    IOps::iter_attach(IOps::predecessor(*from), to);
+    IOps::attach(IOps::iter_predecessor(pos), *from);
+    // to is end of non-empty range, so to's predecessor is dereferenceable.
+    IOps::attach(*to_pred, pos);
+    return make_iterator_to<Result>(*from);
+  }
+
+  /**
+   * Transfers all elements of from_list to this list, inserted before
+   * pos.  Returns an iterator referring to the head of the spliced in
+   * range.  Does not invalidate any iterators.
+   *
+   * precondition: pos must be a valid iterator for this list.
+   * precondition: this != &from_list.
+   *
+   * postcondition: iterators referring to elements that were in
+   * from_list are valid iterators for this list rather than
+   * from_list.
+   *
+   * Complexity: constant if either (a) this does not have a
+   * constant-time size() operation, or (b) from_list has a
+   * constant-time size() operation; otherwise O(number of elements
+   * transferred).
+   */
+  template<typename FromList>
+  iterator splice(const_iterator pos, FromList& from_list) {
+    assert(!is_same_list(from_list), "precondition");
+    return splice(pos, from_list, from_list.cbegin(), from_list.cend());
+  }
+
+  /**
+   * Transfers the element of from_list referred to by from to this
+   * list, inserted before pos.  Returns an iterator referring to the
+   * inserted element.  Does not invalidate any iterators.
+   *
+   * precondition: pos must be a valid iterator for this list.
+   * precondition: from must be a dereferenceable iterator of from_list.
+   * precondition: pos is not in the range to transfer, i.e. if
+   * this == &from_list then pos != from.
+   *
+   * postcondition: iterators referring to the transferred element are
+   * valid iterators for this list rather than from_list.
+   *
+   * complexity: constant.
+   */
+  template<typename FromList>
+  typename EnableIf<Impl::IsCompatibleList<T, entry_member, FromList>::value,
+                    iterator>::type
+  splice(const_iterator pos, FromList& from_list, const_iterator from) {
+    // preparation for supporting reverse iterators too.
+    typedef const_iterator Iterator;
+    typedef typename Impl::MutableIterator<Iterator>::type Result;
+    typedef Impl::IteratorOperations<Iterator> IOps;
+
+    assert_is_iterator(pos);
+    from_list.assert_is_iterator(from);
+
+    from_list.adjust_size(-1);
+    adjust_size(1);
+
+#ifdef ASSERT
+    // Transfer element to this list, or verify pos not in [from, to).
+    if (is_same_list(from_list)) {
+      assert(from != pos, "Splice range includes destination");
+    } else {
+      set_list(*from, &_impl);
+    }
+#endif // ASSERT
+
+    IOps::iter_attach(IOps::predecessor(*from), IOps::successor(*from));
+    IOps::attach(IOps::iter_predecessor(pos), *from);
+    IOps::attach(*from, pos);
+    return make_iterator_to<Result>(*from);
+  }
+
+  /**
+   * Returns a [const_][reverse_]iterator referring to value.
+   *
+   * precondition: value must be an element of the list.
+   * complexity: constant.
+   */
+  iterator iterator_to(reference value) {
+    return make_iterator_to<iterator>(value);
+  }
+
+  const_iterator iterator_to(const_reference value) const {
+    return const_iterator_to(value);
+  }
+
+  const_iterator const_iterator_to(const_reference value) const {
+    return make_iterator_to<const_iterator>(value);
+  }
+
+  reverse_iterator reverse_iterator_to(reference value) {
+    return make_iterator_to<reverse_iterator>(value);
+  }
+
+  const_reverse_iterator reverse_iterator_to(const_reference value) const {
+    return const_reverse_iterator_to(value);
+  }
+
+  const_reverse_iterator const_reverse_iterator_to(const_reference value) const {
+    return make_iterator_to<const_reverse_iterator>(value);
+  }
+
+private:
+  Impl _impl;
+
+  size_type* size_ptr() {
+    return Super::size_ptr();
+  }
+
+  void adjust_size(difference_type value) {
+    Super::adjust_size(value);
+  }
+
+  template<typename OtherList>
+  bool is_same_list(const OtherList& other) const {
+    return &_impl == &other._impl;
+  }
+
+  template<typename Iterator>
+  void assert_is_iterator(const Iterator& i) const {
+    typedef Impl::IteratorOperations<Iterator> IOps;
+    assert(IOps::list_ptr(i) == &_impl,
+           "Iterator " PTR_FORMAT " not for this list " PTR_FORMAT,
+           p2i(IOps::raw_value(i)), p2i(this));
+  }
+
+  void assert_is_element(const_reference value) const {
+    assert(Impl::entry_list(ListTraits::get_entry(value)) == &_impl,
+           "Value " PTR_FORMAT " not in this list " PTR_FORMAT,
+           p2i(&value), p2i(this));
+  }
+
+#ifdef ASSERT
+  void set_list(const_reference value, Impl* list) {
+    Impl::set_entry_list(ListTraits::get_entry(value), list);
+  }
+#endif
+
+  template<typename Result, typename From>
+  Result make_iterator(From i) const {
+    assert_is_iterator(i);
+    return Impl::IteratorOperations<Result>::make_iterator(i);
+  }
+
+  template<typename Iterator>
+  Iterator make_iterator_to(const_reference value) const {
+    assert_is_element(value);
+    return Impl::IteratorOperations<Iterator>::make_iterator_to(value);
+  }
+
+  struct NopDisposer VALUE_OBJ_CLASS_SPEC {
+    void operator()(const_reference) const {}
+  };
+
+  void detach(const_reference value) {
+    assert_is_element(value);
+    Impl::detach(ListTraits::get_entry(value));
+    adjust_size(-1);
+  }
+};
+
+#endif // include guard

--- a/test/hotspot/gtest/utilities/test_intrusiveList.cpp
+++ b/test/hotspot/gtest/utilities/test_intrusiveList.cpp
@@ -1519,12 +1519,12 @@ class IntrusiveListTestWithSize : public IntrusiveListTestWithValues {
 public:
   typedef IntrusiveList<Value, &Value::entry1, true> ListWithSize;
 
-  virtual void SetUp() {
+  void SetUp() override {
     super::SetUp();
     fill_list();
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     list.clear();
     EXPECT_EQ(0u, list.size());
     EXPECT_EQ(list.length(), list.size());

--- a/test/hotspot/gtest/utilities/test_intrusiveList.cpp
+++ b/test/hotspot/gtest/utilities/test_intrusiveList.cpp
@@ -52,8 +52,10 @@ struct TestIntrusiveListValue : public CHeapObj<mtInternal> {
   using Value = TestIntrusiveListValue; // convenience
 
   size_t value() const { return _value; }
-  bool is_attached1() const { return _entry1.is_attached(); }
-  bool is_attached2() const { return _entry2.is_attached(); }
+  static const Entry& entry1(const Value& v) { return v._entry1; }
+  static const Entry& entry2(const Value& v) { return v._entry2; }
+  bool is_attached1() const { return entry1(*this).is_attached(); }
+  bool is_attached2() const { return entry2(*this).is_attached(); }
   Value* This() { return this; }
   const Value* This() const { return this; }
 };
@@ -61,12 +63,12 @@ struct TestIntrusiveListValue : public CHeapObj<mtInternal> {
 // Convenience type aliases.
 using Value = TestIntrusiveListValue;
 
-using List1 = IntrusiveList<Value, &Value::_entry1>;
-using CHeapList1 = IntrusiveList<Value, &Value::_entry1, false, CHeapObj<mtInternal>>;
-using List2 = IntrusiveList<Value, &Value::_entry2>;
+using List1 = IntrusiveList<Value, &Value::entry1>;
+using CHeapList1 = IntrusiveList<Value, &Value::entry1, false, CHeapObj<mtInternal>>;
+using List2 = IntrusiveList<Value, &Value::entry2>;
 
-using CList1 = IntrusiveList<const Value, &Value::_entry1>;
-using CList2 = IntrusiveList<const Value, &Value::_entry2>;
+using CList1 = IntrusiveList<const Value, &Value::entry1>;
+using CList2 = IntrusiveList<const Value, &Value::entry2>;
 
 ////////////////////
 // Some preliminary tests.
@@ -1494,8 +1496,8 @@ class IntrusiveListTestWithSize : public IntrusiveListTestWithValues {
   typedef IntrusiveListTestWithValues super;
 
 public:
-  typedef IntrusiveList<Value, &Value::_entry1, true> ListWithSize;
-  typedef IntrusiveList<Value, &Value::_entry1, true, CHeapObj<mtInternal> > CHeapListWithSize;
+  typedef IntrusiveList<Value, &Value::entry1, true> ListWithSize;
+  typedef IntrusiveList<Value, &Value::entry1, true, CHeapObj<mtInternal> > CHeapListWithSize;
 
   virtual void SetUp() {
     super::SetUp();

--- a/test/hotspot/gtest/utilities/test_intrusiveList.cpp
+++ b/test/hotspot/gtest/utilities/test_intrusiveList.cpp
@@ -173,7 +173,7 @@ public:
 
 class IntrusiveListTestWithDisposal : public IntrusiveListTestWithList1 {
 public:
-  IntrusiveListTestWithDisposal() : ndisposed(0) { }
+  IntrusiveListTestWithDisposal() : ndisposed(0), disposed() { }
 
   size_t ndisposed;
   const Value* disposed[nvalues];

--- a/test/hotspot/gtest/utilities/test_intrusiveList.cpp
+++ b/test/hotspot/gtest/utilities/test_intrusiveList.cpp
@@ -1365,10 +1365,19 @@ TEST_F(IntrusiveListTestSplice, splice_into_const) {
     SCOPED_TRACE("check values");
     check(clist.begin(), clist.end(), 0);
   }
+
+  // Some invalid uses to allow one to examine the compiler errors.
+
   // This doesn't compile, which is as expected.  Transfer from list with
   // const elements to a list with non-const elements is disallowed, because
   // it implicitly casts away const.
   // List1::iterator sresult_c = list_a.splice(list_a.end(), clist);
+
+  // This doesn't compile either, as expected.  Splicing from a non-list.
+  // class Foo {};
+  // Foo foo{};
+  // clist.splice(clist.end(), foo);
+
   clist.clear();
 }
 

--- a/test/hotspot/gtest/utilities/test_intrusiveList.cpp
+++ b/test/hotspot/gtest/utilities/test_intrusiveList.cpp
@@ -1,0 +1,1616 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.inline.hpp"
+#include "utilities/intrusiveList.hpp"
+#include "utilities/macros.hpp"
+#include <type_traits>
+#include "unittest.hpp"
+
+// Note: Hotspot gtest integration doesn't yet support typed tests, so
+// a lot of the tests of the different iterator types are done by hand.
+
+using Entry = IntrusiveListEntry;
+
+struct TestIntrusiveListValue : public CHeapObj<mtInternal> {
+  size_t _value;
+
+  // Note: Entry members need to be public, to work around VS2013 bug.
+
+  Entry _entry1;                // Entry for first list.
+
+  // Used to prove we can have an object in two different kinds of
+  // list.  We only use _entry1 for most other tests.
+  Entry _entry2;                // Entry for second list.
+
+  TestIntrusiveListValue(size_t value) : _value(value) { }
+
+  NONCOPYABLE(TestIntrusiveListValue);
+
+  using Value = TestIntrusiveListValue; // convenience
+
+  size_t value() const { return _value; }
+  Value* This() { return this; }
+  const Value* This() const { return this; }
+};
+
+// Convenience type aliases.
+using Value = TestIntrusiveListValue;
+
+using List1 = IntrusiveList<Value, &Value::_entry1>;
+using CHeapList1 = IntrusiveList<Value, &Value::_entry1, false, CHeapObj<mtInternal>>;
+using List2 = IntrusiveList<Value, &Value::_entry2>;
+
+using CList1 = IntrusiveList<const Value, &Value::_entry1>;
+using CList2 = IntrusiveList<const Value, &Value::_entry2>;
+
+////////////////////
+// Some preliminary tests.
+
+struct IntrusiveListImpl::TestSupport {
+  // Verify expected iterator conversions.
+  using L1Iterator = typename List1::iterator;
+  using L1CIterator = typename List1::const_iterator;
+  using C1Iterator = typename CList1::iterator;
+  using C1CIterator = typename CList1::const_iterator;
+  static_assert(std::is_convertible<L1Iterator, L1Iterator>::value,
+                "not convertible: List1::iterator -> List1::iterator");
+  static_assert(std::is_convertible<L1CIterator, L1CIterator>::value,
+                "not convertible: List1::const_iterator -> List1::const_iterator");
+  static_assert(std::is_convertible<L1CIterator, L1CIterator>::value,
+                "not convertible: List1::const_iterator -> List1::const_iterator");
+  static_assert(std::is_convertible<L1Iterator, L1CIterator>::value,
+                "not convertible: List1::iterator -> List1::const_iterator");
+  static_assert(!std::is_convertible<L1CIterator, L1Iterator>::value,
+                "convertible: List1::iterator -> List1::const_iterator");
+
+  using L2Iterator = typename List2::iterator;
+  static_assert(!std::is_convertible<L1Iterator, L2Iterator>::value,
+                "convertible: List1::iterator -> List2::iterator");
+  static_assert(!std::is_convertible<L2Iterator, L1Iterator>::value,
+                "convertible: List2::iterator -> List1::iterator");
+
+  // Verify can_splice_from for pairwise combinations of const/non-const value type.
+  static_assert(List1::can_splice_from<List1>(), "cannot splice List1 -> List1");
+  static_assert(CList1::can_splice_from<CList1>(), "cannot splice CList1 -> CList1");
+  static_assert(!List1::can_splice_from<CList1>(), "can splice CList1 -> List1");
+  static_assert(CList1::can_splice_from<List1>(), "cannot splice List1 -> CList1");
+
+  // Verify CanSplice is false for different list entries.
+  static_assert(!List2::can_splice_from<List1>(), "can splice List1 -> List2");
+
+};
+
+////////////////////
+// Test fixtures.
+
+class IntrusiveListTestWithValues : public ::testing::Test {
+public:
+  IntrusiveListTestWithValues() {
+    for (size_t i = 0; i < nvalues; ++i) {
+      values[i] = new Value(i);
+    }
+  }
+
+  ~IntrusiveListTestWithValues() {
+    for (size_t i = 0; i < nvalues; ++i) {
+      delete values[i];
+    }
+  }
+
+  static const size_t nvalues = 10;
+  Value* values[nvalues];
+};
+
+const size_t IntrusiveListTestWithValues::nvalues;
+
+class IntrusiveListTestWithList1 : public IntrusiveListTestWithValues {
+public:
+  IntrusiveListTestWithList1() {
+    fill_list();
+  }
+
+  ~IntrusiveListTestWithList1() {
+    list1.clear();
+  }
+
+  List1 list1;
+
+  // Add all values[] to list1, in the same order in values[] and list.
+  void fill_list() {
+    for (size_t i = 0; i < nvalues; ++i) {
+      list1.push_back(*values[i]);
+    }
+  }
+};
+
+class IntrusiveListTestWithCList1 : public IntrusiveListTestWithValues {
+public:
+  IntrusiveListTestWithCList1() {
+    fill_list();
+  }
+
+  ~IntrusiveListTestWithCList1() {
+    list1.clear();
+  }
+
+  CList1 list1;
+
+  // Add all values[] to list1, in the same order in values[] and list.
+  void fill_list() {
+    for (size_t i = 0; i < nvalues; ++i) {
+      list1.push_back(*values[i]);
+    }
+  }
+};
+
+class IntrusiveListTestWithDisposal : public IntrusiveListTestWithList1 {
+public:
+  IntrusiveListTestWithDisposal() : ndisposed(0) { }
+
+  size_t ndisposed;
+  const Value* disposed[nvalues];
+
+  class CollectingDisposer {
+  public:
+    CollectingDisposer(IntrusiveListTestWithDisposal* test) : _test(test) { }
+
+    void operator()(const Value& value) const {
+      _test->disposed[_test->ndisposed++] = &value;
+    }
+
+  private:
+    IntrusiveListTestWithDisposal* _test;
+  };
+};
+
+////////////////////
+// Helper functions
+
+// Doesn't distinguish between reference and non-reference types.
+template<typename Expected, typename T>
+static bool is_expected_type(T) {
+  return std::is_same<Expected, T>::value;
+}
+
+// This lets us distinguish between non-const reference and const
+// reference or value.
+template<typename Expected, typename T>
+static bool is_expected_ref_type(T&) {
+  return std::is_same<Expected, T&>::value;
+};
+
+template<typename It>
+static It step_iterator(It it, ptrdiff_t n) {
+  if (n < 0) {
+    for (ptrdiff_t i = 0; i > n; --i) {
+      --it;
+    }
+  } else {
+    for (ptrdiff_t i = 0; i < n; ++i) {
+      ++it;
+    }
+  }
+  return it;
+}
+
+template<typename List>
+static typename List::reference list_elt(List& list, size_t n) {
+  return *step_iterator(list.begin(), n);
+}
+
+////////////////////
+// CHeapObj List construction
+
+TEST(IntrusiveListBasics, construct_CHeapObj) {
+  CHeapList1* list1 = new CHeapList1();
+  EXPECT_TRUE(list1->empty());
+  EXPECT_EQ(0u, list1->length());
+  delete list1;
+}
+
+////////////////////
+// push_front(), pop_front(), length(), empty()
+// front(), back(), operator[]
+
+TEST_F(IntrusiveListTestWithValues, push_front) {
+  List1 list1;
+  for (size_t i = 0; i < nvalues; ++i) {
+    list1.push_front(*values[i]);
+    EXPECT_FALSE(list1.empty());
+    EXPECT_EQ(i + 1, list1.length());
+    EXPECT_EQ(values[i]->value(), list1.front().value());
+    EXPECT_EQ(values[0]->value(), list1.back().value());
+  }
+  {
+    size_t i = nvalues;
+    for (const Value& v : list1) {
+      EXPECT_EQ(--i, v.value());
+    }
+  }
+  list1.clear();
+}
+
+// Basic test of using list with const elements.
+TEST_F(IntrusiveListTestWithValues, push_front_const) {
+  CList1 list1;
+
+  // Verify we can add a const object.  This doesn't compile for List1.
+  const Value& v0 = *values[0];
+  list1.push_front(v0);
+  list1.clear();
+
+  for (size_t i = 0; i < nvalues; ++i) {
+    list1.push_front(*values[i]);
+    EXPECT_FALSE(list1.empty());
+    EXPECT_EQ(i + 1, list1.length());
+    EXPECT_EQ(values[i]->value(), list1.front().value());
+    EXPECT_EQ(values[0]->value(), list1.back().value());
+  }
+  {
+    size_t i = nvalues;
+    for (const Value& v : list1) {
+      EXPECT_EQ(--i, v.value());
+    }
+  }
+  list1.clear();
+}
+
+TEST_F(IntrusiveListTestWithValues, push_back) {
+  List2 list2;
+  for (size_t i = 0; i < nvalues; ++i) {
+    list2.push_back(*values[i]);
+    EXPECT_FALSE(list2.empty());
+    EXPECT_EQ(i + 1, list2.length());
+    EXPECT_EQ(values[i]->value(), list2.back().value());
+    EXPECT_EQ(values[0]->value(), list2.front().value());
+  }
+  {
+    size_t i = 0;
+    for (const Value& v : list2) {
+      EXPECT_EQ(i++, v.value());
+    }
+  }
+  for (size_t i = 0; i < nvalues; ++i) {
+    EXPECT_EQ(i, list2[i].value());
+  }
+  list2.clear();
+}
+
+TEST_F(IntrusiveListTestWithValues, push_back_const) {
+  CList2 list2;
+
+  // Verify we can add a const object.  This doesn't compile for List1.
+  const Value& v0 = *values[0];
+  list2.push_back(v0);
+  list2.clear();
+
+  for (size_t i = 0; i < nvalues; ++i) {
+    list2.push_back(*values[i]);
+    EXPECT_FALSE(list2.empty());
+    EXPECT_EQ(i + 1, list2.length());
+    EXPECT_EQ(values[i]->value(), list2.back().value());
+    EXPECT_EQ(values[0]->value(), list2.front().value());
+  }
+  {
+    size_t i = 0;
+    for (const Value& v : list2) {
+      EXPECT_EQ(i++, v.value());
+    }
+  }
+  for (size_t i = 0; i < nvalues; ++i) {
+    EXPECT_EQ(i, list2[i].value());
+  }
+  list2.clear();
+}
+
+////////////////////
+// Verify we can construct a singular iterator of each type.
+
+template<typename T> static void ignore(const T&) { }
+
+template<typename It>
+static void construct_singular_iterator() {
+  It it;
+  // There's not much we can do with a singular iterator to test further.
+  ignore(it);
+}
+
+TEST(IntrusiveListBasics, construct_singular_iterators) {
+  construct_singular_iterator<List1::iterator>();
+  construct_singular_iterator<List1::const_iterator>();
+  construct_singular_iterator<List1::reverse_iterator>();
+  construct_singular_iterator<List1::const_reverse_iterator>();
+}
+
+// normal constructor and destructor are tested in the normal course
+// of testing other things.
+
+////////////////////
+// copy construction
+
+template<typename To, typename It>
+static void test_copy_constructor2(const It& it) {
+  To copy(it);
+  EXPECT_EQ(it, copy);
+  EXPECT_EQ(it->This(), copy->This());
+  ++copy;
+  EXPECT_NE(it, copy);
+}
+
+template<typename It>
+static void test_copy_constructor(const It& it) {
+  test_copy_constructor2<It>(it);
+}
+
+TEST_F(IntrusiveListTestWithList1, copy_construct) {
+  test_copy_constructor(list1.begin());
+  test_copy_constructor(list1.cbegin());
+  test_copy_constructor(list1.rbegin());
+  test_copy_constructor(list1.crbegin());
+}
+
+////////////////////
+// copy assign
+
+template<typename To, typename It>
+static void test_copy_assign2(const It& it) {
+  It tmp(it);
+  EXPECT_EQ(it, tmp);
+
+  To copy;
+  // Can't compare against singular copy.
+  copy = ++tmp;
+  EXPECT_NE(it, copy);
+  EXPECT_EQ(tmp, copy);
+  EXPECT_EQ(tmp->This(), copy->This());
+}
+
+template<typename It>
+static void test_copy_assign(const It& it) {
+  test_copy_assign2<It>(it);
+}
+
+TEST_F(IntrusiveListTestWithList1, copy_assign) {
+  test_copy_assign(list1.begin());
+  test_copy_assign(list1.cbegin());
+  test_copy_assign(list1.rbegin());
+  test_copy_assign(list1.crbegin());
+}
+
+////////////////////
+// copy conversion
+// conversion assign
+
+TEST_F(IntrusiveListTestWithList1, copy_conversion) {
+  test_copy_constructor2<List1::const_iterator>(list1.begin());
+  test_copy_constructor2<List1::const_reverse_iterator>(list1.rbegin());
+}
+
+TEST_F(IntrusiveListTestWithList1, conversion_assign) {
+  test_copy_assign2<List1::const_iterator>(list1.begin());
+  test_copy_assign2<List1::const_reverse_iterator>(list1.rbegin());
+}
+
+////////////////////
+// operator*
+// operator->
+
+TEST_F(IntrusiveListTestWithList1, reference_type) {
+  EXPECT_TRUE(is_expected_ref_type<List1::reference>(*list1.begin()));
+  EXPECT_TRUE(is_expected_ref_type<List1::const_reference>(*list1.cbegin()));
+  EXPECT_TRUE(is_expected_ref_type<List1::reference>(*list1.rbegin()));
+  EXPECT_TRUE(is_expected_ref_type<List1::const_reference>(*list1.crbegin()));
+}
+
+TEST_F(IntrusiveListTestWithList1, pointer_type) {
+  EXPECT_TRUE(is_expected_type<List1::pointer>(list1.begin()->This()));
+  EXPECT_TRUE(is_expected_type<List1::const_pointer>(list1.cbegin()->This()));
+  EXPECT_TRUE(is_expected_type<List1::pointer>(list1.rbegin()->This()));
+  EXPECT_TRUE(is_expected_type<List1::const_pointer>(list1.cbegin()->This()));
+}
+
+TEST_F(IntrusiveListTestWithList1, dereference) {
+  EXPECT_EQ(0u, (*list1.begin()).value());
+  EXPECT_EQ(0u, (*list1.cbegin()).value());
+  EXPECT_EQ(nvalues - 1, (*list1.rbegin()).value());
+  EXPECT_EQ(nvalues - 1, (*list1.crbegin()).value());
+}
+
+TEST_F(IntrusiveListTestWithList1, get_pointer) {
+  EXPECT_EQ(0u, list1.begin()->value());
+  EXPECT_EQ(0u, list1.begin()->value());
+  EXPECT_EQ(nvalues - 1, list1.rbegin()->value());
+  EXPECT_EQ(nvalues - 1, list1.crbegin()->value());
+}
+
+////////////////////
+// operator++()
+// operator++(int)
+// operator--()
+// operator--(int)
+
+TEST_F(IntrusiveListTestWithList1, preincrement_type) {
+  EXPECT_TRUE(is_expected_ref_type<List1::iterator&>(++list1.begin()));
+  EXPECT_TRUE(is_expected_ref_type<List1::const_iterator&>(++list1.cbegin()));
+  EXPECT_TRUE(is_expected_ref_type<List1::reverse_iterator&>(++list1.rbegin()));
+  EXPECT_TRUE(is_expected_ref_type<List1::const_reverse_iterator&>(++list1.crbegin()));
+}
+
+TEST_F(IntrusiveListTestWithList1, postincrement_type) {
+  EXPECT_TRUE(is_expected_type<List1::iterator>(list1.begin()++));
+  EXPECT_TRUE(is_expected_type<List1::const_iterator>(list1.cbegin()++));
+  EXPECT_TRUE(is_expected_type<List1::reverse_iterator>(list1.rbegin()++));
+  EXPECT_TRUE(is_expected_type<List1::const_reverse_iterator>(list1.crbegin()++));
+}
+
+TEST_F(IntrusiveListTestWithList1, predecrement_type) {
+  EXPECT_TRUE(is_expected_ref_type<List1::iterator&>(--list1.end()));
+  EXPECT_TRUE(is_expected_ref_type<List1::const_iterator&>(--list1.cend()));
+  EXPECT_TRUE(is_expected_ref_type<List1::reverse_iterator&>(--list1.rend()));
+  EXPECT_TRUE(is_expected_ref_type<List1::const_reverse_iterator&>(--list1.crend()));
+}
+
+TEST_F(IntrusiveListTestWithList1, postdecrement_type) {
+  EXPECT_TRUE(is_expected_type<List1::iterator>(list1.end()--));
+  EXPECT_TRUE(is_expected_type<List1::const_iterator>(list1.cend()--));
+  EXPECT_TRUE(is_expected_type<List1::reverse_iterator>(list1.rend()--));
+  EXPECT_TRUE(is_expected_type<List1::const_reverse_iterator>(list1.crend()--));
+}
+
+class IntrusiveListTestPreStepper : public IntrusiveListTestWithList1 {
+public:
+  template<typename Stepper, typename It>
+  void test_prestepper(Stepper step, It it, size_t idx, size_t idx1) {
+    It it1 = it;
+    EXPECT_EQ(it, it1);
+    EXPECT_EQ(values[idx], it->This());
+    EXPECT_EQ(values[idx], it1->This());
+
+    It it2 = step(it);
+    EXPECT_NE(it, it1);
+    EXPECT_EQ(it, it2);
+    EXPECT_NE(it1, it2);
+    EXPECT_EQ(values[idx1], it->This());
+    EXPECT_EQ(values[idx], it1->This());
+    EXPECT_EQ(values[idx1], it2->This());
+
+    It it3 = step(it1);
+    EXPECT_EQ(it, it1);
+    EXPECT_EQ(it, it2);
+    EXPECT_EQ(it, it3);
+    EXPECT_EQ(values[idx1], it->This());
+    EXPECT_EQ(values[idx1], it1->This());
+    EXPECT_EQ(values[idx1], it2->This());
+    EXPECT_EQ(values[idx1], it3->This());
+  }
+
+  template<bool increment> struct PreStepper;
+};
+
+template<bool increment>
+struct IntrusiveListTestPreStepper::PreStepper {
+  template<typename It> It& operator()(It& it) const { return ++it; }
+};
+
+template<>
+struct IntrusiveListTestPreStepper::PreStepper<false> {
+  template<typename It> It& operator()(It& it) const { return --it; }
+};
+
+TEST_F(IntrusiveListTestPreStepper, preincrement) {
+  PreStepper<true> step;
+  {
+    SCOPED_TRACE("forward non-const iterator");
+    test_prestepper(step, list1.begin(), 0, 1);
+  }
+  {
+    SCOPED_TRACE("forward const iterator");
+    test_prestepper(step, list1.cbegin(), 0, 1);
+  }
+  {
+    SCOPED_TRACE("reverse non-const iterator");
+    test_prestepper(step, list1.rbegin(), nvalues - 1, nvalues - 2);
+  }
+  {
+    SCOPED_TRACE("reverse const iterator");
+    test_prestepper(step, list1.crbegin(), nvalues - 1, nvalues - 2);
+  }
+}
+
+TEST_F(IntrusiveListTestPreStepper, predecrement) {
+  PreStepper<false> step;
+  {
+    SCOPED_TRACE("forward non-const iterator");
+    test_prestepper(step, ++list1.begin(), 1, 0);
+  }
+  {
+    SCOPED_TRACE("forward const iterator");
+    test_prestepper(step, ++list1.cbegin(), 1, 0);
+  }
+  {
+    SCOPED_TRACE("reverse non-const iterator");
+    test_prestepper(step, ++list1.rbegin(), nvalues - 2, nvalues - 1);
+  }
+  {
+    SCOPED_TRACE("reverse const iterator");
+    test_prestepper(step, ++list1.crbegin(), nvalues - 2, nvalues - 1);
+  }
+}
+
+class IntrusiveListTestPostStepper : public IntrusiveListTestWithList1 {
+public:
+  template<typename Stepper, typename It>
+  void test_poststepper(Stepper step, It it, size_t idx, size_t idx1) {
+    It it1 = it;
+    EXPECT_EQ(it, it1);
+    EXPECT_EQ(values[idx], it->This());
+    EXPECT_EQ(values[idx], it1->This());
+
+    It it2 = step(it);
+    EXPECT_NE(it, it2);
+    EXPECT_EQ(it1, it2);
+    EXPECT_EQ(values[idx1], it->This());
+    EXPECT_EQ(values[idx], it1->This());
+    EXPECT_EQ(values[idx], it2->This());
+
+    It it3 = step(it1);
+    EXPECT_EQ(it, it1);
+    EXPECT_EQ(it2, it3);
+    EXPECT_NE(it, it2);
+    EXPECT_NE(it, it3);
+    EXPECT_NE(it1, it2);
+    EXPECT_NE(it1, it3);
+    EXPECT_EQ(values[idx1], it->This());
+    EXPECT_EQ(values[idx1], it1->This());
+    EXPECT_EQ(values[idx], it2->This());
+    EXPECT_EQ(values[idx], it3->This());
+  }
+
+  template<bool increment> struct PostStepper;
+};
+
+template<bool increment>
+struct IntrusiveListTestPostStepper::PostStepper {
+  template<typename It> It operator()(It& it) const { return it++; }
+};
+
+template<>
+struct IntrusiveListTestPostStepper::PostStepper<false> {
+  template<typename It> It operator()(It& it) const { return it--; }
+};
+
+TEST_F(IntrusiveListTestPostStepper, postincrement) {
+  PostStepper<true> step;
+  {
+    SCOPED_TRACE("forward non-const iterator");
+    test_poststepper(step, list1.begin(), 0, 1);
+  }
+  {
+    SCOPED_TRACE("forward const iterator");
+    test_poststepper(step, list1.cbegin(), 0, 1);
+  }
+  {
+    SCOPED_TRACE("reverse non-const iterator");
+    test_poststepper(step, list1.rbegin(), nvalues - 1, nvalues - 2);
+  }
+  {
+    SCOPED_TRACE("reverse const iterator");
+    test_poststepper(step, list1.crbegin(), nvalues - 1, nvalues - 2);
+  }
+}
+
+TEST_F(IntrusiveListTestPostStepper, postdecrement) {
+  PostStepper<false> step;
+  {
+    SCOPED_TRACE("forward non-const iterator");
+    test_poststepper(step, ++list1.begin(), 1, 0);
+  }
+  {
+    SCOPED_TRACE("forward const iterator");
+    test_poststepper(step, ++list1.cbegin(), 1, 0);
+  }
+  {
+    SCOPED_TRACE("reverse non-const iterator");
+    test_poststepper(step, ++list1.rbegin(), nvalues - 2, nvalues - 1);
+  }
+  {
+    SCOPED_TRACE("reverse const iterator");
+    test_poststepper(step, ++list1.crbegin(), nvalues - 2, nvalues - 1);
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// operator==
+// operator!=
+// operator== with peer, both argument orders
+// operator!= with peer, both argument orders
+
+template<typename It, typename CIt>
+static void test_iterator_compare(It it, CIt cit) {
+  It it1 = it;
+  It it2 = it1;
+  ++it2;
+
+  CIt cit1 = cit;
+  CIt cit2 = cit1;
+  ++cit2;
+
+  EXPECT_EQ(it, it1);
+  EXPECT_NE(it, it2);
+
+  EXPECT_EQ(cit, cit1);
+  EXPECT_NE(cit, cit2);
+
+  EXPECT_EQ(it, cit);
+  EXPECT_EQ(cit, it);
+  EXPECT_NE(it, cit2);
+  EXPECT_NE(cit2, it);
+}
+
+TEST_F(IntrusiveListTestWithList1, compare) {
+  test_iterator_compare(list1.begin(), list1.cbegin());
+  test_iterator_compare(list1.rbegin(), list1.crbegin());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// pop_front
+// pop_back
+// pop_front_and_dispose
+// pop_back_and_dispose
+
+TEST_F(IntrusiveListTestWithDisposal, pop) {
+  ASSERT_EQ(nvalues, list1.length());
+  ASSERT_EQ(values[0], list1.front().This());
+  ASSERT_EQ(values[nvalues - 1], list1.back().This());
+
+  list1.pop_front();
+  EXPECT_EQ(nvalues - 1, list1.length());
+  EXPECT_EQ(values[1], list1.front().This());
+
+  list1.pop_front_and_dispose(CollectingDisposer(this));
+  EXPECT_EQ(nvalues - 2, list1.length());
+  EXPECT_EQ(values[2], list1.front().This());
+  EXPECT_EQ(1u, ndisposed);
+  EXPECT_EQ(values[1], disposed[0]);
+
+  list1.pop_back();
+  EXPECT_EQ(nvalues - 3, list1.length());
+  EXPECT_EQ(values[nvalues - 2], list1.back().This());
+
+  list1.pop_back_and_dispose(CollectingDisposer(this));
+  EXPECT_EQ(nvalues - 4, list1.length());
+  EXPECT_EQ(values[nvalues - 3], list1.back().This());
+  EXPECT_EQ(2u, ndisposed);
+  EXPECT_EQ(values[nvalues - 2], disposed[1]);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// front -- const and non-const
+// back -- const and non-const
+
+TEST_F(IntrusiveListTestWithList1, end_access) {
+  const List1& clist1 = list1;
+
+  EXPECT_TRUE(is_expected_ref_type<List1::reference>(list1.front()));
+  EXPECT_TRUE(is_expected_ref_type<List1::reference>(list1.back()));
+
+  EXPECT_TRUE(is_expected_ref_type<List1::const_reference>(clist1.front()));
+  EXPECT_TRUE(is_expected_ref_type<List1::const_reference>(clist1.back()));
+
+  EXPECT_EQ(values[0], list1.front().This());
+  EXPECT_EQ(values[0], clist1.front().This());
+
+  EXPECT_EQ(values[nvalues - 1], list1.back().This());
+  EXPECT_EQ(values[nvalues - 1], clist1.back().This());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// begin -- const and non-const
+// cbegin
+// end -- const and non-const
+// cend
+// rbegin -- const and non-const
+// crbegin
+// rend -- const and non-const
+// crend
+
+TEST_F(IntrusiveListTestWithList1, iter_type) {
+  const List1& clist1 = list1;
+
+  EXPECT_TRUE(is_expected_type<List1::iterator>(list1.begin()));
+  EXPECT_TRUE(is_expected_type<List1::const_iterator>(clist1.begin()));
+  EXPECT_TRUE(is_expected_type<List1::const_iterator>(list1.cbegin()));
+
+  EXPECT_TRUE(is_expected_type<List1::iterator>(list1.end()));
+  EXPECT_TRUE(is_expected_type<List1::const_iterator>(clist1.end()));
+  EXPECT_TRUE(is_expected_type<List1::const_iterator>(list1.cend()));
+
+  EXPECT_TRUE(is_expected_type<List1::reverse_iterator>(list1.rbegin()));
+  EXPECT_TRUE(is_expected_type<List1::const_reverse_iterator>(clist1.rbegin()));
+  EXPECT_TRUE(is_expected_type<List1::const_reverse_iterator>(list1.crbegin()));
+
+  EXPECT_TRUE(is_expected_type<List1::reverse_iterator>(list1.rbegin()));
+  EXPECT_TRUE(is_expected_type<List1::const_reverse_iterator>(clist1.rbegin()));
+  EXPECT_TRUE(is_expected_type<List1::const_reverse_iterator>(list1.crbegin()));
+}
+
+TEST_F(IntrusiveListTestWithList1, iters) {
+  const List1& clist1 = list1;
+
+  List1::pointer front = values[0];
+  List1::pointer back = values[nvalues - 1];
+
+  EXPECT_EQ(front, list1.begin()->This());
+  EXPECT_EQ(front, clist1.begin()->This());
+  EXPECT_EQ(front, list1.cbegin()->This());
+
+  EXPECT_EQ(back, (--list1.end())->This());
+  EXPECT_EQ(back, (--clist1.end())->This());
+  EXPECT_EQ(back, (--list1.cend())->This());
+
+  EXPECT_EQ(back, list1.rbegin()->This());
+  EXPECT_EQ(back, clist1.rbegin()->This());
+  EXPECT_EQ(back, list1.crbegin()->This());
+
+  EXPECT_EQ(front, (--list1.rend())->This());
+  EXPECT_EQ(front, (--clist1.rend())->This());
+  EXPECT_EQ(front, (--list1.crend())->This());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// erase -- one and range, forward and reversed
+// erase_and_dispose -- one and range, forward and reversed
+
+TEST_F(IntrusiveListTestWithList1, erase1) {
+  EXPECT_EQ(nvalues, list1.length());
+
+  int step = 2;
+  unsigned index = step;
+  List1::const_iterator it = step_iterator(list1.begin(), step);
+  List1::const_reference value = *it;
+  EXPECT_EQ(index, value.value());
+  EXPECT_EQ(values[index], value.This());
+
+  List1::iterator nit = list1.erase(it);
+  EXPECT_EQ(nvalues - 1, list1.length());
+  EXPECT_EQ(index + 1, nit->value());
+  nit = step_iterator(nit, -step);
+  EXPECT_EQ(nit, list1.begin());
+}
+
+TEST_F(IntrusiveListTestWithList1, erase1_reversed) {
+  EXPECT_EQ(nvalues, list1.length());
+
+  int step = 2;
+  unsigned index = (nvalues - 1) - step;
+  List1::const_reverse_iterator it = step_iterator(list1.rbegin(), step);
+  List1::const_reference value = *it;
+  EXPECT_EQ(index, value.value());
+  EXPECT_EQ(values[index], value.This());
+
+  List1::reverse_iterator nit = list1.erase(it);
+  EXPECT_EQ(nvalues - 1, list1.length());
+  EXPECT_EQ(index - 1, nit->value());
+  nit = step_iterator(nit, -step);
+  EXPECT_EQ(nit, list1.rbegin());
+}
+
+TEST_F(IntrusiveListTestWithDisposal, erase1_dispose) {
+  EXPECT_EQ(nvalues, list1.length());
+
+  int step = 2;
+  unsigned index = step;
+  List1::const_iterator it = step_iterator(list1.begin(), step);
+  List1::const_reference value = *it;
+  EXPECT_EQ(index, value.value());
+  EXPECT_EQ(values[index], value.This());
+
+  List1::iterator nit = list1.erase_and_dispose(it, CollectingDisposer(this));
+  EXPECT_EQ(nvalues - 1, list1.length());
+  EXPECT_EQ(index + 1, nit->value());
+
+  EXPECT_EQ(1u, ndisposed);
+  EXPECT_EQ(value.value(), disposed[0]->value());
+  EXPECT_EQ(value.This(), disposed[0]);
+
+  nit = step_iterator(nit, -step);
+  EXPECT_EQ(nit, list1.begin());
+}
+
+TEST_F(IntrusiveListTestWithDisposal, erase1_dispose_reversed) {
+  EXPECT_EQ(nvalues, list1.length());
+
+  int step = 2;
+  unsigned index = (nvalues - 1) - step;
+  List1::const_reverse_iterator it = step_iterator(list1.rbegin(), step);
+  List1::const_reference value = *it;
+  EXPECT_EQ(index, value.value());
+  EXPECT_EQ(values[index], value.This());
+
+  List1::reverse_iterator nit = list1.erase_and_dispose(it, CollectingDisposer(this));
+  EXPECT_EQ(nvalues - 1, list1.length());
+  EXPECT_EQ(index - 1, nit->value());
+
+  EXPECT_EQ(1u, ndisposed);
+  EXPECT_EQ(value.value(), disposed[0]->value());
+  EXPECT_EQ(value.This(), disposed[0]);
+
+  nit = step_iterator(nit, -step);
+  EXPECT_EQ(nit, list1.rbegin());
+}
+
+TEST_F(IntrusiveListTestWithList1, erase2) {
+  EXPECT_EQ(nvalues, list1.length());
+
+  int step1 = 2;
+  unsigned index1 = step1;
+  List1::const_iterator it1 = step_iterator(list1.begin(), step1);
+  List1::const_reference value1 = *it1;
+  EXPECT_EQ(index1, value1.value());
+
+  int step2 = 2;
+  unsigned index2 = index1 + step2;
+  List1::const_iterator it2 = step_iterator(it1, step2);
+  List1::const_reference value2 = *it2;
+  EXPECT_EQ(index2, value2.value());
+
+  List1::iterator nit = list1.erase(it1, it2);
+  EXPECT_EQ(nvalues - step2, list1.length());
+  EXPECT_EQ(index2, nit->value());
+  EXPECT_EQ(it2, nit);
+
+  nit = step_iterator(nit, -step1);
+  EXPECT_EQ(nit, list1.begin());
+}
+
+TEST_F(IntrusiveListTestWithList1, erase2_reversed) {
+  EXPECT_EQ(nvalues, list1.length());
+
+  int step1 = 2;
+  unsigned index1 = (nvalues - 1) - step1;
+  List1::const_reverse_iterator it1 = step_iterator(list1.rbegin(), step1);
+  List1::const_reference value1 = *it1;
+  EXPECT_EQ(index1, value1.value());
+
+  int step2 = 2;
+  unsigned index2 = index1 - step2;
+  List1::const_reverse_iterator it2 = step_iterator(it1, step2);
+  List1::const_reference value2 = *it2;
+  EXPECT_EQ(index2, value2.value());
+
+  List1::reverse_iterator nit = list1.erase(it1, it2);
+  EXPECT_EQ(nvalues - step2, list1.length());
+  EXPECT_EQ(index2, nit->value());
+  EXPECT_EQ(it2, nit);
+
+  nit = step_iterator(nit, -step1);
+  EXPECT_EQ(nit, list1.rbegin());
+}
+
+TEST_F(IntrusiveListTestWithDisposal, erase2_dispose) {
+  EXPECT_EQ(nvalues, list1.length());
+
+  int step1 = 2;
+  unsigned index1 = step1;
+  List1::const_iterator it1 = step_iterator(list1.begin(), step1);
+  List1::const_reference value1 = *it1;
+  EXPECT_EQ(index1, value1.value());
+
+  int step2 = 1;
+  unsigned index2 = index1 + step2;
+  List1::const_iterator it2 = step_iterator(it1, step2);
+  List1::const_reference value2 = *it2;
+  EXPECT_EQ(index2, value2.value());
+
+  int step3 = step2 + 1;
+  unsigned index3 = index1 + step3;
+  ++it2;
+  List1::iterator nit = list1.erase_and_dispose(it1, it2, CollectingDisposer(this));
+  EXPECT_EQ(nvalues - step3, list1.length());
+  EXPECT_EQ(index3, nit->value());
+  EXPECT_EQ(it2, nit);
+
+  EXPECT_EQ(unsigned(step3), ndisposed);
+  EXPECT_EQ(value1.value(), disposed[0]->value());
+  EXPECT_EQ(value1.This(), disposed[0]);
+  EXPECT_EQ(value2.value(), disposed[1]->value());
+  EXPECT_EQ(value2.This(), disposed[1]);
+
+  nit = step_iterator(nit, -step1);
+  EXPECT_EQ(nit, list1.begin());
+}
+
+TEST_F(IntrusiveListTestWithDisposal, erase2_dispose_reversed) {
+  EXPECT_EQ(nvalues, list1.length());
+
+  int step1 = 2;
+  unsigned index1 = (nvalues - 1) - step1;
+  List1::const_reverse_iterator it1 = step_iterator(list1.rbegin(), step1);
+  List1::const_reference value1 = *it1;
+  EXPECT_EQ(index1, value1.value());
+
+  int step2 = 1;
+  unsigned index2 = index1 - step2;
+  List1::const_reverse_iterator it2 = step_iterator(it1, step2);
+  List1::const_reference value2 = *it2;
+  EXPECT_EQ(index2, value2.value());
+
+  int step3 = step2 + 1;
+  unsigned index3 = index1 - step3;
+  ++it2;
+  List1::reverse_iterator nit = list1.erase_and_dispose(it1, it2, CollectingDisposer(this));
+  EXPECT_EQ(nvalues - step3, list1.length());
+  EXPECT_EQ(index3, nit->value());
+  EXPECT_EQ(it2, nit);
+
+  EXPECT_EQ(unsigned(step3), ndisposed);
+  EXPECT_EQ(value1.value(), disposed[0]->value());
+  EXPECT_EQ(value1.This(), disposed[0]);
+  EXPECT_EQ(value2.value(), disposed[1]->value());
+  EXPECT_EQ(value2.This(), disposed[1]);
+
+  nit = step_iterator(nit, -step1);
+  EXPECT_EQ(nit, list1.rbegin());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// clear
+// clear_and_dispose
+
+TEST_F(IntrusiveListTestWithList1, clear) {
+  EXPECT_FALSE(list1.empty());
+  EXPECT_EQ(nvalues, list1.length());
+
+  list1.clear();
+  EXPECT_TRUE(list1.empty());
+  EXPECT_EQ(0u, list1.length());
+
+  // verify all values can be reinserted.
+  fill_list();
+}
+
+TEST_F(IntrusiveListTestWithDisposal, clear_dispose) {
+  EXPECT_FALSE(list1.empty());
+  EXPECT_EQ(nvalues, list1.length());
+
+  list1.clear_and_dispose(CollectingDisposer(this));
+  EXPECT_TRUE(list1.empty());
+  EXPECT_EQ(0u, list1.length());
+  EXPECT_EQ(nvalues, ndisposed);
+
+  for (size_t i = 0; i < nvalues; ++i) {
+    EXPECT_EQ(values[i], disposed[i]);
+  }
+
+  // verify all values can be reinserted.
+  fill_list();
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// insert
+
+TEST_F(IntrusiveListTestWithList1, insert) {
+  List1::pointer pvalue = values[0];
+  EXPECT_EQ(pvalue, list1.begin()->This());
+  list1.pop_front();
+  EXPECT_EQ(nvalues - 1, list1.length());
+  EXPECT_NE(pvalue, list1.begin()->This());
+
+  List1::iterator it = step_iterator(list1.begin(), 3);
+  EXPECT_EQ(values[4], it->This());
+
+  List1::iterator nit = list1.insert(it, *pvalue);
+  EXPECT_EQ(values[4], it->This());
+  EXPECT_EQ(nvalues, list1.length());
+  EXPECT_EQ(pvalue, nit->This());
+  EXPECT_NE(it, nit);
+  EXPECT_EQ(it, ++nit);
+  nit = step_iterator(nit, -4);
+  EXPECT_EQ(nit, list1.begin());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// splice
+
+class IntrusiveListTestSplice : public IntrusiveListTestWithValues {
+public:
+  IntrusiveListTestSplice() {
+    fill_lists();
+  }
+
+  ~IntrusiveListTestSplice() {
+    clear_lists();
+  }
+
+  static const size_t group_size = nvalues / 2;
+  List1 list_a;
+  List1 list_b;
+
+  void fill_lists() {
+    for (size_t i = 0; i < group_size; ++i) {
+      list_a.push_back(*values[i]);
+      list_b.push_back(*values[i + group_size]);
+    }
+  }
+
+  void clear_lists() {
+    list_a.clear();
+    list_b.clear();
+  }
+
+  template<typename Iterator1, typename Iterator2>
+  void check(Iterator1 start, Iterator2 end, size_t index) const {
+    for (Iterator1 it = start; it != end; ++it) {
+      ASSERT_EQ(values[index++], &*it);
+    }
+  }
+};
+
+TEST_F(IntrusiveListTestSplice, splice_all_front) {
+  size_t a_size = list_a.length();
+  size_t b_size = list_b.length();
+  List1::iterator a_begin = list_a.begin();
+  List1::iterator a_end = list_a.end();
+  List1::iterator b_begin = list_b.begin();
+
+  List1::iterator sresult = list_a.splice(a_begin, list_b);
+  EXPECT_EQ(list_a.begin(), sresult);
+  EXPECT_EQ(list_a.length(), a_size + b_size);
+  EXPECT_TRUE(list_b.empty());
+  EXPECT_EQ(b_begin, list_a.cbegin());
+  EXPECT_EQ(a_end, list_a.cend());
+  {
+    SCOPED_TRACE("check new values");
+    check(list_a.cbegin(), a_begin, group_size);
+  }
+  {
+    SCOPED_TRACE("check old values");
+    check(a_begin, list_a.cend(), 0);
+  }
+}
+
+TEST_F(IntrusiveListTestSplice, splice_all_back) {
+  size_t a_size = list_a.length();
+  size_t b_size = list_b.length();
+  List1::iterator a_begin = list_a.begin();
+  List1::iterator a_end = list_a.end();
+  List1::iterator a_penult = --List1::iterator(a_end);
+  List1::iterator b_begin = list_b.begin();
+
+  List1::iterator sresult = list_a.splice(list_a.end(), list_b);
+  EXPECT_EQ(++a_penult, List1::iterator(sresult));
+  EXPECT_EQ(list_a.length(), a_size + b_size);
+  EXPECT_TRUE(list_b.empty());
+  EXPECT_EQ(a_begin, list_a.cbegin());
+  EXPECT_EQ(a_end, list_a.cend());
+  {
+    SCOPED_TRACE("check old values");
+    check(list_a.cbegin(), b_begin, 0);
+  }
+  {
+    SCOPED_TRACE("check new values");
+    check(b_begin, list_a.cend(), group_size);
+  }
+}
+
+TEST_F(IntrusiveListTestSplice, splice_all_middle) {
+  const size_t middle_distance = 2;
+  STATIC_ASSERT(middle_distance < group_size);
+  size_t a_size = list_a.length();
+  size_t b_size = list_b.length();
+  List1::iterator a_begin = list_a.begin();
+  List1::iterator a_middle = step_iterator(a_begin, middle_distance);
+  List1::iterator a_pre_middle = --List1::iterator(a_middle);
+  List1::iterator a_end = list_a.end();
+  List1::iterator b_begin = list_b.begin();
+
+  List1::iterator sresult = list_a.splice(a_middle, list_b);
+  EXPECT_EQ(++a_pre_middle, List1::iterator(sresult));
+  EXPECT_EQ(list_a.length(), a_size + b_size);
+  EXPECT_TRUE(list_b.empty());
+  EXPECT_EQ(a_begin, list_a.cbegin());
+  EXPECT_EQ(a_end, list_a.cend());
+  {
+    SCOPED_TRACE("check initial old values");
+    check(a_begin, b_begin, 0);
+  }
+  {
+    SCOPED_TRACE("check new values");
+    check(b_begin, a_middle, group_size);
+  }
+  {
+    SCOPED_TRACE("check trailing old values");
+    check(a_middle, a_end, middle_distance);
+  }
+}
+
+TEST_F(IntrusiveListTestSplice, splice_some_middle) {
+  const size_t middle_distance = 2;
+  STATIC_ASSERT(middle_distance < group_size);
+  const size_t move_start = 1;
+  STATIC_ASSERT(move_start < group_size);
+  const size_t move_size = 2;
+  STATIC_ASSERT(move_start + move_size < group_size);
+  size_t a_size = list_a.length();
+  size_t b_size = list_b.length();
+  List1::iterator a_begin = list_a.begin();
+  List1::iterator a_middle = step_iterator(a_begin, middle_distance);
+  List1::iterator a_pre_middle = --List1::iterator(a_middle);
+  List1::iterator a_end = list_a.end();
+  List1::iterator b_begin = list_b.begin();
+  List1::iterator b_move_start = step_iterator(b_begin, move_start);
+  List1::iterator b_move_end = step_iterator(b_move_start, move_size);
+  List1::iterator b_end = list_b.end();
+
+  List1::iterator sresult = list_a.splice(a_middle, list_b, b_move_start, b_move_end);
+  EXPECT_EQ(++a_pre_middle, List1::iterator(sresult));
+  EXPECT_EQ(list_a.length(), a_size + move_size);
+  EXPECT_EQ(list_b.length(), b_size - move_size);
+  EXPECT_EQ(a_begin, list_a.cbegin());
+  EXPECT_EQ(a_end, list_a.cend());
+  EXPECT_EQ(b_begin, list_b.cbegin());
+  EXPECT_EQ(b_end, list_b.cend());
+  {
+    SCOPED_TRACE("check initial a values");
+    check(list_a.cbegin(), b_move_start, 0);
+  }
+  {
+    SCOPED_TRACE("check new a values");
+    check(b_move_start, a_middle, group_size + move_start);
+  }
+  {
+    SCOPED_TRACE("check trailing a values");
+    check(a_middle, list_a.cend(), middle_distance);
+  }
+  {
+    SCOPED_TRACE("check initial b values");
+    check(b_begin, b_move_end, group_size);
+  }
+  {
+    SCOPED_TRACE("check trailing b values");
+    check(b_move_end, b_end, group_size + move_start + move_size);
+  }
+}
+
+// Verify we can splice between lists with different Base template paramters.
+TEST_F(IntrusiveListTestSplice, splice_different_base) {
+  CHeapList1 cheap;
+  size_t a_size = list_a.length();
+  size_t b_size = list_b.length();
+  List1::iterator a_begin = list_a.begin();
+  List1::iterator a_penultimate = --list_a.end();
+
+  List1::iterator sresult = cheap.splice(cheap.begin(), list_a);
+  EXPECT_EQ(cheap.begin(), sresult);
+  EXPECT_EQ(a_size, cheap.length());
+  EXPECT_TRUE(list_a.empty());
+  EXPECT_EQ(a_begin, cheap.cbegin());
+  EXPECT_EQ(a_penultimate, --cheap.cend());
+  {
+    SCOPED_TRACE("check transfer to cheap");
+    check(cheap.cbegin(), cheap.cend(), 0);
+  }
+
+  List1::iterator b_begin = list_b.begin();
+  list_b.splice(b_begin, cheap);
+  EXPECT_EQ(a_size + b_size, list_b.length());
+  EXPECT_TRUE(cheap.empty());
+  EXPECT_EQ(a_begin, list_b.cbegin());
+  {
+    SCOPED_TRACE("check cheap (was a) prepend to b");
+    check(list_b.cbegin(), b_begin, 0);
+  }
+  {
+    SCOPED_TRACE("check old b");
+    check(b_begin, list_b.cend(), group_size);
+  }
+}
+
+TEST_F(IntrusiveListTestSplice, splice_one_front) {
+  const size_t move_start = 1;
+  size_t a_size = list_a.length();
+  size_t b_size = list_b.length();
+  List1::iterator a_begin = list_a.begin();
+  List1::iterator a_end = list_a.end();
+  List1::iterator b_begin = list_b.begin();
+  List1::iterator b_move_start = step_iterator(b_begin, move_start);
+  List1::iterator b_move_end = step_iterator(b_move_start, 1);
+  List1::iterator b_end = list_b.end();
+
+  List1::iterator sresult = list_a.splice(a_begin, list_b, b_move_start);
+  EXPECT_EQ(list_a.begin(), sresult);
+  EXPECT_EQ(list_a.length(), a_size + 1);
+  EXPECT_EQ(list_b.length(), b_size - 1);
+  EXPECT_EQ(a_begin, ++list_a.begin());
+  EXPECT_EQ(a_end, list_a.end());
+  EXPECT_EQ(b_begin, list_b.begin());
+  EXPECT_EQ(b_end, list_b.end());
+  {
+    SCOPED_TRACE("check new leading a values");
+    check(list_a.cbegin(), a_begin, group_size + move_start);
+  }
+  {
+    SCOPED_TRACE("check trailing a values");
+    check(a_begin, a_end, 0);
+  }
+  {
+    SCOPED_TRACE("check initial b values");
+    check(b_begin, b_move_end, group_size);
+  }
+  {
+    SCOPED_TRACE("check trailing b values");
+    check(b_move_end, b_end, group_size + move_start + 1);
+  }
+}
+
+TEST_F(IntrusiveListTestSplice, splice_one_back) {
+  const size_t move_start = 1;
+  size_t a_size = list_a.length();
+  size_t b_size = list_b.length();
+  List1::iterator a_begin = list_a.begin();
+  List1::iterator a_end = list_a.end();
+  List1::iterator a_penult = --List1::iterator(a_end);
+  List1::iterator b_begin = list_b.begin();
+  List1::iterator b_move_start = step_iterator(b_begin, move_start);
+  List1::iterator b_move_end = step_iterator(b_move_start, 1);
+  List1::iterator b_end = list_b.end();
+
+  List1::iterator sresult = list_a.splice(a_end, list_b, b_move_start);
+  EXPECT_EQ(++a_penult, List1::const_iterator(sresult));
+  EXPECT_EQ(++a_penult, a_end);
+  EXPECT_EQ(list_a.length(), a_size + 1);
+  EXPECT_EQ(list_b.length(), b_size - 1);
+  EXPECT_EQ(a_begin, list_a.begin());
+  EXPECT_EQ(a_end, list_a.end());
+  {
+    SCOPED_TRACE("check old values");
+    check(list_a.cbegin(), b_move_start, 0);
+  }
+  {
+    SCOPED_TRACE("check new values");
+    check(b_move_start, list_a.cend(), group_size + move_start);
+  }
+  {
+    SCOPED_TRACE("check initial a values");
+    check(b_begin, b_move_end, group_size);
+  }
+  {
+    SCOPED_TRACE("check trailing b values");
+    check(b_move_end, b_end, group_size + move_start + 1);
+  }
+}
+
+TEST_F(IntrusiveListTestSplice, splice_one_in_place) {
+  const size_t move_start = 1;
+  size_t a_size = list_a.length();
+  List1::iterator a_begin = list_a.begin();
+  List1::iterator a_end = list_a.end();
+  List1::iterator a_move_start = step_iterator(a_begin, move_start);
+  List1::iterator a_move_end = step_iterator(a_move_start, 1);
+
+  List1::iterator sresult = list_a.splice(a_move_end, list_a, a_move_start);
+  EXPECT_EQ(a_move_start, List1::const_iterator(sresult));
+  EXPECT_EQ(list_a.length(), a_size);
+  EXPECT_EQ(list_a.begin(), a_begin);
+  EXPECT_EQ(list_a.end(), a_end);
+  EXPECT_EQ(a_move_start, step_iterator(a_begin, move_start));
+  EXPECT_EQ(a_move_end, step_iterator(a_begin, move_start + 1));
+  {
+    SCOPED_TRACE("check values");
+    check(a_begin, a_end, 0);
+  }
+}
+
+TEST_F(IntrusiveListTestSplice, splice_into_const) {
+  CList1 clist{};
+  size_t a_size = list_a.length();
+  size_t b_size = list_b.length();
+  CList1::iterator sresult_a = clist.splice(clist.end(), list_a);
+  CList1::iterator sresult_b = clist.splice(clist.end(), list_b);
+  EXPECT_EQ(clist.length(), a_size + b_size);
+  EXPECT_EQ(sresult_a, clist.begin());
+  {
+    SCOPED_TRACE("check values");
+    check(clist.begin(), clist.end(), 0);
+  }
+  // This doesn't compile, which is as expected.  Transfer from list with
+  // const elements to a list with non-const elements is disallowed, because
+  // it implicitly casts away const.
+  // List1::iterator sresult_c = list_a.splice(list_a.end(), clist);
+  clist.clear();
+}
+
+TEST_F(IntrusiveListTestSplice, swap) {
+  List1::reference front_a = list_a.front();
+  List1::reference front_b = list_b.front();
+  list_a.swap(list_b);
+  EXPECT_EQ(&front_a, &list_b.front());
+  EXPECT_EQ(&front_b, &list_a.front());
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// iterator_to - const and non-const
+
+#define CHECK_ITERATOR_TYPE(the_iterator, expected_type)                    \
+  static_assert(std::is_same<decltype(the_iterator), expected_type>::value, \
+                "unexpected iterator type")                                 \
+  /* */
+
+TEST_F(IntrusiveListTestWithList1, iterator_to) {
+  {
+    List1::pointer pvalue = values[3];
+    auto it = list1.iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, List1::iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    List1::const_pointer pvalue = values[3];
+    auto it = list1.iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, List1::const_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    List1::pointer pvalue = values[3];
+    auto it = list1.const_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, List1::const_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    const List1& clist1 = list1;
+    List1::pointer pvalue = values[3];
+    auto it = clist1.iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, List1::const_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    List1::pointer pvalue = values[3];
+    auto it = list1.reverse_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, List1::reverse_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    List1::const_pointer pvalue = values[3];
+    auto it = list1.reverse_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, List1::const_reverse_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    List1::pointer pvalue = values[3];
+    auto it = list1.const_reverse_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, List1::const_reverse_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    const List1& clist1 = list1;
+    List1::pointer pvalue = values[3];
+    auto it = clist1.reverse_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, List1::const_reverse_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+}
+
+TEST_F(IntrusiveListTestWithCList1, iterator_to_const) {
+  {
+    CList1::pointer pvalue = values[3];
+    auto it = list1.iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, CList1::iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    CList1::const_pointer pvalue = values[3];
+    auto it = list1.iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, CList1::const_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    CList1::pointer pvalue = values[3];
+    auto it = list1.const_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, CList1::const_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    const CList1& clist1 = list1;
+    CList1::pointer pvalue = values[3];
+    auto it = clist1.iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, CList1::const_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    CList1::pointer pvalue = values[3];
+    auto it = list1.reverse_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, CList1::reverse_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    CList1::const_pointer pvalue = values[3];
+    auto it = list1.reverse_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, CList1::const_reverse_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    CList1::pointer pvalue = values[3];
+    auto it = list1.const_reverse_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, CList1::const_reverse_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+
+  {
+    const CList1& clist1 = list1;
+    CList1::pointer pvalue = values[3];
+    auto it = clist1.reverse_iterator_to(*pvalue);
+    CHECK_ITERATOR_TYPE(it, CList1::const_reverse_iterator);
+    EXPECT_EQ(pvalue, it->This());
+  }
+}
+
+#undef CHECK_ITERATOR_TYPE
+
+//////////////////////////////////////////////////////////////////////////////
+// optional constant-time size
+
+class IntrusiveListTestWithSize : public IntrusiveListTestWithValues {
+  typedef IntrusiveListTestWithValues super;
+
+public:
+  typedef IntrusiveList<Value, &Value::_entry1, true> ListWithSize;
+  typedef IntrusiveList<Value, &Value::_entry1, true, CHeapObj<mtInternal> > CHeapListWithSize;
+
+  virtual void SetUp() {
+    super::SetUp();
+    fill_list();
+  }
+
+  virtual void TearDown() {
+    list.clear();
+    EXPECT_EQ(0u, list.size());
+    EXPECT_EQ(list.length(), list.size());
+    super::TearDown();
+  }
+
+  void fill_list() {
+    for (size_t i = 0; i < nvalues; ++i) {
+      if (is_even(i)) {
+        list.push_back(*values[i]);
+      } else {
+        list.push_front(*values[i]);
+      }
+      EXPECT_EQ(i + 1, list.size());
+      EXPECT_EQ(list.length(), list.size());
+    }
+  }
+
+  struct NopDisposer {
+    void operator()(const Value& value) const {}
+  };
+
+  ListWithSize list;
+};
+
+// Test push_front/back and clear.
+// Everything is in the setup/teardown
+TEST_F(IntrusiveListTestWithSize, basics) {}
+
+TEST_F(IntrusiveListTestWithSize, pop) {
+  size_t expected = nvalues;
+  STATIC_ASSERT(4 <= nvalues);
+
+  list.pop_back();
+  --expected;
+  EXPECT_EQ(expected, list.size());
+  EXPECT_EQ(list.length(), list.size());
+
+  list.pop_back_and_dispose(NopDisposer());
+  --expected;
+  EXPECT_EQ(expected, list.size());
+  EXPECT_EQ(list.length(), list.size());
+
+  list.pop_front();
+  --expected;
+  EXPECT_EQ(expected, list.size());
+  EXPECT_EQ(list.length(), list.size());
+
+  list.pop_front_and_dispose(NopDisposer());
+  --expected;
+  EXPECT_EQ(expected, list.size());
+  EXPECT_EQ(list.length(), list.size());
+}
+
+TEST_F(IntrusiveListTestWithSize, erase) {
+  typedef ListWithSize::const_iterator const_iterator;
+
+  size_t expected = nvalues;
+  STATIC_ASSERT(7 <= nvalues);
+
+  list.erase(++list.begin());
+  --expected;
+  EXPECT_EQ(expected, list.size());
+  EXPECT_EQ(list.length(), list.size());
+
+  list.erase_and_dispose(++list.begin(), NopDisposer());
+  --expected;
+  EXPECT_EQ(expected, list.size());
+  EXPECT_EQ(list.length(), list.size());
+
+  {
+    const_iterator start = ++list.begin();
+    const_iterator end = step_iterator(start, 2);
+    list.erase(start, end);
+    expected -= 2;
+    EXPECT_EQ(expected, list.size());
+    EXPECT_EQ(list.length(), list.size());
+  }
+
+  {
+    const_iterator start = ++list.begin();
+    const_iterator end = step_iterator(start, 2);
+    list.erase_and_dispose(start, end, NopDisposer());
+    expected -= 2;
+    EXPECT_EQ(expected, list.size());
+    EXPECT_EQ(list.length(), list.size());
+  }
+}
+
+TEST_F(IntrusiveListTestWithSize, splice) {
+  using iterator = ListWithSize::iterator;
+  List1 list1;
+
+  // Transfer part of list to list1.
+  iterator from = step_iterator(list.begin(), 2);
+  iterator to = step_iterator(from, 4);
+  list1.splice(list1.end(), list, from, to);
+  EXPECT_EQ(nvalues - 4, list.size());
+  EXPECT_EQ(list.length(), list.size());
+  EXPECT_EQ(4u, list1.length());
+
+  // Transfer all of list1 back to list.
+  list.splice(to, list1);
+  EXPECT_EQ(nvalues, list.size());
+  EXPECT_EQ(list.length(), list.size());
+  EXPECT_TRUE(list1.empty());
+
+  // Transfer all of list to list1.
+  // Transferring entire list having size() operation is special-cased.
+  list1.splice(list1.end(), list);
+  EXPECT_EQ(0u, list.size());
+  EXPECT_EQ(list.length(), list.size());
+  EXPECT_TRUE(list.empty());
+  EXPECT_EQ(nvalues, list1.length());
+
+  list1.clear();
+}

--- a/test/hotspot/gtest/utilities/test_intrusiveList.cpp
+++ b/test/hotspot/gtest/utilities/test_intrusiveList.cpp
@@ -182,8 +182,8 @@ public:
   public:
     CollectingDisposer(IntrusiveListTestWithDisposal* test) : _test(test) { }
 
-    void operator()(const Value& value) const {
-      _test->disposed[_test->ndisposed++] = &value;
+    void operator()(const Value* value) const {
+      _test->disposed[_test->ndisposed++] = value;
     }
 
   private:
@@ -1596,7 +1596,7 @@ public:
   }
 
   struct NopDisposer {
-    void operator()(const Value& value) const {}
+    void operator()(const Value* value) const {}
   };
 
   ListWithSize list;

--- a/test/hotspot/gtest/utilities/test_intrusiveList.cpp
+++ b/test/hotspot/gtest/utilities/test_intrusiveList.cpp
@@ -238,7 +238,7 @@ TEST(IntrusiveListBasics, construct_CHeapObj) {
 
 ////////////////////
 // push_front(), pop_front(), length(), empty()
-// front(), back(), operator[]
+// front(), back()
 
 TEST_F(IntrusiveListTestWithValues, push_front) {
   List1 list1;
@@ -302,9 +302,6 @@ TEST_F(IntrusiveListTestWithValues, push_back) {
       EXPECT_EQ(i++, v.value());
     }
   }
-  for (size_t i = 0; i < nvalues; ++i) {
-    EXPECT_EQ(i, list2[i].value());
-  }
   list2.clear();
 }
 
@@ -328,9 +325,6 @@ TEST_F(IntrusiveListTestWithValues, push_back_const) {
     for (const Value& v : list2) {
       EXPECT_EQ(i++, v.value());
     }
-  }
-  for (size_t i = 0; i < nvalues; ++i) {
-    EXPECT_EQ(i, list2[i].value());
   }
   list2.clear();
 }

--- a/test/hotspot/gtest/utilities/test_intrusiveList.cpp
+++ b/test/hotspot/gtest/utilities/test_intrusiveList.cpp
@@ -52,6 +52,8 @@ struct TestIntrusiveListValue : public CHeapObj<mtInternal> {
   using Value = TestIntrusiveListValue; // convenience
 
   size_t value() const { return _value; }
+  bool is_attached1() const { return _entry1.is_attached(); }
+  bool is_attached2() const { return _entry2.is_attached(); }
   Value* This() { return this; }
   const Value* This() const { return this; }
 };
@@ -238,7 +240,11 @@ TEST(IntrusiveListBasics, construct_CHeapObj) {
 TEST_F(IntrusiveListTestWithValues, push_front) {
   List1 list1;
   for (size_t i = 0; i < nvalues; ++i) {
+    EXPECT_FALSE(values[i]->is_attached1());
+    EXPECT_FALSE(values[i]->is_attached2());
     list1.push_front(*values[i]);
+    EXPECT_TRUE(values[i]->is_attached1());
+    EXPECT_FALSE(values[i]->is_attached2());
     EXPECT_FALSE(list1.empty());
     EXPECT_EQ(i + 1, list1.length());
     EXPECT_EQ(values[i]->value(), list1.front().value());


### PR DESCRIPTION
Please review this new facility, providing a general mechanism for intrusive
doubly-linked lists. A class supports inclusion in a list by having an
IntrusiveListEntry member, and providing structured information about how to
access that member. A class supports inclusion in multiple lists by having
multiple IntrusiveListEntry members, with different lists specified to use
different members.

The IntrusiveList class template provides the list management. It is modelled
on bidirectional containers such as std::list and boost::intrusive::list,
providing many of the expected member types and functions. (Note that the
member types use the Standard's naming conventions.) (Not all standard
container requirements are met; some operations are not presently supported
because they haven't been needed yet.) This includes iteration support using
(mostly) standard-conforming iterator types (they are presently missing
iterator_category member types, pending being able to include <iterator> so we
can use std::bidirectional_iterator_tag).

This change only provides the new facility, and doesn't include any uses of
it. It is intended to replace the 4-5 (or maybe more) competing intrusive
doubly-linked lists presently in HotSpot.  Unlike most (or perhaps all?) of
those alterantives, this proposal provides a suite of unit tests.

An example of a place that I think might benefit from this is G1's region
handling. There are various places where G1 iterates over all regions in order
to do something with those which satisfy some property (humongous regions,
regions in the collection set, &etc). If it were trivial to create new region
sublists (and this facility makes that easy), some of these could be turned
into direct iteration over only the regions of interest.

Some specific points to consider when reviewing this proposal:

(1) This proposal follows Standard Library API conventions, which differ from
HotSpot in various ways.

(1a) Lists and iterators provide various type members, with names per the
Standard Library. There has been discussion of using some parts of the
Standard Library eventually, in which case this would be important. But for
now some of the naming choices are atypical for HotSpot.

(1b) Some of the function signatures follow the Standard Library APIs even
though the reasons for that form might not apply to HotSpot. For example, the
list pop operations don't return the removed value. For node-based containers
in Standard Library that would introduce exception safety problems, so the
Standard Library API is designed to avoid that. HotSpot doesn't use
exceptions, so the exception safety issue isn't relevant. And for an intrusive
container like this, there isn't an exception safety problem anyway for pop
operations.

(2) It has been suggested this class should be named "List" rather than
"IntrusiveList", as this should be the "list" one usually reaches for in
HotSpot code (because no allocation is involved in list manipulation), and if
one wanted the other kind of list then just use std::list (if we permitted use
of some of the Standard Library).

(3) This proposal use a pointer-to-data-member to access the embedded list
entry in an object. NonblockingQueue and LockFreeStack use a function for that
access. There was a version of MSVC where the pointer to data member approach
didn't work. It also didn't work on some versions of Solaris Studio. Those are
no longer problems for us. We could change those other classes, or we could
change this to similarly use a function, or we could have the inconsistency.

(4) This proposal provides support for a parameterized IntrusiveList allocation
base. If we were using the Standard Library we would need a solution for heap
allocation of Standard Library containers. If we had such, it might be simpler
to use that same approach for this class, rather than using the allocation
base class approach. This of course assumes that there is a need for
heap/resource/arena allocated lists.

Testing:
mach5 tier1, building for all Oracle-supported platforms and running the new
unit tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8189088](https://bugs.openjdk.org/browse/JDK-8189088): Add intrusive doubly-linked list utility (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15896/head:pull/15896` \
`$ git checkout pull/15896`

Update a local copy of the PR: \
`$ git checkout pull/15896` \
`$ git pull https://git.openjdk.org/jdk.git pull/15896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15896`

View PR using the GUI difftool: \
`$ git pr show -t 15896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15896.diff">https://git.openjdk.org/jdk/pull/15896.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15896#issuecomment-1744024440)