### PR TITLE
JDK-8316671: sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java test fails intermittent with Read timed out

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java
@@ -137,7 +137,8 @@ public class SSLSocketCloseHang {
         System.out.println("server ready");
 
         Socket baseSocket = new Socket("localhost", serverPort);
-        baseSocket.setSoTimeout(1000);
+        float timeoutFactor = Float.parseFloat(System.getProperty("test.timeout.factor", "1.0"));
+        baseSocket.setSoTimeout((int)(1000 * timeoutFactor));
 
         SSLSocketFactory sslsf =
             (SSLSocketFactory) SSLSocketFactory.getDefault();


### PR DESCRIPTION
We sometimes run into the following error. This especially occurs when running with fastdebug binaries and on Linux ppc64le machines.
Current timeout set in the test is 1 second.

Server accepting: 315357614990101
Server accepted: 315359219006041
Client starting handshake: 315359228098300
java.net.SocketTimeoutException: Read timed out
at java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:278)
at java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:304)
at java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:346)
at java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:796)
at java.base/java.net.Socket$SocketInputStream.read(Socket.java:1096)
at java.base/sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:489)
at java.base/sun.security.ssl.SSLSocketInputRecord.readHeader(SSLSocketInputRecord.java:483)
at java.base/sun.security.ssl.SSLSocketInputRecord.decode(SSLSocketInputRecord.java:160)
at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:111)
at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1507)
at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1422)
at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:455)
at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:426)
at SSLSocketCloseHang.doClientSide(SSLSocketCloseHang.java:149)
at SSLSocketCloseHang.startClient(SSLSocketCloseHang.java:320)
at SSLSocketCloseHang.<init>(SSLSocketCloseHang.java:246)
at SSLSocketCloseHang.main(SSLSocketCloseHang.java:232)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1570)

Making the timeout dependent on the timeout factor would give us the chance to influence the test on such slower setups.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316671](https://bugs.openjdk.org/browse/JDK-8316671): sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java test fails intermittent with Read timed out (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15912/head:pull/15912` \
`$ git checkout pull/15912`

Update a local copy of the PR: \
`$ git checkout pull/15912` \
`$ git pull https://git.openjdk.org/jdk.git pull/15912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15912`

View PR using the GUI difftool: \
`$ git pr show -t 15912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15912.diff">https://git.openjdk.org/jdk/pull/15912.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15912#issuecomment-1734983311)