### PR TITLE
8317139: [JVMCI] oop handles clearing message pollutes event log

### DIFF
--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -975,7 +975,7 @@ int JVMCIRuntime::release_cleared_oop_handles() {
       object_handles()->release(_oop_handles.adr_at(num_alive), to_release);
 
       // Truncate oop handles to only those with a non-null referent
-      JVMCI_event_1("compacted oop handles in JVMCI runtime %d from %d to %d", _id, _oop_handles.length(), num_alive);
+      JVMCI_event_2("compacted oop handles in JVMCI runtime %d from %d to %d", _id, _oop_handles.length(), num_alive);
       _oop_handles.trunc_to(num_alive);
       // Example: HHH
 


### PR DESCRIPTION
The message for the event of clearing oop handles after each libjvmci compilation should only be logged at level 2 (i.e. `-XX:JVMCIEventLogLevel=2` or `-XX:JVMCITraceLevel=2`). Otherwise, it crowds out more useful events in hs-err crash logs. For example:
```
JVMCI Events (20 events):
Event: 0.853 Thread 0x00007fdde0002470 compacted oop handles in JVMCI runtime 4 from 94 to 68
Event: 0.853 Thread 0x00007fde0002e6d0 compacted oop handles in JVMCI runtime 2 from 102 to 63
Event: 0.855 Thread 0x00007fde0002e6d0 compacted oop handles in JVMCI runtime 2 from 70 to 69
Event: 0.856 Thread 0x00007fdde0002470 compacted oop handles in JVMCI runtime 4 from 71 to 70
Event: 0.861 Thread 0x00007fdde0002470 compacted oop handles in JVMCI runtime 4 from 78 to 77
Event: 0.866 Thread 0x00007fde0002e6d0 compacted oop handles in JVMCI runtime 2 from 82 to 81
Event: 0.870 Thread 0x00007fded01824f0 compacted oop handles in JVMCI runtime 0 from 88 to 85
Event: 0.875 Thread 0x00007fdde0002470 compacted oop handles in JVMCI runtime 4 from 91 to 90
Event: 0.876 Thread 0x00007fded01824f0 compacted oop handles in JVMCI runtime 0 from 86 to 52
Event: 0.878 Thread 0x00007fde0002d2f0 compacted oop handles in JVMCI runtime 1 from 69 to 65
Event: 0.897 Thread 0x00007fde0002e6d0 compacted oop handles in JVMCI runtime 2 from 101 to 99
Event: 0.897 Thread 0x00007fde0002e6d0 compacted oop handles in JVMCI runtime 2 from 100 to 70
Event: 0.897 Thread 0x00007fdde00037f0 compacted oop handles in JVMCI runtime 3 from 99 to 66
Event: 0.902 Thread 0x00007fde0002e6d0 compacted oop handles in JVMCI runtime 2 from 71 to 70
Event: 0.916 Thread 0x00007fde0002d2f0 compacted oop handles in JVMCI runtime 1 from 78 to 62
Event: 0.916 Thread 0x00007fdde00037f0 compacted oop handles in JVMCI runtime 3 from 81 to 79
Event: 0.919 Thread 0x00007fdde0002470 compacted oop handles in JVMCI runtime 4 from 100 to 80
Event: 0.922 Thread 0x00007fde0002d2f0 compacted oop handles in JVMCI runtime 1 from 70 to 69
Event: 0.923 Thread 0x00007fdde0002470 compacted oop handles in JVMCI runtime 4 from 85 to 84
Event: 0.926 Thread 0x00007fded01824f0 compacted oop handles in JVMCI runtime 0 from 77 to 74
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317139](https://bugs.openjdk.org/browse/JDK-8317139): [JVMCI] oop handles clearing message pollutes event log (**Enhancement** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15956/head:pull/15956` \
`$ git checkout pull/15956`

Update a local copy of the PR: \
`$ git checkout pull/15956` \
`$ git pull https://git.openjdk.org/jdk.git pull/15956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15956`

View PR using the GUI difftool: \
`$ git pr show -t 15956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15956.diff">https://git.openjdk.org/jdk/pull/15956.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15956#issuecomment-1738621653)