### PR TITLE
8313631: SA: stack trace printed using "where" command does not show class name

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/ui/classbrowser/HTMLGenerator.java
@@ -1916,7 +1916,7 @@ public class HTMLGenerator implements /* imports */ ClassConstants {
       for (JavaVFrame vf = thread.getLastJavaVFrameDbg(); vf != null; vf = vf.javaSender()) {
          Method method = vf.getMethod();
          buf.append(" - ");
-         buf.append(genMethodLink(method));
+         buf.append(genMethodAndKlassLink(method));
          buf.append(" @bci = " + vf.getBCI());
 
          int lineNumber = method.getLineNumberFromBCI(vf.getBCI());


### PR DESCRIPTION
Please review trivial fix to display class name in the output of "where" command of SA.

Testing: hotspot_serviceability

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313631](https://bugs.openjdk.org/browse/JDK-8313631): SA: stack trace printed using "where" command does not show class name (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15952/head:pull/15952` \
`$ git checkout pull/15952`

Update a local copy of the PR: \
`$ git checkout pull/15952` \
`$ git pull https://git.openjdk.org/jdk.git pull/15952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15952`

View PR using the GUI difftool: \
`$ git pr show -t 15952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15952.diff">https://git.openjdk.org/jdk/pull/15952.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15952#issuecomment-1738060477)