### PR TITLE
8317294: Classloading throws exceptions over already pending exceptions

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -672,6 +672,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
           // Need only to be sure signature is the right type.
           if (Signature::is_method(signature)) {
             throwIllegalSignature("CONSTANT_Dynamic", name, signature, CHECK);
+            return;
           }
         }
         break;
@@ -696,6 +697,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
             // Need only to be sure signature is non-zero length and the right type.
             if (Signature::is_method(signature)) {
               throwIllegalSignature("Field", name, signature, CHECK);
+              return;
             }
           }
         } else {
@@ -705,6 +707,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
             // the right type.
             if (!Signature::is_method(signature)) {
               throwIllegalSignature("Method", name, signature, CHECK);
+              return;
             }
           }
           // If a class method name begins with '<', it must be "<init>" and have void signature.
@@ -718,6 +721,7 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
               return;
             } else if (!Signature::is_void_method(signature)) { // must have void signature.
               throwIllegalSignature("Method", name, signature, CHECK);
+              return;
             }
           }
         }
@@ -4285,6 +4289,7 @@ void ClassFileParser::check_super_class_access(const InstanceKlass* this_klass, 
           "superclass access check failed: %s",
           msg);
       }
+      return;
     }
   }
 }
@@ -4332,6 +4337,7 @@ void ClassFileParser::check_super_interface_access(const InstanceKlass* this_kla
           "superinterface check failed: %s",
           msg);
       }
+      return;
     }
   }
 }
@@ -4968,6 +4974,7 @@ void ClassFileParser::verify_legal_field_signature(const Symbol* name,
 
   if (p == nullptr || (p - bytes) != (int)length) {
     throwIllegalSignature("Field", name, signature, CHECK);
+    return;
   }
 }
 
@@ -4994,6 +5001,7 @@ void ClassFileParser::verify_legal_name_with_signature(const Symbol* name,
       sig_length > 0 &&
       signature->char_at(sig_length - 1) != JVM_SIGNATURE_VOID) {
     throwIllegalSignature("Method", name, signature, THREAD);
+    return;
   }
 }
 

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4285,7 +4285,6 @@ void ClassFileParser::check_super_class_access(const InstanceKlass* this_klass, 
           "superclass access check failed: %s",
           msg);
       }
-      return;
     }
   }
 }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4324,6 +4324,7 @@ void ClassFileParser::check_super_interface_access(const InstanceKlass* this_kla
           (same_module) ? this_klass->joint_in_module_of_loader(k) : this_klass->class_in_module_of_loader(),
           (same_module) ? "" : "; ",
           (same_module) ? "" : k->class_in_module_of_loader());
+        return;
       } else {
         // Add additional message content.
         Exceptions::fthrow(
@@ -4331,8 +4332,8 @@ void ClassFileParser::check_super_interface_access(const InstanceKlass* this_kla
           vmSymbols::java_lang_IllegalAccessError(),
           "superinterface check failed: %s",
           msg);
+        return;
       }
-      return;
     }
   }
 }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -672,7 +672,6 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
           // Need only to be sure signature is the right type.
           if (Signature::is_method(signature)) {
             throwIllegalSignature("CONSTANT_Dynamic", name, signature, CHECK);
-            return;
           }
         }
         break;
@@ -697,7 +696,6 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
             // Need only to be sure signature is non-zero length and the right type.
             if (Signature::is_method(signature)) {
               throwIllegalSignature("Field", name, signature, CHECK);
-              return;
             }
           }
         } else {
@@ -707,7 +705,6 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
             // the right type.
             if (!Signature::is_method(signature)) {
               throwIllegalSignature("Method", name, signature, CHECK);
-              return;
             }
           }
           // If a class method name begins with '<', it must be "<init>" and have void signature.
@@ -721,7 +718,6 @@ void ClassFileParser::parse_constant_pool(const ClassFileStream* const stream,
               return;
             } else if (!Signature::is_void_method(signature)) { // must have void signature.
               throwIllegalSignature("Method", name, signature, CHECK);
-              return;
             }
           }
         }
@@ -4974,7 +4970,6 @@ void ClassFileParser::verify_legal_field_signature(const Symbol* name,
 
   if (p == nullptr || (p - bytes) != (int)length) {
     throwIllegalSignature("Field", name, signature, CHECK);
-    return;
   }
 }
 
@@ -5001,7 +4996,6 @@ void ClassFileParser::verify_legal_name_with_signature(const Symbol* name,
       sig_length > 0 &&
       signature->char_at(sig_length - 1) != JVM_SIGNATURE_VOID) {
     throwIllegalSignature("Method", name, signature, THREAD);
-    return;
   }
 }
 


### PR DESCRIPTION
See the bug for reproducer. I think we are just missing `return` after throwing the previous exception in `ClassFileParser::check_super_interface_access`. So we re-enter the method again with another exception in hand and fail the assert. This path is special, because we are looping, and we really need to exit after the first exception.

It is not easy to add a regression test that pokes into super-interfaces from some JDK internals.

Additional testing:
 - [x] CTW reproducer no longer fails
 - [x] Linux AArch64 `tier1 tier2 tier3` fastdebug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317294](https://bugs.openjdk.org/browse/JDK-8317294): Classloading throws exceptions over already pending exceptions (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [2b78e5b0](https://git.openjdk.org/jdk/pull/15984/files/2b78e5b0bf7087f9a1dabbb1db05943e761b3d9b)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [2b78e5b0](https://git.openjdk.org/jdk/pull/15984/files/2b78e5b0bf7087f9a1dabbb1db05943e761b3d9b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15984/head:pull/15984` \
`$ git checkout pull/15984`

Update a local copy of the PR: \
`$ git checkout pull/15984` \
`$ git pull https://git.openjdk.org/jdk.git pull/15984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15984`

View PR using the GUI difftool: \
`$ git pr show -t 15984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15984.diff">https://git.openjdk.org/jdk/pull/15984.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15984#issuecomment-1740953401)