### PR TITLE
JDK-8316894: make test TEST="jtreg:test/jdk/..." fails on AIX

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -178,7 +178,7 @@ ifeq ($(TEST_JOBS), 0)
       c = c * $(TEST_JOBS_FACTOR_JDL); \
       c = c * $(TEST_JOBS_FACTOR_MACHINE); \
       if (c < 1) c = 1; \
-      printf "%.0f", c; \
+      printf "%d", c; \
     }')
 endif
 

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -178,6 +178,7 @@ ifeq ($(TEST_JOBS), 0)
       c = c * $(TEST_JOBS_FACTOR_JDL); \
       c = c * $(TEST_JOBS_FACTOR_MACHINE); \
       if (c < 1) c = 1; \
+      c = c + 0.5; \
       printf "%d", c; \
     }')
 endif


### PR DESCRIPTION
Running jtreg tests with make test, for example
make test TEST="jtreg:test/jdk/java/util/prefs" fails currently on AIX without setting the number of JOBS manually.
We get this error message:
Error: Bad use of -concurrency

Log of cmdargs shows :
-vmoption:-Xmx768m
-agentvm
-verbose:fail,error,summary
-retain:fail,error
-concurrency:7.000000
....

So currently a float is used for the concurrency value, seems this is not supported.
Reason is an old gawk printing float values instead of the needed ints, so better print ints in the makefile by using %d .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316894](https://bugs.openjdk.org/browse/JDK-8316894): make test  TEST="jtreg:test/jdk/..."  fails on AIX (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15941/head:pull/15941` \
`$ git checkout pull/15941`

Update a local copy of the PR: \
`$ git checkout pull/15941` \
`$ git pull https://git.openjdk.org/jdk.git pull/15941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15941`

View PR using the GUI difftool: \
`$ git pr show -t 15941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15941.diff">https://git.openjdk.org/jdk/pull/15941.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15941#issuecomment-1736940226)