### PR TITLE
8315716: RISC-V: implement ChaCha20 intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1790,6 +1790,11 @@ enum Nf {
   INSN(vlse32_v, 0b0000111, 0b110, 0b10, 0b0);
   INSN(vlse64_v, 0b0000111, 0b111, 0b10, 0b0);
 
+  INSN(vsse8_v,  0b0100111, 0b000, 0b10, 0b0);
+  INSN(vsse16_v, 0b0100111, 0b101, 0b10, 0b0);
+  INSN(vsse32_v, 0b0100111, 0b110, 0b10, 0b0);
+  INSN(vsse64_v, 0b0100111, 0b111, 0b10, 0b0);
+
 #undef INSN
 #undef patch_VLdSt
 

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -143,6 +143,10 @@ constexpr Register x19_sender_sp = x19; // Sender's SP while in interpreter
 constexpr Register t0 = x5;
 constexpr Register t1 = x6;
 constexpr Register t2 = x7;
+constexpr Register t3 = x28;
+constexpr Register t4 = x29;
+constexpr Register t5 = x30;
+constexpr Register t6 = x31;
 
 const Register g_INTArgReg[Argument::n_int_register_parameters_c] = {
   c_rarg0, c_rarg1, c_rarg2, c_rarg3, c_rarg4, c_rarg5, c_rarg6, c_rarg7

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -143,10 +143,6 @@ constexpr Register x19_sender_sp = x19; // Sender's SP while in interpreter
 constexpr Register t0 = x5;
 constexpr Register t1 = x6;
 constexpr Register t2 = x7;
-constexpr Register t3 = x28;
-constexpr Register t4 = x29;
-constexpr Register t5 = x30;
-constexpr Register t6 = x31;
 
 const Register g_INTArgReg[Argument::n_int_register_parameters_c] = {
   c_rarg0, c_rarg1, c_rarg2, c_rarg3, c_rarg4, c_rarg5, c_rarg6, c_rarg7

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2016,6 +2016,13 @@ void MacroAssembler::andi(Register Rd, Register Rn, int64_t imm, Register tmp) {
   }
 }
 
+// rotate vector register left with shift bits, 32-bit version
+void MacroAssembler::vrol_vwi(VectorRegister vd, uint32_t shift, VectorRegister tmp_vr) {
+  vsrl_vi(tmp_vr, vd, 32 - shift);
+  vsll_vi(vd, vd, shift);
+  vor_vv(vd, vd, tmp_vr);
+}
+
 void MacroAssembler::orptr(Address adr, RegisterOrConstant src, Register tmp1, Register tmp2) {
   ld(tmp1, adr);
   if (src.is_register()) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2016,13 +2016,6 @@ void MacroAssembler::andi(Register Rd, Register Rn, int64_t imm, Register tmp) {
   }
 }
 
-// rotate vector register left with shift bits, 32-bit version
-void MacroAssembler::vrol_vwi(VectorRegister vd, uint32_t shift, VectorRegister tmp_vr) {
-  vsrl_vi(tmp_vr, vd, 32 - shift);
-  vsll_vi(vd, vd, shift);
-  vor_vv(vd, vd, tmp_vr);
-}
-
 void MacroAssembler::orptr(Address adr, RegisterOrConstant src, Register tmp1, Register tmp2) {
   ld(tmp1, adr);
   if (src.is_register()) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1289,6 +1289,9 @@ public:
   }
 
   // vector pseudo instructions
+  // rotate vector register left with shift bits, 32-bit version
+  void vrol_vwi(VectorRegister vd, uint32_t shift, VectorRegister tmp_vr);
+
   inline void vl1r_v(VectorRegister vd, Register rs) {
     vl1re8_v(vd, rs);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1290,7 +1290,11 @@ public:
 
   // vector pseudo instructions
   // rotate vector register left with shift bits, 32-bit version
-  void vrol_vwi(VectorRegister vd, uint32_t shift, VectorRegister tmp_vr);
+  inline void vrol_vwi(VectorRegister vd, uint32_t shift, VectorRegister tmp_vr) {
+    vsrl_vi(tmp_vr, vd, 32 - shift);
+    vsll_vi(vd, vd, shift);
+    vor_vv(vd, vd, tmp_vr);
+  }
 
   inline void vl1r_v(VectorRegister vd, Register rs) {
     vl1re8_v(vd, rs);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1290,7 +1290,7 @@ public:
 
   // vector pseudo instructions
   // rotate vector register left with shift bits, 32-bit version
-  inline void vrol_vwi(VectorRegister vd, uint32_t shift, VectorRegister tmp_vr) {
+  inline void vrole32_vi(VectorRegister vd, uint32_t shift, VectorRegister tmp_vr) {
     vsrl_vi(tmp_vr, vd, 32 - shift);
     vsll_vi(vd, vd, shift);
     vor_vv(vd, vd, tmp_vr);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4340,7 +4340,7 @@ class StubGenerator: public StubCodeGenerator {
     // Put 16 here, as com.sun.crypto.providerChaCha20Cipher.KS_MAX_LEN is 1024
     // in java level.
     __ li(avl, 16);
-    __ vsetvli(length, avl, Assembler::e32, Assembler::m1, Assembler::ma, Assembler::ta);
+    __ vsetvli(length, avl, Assembler::e32, Assembler::m1);
 
     // Load from source state
     __ mv(tmp_addr, state);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4342,7 +4342,7 @@ class StubGenerator: public StubCodeGenerator {
       v8, v9, v10, v11, v12, v13, v14, v15
     };
     const VectorRegister tmp_vr = v16;
-    const VectorRegister counter = v17;
+    const VectorRegister counter_vr = v17;
 
     {
       // Put 16 here, as com.sun.crypto.providerChaCha20Cipher.KS_MAX_LEN is 1024
@@ -4358,8 +4358,8 @@ class StubGenerator: public StubCodeGenerator {
       __ addi(tmp_addr, tmp_addr, step);
     }
     // Adjust counter for every individual block.
-    __ vid_v(counter);
-    __ vadd_vv(work_vrs[12], work_vrs[12], counter);
+    __ vid_v(counter_vr);
+    __ vadd_vv(work_vrs[12], work_vrs[12], counter_vr);
 
     // Perform 10 iterations of the 8 quarter round set
     {
@@ -4367,15 +4367,15 @@ class StubGenerator: public StubCodeGenerator {
       __ mv(loop, 10);
       __ BIND(L_Rounds);
 
-      chacha20_quarter_round(work_vrs[0], work_vrs[4], work_vrs[8], work_vrs[12], tmp_vr);
-      chacha20_quarter_round(work_vrs[1], work_vrs[5], work_vrs[9], work_vrs[13], tmp_vr);
+      chacha20_quarter_round(work_vrs[0], work_vrs[4], work_vrs[8],  work_vrs[12], tmp_vr);
+      chacha20_quarter_round(work_vrs[1], work_vrs[5], work_vrs[9],  work_vrs[13], tmp_vr);
       chacha20_quarter_round(work_vrs[2], work_vrs[6], work_vrs[10], work_vrs[14], tmp_vr);
       chacha20_quarter_round(work_vrs[3], work_vrs[7], work_vrs[11], work_vrs[15], tmp_vr);
 
       chacha20_quarter_round(work_vrs[0], work_vrs[5], work_vrs[10], work_vrs[15], tmp_vr);
       chacha20_quarter_round(work_vrs[1], work_vrs[6], work_vrs[11], work_vrs[12], tmp_vr);
-      chacha20_quarter_round(work_vrs[2], work_vrs[7], work_vrs[8], work_vrs[13], tmp_vr);
-      chacha20_quarter_round(work_vrs[3], work_vrs[4], work_vrs[9], work_vrs[14], tmp_vr);
+      chacha20_quarter_round(work_vrs[2], work_vrs[7], work_vrs[8],  work_vrs[13], tmp_vr);
+      chacha20_quarter_round(work_vrs[3], work_vrs[4], work_vrs[9],  work_vrs[14], tmp_vr);
 
       __ sub(loop, loop, 1);
       __ bnez(loop, L_Rounds);
@@ -4391,7 +4391,7 @@ class StubGenerator: public StubCodeGenerator {
       __ vadd_vv(work_vrs[i], work_vrs[i], tmp_vr);
     }
     // Add the counter overlay onto work_vrs[12] at the end.
-    __ vadd_vv(work_vrs[12], work_vrs[12], counter);
+    __ vadd_vv(work_vrs[12], work_vrs[12], counter_vr);
 
     // Store result to key stream.
     {

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4335,7 +4335,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // Put 16 here, as com.sun.crypto.providerChaCha20Cipher.KS_MAX_LEN is 1024
     // in java level.
-    __ li(avl, 16);
+    __ mv(avl, 16);
     __ vsetvli(length, avl, Assembler::e32, Assembler::m1);
 
     // Load from source state
@@ -4348,7 +4348,7 @@ class StubGenerator: public StubCodeGenerator {
     __ vadd_vv(work_vrs[12], work_vrs[12], counter);
 
     // Perform 10 iterations of the 8 quarter round set
-    __ li(loop, 10);
+    __ mv(loop, 10);
     __ BIND(L_Rounds);
 
     chacha20_quarter_round(work_vrs[0], work_vrs[4], work_vrs[8], work_vrs[12], tmp_vr);
@@ -4374,7 +4374,7 @@ class StubGenerator: public StubCodeGenerator {
     __ vadd_vv(work_vrs[12], work_vrs[12], counter);
 
     // Store result to key stream
-    __ li(stride, 64);
+    __ mv(stride, 64);
     for (int i = 0; i < states_len; i += 1) {
       __ vsse32_v(work_vrs[i], key_stream, stride);
       __ addi(key_stream, key_stream, step);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4323,8 +4323,8 @@ class StubGenerator: public StubCodeGenerator {
     const Register loop = t0;
     const Register tmp_addr = t1;
     const Register length = t2;
-    const Register avl = x28;
-    const Register stride = x29;
+    const Register avl = t3;
+    const Register stride = t4;
 
     const VectorRegister work_vrs[16] = {
       v4,  v5,  v6,  v7,  v16, v17, v18, v19,
@@ -4332,10 +4332,6 @@ class StubGenerator: public StubCodeGenerator {
     };
     const VectorRegister tmp_vr = v29;
     const VectorRegister counter = v30;
-
-
-    RegSet saved_regs;
-    __ push_reg(saved_regs, sp);
 
     // Put 16 here, as com.sun.crypto.providerChaCha20Cipher.KS_MAX_LEN is 1024
     // in java level.
@@ -4387,7 +4383,6 @@ class StubGenerator: public StubCodeGenerator {
     // Return length of output key_stream
     __ slli(c_rarg0, length, 6);
 
-    __ pop_reg(saved_regs, sp);
     __ ret();
 
     return (address) start;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4277,29 +4277,36 @@ class StubGenerator: public StubCodeGenerator {
     return (address) start;
   }
 
+  /**
+   * Perform the quarter round calculations on values contained within four vector registers.
+   *
+   * @param aVec the SIMD register containing only the "a" values
+   * @param bVec the SIMD register containing only the "b" values
+   * @param cVec the SIMD register containing only the "c" values
+   * @param dVec the SIMD register containing only the "d" values
+   * @param tmp_vr temporary vector register holds intermedia values.
+   */
   void chacha20_quarter_round(VectorRegister aVec, VectorRegister bVec,
                           VectorRegister cVec, VectorRegister dVec, VectorRegister tmp_vr) {
     // a += b, d ^= a, d <<<= 16
     __ vadd_vv(aVec, aVec, bVec);
     __ vxor_vv(dVec, dVec, aVec);
-    __ vrol_vwi(dVec, 16, tmp_vr);
-
-    // rev32(dVec, T8H, dVec);
+    __ vrole32_vi(dVec, 16, tmp_vr);
 
     // c += d, b ^= c, b <<<= 12
     __ vadd_vv(cVec, cVec, dVec);
     __ vxor_vv(bVec, bVec, cVec);
-    __ vrol_vwi(bVec, 12, tmp_vr);
+    __ vrole32_vi(bVec, 12, tmp_vr);
 
     // a += b, d ^= a, d <<<= 8
     __ vadd_vv(aVec, aVec, bVec);
     __ vxor_vv(dVec, dVec, aVec);
-    __ vrol_vwi(dVec, 8, tmp_vr);
+    __ vrole32_vi(dVec, 8, tmp_vr);
 
     // c += d, b ^= c, b <<<= 7
     __ vadd_vv(cVec, cVec, dVec);
     __ vxor_vv(bVec, bVec, cVec);
-    __ vrol_vwi(bVec, 7, tmp_vr);
+    __ vrole32_vi(bVec, 7, tmp_vr);
   }
 
   /**
@@ -4308,6 +4315,10 @@ class StubGenerator: public StubCodeGenerator {
    *  Input arguments:
    *  c_rarg0   - state, the starting state
    *  c_rarg1   - key_stream, the array that will hold the result of the ChaCha20 block function
+   *
+   *  Implementation Note:
+   *   Parallelization is achieved by loading individual state elements into vectors for N blocks.
+   *   N depends on single vector register length.
    */
   address generate_chacha20Block() {
     Label L_Rounds;
@@ -4315,35 +4326,38 @@ class StubGenerator: public StubCodeGenerator {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", "chacha20Block");
     address start = __ pc();
+    __ enter();
 
     const int states_len = 16;
     const int step = 4;
     const Register state = c_rarg0;
     const Register key_stream = c_rarg1;
-    const Register length = t0;
-    const Register tmp_addr = t1;
+    const Register tmp_addr = t0;
+    const Register length = t1;
 
+    // Organize vector registers in an array that facilitates
+    // putting repetitive opcodes into loop structures below.
     const VectorRegister work_vrs[16] = {
-      v4,  v5,  v6,  v7,  v16, v17, v18, v19,
-      v20, v21, v22, v23, v24, v25, v26, v27
+      v0, v1, v2,  v3,  v4,  v5,  v6,  v7,
+      v8, v9, v10, v11, v12, v13, v14, v15
     };
-    const VectorRegister tmp_vr = v29;
-    const VectorRegister counter = v30;
+    const VectorRegister tmp_vr = v16;
+    const VectorRegister counter = v17;
 
     {
-      const Register avl = t2; // share t2 with other non-overlapping usages.
       // Put 16 here, as com.sun.crypto.providerChaCha20Cipher.KS_MAX_LEN is 1024
       // in java level.
-      __ mv(avl, 16);
-      __ vsetvli(length, avl, Assembler::e32, Assembler::m1);
+      __ vsetivli(length, 16, Assembler::e32, Assembler::m1);
     }
 
-    // Load from source state
+    // Load from source state.
+    // Every element in source state is duplicated to all elements in the corresponding vector.
     __ mv(tmp_addr, state);
     for (int i = 0; i < states_len; i += 1) {
       __ vlse32_v(work_vrs[i], tmp_addr, zr);
       __ addi(tmp_addr, tmp_addr, step);
     }
+    // Adjust counter for every individual block.
     __ vid_v(counter);
     __ vadd_vv(work_vrs[12], work_vrs[12], counter);
 
@@ -4367,18 +4381,22 @@ class StubGenerator: public StubCodeGenerator {
       __ bnez(loop, L_Rounds);
     }
 
-    // Add the end working state back into the original state
+    // Add the original state into the end working state.
+    // We do this by first duplicating every element in source state array to the corresponding
+    // vector, then adding it to the post-loop working state.
     __ mv(tmp_addr, state);
     for (int i = 0; i < states_len; i += 1) {
       __ vlse32_v(tmp_vr, tmp_addr, zr);
       __ addi(tmp_addr, tmp_addr, step);
       __ vadd_vv(work_vrs[i], work_vrs[i], tmp_vr);
     }
+    // Add the counter overlay onto work_vrs[12] at the end.
     __ vadd_vv(work_vrs[12], work_vrs[12], counter);
 
-    // Store result to key stream
+    // Store result to key stream.
     {
       const Register stride = t2; // share t2 with other non-overlapping usages.
+      // Every block occupies 64 bytes, so we use 64 as stride of the vector store.
       __ mv(stride, 64);
       for (int i = 0; i < states_len; i += 1) {
         __ vsse32_v(work_vrs[i], key_stream, stride);
@@ -4389,6 +4407,7 @@ class StubGenerator: public StubCodeGenerator {
     // Return length of output key_stream
     __ slli(c_rarg0, length, 6);
 
+    __ leave();
     __ ret();
 
     return (address) start;

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -254,7 +254,7 @@ void VM_Version::initialize() {
     }
   } else if (UseChaCha20Intrinsics) {
     if (!FLAG_IS_DEFAULT(UseChaCha20Intrinsics)) {
-      warning("Chacha20 Intrinsics requires RVV instructions (not available on this CPU)");
+      warning("Chacha20 intrinsic requires RVV instructions (not available on this CPU)");
     }
     FLAG_SET_DEFAULT(UseChaCha20Intrinsics, false);
   }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -186,10 +186,6 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, true);
   }
 
-  if (UseRVV && FLAG_IS_DEFAULT(UseChaCha20Intrinsics)) {
-    FLAG_SET_DEFAULT(UseChaCha20Intrinsics, true);
-  }
-
   if (UseRVV) {
     if (!ext_V.enabled()) {
       warning("RVV is not supported on this CPU");
@@ -251,6 +247,11 @@ void VM_Version::initialize() {
   } else if (UseBlockZeroing) {
     warning("Block zeroing is not available");
     FLAG_SET_DEFAULT(UseBlockZeroing, false);
+  }
+  if (UseRVV) {
+    if (FLAG_IS_DEFAULT(UseChaCha20Intrinsics)) {
+      FLAG_SET_DEFAULT(UseChaCha20Intrinsics, true);
+    }
   }
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -252,6 +252,11 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseChaCha20Intrinsics)) {
       FLAG_SET_DEFAULT(UseChaCha20Intrinsics, true);
     }
+  } else if (UseChaCha20Intrinsics) {
+    if (!FLAG_IS_DEFAULT(UseChaCha20Intrinsics)) {
+      warning("Chacha20 Intrinsics requires RVV instructions (not available on this CPU)");
+    }
+    FLAG_SET_DEFAULT(UseChaCha20Intrinsics, false);
   }
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -186,6 +186,10 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, true);
   }
 
+  if (UseRVV && FLAG_IS_DEFAULT(UseChaCha20Intrinsics)) {
+    FLAG_SET_DEFAULT(UseChaCha20Intrinsics, true);
+  }
+
   if (UseRVV) {
     if (!ext_V.enabled()) {
       warning("RVV is not supported on this CPU");


### PR DESCRIPTION
Only vector version is included in this patch.

### Test
The patch passed the jdk tests found via `find test/jdk/ -iname *ChaCha*`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315716](https://bugs.openjdk.org/browse/JDK-8315716): RISC-V: implement ChaCha20 intrinsic (**Enhancement** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer) ⚠️ Review applies to [fc19cb23](https://git.openjdk.org/jdk/pull/15899/files/fc19cb2326de6f77e7b8de8ced628c6eb114a981)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [3b42ce13](https://git.openjdk.org/jdk/pull/15899/files/3b42ce1340cdf1762adf2d7168eff6f65a5dc382)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15899/head:pull/15899` \
`$ git checkout pull/15899`

Update a local copy of the PR: \
`$ git checkout pull/15899` \
`$ git pull https://git.openjdk.org/jdk.git pull/15899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15899`

View PR using the GUI difftool: \
`$ git pr show -t 15899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15899.diff">https://git.openjdk.org/jdk/pull/15899.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15899#issuecomment-1737103924)