### PR TITLE
8315721: CloseRace.java#id0 fails transiently on libgraal

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/CloseRace.java
+++ b/test/jdk/java/lang/ProcessBuilder/CloseRace.java
@@ -23,11 +23,13 @@
 
 /**
  * @test
- * @bug 8024521
+ * @bug 8024521 8315721
  * @summary Closing ProcessPipeInputStream at the time the process exits is racy
  *          and leads to data corruption. Run this test manually (as
  *          an ordinary java program) with  -Xmx8M  to repro bug 8024521.
  * @requires !vm.opt.final.ZGenerational
+ * @comment Don't allow -Xcomp, it disturbs the timing
+ * @requires (vm.compMode != "Xcomp")
  * @run main/othervm -Xmx8M -Dtest.duration=2 CloseRace
  */
 
@@ -35,6 +37,8 @@
  * @test
  * @comment Turn up heap size to lower amount of GCs
  * @requires vm.gc.Z & vm.opt.final.ZGenerational
+ * @comment Don't allow -Xcomp, it disturbs the timing
+ * @requires (vm.compMode != "Xcomp")
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xmx32M -Dtest.duration=2 CloseRace
  */
 


### PR DESCRIPTION
The timing of the test can be disturbed by -Xcomp so do not run with -Xcomp.
The problem appears with the Graal compiler but may also occur on other platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315721](https://bugs.openjdk.org/browse/JDK-8315721): CloseRace.java#id0 fails transiently on libgraal (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15930/head:pull/15930` \
`$ git checkout pull/15930`

Update a local copy of the PR: \
`$ git checkout pull/15930` \
`$ git pull https://git.openjdk.org/jdk.git pull/15930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15930`

View PR using the GUI difftool: \
`$ git pr show -t 15930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15930.diff">https://git.openjdk.org/jdk/pull/15930.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15930#issuecomment-1735961487)