### PR TITLE
8316973: GC: Make TestDisableDefaultGC use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
+++ b/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,13 +40,13 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestDisableDefaultGC {
     public static void main(String[] args) throws Exception {
         // Start VM, disabling all possible default GCs
-        ProcessBuilder pb = GCArguments.createJavaProcessBuilder("-XX:-UseSerialGC",
-                                                                 "-XX:-UseParallelGC",
-                                                                 "-XX:-UseG1GC",
-                                                                 "-XX:-UseZGC",
-                                                                 "-XX:+UnlockExperimentalVMOptions",
-                                                                 "-XX:-UseShenandoahGC",
-                                                                 "-version");
+        ProcessBuilder pb = GCArguments.createTestJvm("-XX:-UseSerialGC",
+                                                      "-XX:-UseParallelGC",
+                                                      "-XX:-UseG1GC",
+                                                      "-XX:-UseZGC",
+                                                      "-XX:+UnlockExperimentalVMOptions",
+                                                      "-XX:-UseShenandoahGC",
+                                                      "-version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldMatch("Garbage collector not selected");
         output.shouldHaveExitValue(1);


### PR DESCRIPTION
There seems there is no need to strip external vm flags. The `@requires vm.gc=="null"` will handle the case when we iterate different GCs and we will then just skip the test.

Tested with:
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java JTREG='RETAIN=all;VERBOSE=all;JAVA_OPTIONS=-XX:+UseG1GC'` -> total 0
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestDisableDefaultGC.java` -> success

started tier 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316973](https://bugs.openjdk.org/browse/JDK-8316973): GC: Make TestDisableDefaultGC use createTestJvm (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15931/head:pull/15931` \
`$ git checkout pull/15931`

Update a local copy of the PR: \
`$ git checkout pull/15931` \
`$ git pull https://git.openjdk.org/jdk.git pull/15931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15931`

View PR using the GUI difftool: \
`$ git pr show -t 15931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15931.diff">https://git.openjdk.org/jdk/pull/15931.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15931#issuecomment-1735984446)