### PR TITLE
8316974: ListFormat creation is unsuccessful for some of the supported Locales

### DIFF
--- a/src/java.base/share/classes/java/text/ListFormat.java
+++ b/src/java.base/share/classes/java/text/ListFormat.java
@@ -513,7 +513,7 @@ public final class ListFormat extends Format {
     public String toString() {
         return
             """
-            ListFormat [locale: "%s", start: "%s", middle: "%s",  end: "%s", two: "%s", three: "%s"]
+            ListFormat [locale: "%s", start: "%s", middle: "%s", end: "%s", two: "%s", three: "%s"]
             """.formatted(locale.getDisplayName(), patterns[START], patterns[MIDDLE], patterns[END], patterns[TWO], patterns[THREE]);
     }
 

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -859,7 +859,7 @@ public class LocaleResources {
                     // make sure there is at least one parent locale
                     if (candList.size() >= 2) {
                         var parentPatterns = adapter.getLocaleResources(candList.get(1)).getListPatterns(type, style);
-                        for (int i = 0; i < lpArray.length; i++) {
+                        for (int i = 0; i < 3; i++) { // exclude optional ones, ie, "two"/"three"
                             if (lpArray[i].isEmpty()) {
                                 lpArray[i] = parentPatterns[i];
                             }

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -843,7 +843,7 @@ public class LocaleResources {
         String typeStr = type.toString().toLowerCase(Locale.ROOT);
         String styleStr = style.toString().toLowerCase(Locale.ROOT);
         String[] lpArray;
-        String cacheKey = LIST_PATTERN + typeStr;
+        String cacheKey = LIST_PATTERN + typeStr + styleStr;
 
         removeEmptyReferences();
         ResourceReference data = cache.get(cacheKey);
@@ -867,6 +867,7 @@ public class LocaleResources {
                     }
                 }
             }
+            cache.put(cacheKey, new ResourceReference(cacheKey, lpArray, referenceQueue));
         }
 
         return lpArray;

--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -851,8 +851,21 @@ public class LocaleResources {
         if (data == null || ((lpArray = (String[]) data.get()) == null)) {
             ResourceBundle rb = localeData.getDateFormatData(locale);
             lpArray = rb.getStringArray("ListPatterns_" + typeStr + (style == ListFormat.Style.FULL ? "" : "-" + styleStr));
-            if (lpArray == null) {
-                cache.put(cacheKey, new ResourceReference(cacheKey, new String[5], referenceQueue));
+
+            if (lpArray[0].isEmpty() || lpArray[1].isEmpty() || lpArray[2].isEmpty()) {
+                var adapter = LocaleProviderAdapter.forType(LocaleProviderAdapter.Type.CLDR);
+                if (adapter instanceof ResourceBundleBasedAdapter rbba) {
+                    var candList = rbba.getCandidateLocales("", locale);
+                    // make sure there is at least one parent locale
+                    if (candList.size() >= 2) {
+                        var parentPatterns = adapter.getLocaleResources(candList.get(1)).getListPatterns(type, style);
+                        for (int i = 0; i < lpArray.length; i++) {
+                            if (lpArray[i].isEmpty()) {
+                                lpArray[i] = parentPatterns[i];
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/test/jdk/java/text/Format/ListFormat/TestListFormat.java
+++ b/test/jdk/java/text/Format/ListFormat/TestListFormat.java
@@ -33,7 +33,6 @@ import java.text.FieldPosition;
 import java.text.ListFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 

--- a/test/jdk/java/text/Format/ListFormat/TestListFormat.java
+++ b/test/jdk/java/text/Format/ListFormat/TestListFormat.java
@@ -309,6 +309,18 @@ public class TestListFormat {
         // should be inherited from parent locales.
         Locale.availableLocales().forEach(l -> ListFormat.getInstance(l, type, style));
     }
+    @Test
+    void getInstance_3Arg_InheritanceValidation() {
+        // Tests if inheritance works as expected.
+        // World English ("en-001") has non-Oxford-comma pattern for "end", while
+        // English ("en") has Oxford-comma "end" pattern. Thus missing "standard"/"middle"
+        // should be inherited from "en", but "end" should stay non-Oxford for "en-001"
+        // Note that this test depends on a particular version of CLDR data.
+        assertEquals("""
+            ListFormat [locale: "English (world)", start: "{0}, {1}", middle: "{0}, {1}", end: "{0} and {1}", two: "{0} and {1}", three: "{0}, {1} and {2}"]
+            """,
+            ListFormat.getInstance(Locale.forLanguageTag("en-001"), ListFormat.Type.STANDARD, ListFormat.Style.FULL).toString());
+    }
 
     private static void compareResult(ListFormat f, List<String> input, String expected, boolean roundTrip) throws ParseException {
         var result = f.format(input);

--- a/test/jdk/java/text/Format/ListFormat/TestListFormat.java
+++ b/test/jdk/java/text/Format/ListFormat/TestListFormat.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8041488
+ * @bug 8041488 8316974
  * @summary Tests for ListFormat class
  * @run junit TestListFormat
  */
@@ -33,6 +33,7 @@ import java.text.FieldPosition;
 import java.text.ListFormat;
 import java.text.ParseException;
 import java.text.ParsePosition;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -200,7 +201,19 @@ public class TestListFormat {
                 arguments(CUSTOM_PATTERNS_MINIMAL, SAMPLE4),
         };
     }
-
+    static Arguments[] getInstance_3Arg_InheritPatterns() {
+        return new Arguments[] {
+                arguments(ListFormat.Type.STANDARD, ListFormat.Style.FULL),
+                arguments(ListFormat.Type.STANDARD, ListFormat.Style.SHORT),
+                arguments(ListFormat.Type.STANDARD, ListFormat.Style.NARROW),
+                arguments(ListFormat.Type.OR, ListFormat.Style.FULL),
+                arguments(ListFormat.Type.OR, ListFormat.Style.SHORT),
+                arguments(ListFormat.Type.OR, ListFormat.Style.NARROW),
+                arguments(ListFormat.Type.UNIT, ListFormat.Style.FULL),
+                arguments(ListFormat.Type.UNIT, ListFormat.Style.SHORT),
+                arguments(ListFormat.Type.UNIT, ListFormat.Style.NARROW),
+        };
+    }
     @ParameterizedTest
     @MethodSource
     void getInstance_1Arg(String[] patterns, List<String> input, String expected) throws ParseException {
@@ -287,6 +300,15 @@ public class TestListFormat {
         parsed = f.parseObject(testStr, pp);
         assertNotEquals(input, parsed);
         assertEquals(-1, pp.getErrorIndex());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getInstance_3Arg_InheritPatterns(ListFormat.Type type, ListFormat.Style style) {
+        // No IAE should be thrown for all locales. Some locales in CLDR
+        // have partial patterns (start, middle, end) in it. Lacking ones
+        // should be inherited from parent locales.
+        Locale.availableLocales().forEach(l -> ListFormat.getInstance(l, type, style));
     }
 
     private static void compareResult(ListFormat f, List<String> input, String expected, boolean roundTrip) throws ParseException {


### PR DESCRIPTION
Some CLDR locales have partial list patterns, such as only the "end" pattern, and expect "start" and "middle" patterns to be inherited from parent locales. Made the code capable of the inheritance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316974](https://bugs.openjdk.org/browse/JDK-8316974): ListFormat creation is unsuccessful for some of the supported Locales (**Bug** - P3)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15935/head:pull/15935` \
`$ git checkout pull/15935`

Update a local copy of the PR: \
`$ git checkout pull/15935` \
`$ git pull https://git.openjdk.org/jdk.git pull/15935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15935`

View PR using the GUI difftool: \
`$ git pr show -t 15935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15935.diff">https://git.openjdk.org/jdk/pull/15935.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15935#issuecomment-1736355878)