### PR TITLE
8310727: C2: *_of() methods in PhaseIterGVN should use uint for the node index

### DIFF
--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -546,7 +546,7 @@ public:
   }
 
   // Replace ith edge of "n" with "in"
-  void replace_input_of(Node* n, int i, Node* in) {
+  void replace_input_of(Node* n, uint i, Node* in) {
     rehash_node_delayed(n);
     n->set_req_X(i, in, this);
   }
@@ -558,13 +558,13 @@ public:
   }
 
   // Delete ith edge of "n"
-  void delete_input_of(Node* n, int i) {
+  void delete_input_of(Node* n, uint i) {
     rehash_node_delayed(n);
     n->del_req(i);
   }
 
   // Delete precedence edge i of "n"
-  void delete_precedence_of(Node* n, int i) {
+  void delete_precedence_of(Node* n, uint i) {
     rehash_node_delayed(n);
     n->rm_prec(i);
   }


### PR DESCRIPTION
This changeset addresses the below.
> Some *_of() methods in PhaseIterGVN like replace_input_of() use int instead of uint for the node index. We should change that.

### Testing (on all Oracle-supported platforms)
- `tier1` 
- HotSpot parts of `tier2` and `tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310727](https://bugs.openjdk.org/browse/JDK-8310727): C2: *_of() methods in PhaseIterGVN should use uint for the node index (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15946/head:pull/15946` \
`$ git checkout pull/15946`

Update a local copy of the PR: \
`$ git checkout pull/15946` \
`$ git pull https://git.openjdk.org/jdk.git pull/15946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15946`

View PR using the GUI difftool: \
`$ git pr show -t 15946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15946.diff">https://git.openjdk.org/jdk/pull/15946.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15946#issuecomment-1752730661)