### PR TITLE
8317048: VerifyError with unnamed pattern variable and more than one components

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -907,6 +907,7 @@ public class TransPatterns extends TreeTranslator {
                 }
             } else if (currentBinding != null &&
                        commonBinding.type.tsym == currentBinding.type.tsym &&
+                       commonBinding.isUnnamedVariable() == currentBinding.isUnnamedVariable() &&
                        !previousNullable &&
                        new TreeDiffer(List.of(commonBinding), List.of(currentBinding))
                                .scan(commonNestedExpression, currentNestedExpression)) {

--- a/test/langtools/tools/javac/patterns/T8317048.java
+++ b/test/langtools/tools/javac/patterns/T8317048.java
@@ -35,7 +35,7 @@ public class T8317048 {
     record R2<T>(Integer value) implements R<T> {}
     sealed interface R<T> {}
 
-    static <T1 extends Comparable, T2 extends Comparable> int compareTo(Tuple<R<T1>, R<T2>> o) {
+    static <T1 extends Comparable, T2 extends Comparable> int meth1(Tuple<R<T1>, R<T2>> o) {
         return switch (o) {
             case Tuple<R<T1>, R<T2>>(R1<T1> _, R1<T2> _) -> -1;
             case Tuple<R<T1>, R<T2>>(R1<T1> _, R2<T2> _) -> -1;
@@ -44,7 +44,45 @@ public class T8317048 {
         };
     }
 
+    static <T1 extends Comparable, T2 extends Comparable> int meth2(Tuple<R<T1>, R<T2>> o) {
+        return switch (o) {
+            case Tuple<R<T1>, R<T2>>(R1<T1> _, R1<T2> _) -> -1;
+            case Tuple<R<T1>, R<T2>>(R1<T1> fst, R2<T2> snd) -> fst.value().compareTo(snd.value());
+            case Tuple<R<T1>, R<T2>>(R2<T1> _, R1<T2> _) -> -1;
+            case Tuple<R<T1>, R<T2>>(R2<T1> fst, R2<T2> snd) -> fst.value().compareTo(snd.value());
+        };
+    }
+
+    static <T1 extends Comparable, T2 extends Comparable> int meth3(Tuple<R<T1>, R<T2>> o) {
+        return switch (o) {
+            case Tuple<R<T1>, R<T2>>(R1<T1> fst, R1<T2> _) -> fst.value();
+            case Tuple<R<T1>, R<T2>>(R1<T1> _, R2<T2> snd) -> snd.value();
+            case Tuple<R<T1>, R<T2>>(R2<T1> _, R1<T2> _) -> -1;
+            case Tuple<R<T1>, R<T2>>(R2<T1> fst, R2<T2> snd) -> fst.value().compareTo(snd.value());
+        };
+    }
+
+    static <T1 extends Comparable, T2 extends Comparable> int meth4(Tuple<R<T1>, R<T2>> o) {
+        return switch (o) {
+            case Tuple<R<T1>, R<T2>>(R1<T1> _, R1<T2> _) -> -1;
+            case Tuple<R<T1>, R<T2>>(R1<T1> _, R2<T2> _) -> -1;
+            case Tuple<R<T1>, R<T2>>(R2<T1> fst, R2<T2> snd) -> fst.value().compareTo(snd.value());
+            case Tuple<R<T1>, R<T2>>(R2<T1> _, R1<T2> _) -> -1;
+        };
+    }
+
     public static void main(String[] args) {
-        compareTo(new Tuple<R<Integer>, R<Integer>>(new R2<>(1), new R2<>(2)));
+        assertEquals(1, meth1(new Tuple<R<Integer>, R<Integer>>(new R2<>(2), new R2<>(1))));
+        assertEquals(1, meth2(new Tuple<R<Integer>, R<Integer>>(new R1<>(2), new R2<>(1))));
+        assertEquals(0, meth2(new Tuple<R<Integer>, R<Integer>>(new R2<>(1), new R2<>(1))));
+        assertEquals(2, meth3(new Tuple<R<Integer>, R<Integer>>(new R1<>(2), new R1<>(1))));
+        assertEquals(3, meth3(new Tuple<R<Integer>, R<Integer>>(new R1<>(2), new R2<>(3))));
+        assertEquals(1, meth4(new Tuple<R<Integer>, R<Integer>>(new R2<>(2), new R2<>(1))));
+    }
+
+    static void assertEquals(int expected, int actual) {
+        if (expected != actual) {
+            throw new AssertionError("Expected: " + expected + ", but got: " + actual);
+        }
     }
 }

--- a/test/langtools/tools/javac/patterns/T8317048.java
+++ b/test/langtools/tools/javac/patterns/T8317048.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8317048
+ * @summary VerifyError with unnamed pattern variable and more than one components
+ * @enablePreview
+ * @compile T8317048.java
+ * @run main T8317048
+ */
+
+public class T8317048 {
+    record Tuple<T1, T2>(T1 first, T2 second) {}
+    record R1<T>(Integer value) implements R<T> {}
+    record R2<T>(Integer value) implements R<T> {}
+    sealed interface R<T> {}
+
+    static <T1 extends Comparable, T2 extends Comparable> int compareTo(Tuple<R<T1>, R<T2>> o) {
+        return switch (o) {
+            case Tuple<R<T1>, R<T2>>(R1<T1> _, R1<T2> _) -> -1;
+            case Tuple<R<T1>, R<T2>>(R1<T1> _, R2<T2> _) -> -1;
+            case Tuple<R<T1>, R<T2>>(R2<T1> _, R1<T2> _) -> -1;
+            case Tuple<R<T1>, R<T2>>(R2<T1> fst, R2<T2> snd) -> fst.value().compareTo(snd.value());
+        };
+    }
+
+    public static void main(String[] args) {
+        compareTo(new Tuple<R<Integer>, R<Integer>>(new R2<>(1), new R2<>(2)));
+    }
+}


### PR DESCRIPTION
There were situations when javac optimizes switch structures (by merging the head of cases recursively) when two neighboring cases have a mix of named and unnamed patterns. This resulted translation is like the following:

From this:

```
  static <T1 extends Comparable, T2 extends Comparable> int compareTo(Tuple<R<T1>, R<T2>> o) {
        return switch (o) {
            case Tuple<R<T1>, R<T2>>(R1<T1> _, R1<T2> _) -> -1;
            case Tuple<R<T1>, R<T2>>(R1<T1> _, R2<T2> _) -> -1;
            case Tuple<R<T1>, R<T2>>(R2<T1> _, R1<T2> _) -> -1;
            case Tuple<R<T1>, R<T2>>(R2<T1> fst, R2<T2> snd) -> fst.value().compareTo(snd.value());
        };
    }
```

to code like this from the deeper nested switch (sample taken from `translateTopLevelClass`):

```
...
case 1:
   if (!(let snd = (T8317048.R2)selector10$temp; in true)) {
       index$11 = 2;
       continue;
   }
   yield .value().compareTo(snd.value()); // boom, fst is missing
   break;
...
```

The reason is that in the `resolveAccumulator` we peek the first of the two to replace both, in this case the `R2<T1> _`. 

```
JCPatternCaseLabel leadingTest = 
        (JCPatternCaseLabel) accummulator.first().labels.head;
```

One way to solve this is to not merge two successive type patterns that have different namings (either both named or both unnamed).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317048](https://bugs.openjdk.org/browse/JDK-8317048): VerifyError with unnamed pattern variable and more than one components (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15983/head:pull/15983` \
`$ git checkout pull/15983`

Update a local copy of the PR: \
`$ git checkout pull/15983` \
`$ git pull https://git.openjdk.org/jdk.git pull/15983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15983`

View PR using the GUI difftool: \
`$ git pr show -t 15983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15983.diff">https://git.openjdk.org/jdk/pull/15983.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15983#issuecomment-1740665133)