### PR TITLE
8316998: Remove redundant type arguments in the java.util.stream package

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -336,9 +336,12 @@ public final class Collectors {
      * {@code String}, in encounter order
      */
     public static Collector<CharSequence, ?, String> joining() {
-        return new CollectorImpl<CharSequence, StringBuilder, String>(
+        return new CollectorImpl<>(
                 StringBuilder::new, StringBuilder::append,
-                (r1, r2) -> { r1.append(r2); return r1; },
+                (r1, r2) -> {
+                    r1.append(r2);
+                    return r1;
+                },
                 StringBuilder::toString, CH_NOID);
     }
 
@@ -902,9 +905,12 @@ public final class Collectors {
             }
         }
 
-        return new CollectorImpl<T, OptionalBox, Optional<T>>(
+        return new CollectorImpl<>(
                 OptionalBox::new, OptionalBox::accept,
-                (a, b) -> { if (b.present) a.accept(b.value); return a; },
+                (a, b) -> {
+                    if (b.present) a.accept(b.value);
+                    return a;
+                },
                 a -> Optional.ofNullable(a.value), CH_NOID);
     }
 
@@ -1816,10 +1822,13 @@ public final class Collectors {
      */
     public static <T>
     Collector<T, ?, IntSummaryStatistics> summarizingInt(ToIntFunction<? super T> mapper) {
-        return new CollectorImpl<T, IntSummaryStatistics, IntSummaryStatistics>(
+        return new CollectorImpl<>(
                 IntSummaryStatistics::new,
                 (r, t) -> r.accept(mapper.applyAsInt(t)),
-                (l, r) -> { l.combine(r); return l; }, CH_ID);
+                (l, r) -> {
+                    l.combine(r);
+                    return l;
+                }, CH_ID);
     }
 
     /**
@@ -1836,10 +1845,13 @@ public final class Collectors {
      */
     public static <T>
     Collector<T, ?, LongSummaryStatistics> summarizingLong(ToLongFunction<? super T> mapper) {
-        return new CollectorImpl<T, LongSummaryStatistics, LongSummaryStatistics>(
+        return new CollectorImpl<>(
                 LongSummaryStatistics::new,
                 (r, t) -> r.accept(mapper.applyAsLong(t)),
-                (l, r) -> { l.combine(r); return l; }, CH_ID);
+                (l, r) -> {
+                    l.combine(r);
+                    return l;
+                }, CH_ID);
     }
 
     /**
@@ -1856,10 +1868,13 @@ public final class Collectors {
      */
     public static <T>
     Collector<T, ?, DoubleSummaryStatistics> summarizingDouble(ToDoubleFunction<? super T> mapper) {
-        return new CollectorImpl<T, DoubleSummaryStatistics, DoubleSummaryStatistics>(
+        return new CollectorImpl<>(
                 DoubleSummaryStatistics::new,
                 (r, t) -> r.accept(mapper.applyAsDouble(t)),
-                (l, r) -> { l.combine(r); return l; }, CH_ID);
+                (l, r) -> {
+                    l.combine(r);
+                    return l;
+                }, CH_ID);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -223,7 +223,7 @@ public final class Collectors {
      */
     public static <T, C extends Collection<T>>
     Collector<T, ?, C> toCollection(Supplier<C> collectionFactory) {
-        return new CollectorImpl<>(collectionFactory, Collection<T>::add,
+        return new CollectorImpl<>(collectionFactory, Collection::add,
                                    (r1, r2) -> { r1.addAll(r2); return r1; },
                                    CH_ID);
     }
@@ -1106,7 +1106,7 @@ public final class Collectors {
             A container = m.computeIfAbsent(key, k -> downstreamSupplier.get());
             downstreamAccumulator.accept(container, t);
         };
-        BinaryOperator<Map<K, A>> merger = Collectors.<K, A, Map<K, A>>mapMerger(downstream.combiner());
+        BinaryOperator<Map<K, A>> merger = Collectors.mapMerger(downstream.combiner());
         @SuppressWarnings("unchecked")
         Supplier<Map<K, A>> mangledFactory = (Supplier<Map<K, A>>) mapFactory;
 
@@ -1259,7 +1259,7 @@ public final class Collectors {
                                             Collector<? super T, A, D> downstream) {
         Supplier<A> downstreamSupplier = downstream.supplier();
         BiConsumer<A, ? super T> downstreamAccumulator = downstream.accumulator();
-        BinaryOperator<ConcurrentMap<K, A>> merger = Collectors.<K, A, ConcurrentMap<K, A>>mapMerger(downstream.combiner());
+        BinaryOperator<ConcurrentMap<K, A>> merger = Collectors.mapMerger(downstream.combiner());
         @SuppressWarnings("unchecked")
         Supplier<ConcurrentMap<K, A>> mangledFactory = (Supplier<ConcurrentMap<K, A>>) mapFactory;
         BiConsumer<ConcurrentMap<K, A>, T> accumulator;

--- a/src/java.base/share/classes/java/util/stream/DistinctOps.java
+++ b/src/java.base/share/classes/java/util/stream/DistinctOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/DistinctOps.java
+++ b/src/java.base/share/classes/java/util/stream/DistinctOps.java
@@ -122,7 +122,7 @@ final class DistinctOps {
                 if (StreamOpFlag.DISTINCT.isKnown(flags)) {
                     return sink;
                 } else if (StreamOpFlag.SORTED.isKnown(flags)) {
-                    return new Sink.ChainedReference<T, T>(sink) {
+                    return new Sink.ChainedReference<>(sink) {
                         boolean seenNull;
                         T lastSeen;
 
@@ -153,7 +153,7 @@ final class DistinctOps {
                         }
                     };
                 } else {
-                    return new Sink.ChainedReference<T, T>(sink) {
+                    return new Sink.ChainedReference<>(sink) {
                         Set<T> seen;
 
                         @Override

--- a/src/java.base/share/classes/java/util/stream/DoublePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/DoublePipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/DoublePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/DoublePipeline.java
@@ -167,10 +167,10 @@ abstract class DoublePipeline<E_IN>
     }
 
     private <U> Stream<U> mapToObj(DoubleFunction<? extends U> mapper, int opFlags) {
-        return new ReferencePipeline.StatelessOp<Double, U>(this, StreamShape.DOUBLE_VALUE, opFlags) {
+        return new ReferencePipeline.StatelessOp<>(this, StreamShape.DOUBLE_VALUE, opFlags) {
             @Override
             Sink<Double> opWrapSink(int flags, Sink<U> sink) {
-                return new Sink.ChainedDouble<U>(sink) {
+                return new Sink.ChainedDouble<>(sink) {
                     @Override
                     public void accept(double t) {
                         downstream.accept(mapper.apply(t));
@@ -202,11 +202,11 @@ abstract class DoublePipeline<E_IN>
     @Override
     public final DoubleStream map(DoubleUnaryOperator mapper) {
         Objects.requireNonNull(mapper);
-        return new StatelessOp<Double>(this, StreamShape.DOUBLE_VALUE,
-                                       StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new StatelessOp<>(this, StreamShape.DOUBLE_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Double> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedDouble<Double>(sink) {
+                return new Sink.ChainedDouble<>(sink) {
                     @Override
                     public void accept(double t) {
                         downstream.accept(mapper.applyAsDouble(t));
@@ -225,11 +225,11 @@ abstract class DoublePipeline<E_IN>
     @Override
     public final IntStream mapToInt(DoubleToIntFunction mapper) {
         Objects.requireNonNull(mapper);
-        return new IntPipeline.StatelessOp<Double>(this, StreamShape.DOUBLE_VALUE,
-                                                   StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new IntPipeline.StatelessOp<>(this, StreamShape.DOUBLE_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Double> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedDouble<Integer>(sink) {
+                return new Sink.ChainedDouble<>(sink) {
                     @Override
                     public void accept(double t) {
                         downstream.accept(mapper.applyAsInt(t));
@@ -242,11 +242,11 @@ abstract class DoublePipeline<E_IN>
     @Override
     public final LongStream mapToLong(DoubleToLongFunction mapper) {
         Objects.requireNonNull(mapper);
-        return new LongPipeline.StatelessOp<Double>(this, StreamShape.DOUBLE_VALUE,
-                                                    StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new LongPipeline.StatelessOp<>(this, StreamShape.DOUBLE_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Double> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedDouble<Long>(sink) {
+                return new Sink.ChainedDouble<>(sink) {
                     @Override
                     public void accept(double t) {
                         downstream.accept(mapper.applyAsLong(t));
@@ -259,11 +259,11 @@ abstract class DoublePipeline<E_IN>
     @Override
     public final DoubleStream flatMap(DoubleFunction<? extends DoubleStream> mapper) {
         Objects.requireNonNull(mapper);
-        return new StatelessOp<Double>(this, StreamShape.DOUBLE_VALUE,
-                                        StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
+        return new StatelessOp<>(this, StreamShape.DOUBLE_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<Double> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedDouble<Double>(sink) {
+                return new Sink.ChainedDouble<>(sink) {
                     // true if cancellationRequested() has been called
                     boolean cancellationRequestedCalled;
 
@@ -281,10 +281,10 @@ abstract class DoublePipeline<E_IN>
                             if (result != null) {
                                 if (!cancellationRequestedCalled) {
                                     result.sequential().forEach(downstreamAsDouble);
-                                }
-                                else {
+                                } else {
                                     var s = result.sequential().spliterator();
-                                    do { } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsDouble));
+                                    do {
+                                    } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsDouble));
                                 }
                             }
                         }
@@ -333,7 +333,7 @@ abstract class DoublePipeline<E_IN>
     public DoubleStream unordered() {
         if (!isOrdered())
             return this;
-        return new StatelessOp<Double>(this, StreamShape.DOUBLE_VALUE, StreamOpFlag.NOT_ORDERED) {
+        return new StatelessOp<>(this, StreamShape.DOUBLE_VALUE, StreamOpFlag.NOT_ORDERED) {
             @Override
             Sink<Double> opWrapSink(int flags, Sink<Double> sink) {
                 return sink;
@@ -344,11 +344,11 @@ abstract class DoublePipeline<E_IN>
     @Override
     public final DoubleStream filter(DoublePredicate predicate) {
         Objects.requireNonNull(predicate);
-        return new StatelessOp<Double>(this, StreamShape.DOUBLE_VALUE,
-                                       StreamOpFlag.NOT_SIZED) {
+        return new StatelessOp<>(this, StreamShape.DOUBLE_VALUE,
+                StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<Double> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedDouble<Double>(sink) {
+                return new Sink.ChainedDouble<>(sink) {
                     @Override
                     public void begin(long size) {
                         downstream.begin(-1);
@@ -367,11 +367,11 @@ abstract class DoublePipeline<E_IN>
     @Override
     public final DoubleStream peek(DoubleConsumer action) {
         Objects.requireNonNull(action);
-        return new StatelessOp<Double>(this, StreamShape.DOUBLE_VALUE,
-                                       0) {
+        return new StatelessOp<>(this, StreamShape.DOUBLE_VALUE,
+                0) {
             @Override
             Sink<Double> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedDouble<Double>(sink) {
+                return new Sink.ChainedDouble<>(sink) {
                     @Override
                     public void accept(double t) {
                         action.accept(t);

--- a/src/java.base/share/classes/java/util/stream/IntPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/IntPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/IntPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/IntPipeline.java
@@ -171,10 +171,10 @@ abstract class IntPipeline<E_IN>
     }
 
     private <U> Stream<U> mapToObj(IntFunction<? extends U> mapper, int opFlags) {
-        return new ReferencePipeline.StatelessOp<Integer, U>(this, StreamShape.INT_VALUE, opFlags) {
+        return new ReferencePipeline.StatelessOp<>(this, StreamShape.INT_VALUE, opFlags) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<U> sink) {
-                return new Sink.ChainedInt<U>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     @Override
                     public void accept(int t) {
                         downstream.accept(mapper.apply(t));
@@ -200,10 +200,10 @@ abstract class IntPipeline<E_IN>
 
     @Override
     public final LongStream asLongStream() {
-        return new LongPipeline.StatelessOp<Integer>(this, StreamShape.INT_VALUE, 0) {
+        return new LongPipeline.StatelessOp<>(this, StreamShape.INT_VALUE, 0) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedInt<Long>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     @Override
                     public void accept(int t) {
                         downstream.accept((long) t);
@@ -215,10 +215,10 @@ abstract class IntPipeline<E_IN>
 
     @Override
     public final DoubleStream asDoubleStream() {
-        return new DoublePipeline.StatelessOp<Integer>(this, StreamShape.INT_VALUE, 0) {
+        return new DoublePipeline.StatelessOp<>(this, StreamShape.INT_VALUE, 0) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedInt<Double>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     @Override
                     public void accept(int t) {
                         downstream.accept((double) t);
@@ -236,11 +236,11 @@ abstract class IntPipeline<E_IN>
     @Override
     public final IntStream map(IntUnaryOperator mapper) {
         Objects.requireNonNull(mapper);
-        return new StatelessOp<Integer>(this, StreamShape.INT_VALUE,
-                                        StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new StatelessOp<>(this, StreamShape.INT_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedInt<Integer>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     @Override
                     public void accept(int t) {
                         downstream.accept(mapper.applyAsInt(t));
@@ -259,11 +259,11 @@ abstract class IntPipeline<E_IN>
     @Override
     public final LongStream mapToLong(IntToLongFunction mapper) {
         Objects.requireNonNull(mapper);
-        return new LongPipeline.StatelessOp<Integer>(this, StreamShape.INT_VALUE,
-                                                     StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new LongPipeline.StatelessOp<>(this, StreamShape.INT_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedInt<Long>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     @Override
                     public void accept(int t) {
                         downstream.accept(mapper.applyAsLong(t));
@@ -276,11 +276,11 @@ abstract class IntPipeline<E_IN>
     @Override
     public final DoubleStream mapToDouble(IntToDoubleFunction mapper) {
         Objects.requireNonNull(mapper);
-        return new DoublePipeline.StatelessOp<Integer>(this, StreamShape.INT_VALUE,
-                                                       StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new DoublePipeline.StatelessOp<>(this, StreamShape.INT_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedInt<Double>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     @Override
                     public void accept(int t) {
                         downstream.accept(mapper.applyAsDouble(t));
@@ -293,11 +293,11 @@ abstract class IntPipeline<E_IN>
     @Override
     public final IntStream flatMap(IntFunction<? extends IntStream> mapper) {
         Objects.requireNonNull(mapper);
-        return new StatelessOp<Integer>(this, StreamShape.INT_VALUE,
-                                        StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
+        return new StatelessOp<>(this, StreamShape.INT_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedInt<Integer>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     // true if cancellationRequested() has been called
                     boolean cancellationRequestedCalled;
 
@@ -315,10 +315,10 @@ abstract class IntPipeline<E_IN>
                             if (result != null) {
                                 if (!cancellationRequestedCalled) {
                                     result.sequential().forEach(downstreamAsInt);
-                                }
-                                else {
+                                } else {
                                     var s = result.sequential().spliterator();
-                                    do { } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsInt));
+                                    do {
+                                    } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsInt));
                                 }
                             }
                         }
@@ -366,7 +366,7 @@ abstract class IntPipeline<E_IN>
     public IntStream unordered() {
         if (!isOrdered())
             return this;
-        return new StatelessOp<Integer>(this, StreamShape.INT_VALUE, StreamOpFlag.NOT_ORDERED) {
+        return new StatelessOp<>(this, StreamShape.INT_VALUE, StreamOpFlag.NOT_ORDERED) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Integer> sink) {
                 return sink;
@@ -377,11 +377,11 @@ abstract class IntPipeline<E_IN>
     @Override
     public final IntStream filter(IntPredicate predicate) {
         Objects.requireNonNull(predicate);
-        return new StatelessOp<Integer>(this, StreamShape.INT_VALUE,
-                                        StreamOpFlag.NOT_SIZED) {
+        return new StatelessOp<>(this, StreamShape.INT_VALUE,
+                StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedInt<Integer>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     @Override
                     public void begin(long size) {
                         downstream.begin(-1);
@@ -400,11 +400,11 @@ abstract class IntPipeline<E_IN>
     @Override
     public final IntStream peek(IntConsumer action) {
         Objects.requireNonNull(action);
-        return new StatelessOp<Integer>(this, StreamShape.INT_VALUE,
-                                        0) {
+        return new StatelessOp<>(this, StreamShape.INT_VALUE,
+                0) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedInt<Integer>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     @Override
                     public void accept(int t) {
                         action.accept(t);

--- a/src/java.base/share/classes/java/util/stream/LongPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/LongPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/LongPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/LongPipeline.java
@@ -168,10 +168,10 @@ abstract class LongPipeline<E_IN>
     }
 
     private <U> Stream<U> mapToObj(LongFunction<? extends U> mapper, int opFlags) {
-        return new ReferencePipeline.StatelessOp<Long, U>(this, StreamShape.LONG_VALUE, opFlags) {
+        return new ReferencePipeline.StatelessOp<>(this, StreamShape.LONG_VALUE, opFlags) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<U> sink) {
-                return new Sink.ChainedLong<U>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     @Override
                     public void accept(long t) {
                         downstream.accept(mapper.apply(t));
@@ -197,10 +197,10 @@ abstract class LongPipeline<E_IN>
 
     @Override
     public final DoubleStream asDoubleStream() {
-        return new DoublePipeline.StatelessOp<Long>(this, StreamShape.LONG_VALUE, StreamOpFlag.NOT_DISTINCT) {
+        return new DoublePipeline.StatelessOp<>(this, StreamShape.LONG_VALUE, StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedLong<Double>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     @Override
                     public void accept(long t) {
                         downstream.accept((double) t);
@@ -218,11 +218,11 @@ abstract class LongPipeline<E_IN>
     @Override
     public final LongStream map(LongUnaryOperator mapper) {
         Objects.requireNonNull(mapper);
-        return new StatelessOp<Long>(this, StreamShape.LONG_VALUE,
-                                     StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new StatelessOp<>(this, StreamShape.LONG_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedLong<Long>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     @Override
                     public void accept(long t) {
                         downstream.accept(mapper.applyAsLong(t));
@@ -241,11 +241,11 @@ abstract class LongPipeline<E_IN>
     @Override
     public final IntStream mapToInt(LongToIntFunction mapper) {
         Objects.requireNonNull(mapper);
-        return new IntPipeline.StatelessOp<Long>(this, StreamShape.LONG_VALUE,
-                                                 StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new IntPipeline.StatelessOp<>(this, StreamShape.LONG_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedLong<Integer>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     @Override
                     public void accept(long t) {
                         downstream.accept(mapper.applyAsInt(t));
@@ -258,11 +258,11 @@ abstract class LongPipeline<E_IN>
     @Override
     public final DoubleStream mapToDouble(LongToDoubleFunction mapper) {
         Objects.requireNonNull(mapper);
-        return new DoublePipeline.StatelessOp<Long>(this, StreamShape.LONG_VALUE,
-                                                    StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new DoublePipeline.StatelessOp<>(this, StreamShape.LONG_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedLong<Double>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     @Override
                     public void accept(long t) {
                         downstream.accept(mapper.applyAsDouble(t));
@@ -275,11 +275,11 @@ abstract class LongPipeline<E_IN>
     @Override
     public final LongStream flatMap(LongFunction<? extends LongStream> mapper) {
         Objects.requireNonNull(mapper);
-        return new StatelessOp<Long>(this, StreamShape.LONG_VALUE,
-                                     StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
+        return new StatelessOp<>(this, StreamShape.LONG_VALUE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedLong<Long>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     // true if cancellationRequested() has been called
                     boolean cancellationRequestedCalled;
 
@@ -297,10 +297,10 @@ abstract class LongPipeline<E_IN>
                             if (result != null) {
                                 if (!cancellationRequestedCalled) {
                                     result.sequential().forEach(downstreamAsLong);
-                                }
-                                else {
+                                } else {
                                     var s = result.sequential().spliterator();
-                                    do { } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsLong));
+                                    do {
+                                    } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsLong));
                                 }
                             }
                         }
@@ -348,7 +348,7 @@ abstract class LongPipeline<E_IN>
     public LongStream unordered() {
         if (!isOrdered())
             return this;
-        return new StatelessOp<Long>(this, StreamShape.LONG_VALUE, StreamOpFlag.NOT_ORDERED) {
+        return new StatelessOp<>(this, StreamShape.LONG_VALUE, StreamOpFlag.NOT_ORDERED) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Long> sink) {
                 return sink;
@@ -359,11 +359,11 @@ abstract class LongPipeline<E_IN>
     @Override
     public final LongStream filter(LongPredicate predicate) {
         Objects.requireNonNull(predicate);
-        return new StatelessOp<Long>(this, StreamShape.LONG_VALUE,
-                                     StreamOpFlag.NOT_SIZED) {
+        return new StatelessOp<>(this, StreamShape.LONG_VALUE,
+                StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedLong<Long>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     @Override
                     public void begin(long size) {
                         downstream.begin(-1);
@@ -382,11 +382,11 @@ abstract class LongPipeline<E_IN>
     @Override
     public final LongStream peek(LongConsumer action) {
         Objects.requireNonNull(action);
-        return new StatelessOp<Long>(this, StreamShape.LONG_VALUE,
-                                     0) {
+        return new StatelessOp<>(this, StreamShape.LONG_VALUE,
+                0) {
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedLong<Long>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     @Override
                     public void accept(long t) {
                         action.accept(t);

--- a/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
@@ -152,7 +152,7 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     public Stream<P_OUT> unordered() {
         if (!isOrdered())
             return this;
-        return new StatelessOp<P_OUT, P_OUT>(this, StreamShape.REFERENCE, StreamOpFlag.NOT_ORDERED) {
+        return new StatelessOp<>(this, StreamShape.REFERENCE, StreamOpFlag.NOT_ORDERED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<P_OUT> sink) {
                 return sink;
@@ -163,11 +163,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final Stream<P_OUT> filter(Predicate<? super P_OUT> predicate) {
         Objects.requireNonNull(predicate);
-        return new StatelessOp<P_OUT, P_OUT>(this, StreamShape.REFERENCE,
-                                     StreamOpFlag.NOT_SIZED) {
+        return new StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<P_OUT> sink) {
-                return new Sink.ChainedReference<P_OUT, P_OUT>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     @Override
                     public void begin(long size) {
                         downstream.begin(-1);
@@ -187,11 +187,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @SuppressWarnings("unchecked")
     public final <R> Stream<R> map(Function<? super P_OUT, ? extends R> mapper) {
         Objects.requireNonNull(mapper);
-        return new StatelessOp<P_OUT, R>(this, StreamShape.REFERENCE,
-                                     StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<R> sink) {
-                return new Sink.ChainedReference<P_OUT, R>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     @Override
                     public void accept(P_OUT u) {
                         downstream.accept(mapper.apply(u));
@@ -204,11 +204,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final IntStream mapToInt(ToIntFunction<? super P_OUT> mapper) {
         Objects.requireNonNull(mapper);
-        return new IntPipeline.StatelessOp<P_OUT>(this, StreamShape.REFERENCE,
-                                              StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new IntPipeline.StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedReference<P_OUT, Integer>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     @Override
                     public void accept(P_OUT u) {
                         downstream.accept(mapper.applyAsInt(u));
@@ -221,11 +221,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final LongStream mapToLong(ToLongFunction<? super P_OUT> mapper) {
         Objects.requireNonNull(mapper);
-        return new LongPipeline.StatelessOp<P_OUT>(this, StreamShape.REFERENCE,
-                                      StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new LongPipeline.StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedReference<P_OUT, Long>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     @Override
                     public void accept(P_OUT u) {
                         downstream.accept(mapper.applyAsLong(u));
@@ -238,11 +238,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final DoubleStream mapToDouble(ToDoubleFunction<? super P_OUT> mapper) {
         Objects.requireNonNull(mapper);
-        return new DoublePipeline.StatelessOp<P_OUT>(this, StreamShape.REFERENCE,
-                                        StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
+        return new DoublePipeline.StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedReference<P_OUT, Double>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     @Override
                     public void accept(P_OUT u) {
                         downstream.accept(mapper.applyAsDouble(u));
@@ -255,8 +255,8 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final <R> Stream<R> flatMap(Function<? super P_OUT, ? extends Stream<? extends R>> mapper) {
         Objects.requireNonNull(mapper);
-        return new StatelessOp<P_OUT, R>(this, StreamShape.REFERENCE,
-                                     StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
+        return new StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<R> sink) {
                 return new Sink.ChainedReference<>(sink) {
@@ -274,10 +274,10 @@ abstract class ReferencePipeline<P_IN, P_OUT>
                             if (result != null) {
                                 if (!cancellationRequestedCalled) {
                                     result.sequential().forEach(downstream);
-                                }
-                                else {
+                                } else {
                                     var s = result.sequential().spliterator();
-                                    do { } while (!downstream.cancellationRequested() && s.tryAdvance(downstream));
+                                    do {
+                                    } while (!downstream.cancellationRequested() && s.tryAdvance(downstream));
                                 }
                             }
                         }
@@ -300,11 +300,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final IntStream flatMapToInt(Function<? super P_OUT, ? extends IntStream> mapper) {
         Objects.requireNonNull(mapper);
-        return new IntPipeline.StatelessOp<P_OUT>(this, StreamShape.REFERENCE,
-                                              StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
+        return new IntPipeline.StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedReference<P_OUT, Integer>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     // true if cancellationRequested() has been called
                     boolean cancellationRequestedCalled;
 
@@ -322,10 +322,10 @@ abstract class ReferencePipeline<P_IN, P_OUT>
                             if (result != null) {
                                 if (!cancellationRequestedCalled) {
                                     result.sequential().forEach(downstreamAsInt);
-                                }
-                                else {
+                                } else {
                                     var s = result.sequential().spliterator();
-                                    do { } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsInt));
+                                    do {
+                                    } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsInt));
                                 }
                             }
                         }
@@ -344,11 +344,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final DoubleStream flatMapToDouble(Function<? super P_OUT, ? extends DoubleStream> mapper) {
         Objects.requireNonNull(mapper);
-        return new DoublePipeline.StatelessOp<P_OUT>(this, StreamShape.REFERENCE,
-                                                     StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
+        return new DoublePipeline.StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedReference<P_OUT, Double>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     // true if cancellationRequested() has been called
                     boolean cancellationRequestedCalled;
 
@@ -366,10 +366,10 @@ abstract class ReferencePipeline<P_IN, P_OUT>
                             if (result != null) {
                                 if (!cancellationRequestedCalled) {
                                     result.sequential().forEach(downstreamAsDouble);
-                                }
-                                else {
+                                } else {
                                     var s = result.sequential().spliterator();
-                                    do { } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsDouble));
+                                    do {
+                                    } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsDouble));
                                 }
                             }
                         }
@@ -389,11 +389,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     public final LongStream flatMapToLong(Function<? super P_OUT, ? extends LongStream> mapper) {
         Objects.requireNonNull(mapper);
         // We can do better than this, by polling cancellationRequested when stream is infinite
-        return new LongPipeline.StatelessOp<P_OUT>(this, StreamShape.REFERENCE,
-                                                   StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
+        return new LongPipeline.StatelessOp<>(this, StreamShape.REFERENCE,
+                StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedReference<P_OUT, Long>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     // true if cancellationRequested() has been called
                     boolean cancellationRequestedCalled;
 
@@ -411,10 +411,10 @@ abstract class ReferencePipeline<P_IN, P_OUT>
                             if (result != null) {
                                 if (!cancellationRequestedCalled) {
                                     result.sequential().forEach(downstreamAsLong);
-                                }
-                                else {
+                                } else {
                                     var s = result.sequential().spliterator();
-                                    do { } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsLong));
+                                    do {
+                                    } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsLong));
                                 }
                             }
                         }
@@ -530,11 +530,11 @@ abstract class ReferencePipeline<P_IN, P_OUT>
     @Override
     public final Stream<P_OUT> peek(Consumer<? super P_OUT> action) {
         Objects.requireNonNull(action);
-        return new StatelessOp<P_OUT, P_OUT>(this, StreamShape.REFERENCE,
-                                     0) {
+        return new StatelessOp<>(this, StreamShape.REFERENCE,
+                0) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<P_OUT> sink) {
-                return new Sink.ChainedReference<P_OUT, P_OUT>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     @Override
                     public void accept(P_OUT u) {
                         action.accept(u);

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1384,7 +1384,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * @return an empty sequential stream
      */
     public static<T> Stream<T> empty() {
-        return StreamSupport.stream(Spliterators.<T>emptySpliterator(), false);
+        return StreamSupport.stream(Spliterators.emptySpliterator(), false);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/WhileOps.java
+++ b/src/java.base/share/classes/java/util/stream/WhileOps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/WhileOps.java
+++ b/src/java.base/share/classes/java/util/stream/WhileOps.java
@@ -61,15 +61,14 @@ final class WhileOps {
     static <T> Stream<T> makeTakeWhileRef(AbstractPipeline<?, T, ?> upstream,
                                           Predicate<? super T> predicate) {
         Objects.requireNonNull(predicate);
-        return new ReferencePipeline.StatefulOp<T, T>(upstream, StreamShape.REFERENCE, TAKE_FLAGS) {
+        return new ReferencePipeline.StatefulOp<>(upstream, StreamShape.REFERENCE, TAKE_FLAGS) {
             @Override
             <P_IN> Spliterator<T> opEvaluateParallelLazy(PipelineHelper<T> helper,
                                                          Spliterator<P_IN> spliterator) {
                 if (StreamOpFlag.ORDERED.isKnown(helper.getStreamAndOpFlags())) {
                     return opEvaluateParallel(helper, spliterator, Nodes.castingArray())
                             .spliterator();
-                }
-                else {
+                } else {
                     return new UnorderedWhileSpliterator.OfRef.Taking<>(
                             helper.wrapSpliterator(spliterator), false, predicate);
                 }
@@ -85,7 +84,7 @@ final class WhileOps {
 
             @Override
             Sink<T> opWrapSink(int flags, Sink<T> sink) {
-                return new Sink.ChainedReference<T, T>(sink) {
+                return new Sink.ChainedReference<>(sink) {
                     boolean take = true;
 
                     @Override
@@ -118,15 +117,14 @@ final class WhileOps {
     static IntStream makeTakeWhileInt(AbstractPipeline<?, Integer, ?> upstream,
                                       IntPredicate predicate) {
         Objects.requireNonNull(predicate);
-        return new IntPipeline.StatefulOp<Integer>(upstream, StreamShape.INT_VALUE, TAKE_FLAGS) {
+        return new IntPipeline.StatefulOp<>(upstream, StreamShape.INT_VALUE, TAKE_FLAGS) {
             @Override
             <P_IN> Spliterator<Integer> opEvaluateParallelLazy(PipelineHelper<Integer> helper,
                                                                Spliterator<P_IN> spliterator) {
                 if (StreamOpFlag.ORDERED.isKnown(helper.getStreamAndOpFlags())) {
                     return opEvaluateParallel(helper, spliterator, Integer[]::new)
                             .spliterator();
-                }
-                else {
+                } else {
                     return new UnorderedWhileSpliterator.OfInt.Taking(
                             (Spliterator.OfInt) helper.wrapSpliterator(spliterator), false, predicate);
                 }
@@ -142,7 +140,7 @@ final class WhileOps {
 
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedInt<Integer>(sink) {
+                return new Sink.ChainedInt<>(sink) {
                     boolean take = true;
 
                     @Override
@@ -175,15 +173,14 @@ final class WhileOps {
     static LongStream makeTakeWhileLong(AbstractPipeline<?, Long, ?> upstream,
                                         LongPredicate predicate) {
         Objects.requireNonNull(predicate);
-        return new LongPipeline.StatefulOp<Long>(upstream, StreamShape.LONG_VALUE, TAKE_FLAGS) {
+        return new LongPipeline.StatefulOp<>(upstream, StreamShape.LONG_VALUE, TAKE_FLAGS) {
             @Override
             <P_IN> Spliterator<Long> opEvaluateParallelLazy(PipelineHelper<Long> helper,
                                                             Spliterator<P_IN> spliterator) {
                 if (StreamOpFlag.ORDERED.isKnown(helper.getStreamAndOpFlags())) {
                     return opEvaluateParallel(helper, spliterator, Long[]::new)
                             .spliterator();
-                }
-                else {
+                } else {
                     return new UnorderedWhileSpliterator.OfLong.Taking(
                             (Spliterator.OfLong) helper.wrapSpliterator(spliterator), false, predicate);
                 }
@@ -199,7 +196,7 @@ final class WhileOps {
 
             @Override
             Sink<Long> opWrapSink(int flags, Sink<Long> sink) {
-                return new Sink.ChainedLong<Long>(sink) {
+                return new Sink.ChainedLong<>(sink) {
                     boolean take = true;
 
                     @Override
@@ -232,15 +229,14 @@ final class WhileOps {
     static DoubleStream makeTakeWhileDouble(AbstractPipeline<?, Double, ?> upstream,
                                             DoublePredicate predicate) {
         Objects.requireNonNull(predicate);
-        return new DoublePipeline.StatefulOp<Double>(upstream, StreamShape.DOUBLE_VALUE, TAKE_FLAGS) {
+        return new DoublePipeline.StatefulOp<>(upstream, StreamShape.DOUBLE_VALUE, TAKE_FLAGS) {
             @Override
             <P_IN> Spliterator<Double> opEvaluateParallelLazy(PipelineHelper<Double> helper,
                                                               Spliterator<P_IN> spliterator) {
                 if (StreamOpFlag.ORDERED.isKnown(helper.getStreamAndOpFlags())) {
                     return opEvaluateParallel(helper, spliterator, Double[]::new)
                             .spliterator();
-                }
-                else {
+                } else {
                     return new UnorderedWhileSpliterator.OfDouble.Taking(
                             (Spliterator.OfDouble) helper.wrapSpliterator(spliterator), false, predicate);
                 }
@@ -256,7 +252,7 @@ final class WhileOps {
 
             @Override
             Sink<Double> opWrapSink(int flags, Sink<Double> sink) {
-                return new Sink.ChainedDouble<Double>(sink) {
+                return new Sink.ChainedDouble<>(sink) {
                     boolean take = true;
 
                     @Override


### PR DESCRIPTION
Remove cases of redundant type arguments in the java.util.stream package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316998](https://bugs.openjdk.org/browse/JDK-8316998): Remove redundant type arguments in the java.util.stream package (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15936/head:pull/15936` \
`$ git checkout pull/15936`

Update a local copy of the PR: \
`$ git checkout pull/15936` \
`$ git pull https://git.openjdk.org/jdk.git pull/15936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15936`

View PR using the GUI difftool: \
`$ git pr show -t 15936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15936.diff">https://git.openjdk.org/jdk/pull/15936.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15936#issuecomment-1736770390)