### PR TITLE
Add method appendHex to StringBuilder

### DIFF
--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -35,6 +35,7 @@ import java.util.Spliterator;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 import jdk.internal.util.ArraysSupport;
+import jdk.internal.util.HexDigits;
 import jdk.internal.util.Preconditions;
 
 import static java.lang.String.COMPACT_STRINGS;
@@ -841,6 +842,31 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     }
 
     /**
+     * Appends the hexadecimal string representation of the {@code int}
+     * argument to this sequence.
+     * <p>
+     * The overall effect is exactly as if the argument were converted
+     * to a string by the method {@link Integer#toHexString(int)},
+     * and the characters of that string were then
+     * {@link #append(String) appended} to this character sequence.
+     *
+     * @param   i   an {@code int}.
+     * @return  a reference to this object.
+     */
+    public AbstractStringBuilder appendHex(int i) {
+        int count = this.count;
+        int spaceNeeded = count + HexDigits.stringSize(i);
+        ensureCapacityInternal(spaceNeeded);
+        if (isLatin1()) {
+            HexDigits.getCharsLatin1(i, spaceNeeded, value);
+        } else {
+            HexDigits.getCharsUTF16(i, spaceNeeded, value);
+        }
+        this.count = spaceNeeded;
+        return this;
+    }
+
+    /**
      * Appends the string representation of the {@code long}
      * argument to this sequence.
      * <p>
@@ -860,6 +886,31 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
             StringLatin1.getChars(l, spaceNeeded, value);
         } else {
             StringUTF16.getChars(l, count, spaceNeeded, value);
+        }
+        this.count = spaceNeeded;
+        return this;
+    }
+
+    /**
+     * Appends the hexadecimal string representation of the {@code long}
+     * argument to this sequence.
+     * <p>
+     * The overall effect is exactly as if the argument were converted
+     * to a string by the method {@link Long#toHexString(long)},
+     * and the characters of that string were then
+     * {@link #append(String) appended} to this character sequence.
+     *
+     * @param   l   an {@code int}.
+     * @return  a reference to this object.
+     */
+    public AbstractStringBuilder appendHex(long l) {
+        int count = this.count;
+        int spaceNeeded = count + HexDigits.stringSize(l);
+        ensureCapacityInternal(spaceNeeded);
+        if (isLatin1()) {
+            HexDigits.getCharsLatin1(l, spaceNeeded, value);
+        } else {
+            HexDigits.getCharsUTF16(l, spaceNeeded, value);
         }
         this.count = spaceNeeded;
         return this;

--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -435,6 +435,16 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
     }
 
     /**
+     * {@inheritDoc}
+     * @since 22
+     */
+    @Override
+    public synchronized StringBuffer appendHex(int i) {
+        super.appendHex(i);
+        return this;
+    }
+
+    /**
      * @since 1.5
      */
     @Override
@@ -448,6 +458,16 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
     public synchronized StringBuffer append(long lng) {
         toStringCache = null;
         super.append(lng);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @since 22
+     */
+    @Override
+    public synchronized StringBuffer appendHex(long i) {
+        super.appendHex(i);
         return this;
     }
 

--- a/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -254,9 +254,29 @@ public final class StringBuilder
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     * @since 22
+     */
+    @Override
+    public StringBuilder appendHex(int i) {
+        super.appendHex(i);
+        return this;
+    }
+
     @Override
     public StringBuilder append(long lng) {
         super.append(lng);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @since 22
+     */
+    @Override
+    public StringBuilder appendHex(long i) {
+        super.appendHex(i);
         return this;
     }
 

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2479,6 +2479,9 @@ public final class System {
             public char getUTF16Char(byte[] bytes, int index) {
                 return StringUTF16.getChar(bytes, index);
             }
+            public void putCharUTF16(byte[] bytes, int index, int ch) {
+                StringUTF16.putChar(bytes, index, ch);
+            }
             public byte[] getBytesNoRepl(String s, Charset cs) throws CharacterCodingException {
                 return String.getBytesNoRepl(s, cs);
             }

--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -918,7 +918,7 @@ class Inet6Address extends InetAddress {
         StringBuilder sb = new StringBuilder(39);
         for (int i = 0; i < (INADDRSZ / INT16SZ); i++) {
             sb.appendHex(((src[i<<1]<<8) & 0xff00)
-                                          | (src[(i<<1)+1] & 0xff));
+                        | (src[(i<<1)+1] & 0xff));
             if (i < (INADDRSZ / INT16SZ) -1 ) {
                sb.append(":");
             }

--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -917,8 +917,8 @@ class Inet6Address extends InetAddress {
     static String numericToTextFormat(byte[] src) {
         StringBuilder sb = new StringBuilder(39);
         for (int i = 0; i < (INADDRSZ / INT16SZ); i++) {
-            sb.append(Integer.toHexString(((src[i<<1]<<8) & 0xff00)
-                                          | (src[(i<<1)+1] & 0xff)));
+            sb.appendHex(((src[i<<1]<<8) & 0xff00)
+                                          | (src[(i<<1)+1] & 0xff));
             if (i < (INADDRSZ / INT16SZ) -1 ) {
                sb.append(":");
             }

--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -757,9 +757,9 @@ public final class SocketPermission extends Permission
             StringBuilder sb = new StringBuilder(39);
 
             for (int i = 15; i >= 0; i--) {
-                sb.append(Integer.toHexString(((addr[i]) & 0x0f)));
+                sb.appendHex(((addr[i]) & 0x0f));
                 sb.append('.');
-                sb.append(Integer.toHexString(((addr[i] >> 4) & 0x0f)));
+                sb.appendHex(((addr[i] >> 4) & 0x0f));
                 sb.append('.');
             }
             authHost = "auth." + sb.toString() + "IP6.ARPA";

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -354,6 +354,15 @@ public interface JavaLangAccess {
     char getUTF16Char(byte[] bytes, int index);
 
     /**
+     * Put the char at index in a byte[] in internal UTF-16 representation,
+     * with no bounds checks.
+     *
+     * @param bytes the UTF-16 encoded bytes
+     * @param index of the char to retrieve, 0 <= index < (bytes.length >> 1)
+     */
+    void putCharUTF16(byte[] bytes, int index, int ch);
+
+    /**
      * Encode the given string into a sequence of bytes using utf8.
      *
      * @param s the string to encode

--- a/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
+++ b/src/java.base/share/classes/jdk/internal/icu/text/BidiBase.java
@@ -4704,10 +4704,10 @@ public class BidiBase {
             buf.append(']');
         }
         buf.append(" text: [0x");
-        buf.append(Integer.toHexString(text[0]));
+        buf.appendHex(text[0]);
         for (int i = 1; i < text.length; i++) {
             buf.append(" 0x");
-            buf.append(Integer.toHexString(text[i]));
+            buf.appendHex(text[i]);
         }
         buf.append("]]");
 

--- a/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/Textifier.java
+++ b/src/java.base/share/classes/jdk/internal/org/objectweb/asm/util/Textifier.java
@@ -1414,7 +1414,7 @@ public class Textifier extends Printer {
       */
     protected void appendHandle(final Handle handle) {
         int tag = handle.getTag();
-        stringBuilder.append("// handle kind 0x").append(Integer.toHexString(tag)).append(" : ");
+        stringBuilder.append("// handle kind 0x").appendHex(tag).append(" : ");
         boolean isMethodHandle = false;
         switch (tag) {
             case Opcodes.H_GETFIELD:

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileKey.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileKey.java
@@ -57,7 +57,7 @@ class UnixFileKey {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("(dev=")
-          .append(Long.toHexString(st_dev))
+          .appendHex(st_dev)
           .append(",ino=")
           .append(st_ino)
           .append(')');

--- a/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/KeyEvent.java
@@ -1911,7 +1911,7 @@ public non-sealed class KeyEvent extends InputEvent {
         str.append(",rawCode=").append(rawCode);
         str.append(",primaryLevelUnicode=").append(primaryLevelUnicode);
         str.append(",scancode=").append(scancode);
-        str.append(",extendedKeyCode=0x").append(Long.toHexString(extendedKeyCode));
+        str.append(",extendedKeyCode=0x").appendHex(extendedKeyCode);
 
         return str.toString();
     }

--- a/src/java.desktop/share/classes/javax/swing/GroupLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/GroupLayout.java
@@ -1243,7 +1243,7 @@ public class GroupLayout implements LayoutManager2 {
                     ", matches=" + paddingSpring.getMatchDescription();
         }
         sb.append(indent).append(spring.getClass().getName()).append(' ')
-                .append(Integer.toHexString(spring.hashCode())).append(' ')
+                .appendHex(spring.hashCode()).append(' ')
                 .append(origin).append(", size=").append(spring.getSize())
                 .append(", alignment=").append(spring.getAlignment())
                 .append(" prefs=[").append(spring.getMinimumSize(axis))

--- a/src/java.desktop/share/classes/sun/font/StandardGlyphVector.java
+++ b/src/java.desktop/share/classes/sun/font/StandardGlyphVector.java
@@ -1838,7 +1838,7 @@ public class StandardGlyphVector extends GlyphVector {
                 if (i > 0) {
                     buf.append(", ");
                 }
-                buf.append(Integer.toHexString(glyphs[i]));
+                buf.appendHex(glyphs[i]);
             }
             buf.append("]");
             if (positions != null) {

--- a/src/java.desktop/share/classes/sun/font/StandardTextSource.java
+++ b/src/java.desktop/share/classes/sun/font/StandardTextSource.java
@@ -204,7 +204,7 @@ final class StandardTextSource extends TextSource {
       if (i > chStart) {
         sb.append(" ");
       }
-      sb.append(Integer.toHexString(chars[i]));
+      sb.appendHex(chars[i]);
     }
     sb.append("\"");
     sb.append(", level:");

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -1638,15 +1638,15 @@ public class SwingUtilities2 {
             if (fg.getRed() < 16) {
                 rule.append('0');
             }
-            rule.append(Integer.toHexString(fg.getRed()));
+            rule.appendHex(fg.getRed());
             if (fg.getGreen() < 16) {
                 rule.append('0');
             }
-            rule.append(Integer.toHexString(fg.getGreen()));
+            rule.appendHex(fg.getGreen());
             if (fg.getBlue() < 16) {
                 rule.append('0');
             }
-            rule.append(Integer.toHexString(fg.getBlue()));
+            rule.appendHex(fg.getBlue());
             rule.append(" ; ");
         }
         rule.append(" }");

--- a/src/java.security.jgss/share/classes/sun/security/jgss/GSSHeader.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/GSSHeader.java
@@ -332,8 +332,8 @@ public class GSSHeader {
             int b1 = (bytes[i] >> 4) & 0x0f;
             int b2 = bytes[i] & 0x0f;
 
-            sb.append(Integer.toHexString(b1));
-            sb.append(Integer.toHexString(b2));
+            sb.appendHex(b1);
+            sb.appendHex(b2);
             sb.append(' ');
         }
         return sb.toString();

--- a/src/java.security.jgss/share/classes/sun/security/jgss/GSSToken.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/GSSToken.java
@@ -216,8 +216,8 @@ public abstract class GSSToken {
             int b1 = (bytes[i]>>4) & 0x0f;
             int b2 = bytes[i] & 0x0f;
 
-            sb.append(Integer.toHexString(b1));
-            sb.append(Integer.toHexString(b2));
+            sb.appendHex(b1);
+            sb.appendHex(b2);
             sb.append(' ');
         }
         return sb.toString();

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5Context.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5Context.java
@@ -1347,8 +1347,8 @@ class Krb5Context implements GSSContextSpi {
             int b1 = (bytes[i]>>4) & 0x0f;
             int b2 = bytes[i] & 0x0f;
 
-            sb.append(Integer.toHexString(b1));
-            sb.append(Integer.toHexString(b2));
+            sb.appendHex(b1);
+            sb.appendHex(b2);
             sb.append(' ');
         }
         return sb.toString();

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/EncTicketPart.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/EncTicketPart.java
@@ -123,8 +123,8 @@ public class EncTicketPart {
             int b1 = (bytes[i] >> 4) & 0x0f;
             int b2 = bytes[i] & 0x0f;
 
-            sb.append(Integer.toHexString(b1));
-            sb.append(Integer.toHexString(b2));
+            sb.appendHex(b1);
+            sb.appendHex(b2);
             sb.append(' ');
         }
         return sb.toString();

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/DkCrypto.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/dk/DkCrypto.java
@@ -641,7 +641,7 @@ public abstract class DkCrypto {
 
         for (int i = 0; i < digest.length; i++) {
             if ((digest[i] & 0x000000ff) < 0x10) {
-                digestString.append('0').append(Integer.toHexString(digest[i] & 0x000000ff));
+                digestString.append('0').appendHex(digest[i] & 0x000000ff);
             } else {
                 digestString.append(
                     Integer.toHexString(digest[i] & 0x000000ff));

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Base.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/CramMD5Base.java
@@ -197,7 +197,7 @@ abstract class CramMD5Base {
 
         for (i = 0; i < digest.length; i++) {
             if ((digest[i] & 0x000000ff) < 0x10) {
-                digestString.append('0').append(Integer.toHexString(digest[i] & 0x000000ff));
+                digestString.append('0').appendHex(digest[i] & 0x000000ff);
             } else {
                 digestString.append(
                     Integer.toHexString(digest[i] & 0x000000ff));

--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Base.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/digest/DigestMD5Base.java
@@ -391,7 +391,7 @@ abstract class DigestMD5Base extends AbstractSaslImpl {
 
         for (int i = 0; i < digest.length; i ++) {
             if ((digest[i] & 0x000000ff) < 0x10) {
-                digestString.append('0').append(Integer.toHexString(digest[i] & 0x000000ff));
+                digestString.append('0').appendHex(digest[i] & 0x000000ff);
             } else {
                 digestString.append(
                     Integer.toHexString(digest[i] & 0x000000ff));

--- a/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/RFC2253Parser.java
+++ b/src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/RFC2253Parser.java
@@ -317,7 +317,7 @@ public class RFC2253Parser {
             while ((i = sr.read()) > -1) {
                 if (i < 32) {
                     sb.append('\\');
-                    sb.append(Integer.toHexString(i));
+                    sb.appendHex(i);
                 } else {
                     sb.append((char) i);
                 }

--- a/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/patterns/StepPattern.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/patterns/StepPattern.java
@@ -858,7 +858,7 @@ public class StepPattern extends NodeTest implements SubContextList, ExpressionO
       }
       else
       {
-        buf.append('?').append(Integer.toHexString(pat.m_whatToShow));
+        buf.append('?').appendHex(pat.m_whatToShow);
       }
 
       if (null != pat.m_predicates)

--- a/test/jdk/java/lang/StringBuffer/AppendHex.java
+++ b/test/jdk/java/lang/StringBuffer/AppendHex.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @test
+ * @summary Test StringBuilder.appendHex sanity tests
+ * @run testng/othervm -XX:-CompactStrings AppendHex
+ * @run testng/othervm -XX:+CompactStrings AppendHex
+ */
+@Test
+public class AppendHex {
+    public void appendHex() {
+        int[] ints = new int[] {
+                0x1,
+                0x12,
+                0x123,
+                0x1234,
+                0x12345,
+                0x123456,
+                0x1234567,
+                0x12345678
+        };
+        for (int i = 0; i < ints.length; i++) {
+            int v = ints[i];
+            assertEquals(
+                    Integer.toHexString(v),
+                    new StringBuilder().appendHex(v).toString());
+
+            // utf16
+            String prefix = "\u8336";
+            assertEquals(
+                    prefix + Integer.toHexString(v),
+                    new StringBuilder(prefix).appendHex(v).toString());
+        }
+
+        long[] longs = new long[] {
+                0x1,
+                0x12,
+                0x123,
+                0x1234,
+                0x12345,
+                0x123456,
+                0x1234567,
+                0x12345678,
+                0x123456789L,
+                0x123456789aL,
+                0x123456789abL,
+                0x123456789abcL,
+                0x123456789abcdL,
+                0x123456789abcdeL,
+                0x123456789abcdefL,
+                0x123456789abcdef1L,
+        };
+        for (int i = 0; i < longs.length; i++) {
+            long v = longs[i];
+            assertEquals(
+                    Long.toHexString(v),
+                    new StringBuilder().appendHex(v).toString());
+
+            // utf16
+            String prefix = "\u8336";
+            assertEquals(
+                    prefix + Long.toHexString(v),
+                    new StringBuilder(prefix).appendHex(v).toString());
+        }
+    }
+}

--- a/test/jdk/java/lang/StringBuilder/AppendHex.java
+++ b/test/jdk/java/lang/StringBuilder/AppendHex.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @test
+ * @summary Test StringBuilder.appendHex sanity tests
+ * @run testng/othervm -XX:-CompactStrings AppendHex
+ * @run testng/othervm -XX:+CompactStrings AppendHex
+ */
+@Test
+public class AppendHex {
+    public void appendHex() {
+        int[] ints = new int[] {
+                0x1,
+                0x12,
+                0x123,
+                0x1234,
+                0x12345,
+                0x123456,
+                0x1234567,
+                0x12345678
+        };
+        for (int i = 0; i < ints.length; i++) {
+            int v = ints[i];
+            assertEquals(
+                    Integer.toHexString(v),
+                    new StringBuilder().appendHex(v).toString());
+
+            // utf16
+            String prefix = "\u8336";
+            assertEquals(
+                    prefix + Integer.toHexString(v),
+                    new StringBuilder(prefix).appendHex(v).toString());
+        }
+
+        long[] longs = new long[] {
+                0x1,
+                0x12,
+                0x123,
+                0x1234,
+                0x12345,
+                0x123456,
+                0x1234567,
+                0x12345678,
+                0x123456789L,
+                0x123456789aL,
+                0x123456789abL,
+                0x123456789abcL,
+                0x123456789abcdL,
+                0x123456789abcdeL,
+                0x123456789abcdefL,
+                0x123456789abcdef1L,
+        };
+        for (int i = 0; i < longs.length; i++) {
+            long v = longs[i];
+            assertEquals(
+                    Long.toHexString(v),
+                    new StringBuilder().appendHex(v).toString());
+
+            // utf16
+            String prefix = "\u8336";
+            assertEquals(
+                    prefix + Long.toHexString(v),
+                    new StringBuilder(prefix).appendHex(v).toString());
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -224,6 +224,33 @@ public class StringBuilders {
         return result.toString();
     }
 
+    @Benchmark
+    public String appendHexCombine8() {
+        StringBuilder result = new StringBuilder();
+        result.append(Integer.toHexString(2048));
+        result.append(Integer.toHexString(31337));
+        result.append(Integer.toHexString(0xbeefcace));
+        result.append(Integer.toHexString(9000));
+        result.append(Integer.toHexString(4711));
+        result.append(Integer.toHexString(1337));
+        result.append(Integer.toHexString(2100));
+        result.append(Integer.toHexString(2600));
+        return result.toString();
+    }
+
+    @Benchmark
+    public String appendHex8() {
+        StringBuilder result = new StringBuilder();
+        result.appendHex(2048);
+        result.appendHex(31337);
+        result.appendHex(0xbeefcace);
+        result.appendHex(9000);
+        result.appendHex(4711);
+        result.appendHex(1337);
+        result.appendHex(2100);
+        result.appendHex(2600);
+        return result.toString();
+    }
 
     @Benchmark
     public String toStringCharWithBool8() {


### PR DESCRIPTION
There are a lot of append(Integer.toHexString(x)) codes in the JDK. Adding methods StringBuilder#appendHex(int) and StringBuilder.appendHex(long) can reduce these repeated codes. This method is not only useful internally to the JDK, but also to users.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/15998/head:pull/15998` \
`$ git checkout pull/15998`

Update a local copy of the PR: \
`$ git checkout pull/15998` \
`$ git pull https://git.openjdk.org/jdk.git pull/15998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15998`

View PR using the GUI difftool: \
`$ git pr show -t 15998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/15998.diff">https://git.openjdk.org/jdk/pull/15998.diff</a>

</details>
