### PR TITLE
8280120: [IR Framework] Add attribute to @IR to enable/disable IR matching based on the architecture

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
@@ -109,6 +109,27 @@ public @interface IR {
     String[] applyIf() default {};
 
     /**
+     * Accepts a single feature pair which is composed of platform feature string followed by a true/false
+     * value where a true value necessities existence of platform feature and vice-versa.
+     * IR verifications checks are enforced only if the specified feature constraint is met.
+     */
+    String[] applyIfPlatformFeature() default {};
+
+    /**
+     * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
+     * value where a true value necessities existence of target feature and vice-versa.
+     * IR verifications checks are enforced only if all the specified feature constraints are met.
+     */
+    String[] applyIfPlatformFeatureAnd() default {};
+
+     /**
+     * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
+     * value where a true value necessities existence of target feature and vice-versa.
+     * IR verifications checks are enforced if any of the specified feature constraint is met.
+     */
+    String[] applyIfPlatformFeatureOr() default {};
+
+    /**
      * Accepts a single feature pair which is composed of CPU feature string followed by a true/false
      * value where a true value necessities existence of CPU feature and vice-versa.
      * IR verifications checks are enforced only if the specified feature constraint is met.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
@@ -111,21 +111,21 @@ public @interface IR {
     /**
      * Accepts a single pair composed of a platform string followed by a true/false
      * value where a true value necessitates that we are currently testing on that platform and vice-versa.
-     * IR verifications checks are enforced only if the specified platform constraint is met.
+     * IR checks are enforced only if the specified platform constraint is met.
      */
     String[] applyIfPlatform() default {};
 
     /**
      * Accepts a list of pairs where each pair is composed of a platform string followed by a true/false
      * value where a true value necessitates that we are currently testing on that platform and vice-versa.
-     * IR verifications checks are enforced only if all the specified platform constraints are met.
+     * IR checks are enforced only if all the specified platform constraints are met.
      */
     String[] applyIfPlatformAnd() default {};
 
     /**
      * Accepts a list of pairs where each pair is composed of a platform string followed by a true/false
      * value where a true value necessitates that we are currently testing on that platform and vice-versa.
-     * IR verifications checks are enforced if any of the specified platform constraints are met.
+     * IR checks are enforced if any of the specified platform constraints are met.
      */
     String[] applyIfPlatformOr() default {};
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
@@ -122,7 +122,7 @@ public @interface IR {
      */
     String[] applyIfPlatformFeatureAnd() default {};
 
-     /**
+    /**
      * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
      * value where a true value necessities existence of target feature and vice-versa.
      * IR verifications checks are enforced if any of the specified feature constraint is met.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IR.java
@@ -109,43 +109,43 @@ public @interface IR {
     String[] applyIf() default {};
 
     /**
-     * Accepts a single feature pair which is composed of platform feature string followed by a true/false
-     * value where a true value necessities existence of platform feature and vice-versa.
-     * IR verifications checks are enforced only if the specified feature constraint is met.
+     * Accepts a single pair composed of a platform string followed by a true/false
+     * value where a true value necessitates that we are currently testing on that platform and vice-versa.
+     * IR verifications checks are enforced only if the specified platform constraint is met.
      */
-    String[] applyIfPlatformFeature() default {};
+    String[] applyIfPlatform() default {};
 
     /**
-     * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
-     * value where a true value necessities existence of target feature and vice-versa.
-     * IR verifications checks are enforced only if all the specified feature constraints are met.
+     * Accepts a list of pairs where each pair is composed of a platform string followed by a true/false
+     * value where a true value necessitates that we are currently testing on that platform and vice-versa.
+     * IR verifications checks are enforced only if all the specified platform constraints are met.
      */
-    String[] applyIfPlatformFeatureAnd() default {};
+    String[] applyIfPlatformAnd() default {};
 
     /**
-     * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
-     * value where a true value necessities existence of target feature and vice-versa.
-     * IR verifications checks are enforced if any of the specified feature constraint is met.
+     * Accepts a list of pairs where each pair is composed of a platform string followed by a true/false
+     * value where a true value necessitates that we are currently testing on that platform and vice-versa.
+     * IR verifications checks are enforced if any of the specified platform constraints are met.
      */
-    String[] applyIfPlatformFeatureOr() default {};
+    String[] applyIfPlatformOr() default {};
 
     /**
      * Accepts a single feature pair which is composed of CPU feature string followed by a true/false
-     * value where a true value necessities existence of CPU feature and vice-versa.
+     * value where a true value necessitates existence of CPU feature and vice-versa.
      * IR verifications checks are enforced only if the specified feature constraint is met.
      */
     String[] applyIfCPUFeature() default {};
 
     /**
      * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
-     * value where a true value necessities existence of target feature and vice-versa.
+     * value where a true value necessitates existence of target feature and vice-versa.
      * IR verifications checks are enforced only if all the specified feature constraints are met.
      */
     String[] applyIfCPUFeatureAnd() default {};
 
      /**
      * Accepts a list of feature pairs where each pair is composed of target feature string followed by a true/false
-     * value where a true value necessities existence of target feature and vice-versa.
+     * value where a true value necessitates existence of target feature and vice-versa.
      * IR verifications checks are enforced if any of the specified feature constraint is met.
      */
     String[] applyIfCPUFeatureOr() default {};

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -118,6 +118,11 @@ Sometimes, an `@IR` rule should only be applied if a certain CPU feature is pres
 
 If a `@Test` annotated method has multiple preconditions (for example `applyIf` and `applyIfCPUFeature`), they are evaluated as a logical conjunction. It's worth noting that flags in `applyIf` are checked only if the CPU features in `applyIfCPUFeature` are matched when they are both specified. This avoids the VM flag being evaluated on hardware that does not support it. An example with both `applyIfCPUFeatureXXX` and `applyIfXXX` can be found in [TestPreconditions](../../../testlibrary_tests/ir_framework/tests/TestPreconditions.java) (internal framework test).
 
+#### Disable/Enable IR Rules based on available Platform Features
+`@IR` rules based on platform features can be specified using `applyIfPlatformFeatureXXX` in [@IR](./IR.java). A reference for using these attributes can be found in [TestPlatformFeatureCheck](../../../testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java) (internal framework test).
+
+Platform attributes are evaluated as a logical conjunction, and take precedence over VM Flag attributes. An example with both `applyIfPlatformFeatureXXX` and `applyIfXXX` can be found in [TestPreconditions](../../../testlibrary_tests/ir_framework/tests/TestPreconditions.java) (internal framework test).
+
 #### Implicitly Skipping IR Verification
 An IR verification cannot always be performed. Certain VM flags explicitly disable IR verification, change the IR shape in unexpected ways letting IR rules fail or even make IR verification impossible:
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -118,10 +118,10 @@ Sometimes, an `@IR` rule should only be applied if a certain CPU feature is pres
 
 If a `@Test` annotated method has multiple preconditions (for example `applyIf` and `applyIfCPUFeature`), they are evaluated as a logical conjunction. It's worth noting that flags in `applyIf` are checked only if the CPU features in `applyIfCPUFeature` are matched when they are both specified. This avoids the VM flag being evaluated on hardware that does not support it. An example with both `applyIfCPUFeatureXXX` and `applyIfXXX` can be found in [TestPreconditions](../../../testlibrary_tests/ir_framework/tests/TestPreconditions.java) (internal framework test).
 
-#### Disable/Enable IR Rules based on available Platform Features
-`@IR` rules based on platform features can be specified using `applyIfPlatformFeatureXXX` in [@IR](./IR.java). A reference for using these attributes can be found in [TestPlatformFeatureCheck](../../../testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java) (internal framework test).
+#### Disable/Enable IR Rules based on Platform
+`@IR` rules based on the platform can be specified using `applyIfPlatformXXX` in [@IR](./IR.java). A reference for using these attributes can be found in [TestPlatformChecks](../../../testlibrary_tests/ir_framework/tests/TestPlatformChecks.java) (internal framework test).
 
-Platform attributes are evaluated as a logical conjunction, and take precedence over VM Flag attributes. An example with both `applyIfPlatformFeatureXXX` and `applyIfXXX` can be found in [TestPreconditions](../../../testlibrary_tests/ir_framework/tests/TestPreconditions.java) (internal framework test).
+Platform attributes are evaluated as a logical conjunction, and take precedence over VM Flag attributes. An example with both `applyIfPlatformXXX` and `applyIfXXX` can be found in [TestPreconditions](../../../testlibrary_tests/ir_framework/tests/TestPreconditions.java) (internal framework test).
 
 #### Implicitly Skipping IR Verification
 An IR verification cannot always be performed. Certain VM flags explicitly disable IR verification, change the IR shape in unexpected ways letting IR rules fail or even make IR verification impossible:

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -354,8 +354,7 @@ public class IREncodingPrinter {
 
         String currentPlatform = os + " " + arch + " " + (Platform.is32bit() ? "32-bit" : "64-bit");
 
-        return (trueValue && currentPlatform.contains(platform))
-	    || (falseValue && !currentPlatform.contains(platform));
+        return (trueValue && currentPlatform.contains(platform)) || (falseValue && !currentPlatform.contains(platform));
     }
 
     private boolean hasAllRequiredCPUFeature(String[] andRules) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -248,8 +248,8 @@ public class IREncodingPrinter {
                                     "Use applyIfAnd or applyIfOr or only 1 condition for applyIfNot" + failAt());
         }
         TestFormat.checkNoThrow(flagConstraints <= 1, "Can only specify one flag constraint" + failAt());
-        TestFormat.checkNoThrow(cpuFeatureConstraints <= 1, "Can only specify one platform feature constraint" + failAt());
-        TestFormat.checkNoThrow(platformFeatureConstraints <= 1, "Can only specify one CPU feature constraint" + failAt());
+        TestFormat.checkNoThrow(cpuFeatureConstraints <= 1, "Can only specify one CPU feature constraint" + failAt());
+        TestFormat.checkNoThrow(platformFeatureConstraints <= 1, "Can only specify one platform feature constraint" + failAt());
     }
 
     private boolean isIRNodeUnsupported(IR irAnno) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -64,9 +64,12 @@ public class IREncodingPrinter {
         "linux",
         "mac",
         "windows",
-        // vm.simpleArch values
+        // vm.simpleArch
         "aarch64",
+        "arm",
+        "ppc",
         "riscv64",
+        "s390",
         "x64",
         "x86",
         // corresponds to vm.bits
@@ -335,8 +338,14 @@ public class IREncodingPrinter {
         String arch = "";
         if (Platform.isAArch64()) {
             arch = "aarch64";
+        } else if (Platform.isARM()) {
+            arch = "arm";
+        } else if (Platform.isPPC()) {
+            arch = "ppc";
         } else if (Platform.isRISCV64()) {
             arch = "riscv64";
+        } else if (Platform.isS390x()) {
+            arch = "s390";
         } else if (Platform.isX64()) {
             arch = "x64";
         } else if (Platform.isX86()) {

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -60,7 +60,7 @@ public class IREncodingPrinter {
     // a corresponding value e.g. in a jtreg @requires annotation before adding new features,
     // as adding non-existent features can lead to skipped tests.
     private static final List<String> verifiedPlatformFeatures = new ArrayList<String>( Arrays.asList(
-        // os.name prefixes
+        // os.family
         "linux",
         "mac",
         "windows",

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -59,7 +59,7 @@ public class IREncodingPrinter {
     // Platforms for use in IR preconditions. Please verify that e.g. there is
     // a corresponding use in a jtreg @requires annotation before adding new platforms,
     // as adding non-existent platforms can lead to skipped tests.
-    private static final List<String> irTestingPlatforms = new ArrayList<String>( Arrays.asList(
+    private static final List<String> irTestingPlatforms = new ArrayList<String>(Arrays.asList(
         // os.family
         "linux",
         "mac",

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -244,8 +244,8 @@ public class IREncodingPrinter {
                                     "Use applyIfAnd or applyIfOr or only 1 condition for applyIfNot" + failAt());
         }
         TestFormat.checkNoThrow(flagConstraints <= 1, "Can only specify one flag constraint" + failAt());
-        TestFormat.checkNoThrow(cpuFeatureConstraints <= 1, "Can only specify one CPU feature constraint" + failAt());
         TestFormat.checkNoThrow(platformFeatureConstraints <= 1, "Can only specify one platform feature constraint" + failAt());
+        TestFormat.checkNoThrow(cpuFeatureConstraints <= 1, "Can only specify one CPU feature constraint" + failAt());
     }
 
     private boolean isIRNodeUnsupported(IR irAnno) {
@@ -323,19 +323,27 @@ public class IREncodingPrinter {
             return false;
         }
 
-        String platformFeatures = "";
-
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.startsWith("win")) {
-            platformFeatures += "windows";
-        } else if (osName.startsWith("linux")) {
-            platformFeatures += "linux";
-        } else if (osName.startsWith("mac")) {
-            platformFeatures += "mac";
+        String os = "";
+        if (Platform.isLinux()) {
+            os = "linux";
+        } else if (Platform.isOSX()) {
+            os = "mac";
+        } else if (Platform.isWindows()) {
+            os = "windows";
         }
 
-        platformFeatures += " " + System.getProperty("vm.simpleArch") + " ";
-        platformFeatures += Platform.is32bit() ? "32-bit" : "64-bit";
+        String arch = "";
+        if (Platform.isAArch64()) {
+            arch = "aarch64";
+        } else if (Platform.isRISCV64()) {
+            arch = "riscv64";
+        } else if (Platform.isX64()) {
+            arch = "x64";
+        } else if (Platform.isX86()) {
+            arch = "x86";
+        }
+
+        String platformFeatures = os + " " + arch + " " + (Platform.is32bit() ? "32-bit" : "64-bit");
 
         return (trueValue && platformFeatures.contains(feature)) || (falseValue && !platformFeatures.contains(feature));
     }

--- a/test/hotspot/jtreg/compiler/loopopts/superword/SumRed_Long.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/SumRed_Long.java
@@ -92,7 +92,7 @@ public class SumRed_Long {
     @Test
     @IR(applyIf = {"SuperWordReductions", "false"},
         failOn = {IRNode.ADD_REDUCTION_VL})
-    @IR(applyIfPlatformFeature = {"32-bit", "false"},
+    @IR(applyIfPlatform = {"32-bit", "false"},
         applyIfCPUFeature = {"avx2", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop

--- a/test/hotspot/jtreg/compiler/loopopts/superword/SumRed_Long.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/SumRed_Long.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8076276
  * @summary Add C2 x86 Superword support for scalar sum reduction optimizations : long test
- * @requires vm.bits == "64"
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.SumRed_Long
  */
@@ -93,7 +92,8 @@ public class SumRed_Long {
     @Test
     @IR(applyIf = {"SuperWordReductions", "false"},
         failOn = {IRNode.ADD_REDUCTION_VL})
-    @IR(applyIfCPUFeature = {"avx2", "true"},
+    @IR(applyIfPlatformFeature = {"32-bit", "false"},
+        applyIfCPUFeature = {"avx2", "true"},
         applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long sumReductionImplement(

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformChecks.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformChecks.java
@@ -30,10 +30,10 @@ import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
  * @test 8280120
  * @summary Add attribute to IR to enable/disable IR matching based on the architecture
  * @library /test/lib /
- * @run driver ir_framework.tests.TestPlatformFeatureCheck
+ * @run driver ir_framework.tests.TestPlatformChecks
  */
 
-public class TestPlatformFeatureCheck {
+public class TestPlatformChecks {
     private static final int SIZE = 1000;
     private static int[] a = new int[SIZE];
     private static int[] b = new int[SIZE];
@@ -53,7 +53,7 @@ public class TestPlatformFeatureCheck {
 
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0"},
-        applyIfPlatformFeature = {"x64", "true"},
+        applyIfPlatform = {"x64", "true"},
         applyIfCPUFeature = {"sse4.1", "true"})
     public static void test1() {
         for (int i = 0; i < SIZE; i++) {
@@ -61,10 +61,10 @@ public class TestPlatformFeatureCheck {
         }
     }
 
-    // IR rule is enforced if all the feature conditions holds good
+    // IR rule is enforced if all the platform constraints hold
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0"},
-        applyIfPlatformFeatureAnd = {"x64", "true", "linux", "true"},
+        applyIfPlatformAnd = {"x64", "true", "linux", "true"},
         applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "true"})
     public static void test2() {
         for (int i = 0; i < SIZE; i++) {
@@ -72,10 +72,10 @@ public class TestPlatformFeatureCheck {
         }
     }
 
-    // IR rule is enforced if any of the feature condition holds good
+    // IR rule is enforced if any of the platform constraints hold
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0"},
-        applyIfPlatformFeatureOr = {"linux", "true", "mac", "true"},
+        applyIfPlatformOr = {"linux", "true", "mac", "true"},
         applyIfCPUFeatureOr = {"sse4.1", "true", "avx2", "true"})
     public static void test3() {
         for (int i = 0; i < SIZE; i++) {

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
@@ -52,7 +52,9 @@ public class TestPlatformFeatureCheck {
     }
 
     @Test
-    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeature = {"x64", "true"})
+    @IR(counts = {IRNode.ADD_VI, "> 0"},
+        applyIfPlatformFeature = {"x64", "true"},
+        applyIfCPUFeature = {"sse4.1", "true"})
     public static void test1() {
         for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];
@@ -61,7 +63,9 @@ public class TestPlatformFeatureCheck {
 
     // IR rule is enforced if all the feature conditions holds good
     @Test
-    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeatureAnd = {"x64", "true", "linux", "true"})
+    @IR(counts = {IRNode.ADD_VI, "> 0"},
+        applyIfPlatformFeatureAnd = {"x64", "true", "linux", "true"},
+        applyIfCPUFeatureAnd = {"sse4.1", "true", "avx2", "true"})
     public static void test2() {
         for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];
@@ -70,7 +74,9 @@ public class TestPlatformFeatureCheck {
 
     // IR rule is enforced if any of the feature condition holds good
     @Test
-    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeatureOr = {"x64", "true", "x86", "true"})
+    @IR(counts = {IRNode.ADD_VI, "> 0"},
+        applyIfPlatformFeatureOr = {"linux", "true", "mac", "true"},
+        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     public static void test3() {
         for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
@@ -76,7 +76,7 @@ public class TestPlatformFeatureCheck {
     @Test
     @IR(counts = {IRNode.ADD_VI, "> 0"},
         applyIfPlatformFeatureOr = {"linux", "true", "mac", "true"},
-        applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
+        applyIfCPUFeatureOr = {"sse4.1", "true", "avx2", "true"})
     public static void test3() {
         for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,6 @@ import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
 /*
  * @test 8280120
  * @summary Add attribute to IR to enable/disable IR matching based on the architecture 
- * @requires vm.cpu.features ~= ".*avx512f.*"
- * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @library /test/lib /
  * @run driver ir_framework.tests.TestPlatformFeatureCheck
  */

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package ir_framework.tests;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
+
+/*
+ * @test 8280120
+ * @summary Add attribute to IR to enable/disable IR matching based on the architecture 
+ * @requires vm.cpu.features ~= ".*avx512f.*"
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @library /test/lib /
+ * @run driver ir_framework.tests.TestPlatformFeatureCheck
+ */
+
+public class TestPlatformFeatureCheck {
+    private static final int SIZE = 1000;
+    private static int a[] = new int[SIZE];
+    private static int b[] = new int[SIZE];
+    private static int res[] = new int[SIZE];
+
+    public static void setup() {
+        for (int i = 0; i < SIZE; i++) {
+            a[i] = i;
+            b[i] = i;
+        }
+    }
+
+    public static void main(String args[]) {
+        setup();
+        TestFramework.runWithFlags("-XX:+UseKNLSetting");
+    }
+
+    @Test
+    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeature = {"amd64", "true"})
+    public static void test1() {
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = a[i] + b[i];
+        }
+    }
+
+    // IR rule is enforced if all the feature conditions holds good
+    @Test
+    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeatureAnd={"amd64", "true", "64-bit", "true"})
+    public static void test2() {
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = a[i] + b[i];
+        }
+    }
+
+    // IR rule is enforced if any of the feature condition holds good
+    @Test
+    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeatureOr={"amd64", "true", "x86_64", "true"})
+    public static void test3() {
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = a[i] + b[i];
+        }
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPlatformFeatureCheck.java
@@ -28,16 +28,16 @@ import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
 
 /*
  * @test 8280120
- * @summary Add attribute to IR to enable/disable IR matching based on the architecture 
+ * @summary Add attribute to IR to enable/disable IR matching based on the architecture
  * @library /test/lib /
  * @run driver ir_framework.tests.TestPlatformFeatureCheck
  */
 
 public class TestPlatformFeatureCheck {
     private static final int SIZE = 1000;
-    private static int a[] = new int[SIZE];
-    private static int b[] = new int[SIZE];
-    private static int res[] = new int[SIZE];
+    private static int[] a = new int[SIZE];
+    private static int[] b = new int[SIZE];
+    private static int[] res = new int[SIZE];
 
     public static void setup() {
         for (int i = 0; i < SIZE; i++) {
@@ -46,13 +46,13 @@ public class TestPlatformFeatureCheck {
         }
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         setup();
-        TestFramework.runWithFlags("-XX:+UseKNLSetting");
+        TestFramework.run();
     }
 
     @Test
-    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeature = {"amd64", "true"})
+    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeature = {"x64", "true"})
     public static void test1() {
         for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];
@@ -61,7 +61,7 @@ public class TestPlatformFeatureCheck {
 
     // IR rule is enforced if all the feature conditions holds good
     @Test
-    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeatureAnd={"amd64", "true", "64-bit", "true"})
+    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeatureAnd = {"x64", "true", "linux", "true"})
     public static void test2() {
         for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];
@@ -70,7 +70,7 @@ public class TestPlatformFeatureCheck {
 
     // IR rule is enforced if any of the feature condition holds good
     @Test
-    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeatureOr={"amd64", "true", "x86_64", "true"})
+    @IR(counts = {IRNode.ADD_VI, "> 0"}, applyIfPlatformFeatureOr = {"x64", "true", "x86", "true"})
     public static void test3() {
         for (int i = 0; i < SIZE; i++) {
             res[i] = a[i] + b[i];

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -84,27 +84,45 @@ public class TestPreconditions {
 
     // The IR check should not be applied, since OS can not be both linux and mac.
     @Test
-    @IR(applyIfPlatformFeatureAnd = {"linux", "true", "mac", "true"},
+    @IR(applyIfPlatformAnd = {"linux", "true", "mac", "true"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBothOs() {}
 
     // The IR check should not be applied, since we can't have both 32-bit and 64-bit data model.
     @Test
-    @IR(applyIfPlatformFeatureAnd = {"32-bit", "true", "64-bit", "true"},
+    @IR(applyIfPlatformAnd = {"32-bit", "true", "64-bit", "true"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBothDataModel() {}
 
     // The IR check should not be applied, since the arch can't be both x64 and aarch64.
     @Test
-    @IR(applyIfPlatformFeatureAnd = {"x64", "true", "aarch64", "true"},
+    @IR(applyIfPlatformAnd = {"x64", "true", "aarch64", "true"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBothArch() {}
 
-    // Platform version of testApplyBoth2.
+    // Platform versions of testApplyBoth2/3.
     @Test
-    @IR(applyIfPlatformFeature = {"aarch64", "true"},
+    @IR(applyIfPlatform = {"aarch64", "true"},
         applyIfAnd = {"UseSVE", "= 0", "LoopMaxUnroll", "= 0"},
         counts = {IRNode.LOOP, ">= 1000"})
-    public static void testApplyBoth4() {}
+    public static void testApplyBothPlatformSVE() {}
+
+    @Test
+    @IR(applyIfPlatform = {"x64", "true"},
+        applyIfAnd = {"UseAVX", "= 2", "LoopMaxUnroll", "= 0"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyPlatformAVX() {}
+
+    @Test
+    @IR(applyIfPlatformAnd = {"x64", "true", "linux", "true"},
+        applyIfAnd = {"UseAVX", "= 2", "LoopMaxUnroll", "= 0"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyPlatformAVXAnd() {}
+
+    @Test
+    @IR(applyIfPlatformOr = {"x64", "true", "x86", "true"},
+        applyIfAnd = {"UseSSE", "= 4", "LoopMaxUnroll", "= 0"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyPlatformSSEOr() {}
 
 }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -82,25 +82,29 @@ public class TestPreconditions {
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBoth3() {}
 
-    // The IR check should not be applied, since arch can not be linux and mac.
+    // The IR check should not be applied, since OS can not be both linux and mac.
     @Test
     @IR(applyIfPlatformFeatureAnd = {"linux", "true", "mac", "true"},
-        applyIf = {"LoopMaxUnroll", "= 8"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBothOs() {}
 
     // The IR check should not be applied, since we can't have both 32-bit and 64-bit data model.
     @Test
     @IR(applyIfPlatformFeatureAnd = {"32-bit", "true", "64-bit", "true"},
-        applyIf = {"LoopMaxUnroll", "= 8"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBothDataModel() {}
 
-    // The IR check should not be applied, since we arch can't be both amd64 and aarch64.
+    // The IR check should not be applied, since the arch can't be both x64 and aarch64.
     @Test
-    @IR(applyIfPlatformFeatureAnd = {"amd64", "true", "aarch64", "true"},
-        applyIf = {"LoopMaxUnroll", "= 8"},
+    @IR(applyIfPlatformFeatureAnd = {"x64", "true", "aarch64", "true"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBothArch() {}
+
+    // Platform version of testApplyBoth2.
+    @Test
+    @IR(applyIfPlatformFeature = {"aarch64", "true"},
+        applyIfAnd = {"UseSVE", "= 0", "LoopMaxUnroll", "= 0"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyBoth4() {}
 
 }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -81,4 +81,26 @@ public class TestPreconditions {
         applyIfAnd = {"UseAVX", "= 2", "LoopMaxUnroll", "= 0"},
         counts = {IRNode.LOOP, ">= 1000"})
     public static void testApplyBoth3() {}
+
+    // The IR check should not be applied, since arch can not be linux and mac.
+    @Test
+    @IR(applyIfPlatformFeatureAnd = {"linux", "true", "mac", "true"},
+        applyIf = {"LoopMaxUnroll", "= 8"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyBothOs() {}
+
+    // The IR check should not be applied, since we can't have both 32-bit and 64-bit data model.
+    @Test
+    @IR(applyIfPlatformFeatureAnd = {"32-bit", "true", "64-bit", "true"},
+        applyIf = {"LoopMaxUnroll", "= 8"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyBothDataModel() {}
+
+    // The IR check should not be applied, since we arch can't be both amd64 and aarch64.
+    @Test
+    @IR(applyIfPlatformFeatureAnd = {"amd64", "true", "aarch64", "true"},
+        applyIf = {"LoopMaxUnroll", "= 8"},
+        counts = {IRNode.LOOP, ">= 1000"})
+    public static void testApplyBothArch() {}
+
 }

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPreconditions.java
@@ -105,7 +105,7 @@ public class TestPreconditions {
     @IR(applyIfPlatform = {"aarch64", "true"},
         applyIfAnd = {"UseSVE", "= 0", "LoopMaxUnroll", "= 0"},
         counts = {IRNode.LOOP, ">= 1000"})
-    public static void testApplyBothPlatformSVE() {}
+    public static void testApplyPlatformSVE() {}
 
     @Test
     @IR(applyIfPlatform = {"x64", "true"},


### PR DESCRIPTION
This PR adds support for platform features in IR Framework preconditions. This allows us to write platform-specific IR checks in the same .java test file.

Platforms considered in this PR are: operating system, arch, and data model (32 or 64-bit VM). Supported field values correspond to vm.simpleArch, os.family, and vm.bits, as used in jtreg `@requires` fields. We use the Platform library methods to accomplish this. Otherwise, the new preconditions work similar to the corresponding CPUFeature preconditions.

Testing: T1-T3, GHA.

Additional testing: Tweaked SW test succeeds with removed `@requires` field and added IR platform precondition, but fails with just removed `@requires` field on 32-bit Linux. Performed a few spot tests with incorrectly formatted preconditions, and with valid platform checks but invalid counts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280120](https://bugs.openjdk.org/browse/JDK-8280120): [IR Framework] Add attribute to @<!---->IR to enable/disable IR matching based on the architecture (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15938/head:pull/15938` \
`$ git checkout pull/15938`

Update a local copy of the PR: \
`$ git checkout pull/15938` \
`$ git pull https://git.openjdk.org/jdk.git pull/15938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15938`

View PR using the GUI difftool: \
`$ git pr show -t 15938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15938.diff">https://git.openjdk.org/jdk/pull/15938.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15938#issuecomment-1736772423)