### PR TITLE
8316935: [s390x] Use consistent naming for lightweight locking in MacroAssembler

### DIFF
--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -107,7 +107,7 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
   assert(LockingMode != LM_MONITOR, "LM_MONITOR is already handled, by emit_lock()");
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    fast_lock(Roop, Rmark, tmp, slow_case);
+    lightweight_lock(Roop, Rmark, tmp, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     NearLabel done;
     // and mark it as unlocked.
@@ -171,7 +171,7 @@ void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rb
     z_lgr(tmp, Rmark);
     z_nill(tmp, markWord::monitor_value);
     z_brnz(slow_case);
-    fast_unlock(Roop, Rmark, tmp, slow_case);
+    lightweight_unlock(Roop, Rmark, tmp, slow_case);
   } else if (LockingMode == LM_LEGACY) {
     // Test if object header is pointing to the displaced header, and if so, restore
     // the displaced header in the object. If the object header is not pointing to

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -1030,7 +1030,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
   }
 
   if (LockingMode == LM_LIGHTWEIGHT) {
-    fast_lock(object, /* mark word */ header, tmp, slow_case);
+    lightweight_lock(object, /* mark word */ header, tmp, slow_case);
   } else if (LockingMode == LM_LEGACY) {
 
     // Set header to be (markWord of object | UNLOCK_VALUE).
@@ -1088,7 +1088,7 @@ void InterpreterMacroAssembler::lock_object(Register monitor, Register object) {
   // slow case of monitor enter.
   bind(slow_case);
   if (LockingMode == LM_LIGHTWEIGHT) {
-    // for fast locking we need to use monitorenter_obj, see interpreterRuntime.cpp
+    // for lightweight locking we need to use monitorenter_obj, see interpreterRuntime.cpp
     call_VM(noreg,
             CAST_FROM_FN_PTR(address, InterpreterRuntime::monitorenter_obj),
             object);
@@ -1187,7 +1187,7 @@ void InterpreterMacroAssembler::unlock_object(Register monitor, Register object)
     z_nill(tmp, markWord::monitor_value);
     z_brne(slow_case);
 
-    fast_unlock(object, header, tmp, slow_case);
+    lightweight_unlock(object, header, tmp, slow_case);
 
     z_bru(done);
   } else {

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -722,8 +722,8 @@ class MacroAssembler: public Assembler {
 
   void compiler_fast_lock_object(Register oop, Register box, Register temp1, Register temp2);
   void compiler_fast_unlock_object(Register oop, Register box, Register temp1, Register temp2);
-  void fast_lock(Register obj, Register hdr, Register tmp, Label& slow);
-  void fast_unlock(Register obj, Register hdr, Register tmp, Label& slow);
+  void lightweight_lock(Register obj, Register hdr, Register tmp, Label& slow);
+  void lightweight_unlock(Register obj, Register hdr, Register tmp, Label& slow);
 
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
 


### PR DESCRIPTION
We (s390) also needs to update our naming from fast_lock & fast_unlock to MacroAssembler::lightweight_lock and MacroAssembler::lightweight_unlock respectively.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316935](https://bugs.openjdk.org/browse/JDK-8316935): [s390x] Use consistent naming for lightweight locking in MacroAssembler (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15915/head:pull/15915` \
`$ git checkout pull/15915`

Update a local copy of the PR: \
`$ git checkout pull/15915` \
`$ git pull https://git.openjdk.org/jdk.git pull/15915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15915`

View PR using the GUI difftool: \
`$ git pr show -t 15915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15915.diff">https://git.openjdk.org/jdk/pull/15915.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15915#issuecomment-1735133165)