### PR TITLE
8198918: jio_snprintf and friends are not checked by -Wformat

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -455,7 +455,7 @@ void CompilationPolicy::initialize() {
       c2_size = C2Compiler::initial_code_buffer_size();
 #endif
       size_t buffer_size = c1_only ? c1_size : (c1_size/3 + 2*c2_size/3);
-      int max_count = (ReservedCodeCacheSize - (CodeCacheMinimumUseSpace DEBUG_ONLY(* 3))) / (int)buffer_size;
+      int max_count = ((int)ReservedCodeCacheSize - (CodeCacheMinimumUseSpace DEBUG_ONLY(* 3))) / (int)buffer_size;
       if (count > max_count) {
         // Lower the compiler count such that all buffers fit into the code cache
         count = MAX2(max_count, c1_only ? 1 : 2);

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -479,23 +479,23 @@ bool CompilerConfig::check_args_consistency(bool status) {
   uint min_code_cache_size = CodeCacheMinimumUseSpace DEBUG_ONLY(* 3);
   if (ReservedCodeCacheSize < InitialCodeCacheSize) {
     jio_fprintf(defaultStream::error_stream(),
-                "Invalid ReservedCodeCacheSize: %dK. Must be at least InitialCodeCacheSize=%dK.\n",
+                "Invalid ReservedCodeCacheSize: " UINTX_FORMAT "K. Must be at least InitialCodeCacheSize=" UINTX_FORMAT "K.\n",
                 ReservedCodeCacheSize/K, InitialCodeCacheSize/K);
     status = false;
   } else if (ReservedCodeCacheSize < min_code_cache_size) {
     jio_fprintf(defaultStream::error_stream(),
-                "Invalid ReservedCodeCacheSize=%dK. Must be at least %uK.\n", ReservedCodeCacheSize/K,
+                "Invalid ReservedCodeCacheSize=" UINTX_FORMAT "K. Must be at least " UINTX_FORMAT "K.\n", ReservedCodeCacheSize/K,
                 min_code_cache_size/K);
     status = false;
   } else if (ReservedCodeCacheSize > CODE_CACHE_SIZE_LIMIT) {
     // Code cache size larger than CODE_CACHE_SIZE_LIMIT is not supported.
     jio_fprintf(defaultStream::error_stream(),
-                "Invalid ReservedCodeCacheSize=%dM. Must be at most %uM.\n", ReservedCodeCacheSize/M,
+                "Invalid ReservedCodeCacheSize=" UINTX_FORMAT "M. Must be at most " UINTX_FORMAT "M.\n", ReservedCodeCacheSize/M,
                 CODE_CACHE_SIZE_LIMIT/M);
     status = false;
   } else if (NonNMethodCodeHeapSize < min_code_cache_size) {
     jio_fprintf(defaultStream::error_stream(),
-                "Invalid NonNMethodCodeHeapSize=%dK. Must be at least %uK.\n", NonNMethodCodeHeapSize/K,
+                "Invalid NonNMethodCodeHeapSize=" UINTX_FORMAT "K. Must be at least " UINTX_FORMAT "K.\n", NonNMethodCodeHeapSize/K,
                 min_code_cache_size/K);
     status = false;
   }

--- a/src/hotspot/share/compiler/compilerDefinitions.cpp
+++ b/src/hotspot/share/compiler/compilerDefinitions.cpp
@@ -476,26 +476,26 @@ void CompilerConfig::set_jvmci_specific_flags() {
 bool CompilerConfig::check_args_consistency(bool status) {
   // Check lower bounds of the code cache
   // Template Interpreter code is approximately 3X larger in debug builds.
-  uint min_code_cache_size = CodeCacheMinimumUseSpace DEBUG_ONLY(* 3);
+  size_t min_code_cache_size = CodeCacheMinimumUseSpace DEBUG_ONLY(* 3);
   if (ReservedCodeCacheSize < InitialCodeCacheSize) {
     jio_fprintf(defaultStream::error_stream(),
-                "Invalid ReservedCodeCacheSize: " UINTX_FORMAT "K. Must be at least InitialCodeCacheSize=" UINTX_FORMAT "K.\n",
+                "Invalid ReservedCodeCacheSize: %zuK. Must be at least InitialCodeCacheSize=%zuK.\n",
                 ReservedCodeCacheSize/K, InitialCodeCacheSize/K);
     status = false;
   } else if (ReservedCodeCacheSize < min_code_cache_size) {
     jio_fprintf(defaultStream::error_stream(),
-                "Invalid ReservedCodeCacheSize=" UINTX_FORMAT "K. Must be at least " UINTX_FORMAT "K.\n", ReservedCodeCacheSize/K,
+                "Invalid ReservedCodeCacheSize=%zuK. Must be at least %zuK.\n", ReservedCodeCacheSize/K,
                 min_code_cache_size/K);
     status = false;
   } else if (ReservedCodeCacheSize > CODE_CACHE_SIZE_LIMIT) {
     // Code cache size larger than CODE_CACHE_SIZE_LIMIT is not supported.
     jio_fprintf(defaultStream::error_stream(),
-                "Invalid ReservedCodeCacheSize=" UINTX_FORMAT "M. Must be at most " UINTX_FORMAT "M.\n", ReservedCodeCacheSize/M,
+                "Invalid ReservedCodeCacheSize=%zuM. Must be at most %zuM.\n", ReservedCodeCacheSize/M,
                 CODE_CACHE_SIZE_LIMIT/M);
     status = false;
   } else if (NonNMethodCodeHeapSize < min_code_cache_size) {
     jio_fprintf(defaultStream::error_stream(),
-                "Invalid NonNMethodCodeHeapSize=" UINTX_FORMAT "K. Must be at least " UINTX_FORMAT "K.\n", NonNMethodCodeHeapSize/K,
+                "Invalid NonNMethodCodeHeapSize=%zuK. Must be at least %zuK.\n", NonNMethodCodeHeapSize/K,
                 min_code_cache_size/K);
     status = false;
   }

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -276,7 +276,7 @@ TypedMethodOptionMatcher* TypedMethodOptionMatcher::parse_method_pattern(char*& 
   TypedMethodOptionMatcher* tom = new TypedMethodOptionMatcher();
   MethodMatcher::parse_method_pattern(line, error_msg, tom);
   if (error_msg != nullptr) {
-    jio_snprintf(errorbuf, buf_size, error_msg);
+    ::strncpy(errorbuf, error_msg, buf_size);
     delete tom;
     return nullptr;
   }

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -100,7 +100,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
     }
     if (BootstrapJVMCI && (TieredStopAtLevel < CompLevel_full_optimization)) {
       jio_fprintf(defaultStream::error_stream(),
-          "-XX:+BootstrapJVMCI is not compatible with -XX:TieredStopAtLevel=%d\n", TieredStopAtLevel);
+          "-XX:+BootstrapJVMCI is not compatible with -XX:TieredStopAtLevel=" INTX_FORMAT "\n", TieredStopAtLevel);
       return false;
     }
   }

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2855,7 +2855,6 @@ JVM_END
 // Printing support //////////////////////////////////////////////////
 extern "C" {
 
-ATTRIBUTE_PRINTF(3, 0)
 int jio_vsnprintf(char *str, size_t count, const char *fmt, va_list args) {
   // Reject count values that are negative signed values converted to
   // unsigned; see bug 4399518, 4417214
@@ -2869,7 +2868,6 @@ int jio_vsnprintf(char *str, size_t count, const char *fmt, va_list args) {
   return result;
 }
 
-ATTRIBUTE_PRINTF(3, 4)
 int jio_snprintf(char *str, size_t count, const char *fmt, ...) {
   va_list args;
   int len;
@@ -2879,7 +2877,6 @@ int jio_snprintf(char *str, size_t count, const char *fmt, ...) {
   return len;
 }
 
-ATTRIBUTE_PRINTF(2, 3)
 int jio_fprintf(FILE* f, const char *fmt, ...) {
   int len;
   va_list args;
@@ -2889,7 +2886,6 @@ int jio_fprintf(FILE* f, const char *fmt, ...) {
   return len;
 }
 
-ATTRIBUTE_PRINTF(2, 0)
 int jio_vfprintf(FILE* f, const char *fmt, va_list args) {
   if (Arguments::vfprintf_hook() != nullptr) {
      return Arguments::vfprintf_hook()(f, fmt, args);
@@ -2898,7 +2894,6 @@ int jio_vfprintf(FILE* f, const char *fmt, va_list args) {
   }
 }
 
-ATTRIBUTE_PRINTF(1, 2)
 JNIEXPORT int jio_printf(const char *fmt, ...) {
   int len;
   va_list args;

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1537,7 +1537,7 @@ const int ObjectAlignmentInBytes = 8;
           range(1, 128)                                                     \
           constraint(OptoLoopAlignmentConstraintFunc, AfterErgo)            \
                                                                             \
-  product_pd(uintx, InitialCodeCacheSize,                                   \
+  product_pd(size_t, InitialCodeCacheSize,                                  \
           "Initial code cache size (in bytes)")                             \
           constraint(VMPageSizeConstraintFunc, AtParse)                     \
                                                                             \
@@ -1548,19 +1548,19 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, SegmentedCodeCache, false,                                  \
           "Use a segmented code cache")                                     \
                                                                             \
-  product_pd(uintx, ReservedCodeCacheSize,                                  \
+  product_pd(size_t, ReservedCodeCacheSize,                                 \
           "Reserved code cache size (in bytes) - maximum code cache size")  \
           constraint(VMPageSizeConstraintFunc, AtParse)                     \
                                                                             \
-  product_pd(uintx, NonProfiledCodeHeapSize,                                \
-          "Size of code heap with non-profiled methods (in bytes)")         \
+  product_pd(size_t, NonProfiledCodeHeapSize,                                 \
+          "Size of code heap with non-profiled methods (in bytes)")          \
           range(0, max_uintx)                                               \
                                                                             \
-  product_pd(uintx, ProfiledCodeHeapSize,                                   \
-          "Size of code heap with profiled methods (in bytes)")             \
+  product_pd(size_t, ProfiledCodeHeapSize,                                   \
+          "Size of code heap with profiled methods (in bytes)")              \
           range(0, max_uintx)                                               \
                                                                             \
-  product_pd(uintx, NonNMethodCodeHeapSize,                                 \
+  product_pd(size_t, NonNMethodCodeHeapSize,                                \
           "Size of code heap with non-nmethods (in bytes)")                 \
           constraint(VMPageSizeConstraintFunc, AtParse)                     \
                                                                             \

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -198,15 +198,15 @@ char* os::iso8601_time(jlong milliseconds_since_19700101, char* buffer, size_t b
     abs_local_to_UTC = -(abs_local_to_UTC);
   }
   // Convert time zone offset seconds to hours and minutes.
-  const time_t zone_hours = (abs_local_to_UTC / seconds_per_hour);
-  const time_t zone_min =
-    ((abs_local_to_UTC % seconds_per_hour) / seconds_per_minute);
+  const int zone_hours = (int)(abs_local_to_UTC / seconds_per_hour);
+  const int zone_min =
+    (int)((abs_local_to_UTC % seconds_per_hour) / seconds_per_minute);
 
   // Print an ISO 8601 date and time stamp into the buffer
   const int year = 1900 + time_struct.tm_year;
   const int month = 1 + time_struct.tm_mon;
-  const int printed = os::snprintf(buffer, buffer_length,
-                                   "%04d-%02d-%02dT%02d:%02d:%02d.%03d%c%02ld%02ld",
+  const int printed = jio_snprintf(buffer, buffer_length,
+                                   "%04d-%02d-%02dT%02d:%02d:%02d.%03d%c%02d%02d",
                                    year,
                                    month,
                                    time_struct.tm_mday,

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -205,8 +205,8 @@ char* os::iso8601_time(jlong milliseconds_since_19700101, char* buffer, size_t b
   // Print an ISO 8601 date and time stamp into the buffer
   const int year = 1900 + time_struct.tm_year;
   const int month = 1 + time_struct.tm_mon;
-  const int printed = jio_snprintf(buffer, buffer_length,
-                                   "%04d-%02d-%02dT%02d:%02d:%02d.%03d%c%02d%02d",
+  const int printed = os::snprintf(buffer, buffer_length,
+                                   "%04d-%02d-%02dT%02d:%02d:%02d.%03d%c%02ld%02ld",
                                    year,
                                    month,
                                    time_struct.tm_mday,

--- a/test/hotspot/jtreg/compiler/codecache/stress/RandomAllocationTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/RandomAllocationTest.java
@@ -53,7 +53,7 @@ import jdk.test.lib.Utils;
 
 public class RandomAllocationTest implements Runnable {
     private static final long CODE_CACHE_SIZE
-            = Helper.WHITE_BOX.getUintxVMFlag("ReservedCodeCacheSize");
+            = Helper.WHITE_BOX.getSizeTVMFlag("ReservedCodeCacheSize");
     private static final int MAX_BLOB_SIZE = (int) (CODE_CACHE_SIZE >> 7);
     private static final BlobType[] BLOB_TYPES
             = BlobType.getAvailable().toArray(new BlobType[0]);

--- a/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
@@ -48,7 +48,7 @@ import jdk.test.whitebox.code.BlobType;
 import java.util.ArrayList;
 
 public class ReturnBlobToWrongHeapTest {
-    private static final long largeBlobSize = Helper.WHITE_BOX.getUintxVMFlag("ReservedCodeCacheSize") >> 6;
+    private static final long largeBlobSize = Helper.WHITE_BOX.getSizeTVMFlag("ReservedCodeCacheSize") >> 6;
     private static final long codeCacheMinBlockLength = Helper.WHITE_BOX.getUintxVMFlag("CodeCacheMinBlockLength");
     private static final BlobType[] BLOB_TYPES = BlobType.getAvailable().toArray(new BlobType[0]);
 

--- a/test/hotspot/jtreg/compiler/whitebox/AllocationCodeBlobTest.java
+++ b/test/hotspot/jtreg/compiler/whitebox/AllocationCodeBlobTest.java
@@ -54,7 +54,7 @@ import java.util.EnumSet;
 public class AllocationCodeBlobTest {
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
     private static final long CODE_CACHE_SIZE
-            = WHITE_BOX.getUintxVMFlag("ReservedCodeCacheSize");
+            = WHITE_BOX.getSizeTVMFlag("ReservedCodeCacheSize");
     private static final int SIZE = 1;
 
     public static void main(String[] args) {

--- a/test/jdk/jdk/jfr/event/compiler/TestCodeCacheConfig.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCodeCacheConfig.java
@@ -50,7 +50,7 @@ import jdk.test.whitebox.WhiteBox;
 public class TestCodeCacheConfig {
     private final static String EVENT_NAME = EventNames.CodeCacheConfiguration;
 
-    private static final long CodeCacheExpectedSize = WhiteBox.getWhiteBox().getUintxVMFlag("ReservedCodeCacheSize");
+    private static final long CodeCacheExpectedSize = WhiteBox.getWhiteBox().getSizeTVMFlag("ReservedCodeCacheSize");
 
     public static void main(String[] args) throws Exception {
         Recording recording = new Recording();

--- a/test/lib/jdk/test/whitebox/code/BlobType.java
+++ b/test/lib/jdk/test/whitebox/code/BlobType.java
@@ -103,6 +103,6 @@ public enum BlobType {
     }
 
     public long getSize() {
-        return WhiteBox.getWhiteBox().getUintxVMFlag(sizeOptionName);
+        return WhiteBox.getWhiteBox().getSizeTVMFlag(sizeOptionName);
     }
 }


### PR DESCRIPTION
- The `ATTRIBUTE_PRINTF` usage in cpp files is useless. They are removed.
-  There are cases where `jio_xxprintf` functions use `char *` arguments for format string, rather than a literal like `"%s..."`. These cases are _not compiled_ when `ATTRIBUTE_PRINTF` is used for them. So, first I used the attribute and got the corresponding compile errors. Then I fixed the issues and removed the attribute when all issues were fixed.

### Test
The changes are tested on all platforms tiers 1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8198918](https://bugs.openjdk.org/browse/JDK-8198918): jio_snprintf and friends are not checked by -Wformat (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15918/head:pull/15918` \
`$ git checkout pull/15918`

Update a local copy of the PR: \
`$ git checkout pull/15918` \
`$ git pull https://git.openjdk.org/jdk.git pull/15918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15918`

View PR using the GUI difftool: \
`$ git pr show -t 15918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15918.diff">https://git.openjdk.org/jdk/pull/15918.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15918#issuecomment-1735383577)