### PR TITLE
8295919: java.security.MessageDigest.isEqual does not adhere to @implNote

### DIFF
--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -458,9 +458,11 @@ public abstract class MessageDigest extends MessageDigestSpi {
      *
      * @implNote
      * All bytes in {@code digesta} are examined to determine equality, unless
-     * {@code digestb} is null or has a length of zero bytes. If {@code digestb}
-     * is not {@code null} and does not have a length of zero bytes, then the
-     * calculation time depends only on the length of {@code digesta}.
+     * {@code digestb} is {@code null} or has a length of zero bytes. If
+     * {@code digestb} is not {@code null} and does not have a length of zero
+     * bytes, then the calculation time depends only on the length of
+     * {@code digesta}. It does not depend on the length of {@code digestb} or
+     * the contents of {@code digesta} and {@code digestb}.
      *
      * @param digesta one of the digests to compare.
      *

--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -457,11 +457,10 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * the same length and all bytes at corresponding positions are equal.
      *
      * @implNote
-     * All bytes in {@code digesta} are examined to determine equality.
-     * The calculation time depends only on the length of {@code digesta}.
-     * It does not depend on the length of {@code digestb} or the contents
-     * of {@code digesta} and {@code digestb}, unless {@code digestb} is null
-     * or has a length of zero bytes.
+     * All bytes in {@code digesta} are examined to determine equality, unless
+     * {@code digestb} is null or has a length of zero bytes. If {@code digestb}
+     * is not {@code null} and does not have a length of zero bytes, then the
+     * calculation time depends only on the length of {@code digesta}.
      *
      * @param digesta one of the digests to compare.
      *

--- a/src/java.base/share/classes/java/security/MessageDigest.java
+++ b/src/java.base/share/classes/java/security/MessageDigest.java
@@ -460,7 +460,8 @@ public abstract class MessageDigest extends MessageDigestSpi {
      * All bytes in {@code digesta} are examined to determine equality.
      * The calculation time depends only on the length of {@code digesta}.
      * It does not depend on the length of {@code digestb} or the contents
-     * of {@code digesta} and {@code digestb}.
+     * of {@code digesta} and {@code digestb}, unless {@code digestb} is null
+     * or has a length of zero bytes.
      *
      * @param digesta one of the digests to compare.
      *


### PR DESCRIPTION
Fix JDK-8295919 by updating the javadoc to explain that a null or zero-length `digestb` will also result in a short-circuit response

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295919](https://bugs.openjdk.org/browse/JDK-8295919): java.security.MessageDigest.isEqual does not adhere to @<!---->implNote (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15933/head:pull/15933` \
`$ git checkout pull/15933`

Update a local copy of the PR: \
`$ git checkout pull/15933` \
`$ git pull https://git.openjdk.org/jdk.git pull/15933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15933`

View PR using the GUI difftool: \
`$ git pr show -t 15933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15933.diff">https://git.openjdk.org/jdk/pull/15933.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15933#issuecomment-1736183454)