### PR TITLE
8316342: CLHSDB "dumpclass" command produces invalid classes

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
@@ -80,42 +80,6 @@ public class ByteCodeRewriter
         return (short)cpool.objectToCPIndex(refIndex);
      }
 
-    protected short getConstantPoolIndex(int rawcode, int bci) {
-       // get ConstantPool index from ConstantPoolCacheIndex at given bci
-       String fmt = Bytecodes.format(rawcode);
-       int cpCacheIndex;
-       switch (fmt.length()) {
-       case 2: cpCacheIndex = method.getBytecodeByteArg(bci); break;
-       case 3: cpCacheIndex = method.getBytecodeShortArg(bci); break;
-       case 5:
-           if (fmt.contains("__"))
-               cpCacheIndex = method.getBytecodeShortArg(bci);
-           else
-               cpCacheIndex = method.getBytecodeIntArg(bci);
-           break;
-       default: throw new IllegalArgumentException();
-       }
-
-       if (cpCache == null) {
-          return (short) cpCacheIndex;
-       } else if (fmt.contains("JJJJ")) {
-          // Invokedynamic require special handling
-          cpCacheIndex = ~cpCacheIndex;
-          cpCacheIndex = bytes.swapInt(cpCacheIndex);
-          short cpIndex = (short) cpCache.getIndyEntryAt(cpCacheIndex).getConstantPoolIndex();
-          Assert.that(cpool.getTagAt(cpIndex).isInvokeDynamic(), "CP Entry should be InvokeDynamic");
-          return cpIndex;
-       } else if (fmt.contains("JJ")) {
-          // change byte-ordering and go via cache
-          return (short) cpCache.getEntryAt((int) (0xFFFF & bytes.swapShort((short)cpCacheIndex))).getConstantPoolIndex();
-       } else if (fmt.contains("j")) {
-          // go via cache
-          return (short) cpCache.getEntryAt((int) (0xFF & cpCacheIndex)).getConstantPoolIndex();
-       } else {
-          return (short) cpCacheIndex;
-       }
-    }
-
     private static void writeShort(byte[] buf, int index, short value) {
         buf[index] = (byte) ((value >> 8) & 0x00FF);
         buf[index + 1] = (byte) (value & 0x00FF);
@@ -152,22 +116,29 @@ public class ByteCodeRewriter
                 case Bytecodes._getstatic:
                 case Bytecodes._putstatic:
                 case Bytecodes._getfield:
-                case Bytecodes._putfield:
+                case Bytecodes._putfield: {
+                    int fieldIndex = method.getNativeShortArg(bci + 1);
+                    cpoolIndex = (short) cpCache.getFieldEntryAt(fieldIndex).getConstantPoolIndex();
+                    writeShort(code, bci + 1, cpoolIndex);
+                    break;
+                }
                 case Bytecodes._invokevirtual:
                 case Bytecodes._invokespecial:
                 case Bytecodes._invokestatic:
                 case Bytecodes._invokeinterface: {
-                    cpoolIndex = getConstantPoolIndex(hotspotcode, bci + 1);
+                    int cpci = method.getNativeShortArg(bci + 1);
+                    cpoolIndex = (short) cpCache.getEntryAt(cpci).getConstantPoolIndex();
                     writeShort(code, bci + 1, cpoolIndex);
                     break;
                 }
 
-                case Bytecodes._invokedynamic:
-                    cpoolIndex = getConstantPoolIndex(hotspotcode, bci + 1);
+                case Bytecodes._invokedynamic: {
+                    int cpci = method.getNativeIntArg(bci + 1);
+                    cpoolIndex = (short) cpCache.getIndyEntryAt(~cpci).getConstantPoolIndex();
                     writeShort(code, bci + 1, cpoolIndex);
                     writeShort(code, bci + 3, (short)0);  // clear out trailing bytes
                     break;
-
+                }
                 case Bytecodes._ldc_w:
                     if (hotspotcode != bytecode) {
                         // fast_aldc_w puts constant in reference map

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -130,7 +130,6 @@ serviceability/sa/ClhsdbPmap.java#core 8267433 macosx-x64
 serviceability/sa/ClhsdbPstack.java#core 8267433 macosx-x64
 serviceability/sa/TestJmapCore.java 8267433 macosx-x64
 serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
-serviceability/sa/ClhsdbDumpclass.java 8316342 generic-all
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java 8316658 generic-all


### PR DESCRIPTION
Please review this change to fix the operands of the bytecodes that operate on fields when dumping a class using SA.

Testing: hotspot_serviceability

I have also verified that `test/hotspot/jtreg/serviceability/sa/ClhsdbDumpclass.javaClhsdbDumpclass.java`, which is in the problem list because of this issue, passes with this change.
I have also verified it by dumping the class that has getstatic/putstatic bytecodes and comparing the bytecodes manually with the original classfile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316342](https://bugs.openjdk.org/browse/JDK-8316342): CLHSDB "dumpclass" command produces invalid classes (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15973/head:pull/15973` \
`$ git checkout pull/15973`

Update a local copy of the PR: \
`$ git checkout pull/15973` \
`$ git pull https://git.openjdk.org/jdk.git pull/15973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15973`

View PR using the GUI difftool: \
`$ git pr show -t 15973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15973.diff">https://git.openjdk.org/jdk/pull/15973.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15973#issuecomment-1740032272)