### PR TITLE
8308429: jvmti/StopThread/stopthrd007 failed with "NoClassDefFoundError: Could not initialize class jdk.internal.misc.VirtualThreads"

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,6 +65,11 @@ public class stopthrd007 extends DebugeeClass {
         argHandler = new ArgumentHandler(argv);
         log = new Log(out, argHandler);
         timeout = argHandler.getWaitTime() * 60 * 1000;
+
+        // Unpark virtual threads to load jdk.internal.misc.VirtualThreads
+        // and avoid NoClassDefFoundError if ThreadDeath is happen during unlock.
+        Thread vt = Thread.startVirtualThread(LockSupport::park);
+        LockSupport.unpark(vt);
 
         log.display("Debugee started");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/StopThread/stopthrd007.java
@@ -28,6 +28,8 @@ import java.io.PrintStream;
 import nsk.share.*;
 import nsk.share.jvmti.*;
 
+import java.util.concurrent.locks.LockSupport;
+
 public class stopthrd007 extends DebugeeClass {
 
     // run test from command line


### PR DESCRIPTION
The test fails because ThreadDeath is raised during class jdk.internal.misc.VirtualThreads initialization. The proposed fix is to pre-initialize this step to avoid such failures. See more details in the bug.
I reproduced the original problem and verified that it is not reproduced after fix. 
Tested with tier5 and running nsk/jvmti tests with and without virtual test thread factory.

I don't think that more complex fix is needed. There is a plan to review nsk/jvmti stopThread tests and see if 
./serviceability/jvmti/vthread/StopThreadTest/StopThreadTest.java 
might be improved to cover them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308429](https://bugs.openjdk.org/browse/JDK-8308429): jvmti/StopThread/stopthrd007 failed with "NoClassDefFoundError: Could not initialize class jdk.internal.misc.VirtualThreads" (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15966/head:pull/15966` \
`$ git checkout pull/15966`

Update a local copy of the PR: \
`$ git checkout pull/15966` \
`$ git pull https://git.openjdk.org/jdk.git pull/15966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15966`

View PR using the GUI difftool: \
`$ git pr show -t 15966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15966.diff">https://git.openjdk.org/jdk/pull/15966.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15966#issuecomment-1739712534)