### PR TITLE
8317257: RISC-V: llvm build broken

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1515,7 +1515,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   if (LockingMode == LM_MONITOR) {
     if (op->info() != nullptr) {
       add_debug_info_for_null_check_here(op->info());
-      __ null_check(obj, nullptr);
+      __ null_check(obj, -1);
     }
     __ j(*op->stub()->entry());
   } else if (op->code() == lir_lock) {

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1515,7 +1515,7 @@ void LIR_Assembler::emit_lock(LIR_OpLock* op) {
   if (LockingMode == LM_MONITOR) {
     if (op->info() != nullptr) {
       add_debug_info_for_null_check_here(op->info());
-      __ null_check(obj);
+      __ null_check(obj, nullptr);
     }
     __ j(*op->stub()->entry());
   } else if (op->code() == lir_lock) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2840,7 +2840,7 @@ void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
   #define MAP_FIXED_NOREPLACE MAP_FIXED_NOREPLACE_value
 #else
   // Sanity-check our assumed default value if we build with a new enough libc.
-  static_assert(MAP_FIXED_NOREPLACE == MAP_FIXED_NOREPLACE_value);
+  static_assert(MAP_FIXED_NOREPLACE == MAP_FIXED_NOREPLACE_value, "MAP_FIXED_NOREPLACE != MAP_FIXED_NOREPLACE_value");
 #endif
 
 int os::Linux::commit_memory_impl(char* addr, size_t size,


### PR DESCRIPTION
Please review this small fix to make hotspot compilable with clang on risc-v.
It supposed to fix next error:
```
/home/user/openjdk/jdk/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp:1518:10: error: call to member function 'null_check' is ambiguous
      __ null_check(obj);
      ~~~^~~~~~~~~~
/home/user/openjdk/jdk/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp:238:16: note: candidate function
  virtual void null_check(Register reg, int offset = -1);
               ^
/home/user/openjdk/jdk/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.hpp:109:8: note: candidate function
  void null_check(Register r, Label *Lnull = nullptr) { MacroAssembler::null_check(r); }
       ^
1 error generated.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317257](https://bugs.openjdk.org/browse/JDK-8317257): RISC-V: llvm build broken (**Bug** - P3)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15965/head:pull/15965` \
`$ git checkout pull/15965`

Update a local copy of the PR: \
`$ git checkout pull/15965` \
`$ git pull https://git.openjdk.org/jdk.git pull/15965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15965`

View PR using the GUI difftool: \
`$ git pr show -t 15965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15965.diff">https://git.openjdk.org/jdk/pull/15965.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15965#issuecomment-1739597628)