### PR TITLE
8315031: YoungPLABSize and OldPLABSize not aligned by ObjectAlignmentInBytes

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacStats.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacStats.cpp
@@ -133,7 +133,9 @@ G1EvacStats::G1EvacStats(const char* description, size_t default_per_thread_plab
 // Calculates plab size for current number of gc worker threads.
 size_t G1EvacStats::desired_plab_size(uint no_of_gc_workers) const {
   if (!ResizePLAB) {
-      return align_object_size(_default_plab_size);
+    // There is a circular dependency between the heap and PLAB initialization,
+    // so _default_plab_size can have an unaligned value.
+    return align_object_size(_default_plab_size);
   }
   return align_object_size(clamp(_desired_net_plab_size / no_of_gc_workers, min_size(), max_size()));
 }

--- a/src/hotspot/share/gc/g1/g1EvacStats.cpp
+++ b/src/hotspot/share/gc/g1/g1EvacStats.cpp
@@ -133,7 +133,7 @@ G1EvacStats::G1EvacStats(const char* description, size_t default_per_thread_plab
 // Calculates plab size for current number of gc worker threads.
 size_t G1EvacStats::desired_plab_size(uint no_of_gc_workers) const {
   if (!ResizePLAB) {
-      return _default_plab_size;
+      return align_object_size(_default_plab_size);
   }
   return align_object_size(clamp(_desired_net_plab_size / no_of_gc_workers, min_size(), max_size()));
 }

--- a/src/hotspot/share/gc/shared/plab.cpp
+++ b/src/hotspot/share/gc/shared/plab.cpp
@@ -51,6 +51,13 @@ void PLAB::startup_initialization() {
       FLAG_SET_ERGO(OldPLABSize, MAX2(ThreadLocalAllocBuffer::min_size(), OldPLABSize));
     }
   }
+  uint obj_alignment = checked_cast<uint>(ObjectAlignmentInBytes / HeapWordSize);
+  if (!is_aligned(YoungPLABSize, obj_alignment)) {
+    FLAG_SET_ERGO(YoungPLABSize, align_up(YoungPLABSize, obj_alignment));
+  }
+  if (!is_aligned(OldPLABSize, obj_alignment)) {
+    FLAG_SET_ERGO(OldPLABSize, align_up(OldPLABSize, obj_alignment));
+  }
 }
 
 PLAB::PLAB(size_t desired_plab_sz_) :


### PR DESCRIPTION
Simple fix around unaligned PLAB size. Due to a circular dependency between the heap and PLAB initialization in G1, `_default_plab_size` picks up unaligned PLAB sizes, hence the additional alignment there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315031](https://bugs.openjdk.org/browse/JDK-8315031): YoungPLABSize and OldPLABSize not aligned by ObjectAlignmentInBytes (**Bug** - P2)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15901/head:pull/15901` \
`$ git checkout pull/15901`

Update a local copy of the PR: \
`$ git checkout pull/15901` \
`$ git pull https://git.openjdk.org/jdk.git pull/15901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15901`

View PR using the GUI difftool: \
`$ git pr show -t 15901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15901.diff">https://git.openjdk.org/jdk/pull/15901.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15901#issuecomment-1733622442)