### PR TITLE
8316885: jcmd: Compiler.CodeHeap_Analytics cmd does not inform about missing aggregate

### DIFF
--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -1216,6 +1216,7 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
 
 void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
   if (!initialization_complete) {
+    print_aggregate_missing(out, nullptr);
     return;
   }
 
@@ -1223,6 +1224,7 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
   get_HeapStatGlobals(out, heapName);
 
   if ((StatArray == nullptr) || (TopSizeArray == nullptr) || (used_topSizeBlocks == 0)) {
+    print_aggregate_missing(out, heapName);
     return;
   }
   BUFFEREDSTREAM_DECL(ast, out)
@@ -1426,6 +1428,7 @@ void CodeHeapState::print_usedSpace(outputStream* out, CodeHeap* heap) {
 
 void CodeHeapState::print_freeSpace(outputStream* out, CodeHeap* heap) {
   if (!initialization_complete) {
+    print_aggregate_missing(out, nullptr);
     return;
   }
 
@@ -1433,6 +1436,7 @@ void CodeHeapState::print_freeSpace(outputStream* out, CodeHeap* heap) {
   get_HeapStatGlobals(out, heapName);
 
   if ((StatArray == nullptr) || (FreeArray == nullptr) || (alloc_granules == 0)) {
+    print_aggregate_missing(out, heapName);
     return;
   }
   BUFFEREDSTREAM_DECL(ast, out)
@@ -1600,6 +1604,7 @@ void CodeHeapState::print_freeSpace(outputStream* out, CodeHeap* heap) {
 
 void CodeHeapState::print_count(outputStream* out, CodeHeap* heap) {
   if (!initialization_complete) {
+    print_aggregate_missing(out, nullptr);
     return;
   }
 
@@ -1607,6 +1612,7 @@ void CodeHeapState::print_count(outputStream* out, CodeHeap* heap) {
   get_HeapStatGlobals(out, heapName);
 
   if ((StatArray == nullptr) || (alloc_granules == 0)) {
+    print_aggregate_missing(out, heapName);
     return;
   }
   BUFFEREDSTREAM_DECL(ast, out)
@@ -1758,6 +1764,7 @@ void CodeHeapState::print_count(outputStream* out, CodeHeap* heap) {
 
 void CodeHeapState::print_space(outputStream* out, CodeHeap* heap) {
   if (!initialization_complete) {
+    print_aggregate_missing(out, nullptr);
     return;
   }
 
@@ -1765,6 +1772,7 @@ void CodeHeapState::print_space(outputStream* out, CodeHeap* heap) {
   get_HeapStatGlobals(out, heapName);
 
   if ((StatArray == nullptr) || (alloc_granules == 0)) {
+    print_aggregate_missing(out, heapName);
     return;
   }
   BUFFEREDSTREAM_DECL(ast, out)
@@ -1927,6 +1935,7 @@ void CodeHeapState::print_space(outputStream* out, CodeHeap* heap) {
 
 void CodeHeapState::print_age(outputStream* out, CodeHeap* heap) {
   if (!initialization_complete) {
+    print_aggregate_missing(out, nullptr);
     return;
   }
 
@@ -1934,6 +1943,7 @@ void CodeHeapState::print_age(outputStream* out, CodeHeap* heap) {
   get_HeapStatGlobals(out, heapName);
 
   if ((StatArray == nullptr) || (alloc_granules == 0)) {
+    print_aggregate_missing(out, heapName);
     return;
   }
   BUFFEREDSTREAM_DECL(ast, out)
@@ -2039,6 +2049,7 @@ void CodeHeapState::print_age(outputStream* out, CodeHeap* heap) {
 
 void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
   if (!initialization_complete) {
+    print_aggregate_missing(out, nullptr);
     return;
   }
 
@@ -2046,6 +2057,7 @@ void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
   get_HeapStatGlobals(out, heapName);
 
   if ((StatArray == nullptr) || (alloc_granules == 0)) {
+    print_aggregate_missing(out, heapName);
     return;
   }
   BUFFEREDSTREAM_DECL(ast, out)
@@ -2340,6 +2352,14 @@ void CodeHeapState::print_line_delim(outputStream* out, bufferedStream* ast, cha
     ast->print(INTPTR_FORMAT, p2i(low_bound + ix*granule_size));
     ast->fill_to(19);
     ast->print("(+" UINT32_FORMAT_X_0 "): |", (unsigned int)(ix*granule_size));
+  }
+}
+
+void CodeHeapState::print_aggregate_missing(outputStream* out, const char* heapName) {
+  if (heapName == nullptr) {
+    out->print_cr("No aggregated code heap data available. Run function aggregate first.");
+  } else {
+    out->print_cr("No aggregated data available for heap %s. Run function aggregate first.", heapName);
   }
 }
 

--- a/src/hotspot/share/code/codeHeapState.hpp
+++ b/src/hotspot/share/code/codeHeapState.hpp
@@ -91,6 +91,7 @@ class CodeHeapState : public CHeapObj<mtCode> {
   static void print_age_single(outputStream *ast, int age);
   static void print_line_delim(outputStream* out, bufferedStream *sst, char* low_bound, unsigned int ix, unsigned int gpl);
   static void print_line_delim(outputStream* out, outputStream *sst, char* low_bound, unsigned int ix, unsigned int gpl);
+  static void print_aggregate_missing(outputStream* out, const char* heapName);
   static blobType get_cbType(CodeBlob* cb);
   static bool blob_access_is_safe(CodeBlob* this_blob);
   static bool nmethod_access_is_safe(nmethod* nm);


### PR DESCRIPTION
…missing aggregate

If jcmd users want to print statistical data about a specific property of the code heap (instead of requesting "all"), they first have to aggregate such data. If this step was forgotten, the requested function just returns. This should be improved. 

------ Output before enhancement -------- 
```
> bin/jcmd <pid> Compiler.CodeHeap_Analytics FreeSpace 
<pid>: 

__ CodeHeapStateAnalytics lock wait took 0.000 seconds _________ 

__ CodeHeapStateAnalytics total duration 0.000 seconds _________ 


```

------ Output after enhancement -------- 
```
> bin/jcmd <pid> Compiler.CodeHeap_Analytics FreeSpace 
<pid>: 

__ CodeHeapStateAnalytics lock wait took 0.000 seconds _________ 

No aggregated data available for heap CodeHeap. Run function aggregate first. 

__ CodeHeapStateAnalytics total duration 0.000 seconds _________ 
```

Comments and reviews are very much appreciated.
Tests (GHA and SAP-internal test suite) pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316885](https://bugs.openjdk.org/browse/JDK-8316885): jcmd: Compiler.CodeHeap_Analytics cmd does not inform about missing aggregate (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15900/head:pull/15900` \
`$ git checkout pull/15900`

Update a local copy of the PR: \
`$ git checkout pull/15900` \
`$ git pull https://git.openjdk.org/jdk.git pull/15900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15900`

View PR using the GUI difftool: \
`$ git pr show -t 15900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15900.diff">https://git.openjdk.org/jdk/pull/15900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15900#issuecomment-1733600371)