### PR TITLE
StringBuilder adds method append(int, int width, char pad)

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -841,6 +841,44 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     }
 
     /**
+     * Appends the string representation of the specified integer value to this
+     * sequence with a specified width and padding character.
+     *
+     * @param   i   the integer value to be appended
+     * @param width the width of the resulting string (including the number)
+     * @param pad the padding character to be used for alignment (if necessary)
+     * @return  a reference to this object.
+     *
+     * @since 22
+     */
+    public AbstractStringBuilder append(int i, int width, char pad) {
+        int count = this.count;
+        int integerSize = Integer.stringSize(i);
+        int integerWidth = Math.max(integerSize, width);
+        int padSize = width - integerSize;
+
+        int spaceNeeded = count + integerWidth;
+        ensureCapacityInternal(spaceNeeded);
+
+        if (isLatin1() && StringLatin1.canEncode(pad)) {
+            StringLatin1.getChars(i, spaceNeeded, value);
+            for (int j = 0; j < padSize; j++) {
+                value[count++] = (byte) pad;
+            }
+        } else {
+            if (isLatin1()) {
+                inflate();
+            }
+            StringUTF16.getChars(i, spaceNeeded, value);
+            for (int j = 0; j < padSize; j++) {
+                StringUTF16.putCharSB(value, count++, pad);
+            }
+        }
+        this.count = spaceNeeded;
+        return this;
+    }
+
+    /**
      * Appends the string representation of the {@code long}
      * argument to this sequence.
      * <p>

--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -435,6 +435,16 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
     }
 
     /**
+     * {@inheritDoc}
+     * @since 22
+     */
+    @Override
+    public synchronized StringBuffer append(int i, int width, char pad) {
+        super.append(i, width, pad);
+        return this;
+    }
+
+    /**
      * @since 1.5
      */
     @Override

--- a/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -254,6 +254,16 @@ public final class StringBuilder
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     * @since 22
+     */
+    @Override
+    public StringBuilder append(int i, int width, char pad) {
+        super.append(i, width, pad);
+        return this;
+    }
+
     @Override
     public StringBuilder append(long lng) {
         super.append(lng);

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -1312,15 +1312,9 @@ public class SimpleDateFormat extends DateFormat {
             value = (calendar.get(Calendar.ZONE_OFFSET) +
                      calendar.get(Calendar.DST_OFFSET)) / 60000;
 
-            int width = 4;
-            if (value >= 0) {
-                buffer.append('+');
-            } else {
-                width++;
-            }
-
+            buffer.append(value >= 0 ? '+' : '-');
             int num = (value / 60) * 100 + (value % 60);
-            CalendarUtils.sprintf0d(buffer, num, width);
+            buffer.append(Math.abs(num), 4, '0');
             break;
 
         case PATTERN_ISO_ZONE:   // 'X'
@@ -1340,7 +1334,7 @@ public class SimpleDateFormat extends DateFormat {
                 value = -value;
             }
 
-            CalendarUtils.sprintf0d(buffer, value / 60, 2);
+            buffer.append(value / 60, 2, '0');
             if (count == 1) {
                 break;
             }
@@ -1348,7 +1342,7 @@ public class SimpleDateFormat extends DateFormat {
             if (count == 3) {
                 buffer.append(':');
             }
-            CalendarUtils.sprintf0d(buffer, value % 60, 2);
+            buffer.append(value % 60, 2, '0');
             break;
 
         default:

--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -2154,21 +2154,21 @@ public final class LocalDate
         StringBuilder buf = new StringBuilder(10);
         if (absYear < 1000) {
             if (yearValue < 0) {
-                buf.append(yearValue - 10000).deleteCharAt(1);
-            } else {
-                buf.append(yearValue + 10000).deleteCharAt(0);
+                buf.append('-');
             }
+            buf.append(absYear, 4, '0');
         } else {
             if (yearValue > 9999) {
                 buf.append('+');
             }
             buf.append(yearValue);
         }
-        return buf.append(monthValue < 10 ? "-0" : "-")
-            .append(monthValue)
-            .append(dayValue < 10 ? "-0" : "-")
-            .append(dayValue)
-            .toString();
+
+        return buf.append('-')
+                .append(monthValue, 2, '0')
+                .append('-')
+                .append(dayValue, 2, '0')
+                .toString();
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/LocalTime.java
+++ b/src/java.base/share/classes/java/time/LocalTime.java
@@ -1634,18 +1634,18 @@ public final class LocalTime
         int minuteValue = minute;
         int secondValue = second;
         int nanoValue = nano;
-        buf.append(hourValue < 10 ? "0" : "").append(hourValue)
-            .append(minuteValue < 10 ? ":0" : ":").append(minuteValue);
+        buf.append(hourValue, 2, '0')
+            .append(':').append(minuteValue, 2, '0');
         if (secondValue > 0 || nanoValue > 0) {
-            buf.append(secondValue < 10 ? ":0" : ":").append(secondValue);
+            buf.append(':').append(secondValue, 2, '0');
             if (nanoValue > 0) {
                 buf.append('.');
                 if (nanoValue % 1000_000 == 0) {
-                    buf.append(Integer.toString((nanoValue / 1000_000) + 1000).substring(1));
+                    buf.append(nanoValue / 1000_000, 3, '0');
                 } else if (nanoValue % 1000 == 0) {
-                    buf.append(Integer.toString((nanoValue / 1000) + 1000_000).substring(1));
+                    buf.append(nanoValue / 1000, 6, '0');
                 } else {
-                    buf.append(Integer.toString((nanoValue) + 1000_000_000).substring(1));
+                    buf.append(nanoValue, 9, '0');
                 }
             }
         }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -4274,8 +4274,7 @@ public final class DateTimeFormatterBuilder {
         }
 
         private static StringBuilder appendHMS(StringBuilder buf, int t) {
-            return buf.append((char)(t / 10 + '0'))
-                      .append((char)(t % 10 + '0'));
+            return buf.append(t, 2, '0');
         }
 
         @Override

--- a/src/java.base/share/classes/java/util/Date.java
+++ b/src/java.base/share/classes/java/util/Date.java
@@ -1035,11 +1035,10 @@ public class Date
         }
         convertToAbbr(sb, wtb[index]).append(' ');                        // EEE
         convertToAbbr(sb, wtb[date.getMonth() - 1 + 2 + 7]).append(' ');  // MMM
-        CalendarUtils.sprintf0d(sb, date.getDayOfMonth(), 2).append(' '); // dd
-
-        CalendarUtils.sprintf0d(sb, date.getHours(), 2).append(':');   // HH
-        CalendarUtils.sprintf0d(sb, date.getMinutes(), 2).append(':'); // mm
-        CalendarUtils.sprintf0d(sb, date.getSeconds(), 2).append(' '); // ss
+        sb.append(date.getDayOfMonth(), 2, '0').append(' ') // dd
+          .append(date.getHours(), 2, '0').append(':') // HH
+          .append(date.getMinutes(), 2, '0').append(':') // mm
+          .append(date.getSeconds(), 2, '0').append(' '); // ss
         TimeZone zi = date.getZone();
         if (zi != null) {
             sb.append(zi.getDisplayName(date.isDaylightTime(), TimeZone.SHORT, Locale.US)); // zzz
@@ -1122,13 +1121,13 @@ public class Date
         BaseCalendar.Date date =
             (BaseCalendar.Date) cal.getCalendarDate(getTime(), (TimeZone)null);
         StringBuilder sb = new StringBuilder(32);
-        CalendarUtils.sprintf0d(sb, date.getDayOfMonth(), 1).append(' '); // d
+        sb.append(date.getDayOfMonth()).append(' '); // d
         convertToAbbr(sb, wtb[date.getMonth() - 1 + 2 + 7]).append(' ');  // MMM
-        sb.append(date.getYear()).append(' ');                            // yyyy
-        CalendarUtils.sprintf0d(sb, date.getHours(), 2).append(':');      // HH
-        CalendarUtils.sprintf0d(sb, date.getMinutes(), 2).append(':');    // mm
-        CalendarUtils.sprintf0d(sb, date.getSeconds(), 2);                // ss
-        sb.append(" GMT");                                                // ' GMT'
+        sb.append(date.getYear()).append(' ')                             // yyyy
+          .append(date.getHours(), 2, '0').append(':')                    // HH
+          .append(date.getMinutes(), 2, '0').append(':')                  // mm
+          .append(date.getSeconds(), 2, '0')                              // ss
+          .append(" GMT");                                                // ' GMT'
         return sb.toString();
     }
 

--- a/src/java.base/share/classes/sun/util/calendar/CalendarDate.java
+++ b/src/java.base/share/classes/sun/util/calendar/CalendarDate.java
@@ -386,13 +386,16 @@ public sealed abstract class CalendarDate implements Cloneable
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        CalendarUtils.sprintf0d(sb, year, 4).append('-');
-        CalendarUtils.sprintf0d(sb, month, 2).append('-');
-        CalendarUtils.sprintf0d(sb, dayOfMonth, 2).append('T');
-        CalendarUtils.sprintf0d(sb, hours, 2).append(':');
-        CalendarUtils.sprintf0d(sb, minutes, 2).append(':');
-        CalendarUtils.sprintf0d(sb, seconds, 2).append('.');
-        CalendarUtils.sprintf0d(sb, millis, 3);
+        if (year < 0) {
+            sb.append('-');
+        }
+        sb.append(Math.abs(year), 4, '0').append('-')
+          .append(month, 2, '0').append('-')
+          .append(dayOfMonth, 2, '0').append('T')
+          .append(hours, 2, '0').append(':')
+          .append(minutes, 2, '0').append(':')
+          .append(seconds, 2, '0').append('.')
+          .append(millis, 3, '0');
         if (zoneOffset == 0) {
             sb.append('Z');
         } else if (zoneOffset != FIELD_UNDEFINED) {
@@ -406,9 +409,9 @@ public sealed abstract class CalendarDate implements Cloneable
                 sign = '-';
             }
             offset /= 60000;
-            sb.append(sign);
-            CalendarUtils.sprintf0d(sb, offset / 60, 2);
-            CalendarUtils.sprintf0d(sb, offset % 60, 2);
+            sb.append(sign)
+              .append(offset / 60, 2, '0')
+              .append(offset % 60, 2, '0');
         } else {
             sb.append(" local time");
         }

--- a/src/java.base/share/classes/sun/util/calendar/CalendarUtils.java
+++ b/src/java.base/share/classes/sun/util/calendar/CalendarUtils.java
@@ -126,45 +126,4 @@ public final class CalendarUtils {
         long z = mod(x, y);
         return (z == 0) ? y : z;
     }
-
-    /**
-     * Mimics sprintf(buf, "%0*d", decaimal, width).
-     */
-    public static StringBuilder sprintf0d(StringBuilder sb, int value, int width) {
-        long d = value;
-        if (d < 0) {
-            sb.append('-');
-            d = -d;
-            --width;
-        }
-        int n = 10;
-        for (int i = 2; i < width; i++) {
-            n *= 10;
-        }
-        for (int i = 1; i < width && d < n; i++) {
-            sb.append('0');
-            n /= 10;
-        }
-        sb.append(d);
-        return sb;
-    }
-
-    public static StringBuffer sprintf0d(StringBuffer sb, int value, int width) {
-        long d = value;
-        if (d < 0) {
-            sb.append('-');
-            d = -d;
-            --width;
-        }
-        int n = 10;
-        for (int i = 2; i < width; i++) {
-            n *= 10;
-        }
-        for (int i = 1; i < width && d < n; i++) {
-            sb.append('0');
-            n /= 10;
-        }
-        sb.append(d);
-        return sb;
-    }
 }

--- a/src/java.base/share/classes/sun/util/calendar/JulianCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/JulianCalendar.java
@@ -106,10 +106,10 @@ public final class JulianCalendar extends BaseCalendar {
                     sb.append(n).append(' ');
                 }
             }
-            sb.append(getYear()).append('-');
-            CalendarUtils.sprintf0d(sb, getMonth(), 2).append('-');
-            CalendarUtils.sprintf0d(sb, getDayOfMonth(), 2);
-            sb.append(time);
+            sb.append(getYear()).append('-')
+              .append(getMonth(), 2, '0').append('-')
+              .append(getDayOfMonth(), 2, '0')
+              .append(time);
             return sb.toString();
         }
     }

--- a/src/java.base/share/classes/sun/util/calendar/LocalGregorianCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/LocalGregorianCalendar.java
@@ -131,10 +131,10 @@ public final class LocalGregorianCalendar extends BaseCalendar {
                     sb.append(abbr);
                 }
             }
-            sb.append(getYear()).append('.');
-            CalendarUtils.sprintf0d(sb, getMonth(), 2).append('.');
-            CalendarUtils.sprintf0d(sb, getDayOfMonth(), 2);
-            sb.append(time);
+            sb.append(getYear()).append('.')
+              .append(getMonth(), 2, '0').append('.')
+              .append(getDayOfMonth(), 2, '0')
+              .append(time);
             return sb.toString();
         }
     }

--- a/test/jdk/java/util/Calendar/CalendarTestScripts/CalendarAdapter.java
+++ b/test/jdk/java/util/Calendar/CalendarTestScripts/CalendarAdapter.java
@@ -370,20 +370,25 @@ public class CalendarAdapter extends Calendar {
         }
 
         sb.append(eraNames[cal.get(ERA)]);
-        if (sb.length() > 0)
+        if (sb.length() > 0) {
             sb.append(' ');
-        CalendarUtils.sprintf0d(sb, cal.get(YEAR), 4).append('-');
-        CalendarUtils.sprintf0d(sb, cal.get(MONTH)+1, 2).append('-');
-        CalendarUtils.sprintf0d(sb, cal.get(DAY_OF_MONTH), 2);
+        }
+        int year = cal.get(YEAR);
+        if (year < 0) {
+            sb.append('-');
+        }
+        sb.append(Math.abs(year), 4, '0').append('-')
+          .append(cal.get(MONTH) + 1, 2, '0').append('-')
+          .append(cal.get(DAY_OF_MONTH), 2, '0');
         return sb.toString();
     }
 
     String toTimeString() {
-        StringBuffer sb = new StringBuffer();
-        CalendarUtils.sprintf0d(sb, cal.get(HOUR_OF_DAY), 2).append(':');
-        CalendarUtils.sprintf0d(sb, cal.get(MINUTE), 2).append(':');
-        CalendarUtils.sprintf0d(sb, cal.get(SECOND),2 ).append('.');
-        CalendarUtils.sprintf0d(sb, cal.get(MILLISECOND), 3);
+        StringBuffer sb = new StringBuffer()
+                .append(get(HOUR_OF_DAY), 2, '0').append(':')
+                .append(get(MINUTE), 2, '0').append(':')
+                .append(get(SECOND), 2, '0').append('.')
+                .append(cal.get(MILLISECOND), 3, '0');
         int zoneOffset = cal.get(ZONE_OFFSET) + cal.get(DST_OFFSET);
         if (zoneOffset == 0) {
             sb.append('Z');
@@ -398,9 +403,9 @@ public class CalendarAdapter extends Calendar {
                 sign = '-';
             }
             offset /= 60000;
-            sb.append(sign);
-            CalendarUtils.sprintf0d(sb, offset / 60, 2);
-            CalendarUtils.sprintf0d(sb, offset % 60, 2);
+            sb.append(sign)
+              .append(offset / 60, 2, '0')
+              .append(offset % 60, 2, '0');
         }
         return sb.toString();
     }


### PR DESCRIPTION
In the JDK date processing code, there are many places where StringBuilder.append(int) is used to specify the width. If the width is not enough, '0' should be used for padding. This PR adds a method to StringBuilder and refactors JDK related code.

```java
public abstract class AbstractBuilder {
     public AbstractStringBuilder append(int i, int width, char pad) {
         // ...
     }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15979/head:pull/15979` \
`$ git checkout pull/15979`

Update a local copy of the PR: \
`$ git checkout pull/15979` \
`$ git pull https://git.openjdk.org/jdk.git pull/15979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15979`

View PR using the GUI difftool: \
`$ git pr show -t 15979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15979.diff">https://git.openjdk.org/jdk/pull/15979.diff</a>

</details>
