### PR TITLE
8317300: javac erroneously allows "final" in front of a record pattern

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -910,6 +910,7 @@ public class JavacParser implements Parser {
                 if (mods.annotations.nonEmpty()) {
                     log.error(mods.annotations.head.pos(), Errors.RecordPatternsAnnotationsNotAllowed);
                 }
+                checkNoMods(pos, mods.flags & Flags.FINAL);
                 new TreeScanner() {
                     @Override
                     public void visitAnnotatedType(JCAnnotatedType tree) {

--- a/test/langtools/tools/javac/patterns/T8317300.java
+++ b/test/langtools/tools/javac/patterns/T8317300.java
@@ -1,0 +1,24 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8317300
+ * @summary javac erroneously allows "final" in front of a record pattern
+ * @compile/fail/ref=T8317300.out -XDrawDiagnostics T8317300.java
+ */
+public class T8317300 {
+    record Foo (int x) {}
+    record Bar (Foo x) {}
+
+    void test1(Object obj) {
+        switch (obj) {
+            case final Foo(int x) -> {}
+            default -> {}
+        }
+    }
+
+    void test2(Object obj) {
+        switch (obj) {
+            case Bar(final Foo(int x)) -> {}
+            default -> {}
+        }
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8317300.out
+++ b/test/langtools/tools/javac/patterns/T8317300.out
@@ -1,0 +1,5 @@
+T8317300.java:13:18: compiler.err.mod.not.allowed.here: final
+T8317300.java:20:22: compiler.err.illegal.start.of.expr
+T8317300.java:20:31: compiler.err.expected: token.identifier
+T8317300.java:20:37: compiler.err.expected: ';'
+4 errors


### PR DESCRIPTION
Introduces the relevant check for `final` in record patterns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317300](https://bugs.openjdk.org/browse/JDK-8317300): javac erroneously allows "final" in front of a record pattern (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15997/head:pull/15997` \
`$ git checkout pull/15997`

Update a local copy of the PR: \
`$ git checkout pull/15997` \
`$ git pull https://git.openjdk.org/jdk.git pull/15997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15997`

View PR using the GUI difftool: \
`$ git pr show -t 15997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15997.diff">https://git.openjdk.org/jdk/pull/15997.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/15997#issuecomment-1741710838)