### PR TITLE
8315936: Parallelize gc/stress/TestStressG1Humongous.java test

### DIFF
--- a/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
@@ -75,19 +75,19 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class TestStressG1Humongous{
 
     public static void main(String[] args) throws Exception {
+        if (args.length != 4) {
+            throw new IllegalArgumentException("Test expects 4 arguments");
+        }
+
         // Limit heap size on 32-bit platforms
         int heapSize = Platform.is32bit() ? 512 : 1024;
+
         // Region size, threads, humongous size, and timeout passed as @run arguments
         int regionSize = Integer.parseInt(args[0]);
         int threads = Integer.parseInt(args[1]);
         double humongousSize = Double.parseDouble(args[2]);
         int timeout = Integer.parseInt(args[3]);
-        
-        run(heapSize, regionSize, threads, humongousSize, timeout);
-    }
 
-    private static void run(int heapSize, int regionSize, int threads, double humongousSize, int timeout)
-            throws Exception {
         ArrayList<String> options = new ArrayList<>();
         Collections.addAll(options, Utils.getTestJavaOpts());
         Collections.addAll(options,

--- a/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
@@ -23,7 +23,7 @@
 
 package gc.stress;
 
- /*
+/*
  * @test
  * @key stress
  * @summary Stress G1 by humongous allocations in situation near OOM
@@ -34,7 +34,7 @@ package gc.stress;
  * @run driver/timeout=180 gc.stress.TestStressG1Humongous 4 3 1.1 120
  */
 
- /*
+/*
  * @test
  * @requires vm.gc.G1
  * @requires !vm.flightRecorder
@@ -43,7 +43,7 @@ package gc.stress;
  * @run driver/timeout=180 gc.stress.TestStressG1Humongous 16 5 2.1 120
  */
 
- /*
+/*
  * @test
  * @requires vm.gc.G1
  * @requires !vm.flightRecorder
@@ -52,7 +52,7 @@ package gc.stress;
  * @run driver/timeout=180 gc.stress.TestStressG1Humongous 32 4 0.6 120
  */
 
- /*
+/*
  * @test
  * @requires vm.gc.G1
  * @requires !vm.flightRecorder

--- a/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
+++ b/test/hotspot/jtreg/gc/stress/TestStressG1Humongous.java
@@ -23,15 +23,42 @@
 
 package gc.stress;
 
-/*
- * @test TestStressG1Humongous
+ /*
+ * @test
  * @key stress
  * @summary Stress G1 by humongous allocations in situation near OOM
  * @requires vm.gc.G1
  * @requires !vm.flightRecorder
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
- * @run driver/timeout=1300 gc.stress.TestStressG1Humongous
+ * @run driver/timeout=180 gc.stress.TestStressG1Humongous 4 3 1.1 120
+ */
+
+ /*
+ * @test
+ * @requires vm.gc.G1
+ * @requires !vm.flightRecorder
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=180 gc.stress.TestStressG1Humongous 16 5 2.1 120
+ */
+
+ /*
+ * @test
+ * @requires vm.gc.G1
+ * @requires !vm.flightRecorder
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=180 gc.stress.TestStressG1Humongous 32 4 0.6 120
+ */
+
+ /*
+ * @test
+ * @requires vm.gc.G1
+ * @requires !vm.flightRecorder
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver/timeout=900 gc.stress.TestStressG1Humongous 1 7 0.6 600
  */
 
 import java.util.ArrayList;
@@ -50,11 +77,13 @@ public class TestStressG1Humongous{
     public static void main(String[] args) throws Exception {
         // Limit heap size on 32-bit platforms
         int heapSize = Platform.is32bit() ? 512 : 1024;
-        // Heap size, region size, threads, humongous size, timeout
-        run(heapSize, 4, 3, 1.1, 120);
-        run(heapSize, 16, 5, 2.1, 120);
-        run(heapSize, 32, 4, 0.6, 120);
-        run(heapSize, 1, 7, 0.6, 600);
+        // Region size, threads, humongous size, and timeout passed as @run arguments
+        int regionSize = Integer.parseInt(args[0]);
+        int threads = Integer.parseInt(args[1]);
+        double humongousSize = Double.parseDouble(args[2]);
+        int timeout = Integer.parseInt(args[3]);
+        
+        run(heapSize, regionSize, threads, humongousSize, timeout);
     }
 
     private static void run(int heapSize, int regionSize, int threads, double humongousSize, int timeout)


### PR DESCRIPTION
TestStressG1Humongous runs in hotspot:tier4 and takes about 900 seconds to run. It is one of the slowest tests in tier4, and it runs when concurrency is generally low due to exclusive adjacent tests. Thus, it limits the effective parallelism of tier4.

In test main method, there are a few independent test cases, which can be expressed in jtreg to gain parallel execution.

TestStressG1Humongous current runtime: **4917.51s user 410.97s system 549% cpu 16:10.07 total**
TestStressG1Humongous parallelized runtime: **4672.49s user 510.17s system 849% cpu 10:10.05 total**

This change takes the previous `run()` methods out of the main method and instead passes the parameters as part of the `@run` jtreg test annotation, allowing them to be run in parallel.

The last test runs the longest on its own, and this is why the runtime can't be reduced under the 10 minute mark.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8315936](https://bugs.openjdk.org/browse/JDK-8315936): Parallelize gc/stress/TestStressG1Humongous.java test (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [8fc6438c](https://git.openjdk.org/jdk/pull/15943/files/8fc6438cb0c56ed51fd15c3757ab541d15a143d9)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15943/head:pull/15943` \
`$ git checkout pull/15943`

Update a local copy of the PR: \
`$ git checkout pull/15943` \
`$ git pull https://git.openjdk.org/jdk.git pull/15943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15943`

View PR using the GUI difftool: \
`$ git pr show -t 15943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15943.diff">https://git.openjdk.org/jdk/pull/15943.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15943#issuecomment-1737260112)