### PR TITLE
8316566: RISC-V: Zero extended narrow oop passed to Atomic::cmpxchg

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/orderAccess_linux_riscv.hpp
@@ -37,7 +37,7 @@ inline void OrderAccess::storestore() { release(); }
 inline void OrderAccess::loadstore()  { acquire(); }
 inline void OrderAccess::storeload()  { fence(); }
 
-#define FULL_MEM_BARRIER  __sync_synchronize()
+#define FULL_MEM_BARRIER  __atomic_thread_fence(__ATOMIC_SEQ_CST);
 #define READ_MEM_BARRIER  __atomic_thread_fence(__ATOMIC_ACQUIRE);
 #define WRITE_MEM_BARRIER __atomic_thread_fence(__ATOMIC_RELEASE);
 


### PR DESCRIPTION
Hi, please consider!

There is bug in gcc < 12 where __synch_synchronize() in some corner-cases don't enforce the compiler barrier.
This causes some code to be placed after the __synch_synchronize(), and in this case causing a word to to be not be sign extended as a collateral issue of the bug.
You can see the 'bad' assembly in JBS, where a branch is moved over the compiler barrier.

Trying to get information from gcc folks.

It seems like either adding a extra compiler barrier, or use  __atomic_thread_fence(__ATOMIC_SEQ_CST) fixes it.

Tested https://bugs.openjdk.org/browse/JDK-8316186 with this fix.
Manually verified assembly, with this fix we generate the same as gcc 12.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316566](https://bugs.openjdk.org/browse/JDK-8316566): RISC-V: Zero extended narrow oop passed to Atomic::cmpxchg (**Bug** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15917/head:pull/15917` \
`$ git checkout pull/15917`

Update a local copy of the PR: \
`$ git checkout pull/15917` \
`$ git pull https://git.openjdk.org/jdk.git pull/15917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15917`

View PR using the GUI difftool: \
`$ git pr show -t 15917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15917.diff">https://git.openjdk.org/jdk/pull/15917.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15917#issuecomment-1735362168)