### PR TITLE
8309599: WeakHandle and OopHandle release should clear obj pointer

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -154,7 +154,7 @@ class StringTableConfig : public StackObj {
     StringTable::item_added();
     return AllocateHeap(size, mtSymbol);
   }
-  static void free_node(void* context, void* memory, Value const& value) {
+  static void free_node(void* context, void* memory, Value& value) {
     value.release(StringTable::_oop_storage);
     FreeHeap(memory);
     StringTable::item_removed();

--- a/src/hotspot/share/oops/oopHandle.inline.hpp
+++ b/src/hotspot/share/oops/oopHandle.inline.hpp
@@ -52,6 +52,7 @@ inline void OopHandle::release(OopStorage* storage) {
     // Clear the OopHandle first
     NativeAccess<>::oop_store(_obj, nullptr);
     storage->release(_obj);
+    _obj = nullptr;
   }
 }
 

--- a/src/hotspot/share/oops/weakHandle.cpp
+++ b/src/hotspot/share/oops/weakHandle.cpp
@@ -46,13 +46,14 @@ WeakHandle::WeakHandle(OopStorage* storage, oop obj) :
   NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(_obj, obj);
 }
 
-void WeakHandle::release(OopStorage* storage) const {
+void WeakHandle::release(OopStorage* storage) {
   // Only release if the pointer to the object has been created.
   if (_obj != nullptr) {
     // Clear the WeakHandle.  For race in creating ClassLoaderData, we can release this
     // WeakHandle before it is cleared by GC.
     NativeAccess<ON_PHANTOM_OOP_REF>::oop_store(_obj, nullptr);
     storage->release(_obj);
+    _obj = nullptr;
   }
 }
 

--- a/src/hotspot/share/oops/weakHandle.hpp
+++ b/src/hotspot/share/oops/weakHandle.hpp
@@ -52,9 +52,8 @@ class WeakHandle {
 
   inline oop resolve() const;
   inline oop peek() const;
-  void release(OopStorage* storage) const;
+  void release(OopStorage* storage);
   bool is_null() const { return _obj == nullptr; }
-  void set_null() { _obj = nullptr; }
 
   void replace(oop with_obj);
 

--- a/src/hotspot/share/prims/jvmtiTagMapTable.hpp
+++ b/src/hotspot/share/prims/jvmtiTagMapTable.hpp
@@ -50,7 +50,7 @@ class JvmtiTagMapKey : public CHeapObj<mtServiceability> {
 
   oop object() const;
   oop object_no_keepalive() const;
-  void release_weak_handle() const;
+  void release_weak_handle();
 
   static unsigned get_hash(const JvmtiTagMapKey& entry) {
     assert(entry._obj != nullptr, "must lookup obj to hash");

--- a/src/hotspot/share/prims/resolvedMethodTable.cpp
+++ b/src/hotspot/share/prims/resolvedMethodTable.cpp
@@ -85,7 +85,7 @@ class ResolvedMethodTableConfig : public AllStatic {
     ResolvedMethodTable::item_added();
     return AllocateHeap(size, mtClass);
   }
-  static void free_node(void* context, void* memory, Value const& value) {
+  static void free_node(void* context, void* memory, Value& value) {
     value.release(ResolvedMethodTable::_oop_storage);
     FreeHeap(memory);
     ResolvedMethodTable::item_removed();

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -364,7 +364,7 @@ private:
   // Deflation support
   bool      deflate_monitor();
   void      install_displaced_markword_in_object(const oop obj);
-  void      release_object() { _object.release(_oop_storage); _object.set_null(); }
+  void      release_object() { _object.release(_oop_storage); }
 };
 
 #endif // SHARE_RUNTIME_OBJECTMONITOR_HPP


### PR DESCRIPTION
This change makes WeakHandle and OopHandle release null out the obj pointer, at the cost of making the release function non-const and some changes that propagated from that.  This enables ObjectMonitor code to test for null to see if the obj was already released, and seems like the right thing to do.  See comments from related PR in the bug report.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309599](https://bugs.openjdk.org/browse/JDK-8309599): WeakHandle and OopHandle release should clear obj pointer (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15920/head:pull/15920` \
`$ git checkout pull/15920`

Update a local copy of the PR: \
`$ git checkout pull/15920` \
`$ git pull https://git.openjdk.org/jdk.git pull/15920/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15920`

View PR using the GUI difftool: \
`$ git pr show -t 15920`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15920.diff">https://git.openjdk.org/jdk/pull/15920.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15920#issuecomment-1735487583)