### PR TITLE
8316879: RegionMatches1Tests fails if CompactStrings are disabled after JDK-8302163

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2156,6 +2156,10 @@ public final class String
              (ooffset > (long)other.length() - len)) {
             return false;
         }
+        // Any strings match if length < 0
+        if (len < 0) {
+           return true;
+        }
         byte[] tv = value;
         byte[] ov = other.value;
         byte coder = coder();

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2156,8 +2156,8 @@ public final class String
              (ooffset > (long)other.length() - len)) {
             return false;
         }
-        // Any strings match if len < 0
-        if (len < 0) {
+        // Any strings match if len <= 0
+        if (len <= 0) {
            return true;
         }
         byte[] tv = value;

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2156,7 +2156,7 @@ public final class String
              (ooffset > (long)other.length() - len)) {
             return false;
         }
-        // Any strings match if length < 0
+        // Any strings match if len < 0
         if (len < 0) {
            return true;
         }

--- a/test/jdk/java/lang/String/RegionMatches.java
+++ b/test/jdk/java/lang/String/RegionMatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,13 @@
  * @test
  * @bug 4016509 8316879
  * @summary test regionMatches corner cases
- * @run testng RegionMatches
+ * @run junit RegionMatches
  */
 
 import java.io.UnsupportedEncodingException;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Test
 public class RegionMatches {
 
   private final String s1_LATIN1 = "abc";
@@ -43,8 +43,8 @@ public class RegionMatches {
   @Test
   public void TestLATIN1() {
       // Test for 4016509
-      if (!s1_LATIN1.regionMatches(0, s2_LATIN1, 0, Integer.MIN_VALUE))
-          throw new RuntimeException("Integer overflow in RegionMatches when comparing LATIN1 strings");
+      boolean result = s1_LATIN1.regionMatches(0, s2_LATIN1, 0, Integer.MIN_VALUE);
+      assertTrue(result, "Integer overflow in RegionMatches when comparing LATIN1 strings");
   }
 
   @Test
@@ -52,7 +52,7 @@ public class RegionMatches {
       // Test for 8316879
       String s1_UTF16 = new String(b1_UTF16, "UTF-16");
       String s2_UTF16 = new String(b2_UTF16, "UTF-16");
-      if (!s1_UTF16.regionMatches(0, s2_UTF16, 0, Integer.MIN_VALUE + 1))
-          throw new RuntimeException("Integer overflow in RegionMatches when comparing UTF16 strings");
+      boolean result = s1_UTF16.regionMatches(0, s2_UTF16, 0, Integer.MIN_VALUE + 1);
+      assertTrue(result, "Integer overflow in RegionMatches when comparing UTF16 strings");
   }
 }

--- a/test/jdk/java/lang/String/RegionMatches.java
+++ b/test/jdk/java/lang/String/RegionMatches.java
@@ -23,18 +23,36 @@
 
 /**
  * @test
- * @bug 4016509
- * @summary test regionMatches corner case
+ * @bug 4016509 8316879
+ * @summary test regionMatches corner cases
+ * @run testng RegionMatches
  */
 
+import java.io.UnsupportedEncodingException;
+import org.testng.annotations.Test;
 
+@Test
 public class RegionMatches {
 
-  public static void main (String args[]) throws Exception {
-      String s1="abc";
-      String s2="def";
+  private final String s1_LATIN1 = "abc";
+  private final String s2_LATIN1 = "def";
 
-      if (!s1.regionMatches(0,s2,0,Integer.MIN_VALUE))
-          throw new RuntimeException("Integer overflow in RegionMatches");
+  private final byte[] b1_UTF16 = new byte[]{0x04, 0x3d, 0x04, 0x30, 0x04, 0x36, 0x04, 0x34};
+  private final byte[] b2_UTF16 = new byte[]{0x04, 0x32, 0x00, 0x20, 0x04, 0x41, 0x04, 0x42};
+
+  @Test
+  public void TestLATIN1() {
+      // Test for 4016509
+      if (!s1_LATIN1.regionMatches(0, s2_LATIN1, 0, Integer.MIN_VALUE))
+          throw new RuntimeException("Integer overflow in RegionMatches when comparing LATIN1 strings");
+  }
+
+  @Test
+  public void TestUTF16() throws UnsupportedEncodingException{
+      // Test for 8316879
+      String s1_UTF16 = new String(b1_UTF16, "UTF-16");
+      String s2_UTF16 = new String(b2_UTF16, "UTF-16");
+      if (!s1_UTF16.regionMatches(0, s2_UTF16, 0, Integer.MIN_VALUE + 1))
+          throw new RuntimeException("Integer overflow in RegionMatches when comparing UTF16 strings");
   }
 }

--- a/test/jdk/java/lang/String/RegionMatches.java
+++ b/test/jdk/java/lang/String/RegionMatches.java
@@ -37,8 +37,8 @@ public class RegionMatches {
   private final String s1_LATIN1 = "abc";
   private final String s2_LATIN1 = "def";
 
-  private final byte[] b1_UTF16 = new byte[]{0x04, 0x3d, 0x04, 0x30, 0x04, 0x36, 0x04, 0x34};
-  private final byte[] b2_UTF16 = new byte[]{0x04, 0x32, 0x00, 0x20, 0x04, 0x41, 0x04, 0x42};
+  private final String s1_UTF16 = "\u041e\u0434\u043d\u0430\u0436\u0434\u044b";
+  private final String s2_UTF16 = "\u0432\u0441\u0442\u0443\u0434\u0435\u043d";
 
   @Test
   public void TestLATIN1() {
@@ -50,8 +50,6 @@ public class RegionMatches {
   @Test
   public void TestUTF16() throws UnsupportedEncodingException{
       // Test for 8316879
-      String s1_UTF16 = new String(b1_UTF16, "UTF-16");
-      String s2_UTF16 = new String(b2_UTF16, "UTF-16");
       boolean result = s1_UTF16.regionMatches(0, s2_UTF16, 0, Integer.MIN_VALUE + 1);
       assertTrue(result, "Integer overflow in RegionMatches when comparing UTF16 strings");
   }


### PR DESCRIPTION
test java.lang.String.RegionMatches1Tests fails on all platforms with -XX:-CompactStrings option and on ARM32 where Compact Strings is disabled by default. The fix is to return true immediately if len is negative, since for negative length this condition will never be satisfied.

Testing: JCK, JTREG passed with the fix with -XX:-CompactStrings on x86_64 and on ARM32.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8316879](https://bugs.openjdk.org/browse/JDK-8316879): RegionMatches1Tests fails if CompactStrings are disabled after JDK-8302163 (**Bug** - P2)


### Reviewers
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**) ⚠️ Review applies to [b95bf8f0](https://git.openjdk.org/jdk/pull/15906/files/b95bf8f05646f4184488fc2be41a280b10c8a029)
 * @M4ximumPizza (no known openjdk.org user name / role) ⚠️ Review applies to [b95bf8f0](https://git.openjdk.org/jdk/pull/15906/files/b95bf8f05646f4184488fc2be41a280b10c8a029)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15906/head:pull/15906` \
`$ git checkout pull/15906`

Update a local copy of the PR: \
`$ git checkout pull/15906` \
`$ git pull https://git.openjdk.org/jdk.git pull/15906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15906`

View PR using the GUI difftool: \
`$ git pr show -t 15906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15906.diff">https://git.openjdk.org/jdk/pull/15906.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15906#issuecomment-1734040868)