### PR TITLE
8154846: SwingNode does not resize when content size constraints are changed

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java
+++ b/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java
@@ -370,6 +370,7 @@ public final class JLightweightFrame extends LightweightFrame implements RootPan
             }
         };
         contentPane.setLayout(new BorderLayout());
+
         contentPane.addContainerListener(new ContainerListener() {
             @Override
             public void componentAdded(ContainerEvent e) {
@@ -389,13 +390,14 @@ public final class JLightweightFrame extends LightweightFrame implements RootPan
             }
         });
         contentPane.add(component);
+        contentPane.revalidate();
+        contentPane.repaint();
         if ("true".equals(AccessController.
             doPrivileged(new GetPropertyAction("swing.jlf.contentPaneTransparent", "false"))))
         {
             contentPane.setOpaque(false);
         }
         setContentPane(contentPane);
-
     }
 
     @SuppressWarnings("deprecation")

--- a/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java
+++ b/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java
@@ -369,8 +369,12 @@ public final class JLightweightFrame extends LightweightFrame implements RootPan
                 return true;
             }
         };
+        component.removePropertyChangeListener(layoutSizeListener);
         contentPane.setLayout(new BorderLayout());
         contentPane.add(component);
+        component.addPropertyChangeListener("preferredSize", layoutSizeListener);
+        component.addPropertyChangeListener("maximumSize", layoutSizeListener);
+        component.addPropertyChangeListener("minimumSize", layoutSizeListener);
         if ("true".equals(AccessController.
             doPrivileged(new GetPropertyAction("swing.jlf.contentPaneTransparent", "false"))))
         {
@@ -378,24 +382,6 @@ public final class JLightweightFrame extends LightweightFrame implements RootPan
         }
         setContentPane(contentPane);
 
-        contentPane.addContainerListener(new ContainerListener() {
-            @Override
-            public void componentAdded(ContainerEvent e) {
-                Component c = JLightweightFrame.this.component;
-                if (e.getChild() == c) {
-                    c.addPropertyChangeListener("preferredSize", layoutSizeListener);
-                    c.addPropertyChangeListener("maximumSize", layoutSizeListener);
-                    c.addPropertyChangeListener("minimumSize", layoutSizeListener);
-                }
-            }
-            @Override
-            public void componentRemoved(ContainerEvent e) {
-                Component c = JLightweightFrame.this.component;
-                if (e.getChild() == c) {
-                    c.removePropertyChangeListener(layoutSizeListener);
-                }
-            }
-        });
     }
 
     @SuppressWarnings("deprecation")

--- a/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java
+++ b/src/java.desktop/share/classes/sun/swing/JLightweightFrame.java
@@ -369,12 +369,26 @@ public final class JLightweightFrame extends LightweightFrame implements RootPan
                 return true;
             }
         };
-        component.removePropertyChangeListener(layoutSizeListener);
         contentPane.setLayout(new BorderLayout());
+        contentPane.addContainerListener(new ContainerListener() {
+            @Override
+            public void componentAdded(ContainerEvent e) {
+                Component c = JLightweightFrame.this.component;
+                if (e.getChild() == c) {
+                    c.addPropertyChangeListener("preferredSize", layoutSizeListener);
+                    c.addPropertyChangeListener("maximumSize", layoutSizeListener);
+                    c.addPropertyChangeListener("minimumSize", layoutSizeListener);
+                }
+            }
+            @Override
+            public void componentRemoved(ContainerEvent e) {
+                Component c = JLightweightFrame.this.component;
+                if (e.getChild() == c) {
+                    c.removePropertyChangeListener(layoutSizeListener);
+                }
+            }
+        });
         contentPane.add(component);
-        component.addPropertyChangeListener("preferredSize", layoutSizeListener);
-        component.addPropertyChangeListener("maximumSize", layoutSizeListener);
-        component.addPropertyChangeListener("minimumSize", layoutSizeListener);
         if ("true".equals(AccessController.
             doPrivileged(new GetPropertyAction("swing.jlf.contentPaneTransparent", "false"))))
         {


### PR DESCRIPTION
SwingNode does not update its internal cache of Swing pref/max/min height and widths when its JComponent content's corresponding size constraints are updated. As such, it isn't resized to honor those size constraints. 

JLightweightFrame does install a PropertyChangeListener for "preferredSize", "maximumSize", and "minimumSize" properties, but this only happens via a ContainerListener which is not added until after the content has already been added to the content pane, and since the application cannot call this methods directly as per the documentation for the SwingNode.resize() method: `Applications should not invoke this method directly. If an application needs to directly set the size of the SwingNode, it should set the Swing component's minimum/preferred/maximum size constraints which will be propagated correspondingly to the SwingNode and it's parent will honor those settings during layout.`

so the fix is to add the listener as soon as the component is added to the JLightweightFrame's content.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8154846](https://bugs.openjdk.org/browse/JDK-8154846): SwingNode does not resize when content size constraints are changed (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - no project role)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15960/head:pull/15960` \
`$ git checkout pull/15960`

Update a local copy of the PR: \
`$ git checkout pull/15960` \
`$ git pull https://git.openjdk.org/jdk.git pull/15960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15960`

View PR using the GUI difftool: \
`$ git pr show -t 15960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15960.diff">https://git.openjdk.org/jdk/pull/15960.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15960#issuecomment-1738836936)