### PR TITLE
8316401: sun/tools/jhsdb/JStackStressTest.java failed with "InternalError: We should have found a thread that owns the anonymous lock"

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -241,7 +241,10 @@ public class Threads {
                         return thread;
                      }
                 }
-                throw new InternalError("We should have found a thread that owns the anonymous lock");
+                // We should have found the owner. However, the code can run concurrently with
+                // Java code and locking state can change at any time. This code is not
+                // expected to be precise, so we return null here.
+                return null;
             }
             // Owner can only be threads at this point.
             Address o = monitor.owner();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -244,6 +244,8 @@ public class Threads {
                 // We should have found the owner. However, the code can run concurrently with
                 // Java code and locking state can change at any time. This code is not
                 // expected to be precise, so we return null here.
+                System.out.println("Warning: We failed to find a thread that owns an anonymous lock. This is likely");
+                System.out.println("due to the JVM currently running a GC. Locking information may not be accurate.");
                 return null;
             }
             // Owner can only be threads at this point.

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
@@ -241,9 +241,8 @@ public class Threads {
                         return thread;
                      }
                 }
-                // We should have found the owner. However, the code can run concurrently with
-                // Java code and locking state can change at any time. This code is not
-                // expected to be precise, so we return null here.
+                // We should have found the owner, however, as the VM could be in any state, including the middle
+                // of performing GC, it is not always possible to do so. Just return null if we can't locate it.
                 System.out.println("Warning: We failed to find a thread that owns an anonymous lock. This is likely");
                 System.out.println("due to the JVM currently running a GC. Locking information may not be accurate.");
                 return null;


### PR DESCRIPTION
The SA can run concurrently with Java threads, SA code that inspects locking state should be able to deal with that. On the other hand, the particular code is only used in printing routine and is not expected to be precise. When resolving an anonymous owner, we may not find one, because Java threads may already have moved on. Instead of crashing with a stacktrace, we should gracefully return null here.

Testing:
 - [x] sun/tools/jhsdb/JStackStressTest.java
 - [x] sun/tools/jhsdb
 - [x] serviceability/sa

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316401](https://bugs.openjdk.org/browse/JDK-8316401): sun/tools/jhsdb/JStackStressTest.java failed with "InternalError: We should have found a thread that owns the anonymous lock" (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [4ddaf577](https://git.openjdk.org/jdk/pull/15907/files/4ddaf577300be8fd6bfbaaa7e415cb9d43e227bc)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15907/head:pull/15907` \
`$ git checkout pull/15907`

Update a local copy of the PR: \
`$ git checkout pull/15907` \
`$ git pull https://git.openjdk.org/jdk.git pull/15907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15907`

View PR using the GUI difftool: \
`$ git pr show -t 15907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15907.diff">https://git.openjdk.org/jdk/pull/15907.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15907#issuecomment-1734084741)