### PR TITLE
8317327 Remove JT_JAVA dead code in jib-profiles.js

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -945,10 +945,7 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_os: input.build_os,
             target_cpu: input.build_cpu,
             dependencies: [ "jtreg", "gnumake", "boot_jdk", "devkit", "jib" ],
-            labels: "test",
-            environment: {
-                "JT_JAVA": common.boot_jdk_home
-            }
+            labels: "test"
         }
     };
     profiles = concatObjects(profiles, testOnlyProfiles);


### PR DESCRIPTION
make/conf/jib-profiles.js passes JT_JAVA in the testOnlyProfiles. This can be used to control jtreg's launcher script, but we don't launch that way anymore, we launch jtreg directly using jtreg.jar. Therefore this is dead code and should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317327](https://bugs.openjdk.org/browse/JDK-8317327): Remove JT_JAVA dead code in jib-profiles.js (**Bug** - P5)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15992/head:pull/15992` \
`$ git checkout pull/15992`

Update a local copy of the PR: \
`$ git checkout pull/15992` \
`$ git pull https://git.openjdk.org/jdk.git pull/15992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15992`

View PR using the GUI difftool: \
`$ git pr show -t 15992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15992.diff">https://git.openjdk.org/jdk/pull/15992.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15992#issuecomment-1741347902)