### PR TITLE
8316907: Fix nonnull-compare warnings

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -726,7 +726,6 @@ void ArchDesc::build_pipe_classes(FILE *fp_cpp) {
   fprintf(fp_cpp, "  }\n");
   fprintf(fp_cpp, "#endif\n\n");
 #endif
-  fprintf(fp_cpp, "  assert(this, \"null pipeline info\");\n");
   fprintf(fp_cpp, "  assert(pred, \"null predecessor pipline info\");\n\n");
   fprintf(fp_cpp, "  if (pred->hasFixedLatency())\n    return (pred->fixedLatency());\n\n");
   fprintf(fp_cpp, "  // If this is not an operand, then assume a dependence with 0 latency\n");

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1061,11 +1061,6 @@ void CodeSection::print(const char* name) {
 }
 
 void CodeBuffer::print() {
-  if (this == nullptr) {
-    tty->print_cr("null CodeBuffer pointer");
-    return;
-  }
-
   tty->print_cr("CodeBuffer:");
   for (int n = 0; n < (int)SECT_LIMIT; n++) {
     // print each section


### PR DESCRIPTION
Please review this patch that fixes nonnull-compare warnings emitted by GCC after removing `-fno-delete-null-pointer-checks`.

The changes are pretty straightforward:
- removal of `assert(this)` only changes the behavior of debug code; assertion failure in that place would result in a crash later on,
- the check in `CodeBuffer::print` is a bit more complex to review; fortunately all uses except [`print_buf_locs`](https://github.com/openjdk/jdk/blob/1f7dfda7059f9dc14bff61b3c77d769ade85557d/src/hotspot/share/code/relocInfo.cpp#L990) are in CodeBuffer, and `print_buf_locs` is only used by developers from debugger.

I verified tier1-5 tests, just in case. No new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316907](https://bugs.openjdk.org/browse/JDK-8316907): Fix nonnull-compare warnings (**Sub-task** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15927/head:pull/15927` \
`$ git checkout pull/15927`

Update a local copy of the PR: \
`$ git checkout pull/15927` \
`$ git pull https://git.openjdk.org/jdk.git pull/15927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15927`

View PR using the GUI difftool: \
`$ git pr show -t 15927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15927.diff">https://git.openjdk.org/jdk/pull/15927.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15927#issuecomment-1735930469)