### PR TITLE
8317128: java/nio/file/Files/CopyAndMove.java failed with AccessDeniedException

### DIFF
--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -137,10 +137,14 @@ class CopyMoveHelper {
         if (sourceAttrs.isSymbolicLink())
             throw new IOException("Copying of symbolic links not supported");
 
+        // delete target if it exists and REPLACE_EXISTING is specified
+        if (opts.replaceExisting) {
+            Files.deleteIfExists(target);
+        } else if (Files.exists(target))
+            throw new FileAlreadyExistsException(target.toString());
+
         // create directory or copy file
         if (sourceAttrs.isDirectory()) {
-            if (opts.replaceExisting)
-                Files.deleteIfExists(target);
             Files.createDirectory(target);
         } else {
             try (InputStream in = Files.newInputStream(source)) {

--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -69,14 +69,6 @@ class CopyMoveHelper {
             }
             return result;
         }
-
-        CopyOption[] replaceExistingOrEmpty() {
-            if (replaceExisting) {
-                return new CopyOption[] { StandardCopyOption.REPLACE_EXISTING };
-            } else {
-                return new CopyOption[0];
-            }
-        }
     }
 
     /**
@@ -148,7 +140,7 @@ class CopyMoveHelper {
             Files.createDirectory(target);
         } else {
             try (InputStream in = Files.newInputStream(source)) {
-                Files.copy(in, target, opts.replaceExistingOrEmpty());
+                Files.copy(in, target);
             }
         }
 

--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -25,9 +25,13 @@
 
 package java.nio.file;
 
-import java.nio.file.attribute.*;
 import java.io.InputStream;
 import java.io.IOException;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.spi.FileSystemProvider;
 
 /**
  * Helper class to support copying or moving files when the source and target
@@ -131,6 +135,10 @@ class CopyMoveHelper {
 
         // delete target if it exists and REPLACE_EXISTING is specified
         if (opts.replaceExisting) {
+            // ensure source can be copied
+            FileSystemProvider provider = source.getFileSystem().provider();
+            provider.checkAccess(source, AccessMode.READ);
+
             Files.deleteIfExists(target);
         } else if (Files.exists(target))
             throw new FileAlreadyExistsException(target.toString());

--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -133,14 +133,14 @@ class CopyMoveHelper {
         if (sourceAttrs.isSymbolicLink())
             throw new IOException("Copying of symbolic links not supported");
 
-        // delete target if it exists and REPLACE_EXISTING is specified
-        if (opts.replaceExisting) {
-            // ensure source can be copied
-            FileSystemProvider provider = source.getFileSystem().provider();
-            provider.checkAccess(source, AccessMode.READ);
+        // ensure source can be copied
+        FileSystemProvider provider = source.getFileSystem().provider();
+        provider.checkAccess(source, AccessMode.READ);
 
+        // delete target if it exists and REPLACE_EXISTING is specified
+        if (opts.replaceExisting)
             Files.deleteIfExists(target);
-        } else if (Files.exists(target))
+        else if (Files.exists(target))
             throw new FileAlreadyExistsException(target.toString());
 
         // create directory or copy file

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsException.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import java.io.IOException;
 import static sun.nio.fs.WindowsConstants.*;
 
 /**
- * Internal exception thrown when a Win32 calls fails.
+ * Internal exception thrown when a Win32 call fails.
  */
 
 class WindowsException extends Exception {


### PR DESCRIPTION
The change #15501 removed explicit throwing of a `FileAlreadyExistsException` in `copyToForeignTarget` for non-directories when the target exists and `REPLACE_EXISTING` is not specified, instead relying on `FileChannel.open` eventually to throw this exception. The test, however, reuses the same file path, and on Windows `CreateFile`, which is invoked by `open`, can throw an `AccessDeniedException` if the file exists and has been marked for deletion but not yet actually deleted. This change proposes to reinstate explicitly throwing a FAEE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317128](https://bugs.openjdk.org/browse/JDK-8317128): java/nio/file/Files/CopyAndMove.java failed with AccessDeniedException (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15991/head:pull/15991` \
`$ git checkout pull/15991`

Update a local copy of the PR: \
`$ git checkout pull/15991` \
`$ git pull https://git.openjdk.org/jdk.git pull/15991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15991`

View PR using the GUI difftool: \
`$ git pr show -t 15991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15991.diff">https://git.openjdk.org/jdk/pull/15991.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15991#issuecomment-1741208655)