### PR TITLE
8317141: Remove unused validIndex method from URLClassPath$JarLoader

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -433,9 +433,7 @@ public class URLClassPath {
                 if (url == null)
                     return null;
             }
-            // Skip this URL if it already has a Loader. (Loader
-            // may be null in the case where URL has not been opened
-            // but is referenced by a JAR index.)
+            // Skip this URL if it already has a Loader.
             String urlNoFragString = URLUtil.urlNoFragString(url);
             if (lmap.containsKey(urlNoFragString)) {
                 continue;
@@ -489,12 +487,12 @@ public class URLClassPath {
                                     // extract the nested URL
                                     @SuppressWarnings("deprecation")
                                     URL nestedUrl = new URL(file.substring(0, file.length() - 2));
-                                    return new JarLoader(nestedUrl, jarHandler, lmap, acc);
+                                    return new JarLoader(nestedUrl, jarHandler, acc);
                                 } else {
                                     return new Loader(url);
                                 }
                             } else {
-                                return new JarLoader(url, jarHandler, lmap, acc);
+                                return new JarLoader(url, jarHandler, acc);
                             }
                         }
                     }, acc);
@@ -708,8 +706,6 @@ public class URLClassPath {
     private static class JarLoader extends Loader {
         private JarFile jar;
         private final URL csu;
-        private URLStreamHandler handler;
-        private final HashMap<String, Loader> lmap;
         @SuppressWarnings("removal")
         private final AccessControlContext acc;
         private boolean closed = false;
@@ -721,14 +717,11 @@ public class URLClassPath {
          * a JAR file.
          */
         private JarLoader(URL url, URLStreamHandler jarHandler,
-                          HashMap<String, Loader> loaderMap,
                           @SuppressWarnings("removal") AccessControlContext acc)
             throws IOException
         {
             super(newURL("jar", "", -1, url + "!/", jarHandler));
             csu = url;
-            handler = jarHandler;
-            lmap = loaderMap;
             this.acc = acc;
 
             ensureOpen();
@@ -750,10 +743,6 @@ public class URLClassPath {
                 ensureOpen();
                 jar.close();
             }
-        }
-
-        JarFile getJarFile () {
-            return jar;
         }
 
         private boolean isOptimizable(URL url) {
@@ -869,33 +858,6 @@ public class URLClassPath {
                     return bytes;
                 }
             };
-        }
-
-
-        /*
-         * Returns true iff at least one resource in the jar file has the same
-         * package name as that of the specified resource name.
-         */
-        boolean validIndex(final String name) {
-            String packageName = name;
-            int pos;
-            if ((pos = name.lastIndexOf('/')) != -1) {
-                packageName = name.substring(0, pos);
-            }
-
-            String entryName;
-            ZipEntry entry;
-            Enumeration<JarEntry> enum_ = jar.entries();
-            while (enum_.hasMoreElements()) {
-                entry = enum_.nextElement();
-                entryName = entry.getName();
-                if ((pos = entryName.lastIndexOf('/')) != -1)
-                    entryName = entryName.substring(0, pos);
-                if (entryName.equals(packageName)) {
-                    return true;
-                }
-            }
-            return false;
         }
 
         /*


### PR DESCRIPTION
Can I please get a review of this change which removes unused (internal) method from the `private` `URLClassPath$JarLoader`? 

The `validIndex` method which is being removed here was being used when JAR index was supported. We removed support for JAR index in https://bugs.openjdk.org/browse/JDK-8302819. This method is now a leftover and no longer used.

The commit in this PR also removes a couple of other member fields in `URLClassPath$JarLoader`. These fields too were used previously when JAR index was in use and are no longer used.

tier1, tier2 and tier3 tests continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317141](https://bugs.openjdk.org/browse/JDK-8317141): Remove unused validIndex method from URLClassPath$JarLoader (**Task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15976/head:pull/15976` \
`$ git checkout pull/15976`

Update a local copy of the PR: \
`$ git checkout pull/15976` \
`$ git pull https://git.openjdk.org/jdk.git pull/15976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15976`

View PR using the GUI difftool: \
`$ git pr show -t 15976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15976.diff">https://git.openjdk.org/jdk/pull/15976.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15976#issuecomment-1740346083)