### PR TITLE
8314986: Module readability resolution is slow with large numbers of automatic modules

### DIFF
--- a/test/jdk/java/lang/module/AutomaticModulesTest.java
+++ b/test/jdk/java/lang/module/AutomaticModulesTest.java
@@ -584,15 +584,18 @@ public class AutomaticModulesTest {
 
         assertTrue(a.reads().size() == 3);
         assertTrue(a.reads().contains(base));
+        assertFalse(a.reads().contains(a));  // should not read itself
         assertTrue(a.reads().contains(b));
         assertTrue(a.reads().contains(c));
 
         assertTrue(b.reads().contains(a));
+        assertFalse(b.reads().contains(b));  // should not read itself
         assertTrue(b.reads().contains(c));
         testReadAllBootModules(cf, "b");  // b reads all modules in boot layer
 
         assertTrue(c.reads().contains(a));
         assertTrue(c.reads().contains(b));
+        assertFalse(c.reads().contains(c));  // should not read itself
         testReadAllBootModules(cf, "c");  // c reads all modules in boot layer
 
     }


### PR DESCRIPTION
Fixes the issue (hopefully) by resolving automatic modules and automatic module dependencies after propagation of non-automatic transitive dependencies. The module tests run.

I also added a few asserts to validate that the automatic modules don't read themselves (previously this was the case with > 1 automatic module). Should these asserts be added in more places or is this enough?

Alan also mentioned a conflict with the spec, I'm not sure which spec is being referred to. The documentation of `ResolvedModule#reads` states `A possibly-empty unmodifiable set`, implying that the set can be empty.

Finally, `Configuration#reads` states `// The sets stored in the graph are already immutable sets` but that does not seem to be true. Should something be done about this to limit allocation?

Please let me know!
Cheers

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8314986](https://bugs.openjdk.org/browse/JDK-8314986): Module readability resolution is slow with large numbers of automatic modules (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15926/head:pull/15926` \
`$ git checkout pull/15926`

Update a local copy of the PR: \
`$ git checkout pull/15926` \
`$ git pull https://git.openjdk.org/jdk.git pull/15926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15926`

View PR using the GUI difftool: \
`$ git pr show -t 15926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15926.diff">https://git.openjdk.org/jdk/pull/15926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15926#issuecomment-1735661422)