### PR TITLE
8316955: Unnecessary memory barrier for reading OopMapCacheEntry from OopMapCache

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -464,7 +464,7 @@ OopMapCache::~OopMapCache() {
 }
 
 OopMapCacheEntry* OopMapCache::entry_at(int i) const {
-  return Atomic::load_acquire(&(_array[i % _size]));
+  return Atomic::load(&(_array[i % _size]));
 }
 
 bool OopMapCache::put_at(int i, OopMapCacheEntry* entry, OopMapCacheEntry* old) {


### PR DESCRIPTION
OopMapCacheEntry is installed by CAS with memory_order_conservative, there is no need a memory barrier on read side.

Test:
  hotspot_gc on MacOSX (fastdebug and release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316955](https://bugs.openjdk.org/browse/JDK-8316955): Unnecessary memory barrier for reading OopMapCacheEntry from OopMapCache (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15944/head:pull/15944` \
`$ git checkout pull/15944`

Update a local copy of the PR: \
`$ git checkout pull/15944` \
`$ git pull https://git.openjdk.org/jdk.git pull/15944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15944`

View PR using the GUI difftool: \
`$ git pr show -t 15944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15944.diff">https://git.openjdk.org/jdk/pull/15944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15944#issuecomment-1737403731)