### PR TITLE
8317188: G1: Make TestG1ConcRefinementThreads use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ package gc.arguments;
 /*
  * @test TestG1ConcRefinementThreads
  * @bug 8047976
- * @requires vm.gc.G1
+ * @requires vm.gc.G1 & vm.opt.G1ConcRefinementThreads == null
  * @summary Tests argument processing for G1ConcRefinementThreads
  * @library /test/lib
  * @library /
@@ -69,7 +69,7 @@ public class TestG1ConcRefinementThreads {
     }
     Collections.addAll(vmOpts, "-XX:+UseG1GC", "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(vmOpts);
+    ProcessBuilder pb = GCArguments.createTestJvm(vmOpts);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     output.shouldHaveExitValue(0);


### PR DESCRIPTION
Testing after changes:

`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java JTREG='JAVA_OPTIONS=-XX:+UseG1GC' ` -> PASS 1
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java JTREG='JAVA_OPTIONS=-XX:+UseZGC' ` -> TOTAL 0
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestG1ConcRefinementThreads.java JTREG='JAVA_OPTIONS=-XX:G1ConcRefinementThreads=42' ` -> TOTAL 0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317188](https://bugs.openjdk.org/browse/JDK-8317188): G1: Make  TestG1ConcRefinementThreads use createTestJvm (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15958/head:pull/15958` \
`$ git checkout pull/15958`

Update a local copy of the PR: \
`$ git checkout pull/15958` \
`$ git pull https://git.openjdk.org/jdk.git pull/15958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15958`

View PR using the GUI difftool: \
`$ git pr show -t 15958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15958.diff">https://git.openjdk.org/jdk/pull/15958.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15958#issuecomment-1738724659)