### PR TITLE
8316964: Security tools should not call System.exit

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -405,26 +405,39 @@ public final class Main {
         collator.setStrength(Collator.PRIMARY);
     }
 
-    private Main() { }
-
     public static void main(String[] args) throws Exception {
         Main kt = new Main();
-        kt.run(args, System.out);
+        try {
+            kt.run(args, System.out);
+        } catch (ExitException ee) {
+            System.exit(ee.errorCode);
+        }
     }
 
-    private void run(String[] args, PrintStream out) throws Exception {
+    private static class ExitException extends RuntimeException {
+        @java.io.Serial
+        static final long serialVersionUID = 0L;
+        private final int errorCode;
+        public ExitException(int errorCode) {
+            this.errorCode = errorCode;
+        }
+    }
+
+    public void run(String[] args, PrintStream out) throws Exception {
         try {
-            args = parseArgs(args);
+            parseArgs(args);
             if (command != null) {
                 doCommands(out);
             }
+        } catch (ExitException ee) {
+            throw ee;
         } catch (Exception e) {
             System.out.println(rb.getString("keytool.error.") + e);
             if (verbose) {
                 e.printStackTrace(System.out);
             }
             if (!debug) {
-                System.exit(1);
+                throw new ExitException(1);
             } else {
                 throw e;
             }
@@ -5247,7 +5260,7 @@ public final class Main {
         if (debug) {
             throw new RuntimeException("NO BIG ERROR, SORRY");
         } else {
-            System.exit(1);
+            throw new ExitException(1);
         }
     }
 

--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -407,10 +407,9 @@ public final class Main {
 
     public static void main(String[] args) throws Exception {
         Main kt = new Main();
-        try {
-            kt.run(args, System.out);
-        } catch (ExitException ee) {
-            System.exit(ee.errorCode);
+        int exitCode = kt.run(args, System.out);
+        if (exitCode != 0) {
+            System.exit(exitCode);
         }
     }
 
@@ -423,21 +422,21 @@ public final class Main {
         }
     }
 
-    public void run(String[] args, PrintStream out) throws Exception {
+    public int run(String[] args, PrintStream out) throws Exception {
         try {
             parseArgs(args);
             if (command != null) {
                 doCommands(out);
             }
         } catch (ExitException ee) {
-            throw ee;
+            return ee.errorCode;
         } catch (Exception e) {
             System.out.println(rb.getString("keytool.error.") + e);
             if (verbose) {
                 e.printStackTrace(System.out);
             }
             if (!debug) {
-                throw new ExitException(1);
+                return 1;
             } else {
                 throw e;
             }
@@ -454,6 +453,7 @@ public final class Main {
                 ksStream.close();
             }
         }
+        return 0;
     }
 
     /**

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Kinit.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Kinit.java
@@ -93,10 +93,9 @@ public class Kinit {
 
     public static void main(String[] args) {
         Kinit kinit = new Kinit();
-        try {
-            kinit.run(args);
-        } catch (Exception e) {
-            System.exit(-1);
+        int exitCode = kinit.run(args);
+        if (exitCode != 0) {
+            System.exit(exitCode);
         }
     }
 
@@ -104,12 +103,9 @@ public class Kinit {
      * Run the Kinit command.
      * @param args array of ticket request options.
      * Available options are: -f, -p, -c, principal, password.
-     * @exception IOException if an I/O error occurs.
-     * @exception RealmException if the Realm could not be instantiated.
-     * @exception KrbException if error occurs during Kerberos operation.
+     * @return the exit code
      */
-    public void run(String[] args)
-            throws IOException, RealmException, KrbException {
+    public int run(String[] args) {
         try {
             if (args == null || args.length == 0) {
                 options = new KinitOptions();
@@ -131,7 +127,7 @@ public class Kinit {
                             + options.action);
             }
         } catch (Exception e) {
-            String msg = null;
+            String msg;
             if (e instanceof KrbException) {
                 msg = ((KrbException)e).krbErrorMessage() + " " +
                         ((KrbException)e).returnCodeMessage();
@@ -144,8 +140,9 @@ public class Kinit {
                 System.out.println("Exception: " + e);
             }
             e.printStackTrace();
-            throw e;
+            return -1;
         }
+        return 0;
     }
 
     private void renew()

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Kinit.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Kinit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,14 +92,49 @@ public class Kinit {
      */
 
     public static void main(String[] args) {
+        Kinit kinit = new Kinit();
         try {
-            Kinit self = new Kinit(args);
+            kinit.run(args);
+        } catch (Exception e) {
+            System.exit(-1);
         }
-        catch (Exception e) {
+    }
+
+    /**
+     * Run the Kinit command.
+     * @param args array of ticket request options.
+     * Available options are: -f, -p, -c, principal, password.
+     * @exception IOException if an I/O error occurs.
+     * @exception RealmException if the Realm could not be instantiated.
+     * @exception KrbException if error occurs during Kerberos operation.
+     */
+    public void run(String[] args)
+            throws IOException, RealmException, KrbException {
+        try {
+            if (args == null || args.length == 0) {
+                options = new KinitOptions();
+            } else {
+                options = new KinitOptions(args);
+            }
+            switch (options.action) {
+                case 0:
+                    // Help, already displayed in new KinitOptions().
+                    break;
+                case 1:
+                    acquire();
+                    break;
+                case 2:
+                    renew();
+                    break;
+                default:
+                    throw new KrbException("kinit does not support action "
+                            + options.action);
+            }
+        } catch (Exception e) {
             String msg = null;
             if (e instanceof KrbException) {
                 msg = ((KrbException)e).krbErrorMessage() + " " +
-                    ((KrbException)e).returnCodeMessage();
+                        ((KrbException)e).returnCodeMessage();
             } else  {
                 msg = e.getMessage();
             }
@@ -109,36 +144,7 @@ public class Kinit {
                 System.out.println("Exception: " + e);
             }
             e.printStackTrace();
-            System.exit(-1);
-        }
-        return;
-    }
-
-    /**
-     * Constructs a new Kinit object.
-     * @param args array of ticket request options.
-     * Available options are: -f, -p, -c, principal, password.
-     * @exception IOException if an I/O error occurs.
-     * @exception RealmException if the Realm could not be instantiated.
-     * @exception KrbException if error occurs during Kerberos operation.
-     */
-    private Kinit(String[] args)
-        throws IOException, RealmException, KrbException {
-        if (args == null || args.length == 0) {
-            options = new KinitOptions();
-        } else {
-            options = new KinitOptions(args);
-        }
-        switch (options.action) {
-            case 1:
-                acquire();
-                break;
-            case 2:
-                renew();
-                break;
-            default:
-                throw new KrbException("kinit does not support action "
-                        + options.action);
+            throw e;
         }
     }
 

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Kinit.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Kinit.java
@@ -128,9 +128,8 @@ public class Kinit {
             }
         } catch (Exception e) {
             String msg;
-            if (e instanceof KrbException) {
-                msg = ((KrbException)e).krbErrorMessage() + " " +
-                        ((KrbException)e).returnCodeMessage();
+            if (e instanceof KrbException ke) {
+                msg = ke.krbErrorMessage() + " " + ke.returnCodeMessage();
             } else  {
                 msg = e.getMessage();
             }

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/KinitOptions.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/KinitOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import java.io.FileInputStream;
  */
 class KinitOptions {
 
-    // 1. acquire, 2. renew, 3. validate
+    // 0. Help, 1. acquire, 2. renew, 3. validate, 4. Help
     public int action = 1;
 
     // forwardable and proxiable flags have two states:
@@ -143,7 +143,8 @@ class KinitOptions {
                        // -help: legacy.
                        args[i].equalsIgnoreCase("-help")) {
                 printHelp();
-                System.exit(0);
+                action = 0;
+                return;
             } else if (p == null) { // Haven't yet processed a "principal"
                 p = args[i];
                 try {

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/KinitOptions.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/KinitOptions.java
@@ -46,7 +46,7 @@ import java.io.FileInputStream;
  */
 class KinitOptions {
 
-    // 0. Help, 1. acquire, 2. renew, 3. validate, 4. Help
+    // 0. Help, 1. acquire, 2. renew, 3. validate
     public int action = 1;
 
     // forwardable and proxiable flags have two states:

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Klist.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Klist.java
@@ -148,7 +148,7 @@ public class Klist {
             } else
                 target = CredentialsCache.getInstance(name);
 
-            if (target != null)  {
+            if (target != null) {
                 return displayCache();
             } else {
                 return displayError("Credentials cache");
@@ -197,7 +197,7 @@ public class Klist {
                                    entries.length + " entries found.\n");
             for (int i = 0; i < entries.length; i++) {
                 System.out.println("[" + (i + 1) + "] " +
-                                   "Service principal: "  +
+                                   "Service principal: " +
                                    entries[i].getService().toString());
                 System.out.println("\t KVNO: " +
                                    entries[i].getKey().getKeyVersionNumber());
@@ -229,7 +229,7 @@ public class Klist {
                                 name);
             return -1;
         }
-        System.out.println("\nCredentials cache: " +  name);
+        System.out.println("\nCredentials cache: " + name);
         String defaultPrincipal = cache.getPrimaryPrincipal().toString();
         int num = creds.length;
 

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Klist.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Klist.java
@@ -151,8 +151,7 @@ public class Klist {
             if (target != null)  {
                 return displayCache();
             } else {
-                displayMessage("Credentials cache");
-                return -1;
+                return displayError("Credentials cache");
             }
         case 'k':
             KeyTab ktab = KeyTab.getInstance(name);
@@ -177,8 +176,7 @@ public class Klist {
                 if (target != null) {
                     return displayCache();
                 } else {
-                    displayMessage("Credentials cache");
-                    return -1;
+                    return displayError("Credentials cache");
                 }
             }
         }
@@ -345,12 +343,13 @@ public class Klist {
         return 0;
     }
 
-    void displayMessage(String target) {
+    int displayError(String target) {
         if (name == null) {
             System.out.println("Default " + target + " not found.");
         } else {
             System.out.println(target + " " + name + " not found.");
         }
+        return -1;
     }
     /**
      * Reformats the date from the form -

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Ktab.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Ktab.java
@@ -73,10 +73,9 @@ public class Ktab {
      */
     public static void main(String[] args) {
         Ktab ktab = new Ktab();
-        try {
-            ktab.run(args);
-        } catch (ExitException ee) {
-            System.exit(ee.errorCode);
+        int exitCode = ktab.run(args);
+        if (exitCode != 0) {
+            System.exit(exitCode);
         }
     }
 
@@ -89,7 +88,16 @@ public class Ktab {
         }
     }
 
-    public void run(String[] args) throws ExitException {
+    public int run(String[] args) {
+        try {
+            run0(args);
+            return 0;
+        } catch (ExitException ee) {
+            return ee.errorCode;
+        }
+    }
+
+    private void run0(String[] args) throws ExitException {
         if ((args.length == 1) &&
             ((args[0].equalsIgnoreCase("-?")) ||
              (args[0].equalsIgnoreCase("-h")) ||

--- a/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Ktab.java
+++ b/src/java.security.jgss/windows/classes/sun/security/krb5/internal/tools/Ktab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,52 +73,68 @@ public class Ktab {
      */
     public static void main(String[] args) {
         Ktab ktab = new Ktab();
+        try {
+            ktab.run(args);
+        } catch (ExitException ee) {
+            System.exit(ee.errorCode);
+        }
+    }
+
+    private static class ExitException extends RuntimeException {
+        @java.io.Serial
+        static final long serialVersionUID = 0L;
+        private final int errorCode;
+        public ExitException(int errorCode) {
+            this.errorCode = errorCode;
+        }
+    }
+
+    public void run(String[] args) throws ExitException {
         if ((args.length == 1) &&
             ((args[0].equalsIgnoreCase("-?")) ||
              (args[0].equalsIgnoreCase("-h")) ||
              (args[0].equalsIgnoreCase("--help")) ||
              // -help: legacy.
              (args[0].equalsIgnoreCase("-help")))) {
-            ktab.printHelp();
-            System.exit(0);
+            printHelp();
             return;
         } else if ((args == null) || (args.length == 0)) {
-            ktab.action = 'l';
+            action = 'l';
         } else {
-            ktab.processArgs(args);
+            processArgs(args);
         }
-        ktab.table = KeyTab.getInstance(ktab.name);
-        if (ktab.table.isMissing() && ktab.action != 'a') {
-            if (ktab.name == null) {
+        table = KeyTab.getInstance(name);
+        if (table.isMissing() && action != 'a') {
+            if (name == null) {
                 System.out.println("No default key table exists.");
             } else {
                 System.out.println("Key table " +
-                        ktab.name + " does not exist.");
+                        name + " does not exist.");
             }
-            System.exit(-1);
+            throw new ExitException(-1);
         }
-        if (!ktab.table.isValid()) {
-            if (ktab.name == null) {
+        if (!table.isValid()) {
+            if (name == null) {
                 System.out.println("The format of the default key table " +
                         " is incorrect.");
             } else {
                 System.out.println("The format of key table " +
-                        ktab.name + " is incorrect.");
+                        name + " is incorrect.");
             }
-            System.exit(-1);
+            throw new ExitException(-1);
         }
-        switch (ktab.action) {
+        switch (action) {
         case 'l':
-            ktab.listKt();
+            listKt();
             break;
         case 'a':
-            ktab.addEntry();
+            addEntry();
             break;
         case 'd':
-            ktab.deleteEntry();
+            deleteEntry();
             break;
         default:
-            ktab.error("A command must be provided");
+            error("A command must be provided");
         }
     }
 
@@ -267,7 +283,7 @@ public class Ktab {
     void addEntry() {
         if (salt != null && fopt) {
             System.err.println("-s and -f cannot coexist when adding a keytab entry.");
-            System.exit(-1);
+            throw new ExitException(-1);
         }
         PrincipalName pname = null;
         try {
@@ -276,7 +292,7 @@ public class Ktab {
             System.err.println("Failed to add " + principal +
                                " to keytab.");
             e.printStackTrace();
-            System.exit(-1);
+            throw new ExitException(-1);
         }
         if (password == null) {
             try {
@@ -288,7 +304,7 @@ public class Ktab {
             } catch (IOException e) {
                 System.err.println("Failed to read the password.");
                 e.printStackTrace();
-                System.exit(-1);
+                throw new ExitException(-1);
             }
 
         }
@@ -313,11 +329,11 @@ public class Ktab {
         } catch (KrbException e) {
             System.err.println("Failed to add " + principal + " to keytab.");
             e.printStackTrace();
-            System.exit(-1);
+            throw new ExitException(-1);
         } catch (IOException e) {
             System.err.println("Failed to save new entry.");
             e.printStackTrace();
-            System.exit(-1);
+            throw new ExitException(-1);
         }
     }
 
@@ -399,22 +415,23 @@ public class Ktab {
                 System.out.flush();
                 answer = cis.readLine();
                 if (answer.equalsIgnoreCase("Y") ||
-                    answer.equalsIgnoreCase("Yes"));
-                else {
+                    answer.equalsIgnoreCase("Yes")) {
+                    ;
+                } else {
                     // no error, the user did not want to delete the entry
-                    System.exit(0);
+                    return;
                 }
             }
         } catch (KrbException e) {
             System.err.println("Error occurred while deleting the entry. "+
                                "Deletion failed.");
             e.printStackTrace();
-            System.exit(-1);
+            throw new ExitException(-1);
         } catch (IOException e) {
             System.err.println("Error occurred while deleting the entry. "+
                                " Deletion failed.");
             e.printStackTrace();
-            System.exit(-1);
+            throw new ExitException(-1);
         }
 
         int count = table.deleteEntries(pname, etype, vDel);
@@ -422,7 +439,7 @@ public class Ktab {
         if (count == 0) {
             System.err.println("No matched entry in the keytab. " +
                                "Deletion fails.");
-            System.exit(-1);
+            throw new ExitException(-1);
         } else {
             try {
                 table.save();
@@ -430,7 +447,7 @@ public class Ktab {
                 System.err.println("Error occurs while saving the keytab. " +
                                    "Deletion fails.");
                 e.printStackTrace();
-                System.exit(-1);
+                throw new ExitException(-1);
             }
             System.out.println("Done! " + count + " entries removed.");
         }
@@ -441,7 +458,7 @@ public class Ktab {
             System.out.println("Error: " + error + ".");
         }
         printHelp();
-        System.exit(-1);
+        throw new ExitException(-1);
     }
 
     /**

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -135,10 +135,9 @@ public class Main {
     // This is the entry that get launched by the security tool jarsigner.
     public static void main(String args[]) throws Exception {
         Main js = new Main();
-        try {
-            js.run(args);
-        } catch (ExitException ee) {
-            System.exit(ee.errorCode);
+        int exitCode = js.run(args);
+        if (exitCode != 0) {
+            System.exit(exitCode);
         }
     }
 
@@ -247,7 +246,7 @@ public class Main {
     PKIXBuilderParameters pkixParameters;
     Set<X509Certificate> trustedCerts = new HashSet<>();
 
-    public void run(String args[]) {
+    public int run(String args[]) {
         try {
             parseArgs(args);
 
@@ -313,17 +312,13 @@ public class Main {
                 signJar(jarfile, alias);
             }
         } catch (ExitException ee) {
-            if (ee.errorCode == 0) {
-                return;
-            } else {
-                throw ee;
-            }
+            return ee.errorCode;
         } catch (Exception e) {
             System.out.println(rb.getString("jarsigner.error.") + e);
             if (debug) {
                 e.printStackTrace();
             }
-            exit(1);
+            return 1;
         } finally {
             // zero-out private key password
             if (keypass != null) {
@@ -356,10 +351,10 @@ public class Main {
             if (tsaChainNotValidated) {
                 exitCode |= 64;
             }
-            if (exitCode != 0) {
-                exit(exitCode);
-            }
+            return exitCode;
         }
+
+        return 0;
     }
 
     /*

--- a/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
+++ b/src/jdk.jartool/share/classes/sun/security/tools/jarsigner/Main.java
@@ -150,10 +150,6 @@ public class Main {
         }
     }
 
-    private static void exit(int exitCode) {
-        throw new ExitException(exitCode);
-    }
-
     X509Certificate[] certChain;    // signer's cert chain (when composing)
     PrivateKey privateKey;          // private key
     KeyStore store;                 // the keystore specified by -keystore
@@ -620,12 +616,12 @@ public class Main {
     static void usage() {
         System.out.println();
         System.out.println(rb.getString("Please.type.jarsigner.help.for.usage"));
-        exit(1);
+        throw new ExitException(1);
     }
 
     static void doPrintVersion() {
         System.out.println("jarsigner " + System.getProperty("java.version"));
-        exit(0);
+        throw new ExitException(0);
     }
 
     static void fullusage() {
@@ -727,7 +723,7 @@ public class Main {
                 (".print.this.help.message"));
         System.out.println();
 
-        exit(0);
+        throw new ExitException(0);
     }
 
     void verifyJar(String jarName)
@@ -2469,7 +2465,7 @@ public class Main {
 
     void error(String message) {
         System.out.println(rb.getString("jarsigner.")+message);
-        exit(1);
+        throw new ExitException(1);
     }
 
 
@@ -2478,7 +2474,7 @@ public class Main {
         if (debug) {
             e.printStackTrace();
         }
-        exit(1);
+        throw new ExitException(1);
     }
 
     /**

--- a/test/jdk/sun/security/krb5/tools/ExitOrNot.java
+++ b/test/jdk/sun/security/krb5/tools/ExitOrNot.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8316964
+ * @summary check exit code in kinit, klist, and ktab
+ * @requires os.family == "windows"
+ * @library /test/lib
+ * @modules java.security.jgss/sun.security.krb5.internal.tools
+ */
+
+import jdk.test.lib.SecurityTools;
+
+public class ExitOrNot {
+    public static void main(String[] args) throws Exception {
+
+        // launching the tool still exits
+        SecurityTools.kinit("u@R p1 p2")
+                .shouldHaveExitValue(-1);
+
+        SecurityTools.klist("-x")
+                .shouldHaveExitValue(-1);
+
+        SecurityTools.ktab("-x")
+                .shouldHaveExitValue(-1);
+
+        // calling the run() methods no longer
+        try {
+            new sun.security.krb5.internal.tools.Kinit()
+                    .run("u@R p1 p2".split(" "));
+        } catch (Exception e) {
+            // whatever
+        }
+        try {
+            new sun.security.krb5.internal.tools.Klist()
+                    .run("-x".split(" "));
+        } catch (Exception e) {
+            // whatever
+        }
+        try {
+            new sun.security.krb5.internal.tools.Ktab()
+                    .run("-x".split(" "));
+        } catch (Exception e) {
+            // whatever
+        }
+    }
+}

--- a/test/jdk/sun/security/krb5/tools/ExitOrNot.java
+++ b/test/jdk/sun/security/krb5/tools/ExitOrNot.java
@@ -30,39 +30,32 @@
  * @modules java.security.jgss/sun.security.krb5.internal.tools
  */
 
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Platform;
 import jdk.test.lib.SecurityTools;
 
 public class ExitOrNot {
+
+    private static final int BAD = Platform.isWindows() ? -1 : 255;
+
     public static void main(String[] args) throws Exception {
 
         // launching the tool still exits
         SecurityTools.kinit("u@R p1 p2")
-                .shouldHaveExitValue(-1);
+                .shouldHaveExitValue(BAD);
 
         SecurityTools.klist("-x")
-                .shouldHaveExitValue(-1);
+                .shouldHaveExitValue(BAD);
 
         SecurityTools.ktab("-x")
-                .shouldHaveExitValue(-1);
+                .shouldHaveExitValue(BAD);
 
-        // calling the run() methods no longer
-        try {
-            new sun.security.krb5.internal.tools.Kinit()
-                    .run("u@R p1 p2".split(" "));
-        } catch (Exception e) {
-            // whatever
-        }
-        try {
-            new sun.security.krb5.internal.tools.Klist()
-                    .run("-x".split(" "));
-        } catch (Exception e) {
-            // whatever
-        }
-        try {
-            new sun.security.krb5.internal.tools.Ktab()
-                    .run("-x".split(" "));
-        } catch (Exception e) {
-            // whatever
-        }
+        // calling the run() methods returns the exit code
+        Asserts.assertEQ(new sun.security.krb5.internal.tools.Kinit()
+                .run("u@R p1 p2".split(" ")), -1);
+        Asserts.assertEQ(new sun.security.krb5.internal.tools.Klist()
+                .run("-x".split(" ")), -1);
+        Asserts.assertEQ(new sun.security.krb5.internal.tools.Ktab()
+                .run("-x".split(" ")), -1);
     }
 }

--- a/test/jdk/sun/security/tools/jarsigner/ExitOrNot.java
+++ b/test/jdk/sun/security/tools/jarsigner/ExitOrNot.java
@@ -30,6 +30,7 @@
  *          jdk.jartool/sun.security.tools.jarsigner
  */
 
+import jdk.test.lib.Asserts;
 import jdk.test.lib.SecurityTools;
 
 public class ExitOrNot {
@@ -42,18 +43,10 @@ public class ExitOrNot {
                 .shouldHaveExitValue(1);
 
         // calling the run() methods no longer
-        try {
-            new sun.security.tools.jarsigner.Main()
-                    .run("1 2 3".split(" "));
-        } catch (Exception e) {
-            // whatever
-        }
+        Asserts.assertEQ(new sun.security.tools.jarsigner.Main()
+                    .run("1 2 3".split(" ")), 1);
 
-        try {
-            new sun.security.tools.keytool.Main()
-                    .run("-x".split(" "), System.out);
-        } catch (Exception e) {
-            // whatever
-        }
+        Asserts.assertEQ(new sun.security.tools.keytool.Main()
+                    .run("-x".split(" "), System.out), 1);
     }
 }

--- a/test/jdk/sun/security/tools/jarsigner/ExitOrNot.java
+++ b/test/jdk/sun/security/tools/jarsigner/ExitOrNot.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8316964
+ * @summary check exit code in jarsigner and keytool
+ * @library /test/lib
+ * @modules java.base/sun.security.tools.keytool
+ *          jdk.jartool/sun.security.tools.jarsigner
+ */
+
+import jdk.test.lib.SecurityTools;
+
+public class ExitOrNot {
+    public static void main(String[] args) throws Exception {
+
+        // launching the tool still exits
+        SecurityTools.jarsigner("1 2 3")
+                .shouldHaveExitValue(1);
+        SecurityTools.keytool("-x")
+                .shouldHaveExitValue(1);
+
+        // calling the run() methods no longer
+        try {
+            new sun.security.tools.jarsigner.Main()
+                    .run("1 2 3".split(" "));
+        } catch (Exception e) {
+            // whatever
+        }
+
+        try {
+            new sun.security.tools.keytool.Main()
+                    .run("-x".split(" "), System.out);
+        } catch (Exception e) {
+            // whatever
+        }
+    }
+}


### PR DESCRIPTION
Remove most `System.exit()` calls in various security tools and only leave one in the `main` method. This paves the way to convert them to JSR 199 tools.

Note: before this change, the behavior of a successful `main()` method execution is not consistent. Sometimes the method returns silently, sometimes a `System.exit(0)` is called somewhere. After this change, the method always returns silently. This makes sure that existing programs that calls the `main` method directly will continue and does not exit the VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316964](https://bugs.openjdk.org/browse/JDK-8316964): Security tools should not call System.exit (**Bug** - P3)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15951/head:pull/15951` \
`$ git checkout pull/15951`

Update a local copy of the PR: \
`$ git checkout pull/15951` \
`$ git pull https://git.openjdk.org/jdk.git pull/15951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15951`

View PR using the GUI difftool: \
`$ git pr show -t 15951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15951.diff">https://git.openjdk.org/jdk/pull/15951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15951#issuecomment-1738049526)