### PR TITLE
JDK-8308659: Use CSS scroll-margin instead of flexbox layout in API documentation

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriter.java
@@ -94,9 +94,9 @@ public class AnnotationTypeMemberWriter extends AbstractMemberWriter {
             for (Element member : members) {
                 currentMember = member;
                 Content annotationContent = getAnnotationHeaderContent(currentMember);
-
-                buildAnnotationTypeMemberChildren(annotationContent);
-
+                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildAnnotationTypeMemberChildren(scrollBox);
+                annotationContent.add(scrollBox);
                 memberList.add(writer.getMemberListItem(annotationContent));
             }
             Content annotationDetails = getAnnotationDetails(annotationDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AnnotationTypeMemberWriter.java
@@ -94,9 +94,9 @@ public class AnnotationTypeMemberWriter extends AbstractMemberWriter {
             for (Element member : members) {
                 currentMember = member;
                 Content annotationContent = getAnnotationHeaderContent(currentMember);
-                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
-                buildAnnotationTypeMemberChildren(scrollBox);
-                annotationContent.add(scrollBox);
+                Content div = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildAnnotationTypeMemberChildren(div);
+                annotationContent.add(div);
                 memberList.add(writer.getMemberListItem(annotationContent));
             }
             Content annotationDetails = getAnnotationDetails(annotationDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
@@ -158,7 +158,7 @@ public class ClassWriter extends SubWriterHolderWriter {
      * @param target the content to which the documentation will be added
      */
     protected void buildClassInfo(Content target) {
-        Content c = new ContentBuilder();
+        Content c = HtmlTree.DIV(HtmlStyle.horizontalScroll);
         buildParamInfo(c);
         buildSuperInterfacesInfo(c);
         buildImplementedInterfacesInfo(c);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
@@ -106,13 +106,13 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
             for (Element constructor : constructors) {
                 currentConstructor = (ExecutableElement)constructor;
                 Content constructorContent = getConstructorHeaderContent(currentConstructor);
-                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
-                buildSignature(scrollBox);
-                buildDeprecationInfo(scrollBox);
-                buildPreviewInfo(scrollBox);
-                buildConstructorComments(scrollBox);
-                buildTagInfo(scrollBox);
-                constructorContent.add(scrollBox);
+                Content div = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(div);
+                buildDeprecationInfo(div);
+                buildPreviewInfo(div);
+                buildConstructorComments(div);
+                buildTagInfo(div);
+                constructorContent.add(div);
                 memberList.add(getMemberListItem(constructorContent));
             }
             Content constructorDetails = getConstructorDetails(constructorDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
@@ -106,13 +106,13 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
             for (Element constructor : constructors) {
                 currentConstructor = (ExecutableElement)constructor;
                 Content constructorContent = getConstructorHeaderContent(currentConstructor);
-
-                buildSignature(constructorContent);
-                buildDeprecationInfo(constructorContent);
-                buildPreviewInfo(constructorContent);
-                buildConstructorComments(constructorContent);
-                buildTagInfo(constructorContent);
-
+                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(scrollBox);
+                buildDeprecationInfo(scrollBox);
+                buildPreviewInfo(scrollBox);
+                buildConstructorComments(scrollBox);
+                buildTagInfo(scrollBox);
+                constructorContent.add(scrollBox);
                 memberList.add(getMemberListItem(constructorContent));
             }
             Content constructorDetails = getConstructorDetails(constructorDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/EnumConstantWriter.java
@@ -73,13 +73,13 @@ public class EnumConstantWriter extends AbstractMemberWriter {
             for (Element enumConstant : enumConstants) {
                 currentElement = (VariableElement)enumConstant;
                 Content enumConstantContent = getEnumConstantsHeader(currentElement);
-
-                buildSignature(enumConstantContent);
-                buildDeprecationInfo(enumConstantContent);
-                buildPreviewInfo(enumConstantContent);
-                buildEnumConstantComments(enumConstantContent);
-                buildTagInfo(enumConstantContent);
-
+                Content div = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(div);
+                buildDeprecationInfo(div);
+                buildPreviewInfo(div);
+                buildEnumConstantComments(div);
+                buildTagInfo(div);
+                enumConstantContent.add(div);
                 memberList.add(getMemberListItem(enumConstantContent));
             }
             Content enumConstantDetails = getEnumConstantsDetails(

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriter.java
@@ -83,13 +83,13 @@ public class FieldWriter extends AbstractMemberWriter {
             for (Element element : fields) {
                 currentElement = (VariableElement)element;
                 Content fieldContent = getFieldHeaderContent(currentElement);
-                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
-                buildSignature(scrollBox);
-                buildDeprecationInfo(scrollBox);
-                buildPreviewInfo(scrollBox);
-                buildFieldComments(scrollBox);
-                buildTagInfo(scrollBox);
-                fieldContent.add(scrollBox);
+                Content div = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(div);
+                buildDeprecationInfo(div);
+                buildPreviewInfo(div);
+                buildFieldComments(div);
+                buildTagInfo(div);
+                fieldContent.add(div);
                 memberList.add(getMemberListItem(fieldContent));
             }
             Content fieldDetails = getFieldDetails(fieldDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/FieldWriter.java
@@ -83,13 +83,13 @@ public class FieldWriter extends AbstractMemberWriter {
             for (Element element : fields) {
                 currentElement = (VariableElement)element;
                 Content fieldContent = getFieldHeaderContent(currentElement);
-
-                buildSignature(fieldContent);
-                buildDeprecationInfo(fieldContent);
-                buildPreviewInfo(fieldContent);
-                buildFieldComments(fieldContent);
-                buildTagInfo(fieldContent);
-
+                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(scrollBox);
+                buildDeprecationInfo(scrollBox);
+                buildPreviewInfo(scrollBox);
+                buildFieldComments(scrollBox);
+                buildTagInfo(scrollBox);
+                fieldContent.add(scrollBox);
                 memberList.add(getMemberListItem(fieldContent));
             }
             Content fieldDetails = getFieldDetails(fieldDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -518,10 +518,9 @@ public abstract class HtmlDocletWriter {
      * @return the {@code <header>} element
      */
     protected Content getHeader(Navigation.PageMode pageMode, Element element) {
-        return new ContentBuilder()
-                .add(RawHtml.of(replaceDocRootDir(options.top())))
-                .add(HtmlTree.HEADER()
-                        .add(getNavBar(pageMode, element).getContent()));
+        return HtmlTree.HEADER()
+                        .add(RawHtml.of(replaceDocRootDir(options.top())))
+                        .add(getNavBar(pageMode, element).getContent());
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -504,7 +504,7 @@ public abstract class HtmlDocletWriter {
      *
      * @return the {@code <header>} element
      */
-    protected HtmlTree getHeader(Navigation.PageMode pageMode) {
+    protected Content getHeader(Navigation.PageMode pageMode) {
         return getHeader(pageMode, null);
     }
 
@@ -517,10 +517,11 @@ public abstract class HtmlDocletWriter {
      *
      * @return the {@code <header>} element
      */
-    protected HtmlTree getHeader(Navigation.PageMode pageMode, Element element) {
-        return HtmlTree.HEADER()
+    protected Content getHeader(Navigation.PageMode pageMode, Element element) {
+        return new ContentBuilder()
                 .add(RawHtml.of(replaceDocRootDir(options.top())))
-                .add(getNavBar(pageMode, element).getContent());
+                .add(HtmlTree.HEADER()
+                        .add(getNavBar(pageMode, element).getContent()));
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
@@ -105,13 +105,13 @@ public class MethodWriter extends AbstractExecutableMemberWriter {
             for (Element method : methods) {
                 currentMethod = (ExecutableElement)method;
                 Content methodContent = getMethodHeader(currentMethod);
-                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
-                buildSignature(scrollBox);
-                buildDeprecationInfo(scrollBox);
-                buildPreviewInfo(scrollBox);
-                buildMethodComments(scrollBox);
-                buildTagInfo(scrollBox);
-                methodContent.add(scrollBox);
+                Content div = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(div);
+                buildDeprecationInfo(div);
+                buildPreviewInfo(div);
+                buildMethodComments(div);
+                buildTagInfo(div);
+                methodContent.add(div);
                 memberList.add(writer.getMemberListItem(methodContent));
             }
             Content methodDetails = getMethodDetails(methodDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/MethodWriter.java
@@ -105,13 +105,13 @@ public class MethodWriter extends AbstractExecutableMemberWriter {
             for (Element method : methods) {
                 currentMethod = (ExecutableElement)method;
                 Content methodContent = getMethodHeader(currentMethod);
-
-                buildSignature(methodContent);
-                buildDeprecationInfo(methodContent);
-                buildPreviewInfo(methodContent);
-                buildMethodComments(methodContent);
-                buildTagInfo(methodContent);
-
+                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(scrollBox);
+                buildDeprecationInfo(scrollBox);
+                buildPreviewInfo(scrollBox);
+                buildMethodComments(scrollBox);
+                buildTagInfo(scrollBox);
+                methodContent.add(scrollBox);
                 memberList.add(writer.getMemberListItem(methodContent));
             }
             Content methodDetails = getMethodDetails(methodDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
@@ -191,9 +191,11 @@ public class ModuleWriter extends HtmlDocletWriter {
      */
     protected void buildContent() {
         Content moduleContent = getContentHeader();
-
-        addModuleSignature(moduleContent);
-        buildModuleDescription(moduleContent);
+        moduleContent.add(new HtmlTree(TagName.HR));
+        Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+        addModuleSignature(scrollBox);
+        buildModuleDescription(scrollBox);
+        moduleContent.add(scrollBox);
         buildSummary(moduleContent);
 
         addModuleContent(moduleContent);
@@ -875,16 +877,13 @@ public class ModuleWriter extends HtmlDocletWriter {
                     .setId(HtmlIds.MODULE_DESCRIPTION);
             addDeprecationInfo(tree);
             tree.add(MarkerComments.START_OF_MODULE_DESCRIPTION);
-            Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
-            addInlineComment(mdle, scrollBox);
-            addTagsInfo(mdle, scrollBox);
-            tree.add(scrollBox);
+            addInlineComment(mdle, tree);
+            addTagsInfo(mdle, tree);
             moduleContent.add(tree);
         }
     }
 
     protected void addModuleSignature(Content moduleContent) {
-        moduleContent.add(new HtmlTree(TagName.HR));
         moduleContent.add(Signatures.getModuleSignature(mdle, this));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
@@ -875,8 +875,10 @@ public class ModuleWriter extends HtmlDocletWriter {
                     .setId(HtmlIds.MODULE_DESCRIPTION);
             addDeprecationInfo(tree);
             tree.add(MarkerComments.START_OF_MODULE_DESCRIPTION);
-            addInlineComment(mdle, tree);
-            addTagsInfo(mdle, tree);
+            Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+            addInlineComment(mdle, scrollBox);
+            addTagsInfo(mdle, scrollBox);
+            tree.add(scrollBox);
             moduleContent.add(tree);
         }
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
@@ -192,10 +192,10 @@ public class ModuleWriter extends HtmlDocletWriter {
     protected void buildContent() {
         Content moduleContent = getContentHeader();
         moduleContent.add(new HtmlTree(TagName.HR));
-        Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
-        addModuleSignature(scrollBox);
-        buildModuleDescription(scrollBox);
-        moduleContent.add(scrollBox);
+        Content div = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+        addModuleSignature(div);
+        buildModuleDescription(div);
+        moduleContent.add(div);
         buildSummary(moduleContent);
 
         addModuleContent(moduleContent);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
@@ -72,7 +72,7 @@ public class PackageWriter extends HtmlDocletWriter {
     /**
      * The HTML element for the section tag being written.
      */
-    private final HtmlTree section = HtmlTree.SECTION(HtmlStyle.packageDescription, new ContentBuilder());
+    private final HtmlTree section = HtmlTree.SECTION(HtmlStyle.packageDescription);
 
     private final BodyContents bodyContents = new BodyContents();
 
@@ -128,10 +128,12 @@ public class PackageWriter extends HtmlDocletWriter {
      */
     protected void buildContent() {
         Content packageContent = getContentHeader();
-
-        addPackageSignature(packageContent);
-        buildPackageDescription(packageContent);
-        buildPackageTags(packageContent);
+        packageContent.add(new HtmlTree(TagName.HR));
+        Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+        addPackageSignature(scrollBox);
+        buildPackageDescription(scrollBox);
+        buildPackageTags(scrollBox);
+        packageContent.add(scrollBox);
         buildSummary(packageContent);
 
         addPackageContent(packageContent);
@@ -177,10 +179,9 @@ public class PackageWriter extends HtmlDocletWriter {
      *                       be added
      */
     protected void buildPackageDescription(Content packageContent) {
-        if (options.noComment()) {
-            return;
+        if (!options.noComment()) {
+            addPackageDescription(packageContent);
         }
-        addPackageDescription(packageContent);
     }
 
     /**
@@ -189,10 +190,9 @@ public class PackageWriter extends HtmlDocletWriter {
      * @param packageContent the content to which the package tags will be added
      */
     protected void buildPackageTags(Content packageContent) {
-        if (options.noComment()) {
-            return;
+        if (!options.noComment()) {
+            addPackageTags(packageContent);
         }
-        addPackageTags(packageContent);
     }
 
     protected Content getPackageHeader() {
@@ -222,7 +222,7 @@ public class PackageWriter extends HtmlDocletWriter {
     }
 
     protected Content getContentHeader() {
-        return HtmlTree.DIV(HtmlStyle.horizontalScroll);
+        return new ContentBuilder();
     }
 
     private void computePackageData() {
@@ -422,7 +422,6 @@ public class PackageWriter extends HtmlDocletWriter {
     }
 
     protected void addPackageSignature(Content packageContent) {
-        packageContent.add(new HtmlTree(TagName.HR));
         packageContent.add(Signatures.getPackageSignature(packageElement, this));
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
@@ -129,11 +129,11 @@ public class PackageWriter extends HtmlDocletWriter {
     protected void buildContent() {
         Content packageContent = getContentHeader();
         packageContent.add(new HtmlTree(TagName.HR));
-        Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
-        addPackageSignature(scrollBox);
-        buildPackageDescription(scrollBox);
-        buildPackageTags(scrollBox);
-        packageContent.add(scrollBox);
+        Content div = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+        addPackageSignature(div);
+        buildPackageDescription(div);
+        buildPackageTags(div);
+        packageContent.add(div);
         buildSummary(packageContent);
 
         addPackageContent(packageContent);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
@@ -222,7 +222,7 @@ public class PackageWriter extends HtmlDocletWriter {
     }
 
     protected Content getContentHeader() {
-        return new ContentBuilder();
+        return HtmlTree.DIV(HtmlStyle.horizontalScroll);
     }
 
     private void computePackageData() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriter.java
@@ -78,13 +78,13 @@ public class PropertyWriter extends AbstractMemberWriter {
             for (Element property : properties) {
                 currentProperty = (ExecutableElement)property;
                 Content propertyContent = getPropertyHeaderContent(currentProperty);
-                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
-                buildSignature(scrollBox);
-                buildDeprecationInfo(scrollBox);
-                buildPreviewInfo(scrollBox);
-                buildPropertyComments(scrollBox);
-                buildTagInfo(scrollBox);
-                propertyContent.add(scrollBox);
+                Content div = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(div);
+                buildDeprecationInfo(div);
+                buildPreviewInfo(div);
+                buildPropertyComments(div);
+                buildTagInfo(div);
+                propertyContent.add(div);
                 memberList.add(getMemberListItem(propertyContent));
             }
             Content propertyDetails = getPropertyDetails(propertyDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PropertyWriter.java
@@ -78,13 +78,13 @@ public class PropertyWriter extends AbstractMemberWriter {
             for (Element property : properties) {
                 currentProperty = (ExecutableElement)property;
                 Content propertyContent = getPropertyHeaderContent(currentProperty);
-
-                buildSignature(propertyContent);
-                buildDeprecationInfo(propertyContent);
-                buildPreviewInfo(propertyContent);
-                buildPropertyComments(propertyContent);
-                buildTagInfo(propertyContent);
-
+                Content scrollBox = HtmlTree.DIV(HtmlStyle.horizontalScroll);
+                buildSignature(scrollBox);
+                buildDeprecationInfo(scrollBox);
+                buildPreviewInfo(scrollBox);
+                buildPropertyComments(scrollBox);
+                buildTagInfo(scrollBox);
+                propertyContent.add(scrollBox);
                 memberList.add(getMemberListItem(propertyContent));
             }
             Content propertyDetails = getPropertyDetails(propertyDetailsHeader, memberList);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/BodyContents.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/BodyContents.java
@@ -43,20 +43,20 @@ import java.util.Objects;
 public class BodyContents extends Content {
 
     private final List<Content> mainContents = new ArrayList<>();
-    private HtmlTree header = null;
-    private HtmlTree footer = null;
+    private Content header = null;
+    private Content footer = null;
 
     public BodyContents addMainContent(Content content) {
         mainContents.add(content);
         return this;
     }
 
-    public BodyContents setHeader(HtmlTree header) {
+    public BodyContents setHeader(Content header) {
         this.header = Objects.requireNonNull(header);
         return this;
     }
 
-    public BodyContents setFooter(HtmlTree footer) {
+    public BodyContents setFooter(Content footer) {
         this.footer = footer;
         return this;
     }
@@ -87,14 +87,9 @@ public class BodyContents extends Content {
         if (header == null)
             throw new NullPointerException();
 
-        HtmlTree flexHeader = header.addStyle(HtmlStyle.flexHeader);
-
-        var flexContent = HtmlTree.DIV(HtmlStyle.flexContent)
+        return new ContentBuilder()
+                .add(header)
                 .add(HtmlTree.MAIN().add(mainContents))
                 .add(footer == null ? Text.EMPTY : footer);
-
-        return HtmlTree.DIV(HtmlStyle.flexBox)
-                .add(flexHeader)
-                .add(flexContent);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/HtmlStyle.java
@@ -563,29 +563,6 @@ public enum HtmlStyle {
     notes,
     //</editor-fold>
 
-    //<editor-fold desc="flex layout">
-    //
-    // The following constants are used for the components of the top-level structures for "flex" layout.
-
-    /**
-     * The class of the top-level {@code div} element used to arrange for "flex" layout in
-     * a browser window. The element should contain two child elements: one with class
-     * {@link #flexHeader flex-header} and one with class {@link #flexContent flex-content}.
-     */
-    flexBox,
-
-    /**
-     * The class of the {@code header} element within a {@link #flexBox flex-box} container.
-     * The element is always displayed at the top of the viewport.
-     */
-    flexHeader,
-
-    /**
-     * The class of the {@code div} element within a {@link #flexBox flex-box} container
-     * This element appears below the header and can be scrolled if too big for the available height.
-     */
-    flexContent,
-    //</editor-fold>
 
     //<editor-fold desc="signatures">
     //
@@ -963,6 +940,11 @@ public enum HtmlStyle {
      * The class of a {@code ul} element with horizontal (inline) display style.
      */
     horizontal,
+
+    /**
+     * The class of a {@code div} element that allows its horizontal overflow to be scrolled.
+     */
+    horizontalScroll,
 
     /**
      * The class of a {@code span} element containing implementation details of

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js
@@ -227,27 +227,3 @@ function switchCopyLabel(button, span) {
         }, 100);
     }, 1900);
 }
-// Workaround for scroll position not being included in browser history (8249133)
-document.addEventListener("DOMContentLoaded", function(e) {
-    var contentDiv = document.querySelector("div.flex-content");
-    window.addEventListener("popstate", function(e) {
-        if (e.state !== null) {
-            contentDiv.scrollTop = e.state;
-        }
-    });
-    window.addEventListener("hashchange", function(e) {
-        history.replaceState(contentDiv.scrollTop, document.title);
-    });
-    var timeoutId;
-    contentDiv.addEventListener("scroll", function(e) {
-        if (timeoutId) {
-            clearTimeout(timeoutId);
-        }
-        timeoutId = setTimeout(function() {
-            history.replaceState(contentDiv.scrollTop, document.title);
-        }, 100);
-    });
-    if (!location.hash) {
-        history.replaceState(contentDiv.scrollTop, document.title);
-    }
-});

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js
@@ -227,3 +227,10 @@ function switchCopyLabel(button, span) {
         }, 100);
     }, 1900);
 }
+// Dynamically set scroll margin to accomodate for draft header
+document.addEventListener("DOMContentLoaded", function(e) {
+    document.querySelectorAll(':not(input)[id]').forEach(
+        function(c) {
+            c.style["scroll-margin-top"] = Math.ceil(document.querySelector("header").offsetHeight) + "px"
+        });
+});

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -447,6 +447,7 @@ $(function() {
     $(window).on("orientationchange", collapse).on("resize", function(e) {
         if (expanded && windowWidth !== window.innerWidth) collapse();
     });
+    $(":not(input)[id]").css("scroll-margin-top", Math.ceil($("header").height()) + "px");
     var search = $("#search-input");
     var reset = $("#reset-button");
     search.catcomplete({

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template
@@ -447,7 +447,6 @@ $(function() {
     $(window).on("orientationchange", collapse).on("resize", function(e) {
         if (expanded && windowWidth !== window.innerWidth) collapse();
     });
-    $(":not(input)[id]").css("scroll-margin-top", Math.ceil($("header").height()) + "px");
     var search = $("#search-input");
     var reset = $("#reset-button");
     search.catcomplete({

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -300,11 +300,12 @@ body.module-declaration-page .block-list h2 {
     margin:15px 0;
 }
 body.class-declaration-page .summary h3,
-body.class-declaration-page .details h3{
+body.class-declaration-page .details h3 {
     background-color:var(--subnav-background-color);
     border:1px solid var(--border-color);
     margin:0 0 6px -8px;
     padding:7px 5px;
+    overflow-x:auto;
 }
 /*
  * Styles for page layout containers.
@@ -314,8 +315,11 @@ main {
     padding:10px 20px;
     position:relative;
 }
-dl.notes {
-    margin-bottom:10px;
+section[id$=-description] :is(dl, ol, ul, p, div, blockquote, pre):last-child {
+    margin-bottom:4px;
+    & :is(li, dd):last-child {
+          margin-bottom: 4px;
+    }
 }
 dl.notes > dt {
     font-family: var(--body-font-family);
@@ -361,7 +365,7 @@ ul.block-list,
 ul.details-list,
 ul.member-list,
 ul.summary-list {
-    margin:4px 0 10px 0;
+    margin:10px 0 10px 0;
     padding:0;
 }
 ul.block-list > li,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -300,11 +300,10 @@ body.module-declaration-page .block-list h2 {
     margin:15px 0;
 }
 body.class-declaration-page .summary h3,
-body.class-declaration-page .details h3,
-body.class-declaration-page .summary .inherited-list h2 {
+body.class-declaration-page .details h3{
     background-color:var(--subnav-background-color);
     border:1px solid var(--border-color);
-    margin:0 0 0 -8px;
+    margin:0 0 6px -8px;
     padding:7px 5px;
 }
 /*
@@ -359,7 +358,7 @@ ul.block-list,
 ul.details-list,
 ul.member-list,
 ul.summary-list {
-    margin:0 0 10px 0;
+    margin:4px 0 10px 0;
     padding:0;
 }
 ul.block-list > li,
@@ -612,7 +611,7 @@ div.block {
 .member-signature {
     font-family:var(--code-font-family);
     font-size:1em;
-    margin:14px 0;
+    margin:8px 0 14px 0;
     white-space: pre-wrap;
 }
 .module-signature,
@@ -856,6 +855,9 @@ span#page-search-link {
 }
 .horizontal-scroll {
     overflow: auto hidden;
+}
+:not(.detail) > .horizontal-scroll > :last-child {
+    margin-bottom: 10px;
 }
 section.class-description {
     line-height: 1.4;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -315,11 +315,9 @@ main {
     padding:10px 20px;
     position:relative;
 }
-section[id$=-description] :is(dl, ol, ul, p, div, blockquote, pre):last-child {
+section[id$=-description] :is(dl, ol, ul, p, div, blockquote, pre):last-child,
+section[id$=-description] :is(dl, ol, ul):last-child > :is(li, dd):last-child {
     margin-bottom:4px;
-    & :is(li, dd):last-child {
-          margin-bottom: 4px;
-    }
 }
 dl.notes > dt {
     font-family: var(--body-font-family);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -314,6 +314,9 @@ main {
     padding:10px 20px;
     position:relative;
 }
+dl.notes {
+    margin-bottom:10px;
+}
 dl.notes > dt {
     font-family: var(--body-font-family);
     font-size:0.856em;
@@ -855,9 +858,6 @@ span#page-search-link {
 }
 .horizontal-scroll {
     overflow: auto hidden;
-}
-:not(.detail) > .horizontal-scroll > :last-child {
-    margin-bottom: 10px;
 }
 section.class-description {
     line-height: 1.4;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -84,6 +84,9 @@ iframe {
     overflow-y:scroll;
     border:none;
 }
+:not(input)[id] {
+    scroll-margin-top: 78px;
+}
 a:link, a:visited {
     text-decoration:none;
     color:var(--link-color);
@@ -172,19 +175,11 @@ button {
  * Styles for navigation bar.
  */
 @media screen {
-    div.flex-box {
-        position:fixed;
-        display:flex;
-        flex-direction:column;
-        height: 100%;
-        width: 100%;
-    }
-    header.flex-header {
-        flex: 0 0 auto;
-    }
-    div.flex-content {
-        flex: 1 1 auto;
-        overflow-y: auto;
+    header {
+        position:sticky;
+        top:0;
+        z-index:1;
+        background: var(--body-background-color);
     }
 }
 .top-nav {
@@ -309,7 +304,7 @@ body.class-declaration-page .details h3,
 body.class-declaration-page .summary .inherited-list h2 {
     background-color:var(--subnav-background-color);
     border:1px solid var(--border-color);
-    margin:0 0 6px -8px;
+    margin:0 0 0 -8px;
     padding:7px 5px;
 }
 /*
@@ -364,7 +359,7 @@ ul.block-list,
 ul.details-list,
 ul.member-list,
 ul.summary-list {
-    margin:10px 0 10px 0;
+    margin:0 0 10px 0;
     padding:0;
 }
 ul.block-list > li,
@@ -444,7 +439,9 @@ ul.preview-feature-list {
 }
 div.table-tabs {
     padding:10px 0 0 1px;
-    margin:10px 0 0 0;
+    margin: 0;
+    overflow: auto hidden;
+    white-space: pre;
 }
 div.table-tabs > button {
     border: none;
@@ -527,7 +524,7 @@ div.checkboxes > label > input {
 .summary-table > div, .details-table > div {
     text-align:left;
     padding: 8px 3px 3px 7px;
-    overflow-x: auto;
+    overflow: auto hidden;
     scrollbar-width: thin;
 }
 .col-first, .col-second, .col-last, .col-constructor-name, .col-summary-item-name {
@@ -698,6 +695,9 @@ details summary {
 main, nav, header, footer, section {
     display:block;
 }
+nav {
+    overflow:hidden;
+}
 /*
  * Styles for javadoc search.
  */
@@ -853,6 +853,9 @@ span#page-search-link {
 }
 .inherited-list {
     margin: 10px 0 10px 0;
+}
+.horizontal-scroll {
+    overflow: auto hidden;
 }
 section.class-description {
     line-height: 1.4;
@@ -1098,7 +1101,7 @@ table.striped > tbody > tr > th {
  * Tweak style for small screens.
  */
 @media screen and (max-width: 920px) {
-    header.flex-header {
+    header {
         max-height: 100vh;
         overflow-y: auto;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -444,8 +444,10 @@ ul.preview-feature-list {
     height:16px;
 }
 div.table-tabs {
-    padding:10px 0 0 1px;
+    padding: 10px 0 0 1px;
     margin: 0;
+}
+div.table-tabs:has(button) {
     overflow: auto hidden;
     white-space: pre;
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -445,10 +445,6 @@ div.table-tabs {
     padding: 10px 0 0 1px;
     margin: 0;
 }
-div.table-tabs:has(button) {
-    overflow: auto hidden;
-    white-space: pre;
-}
 div.table-tabs > button {
     border: none;
     cursor: pointer;

--- a/test/langtools/jdk/javadoc/doclet/testAnnotationTypes/TestAnnotationTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testAnnotationTypes/TestAnnotationTypes.java
@@ -66,6 +66,7 @@ public class TestAnnotationTypes extends JavadocTester {
                 """
                     <section class="detail" id="DEFAULT_NAME">
                     <h3>DEFAULT_NAME</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">static final</span>&nbsp;<\
                     span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">DEFAULT_NAME</span></div>
                     """);
@@ -132,17 +133,21 @@ public class TestAnnotationTypes extends JavadocTester {
                     <li>
                     <section class="detail" id="value()">
                     <h3>value</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="return-type">int</span>&nbsp;<span class="element-name">value</span></div>
+                    </div>
                     </section>
                     </li>
                     <li>
                     <section class="detail" id="optional()">
                     <h3>optional</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="return-type">java.lang.String</span>&nbsp;<span class="element-name">optional</span></div>
                     <dl class="notes">
                     <dt>Default:</dt>
                     <dd><code>""</code></dd>
                     </dl>
+                    </div>
                     </section>
                     </li>
                     </ul>

--- a/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
+++ b/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
+++ b/test/langtools/jdk/javadoc/doclet/testDeprecatedDocs/TestDeprecatedDocs.java
@@ -193,7 +193,7 @@ public class TestDeprecatedDocs extends JavadocTester {
                     </div>
                     </div>""");
 
-        checkOutput("pkg/TestClass.html", false,
+        checkOutput("pkg/TestClass.html", true,
                 """
                     <div class="deprecation-comment">class_test2 passes. This is the second sentence\
                      of deprecated description for a field.</div>
@@ -205,7 +205,7 @@ public class TestDeprecatedDocs extends JavadocTester {
                     </div>
                     </div>""",
                 """
-                    <div class="deprecation-comment">class_test4 passes. This is the second sentence\
+                    <div class="deprecation-comment">class_test5 passes. This is the second sentence\
                      of deprecated description for a method.</div>
                     </div>
                     </div>""");

--- a/test/langtools/jdk/javadoc/doclet/testDirectedInheritance/TestDirectedInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testDirectedInheritance/TestDirectedInheritance.java
@@ -277,6 +277,7 @@ public class TestDirectedInheritance extends JavadocTester {
         var m = """
                 <section class="detail" id="m()">
                 <h3>m</h3>
+                <div class="horizontal-scroll">
                 <div class="member-signature"><span class="modifiers">\
                 public</span>&nbsp;<span class="return-type">void</span>\
                 &nbsp;<span class="element-name">m</span>()</div>
@@ -336,6 +337,7 @@ public class TestDirectedInheritance extends JavadocTester {
         var m = """
                 <section class="detail" id="m()">
                 <h3>m</h3>
+                <div class="horizontal-scroll">
                 <div class="member-signature"><span class="modifiers">\
                 public</span>&nbsp;<span class="return-type">void</span>\
                 &nbsp;<span class="element-name">m</span>()</div>

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
@@ -386,12 +386,14 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type">void</span>&nbsp;<span class="element-name">readObject</span>()
                                     throws <span class="exceptions">java.io.IOException</span></div>
+                    </div>
                     </section>
                     </li>""");
 
         checkOutput("pkg1/C2.html", expectFound,
                 """
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span class="element-name">C2</span>()</div>
+                    </div>
                     </section>
                     </li>""");
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlDefinitionListTag/TestHtmlDefinitionListTag.java
@@ -403,6 +403,7 @@ public class TestHtmlDefinitionListTag extends JavadocTester {
                     &nbsp;<span class="return-type"><a href="C1.ModalExclusionType.html" title="enum\
                      class in pkg1">C1.ModalExclusionType</a></span>&nbsp;<span class="element-name">APPLICATION_E\
                     XCLUDE</span></div>
+                    </div>
                     </section>
                     </li>""");
 

--- a/test/langtools/jdk/javadoc/doclet/testHtmlLandmarkRegions/TestHtmlLandmarkRegions.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlLandmarkRegions/TestHtmlLandmarkRegions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testHtmlLandmarkRegions/TestHtmlLandmarkRegions.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlLandmarkRegions/TestHtmlLandmarkRegions.java
@@ -76,7 +76,7 @@ public class TestHtmlLandmarkRegions extends JavadocTester {
 
         checkOrder("index.html",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">""",
                 """
                     <main role="main">
@@ -106,7 +106,7 @@ public class TestHtmlLandmarkRegions extends JavadocTester {
 
         checkOrder("index.html",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">""",
                 """
                     <main role="main">
@@ -144,7 +144,7 @@ public class TestHtmlLandmarkRegions extends JavadocTester {
 
         checkOrder("pkg1/doc-files/s.html",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     """,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
+++ b/test/langtools/jdk/javadoc/doclet/testHtmlVersion/TestHtmlVersion.java
@@ -81,7 +81,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <div class="caption"><span>Packages</span></div>
                     <div class="summary-table two-column-summary">""",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -99,7 +99,7 @@ public class TestHtmlVersion extends JavadocTester {
                 """
                     <div class="summary-table two-column-summary" aria-labelledby="class-summary-tab0">""",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -131,7 +131,7 @@ public class TestHtmlVersion extends JavadocTester {
                     """,
                 "<li class=\"circle\">",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -164,7 +164,7 @@ public class TestHtmlVersion extends JavadocTester {
                 """
                     <div class="summary-table two-column-summary">""",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -185,7 +185,7 @@ public class TestHtmlVersion extends JavadocTester {
                 """
                     <div class="summary-table three-column-summary">""",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -214,7 +214,7 @@ public class TestHtmlVersion extends JavadocTester {
                 """
                     <div class="summary-table two-column-summary">""",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -233,7 +233,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -257,7 +257,7 @@ public class TestHtmlVersion extends JavadocTester {
                     """,
                 "<li class=\"circle\">",
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -292,12 +292,11 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
                     </header>
-                    <div class="flex-content">
                     <main role="main">""",
                 """
                     <footer role="contentinfo">""",
@@ -319,7 +318,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -350,7 +349,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -400,7 +399,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -441,7 +440,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -473,7 +472,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -500,7 +499,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -527,7 +526,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """
@@ -565,7 +564,7 @@ public class TestHtmlVersion extends JavadocTester {
                     <ul id="navbar-top-firstrow" class="nav-list" title="Navigation">
                     """,
                 """
-                    <header role="banner" class="flex-header">
+                    <header role="banner">
                     <nav role="navigation">
                     <!-- ========= START OF TOP NAVBAR ======= -->""",
                 """

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -128,6 +128,7 @@ public class TestInterface extends JavadocTester {
                 """
                     <section class="detail" id="f">
                     <h3>f</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public static</span>&nbsp;\
                     <span class="return-type">int</span>&nbsp;<span class="element-name">f</span></div>
                     <div class="block">A hider field</div>""",
@@ -147,6 +148,7 @@ public class TestInterface extends JavadocTester {
                 """
                     <section class="detail" id="staticMethod()">
                     <h3>staticMethod</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public static</span>&nbsp;\
                     <span class="return-type">void</span>&nbsp;<span class="element-name">staticMethod</span\
                     >()</div>
@@ -157,6 +159,7 @@ public class TestInterface extends JavadocTester {
                 """
                     <section class="detail" id="staticMethod()">
                     <h3>staticMethod</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public static</span>&nbsp;\
                     <span class="return-type">void</span>&nbsp;<span class="element-name">staticMethod</span\
                     >()</div>
@@ -311,17 +314,20 @@ public class TestInterface extends JavadocTester {
                 <li>
                 <section class="detail" id="hashCode()">
                 <h3>hashCode</h3>
+                <div class="horizontal-scroll">
                 <div class="member-signature"><span class="return-type">\
                 int</span>&nbsp;<span class="element-name">hashCode</span>()</div>
                 <dl class="notes">
                 <dt>Overrides:</dt>
                 <dd><code>hashCode</code>&nbsp;in class&nbsp;<code>java.lang.Object</code></dd>
                 </dl>
+                </div>
                 </section>
                 </li>
                 <li>
                 <section class="detail" id="equals(java.lang.Object)">
                 <h3>equals</h3>
+                <div class="horizontal-scroll">
                 <div class="member-signature"><span class="return-type">\
                 boolean</span>&nbsp;<span class="element-name">equals</span>\
                 <wbr><span class="parameters">(java.lang.Object&nbsp;obj)</span></div>
@@ -329,24 +335,29 @@ public class TestInterface extends JavadocTester {
                 <dt>Overrides:</dt>
                 <dd><code>equals</code>&nbsp;in class&nbsp;<code>java.lang.Object</code></dd>
                 </dl>
+                </div>
                 </section>
                 </li>
                 <li>
                 <section class="detail" id="toString()">
                 <h3>toString</h3>
+                <div class="horizontal-scroll">
                 <div class="member-signature"><span class="return-type">\
                 java.lang.String</span>&nbsp;<span class="element-name">toString</span>()</div>
                 <dl class="notes">
                 <dt>Overrides:</dt>
                 <dd><code>toString</code>&nbsp;in class&nbsp;<code>java.lang.Object</code></dd>
                 </dl>
+                </div>
                 </section>
                 </li>
                 <li>
                 <section class="detail" id="clone()">
                 <h3>clone</h3>
+                <div class="horizontal-scroll">
                 <div class="member-signature"><span class="return-type">\
                 java.lang.Object</span>&nbsp;<span class="element-name">clone</span>()</div>
+                </div>
                 </section>
                 </li>
                 """);

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFX.java
@@ -107,6 +107,7 @@ public class TestJavaFX extends JavadocTester {
                 """
                     <section class="detail" id="pausedProperty">
                     <h3>paused</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type"><a href="C.BooleanProperty.html" title="class in pkg1">\
                     C.BooleanProperty</a></span>&nbsp;<span class="element-name">pausedProperty</span></div>
@@ -114,6 +115,7 @@ public class TestJavaFX extends JavadocTester {
                 """
                     <section class="detail" id="isPaused()">
                     <h3>isPaused</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type">double</span>&nbsp;<span class="element-name">isPaused<\
                     /span>()</div>
@@ -121,6 +123,7 @@ public class TestJavaFX extends JavadocTester {
                 """
                     <section class="detail" id="setPaused(boolean)">
                     <h3>setPaused</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type">void</span>&nbsp;<span class="element-name">setPaused</\
                     span><wbr><span class="parameters">(boolean&nbsp;value)</span></div>
@@ -133,6 +136,7 @@ public class TestJavaFX extends JavadocTester {
                 """
                     <section class="detail" id="isPaused()">
                     <h3>isPaused</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type">double</span>&nbsp;<span class="element-name">isPaused<\
                     /span>()</div>
@@ -145,6 +149,7 @@ public class TestJavaFX extends JavadocTester {
                 """
                     <section class="detail" id="rateProperty">
                     <h3>rate</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type"><a href="C.DoubleProperty.html" title="class in pkg1">C\
                     .DoubleProperty</a></span>&nbsp;<span class="element-name">rateProperty</span></div>
@@ -153,6 +158,7 @@ public class TestJavaFX extends JavadocTester {
                 """
                     <section class="detail" id="setRate(double)">
                     <h3>setRate</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type">void</span>&nbsp;<span class="element-name">setRate</sp\
                     an><wbr><span class="parameters">(double&nbsp;value)</span></div>
@@ -170,6 +176,7 @@ public class TestJavaFX extends JavadocTester {
                 """
                     <section class="detail" id="getRate()">
                     <h3>getRate</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                     span class="return-type">double</span>&nbsp;<span class="element-name">getRate</span>()<\
                     /div>
@@ -262,6 +269,7 @@ public class TestJavaFX extends JavadocTester {
                         <li>
                         <section class="detail" id="betaProperty">
                         <h3>beta</h3>
+                        <div class="horizontal-scroll">
                         <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                         lass="return-type">java.lang.Object</span>&nbsp;<span class="element-name">betaProperty<\
                         /span></div>
@@ -273,11 +281,13 @@ public class TestJavaFX extends JavadocTester {
                         </ul>
                         </dd>
                         </dl>
+                        </div>
                         </section>
                         </li>
                         <li>
                         <section class="detail" id="gammaProperty">
                         <h3>gamma</h3>
+                        <div class="horizontal-scroll">
                         <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                         span class="return-type">java.util.List&lt;java.lang.String&gt;</span>&nbsp;<spa\
                         n class="element-name">gammaProperty</span></div>
@@ -289,11 +299,13 @@ public class TestJavaFX extends JavadocTester {
                         </ul>
                         </dd>
                         </dl>
+                        </div>
                         </section>
                         </li>
                         <li>
                         <section class="detail" id="deltaProperty">
                         <h3>delta</h3>
+                        <div class="horizontal-scroll">
                         <div class="member-signature"><span class="modifiers">public final</span>&nbsp;<\
                         span class="return-type">java.util.List&lt;java.util.Set&lt;? super java.lang.Ob\
                         ject&gt;&gt;</span>&nbsp;<span class="element-name">deltaProperty</span></div>
@@ -305,6 +317,7 @@ public class TestJavaFX extends JavadocTester {
                         </ul>
                         </dd>
                         </dl>
+                        </div>
                         </section>
                         </li>
                         </ul>

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXCombo.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXCombo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,6 +154,7 @@ public class TestJavaFXCombo extends JavadocTester {
                             """
                                 <section class="detail" id="getExample()">
                                 <h3>getExample</h3>
+                                <div class="horizontal-scroll">
                                 <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span class="return-type">boolean</span>&nbsp;<span class="element-name">getExample</span>()</div>
                                 <div class="block">Gets the value of the <code>example</code> property.</div>
                                 <dl class="notes">
@@ -163,6 +164,7 @@ public class TestJavaFXCombo extends JavadocTester {
                                 <dd>the value of the <code>example</code> property</dd>
                                 #SEE#
                                 </dl>
+                                </div>
                                 </section>
                                 """
                                 .replace("#DESC#", getPropertyDescription(fk, pk))
@@ -176,12 +178,14 @@ public class TestJavaFXCombo extends JavadocTester {
                             """
                                 <section class="detail" id="getExample()">
                                 <h3>getExample</h3>
+                                <div class="horizontal-scroll">
                                 <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span class="return-type">boolean</span>&nbsp;<span class="element-name">getExample</span>()</div>
                                 <div class="block">Getter method description. More getter method description.</div>
                                 <dl class="notes">
                                 <dt>Returns:</dt>
                                 <dd>the <code>example</code> property</dd>
                                 </dl>
+                                </div>
                                 </section>
                                     """);
         }
@@ -199,6 +203,7 @@ public class TestJavaFXCombo extends JavadocTester {
                             """
                                 <section class="detail" id="setExample(boolean)">
                                 <h3>setExample</h3>
+                                <div class="horizontal-scroll">
                                 <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span class="return-type">void</span>&nbsp;<span class="element-name">setExample</span><wbr><span class="parameters">(boolean&nbsp;b)</span></div>
                                 <div class="block">Sets the value of the <code>example</code> property.</div>
                                 <dl class="notes">
@@ -208,6 +213,7 @@ public class TestJavaFXCombo extends JavadocTester {
                                 <dd><code>b</code> - the value for the <code>example</code> property</dd>
                                 #SEE#
                                 </dl>
+                                </div>
                                 </section>
                                 """
                                 .replace("#DESC#", getPropertyDescription(fk, pk))
@@ -220,12 +226,14 @@ public class TestJavaFXCombo extends JavadocTester {
                             """
                                 <section class="detail" id="setExample(boolean)">
                                 <h3>setExample</h3>
+                                <div class="horizontal-scroll">
                                 <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span class="return-type">void</span>&nbsp;<span class="element-name">setExample</span><wbr><span class="parameters">(boolean&nbsp;b)</span></div>
                                 <div class="block">Setter method description. More setter method description.</div>
                                 <dl class="notes">
                                 <dt>Parameters:</dt>
                                 <dd><code>b</code> - the new value for the property</dd>
                                 </dl>
+                                </div>
                                 </section>
                                 """);
         }
@@ -242,6 +250,7 @@ public class TestJavaFXCombo extends JavadocTester {
                             """
                                 <section class="detail" id="exampleProperty()">
                                 <h3>exampleProperty</h3>
+                                <div class="horizontal-scroll">
                                 <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span class="return-type"><a href="BooleanProperty.html" title="class in p">BooleanProperty</a></span>&nbsp;<span class="element-name">exampleProperty</span>()</div>
                                 #PCOMM#
                                 <dl class="notes">
@@ -249,6 +258,7 @@ public class TestJavaFXCombo extends JavadocTester {
                                 <dd>the <code>example</code> property</dd>
                                 #SEE#
                                 </dl>
+                                </div>
                                 </section>
                                 """
                                 .replace("#PCOMM#", getPropertyMethodComment(fk, pk))
@@ -262,6 +272,7 @@ public class TestJavaFXCombo extends JavadocTester {
                             """
                                 <section class="detail" id="exampleProperty()">
                                 <h3>exampleProperty</h3>
+                                <div class="horizontal-scroll">
                                 <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span class="return-type"><a href="BooleanProperty.html" title="class in p">BooleanProperty</a></span>&nbsp;<span class="element-name">exampleProperty</span>()</div>
                                 <div class="block">Property method description. More property method description.</div>
                                 <dl class="notes">
@@ -269,6 +280,7 @@ public class TestJavaFXCombo extends JavadocTester {
                                 <dd>the <code>example</code> property</dd>
                                 #SEE#
                                 </dl>
+                                </div>
                                 </section>
                                 """
                                 .replace("#SEE#", (fk == Kind.COMMENT ? "" : getSee(null, gk, sk)))

--- a/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java
+++ b/test/langtools/jdk/javadoc/doclet/testJavaFX/TestJavaFXMissingPropComments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,6 +89,7 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                 """
                     <section class="detail" id="getValue()">
                     <h3>getValue</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type">boolean</span>&nbsp;<span class="element-name">getValue</span\
                     >()</div>
@@ -105,6 +106,7 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                     </ul>
                     </dd>
                     </dl>
+                    </div>
                     </section>"""
                 );
     }
@@ -153,6 +155,7 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                 """
                     <section class="detail" id="getValue()">
                     <h3>getValue</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type">boolean</span>&nbsp;<span class="element-name">getValue</span\
                     >()</div>
@@ -169,6 +172,7 @@ public class TestJavaFXMissingPropComments extends JavadocTester {
                     </ul>
                     </dd>
                     </dl>
+                    </div>
                     </section>"""
         );
     }

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,10 +120,12 @@ public class TestMemberInheritance extends JavadocTester {
         checkOutput("pkg2/DocumentedNonGenericChild.html", true,
                 """
                     <section class="class-description" id="class-description">
+                    <div class="horizontal-scroll">
                     <hr>
                     <div class="type-signature"><span class="modifiers">public abstract class </span\
                     ><span class="element-name type-name-label">DocumentedNonGenericChild</span>
                     <span class="extends-implements">extends java.lang.Object</span></div>
+                    </div>
                     </section>""");
 
         checkOutput("pkg2/DocumentedNonGenericChild.html", true,
@@ -142,6 +144,7 @@ public class TestMemberInheritance extends JavadocTester {
                 """
                     <section class="detail" id="parentMethod(T)">
                     <h3 id="parentMethod(java.lang.Object)">parentMethod</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">protected abstract</span>&\
                     nbsp;<span class="return-type">java.lang.String</span>&nbsp;<span class="element\
                     -name">parentMethod</span><wbr><span class="parameters">(java.lang.String&nbsp;t\
@@ -169,10 +172,12 @@ public class TestMemberInheritance extends JavadocTester {
                 """
                     <section class="detail" id="parentField">
                     <h3>parentField</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type">java.lang.String</span>&nbsp;<span class="element-name">parentField</\
                     span></div>
                     <div class="block">A field.</div>
+                    </div>
                     </section>""");
 
         checkOutput("pkg3/PrivateGenericParent.PublicChild.html", true,
@@ -185,9 +190,11 @@ public class TestMemberInheritance extends JavadocTester {
                 """
                     <section class="detail" id="method(T)">
                     <h3 id="method(java.lang.Object)">method</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type">java.lang.String</span>&nbsp;<span class="element-name">metho\
                     d</span><wbr><span class="parameters">(java.lang.String&nbsp;t)</span></div>
+                    </div>
                     </section>""");
 
         checkOutput("index-all.html", true,
@@ -231,6 +238,7 @@ public class TestMemberInheritance extends JavadocTester {
                 """
                     <section class="detail" id="parentMethod(T)">
                     <h3 id="parentMethod(java.lang.Object)">parentMethod</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">protected abstract</span>&\
                     nbsp;<span class="return-type">java.lang.String</span>&nbsp;<span class="element\
                     -name">parentMethod</span><wbr><span class="parameters">(java.lang.String&nbsp;t\

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -507,7 +507,6 @@ public class TestModules extends JavadocTester {
                     <div class="deprecation-comment">This module is deprecated.</div>
                     </div>
                     <!-- ============ MODULE DESCRIPTION =========== -->
-                    <div class="horizontal-scroll">
                     <div class="block">This is a test description for the moduleA module with a Sear\
                     ch phrase <span id="searchphrase" class="search-tag-result">search phrase</span>\
                     .</div>""");
@@ -515,7 +514,6 @@ public class TestModules extends JavadocTester {
                 """
                     <section class="module-description" id="module-description">
                     <!-- ============ MODULE DESCRIPTION =========== -->
-                    <div class="horizontal-scroll">
                     <div class="block">This is a test description for the moduleB module. Search wor\
                     d <span id="search_word" class="search-tag-result">search_word</span> with no de\
                     scription.</div>""");
@@ -547,8 +545,10 @@ public class TestModules extends JavadocTester {
                     <h1 title="Module moduleA" class="title">Module moduleA</h1>
                     </div>
                     <hr>
+                    <div class="horizontal-scroll">
                     <div class="module-signature"><span class="annotations">@Deprecated(forRemoval=true)
                     </span>module <span class="element-name">moduleA</span></div>
+                    </div>
                     <section class="summary">
                     <ul class="summary-list">
                     <li>
@@ -560,12 +560,14 @@ public class TestModules extends JavadocTester {
                     <h1 title="Module moduleB" class="title">Module moduleB</h1>
                     </div>
                     <hr>
+                    <div class="horizontal-scroll">
                     <div class="module-signature"><span class="annotations"><a href="testpkgmdlB/Ann\
                     otationType.html" title="annotation interface in testpkgmdlB">@AnnotationType</a\
                     >(<a href="testpkgmdlB/AnnotationType.html#optional()">optional</a>="Module Anno\
                     tation",
                                     <a href="testpkgmdlB/AnnotationType.html#required()">required</a>=2016)
                     </span>module <span class="element-name">moduleB</span></div>
+                    </div>
                     <section class="summary">
                     <ul class="summary-list">
                     <li>
@@ -1129,6 +1131,7 @@ public class TestModules extends JavadocTester {
                     <h1 title="Module moduletags" class="title">Module moduletags</h1>
                     </div>
                     <hr>
+                    <div class="horizontal-scroll">
                     <div class="module-signature"><span class="annotations">@Deprecated
                     </span>module <span class="element-name">moduletags</span></div>""",
                 """
@@ -1142,6 +1145,7 @@ public class TestModules extends JavadocTester {
                     <h1 title="Module moduleB" class="title">Module moduleB</h1>
                     </div>
                     <hr>
+                    <div class="horizontal-scroll">
                     <div class="module-signature"><span class="annotations"><a href="testpkgmdlB/Ann\
                     otationType.html" title="annotation interface in testpkgmdlB">@AnnotationType</a\
                     >(<a href="testpkgmdlB/AnnotationType.html#optional()">optional</a>="Module Anno\

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -507,6 +507,7 @@ public class TestModules extends JavadocTester {
                     <div class="deprecation-comment">This module is deprecated.</div>
                     </div>
                     <!-- ============ MODULE DESCRIPTION =========== -->
+                    <div class="horizontal-scroll">
                     <div class="block">This is a test description for the moduleA module with a Sear\
                     ch phrase <span id="searchphrase" class="search-tag-result">search phrase</span>\
                     .</div>""");
@@ -514,6 +515,7 @@ public class TestModules extends JavadocTester {
                 """
                     <section class="module-description" id="module-description">
                     <!-- ============ MODULE DESCRIPTION =========== -->
+                    <div class="horizontal-scroll">
                     <div class="block">This is a test description for the moduleB module. Search wor\
                     d <span id="search_word" class="search-tag-result">search_word</span> with no de\
                     scription.</div>""");
@@ -521,7 +523,6 @@ public class TestModules extends JavadocTester {
                 """
                     </nav>
                     </header>
-                    <div class="flex-content">
                     <main role="main">
                     <div class="block">The overview summary page header.</div>
                     <div id="all-modules-table">
@@ -707,7 +708,6 @@ public class TestModules extends JavadocTester {
                 """
                     </nav>
                     </header>
-                    <div class="flex-content">
                     <main role="main">
                     <div class="block">The overview summary page header.</div>
                     <div id="all-packages-table">
@@ -1354,11 +1354,13 @@ public class TestModules extends JavadocTester {
         checkOutput("moduleA/testpkgmdlA/TestClassInModuleA.html", true,
                 """
                     <section class="class-description" id="class-description">
+                    <div class="horizontal-scroll">
                     <hr>
                     <div class="type-signature"><span class="modifiers">public class </span><span cl\
                     ass="element-name"><a href="../../src-html/moduleA/testpkgmdlA/TestClassInModule\
                     A.html#line-25">TestClassInModuleA</a></span>
                     <span class="extends-implements">extends java.lang.Object</span></div>
+                    </div>
                     </section>""");
         checkOutput("src-html/moduleA/testpkgmdlA/TestClassInModuleA.html", true,
                 """

--- a/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
@@ -91,7 +91,6 @@ public class TestNavigation extends JavadocTester {
                     <!-- ========= END OF TOP NAVBAR ========= -->
                     <span class="skip-nav" id="skip-navbar-top"></span></nav>
                     </header>
-                    <div class="flex-content">
                     <main role="main">
                     <!-- ======== START OF CLASS DATA ======== -->""");
 
@@ -100,7 +99,6 @@ public class TestNavigation extends JavadocTester {
                     <!-- ========= END OF TOP NAVBAR ========= -->
                     <span class="skip-nav" id="skip-navbar-top"></span></nav>
                     </header>
-                    <div class="flex-content">
                     <main role="main">
                     <div class="header">""");
     }
@@ -120,7 +118,6 @@ public class TestNavigation extends JavadocTester {
                     <!-- ========= END OF TOP NAVBAR ========= -->
                     <span class="skip-nav" id="skip-navbar-top"></span></nav>
                     </header>
-                    <div class="flex-content">
                     <main role="main">
                     <!-- ======== START OF CLASS DATA ======== -->""");
 

--- a/test/langtools/jdk/javadoc/doclet/testOptions/TestOptions.java
+++ b/test/langtools/jdk/javadoc/doclet/testOptions/TestOptions.java
@@ -232,6 +232,7 @@ public class TestOptions extends JavadocTester {
                 """
                     <section class="detail" id="DEFAULT_NAME">
                     <h3>DEFAULT_NAME</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">static final</span>&nbsp;<\
                     span class="return-type">java.lang.String</span>&nbsp;<span class="element-name"><a href\
                     ="../src-html/linksource/AnnotationTypeField.html#line-32">DEFAULT_NAME</a></spa\
@@ -239,6 +240,7 @@ public class TestOptions extends JavadocTester {
                 """
                     <section class="detail" id="name()">
                     <h3>name</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="return-type">java.lang.String</span>&\
                     nbsp;<span class="element-name"><a href="../src-html/linksource/AnnotationTypeField.html\
                     #line-34">name</a></span></div>""");

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
@@ -54,6 +54,7 @@ public class TestPackageAnnotation extends JavadocTester {
                     <div class="header">
                     <h1 title="Package pkg1" class="title">Package pkg1</h1>
                     </div>
+                    <div class="horizontal-scroll">
                     <hr>
                     <div class="package-signature"><span class="annotations">@Deprecated(since="1&lt;2&gt;3")
                     </span>package <span class="element-name">pkg1</span></div>
@@ -90,6 +91,7 @@ public class TestPackageAnnotation extends JavadocTester {
                     <div class="header">
                     <h1 title="Package pkg3" class="title">Package pkg3</h1>
                     </div>
+                    <div class="horizontal-scroll">
                     <hr>
                     <div class="package-signature"><span class="annotations">@Deprecated(since="1&lt;2&gt;3")
                     </span>package <span class="element-name">pkg3</span></div>

--- a/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
+++ b/test/langtools/jdk/javadoc/doclet/testPackageAnnotation/TestPackageAnnotation.java
@@ -54,8 +54,8 @@ public class TestPackageAnnotation extends JavadocTester {
                     <div class="header">
                     <h1 title="Package pkg1" class="title">Package pkg1</h1>
                     </div>
-                    <div class="horizontal-scroll">
                     <hr>
+                    <div class="horizontal-scroll">
                     <div class="package-signature"><span class="annotations">@Deprecated(since="1&lt;2&gt;3")
                     </span>package <span class="element-name">pkg1</span></div>
                     """);
@@ -91,8 +91,8 @@ public class TestPackageAnnotation extends JavadocTester {
                     <div class="header">
                     <h1 title="Package pkg3" class="title">Package pkg3</h1>
                     </div>
-                    <div class="horizontal-scroll">
                     <hr>
+                    <div class="horizontal-scroll">
                     <div class="package-signature"><span class="annotations">@Deprecated(since="1&lt;2&gt;3")
                     </span>package <span class="element-name">pkg3</span></div>
                     """);

--- a/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testReturnTag/TestReturnTag.java
@@ -292,6 +292,7 @@ public class TestReturnTag extends JavadocTester {
         checkOutput("C.html", true,
                 """
                     <div class="block">Some text. Returns the result. More text.</div>
+                    </div>
                     </section>
                     """);
     }

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -434,8 +434,6 @@ public class TestSearch extends JavadocTester {
                     <input type="text" id="search-input" disabled placeholder="Search">
                     <input type="reset" id="reset-button" disabled value="reset">
                     """);
-        checkOutput(fileName, true,
-                "<div class=\"flex-box\">");
     }
 
     void checkSingleIndex() {

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -138,7 +138,7 @@ public class TestStylesheet extends JavadocTester {
                     .summary-table > div, .details-table > div {
                         text-align:left;
                         padding: 8px 3px 3px 7px;
-                        overflow-x: auto;
+                        overflow: auto hidden;
                         scrollbar-width: thin;
                     }""",
                 "@import url('fonts/dejavu.css');",

--- a/test/langtools/jdk/javadoc/doclet/testSummaryTag/TestSummaryTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSummaryTag/TestSummaryTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,9 +92,11 @@ public class TestSummaryTag extends JavadocTester {
              """
                  <section class="detail" id="m3()">
                  <h3>m3</h3>
+                 <div class="horizontal-scroll">
                  <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                  lass="return-type">void</span>&nbsp;<span class="element-name">m3</span>()</div>
                  <div class="block">First sentence  some text maybe second sentence.</div>
+                 </div>
                  </section>
                  """
         );

--- a/test/langtools/jdk/javadoc/doclet/testSystemPropertyPage/TestSystemPropertyPage.java
+++ b/test/langtools/jdk/javadoc/doclet/testSystemPropertyPage/TestSystemPropertyPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testSystemPropertyPage/TestSystemPropertyPage.java
+++ b/test/langtools/jdk/javadoc/doclet/testSystemPropertyPage/TestSystemPropertyPage.java
@@ -67,11 +67,9 @@ public class TestSystemPropertyPage extends JavadocTester {
 
         checkOutput("system-properties.html", true,
                 """
-                    <div class="flex-box">
-                    <header role="banner" class="flex-header">""",
+                    <header role="banner">""",
 
                 """
-                    <div class="flex-content">
                     <main role="main">
                     <div class="header">
                     <h1>System Properties</h1>

--- a/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -680,6 +680,7 @@ public class TestOneToMany extends JavadocTester {
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - grandparent 1</dd>
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - grandparent 2</dd>
                 </dl>
+                </div>
                 </section>
                 """);
     }
@@ -735,6 +736,7 @@ public class TestOneToMany extends JavadocTester {
                 <dt>Throws:</dt>
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - "'grandparent'"</dd>
                 </dl>
+                </div>
                 </section>
                 """);
     }

--- a/test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
+++ b/test/langtools/jdk/javadoc/doclet/testUnicode/TestUnicode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,7 @@ public class TestUnicode extends JavadocTester {
                 """
                     <section class="detail" id="set##(int)">
                     <h3>set##</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public</span>&nbsp;<span c\
                     lass="return-type">void</span>&nbsp;<span class="element-name">set##</span><wbr>\
                     <span class="parameters">(int&nbsp;##)</span></div>
@@ -115,6 +116,7 @@ public class TestUnicode extends JavadocTester {
                     <dt>Parameters:</dt>
                     <dd><code>##</code> - the ##</dd>
                     </dl>
+                    </div>
                     </section>
                     """.replaceAll("##", chineseElephant)
                 );

--- a/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueFormats.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueFormats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,11 +80,13 @@ public class TestValueFormats extends JavadocTester {
         checkOutput("p/C.html", true,
                 """
                     <h3>i65535</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public static final</span>&nbsp;<span clas\
                     s="return-type">int</span>&nbsp;<span class="element-name">i65535</span></div>
                     <div class="block">The value 65535 is ffff or 0xffff.</div>""",
                 """
                     <h3>pi</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public static final</span>&nbsp;<span class="return-type">double</span>&nbsp;<span class="element-name">pi</span></div>
                     <div class="block">The value 3.1415926525 is %5.2f.</div>""".formatted(3.14));
     }
@@ -113,6 +115,7 @@ public class TestValueFormats extends JavadocTester {
         checkOutput("p/C.html", true,
                 """
                     <h3>i65535</h3>
+                    <div class="horizontal-scroll">
                     <div class="member-signature"><span class="modifiers">public static final</span>&nbsp;<span class="return-type">int</span>&nbsp;<span class="element-name">i65535</span></div>
                     <div class="block">The value 65535 is <span class="invalid-tag">invalid format: %a</span>.</div>""");
     }

--- a/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTagInModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTagInModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,6 @@ public class TestValueTagInModule extends JavadocTester {
                 """
                     <section class="module-description" id="module-description">
                     <!-- ============ MODULE DESCRIPTION =========== -->
-                    <div class="horizontal-scroll">
                     <div class="block">value of field CONS : <a href="pkg/A.html#CONS">100</a></div>""");
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTagInModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testValueTag/TestValueTagInModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ public class TestValueTagInModule extends JavadocTester {
                 """
                     <section class="module-description" id="module-description">
                     <!-- ============ MODULE DESCRIPTION =========== -->
+                    <div class="horizontal-scroll">
                     <div class="block">value of field CONS : <a href="pkg/A.html#CONS">100</a></div>""");
     }
 


### PR DESCRIPTION
A few years ago we switched to [Flexbox Layout](https://developer.mozilla.org/en-US/docs/Glossary/Flexbox) to implement the sticky header in the API docs generated by `javadoc`. This solved the problem of anchor link targets [not being positioned correctly](https://bugs.openjdk.org/browse/JDK-8223378), but it also introduced a few new ones:

 - It required a workaround to get browser history to work (JDK-8249133, JDK-8250779, 8286832)
 - It changed certain aspects of scrolling behavior in the browser (JDK-8301080)
 - It changed the way some CSS properties are interpreted (JDK-8315800)

The reason for most of these problems is that the layout paradigm used by Flexbox is very different from traditional layout of HTML pages. The `scroll-margin-*` CSS properties introduced by the [CSS Scroll Snap Module](https://www.w3.org/TR/css-scroll-snap-1/) provide a simpler and less intrusive way to implement link target offsets in combination with sticky elements implemented using [`position: sticky`](https://developer.mozilla.org/en-US/docs/Web/CSS/position). However, although it is implemented [in all supported browsers](https://caniuse.com/?search=scroll-margin), it comes with its own challanges and quirks, which are explained below.

The first problem to overcome was that `position: sticky` is more fragile on mobile browsers than Flexbox. If some part of the page content overflows the allotted horizontal space, the whole page can be zoomed out to view the whole content. This causes the header to become unsticky and the link target offsets to become erroneous. It was therefore necessary to make sure page content never overflows its allotted horizontal space, either by adding line break opportunities, or by making all or part of the page horizontally scrollable when its content overflows. Line break opportunities are difficult to add especially in  preformatted code, so I opted for making the parts of the page most likely containing long lines of code scrollable. 

The next problem was that enabling horizontal scrolling on an element or one of its containing elements breaks the `scroll-margin-top` property in Chrome due to a browser quirk (both desktop and mobile versions). This means that the scrolling must occur in a child element rather than the sections or other elements serving as link targets. 

When enabling horizontal scrolling on the contents of sections containing user-provided content, another problem is that it disables [Margin Collapse](https://www.joshwcomeau.com/css/rules-of-margin-collapse/) which regulates margins between adjacent and contained boxes. Since these sections can contain a mix of HTML containers, it is almost impossible to preserve the margins between elements while making them scrollable. 

The solution to these problems was to add a new `<div class="horizontal-scroll">` to the sections containing user-provided content. Adding a single scrollable element per section allowed the margins to be controlled in a relatively safe way, although some CSS is introduced to limit the margin of certain trailing block elements in certain sections. 

The `scroll-margin-top` property is set to the normal height of the sticky header in `stylesheet.css`, with a line added to `search.js` to set the property dynamically to the actual header height to accommodate for the pre-release notification banner. In a previous version of this branch, the pre-release banner was excluded from the sticky header, but it was made sticky again in the final version to make the output more comparable. 

The generated documentation should render the same on supported browsers pixel by pixel. Before/after snapshots of the JDK docs are available here:

Before: https://cr.openjdk.org/~hannesw/8308659/api.00/
After: https://cr.openjdk.org/~hannesw/8308659/api.01/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308659](https://bugs.openjdk.org/browse/JDK-8308659): Use CSS scroll-margin instead of flexbox layout in API documentation (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [fcfcc5fe](https://git.openjdk.org/jdk/pull/15969/files/fcfcc5fea7c3c8382f3a62d4ce3418cd22cd9493)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15969/head:pull/15969` \
`$ git checkout pull/15969`

Update a local copy of the PR: \
`$ git checkout pull/15969` \
`$ git pull https://git.openjdk.org/jdk.git pull/15969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15969`

View PR using the GUI difftool: \
`$ git pr show -t 15969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15969.diff">https://git.openjdk.org/jdk/pull/15969.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15969#issuecomment-1749125457)