### PR TITLE
8317335: Build on windows fails after 8316645

### DIFF
--- a/test/hotspot/gtest/runtime/test_atomic.cpp
+++ b/test/hotspot/gtest/runtime/test_atomic.cpp
@@ -151,7 +151,7 @@ struct AtomicCmpxchg1ByteStressSupport {
   int  _base;
   char _array[7+32+7];
 
-  AtomicCmpxchg1ByteStressSupport() : _default_val(0xaa), _base(7), _array{} {}
+  AtomicCmpxchg1ByteStressSupport() : _default_val(0x7a), _base(7), _array{} {}
 
   void validate(char val, char val2, int index) {
     for (int i = 0; i < 7; i++) {


### PR DESCRIPTION
Please review this trivial change that fixes a build failure with Visual
Studio in Oracle's CI. The failure is a constant truncation warning because
the constant initial value of a `char` member is 0xaa, which is out of range
for a signed 8bit char. This change uses 0x7a as the initial value, which is
in the required range.

Note that the problem code successfully builds in GitHub Actions.  I don't
know why we're seeing this problem in Oracle's CI but not GA; perhaps a
difference in compiler versions?

Testing:
mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317335](https://bugs.openjdk.org/browse/JDK-8317335): Build on windows fails after 8316645 (**Bug** - P1)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16000/head:pull/16000` \
`$ git checkout pull/16000`

Update a local copy of the PR: \
`$ git checkout pull/16000` \
`$ git pull https://git.openjdk.org/jdk.git pull/16000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16000`

View PR using the GUI difftool: \
`$ git pr show -t 16000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16000.diff">https://git.openjdk.org/jdk/pull/16000.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16000#issuecomment-1742183219)