### PR TITLE
8316971: Add Lint warning for restricted method calls

### DIFF
--- a/make/modules/java.base/Java.gmk
+++ b/make/modules/java.base/Java.gmk
@@ -23,7 +23,7 @@
 # questions.
 #
 
-DISABLED_WARNINGS_java += this-escape
+DISABLED_WARNINGS_java += this-escape restricted
 
 DOCLINT += -Xdoclint:all/protected \
     '-Xdoclint/package:java.*,javax.*'

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -91,7 +91,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
     SMALL_JAVA := false, \
     CLASSPATH := $(MICROBENCHMARK_CLASSPATH), \
-    DISABLED_WARNINGS := this-escape processing rawtypes cast serial preview, \
+    DISABLED_WARNINGS := restricted this-escape processing rawtypes cast serial preview, \
     SRC := $(MICROBENCHMARK_SRC), \
     BIN := $(MICROBENCHMARK_CLASSES), \
     JAVAC_FLAGS := --add-exports java.base/sun.security.util=ALL-UNNAMED \

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -390,6 +390,11 @@ public class Flags {
     public static final long SEALED = 1L<<62; // ClassSymbols
 
     /**
+     * Flag to indicate sealed class/interface declaration.
+     */
+    public static final long RESTRICTED = 1L<<62; // MethodSymbols
+
+    /**
      * Flag to indicate that the class/interface was declared with the non-sealed modifier.
      */
     public static final long NON_SEALED = 1L<<63; // ClassSymbols

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -390,7 +390,7 @@ public class Flags {
     public static final long SEALED = 1L<<62; // ClassSymbols
 
     /**
-     * Flag to indicate sealed class/interface declaration.
+     * Flag to indicate restricted method declaration.
      */
     public static final long RESTRICTED = 1L<<62; // MethodSymbols
 
@@ -400,7 +400,7 @@ public class Flags {
     public static final long NON_SEALED = 1L<<63; // ClassSymbols
 
     /**
-     * Describe modifier flags as they migh appear in source code, i.e.,
+     * Describe modifier flags as they might appear in source code, i.e.,
      * separated by spaces and in the order suggested by JLS 8.1.1.
      */
     public static String toSource(long flags) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -335,7 +335,12 @@ public class Lint
         /**
          * Warn about use of preview features.
          */
-        PREVIEW("preview");
+        PREVIEW("preview"),
+
+        /**
+         * Warn about use of restricted methods.
+         */
+        RESTRICTED("restricted");
 
         LintCategory(String option) {
             this(option, false);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -220,6 +220,7 @@ public class Symtab {
     public final Type functionalInterfaceType;
     public final Type previewFeatureType;
     public final Type previewFeatureInternalType;
+    public final Type restrictedType;
     public final Type typeDescriptorType;
     public final Type recordType;
     public final Type switchBootstrapsType;
@@ -610,6 +611,7 @@ public class Symtab {
         functionalInterfaceType = enterClass("java.lang.FunctionalInterface");
         previewFeatureType = enterClass("jdk.internal.javac.PreviewFeature");
         previewFeatureInternalType = enterSyntheticAnnotation("jdk.internal.PreviewFeature+Annotation");
+        restrictedType = enterClass("jdk.internal.javac.Restricted");
         typeDescriptorType = enterClass("java.lang.invoke.TypeDescriptor");
         recordType = enterClass("java.lang.Record");
         switchBootstrapsType = enterClass("java.lang.runtime.SwitchBootstraps");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -379,6 +379,11 @@ public class Annotate {
                     && types.isSameType(c.type, syms.valueBasedType)) {
                 toAnnotate.flags_field |= Flags.VALUE_BASED;
             }
+
+            if (!c.type.isErroneous()
+                    && types.isSameType(c.type, syms.restrictedType)) {
+                toAnnotate.flags_field |= Flags.RESTRICTED;
+            }
         }
 
         List<T> buf = List.nil();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4742,6 +4742,7 @@ public class Attr extends JCTree.Visitor {
                         new ResultInfo(resultInfo.pkind, resultInfo.pt.getReturnType(), resultInfo.checkContext, resultInfo.checkMode),
                         env, TreeInfo.args(env.tree), resultInfo.pt.getParameterTypes(),
                         resultInfo.pt.getTypeArguments());
+                chk.checkRestricted(tree.pos(), sym);
                 break;
             }
             case PCK: case ERR:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -283,6 +283,15 @@ public class Check {
             preview.reportPreviewWarning(pos, Warnings.DeclaredUsingPreview(kindName(sym), sym));
     }
 
+    /** Log a preview warning.
+     *  @param pos        Position to be used for error reporting.
+     *  @param msg        A Warning describing the problem.
+     */
+    public void warnRestrictedAPI(DiagnosticPosition pos, Symbol sym) {
+        if (lint.isEnabled(LintCategory.RESTRICTED))
+            log.warning(LintCategory.RESTRICTED, pos, Warnings.RestrictedMethodCall(sym));
+    }
+
     /** Warn about unchecked operation.
      *  @param pos        Position to be used for error reporting.
      *  @param msg        A string describing the problem.
@@ -3847,6 +3856,12 @@ public class Check {
                 preview.markUsesPreview(pos);
                 deferredLintHandler.report(() -> warnDeclaredUsingPreview(pos, s));
             }
+        }
+    }
+
+    void checkRestricted(DiagnosticPosition pos, Symbol s) {
+        if (s.kind == MTH && (s.flags() & RESTRICTED) != 0) {
+            deferredLintHandler.report(() -> warnRestrictedAPI(pos, s));
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -289,7 +289,7 @@ public class Check {
      */
     public void warnRestrictedAPI(DiagnosticPosition pos, Symbol sym) {
         if (lint.isEnabled(LintCategory.RESTRICTED))
-            log.warning(LintCategory.RESTRICTED, pos, Warnings.RestrictedMethodCall(sym.enclClass(), sym));
+            log.warning(LintCategory.RESTRICTED, pos, Warnings.RestrictedMethod(sym.enclClass(), sym));
     }
 
     /** Warn about unchecked operation.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -289,7 +289,7 @@ public class Check {
      */
     public void warnRestrictedAPI(DiagnosticPosition pos, Symbol sym) {
         if (lint.isEnabled(LintCategory.RESTRICTED))
-            log.warning(LintCategory.RESTRICTED, pos, Warnings.RestrictedMethodCall(sym));
+            log.warning(LintCategory.RESTRICTED, pos, Warnings.RestrictedMethodCall(sym.enclClass(), sym));
     }
 
     /** Warn about unchecked operation.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1509,6 +1509,9 @@ public class ClassReader {
             } else if (proxy.type.tsym.flatName() == syms.valueBasedInternalType.tsym.flatName()) {
                 Assert.check(sym.kind == TYP);
                 sym.flags_field |= VALUE_BASED;
+            } else if (proxy.type.tsym.flatName() == syms.restrictedType.tsym.flatName()) {
+                Assert.check(sym.kind == MTH);
+                sym.flags_field |= RESTRICTED;
             } else {
                 if (proxy.type.tsym == syms.annotationTargetType.tsym) {
                     target = proxy;
@@ -1522,6 +1525,9 @@ public class ClassReader {
                     setFlagIfAttributeTrue(proxy, sym, names.reflective, PREVIEW_REFLECTIVE);
                 }  else if (proxy.type.tsym == syms.valueBasedType.tsym && sym.kind == TYP) {
                     sym.flags_field |= VALUE_BASED;
+                }  else if (proxy.type.tsym == syms.restrictedType.tsym) {
+                    Assert.check(sym.kind == MTH);
+                    sym.flags_field |= RESTRICTED;
                 }
                 proxies.append(proxy);
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1917,9 +1917,9 @@ compiler.err.is.preview=\
 compiler.warn.is.preview.reflective=\
     {0} is a reflective preview API and may be removed in a future release.
 
-# 0: symbol
+# 0: symbol, 1: symbol
 compiler.warn.restricted.method.call=\
-    {0} is a restricted method.\n\
+    {0}.{1} is a restricted method.\n\
     (Restricted methods are unsafe, and, if used incorrectly, they might crash \
     the JVM or result in memory corruption)
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1918,7 +1918,7 @@ compiler.warn.is.preview.reflective=\
     {0} is a reflective preview API and may be removed in a future release.
 
 # 0: symbol, 1: symbol
-compiler.warn.restricted.method.call=\
+compiler.warn.restricted.method=\
     {0}.{1} is a restricted method.\n\
     (Restricted methods are unsafe and, if used incorrectly, might crash the Java runtime or corrupt memory)
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1920,8 +1920,7 @@ compiler.warn.is.preview.reflective=\
 # 0: symbol, 1: symbol
 compiler.warn.restricted.method.call=\
     {0}.{1} is a restricted method.\n\
-    (Restricted methods are unsafe, and, if used incorrectly, they might crash \
-    the JVM or result in memory corruption)
+    (Restricted methods are unsafe and, if used incorrectly, might crash the Java runtime or corrupt memory)
 
 # 0: symbol
 compiler.warn.has.been.deprecated.module=\

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1918,6 +1918,12 @@ compiler.warn.is.preview.reflective=\
     {0} is a reflective preview API and may be removed in a future release.
 
 # 0: symbol
+compiler.warn.restricted.method.call=\
+    {0} is a restricted method.\n\
+    (Restricted methods are unsafe, and, if used incorrectly, they might crash \
+    the JVM or result in memory corruption)
+
+# 0: symbol
 compiler.warn.has.been.deprecated.module=\
     module {0} has been deprecated
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -282,6 +282,9 @@ javac.opt.Xlint.desc.varargs=\
 javac.opt.Xlint.desc.preview=\
     Warn about use of preview language features.
 
+javac.opt.Xlint.desc.restricted=\
+    Warn about use of restricted methods.
+
 javac.opt.Xlint.desc.synchronization=\
     Warn about synchronization attempts on instances of value-based classes.
 

--- a/src/jdk.compiler/share/classes/module-info.java
+++ b/src/jdk.compiler/share/classes/module-info.java
@@ -173,6 +173,7 @@ import javax.tools.StandardLocation;
  * <tr><th scope="row">{@code preview}              <td>use of preview language features
  * <tr><th scope="row">{@code rawtypes}             <td>use of raw types
  * <tr><th scope="row">{@code removal}              <td>use of API that has been marked for removal
+ * <tr><th scope="row">{@code restricted}           <td>use of restricted methods
  * <tr><th scope="row">{@code requires-automatic}   <td>use of automatic modules in the {@code requires} clauses
  * <tr><th scope="row">{@code requires-transitive-automatic} <td>automatic modules in {@code requires transitive}
  * <tr><th scope="row">{@code serial}               <td>{@link java.base/java.io.Serializable Serializable} classes

--- a/test/langtools/tools/javac/RestrictedMethods.java
+++ b/test/langtools/tools/javac/RestrictedMethods.java
@@ -7,12 +7,18 @@
  */
 
 import java.lang.foreign.MemorySegment;
+import java.util.function.Function;
 
 class RestrictedMethods {
 
-    MemorySegment warn = MemorySegment.NULL.reinterpret(10);
+    MemorySegment warn = MemorySegment.NULL.reinterpret(10); // warning here
     @SuppressWarnings("restricted")
-    MemorySegment suppressed = MemorySegment.NULL.reinterpret(10);
+    MemorySegment suppressed = MemorySegment.NULL.reinterpret(10); // no warning here
+
+    Function<Integer, MemorySegment> warn_ref = MemorySegment.NULL::reinterpret; // warning here
+
+    @SuppressWarnings("restricted")
+    Function<Integer, MemorySegment> suppressed_ref = MemorySegment.NULL::reinterpret; // no warning here
 
     void testWarn() {
         MemorySegment.NULL.reinterpret(10); // warning here
@@ -23,12 +29,27 @@ class RestrictedMethods {
         MemorySegment.NULL.reinterpret(10); // no warning here
     }
 
+    Function<Integer, MemorySegment> testWarnRef() {
+        return MemorySegment.NULL::reinterpret; // warning here
+    }
+
+    @SuppressWarnings("restricted")
+    Function<Integer, MemorySegment> testSuppressedRef() {
+        return MemorySegment.NULL::reinterpret; // no warning here
+    }
+
     @SuppressWarnings("restricted")
     static class Nested {
-        MemorySegment suppressedNested = MemorySegment.NULL.reinterpret(10);
+        MemorySegment suppressedNested = MemorySegment.NULL.reinterpret(10); // no warning here
+
+        Function<Integer, MemorySegment> suppressedNested_ref = MemorySegment.NULL::reinterpret; // no warning here
 
         void testSuppressedNested() {
             MemorySegment.NULL.reinterpret(10); // no warning here
+        }
+
+        Function<Integer, MemorySegment> testSuppressedNestedRef() {
+            return MemorySegment.NULL::reinterpret; // no warning here
         }
     }
 }

--- a/test/langtools/tools/javac/RestrictedMethods.java
+++ b/test/langtools/tools/javac/RestrictedMethods.java
@@ -1,0 +1,34 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8316971
+ * @summary Smoke test for restricted method call warnings
+ * @compile/fail/ref=RestrictedMethods.out -Xlint:restricted -Werror -XDrawDiagnostics --enable-preview --source ${jdk.version} RestrictedMethods.java
+ * @compile -Werror --enable-preview --source ${jdk.version} RestrictedMethods.java
+ */
+
+import java.lang.foreign.MemorySegment;
+
+class RestrictedMethods {
+
+    MemorySegment warn = MemorySegment.NULL.reinterpret(10);
+    @SuppressWarnings("restricted")
+    MemorySegment suppressed = MemorySegment.NULL.reinterpret(10);
+
+    void testWarn() {
+        MemorySegment.NULL.reinterpret(10); // warning here
+    }
+
+    @SuppressWarnings("restricted")
+    void testSuppressed() {
+        MemorySegment.NULL.reinterpret(10); // no warning here
+    }
+
+    @SuppressWarnings("restricted")
+    static class Nested {
+        MemorySegment suppressedNested = MemorySegment.NULL.reinterpret(10);
+
+        void testSuppressedNested() {
+            MemorySegment.NULL.reinterpret(10); // no warning here
+        }
+    }
+}

--- a/test/langtools/tools/javac/RestrictedMethods.out
+++ b/test/langtools/tools/javac/RestrictedMethods.out
@@ -1,0 +1,7 @@
+RestrictedMethods.java:13:44: compiler.warn.restricted.method.call: reinterpret(long)
+RestrictedMethods.java:18:27: compiler.warn.restricted.method.call: reinterpret(long)
+- compiler.err.warnings.and.werror
+- compiler.note.preview.filename: RestrictedMethods.java, DEFAULT
+- compiler.note.preview.recompile
+1 error
+2 warnings

--- a/test/langtools/tools/javac/RestrictedMethods.out
+++ b/test/langtools/tools/javac/RestrictedMethods.out
@@ -1,7 +1,9 @@
-RestrictedMethods.java:13:44: compiler.warn.restricted.method.call: java.lang.foreign.MemorySegment, reinterpret(long)
-RestrictedMethods.java:18:27: compiler.warn.restricted.method.call: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:14:44: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:18:49: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:24:27: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:33:16: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
 - compiler.err.warnings.and.werror
 - compiler.note.preview.filename: RestrictedMethods.java, DEFAULT
 - compiler.note.preview.recompile
 1 error
-2 warnings
+4 warnings

--- a/test/langtools/tools/javac/RestrictedMethods.out
+++ b/test/langtools/tools/javac/RestrictedMethods.out
@@ -1,5 +1,5 @@
-RestrictedMethods.java:13:44: compiler.warn.restricted.method.call: reinterpret(long)
-RestrictedMethods.java:18:27: compiler.warn.restricted.method.call: reinterpret(long)
+RestrictedMethods.java:13:44: compiler.warn.restricted.method.call: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:18:27: compiler.warn.restricted.method.call: java.lang.foreign.MemorySegment, reinterpret(long)
 - compiler.err.warnings.and.werror
 - compiler.note.preview.filename: RestrictedMethods.java, DEFAULT
 - compiler.note.preview.recompile

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -217,4 +217,4 @@ compiler.misc.illegal.signature                               # the compiler can
 compiler.err.annotation.unrecognized.attribute.name
 
 # this one is transitional (waiting for FFM API to exit preview)
-compiler.warn.restricted.method.call
+compiler.warn.restricted.method

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -215,3 +215,6 @@ compiler.misc.illegal.signature                               # the compiler can
 
 # this one needs a forged class file to be reproduced
 compiler.err.annotation.unrecognized.attribute.name
+
+# this one is transitional (waiting for FFM API to exit preview)
+compiler.warn.restricted.method.call


### PR DESCRIPTION
This patch adds a new lint warning category, namely `-Xlint:restricted` to enable warnings on restricted method calls.

The patch is relatively straightforward: javac marks methods that are marked with the `@Restricted` annotation with a corresponding internal flag. This is done both in `Annotate` when compiling JDK from source, and in `ClassReader` when JDK classfiles are read. When calls to methods marked with the special flag are found, a new warning is issued.

While there are some similarities between this new warning and the preview API warnings, the compiler does *not* emit a mandatory note when a compilation unit is found to have one or more restricted method calls. In other words, this is just a plain lint warning.

The output from javac looks as follows:

```
Foo.java:6: warning: [restricted] MemorySegment.reinterpret(long) is a restricted method.
      Arena.ofAuto().allocate(10).reinterpret(100);
                                 ^
  (Restricted methods are unsafe, and, if used incorrectly, they might crash the JVM or result in memory corruption)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8317242](https://bugs.openjdk.org/browse/JDK-8317242) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8316971](https://bugs.openjdk.org/browse/JDK-8316971): Add Lint warning for restricted method calls (**Enhancement** - P4)
 * [JDK-8317242](https://bugs.openjdk.org/browse/JDK-8317242): Add Lint warning for restricted method calls (**CSR**)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [8370e79d](https://git.openjdk.org/jdk/pull/15964/files/8370e79dc52c9980c4e762da7e2c1d1b28ffaa10)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to [1951b742](https://git.openjdk.org/jdk/pull/15964/files/1951b742867fefdcf09e080a02a818c39097336a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15964/head:pull/15964` \
`$ git checkout pull/15964`

Update a local copy of the PR: \
`$ git checkout pull/15964` \
`$ git pull https://git.openjdk.org/jdk.git pull/15964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15964`

View PR using the GUI difftool: \
`$ git pr show -t 15964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15964.diff">https://git.openjdk.org/jdk/pull/15964.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15964#issuecomment-1739157495)