### PR TITLE
8317034: Remove redundant type cast in the java.util.stream package

### DIFF
--- a/src/java.base/share/classes/java/util/stream/DoublePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/DoublePipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/DoublePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/DoublePipeline.java
@@ -388,7 +388,7 @@ abstract class DoublePipeline<E_IN>
     public final DoubleStream limit(long maxSize) {
         if (maxSize < 0)
             throw new IllegalArgumentException(Long.toString(maxSize));
-        return SliceOps.makeDouble(this, (long) 0, maxSize);
+        return SliceOps.makeDouble(this, 0, maxSize);
     }
 
     @Override
@@ -422,7 +422,7 @@ abstract class DoublePipeline<E_IN>
     public final DoubleStream distinct() {
         // While functional and quick to implement, this approach is not very efficient.
         // An efficient version requires a double-specific map/set implementation.
-        return boxed().distinct().mapToDouble(i -> (double) i);
+        return boxed().distinct().mapToDouble(i -> i);
     }
 
     // Terminal ops from DoubleStream

--- a/src/java.base/share/classes/java/util/stream/DoublePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/DoublePipeline.java
@@ -388,7 +388,7 @@ abstract class DoublePipeline<E_IN>
     public final DoubleStream limit(long maxSize) {
         if (maxSize < 0)
             throw new IllegalArgumentException(Long.toString(maxSize));
-        return SliceOps.makeDouble(this, 0, maxSize);
+        return SliceOps.makeDouble(this, 0L, maxSize);
     }
 
     @Override

--- a/src/java.base/share/classes/java/util/stream/LongPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/LongPipeline.java
@@ -435,7 +435,7 @@ abstract class LongPipeline<E_IN>
     public final LongStream distinct() {
         // While functional and quick to implement, this approach is not very efficient.
         // An efficient version requires a long-specific map/set implementation.
-        return boxed().distinct().mapToLong(i -> (long) i);
+        return boxed().distinct().mapToLong(i -> i);
     }
 
     // Terminal ops from LongStream

--- a/src/java.base/share/classes/java/util/stream/LongPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/LongPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/StreamSpliterators.java
+++ b/src/java.base/share/classes/java/util/stream/StreamSpliterators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/StreamSpliterators.java
+++ b/src/java.base/share/classes/java/util/stream/StreamSpliterators.java
@@ -307,7 +307,7 @@ class StreamSpliterators {
                 Objects.requireNonNull(consumer);
                 init();
 
-                ph.wrapAndCopyInto((Sink<P_OUT>) consumer::accept, spliterator);
+                ph.wrapAndCopyInto(consumer::accept, spliterator);
                 finished = true;
             }
             else {


### PR DESCRIPTION
Remove redundant type cast in the java.util.stream package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317034](https://bugs.openjdk.org/browse/JDK-8317034): Remove redundant type cast in the java.util.stream package (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15942/head:pull/15942` \
`$ git checkout pull/15942`

Update a local copy of the PR: \
`$ git checkout pull/15942` \
`$ git pull https://git.openjdk.org/jdk.git pull/15942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15942`

View PR using the GUI difftool: \
`$ git pr show -t 15942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15942.diff">https://git.openjdk.org/jdk/pull/15942.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15942#issuecomment-1736989193)