### PR TITLE
8316958: Add test for unstructured locking

### DIFF
--- a/test/hotspot/jtreg/runtime/locking/TestUnstructuredLocking.jasm
+++ b/test/hotspot/jtreg/runtime/locking/TestUnstructuredLocking.jasm
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Check that monitorenter A; monitorenter B; monitorexit A; monitorexit B; works
+ * @compile TestUnstructuredLocking.jasm
+ * @run main/othervm -Xint TestUnstructuredLocking
+ */
+
+super public class TestUnstructuredLocking version 64:0 {
+
+    public static Method main:"([Ljava/lang/String;)V" stack 2 locals 4 {
+        new class java/lang/Object;
+        dup;
+        invokespecial Method java/lang/Object."<init>":"()V";
+        astore_1;
+        new class java/lang/Object;
+        dup;
+        invokespecial Method java/lang/Object."<init>":"()V";
+        astore_2;
+        aload_1;
+        monitorenter;
+        aload_2;
+        monitorenter;
+        aload_1;
+        monitorexit;
+        aload_2;
+        invokevirtual Method java/lang/Object.notify:"()V";
+        aload_2;
+        monitorexit;
+        return;
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/locking/TestUnstructuredLocking.jasm
+++ b/test/hotspot/jtreg/runtime/locking/TestUnstructuredLocking.jasm
@@ -23,10 +23,16 @@
  */
 
 /*
- * @test
+ * @test id=Xint
  * @summary Check that monitorenter A; monitorenter B; monitorexit A; monitorexit B; works
  * @compile TestUnstructuredLocking.jasm
  * @run main/othervm -Xint TestUnstructuredLocking
+ */
+/*
+ * @test id=Xcamp
+ * @summary Check that monitorenter A; monitorenter B; monitorexit A; monitorexit B; works, with -Xcomp
+ * @compile TestUnstructuredLocking.jasm
+ * @run main/othervm -Xcomp TestUnstructuredLocking
  */
 
 super public class TestUnstructuredLocking version 64:0 {
@@ -46,8 +52,6 @@ super public class TestUnstructuredLocking version 64:0 {
         monitorenter;
         aload_1;
         monitorexit;
-        aload_2;
-        invokevirtual Method java/lang/Object.notify:"()V";
         aload_2;
         monitorexit;
         return;

--- a/test/hotspot/jtreg/runtime/locking/TestUnstructuredLocking.jasm
+++ b/test/hotspot/jtreg/runtime/locking/TestUnstructuredLocking.jasm
@@ -29,7 +29,7 @@
  * @run main/othervm -Xint TestUnstructuredLocking
  */
 /*
- * @test id=Xcamp
+ * @test id=Xcomp
  * @summary Check that monitorenter A; monitorenter B; monitorexit A; monitorexit B; works, with -Xcomp
  * @compile TestUnstructuredLocking.jasm
  * @run main/othervm -Xcomp TestUnstructuredLocking

--- a/test/hotspot/jtreg/runtime/locking/TestUnstructuredLocking.jasm
+++ b/test/hotspot/jtreg/runtime/locking/TestUnstructuredLocking.jasm
@@ -23,13 +23,13 @@
  */
 
 /*
- * @test id=Xint
+ * @test id=int
  * @summary Check that monitorenter A; monitorenter B; monitorexit A; monitorexit B; works
  * @compile TestUnstructuredLocking.jasm
  * @run main/othervm -Xint TestUnstructuredLocking
  */
 /*
- * @test id=Xcomp
+ * @test id=comp
  * @summary Check that monitorenter A; monitorenter B; monitorexit A; monitorexit B; works, with -Xcomp
  * @compile TestUnstructuredLocking.jasm
  * @run main/othervm -Xcomp TestUnstructuredLocking


### PR DESCRIPTION
In my original lightweight-locking PR, I had a testcase that exercises unstructured locking, which is permitted by the JVM spec, but not generated by javac, and thus not executed anywhere. JITs don't compile unstructured-locked code, therefore any code which attempts this would be slow anyway.

Testing:
 - [x] runtime/locking

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316958](https://bugs.openjdk.org/browse/JDK-8316958): Add test for unstructured locking (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [d232eb26](https://git.openjdk.org/jdk/pull/15925/files/d232eb26a3464678b9d07c8380bf76f0cf4553e8)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15925/head:pull/15925` \
`$ git checkout pull/15925`

Update a local copy of the PR: \
`$ git checkout pull/15925` \
`$ git pull https://git.openjdk.org/jdk.git pull/15925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15925`

View PR using the GUI difftool: \
`$ git pr show -t 15925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15925.diff">https://git.openjdk.org/jdk/pull/15925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15925#issuecomment-1735644980)