### PR TITLE
8316947: Write a test to check textArea triggers MouseEntered/MouseExited events properly

### DIFF
--- a/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.List;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextArea;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4454304
+ * @summary On Solaris,TextArea triggers MouseEntered when the mouse is inside the component
+ * @run main MouseEnterExitTest
+ */
+public class MouseEnterExitTest {
+
+    private static Frame frame;
+    private volatile static TextArea textArea;
+    private volatile static List list;
+    private static Robot robot;
+    private volatile static boolean entered = false;
+    private volatile static boolean exited = false;
+    private volatile static boolean passed = true;
+    private volatile static Point compAt;
+    private volatile static Dimension compSize;
+
+    private static MouseListener mListener = new MouseListener() {
+        public void mouseClicked(MouseEvent e) {
+        }
+
+        public void mousePressed(MouseEvent e) {
+        }
+
+        public void mouseReleased(MouseEvent e) {
+        }
+
+        public void mouseEntered(MouseEvent e) {
+            System.out
+                .println("MouseEntered " + e.getSource().getClass().getName());
+            if (entered) {
+                passed = false;
+            }
+            entered = true;
+            exited = false;
+        }
+
+        public void mouseExited(MouseEvent e) {
+            System.out
+                .println("MouseExited " + e.getSource().getClass().getName());
+            if (exited) {
+                passed = false;
+            }
+            entered = false;
+            exited = true;
+        }
+    };
+
+    private static void initializeGUI() {
+        frame = new Frame("MouseEnterExitTest");
+        frame.setLayout(new FlowLayout());
+        list = new List(4);
+        for (int i = 0; i < 10; i++) {
+            list.add("item " + i);
+        }
+        list.addMouseListener(mListener);
+        frame.add(list);
+
+        textArea = new TextArea("TextArea");
+        textArea.addMouseListener(mListener);
+        frame.add(textArea);
+
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        try {
+            EventQueue.invokeAndWait(MouseEnterExitTest::initializeGUI);
+            robot = new Robot();
+            robot.setAutoDelay(100);
+            robot.setAutoWaitForIdle(true);
+
+            EventQueue.invokeAndWait(() -> {
+                compAt = frame.getLocationOnScreen();
+                compSize = frame.getSize();
+            });
+			compAt.y += compSize.getHeight() / 2;
+            int xr = compAt.x + compSize.width + 1;
+            for (int i = compAt.x - 5; (i < xr) && passed; i++) {
+                robot.mouseMove(i, compAt.y);
+            }
+            if (!passed || entered || !exited) {
+                throw new RuntimeException(
+                    "MouseEnterExitTest FAILED. MouseEntered/MouseExited "
+                        + "not properly triggered. Please see the log");
+            }
+            System.out.println("Test PASSED");
+        } finally {
+            EventQueue.invokeAndWait(MouseEnterExitTest::disposeFrame);
+        }
+    }
+
+    public static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+            frame = null;
+        }
+    }
+}

--- a/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
@@ -43,13 +43,16 @@ import java.awt.event.MouseListener;
 public class MouseEnterExitTest {
 
     private static Frame frame;
+
     private volatile static boolean entered = false;
     private volatile static boolean exited = false;
     private volatile static boolean passed = true;
+
     private volatile static Point compAt;
     private volatile static Dimension compSize;
 
     private static final MouseListener mouseListener = new MouseAdapter() {
+        @Override
         public void mouseEntered(MouseEvent e) {
             System.out.println(
                 "MouseEntered component " + e.getSource().getClass().getName());
@@ -60,6 +63,7 @@ public class MouseEnterExitTest {
             exited = false;
         }
 
+        @Override
         public void mouseExited(MouseEvent e) {
             System.out.println(
                 "MouseExited component " + e.getSource().getClass().getName());
@@ -98,6 +102,7 @@ public class MouseEnterExitTest {
 
             EventQueue.invokeAndWait(MouseEnterExitTest::initializeGUI);
             robot.waitForIdle();
+
             EventQueue.invokeAndWait(() -> {
                 compAt = frame.getLocationOnScreen();
                 compSize = frame.getSize();
@@ -107,6 +112,7 @@ public class MouseEnterExitTest {
             for (int i = compAt.x - 5; (i < xr) && passed; i++) {
                 robot.mouseMove(i, compAt.y);
             }
+
             if (!passed || entered || !exited) {
                 throw new RuntimeException(
                     "MouseEnterExitTest FAILED. MouseEntered/MouseExited "
@@ -118,7 +124,7 @@ public class MouseEnterExitTest {
         }
     }
 
-    public static void disposeFrame() {
+    private static void disposeFrame() {
         if (frame != null) {
             frame.dispose();
         }

--- a/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
@@ -29,6 +29,7 @@ import java.awt.List;
 import java.awt.Point;
 import java.awt.Robot;
 import java.awt.TextArea;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 
@@ -42,8 +43,8 @@ import java.awt.event.MouseListener;
 public class MouseEnterExitTest {
 
     private static Frame frame;
-    private volatile static TextArea textArea;
-    private volatile static List list;
+    private static TextArea textArea;
+    private static List list;
     private static Robot robot;
     private volatile static boolean entered = false;
     private volatile static boolean exited = false;
@@ -51,19 +52,10 @@ public class MouseEnterExitTest {
     private volatile static Point compAt;
     private volatile static Dimension compSize;
 
-    private static MouseListener mListener = new MouseListener() {
-        public void mouseClicked(MouseEvent e) {
-        }
-
-        public void mousePressed(MouseEvent e) {
-        }
-
-        public void mouseReleased(MouseEvent e) {
-        }
-
+    private static MouseListener mListener = new MouseAdapter() {
         public void mouseEntered(MouseEvent e) {
-            System.out
-                .println("MouseEntered " + e.getSource().getClass().getName());
+            System.out.println(
+                "MouseEntered component " + e.getSource().getClass().getName());
             if (entered) {
                 passed = false;
             }
@@ -72,8 +64,8 @@ public class MouseEnterExitTest {
         }
 
         public void mouseExited(MouseEvent e) {
-            System.out
-                .println("MouseExited " + e.getSource().getClass().getName());
+            System.out.println(
+                "MouseExited component " + e.getSource().getClass().getName());
             if (exited) {
                 passed = false;
             }
@@ -92,7 +84,7 @@ public class MouseEnterExitTest {
         list.addMouseListener(mListener);
         frame.add(list);
 
-        textArea = new TextArea("TextArea");
+        textArea = new TextArea("TextArea", 10, 20);
         textArea.addMouseListener(mListener);
         frame.add(textArea);
 
@@ -131,7 +123,6 @@ public class MouseEnterExitTest {
     public static void disposeFrame() {
         if (frame != null) {
             frame.dispose();
-            frame = null;
         }
     }
 }

--- a/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
@@ -112,7 +112,7 @@ public class MouseEnterExitTest {
                 compAt = frame.getLocationOnScreen();
                 compSize = frame.getSize();
             });
-			compAt.y += compSize.getHeight() / 2;
+            compAt.y += compSize.getHeight() / 2;
             int xr = compAt.x + compSize.width + 1;
             for (int i = compAt.x - 5; (i < xr) && passed; i++) {
                 robot.mouseMove(i, compAt.y);

--- a/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/MouseEnterExitTest.java
@@ -37,22 +37,19 @@ import java.awt.event.MouseListener;
  * @test
  * @key headful
  * @bug 4454304
- * @summary On Solaris,TextArea triggers MouseEntered when the mouse is inside the component
+ * @summary On Solaris, TextArea triggers MouseEntered when the mouse is inside the component
  * @run main MouseEnterExitTest
  */
 public class MouseEnterExitTest {
 
     private static Frame frame;
-    private static TextArea textArea;
-    private static List list;
-    private static Robot robot;
     private volatile static boolean entered = false;
     private volatile static boolean exited = false;
     private volatile static boolean passed = true;
     private volatile static Point compAt;
     private volatile static Dimension compSize;
 
-    private static MouseListener mListener = new MouseAdapter() {
+    private static final MouseListener mouseListener = new MouseAdapter() {
         public void mouseEntered(MouseEvent e) {
             System.out.println(
                 "MouseEntered component " + e.getSource().getClass().getName());
@@ -77,15 +74,15 @@ public class MouseEnterExitTest {
     private static void initializeGUI() {
         frame = new Frame("MouseEnterExitTest");
         frame.setLayout(new FlowLayout());
-        list = new List(4);
+        List list = new List(4);
         for (int i = 0; i < 10; i++) {
             list.add("item " + i);
         }
-        list.addMouseListener(mListener);
+        list.addMouseListener(mouseListener);
         frame.add(list);
 
-        textArea = new TextArea("TextArea", 10, 20);
-        textArea.addMouseListener(mListener);
+        TextArea textArea = new TextArea("TextArea", 10, 20);
+        textArea.addMouseListener(mouseListener);
         frame.add(textArea);
 
         frame.pack();
@@ -95,11 +92,12 @@ public class MouseEnterExitTest {
 
     public static void main(String[] args) throws Exception {
         try {
-            EventQueue.invokeAndWait(MouseEnterExitTest::initializeGUI);
-            robot = new Robot();
+            Robot robot = new Robot();
             robot.setAutoDelay(100);
             robot.setAutoWaitForIdle(true);
 
+            EventQueue.invokeAndWait(MouseEnterExitTest::initializeGUI);
+            robot.waitForIdle();
             EventQueue.invokeAndWait(() -> {
                 compAt = frame.getLocationOnScreen();
                 compSize = frame.getSize();


### PR DESCRIPTION
Write a test to check textArea triggers MouseEntered/MouseExited events properly

MouseEntered should be triggered only when the mouse enters the component and MouseExited should be triggered when the mouse goes out of the component.

In TextArea, when we moved the mouse inside the component MouseMoved events are triggered properly. But when we slowly took the mouse outside the component that is towards the scrollbars, we could see a MouseEntered event being triggered followed by MouseExited.(before actually mouse enters the scrollbar)

Testing:
Tested using Mach5(20 times per platform) in macos,linux and windows and got all pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316947](https://bugs.openjdk.org/browse/JDK-8316947): Write a test to check textArea triggers MouseEntered/MouseExited events properly (**Enhancement** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [3a622f77](https://git.openjdk.org/jdk/pull/15961/files/3a622f77b46dccd3ab83aed0e441fa028f1d9fde)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [a9518ac5](https://git.openjdk.org/jdk/pull/15961/files/a9518ac55c953a641c1a2a71c111763eeb1e1b7e)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15961/head:pull/15961` \
`$ git checkout pull/15961`

Update a local copy of the PR: \
`$ git checkout pull/15961` \
`$ git pull https://git.openjdk.org/jdk.git pull/15961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15961`

View PR using the GUI difftool: \
`$ git pr show -t 15961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15961.diff">https://git.openjdk.org/jdk/pull/15961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15961#issuecomment-1738971616)