### PR TITLE
8316924: java/lang/Thread/virtual/stress/ParkALot.java times out

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
@@ -31,7 +31,7 @@
 /*
  * @test
  * @requires vm.debug == true
- * @run main/othervm ParkALot 200000
+ * @run main/othervm ParkALot 100000
  */
 
 import java.time.Instant;
@@ -50,15 +50,16 @@ public class ParkALot {
             iterations = ITERATIONS;
         }
 
-        int maxThreads = Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
+        int maxThreads = Math.clamp(Runtime.getRuntime().availableProcessors() / 2, 1, 4);
         for (int nthreads = 1; nthreads <= maxThreads; nthreads++) {
-            System.out.format("%s %d threads ...%n", Instant.now(), nthreads);
+            System.out.format("%s %d thread(s) ...%n", Instant.now(), nthreads);
             ThreadFactory factory = Thread.ofPlatform().factory();
             try (var executor = Executors.newThreadPerTaskExecutor(factory)) {
                 for (int i = 0; i < nthreads; i++) {
                     executor.submit(() -> parkALot(iterations));
                 }
             }
+            System.out.format("%s %d thread(s) done%n", Instant.now(), nthreads);
         }
     }
 
@@ -87,7 +88,7 @@ public class ParkALot {
             if (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
                 LockSupport.unpark(vthread);
             } else {
-                Thread.onSpinWait();
+                Thread.yield();
             }
         }
     }


### PR DESCRIPTION
A test only change to a stress test for virtual thread parking/unparking to limit execution time on a larger systems. Right run, the test bashes parking/unparking for 1, 2, 3, ... up to the number of half the hardware threads. It is changed to limit it to 4 iterations. It is also dialed down for debug builds as they may run with -XX:+VerifyContinuations which is an expensive assert (but an important one for tests like that).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316924](https://bugs.openjdk.org/browse/JDK-8316924): java/lang/Thread/virtual/stress/ParkALot.java times out (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15940/head:pull/15940` \
`$ git checkout pull/15940`

Update a local copy of the PR: \
`$ git checkout pull/15940` \
`$ git pull https://git.openjdk.org/jdk.git pull/15940/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15940`

View PR using the GUI difftool: \
`$ git pr show -t 15940`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15940.diff">https://git.openjdk.org/jdk/pull/15940.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15940#issuecomment-1736889743)