### PR TITLE
8303773: Replace "main.wrapper" with "test.thread.factory" property in test code

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/monitor/monitor001/monitor001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,7 +152,7 @@ public class monitor001 extends JdbTest {
 
         // check 'threads', searching for "java.lang.Thread" followed by the main thread name.
         v.add("java.lang.Thread");
-        if (System.getProperty("main.wrapper") != null) {
+        if (System.getProperty("test.thread.factory") != null) {
             v.add(nsk.share.MainWrapper.OLD_MAIN_THREAD_NAME);
         } else {
             v.add("main");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/threads/threads003/threads003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ public class threads003 extends JdbTest {
         int count;
         Vector v;
         String[] threads;
-        boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+        boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
 
         if (!vthreadMode) {
             // This test is only meant to be run in vthread mode.

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/unmonitor/unmonitor001/unmonitor001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,7 +186,7 @@ public class unmonitor001 extends JdbTest {
 
         // check 'threads', searching for "java.lang.Thread" followed by the main thread name.
         v.add("java.lang.Thread");
-        if (System.getProperty("main.wrapper") != null) {
+        if (System.getProperty("test.thread.factory") != null) {
             v.add(nsk.share.MainWrapper.OLD_MAIN_THREAD_NAME);
         } else {
             v.add("main");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/_bounds_/bounds002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/StackFrame/_bounds_/bounds002.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,7 +191,7 @@ public class bounds002 {
             complain("Unexpected " + e);
             exitStatus = Consts.TEST_FAILED;
         }
-        boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+        boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
         display("vthreadMode: " + vthreadMode + ", isTopmostFrame: " + isTopmostFrame);
         try {
             stackFrame.setValue(var, null);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadGroupReference/threads/threads001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadGroupReference/threads/threads001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,8 +134,8 @@ public class threads001 {
     private int runThis (String argv[], PrintStream out) {
 
         Debugee debuggee;
-        boolean usingWrapper = System.getProperty("main.wrapper") != null;
-        boolean usingVThreadWrapper = "Virtual".equals(System.getProperty("main.wrapper"));
+        boolean usingTTF = System.getProperty("test.thread.factory") != null;
+        boolean usingVirtualTTF = "Virtual".equals(System.getProperty("test.thread.factory"));
 
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
@@ -253,10 +253,10 @@ public class threads001 {
                  * the "VirtualThreads" ThreadGroup, and threfore do not show up in group1.
                  */
                 int expectedNumThreads;
-                if (usingVThreadWrapper) {
+                if (usingVirtualTTF) {
                     expectedNumThreads = 1;
                 } else {
-                    expectedNumThreads = usingWrapper ? 3 : 2;
+                    expectedNumThreads = usingTTF ? 3 : 2;
                 }
                 if (threads.size() < expectedNumThreads) {
                     log3("ERROR: threads.size() < 2 for group1 : " + threads.size() );
@@ -277,7 +277,7 @@ public class threads001 {
                     if (s1.equals("Thread2"))
                         nThread2 += 1;
                 }
-                if (nMain != 1 && !usingVThreadWrapper) {
+                if (nMain != 1 && !usingVirtualTTF) {
                     log3("ERROR: # of 'main' threads != 1  : " + nMain);
                     expresult = 1;
                 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001.java
@@ -69,7 +69,7 @@ public class stop001 {
     static final int PASSED = 0;
     static final int FAILED = 2;
     static final int PASS_BASE = 95;
-    static final boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+    static final boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
 
     //----------------------------------------------------- templete parameters
     static final String

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop001a.java
@@ -189,7 +189,7 @@ class Threadstop001a extends NamedTask {
 
     public static Object lockingObject2 = new Object();
 
-    static final boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+    static final boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
 
     private int i1 = 0, i2 = 10;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002.java
@@ -75,7 +75,7 @@ public class stop002 {
     static final String COMMAND_GO = "go";
     static final String COMMAND_QUIT = "quit";
 
-    static final boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+    static final boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
 
     private ArgumentHandler argHandler;
     private Log log;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/stop/stop002t.java
@@ -38,7 +38,7 @@ public class stop002t {
     volatile boolean stopLooping1 = false;
     volatile boolean stopLooping2 = false;
     volatile static int testNumReady = 0;
-    static final boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+    static final boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
 
     public static void main(String args[]) {
         System.exit(run(args) + Consts.JCK_STATUS_BASE);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadStartEvent/thread/thread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,7 +251,7 @@ public class thread001 {
                                       // debug agent has already generated the THREAD_START event for the
                                       // original "main", so we end up with two THREAD_START events for "main".
                                       // We need to allow for this.
-                                      if ((System.getProperty("main.wrapper") != null) &&
+                                      if ((System.getProperty("test.thread.factory") != null) &&
                                               checkedThreads[i][0].equals("main") &&
                                               checkedThreads[i][1].equals("1")) {
                                           checkedThreads[i][1] = "2";

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/MainWrapper.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/MainWrapper.java
@@ -47,7 +47,7 @@ public final class MainWrapper {
         finalizableObject.registerCleanup();
 
         // Some tests use this property to understand if virtual threads are used
-        System.setProperty("main.wrapper", wrapperName);
+        System.setProperty("test.thread.factory", wrapperName);
 
         Runnable task = () -> {
             try {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/Launcher.java
@@ -163,7 +163,7 @@ public class Launcher extends DebugeeBinder {
         args.add(jdbExecPath.trim());
 
         if (argumentHandler.isLaunchingConnector()) {
-            boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+            boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
             if (vthreadMode) {
                 /* Some tests need more carrier threads than the default provided. */
                 args.add("-R-Djdk.virtualThreadScheduler.parallelism=15");
@@ -230,8 +230,8 @@ public class Launcher extends DebugeeBinder {
                 if (argumentHandler.verbose()) {
                     cmdline += " -verbose";
                 }
-                if (System.getProperty("main.wrapper") != null) {
-                    cmdline = MainWrapper.class.getName() + " " + System.getProperty("main.wrapper") +  " " + cmdline;
+                if (System.getProperty("test.thread.factory") != null) {
+                    cmdline = MainWrapper.class.getName() + " " + System.getProperty("test.thread.factory") +  " " + cmdline;
                 }
                 connect.append(",main=" + cmdline.trim());
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -708,7 +708,7 @@ public class Binder extends DebugeeBinder {
 
         String cmdline = classToExecute + " " + ArgumentHandler.joinArguments(rawArgs, quote);
 
-        if(System.getProperty("test.thread.factory") != null) {
+        if (System.getProperty("test.thread.factory") != null) {
             cmdline = MainWrapper.class.getName() + " " + System.getProperty("test.thread.factory") + " " + cmdline;
         }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -708,8 +708,8 @@ public class Binder extends DebugeeBinder {
 
         String cmdline = classToExecute + " " + ArgumentHandler.joinArguments(rawArgs, quote);
 
-        if(System.getProperty("main.wrapper") != null) {
-            cmdline = MainWrapper.class.getName() + " " + System.getProperty("main.wrapper") + " " + cmdline;
+        if(System.getProperty("test.thread.factory") != null) {
+            cmdline = MainWrapper.class.getName() + " " + System.getProperty("test.thread.factory") + " " + cmdline;
         }
 
         arg = (Connector.StringArgument) arguments.get("main");
@@ -749,7 +749,7 @@ public class Binder extends DebugeeBinder {
             vmArgs = vmUserArgs;
         }
 
-        boolean vthreadMode = "Virtual".equals(System.getProperty("main.wrapper"));
+        boolean vthreadMode = "Virtual".equals(System.getProperty("test.thread.factory"));
         if (vthreadMode) {
             /* Some tests need more carrier threads than the default provided. */
             vmArgs += " -Djdk.virtualThreadScheduler.parallelism=15";

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,7 +251,7 @@ abstract public class Debugee extends DebugeeProcess {
             if (thread.name().equals(name))
                 return thread;
         }
-        if ("Virtual".equals(System.getProperty("main.wrapper"))) {
+        if ("Virtual".equals(System.getProperty("test.thread.factory"))) {
             return null;
         }
         throw new JDITestRuntimeException("** Thread IS NOT found ** : " + name);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIThreadFactory.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/JDIThreadFactory.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ThreadFactory;
 
 public class JDIThreadFactory {
 
-    private static ThreadFactory threadFactory = "Virtual".equals(System.getProperty("main.wrapper"))
+    private static ThreadFactory threadFactory = "Virtual".equals(System.getProperty("test.thread.factory"))
             ? virtualThreadFactory() : platformThreadFactory();
 
     public static Thread newThread(NamedTask task) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
@@ -350,9 +350,9 @@ public class DebugeeBinder extends Log.Logger implements Finalizable {
 
         args.add(jdwpArgs);
 
-        if(System.getProperty("main.wrapper") != null) {
+        if(System.getProperty("test.thread.factory") != null) {
             args.add(MainWrapper.class.getName());
-            args.add(System.getProperty("main.wrapper"));
+            args.add(System.getProperty("test.thread.factory"));
         }
 
         if (classToExecute != null) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeBinder.java
@@ -350,7 +350,7 @@ public class DebugeeBinder extends Log.Logger implements Finalizable {
 
         args.add(jdwpArgs);
 
-        if(System.getProperty("test.thread.factory") != null) {
+        if (System.getProperty("test.thread.factory") != null) {
             args.add(MainWrapper.class.getName());
             args.add(System.getProperty("test.thread.factory"));
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/runner/RunParams.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/runner/RunParams.java
@@ -225,7 +225,7 @@ public class RunParams {
                                 iterations = Integer.parseInt(args[++i]);
                 }
                 // Allow to force using vthreads using wrapper property
-                if(System.getProperty("test.thread.factory") != null && System.getProperty("test.thread.factory").equals("Virtual")) {
+                if("Virtual".equals(System.getProperty("test.thread.factory"))) {
                         useVirtualThreads = true;
                 }
                 printConfig(System.out);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/runner/RunParams.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/runner/RunParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,7 +225,7 @@ public class RunParams {
                                 iterations = Integer.parseInt(args[++i]);
                 }
                 // Allow to force using vthreads using wrapper property
-                if(System.getProperty("main.wrapper") != null && System.getProperty("main.wrapper").equals("Virtual")) {
+                if(System.getProperty("test.thread.factory") != null && System.getProperty("test.thread.factory").equals("Virtual")) {
                         useVirtualThreads = true;
                 }
                 printConfig(System.out);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/runner/RunParams.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/runner/RunParams.java
@@ -225,7 +225,7 @@ public class RunParams {
                                 iterations = Integer.parseInt(args[++i]);
                 }
                 // Allow to force using vthreads using wrapper property
-                if("Virtual".equals(System.getProperty("test.thread.factory"))) {
+                if ("Virtual".equals(System.getProperty("test.thread.factory"))) {
                         useVirtualThreads = true;
                 }
                 printConfig(System.out);

--- a/test/jdk/com/sun/jdi/DebuggeeWrapper.java
+++ b/test/jdk/com/sun/jdi/DebuggeeWrapper.java
@@ -26,20 +26,20 @@ import java.util.concurrent.ThreadFactory;
 
 public class DebuggeeWrapper {
 
-    public static String PROPERTY_NAME = "main.wrapper";
+    public static String PROPERTY_NAME = "test.thread.factory";
 
     private static final String OLD_MAIN_THREAD_NAME = "old-m-a-i-n";
 
     private static ThreadFactory threadFactory = r -> new Thread(r);
 
-    private static final String wrapperName = System.getProperty(PROPERTY_NAME);
+    private static final String testThreadFactoryName = System.getProperty(PROPERTY_NAME);
 
-    public static String getWrapperName() {
-        return wrapperName;
+    public static String getTestThreadFactoryName() {
+        return testThreadFactoryName;
     }
 
     public static boolean isVirtual() {
-        return "Virtual".equals(wrapperName);
+        return "Virtual".equals(testThreadFactoryName);
     }
 
     public static Thread newThread(Runnable task) {
@@ -85,7 +85,7 @@ public class DebuggeeWrapper {
                 tg.uncaughtThrowable.printStackTrace(System.out);
                 System.exit(1);
             }
-        } else if (getWrapperName().equals("Kernel")) {
+        } else if (getTestThreadFactoryName().equals("Kernel")) {
             MainThreadGroup tg = new MainThreadGroup();
             Thread t = new Thread(tg, () -> {
                 try {

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -512,7 +512,7 @@ abstract public class TestScaffold extends TargetAdapter {
         //     argInfo.targetVMArgs : -Xss4M
         // The result with wrapper enabled:
         //     argInfo.targetAppCommandLine : DebuggeeWrapper Frames2Targ
-        //     argInfo.targetVMArgs : -Xss4M -Dmain.wrapper=Virtual
+        //     argInfo.targetVMArgs : -Xss4M -Dtest.thread.factory=Virtual
         boolean classNameParsed = false;
         for (int i = 0; i < args.length; i++) {
             String arg = args[i].trim();
@@ -548,10 +548,10 @@ abstract public class TestScaffold extends TargetAdapter {
         }
 
         // Need to change args to run wrapper using command like 'DebuggeeWrapper <app-name>'
-        // and set property 'main.wrapper' so test could use DebuggeeWrapper.isVirtual() method
-        String mainWrapper = DebuggeeWrapper.getWrapperName();
-        if (mainWrapper != null && !argInfo.targetAppCommandLine.isEmpty()) {
-            argInfo.targetVMArgs += "-D" + DebuggeeWrapper.PROPERTY_NAME + "=" + mainWrapper;
+        // and set property 'test.thread.factory' so test could use DebuggeeWrapper.isVirtual() method
+        String testThreadFactoryName = DebuggeeWrapper.getTestThreadFactoryName();
+        if (testThreadFactoryName != null && !argInfo.targetAppCommandLine.isEmpty()) {
+            argInfo.targetVMArgs += "-D" + DebuggeeWrapper.PROPERTY_NAME + "=" + testThreadFactoryName;
             argInfo.targetAppCommandLine = DebuggeeWrapper.class.getName() + ' ' + argInfo.targetAppCommandLine;
         } else if ("true".equals(System.getProperty("test.enable.preview"))) {
             // the test specified @enablePreview.

--- a/test/jtreg_test_thread_factory/src/share/classes/Virtual.java
+++ b/test/jtreg_test_thread_factory/src/share/classes/Virtual.java
@@ -28,7 +28,7 @@ public class Virtual implements ThreadFactory {
     static {
         // This property is used by ProcessTools and some tests
         try {
-            System.setProperty("main.wrapper", "Virtual");
+            System.setProperty("test.thread.factory", "Virtual");
         } catch (Throwable t) {
             // might be thrown by security manager
         }

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -387,7 +387,7 @@ public final class ProcessTools {
     }
 
     /*
-      Convert arguments for tests running with virtual threads test thread factory
+      Convert arguments for tests running with virtual threads test thread factory.
       When test is executed with test thread factory the line is changed from
       java <jvm-args> <test-class> <test-args>
       to

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.lang.Thread.State;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
@@ -388,14 +387,14 @@ public final class ProcessTools {
     }
 
     /*
-      Convert arguments for tests running with virtual threads main wrapper
-      When test is executed with process wrapper the line is changed from
+      Convert arguments for tests running with virtual threads test thread factory
+      When test is executed with test thread factory the line is changed from
       java <jvm-args> <test-class> <test-args>
       to
-      java <jvm-args> -Dmain.wrapper=<wrapper-name> jdk.test.lib.process.ProcessTools <wrapper-name> <test-class> <test-args>
+      java <jvm-args> -Dtest.thread.factory=<test-thread-factory-name> jdk.test.lib.process.ProcessTools <test-thread-factory-name> <test-class> <test-args>
      */
 
-    private static List<String> addMainWrapperArgs(String mainWrapper, List<String> command) {
+    private static List<String> addTestThreadFactoryArgs(String testThreadFactoryName, List<String> command) {
 
         final List<String> unsupportedArgs = List.of(
                 "-jar", "-cp", "-classpath", "--class-path", "--describe-module", "-d",
@@ -408,9 +407,9 @@ public final class ProcessTools {
         ArrayList<String> args = new ArrayList<>();
 
         boolean expectSecondArg = false;
-        boolean isWrapperClassAdded = false;
+        boolean isTestThreadFactoryAdded = false;
         for (String cmd : command) {
-            if (isWrapperClassAdded) {
+            if (isTestThreadFactoryAdded) {
                 args.add(cmd);
                 continue;
             }
@@ -443,10 +442,10 @@ public final class ProcessTools {
             }
             // Some tests might check property to understand
             // if virtual threads are tested
-            args.add("-Dmain.wrapper=" + mainWrapper);
+            args.add("-Dtest.thread.factory=" + testThreadFactoryName);
             args.add("jdk.test.lib.process.ProcessTools");
-            args.add(mainWrapper);
-            isWrapperClassAdded = true;
+            args.add(testThreadFactoryName);
+            isTestThreadFactoryAdded = true;
             args.add(cmd);
         }
         return args;
@@ -471,9 +470,9 @@ public final class ProcessTools {
             args.add(System.getProperty("java.class.path"));
         }
 
-        String mainWrapper = System.getProperty("main.wrapper");
-        if (mainWrapper != null) {
-            args.addAll(addMainWrapperArgs(mainWrapper, Arrays.asList(command)));
+        String testThreadFactoryName = System.getProperty("test.thread.factory");
+        if (testThreadFactoryName != null) {
+            args.addAll(addTestThreadFactoryArgs(testThreadFactoryName, Arrays.asList(command)));
         } else {
             Collections.addAll(args, command);
         }
@@ -881,10 +880,10 @@ public final class ProcessTools {
 
     public static final String OLD_MAIN_THREAD_NAME = "old-m-a-i-n";
 
-    // ProcessTools as a wrapper
+    // ProcessTools as a wrapper for test execution
     // It executes method main in a separate virtual or platform thread
     public static void main(String[] args) throws Throwable {
-        String wrapper = args[0];
+        String testThreadFactoryName = args[0];
         String className = args[1];
         String[] classArgs = new String[args.length - 2];
         System.arraycopy(args, 2, classArgs, 0, args.length - 2);
@@ -892,7 +891,7 @@ public final class ProcessTools {
         Method mainMethod = c.getMethod("main", new Class[] { String[].class });
         mainMethod.setAccessible(true);
 
-        if (wrapper.equals("Virtual")) {
+        if (testThreadFactoryName.equals("Virtual")) {
             // MainThreadGroup used just as a container for exceptions
             // when main is executed in virtual thread
             MainThreadGroup tg = new MainThreadGroup();
@@ -912,7 +911,7 @@ public final class ProcessTools {
             if (tg.uncaughtThrowable != null) {
                 throw tg.uncaughtThrowable;
             }
-        } else if (wrapper.equals("Kernel")) {
+        } else if (testThreadFactoryName.equals("Kernel")) {
             MainThreadGroup tg = new MainThreadGroup();
             Thread t = new Thread(tg, () -> {
                     try {


### PR DESCRIPTION
The main.wrapper was the first name for jtreg test thread factory plugin. However, during integration of this feature in jtreg it was decided to use test.thread.factory name. So this fix just renames "main.wrapper" property to  "test.thread.factory" so it is more compliant with jtreg naming. Also, it makes more sense for tests when it is used to create other then main threads in test.
Testing: tier1-5.
Verified that "main.wrapper" is not used in test sources anymore.

I haven't rename DebugeeWrapperd and MainWrapper classes in JDI test frameworks because they are actually more main wrappers than thread factories.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303773](https://bugs.openjdk.org/browse/JDK-8303773): Replace "main.wrapper" with "test.thread.factory" property in test code (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [896065e5](https://git.openjdk.org/jdk/pull/15950/files/896065e5f9e61bfd60e64e666f3af7bdedd65bb3)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [896065e5](https://git.openjdk.org/jdk/pull/15950/files/896065e5f9e61bfd60e64e666f3af7bdedd65bb3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15950/head:pull/15950` \
`$ git checkout pull/15950`

Update a local copy of the PR: \
`$ git checkout pull/15950` \
`$ git pull https://git.openjdk.org/jdk.git pull/15950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15950`

View PR using the GUI difftool: \
`$ git pr show -t 15950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15950.diff">https://git.openjdk.org/jdk/pull/15950.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15950#issuecomment-1738041183)