### PR TITLE
8316851: Add @sealedGraph to Executable

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -46,6 +46,7 @@ import sun.reflect.generics.repository.ConstructorRepository;
  * A shared superclass for the common functionality of {@link Method}
  * and {@link Constructor}.
  *
+ * @sealedGraph
  * @since 1.8
  */
 public abstract sealed class Executable extends AccessibleObject


### PR DESCRIPTION
This PR proposes to add the @sealedGraph tag to `java.lang.reflect.Executable`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316851](https://bugs.openjdk.org/browse/JDK-8316851): Add @<!---->sealedGraph to Executable (**Sub-task** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [6b27cf5a](https://git.openjdk.org/jdk/pull/15897/files/6b27cf5a3eafa1dca3d2a941c2bbdc19489dea1e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15897/head:pull/15897` \
`$ git checkout pull/15897`

Update a local copy of the PR: \
`$ git checkout pull/15897` \
`$ git pull https://git.openjdk.org/jdk.git pull/15897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15897`

View PR using the GUI difftool: \
`$ git pr show -t 15897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15897.diff">https://git.openjdk.org/jdk/pull/15897.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15897#issuecomment-1733152113)