### PR TITLE
8317336: Assertion error thrown during 'this' escape analysis

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
@@ -1100,7 +1100,7 @@ class ThisEscapeAnalyzer extends TreeScanner {
             // Perform action
             Assert.check(checkInvariants(true, false));
             action.run();
-            Assert.check(checkInvariants(true, promote));
+            Assert.check(checkInvariants(true, true));
 
             // "Promote" ExprRef's to the enclosing lexical scope, if requested
             if (promote) {

--- a/test/langtools/tools/javac/warnings/ThisEscape.java
+++ b/test/langtools/tools/javac/warnings/ThisEscape.java
@@ -601,4 +601,11 @@ public class ThisEscape {
         public static final class Sub2 extends ThisEscapeSealed {
         }
     }
+
+    // Verify no assertion error occurs (JDK-8317336)
+    public static class ThisAssertionError {
+        public ThisAssertionError() {
+            System.out.println((Supplier<Object>)() -> this);
+        }
+    }
 }


### PR DESCRIPTION
The 'this' escape analyzer was assuming that lambas could always be treated like blocks, in the sense that we can assume a block can never end in a plain expression. This assumption is not true for lambda's of the form `() -> foo` which do exactly that. In the case that `foo` was `this`, an assertion failure would ensue.

This patch relaxes this invariant check to allow for this case.