### PR TITLE
8317283: jpackage tests run osx-specific checks on windows and linux

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -832,6 +832,8 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         final Path lookupPath = AppImageFile.getPathInAppImage(appImageDir);
         if (isRuntime() || (!isImagePackageType() && !TKit.isOSX())) {
             assertFileInAppImage(lookupPath, null);
+        } else if (!TKit.isOSX()) {
+            assertFileInAppImage(lookupPath, lookupPath);
         } else {
             assertFileInAppImage(lookupPath, lookupPath);
 
@@ -842,15 +844,17 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
                 final Path rootDir = isImagePackageType() ? outputBundle() :
                         pathToUnpackedPackageFile(appInstallationDirectory());
 
+                AppImageFile aif = AppImageFile.load(rootDir);
+
                 boolean expectedValue = hasArgument("--mac-sign");
-                boolean actualValue = AppImageFile.load(rootDir).isSigned();
-                TKit.assertTrue(expectedValue == actualValue,
-                    "Unexptected value in app image file for <signed>");
+                boolean actualValue = aif.isSigned();
+                TKit.assertEquals(Boolean.toString(expectedValue), Boolean.toString(actualValue),
+                    "Check for unexptected value in app image file for <signed>");
 
                 expectedValue = hasArgument("--mac-app-store");
-                actualValue = AppImageFile.load(rootDir).isAppStore();
-                TKit.assertTrue(expectedValue == actualValue,
-                    "Unexptected value in app image file for <app-store>");
+                actualValue = aif.isAppStore();
+                TKit.assertEquals(Boolean.toString(expectedValue), Boolean.toString(actualValue),
+                    "Check for unexptected value in app image file for <app-store>");
             }
         }
     }


### PR DESCRIPTION
- Don't run osx specific checks on Linux and Windows
 - Rework checks output from 
```
[17:31:52.845] TRACE: assertTrue(): Unexptected value in app image file for <signed>
[17:31:52.860] TRACE: assertTrue(): Unexptected value in app image file for <app-store>
```
to
```
[22:07:46.519] TRACE: assertEquals(false): Check for unexptected value in app image file for <signed>
[22:07:46.519] TRACE: assertEquals(false): Check for unexptected value in app image file for <app-store>
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317283](https://bugs.openjdk.org/browse/JDK-8317283): jpackage tests run osx-specific checks on windows and linux (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15975/head:pull/15975` \
`$ git checkout pull/15975`

Update a local copy of the PR: \
`$ git checkout pull/15975` \
`$ git pull https://git.openjdk.org/jdk.git pull/15975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15975`

View PR using the GUI difftool: \
`$ git pr show -t 15975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15975.diff">https://git.openjdk.org/jdk/pull/15975.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15975#issuecomment-1740176454)