### PR TITLE
8316895: SeenThread::print_action_queue called on a null pointer

### DIFF
--- a/src/hotspot/share/classfile/placeholders.cpp
+++ b/src/hotspot/share/classfile/placeholders.cpp
@@ -80,8 +80,7 @@ public:
    void set_next(SeenThread* seen) { _stnext = seen; }
    void set_prev(SeenThread* seen) { _stprev = seen; }
 
-  void print_action_queue(outputStream* st) {
-    SeenThread* seen = this;
+  static void print_action_queue(SeenThread* seen, outputStream* st) {
     while (seen != nullptr) {
       seen->thread()->print_value_on(st);
       st->print(", ");
@@ -327,13 +326,13 @@ void PlaceholderEntry::print_on(outputStream* st) const {
   }
   st->cr();
   st->print("loadInstanceThreadQ threads:");
-  loadInstanceThreadQ()->print_action_queue(st);
+  SeenThread::print_action_queue(loadInstanceThreadQ(), st);
   st->cr();
   st->print("superThreadQ threads:");
-  superThreadQ()->print_action_queue(st);
+  SeenThread::print_action_queue(superThreadQ(), st);
   st->cr();
   st->print("defineThreadQ threads:");
-  defineThreadQ()->print_action_queue(st);
+  SeenThread::print_action_queue(defineThreadQ(), st);
   st->cr();
 }
 


### PR DESCRIPTION
This patch fixes a crash in `test/hotspot/jtreg/runtime/logging/RedefineClasses.java` when the code is compiled without `-fno-delete-null-pointer-checks`.

The test crashes because the method `print_action_queue` is called on a null object reference, which leads to undefined behavior. Some C++ compilers take that as a permission to assume that `this` is never null and remove all such checks.

The patch simply changes `print_action_queue` to a static method taking a pointer to what was formerly `this`. There's not much that could possibly go wrong.

Should I add the bug ID to `test/hotspot/jtreg/runtime/logging/RedefineClasses.java`? The existing code does not crash now; it would only start crashing after [JDK-8316893](https://bugs.openjdk.org/browse/JDK-8316893) is addressed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316895](https://bugs.openjdk.org/browse/JDK-8316895): SeenThread::print_action_queue called on a null pointer (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15932/head:pull/15932` \
`$ git checkout pull/15932`

Update a local copy of the PR: \
`$ git checkout pull/15932` \
`$ git pull https://git.openjdk.org/jdk.git pull/15932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15932`

View PR using the GUI difftool: \
`$ git pr show -t 15932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15932.diff">https://git.openjdk.org/jdk/pull/15932.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15932#issuecomment-1736089445)