### PR TITLE
8316410: GC: Make TestCompressedClassFlags use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jdk.test.lib.Platform;
  * @library /
  * @modules java.base/jdk.internal.misc
  *          java.management
+ * @requires vm.opt.CompressedClassSpaceSize == null & vm.opt.UseCompressedClassPointers == null
  * @run driver gc.arguments.TestCompressedClassFlags
  */
 public class TestCompressedClassFlags {
@@ -50,7 +51,7 @@ public class TestCompressedClassFlags {
     }
 
     private static OutputAnalyzer runJava(String ... args) throws Exception {
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder(args);
+        ProcessBuilder pb = GCArguments.createTestJvm(args);
         return new OutputAnalyzer(pb.start());
     }
 }


### PR DESCRIPTION
Use createTestJvm.

Tested with:
```
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UseSerialGC' ==> TOTAL:1 PASS:1
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UseParallelGC' ==> TOTAL:1 PASS:1
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UseG1GC' ==> TOTAL:1 PASS:1
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UseZGC' ==> TOTAL:1 PASS:1
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UseZGC -XX:+ZGenerational' ==> TOTAL:1 PASS:1
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UseShenandoahGC' ==> TOTAL:1 PASS:1
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC' ==> TOTAL:1 PASS:1
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:CompressedClassSpaceSize=1g -XX:-UseCompressedClassPointers' ==> TOTAL:0
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:CompressedClassSpaceSize=1g' ==> TOTAL:0
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:-UseCompressedClassPointers' ==> TOTAL:0
make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestCompressedClassFlags.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UseCompressedClassPointers' ==> TOTAL:0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316410](https://bugs.openjdk.org/browse/JDK-8316410): GC: Make TestCompressedClassFlags use createTestJvm (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15929/head:pull/15929` \
`$ git checkout pull/15929`

Update a local copy of the PR: \
`$ git checkout pull/15929` \
`$ git pull https://git.openjdk.org/jdk.git pull/15929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15929`

View PR using the GUI difftool: \
`$ git pr show -t 15929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15929.diff">https://git.openjdk.org/jdk/pull/15929.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15929#issuecomment-1735961038)