### PR TITLE
8317218: G1: Make TestG1HeapRegionSize use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ package gc.arguments;
 /*
  * @test TestG1HeapRegionSize
  * @bug 8021879
- * @requires vm.gc.G1
+ * @requires vm.gc.G1 & vm.opt.G1HeapRegionSize == null
  * @summary Verify that the flag G1HeapRegionSize is updated properly
  * @modules java.base/jdk.internal.misc
  * @modules java.management/sun.management
@@ -53,7 +53,7 @@ public class TestG1HeapRegionSize {
     flagList.add("-XX:+PrintFlagsFinal");
     flagList.add("-version");
 
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(flagList);
+    ProcessBuilder pb = GCArguments.createTestJvm(flagList);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(exitValue);
 


### PR DESCRIPTION
Tested with:
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java JTREG='JAVA_OPTIONS=-XX:+UseG1GC'` -> PASS 1
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java JTREG='JAVA_OPTIONS=-XX:+UseZGC'` -> TOTAL 0
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java JTREG='JAVA_OPTIONS=-XX:G1HeapRegionSize=80000'` > TOTAL 0
`make run-test TEST=open/test/hotspot/jtreg/gc/arguments/TestG1HeapRegionSize.java JTREG='JAVA_OPTIONS='` -> PASS 1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317218](https://bugs.openjdk.org/browse/JDK-8317218): G1: Make TestG1HeapRegionSize use createTestJvm (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15959/head:pull/15959` \
`$ git checkout pull/15959`

Update a local copy of the PR: \
`$ git checkout pull/15959` \
`$ git pull https://git.openjdk.org/jdk.git pull/15959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15959`

View PR using the GUI difftool: \
`$ git pr show -t 15959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15959.diff">https://git.openjdk.org/jdk/pull/15959.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15959#issuecomment-1738774926)