### PR TITLE
8316970: Add internal annotation to mark restricted methods

### DIFF
--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jdk.internal.javac.PreviewFeature;
+import jdk.internal.javac.Restricted;
 import jdk.internal.loader.ClassLoaderValue;
 import jdk.internal.loader.Loader;
 import jdk.internal.loader.LoaderPool;
@@ -325,6 +326,7 @@ public final class ModuleLayer {
          */
         @PreviewFeature(feature=PreviewFeature.Feature.FOREIGN)
         @CallerSensitive
+        @Restricted
         public Controller enableNativeAccess(Module target) {
             ensureInLayer(target);
             Reflection.ensureNativeAccess(Reflection.getCallerClass(), Module.class,

--- a/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AddressLayout.java
@@ -27,6 +27,7 @@ package java.lang.foreign;
 
 import jdk.internal.foreign.layout.ValueLayouts;
 import jdk.internal.javac.PreviewFeature;
+import jdk.internal.javac.Restricted;
 import jdk.internal.reflect.CallerSensitive;
 
 import java.lang.foreign.Linker.Option;
@@ -108,6 +109,7 @@ public sealed interface AddressLayout extends ValueLayout permits ValueLayouts.O
      * @see #targetLayout()
      */
     @CallerSensitive
+    @Restricted
     AddressLayout withTargetLayout(MemoryLayout layout);
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -30,6 +30,7 @@ import jdk.internal.foreign.abi.LinkerOptions;
 import jdk.internal.foreign.abi.CapturableState;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.javac.PreviewFeature;
+import jdk.internal.javac.Restricted;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 
@@ -528,6 +529,7 @@ public sealed interface Linker permits AbstractLinker {
      * @see SymbolLookup
      */
     @CallerSensitive
+    @Restricted
     MethodHandle downcallHandle(MemorySegment address, FunctionDescriptor function, Option... options);
 
     /**
@@ -574,6 +576,7 @@ public sealed interface Linker permits AbstractLinker {
      * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
      */
     @CallerSensitive
+    @Restricted
     MethodHandle downcallHandle(FunctionDescriptor function, Option... options);
 
     /**
@@ -618,6 +621,7 @@ public sealed interface Linker permits AbstractLinker {
      * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
      */
     @CallerSensitive
+    @Restricted
     MemorySegment upcallStub(MethodHandle target, FunctionDescriptor function, Arena arena, Linker.Option... options);
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -50,6 +50,7 @@ import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.layout.ValueLayouts;
 import jdk.internal.javac.PreviewFeature;
+import jdk.internal.javac.Restricted;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -607,6 +608,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
      */
     @CallerSensitive
+    @Restricted
     MemorySegment reinterpret(long newSize);
 
     /**
@@ -646,6 +648,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
      */
     @CallerSensitive
+    @Restricted
     MemorySegment reinterpret(Arena arena, Consumer<MemorySegment> cleanup);
 
     /**
@@ -688,6 +691,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
      */
     @CallerSensitive
+    @Restricted
     MemorySegment reinterpret(long newSize, Arena arena, Consumer<MemorySegment> cleanup);
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -30,6 +30,7 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.Utils;
 import jdk.internal.javac.PreviewFeature;
+import jdk.internal.javac.Restricted;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.NativeLibrary;
 import jdk.internal.loader.RawNativeLibraries;
@@ -232,6 +233,7 @@ public interface SymbolLookup {
      * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
      */
     @CallerSensitive
+    @Restricted
     static SymbolLookup libraryLookup(String name, Arena arena) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass(), SymbolLookup.class, "libraryLookup");
         if (Utils.containsNullChars(name)) {
@@ -264,6 +266,7 @@ public interface SymbolLookup {
      * @throws IllegalCallerException If the caller is in a module that does not have native access enabled.
      */
     @CallerSensitive
+    @Restricted
     static SymbolLookup libraryLookup(Path path, Arena arena) {
         Reflection.ensureNativeAccess(Reflection.getCallerClass(), SymbolLookup.class, "libraryLookup");
         return libraryLookup(path, RawNativeLibraries::load, arena);

--- a/src/java.base/share/classes/jdk/internal/javac/Restricted.java
+++ b/src/java.base/share/classes/jdk/internal/javac/Restricted.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.javac;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to mark <em>restricted</em> methods in the Java SE API
+ * (e.g. {@link java.lang.foreign.MemorySegment#reinterpret(long)}).
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.CLASS)
+public @interface Restricted {
+}

--- a/src/java.base/share/classes/jdk/internal/javac/Restricted.java
+++ b/src/java.base/share/classes/jdk/internal/javac/Restricted.java
@@ -34,6 +34,6 @@ import java.lang.annotation.Target;
  * (e.g. {@link java.lang.foreign.MemorySegment#reinterpret(long)}).
  */
 @Target({ElementType.METHOD})
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface Restricted {
 }

--- a/test/jdk/java/foreign/TestRestricted.java
+++ b/test/jdk/java/foreign/TestRestricted.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ * @requires jdk.foreign.linker != "UNSUPPORTED"
+ * @modules java.base/jdk.internal.javac
+ * @modules java.base/jdk.internal.reflect
+ * @run testng TestRestricted
+ */
+
+import jdk.internal.javac.Restricted;
+import jdk.internal.reflect.CallerSensitive;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.foreign.AddressLayout;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.lang.module.ModuleReader;
+import java.lang.module.ModuleReference;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * This test checks all methods in java.base to make sure that methods annotated with {@link Restricted} are
+ * expected restricted methods. Conversely, the test also checks that there is no expected restricted method
+ * that is not marked with the annotation. For each restricted method, we also check that they are
+ * marked with the {@link CallerSensitive} annotation.
+ */
+public class TestRestricted {
+
+    record RestrictedMethod(Class<?> owner, String name, MethodType type) {
+        static RestrictedMethod from(Method method) {
+            return of(method.getDeclaringClass(), method.getName(), method.getReturnType(), method.getParameterTypes());
+        }
+
+        static RestrictedMethod of(Class<?> owner, String name, Class<?> returnType, Class<?>... paramTypes) {
+            return new RestrictedMethod(owner, name, MethodType.methodType(returnType, paramTypes));
+        }
+    };
+
+    static final Set<RestrictedMethod> RESTRICTED_METHODS = Set.of(
+            RestrictedMethod.of(SymbolLookup.class, "libraryLookup", SymbolLookup.class, String.class, Arena.class),
+            RestrictedMethod.of(SymbolLookup.class, "libraryLookup", SymbolLookup.class, Path.class, Arena.class),
+            RestrictedMethod.of(Linker.class, "downcallHandle", MethodHandle.class, FunctionDescriptor.class, Linker.Option[].class),
+            RestrictedMethod.of(Linker.class, "downcallHandle", MethodHandle.class, MemorySegment.class, FunctionDescriptor.class, Linker.Option[].class),
+            RestrictedMethod.of(Linker.class, "upcallStub", MemorySegment.class, MethodHandle.class, FunctionDescriptor.class, Arena.class, Linker.Option[].class),
+            RestrictedMethod.of(MemorySegment.class, "reinterpret", MemorySegment.class, long.class),
+            RestrictedMethod.of(MemorySegment.class, "reinterpret", MemorySegment.class, Arena.class, Consumer.class),
+            RestrictedMethod.of(MemorySegment.class, "reinterpret", MemorySegment.class, long.class, Arena.class, Consumer.class),
+            RestrictedMethod.of(AddressLayout.class, "withTargetLayout", AddressLayout.class, MemoryLayout.class),
+            RestrictedMethod.of(ModuleLayer.Controller.class, "enableNativeAccess", ModuleLayer.Controller.class, Module.class)
+    );
+
+    @Test
+    public void testRestricted() {
+        Set<RestrictedMethod> restrictedMethods = new HashSet<>(RESTRICTED_METHODS);
+        restrictedMethods(Object.class.getModule()).forEach(m -> checkRestrictedMethod(m, restrictedMethods));
+        if (!restrictedMethods.isEmpty()) {
+            fail("@Restricted annotation not found for methods: " + restrictedMethods);
+        }
+    }
+
+    void checkRestrictedMethod(Method meth, Set<RestrictedMethod> restrictedMethods) {
+        String sig = meth.getDeclaringClass().getName() + "::" + shortSig(meth);
+        boolean expectRestricted = restrictedMethods.remove(RestrictedMethod.from(meth));
+        assertTrue(expectRestricted, "unexpected @Restricted annotation found on method " + sig);
+        assertTrue(meth.isAnnotationPresent(CallerSensitive.class), "@CallerSensitive annotation not found on restricted method " + sig);
+    }
+
+    /**
+     * Returns a stream of all restricted methods on public classes in packages
+     * exported by a named module. This logic is borrowed from CallerSensitiveTest.
+     */
+    static Stream<Method> restrictedMethods(Module module) {
+        assert module.isNamed();
+        ModuleReference mref = module.getLayer().configuration()
+                .findModule(module.getName())
+                .orElseThrow(() -> new RuntimeException())
+                .reference();
+        // find all ".class" resources in the module
+        // transform the resource name to a class name
+        // load every class in the exported packages
+        // return the restricted methods of the public classes
+        try (ModuleReader reader = mref.open()) {
+            return reader.list()
+                    .filter(rn -> rn.endsWith(".class"))
+                    .map(rn -> rn.substring(0, rn.length() - 6)
+                            .replace('/', '.'))
+                    .filter(cn -> module.isExported(packageName(cn)))
+                    .map(cn -> Class.forName(module, cn))
+                    .filter(refc -> refc != null
+                            && Modifier.isPublic(refc.getModifiers()))
+                    .map(refc -> restrictedMethods(refc))
+                    .flatMap(List::stream);
+        } catch (IOException ioe) {
+            throw new UncheckedIOException(ioe);
+        }
+    }
+
+    static String packageName(String cn) {
+        int last = cn.lastIndexOf('.');
+        if (last > 0) {
+            return cn.substring(0, last);
+        } else {
+            return "";
+        }
+    }
+
+    static String shortSig(Method m) {
+        StringJoiner sj = new StringJoiner(",", m.getName() + "(", ")");
+        for (Class<?> parameterType : m.getParameterTypes()) {
+            sj.add(parameterType.getTypeName());
+        }
+        return sj.toString();
+    }
+
+    /**
+     * Returns a list of restricted methods directly declared by the given
+     * class.
+     */
+    static List<Method> restrictedMethods(Class<?> refc) {
+        return Arrays.stream(refc.getDeclaredMethods())
+                .filter(m -> m.isAnnotationPresent(Restricted.class))
+                .collect(Collectors.toList());
+    }
+}

--- a/test/jdk/java/foreign/TestRestricted.java
+++ b/test/jdk/java/foreign/TestRestricted.java
@@ -24,7 +24,6 @@
 /*
  * @test
  * @enablePreview
- * @requires jdk.foreign.linker != "UNSUPPORTED"
  * @modules java.base/jdk.internal.javac
  * @modules java.base/jdk.internal.reflect
  * @run testng TestRestricted


### PR DESCRIPTION
This patch adds a new internal annotation that is used to mark all restricted me
thods in the FFM API. The new annotation is similar to the one we used for preview API methods.

We plan to use the new annotation for adding new javac warnings when calling restricted methods, as well as to add better javadoc support for restricted methods.

I have added a test which, similar to the test for `@CallerSensitive` checks all methods in `java.base` that are annotated with `@Restricted` and makes sure they conform to the list of restricted methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316970](https://bugs.openjdk.org/browse/JDK-8316970): Add internal annotation to mark restricted methods (**Enhancement** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [f2f3692a](https://git.openjdk.org/jdk/pull/15947/files/f2f3692af61bb8c7c6afaa0d6fd53008df7922b8)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15947/head:pull/15947` \
`$ git checkout pull/15947`

Update a local copy of the PR: \
`$ git checkout pull/15947` \
`$ git pull https://git.openjdk.org/jdk.git pull/15947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15947`

View PR using the GUI difftool: \
`$ git pr show -t 15947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15947.diff">https://git.openjdk.org/jdk/pull/15947.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15947#issuecomment-1737705416)