### PR TITLE
8311906: Race condition in String constructor

### DIFF
--- a/src/java.base/share/classes/java/lang/StringCoding.java
+++ b/src/java.base/share/classes/java/lang/StringCoding.java
@@ -41,6 +41,9 @@ class StringCoding {
     /**
      * Count the number of leading positive bytes in the range.
      *
+     * <br><strong>Warning: Make sure the byte array is not leaked to public,
+     * Or the bytes may be non-positive when the caller reads the array again!</strong>
+     *
      * @implSpec the implementation must return len if there are no negative
      *   bytes in the range. If there are negative bytes, the implementation must return
      *   a value that is less than or equal to the index of the first negative byte

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -158,6 +158,45 @@ final class StringUTF16 {
         return val;
     }
 
+    /**
+     * Compresses a UTF16 array to LATIN1 if possible. Will not return
+     * a compressible UTF16 array with any 0-valued significant bytes,
+     * which is erroneous if COMPACT_STRING is enabled.
+     */
+    public static byte[] maybeCompressUntrusted(char[] val, int off, int len) {
+        byte[] compressed = new byte[len];
+        if (compress(val, off, compressed, 0, len) == len) {
+            return compressed;
+        }
+
+        byte[] trusted = toBytes(val, off, len); // now not leaked
+        if (compress(trusted, 0, compressed, 0, len) == len) {
+            return compressed;
+        }
+        return trusted;
+    }
+
+    /**
+     * Compresses a UTF16 array to LATIN1 if possible. Will not return
+     * a compressible UTF16 array with any 0-valued significant bytes,
+     * which is erroneous if COMPACT_STRING is enabled.
+     *
+     * <p>The off and len are in char array/UTF16 coder units.
+     */
+    public static byte[] maybeCompressUntrusted(byte[] val, int off, int len) {
+        byte[] compressed = new byte[len];
+        if (compress(val, off, compressed, 0, len) == len) {
+            return compressed;
+        }
+
+        byte[] trusted = Arrays.copyOfRange(val, off << 1, len << 1); // now not leaked
+        if (compress(trusted, 0, compressed, 0, len) == len) {
+            return compressed;
+        }
+        return trusted;
+    }
+
+    // must not be used with leaked arrays
     public static byte[] compress(char[] val, int off, int len) {
         byte[] ret = new byte[len];
         if (compress(val, off, ret, 0, len) == len) {
@@ -166,6 +205,7 @@ final class StringUTF16 {
         return null;
     }
 
+    // must not be used with leaked arrays
     public static byte[] compress(byte[] val, int off, int len) {
         byte[] ret = new byte[len];
         if (compress(val, off, ret, 0, len) == len) {
@@ -1163,6 +1203,7 @@ final class StringUTF16 {
         }
     }
 
+    // val must not be leaked
     public static String newString(byte[] val, int index, int len) {
         if (len == 0) {
             return "";


### PR DESCRIPTION
In the constructor of String, many locations the user-supplied byte or char arrays are read multiple times with a plain memory access; if a user previously wrote to one of such locations out of happens-before order, distinct plain memory reads may result in different unanticipated values.

The main problem caused by such error is that String constructor may incorrectly produce a UTF16 coder string with all-LATIN1 compatible characters when `COMPACT_STRING` is true, which breaks the contract of String. (The error can happen the other way around, but the resulting LATIN1 string is valid; this patch does not address that.)

Thus, I modified the String data compression for non-trusted arrays: a LATIN1 compression first-pass is still done, but if the first compression fails, a second compression pass is done on a trusted (that is, copied from the original data) data where reading would be consistent. The approach takes a toll on UTF16 string construction time, but should not be more costly memory-wise.

A separate routine to decode UTF8 in String constructor that takes byte encoding has the same multi-read problem, that the old `offset--` leads to a problematic double read. This is resolved by copying the data to decode to a local array at first instead of reading from the user-provided byte array. This fix also costs more runtime but at no extra memory cost.

Internal APIs such as newStringNoRepl are not guarded by this patch, as they are already trusted to be immutable and unshared.

`test/jdk/java/lang/String` tests pass. More testing is needed to see if there are other edge cases not covered.

Please review and don't hesitate to critique my approach and patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8319228](https://bugs.openjdk.org/browse/JDK-8319228) to be approved

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8311906](https://bugs.openjdk.org/browse/JDK-8311906)

### Issues
 * [JDK-8311906](https://bugs.openjdk.org/browse/JDK-8311906): Improve robustness of String constructors with mutable array inputs (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.
 * [JDK-8319228](https://bugs.openjdk.org/browse/JDK-8319228): Improve robustness of String constructors with mutable array inputs (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15902/head:pull/15902` \
`$ git checkout pull/15902`

Update a local copy of the PR: \
`$ git checkout pull/15902` \
`$ git pull https://git.openjdk.org/jdk.git pull/15902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15902`

View PR using the GUI difftool: \
`$ git pr show -t 15902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15902.diff">https://git.openjdk.org/jdk/pull/15902.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15902#issuecomment-1733628963)