### PR TITLE
8317126: Redundant entries in Windows `tzmappings` file

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -1184,6 +1184,8 @@ public class CLDRConverter {
         Files.createDirectories(Paths.get(DESTINATION_DIR, "windows", "conf"));
         Files.write(Paths.get(DESTINATION_DIR, "windows", "conf", "tzmappings"),
             handlerWinZones.keySet().stream()
+                .filter(k -> k.endsWith(":001") ||
+                             !handlerWinZones.get(k).equals(handlerWinZones.get(k.replaceFirst(":\\w{2,3}$", ":001"))))
                 .map(k -> k + ":" + handlerWinZones.get(k) + ":")
                 .sorted(new Comparator<String>() {
                     public int compare(String t1, String t2) {


### PR DESCRIPTION
Removing redundant entries in `lib/tzmappings` file on Windows. The file maps Windows time zones to Java time zones according to the region. Since `001` means world, no region-specific entries are needed if those time zones are the same. The diff of the generated tzmappings files, before and after the fix, is attached.
[tzmappings.diff.txt](https://github.com/openjdk/jdk/files/12752377/tzmappings.diff.txt)
