### PR TITLE
8316906 Clarify TLABWasteTargetPercent flag

### DIFF
--- a/src/hotspot/share/gc/shared/tlab_globals.hpp
+++ b/src/hotspot/share/gc/shared/tlab_globals.hpp
@@ -70,10 +70,13 @@
           "Allocation averaging weight")                                    \
           range(0, 100)                                                     \
                                                                             \
+  /* At GC all TLABs are retired, and each thread's active  */              \
+  /* TLAB is assumed to be half full on average. The        */              \
+  /* remaining space is waste, proportional to TLAB size.   */              \
+  product(uintx, TLABWasteTargetPercent, 1,                                 \
+          "Percentage of Eden that can be wasted (half-full TLABs at GC)")  \
   /* Limit the lower bound of this flag to 1 as it is used  */              \
   /* in a division expression.                              */              \
-  product(uintx, TLABWasteTargetPercent, 1,                                 \
-          "Percentage of Eden that can be wasted (half-full TLABs at GC)"   \
           range(1, 100)                                                     \
                                                                             \
   product(uintx, TLABRefillWasteFraction,    64,                            \

--- a/src/hotspot/share/gc/shared/tlab_globals.hpp
+++ b/src/hotspot/share/gc/shared/tlab_globals.hpp
@@ -73,7 +73,7 @@
   /* Limit the lower bound of this flag to 1 as it is used  */              \
   /* in a division expression.                              */              \
   product(uintx, TLABWasteTargetPercent, 1,                                 \
-          "Percentage of Eden that can be wasted")                          \
+          "Percentage of Eden that can be wasted (half-full TLABs at GC)"   \
           range(1, 100)                                                     \
                                                                             \
   product(uintx, TLABRefillWasteFraction,    64,                            \


### PR DESCRIPTION
This flag is currently described as "Percentage of Eden that can be wasted". However, it does not address all kinds of waste. It specifically only controls the waste due to half-full TLABs at GC time. I propose to clarify this description, because it took me a lot of time to figure it out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316906](https://bugs.openjdk.org/browse/JDK-8316906): Clarify TLABWasteTargetPercent flag (**Enhancement** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15904/head:pull/15904` \
`$ git checkout pull/15904`

Update a local copy of the PR: \
`$ git checkout pull/15904` \
`$ git pull https://git.openjdk.org/jdk.git pull/15904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15904`

View PR using the GUI difftool: \
`$ git pr show -t 15904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15904.diff">https://git.openjdk.org/jdk/pull/15904.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15904#issuecomment-1734023028)