### PR TITLE
Update the javadoc on String.format

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4380,6 +4380,8 @@ public final class String
      *          formatting errors, see the <a
      *          href="../util/Formatter.html#detail">Details</a> section of the
      *          formatter class specification.
+     *          {@link  java.lang.NullPointerException}
+     *          If a format string is null.
      *
      * @return  A formatted string
      *
@@ -4421,6 +4423,8 @@ public final class String
      *          formatting errors, see the <a
      *          href="../util/Formatter.html#detail">Details</a> section of the
      *          formatter class specification
+     *          {@link  java.lang.NullPointerException}
+     *          If a format string is null.
      *
      * @return  A formatted string
      *


### PR DESCRIPTION
`String.format(Locale.ENGLISH, null, 1); or  String.format(Locale.ENGLISH, null);`

throws NPE and I am updating the java doc. 
```
Exception in thread "main" java.lang.NullPointerException
	at java.util.regex.Matcher.getTextLength(Matcher.java:1283)
	at java.util.regex.Matcher.reset(Matcher.java:309)
	at java.util.regex.Matcher.<init>(Matcher.java:229)
	at java.util.regex.Pattern.matcher(Pattern.java:1093)
	at java.util.Formatter.parse(Formatter.java:2547)
	at java.util.Formatter.format(Formatter.java:2501)
	at java.util.Formatter.format(Formatter.java:2455)
	at java.lang.String.format(String.java:2981)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15995/head:pull/15995` \
`$ git checkout pull/15995`

Update a local copy of the PR: \
`$ git checkout pull/15995` \
`$ git pull https://git.openjdk.org/jdk.git pull/15995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15995`

View PR using the GUI difftool: \
`$ git pr show -t 15995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15995.diff">https://git.openjdk.org/jdk/pull/15995.diff</a>

</details>
