### PR TITLE
8317132: Prepare HotSpot for permissive-

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -562,7 +562,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # The -utf-8 option sets source and execution character sets to UTF-8 to enable correct
     # compilation of all source files regardless of the active code page on Windows.
-    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:inline -utf-8 -MP"
+    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:inline -utf-8 -permissive- -MP"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:inline -utf-8 -Zc:wchar_t-"
   fi
 

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -562,7 +562,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # The -utf-8 option sets source and execution character sets to UTF-8 to enable correct
     # compilation of all source files regardless of the active code page on Windows.
-    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:inline -utf-8 -permissive- -MP"
+    TOOLCHAIN_CFLAGS_JVM="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:inline -permissive- -utf-8 -MP"
     TOOLCHAIN_CFLAGS_JDK="-nologo -MD -Zc:preprocessor -Zc:strictStrings -Zc:inline -utf-8 -Zc:wchar_t-"
   fi
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2909,22 +2909,25 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  if (InterceptOSException) return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
-  DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
+  if (InterceptOSException) {
+    goto result;
+  } else {
+    DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
-  address pc = (address) exceptionInfo->ContextRecord->Pc;
+    address pc = (address) exceptionInfo->ContextRecord->Pc;
 #elif defined(_M_AMD64)
-  address pc = (address) exceptionInfo->ContextRecord->Rip;
+    address pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
-  address pc = (address) exceptionInfo->ContextRecord->Eip;
+    address pc = (address) exceptionInfo->ContextRecord->Eip;
 #endif
-  Thread* thread = Thread::current_or_null_safe();
+    Thread* thread = Thread::current_or_null_safe();
 
-  if (exceptionCode != EXCEPTION_BREAKPOINT) {
-    report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
-                exceptionInfo->ContextRecord);
+    if (exceptionCode != EXCEPTION_BREAKPOINT) {
+      report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
+                  exceptionInfo->ContextRecord);
+    }
   }
-
+result:
   return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
 }
 #endif

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2918,8 +2918,7 @@ LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* excepti
 #else
     address pc = (address) exceptionInfo->ContextRecord->Eip;
 #endif
-    Thread* thread;
-    thread = Thread::current_or_null_safe();
+    Thread* thread = Thread::current_or_null_safe();
 
     if (exceptionCode != EXCEPTION_BREAKPOINT) {
       report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2909,25 +2909,22 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  if (InterceptOSException) {
-    goto result;
-  } else {
-    DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
+  if (InterceptOSException) return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
+  DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
-    address pc = (address) exceptionInfo->ContextRecord->Pc;
+  address pc = (address) exceptionInfo->ContextRecord->Pc;
 #elif defined(_M_AMD64)
-    address pc = (address) exceptionInfo->ContextRecord->Rip;
+  address pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
-    address pc = (address) exceptionInfo->ContextRecord->Eip;
+  address pc = (address) exceptionInfo->ContextRecord->Eip;
 #endif
-    Thread* thread = Thread::current_or_null_safe();
+  Thread* thread = Thread::current_or_null_safe();
 
-    if (exceptionCode != EXCEPTION_BREAKPOINT) {
-      report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
-                  exceptionInfo->ContextRecord);
-    }
+  if (exceptionCode != EXCEPTION_BREAKPOINT) {
+    report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
+                exceptionInfo->ContextRecord);
   }
-result:
+
   return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
 }
 #endif

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2258,7 +2258,7 @@ void* os::win32::install_signal_handler(int sig, signal_handler_t handler) {
     sigbreakHandler = handler;
     return oldHandler;
   } else {
-    return ::signal(sig, handler);
+    return CAST_FROM_FN_PTR(void*, ::signal(sig, handler));
   }
 }
 
@@ -2909,20 +2909,23 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  if (InterceptOSException) goto exit;
-  DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
+  if (InterceptOSException) {
+    goto exit;
+  } else {
+    DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
-  address pc = (address)exceptionInfo->ContextRecord->Pc;
+    address pc = (address)exceptionInfo->ContextRecord->Pc;
 #elif defined(_M_AMD64)
-  address pc = (address) exceptionInfo->ContextRecord->Rip;
+    address pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
-  address pc = (address) exceptionInfo->ContextRecord->Eip;
+    address pc = (address) exceptionInfo->ContextRecord->Eip;
 #endif
-  Thread* t = Thread::current_or_null_safe();
+    Thread* t = Thread::current_or_null_safe();
 
-  if (exception_code != EXCEPTION_BREAKPOINT) {
-    report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
-                exceptionInfo->ContextRecord);
+    if (exception_code != EXCEPTION_BREAKPOINT) {
+      report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
+                  exceptionInfo->ContextRecord);
+    }
   }
 exit:
   return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2922,7 +2922,7 @@ LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* excepti
   Thread* thread;
   thread = Thread::current_or_null_safe();
 
-  if (exception_code != EXCEPTION_BREAKPOINT) {
+  if (exceptionCode != EXCEPTION_BREAKPOINT) {
     report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
                 exceptionInfo->ContextRecord);
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2909,24 +2909,26 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  if (InterceptOSException) {
-    goto exit;
-  } else {
-    DWORD exception_code = exceptionInfo->ExceptionRecord->ExceptionCode;
-#if defined(_M_ARM64)
-    address pc = (address)exceptionInfo->ContextRecord->Pc;
-#elif defined(_M_AMD64)
-    address pc = (address) exceptionInfo->ContextRecord->Rip;
-#else
-    address pc = (address) exceptionInfo->ContextRecord->Eip;
-#endif
-    Thread* t = Thread::current_or_null_safe();
+  if (InterceptOSException) goto exit;
 
-    if (exception_code != EXCEPTION_BREAKPOINT) {
-      report_error(t, exception_code, pc, exceptionInfo->ExceptionRecord,
-                  exceptionInfo->ContextRecord);
-    }
+  address pc;
+  DWORD exceptionCode;
+  exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
+#if defined(_M_ARM64)
+  pc = (address) exceptionInfo->ContextRecord->Pc;
+#elif defined(_M_AMD64)
+  pc = (address) exceptionInfo->ContextRecord->Rip;
+#else
+  pc = (address) exceptionInfo->ContextRecord->Eip;
+#endif
+  Thread* thread;
+  thread = Thread::current_or_null_safe();
+
+  if (exception_code != EXCEPTION_BREAKPOINT) {
+    report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
+                exceptionInfo->ContextRecord);
   }
+
 exit:
   return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2910,7 +2910,6 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (InterceptOSException) return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
-
   DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
   address pc = (address) exceptionInfo->ContextRecord->Pc;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2909,20 +2909,21 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  if (InterceptOSException) return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
-  DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
+  if (!InterceptOSException) {
+    DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
-  address pc = (address) exceptionInfo->ContextRecord->Pc;
+    address pc = (address) exceptionInfo->ContextRecord->Pc;
 #elif defined(_M_AMD64)
-  address pc = (address) exceptionInfo->ContextRecord->Rip;
+    address pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
-  address pc = (address) exceptionInfo->ContextRecord->Eip;
+    address pc = (address) exceptionInfo->ContextRecord->Eip;
 #endif
-  Thread* thread = Thread::current_or_null_safe();
+    Thread* thread = Thread::current_or_null_safe();
 
-  if (exceptionCode != EXCEPTION_BREAKPOINT) {
-    report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
-                exceptionInfo->ContextRecord);
+    if (exceptionCode != EXCEPTION_BREAKPOINT) {
+      report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
+                  exceptionInfo->ContextRecord);
+    }
   }
 
   return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2909,7 +2909,9 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  if (!InterceptOSException) {
+  if (InterceptOSException) {
+    // Do nothing
+  } else {
     DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
     address pc = (address) exceptionInfo->ContextRecord->Pc;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2909,7 +2909,7 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  if (InterceptOSException) {
+  if (!InterceptOSException) {
     DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
     address pc = (address) exceptionInfo->ContextRecord->Pc;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2909,24 +2909,24 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
-  if (InterceptOSException) goto exit;
-  DWORD exceptionCode;
-  exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
+  if (InterceptOSException) {
+    DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
-  address pc; pc = (address) exceptionInfo->ContextRecord->Pc;
+    address pc = (address) exceptionInfo->ContextRecord->Pc;
 #elif defined(_M_AMD64)
-  address pc; pc = (address) exceptionInfo->ContextRecord->Rip;
+    address pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
-  address pc; pc = (address) exceptionInfo->ContextRecord->Eip;
+    address pc = (address) exceptionInfo->ContextRecord->Eip;
 #endif
-  Thread* thread;
-  thread = Thread::current_or_null_safe();
+    Thread* thread;
+    thread = Thread::current_or_null_safe();
 
-  if (exceptionCode != EXCEPTION_BREAKPOINT) {
-    report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
-                exceptionInfo->ContextRecord);
+    if (exceptionCode != EXCEPTION_BREAKPOINT) {
+      report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
+                  exceptionInfo->ContextRecord);
+    }
   }
-exit:
+
   return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
 }
 #endif

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -2910,16 +2910,14 @@ LONG WINAPI topLevelVectoredExceptionFilter(struct _EXCEPTION_POINTERS* exceptio
 #if defined(USE_VECTORED_EXCEPTION_HANDLING)
 LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* exceptionInfo) {
   if (InterceptOSException) goto exit;
-
-  address pc;
   DWORD exceptionCode;
   exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 #if defined(_M_ARM64)
-  pc = (address) exceptionInfo->ContextRecord->Pc;
+  address pc; pc = (address) exceptionInfo->ContextRecord->Pc;
 #elif defined(_M_AMD64)
-  pc = (address) exceptionInfo->ContextRecord->Rip;
+  address pc; pc = (address) exceptionInfo->ContextRecord->Rip;
 #else
-  pc = (address) exceptionInfo->ContextRecord->Eip;
+  address pc; pc = (address) exceptionInfo->ContextRecord->Eip;
 #endif
   Thread* thread;
   thread = Thread::current_or_null_safe();
@@ -2928,7 +2926,6 @@ LONG WINAPI topLevelUnhandledExceptionFilter(struct _EXCEPTION_POINTERS* excepti
     report_error(thread, exceptionCode, pc, exceptionInfo->ExceptionRecord,
                 exceptionInfo->ContextRecord);
   }
-
 exit:
   return previousUnhandledExceptionFilter ? previousUnhandledExceptionFilter(exceptionInfo) : EXCEPTION_CONTINUE_SEARCH;
 }

--- a/src/hotspot/os/windows/symbolengine.cpp
+++ b/src/hotspot/os/windows/symbolengine.cpp
@@ -111,7 +111,7 @@ public:
       _p = _fallback_buffer;
       _capacity = (int)(sizeof(_fallback_buffer) / sizeof(T));
     }
-    _p[0] = '\0';
+    _p[0] = 0;
     imprint_sentinel();
   }
 
@@ -123,7 +123,7 @@ public:
     }
     _p = _fallback_buffer;
     _capacity = (int)(sizeof(_fallback_buffer) / sizeof(T));
-    _p[0] = '\0';
+    _p[0] = 0;
     imprint_sentinel();
   }
 

--- a/src/hotspot/os/windows/symbolengine.cpp
+++ b/src/hotspot/os/windows/symbolengine.cpp
@@ -111,7 +111,7 @@ public:
       _p = _fallback_buffer;
       _capacity = (int)(sizeof(_fallback_buffer) / sizeof(T));
     }
-    _p[0] = 0;
+    _p[0] = '\0';
     imprint_sentinel();
   }
 

--- a/src/hotspot/os/windows/symbolengine.cpp
+++ b/src/hotspot/os/windows/symbolengine.cpp
@@ -111,7 +111,7 @@ public:
       _p = _fallback_buffer;
       _capacity = (int)(sizeof(_fallback_buffer) / sizeof(T));
     }
-    _p[0] = '\0';
+    _p[0] = 0;
     imprint_sentinel();
   }
 

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -111,7 +111,7 @@ void* ArenaObj::operator new(size_t size, Arena *arena) throw() {
 // AnyObj
 //
 
-void* AnyObj::operator new(size_t size, Arena *arena) throw() {
+void* AnyObj::operator new(size_t size, Arena *arena) {
   address res = (address)arena->Amalloc(size);
   DEBUG_ONLY(set_allocation_type(res, ARENA);)
   return res;


### PR DESCRIPTION
Prepare HotSpot for the permissive- Visual C++ flag, this change contains all of the fixes required for HotSpot to compile under the stricter mode activated when the permissive- flag is passed

- Reworks code in topLevelUnhandledExceptionFilter for os_windows.cpp to avoid goto jumping across uninitialized locals
- Adds a CAST\_FROM\_FN\_PTR cast to the return value from ::signal to void, as they cannot be implicitly converted
- symbolengine.cpp's SimpleBufferWithFallback's templates cannot work with a raw char (Actual fix under discussion)
- Removed a throw() specification from a mismatched definition in allocation.cpp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8317132](https://bugs.openjdk.org/browse/JDK-8317132): Prepare HotSpot for permissive- (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [0d95d969](https://git.openjdk.org/jdk/pull/15955/files/0d95d96935ae43beef2726ec1e1ec01f2f9b3217)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) ⚠️ Review applies to [0d95d969](https://git.openjdk.org/jdk/pull/15955/files/0d95d96935ae43beef2726ec1e1ec01f2f9b3217)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15955/head:pull/15955` \
`$ git checkout pull/15955`

Update a local copy of the PR: \
`$ git checkout pull/15955` \
`$ git pull https://git.openjdk.org/jdk.git pull/15955/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15955`

View PR using the GUI difftool: \
`$ git pr show -t 15955`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15955.diff">https://git.openjdk.org/jdk/pull/15955.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15955#issuecomment-1738382401)