### PR TITLE
8314258: checked_cast doesn't properly check some cases

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -274,7 +274,7 @@ ClassFileStream* ClassPathDirEntry::open_stream(JavaThread* current, const char*
         // bootloader so we have control of this.
         // Resource allocated
         return new ClassFileStream(buffer,
-                                   checked_cast<int>(st.st_size),
+                                   checked_cast<int, true>(st.st_size),
                                    _dir,
                                    ClassFileStream::verify);
       }

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -112,7 +112,7 @@ public:
   void write_on(CompressedWriteStream* stream) {
     stream->write_int(value());
     if(is_callee_saved() || is_derived_oop()) {
-      stream->write_int(checked_cast<int>(content_reg()->value()));
+      stream->write_int(content_reg()->value());
     }
   }
 

--- a/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
@@ -189,7 +189,8 @@ public:
     // A table with the new size should be at most filled by this factor. Otherwise
     // we would grow again quickly.
     const float WantedLoadFactor = 0.5;
-    size_t min_expected_size = checked_cast<size_t>(ceil(current_size / WantedLoadFactor));
+    assert((current_size / WantedLoadFactor) <= SIZE_MAX, "table overflow");
+    size_t min_expected_size = current_size / WantedLoadFactor;
 
     size_t result = Log2DefaultNumBuckets;
     if (min_expected_size != 0) {

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -709,7 +709,7 @@ void MutableNUMASpace::LGRPSpace::scan_pages(size_t page_size, size_t page_count
 
   os::page_info page_expected, page_found;
   page_expected.size = page_size;
-  page_expected.lgrp_id = checked_cast<uint>(lgrp_id());
+  page_expected.lgrp_id = lgrp_id();
 
   char *s = scan_start;
   while (s < scan_end) {

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1236,7 +1236,7 @@ void PhaseIdealLoop::transform_long_range_checks(int stride_con, const Node_List
   set_ctrl(int_zero, this->C->root());
   Node* long_one = _igvn.longcon(1);
   set_ctrl(long_one, this->C->root());
-  Node* int_stride = _igvn.intcon(checked_cast<int>(stride_con));
+  Node* int_stride = _igvn.intcon(stride_con);
   set_ctrl(int_stride, this->C->root());
 
   for (uint i = 0; i < range_checks.size(); i++) {

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1081,7 +1081,7 @@ protected:
       objArrayOop cache = CacheType::cache(ik);
       assert(cache->length() > 0, "Empty cache");
       _low = BoxType::value(cache->obj_at(0));
-      _high = checked_cast<PrimitiveType>(_low + cache->length() - 1);
+      _high = checked_cast<PrimitiveType, true>(_low + cache->length() - 1);
       _cache = JNIHandles::make_global(Handle(thread, cache));
     }
   }
@@ -1100,7 +1100,7 @@ public:
   }
   oop lookup(PrimitiveType value) {
     if (_low <= value && value <= _high) {
-      int offset = checked_cast<int>(value - _low);
+      int offset = checked_cast<int, true>(value - _low);
       return objArrayOop(JNIHandles::resolve_non_null(_cache))->obj_at(offset);
     }
     return nullptr;

--- a/src/hotspot/share/utilities/align.hpp
+++ b/src/hotspot/share/utilities/align.hpp
@@ -72,7 +72,7 @@ constexpr T align_down(T size, A alignment) {
 
 template<typename T, typename A, ENABLE_IF(std::is_integral<T>::value)>
 constexpr T align_up(T size, A alignment) {
-  T adjusted = checked_cast<T>(size + alignment_mask(alignment));
+  T adjusted = checked_cast<T, true>(size + alignment_mask(alignment));
   return align_down(adjusted, alignment);
 }
 

--- a/src/hotspot/share/utilities/checkedCast.hpp
+++ b/src/hotspot/share/utilities/checkedCast.hpp
@@ -25,22 +25,177 @@
 #ifndef SHARE_UTILITIES_CHECKEDCAST_HPP
 #define SHARE_UTILITIES_CHECKEDCAST_HPP
 
+#include "metaprogramming/enableIf.hpp"
 #include "utilities/debug.hpp"
+#include "utilities/macros.hpp"
+#include <limits>
+#include <type_traits>
 
-// In many places we've added C-style casts to silence compiler
-// warnings, for example when truncating a size_t to an int when we
-// know the size_t is a small struct. Such casts are risky because
-// they effectively disable useful compiler warnings. We can make our
-// lives safer with this function, which ensures that any cast is
-// reversible without loss of information. It doesn't check
-// everything: it isn't intended to make sure that pointer types are
-// compatible, for example.
-template <typename T2, typename T1>
-constexpr T2 checked_cast(T1 thing) {
-  T2 result = static_cast<T2>(thing);
-  assert(static_cast<T1>(result) == thing, "must be");
-  return result;
+// Implementation support for checked_cast.
+//
+// Because of details of C++ conversion rules, including undefined or
+// implementation-defined behavior in some cases, along with the possibility
+// of tautological comparison warnings from some compilers, the implementation
+// is not as simple as doing the obvious range checks.
+class CheckedCastImpl {
+  template<typename To, typename From, bool permit_tautology>
+  struct CheckSameSign;
+
+  template<typename To, typename From, bool permit_tautology,
+           bool is_narrowing = (sizeof(To) <= sizeof(From))>
+  struct CheckToSigned;
+
+  template<typename To, typename From, bool permit_tautology,
+           bool is_narrowing = (sizeof(To) < sizeof(From))>
+  struct CheckFromSigned;
+
+  template<typename To, typename From>
+  static constexpr bool check_range(From from) {
+    To to_max = std::numeric_limits<To>::max();
+    return from <= static_cast<From>(to_max);
+  }
+
+  template<typename To, typename From, bool permit_tautology>
+  struct Dispatcher {
+    static const bool to_signed = std::is_signed<To>::value;
+    static const bool from_signed = std::is_signed<From>::value;
+    using SameSign = CheckSameSign<To, From, permit_tautology>;
+    using ToSigned = CheckToSigned<To, From, permit_tautology>;
+    using FromSigned = CheckFromSigned<To, From, permit_tautology>;
+    using type =
+      std::conditional_t<(to_signed == from_signed),
+                         SameSign,
+                         std::conditional_t<to_signed, ToSigned, FromSigned>>;
+  };
+
+public:
+  template<typename To, typename From>
+  static constexpr bool is_tautology() {
+    using Dispatcher = Dispatcher<To, From, true>;
+    using Checker = typename Dispatcher::type;
+    return Checker::is_tautology;
+  }
+
+  template<typename To, bool permit_tautology, typename From>
+  static constexpr bool check(From from) {
+    using Dispatcher = Dispatcher<To, From, permit_tautology>;
+    using Checker = typename Dispatcher::type;
+    return Checker()(from);
+  }
+};
+
+// If both types are signed or both are unsigned, only a narrowing conversion
+// can lose information.  We check for such loss via a round-trip conversion.
+// C++14 4.7 defines the result for unsigned types, and implementation-defined
+// for signed types.  All supported implementations do the "obvious" discard
+// of high-order bits when narrowing signed values, and C++20 requires that
+// behavior.  This approach avoids any additional complexity to avoid
+// potential tautological comparisons.
+template<typename To, typename From, bool permit_tautology>
+struct CheckedCastImpl::CheckSameSign {
+  static const bool is_narrowing = sizeof(To) < sizeof(From);
+  static const bool is_tautology = !is_narrowing;
+  static_assert(permit_tautology || is_narrowing, "tautological checked_cast");
+  constexpr bool operator()(From from) const {
+    return !is_narrowing || (static_cast<From>(static_cast<To>(from)) == from);
+  }
+};
+
+// Conversion from unsigned to signed is okay if value <= To's max.
+template<typename To, typename From, bool permit_tautology>
+struct CheckedCastImpl::CheckToSigned<To, From, permit_tautology, true /* is_narrowing */> {
+  static const bool is_tautology = false;
+  constexpr bool operator()(From from) const {
+    return check_range<To>(from);
+  }
+};
+
+// Avoid tautological comparison when not narrowing.
+template<typename To, typename From, bool permit_tautology>
+struct CheckedCastImpl::CheckToSigned<To, From, permit_tautology, false /* is_narrowing */> {
+  static const bool is_tautology = true;
+  static_assert(permit_tautology, "tautological checked_cast");
+  constexpr bool operator()(From from) const {
+    return true;
+  }
+};
+
+// Conversion from signed to unsigned is okay when 0 <= value <= To's max.
+template<typename To, typename From, bool permit_tautology>
+struct CheckedCastImpl::CheckFromSigned<To, From, permit_tautology, true /* is_narrowing */> {
+  static const bool is_tautology = false;
+  constexpr bool operator()(From from) const {
+    return (from >= 0) && check_range<To>(from);
+  }
+};
+
+// Avoid tautological comparison when not narrowing.
+template<typename To, typename From, bool permit_tautology>
+struct CheckedCastImpl::CheckFromSigned<To, From, permit_tautology, false /* is_narrowing */> {
+  static const bool is_tautology = false;
+  constexpr bool operator()(From from) const {
+    return (from >= 0);
+  }
+};
+
+/**
+ * Convert an integral value to another integral type via static_cast, after a
+ * debug-only check that the value is within the range for the destination
+ * type.
+ *
+ * * To is the desired result type, which must be integral.
+ *
+ * * From is the type of the argument, which must be integral.
+ *
+ * * permit_tautology determines the behavior when a conversion will
+ * always succeed because the range of values for the From type is enclosed by
+ * the range of values for the To type.  If true, the conversion will be
+ * performed as requested.  If false, a compile-time error is produced.  The
+ * default is false for 64bit platforms, true for 32bit platforms.
+ *
+ * * from is the value to be converted.
+ *
+ * Unnecessary checked_casts make code harder to understand.  Hence the
+ * compile-time failure for tautological conversions, to alert that a code
+ * change is making a checked_cast unnecessary.  This can be suppressed on a
+ * per-call basis, because there are cases where a conversion might only
+ * sometimes be tautological.  For example, the types involved may vary by
+ * platform.  Another case is if the operation is in a template with dependent
+ * types, with the operation only being tautological for some instantiations.
+ * Suppressing the tautology check is an alternative to possibly complex
+ * metaprogramming to only perform the checked_cast when necessary.
+ *
+ * Despite that, for 32bit platforms the default is to not reject unnecessary
+ * checked_casts.  This is because 64bit platforms are the primary target, and
+ * are likely to require conversions in some places.  However, some of those
+ * conversions will be tautological on 32bit platforms.
+ */
+template<typename To,
+         bool permit_tautology = LP64_ONLY(false) NOT_LP64(true),
+         typename From,
+         ENABLE_IF(std::is_integral<To>::value),
+         ENABLE_IF(std::is_integral<From>::value)>
+constexpr To checked_cast(From from) {
+  assert((CheckedCastImpl::check<To, permit_tautology>(from)), "checked_cast failed");
+  return static_cast<To>(from);
+}
+
+/**
+ * Convert an enumerator to an integral value via static_cast, after a
+ * debug-only check that the value is within the range for the destination
+ * type.  This is mostly for compatibility with old code.  Class scoped enums
+ * were used to work around ancient compilers that didn't implement class
+ * scoped static integral constants properly, and HotSpot code still has many
+ * examples of this.  For others it might be sufficient to provide an explicit
+ * underlying type and either permit implicit conversions or use
+ * PrimitiveConversion::cast.
+ */
+template<typename To, typename From,
+         ENABLE_IF(std::is_integral<To>::value),
+         ENABLE_IF(std::is_enum<From>::value)>
+constexpr To checked_cast(From from) {
+  using U = std::underlying_type_t<From>;
+  return checked_cast<To, true /* permit_tautology */>(static_cast<U>(from));
 }
 
 #endif // SHARE_UTILITIES_CHECKEDCAST_HPP
-

--- a/src/hotspot/share/utilities/population_count.hpp
+++ b/src/hotspot/share/utilities/population_count.hpp
@@ -65,7 +65,8 @@ inline unsigned population_count(T x) {
   // The preceding multiply by z_ones is the only place where the intermediate
   // calculations can exceed the range of T. We need to discard any such excess
   // before the right-shift, hence the conversion back to T.
-  return checked_cast<unsigned>(static_cast<T>(r) >> (((sizeof(T) - 1) * BitsPerByte)));
+  T result = static_cast<T>(r) >> ((sizeof(T) - 1) * BitsPerByte);
+  return static_cast<unsigned>(result); // Safe potentially narrowing conversion.
 }
 
 #endif // SHARE_UTILITIES_POPULATION_COUNT_HPP

--- a/test/hotspot/gtest/utilities/test_checkedCast.cpp
+++ b/test/hotspot/gtest/utilities/test_checkedCast.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "utilities/checkedCast.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include <limits>
+#include <type_traits>
+#include "unittest.hpp"
+
+// Enable gcc warnings to verify we don't get any of these.
+// Eventually we plan to have these globally enabled, but not there yet.
+#ifdef __GNUC__
+#pragma GCC diagnostic warning "-Wconversion"
+#pragma GCC diagnostic warning "-Wsign-conversion"
+#endif
+
+template<typename To, typename From>
+static constexpr bool is_tautology() {
+  return CheckedCastImpl::is_tautology<To, From>();
+}
+
+template<typename To, typename From>
+static constexpr bool check_normal(From from) {
+  return !is_tautology<To, From>() && CheckedCastImpl::check<To, false>(from);
+}
+
+template<typename To, typename From>
+static constexpr bool check_tautological(From from) {
+  return is_tautology<To, From>() && CheckedCastImpl::check<To, true>(from);
+}
+
+template<typename T>
+struct TestCheckedCastValues {
+  static TestCheckedCastValues values;
+
+  T minus_one = static_cast<T>(-1);
+  T zero = static_cast<T>(0);
+  T one = static_cast<T>(1);
+  T min = std::numeric_limits<T>::min();
+  T max = std::numeric_limits<T>::max();
+};
+
+template<typename T>
+TestCheckedCastValues<T> TestCheckedCastValues<T>::values{};
+
+template<typename Small, typename Large>
+struct TestCheckedCastSmallAsLargeValues {
+  static TestCheckedCastSmallAsLargeValues values;
+
+  Large min = static_cast<Large>(std::numeric_limits<Small>::min());
+  Large max = static_cast<Large>(std::numeric_limits<Small>::max());
+};
+
+template<typename Small, typename Large>
+TestCheckedCastSmallAsLargeValues<Small, Large>
+TestCheckedCastSmallAsLargeValues<Small, Large>::values{};
+
+//////////////////////////////////////////////////////////////////////////////
+// Checked casts between integral types of different sizes.
+// Test narrowing to verify checking.
+// Test widening to verify no compiler warnings for tautological comparisons.
+
+template<typename Small, typename Large>
+struct TestCheckedCastIntegerValues {
+  static TestCheckedCastIntegerValues values;
+
+  TestCheckedCastValues<Small> small;
+  TestCheckedCastValues<Large> large;
+  TestCheckedCastSmallAsLargeValues<Small, Large> small_as_large;
+};
+
+template<typename Small, typename Large>
+TestCheckedCastIntegerValues<Small, Large>
+TestCheckedCastIntegerValues<Small, Large>::values{};
+
+TEST(TestCheckedCast, signed_integers) {
+  using T32 = int32_t;
+  using T64 = int64_t;
+  using Values = TestCheckedCastIntegerValues<T32, T64>;
+  const Values& values = Values::values;
+
+  EXPECT_TRUE(check_normal<T32>(values.large.minus_one));
+  EXPECT_TRUE(check_normal<T32>(values.large.zero));
+  EXPECT_TRUE(check_normal<T32>(values.large.one));
+  EXPECT_FALSE(check_normal<T32>(values.large.min));
+  EXPECT_FALSE(check_normal<T32>(values.large.max));
+  EXPECT_TRUE(check_normal<T32>(values.small_as_large.min));
+  EXPECT_TRUE(check_normal<T32>(values.small_as_large.max));
+
+  EXPECT_TRUE(check_tautological<T64>(values.small.minus_one));
+  EXPECT_TRUE(check_tautological<T64>(values.small.zero));
+  EXPECT_TRUE(check_tautological<T64>(values.small.one));
+  EXPECT_TRUE(check_tautological<T64>(values.small.min));
+  EXPECT_TRUE(check_tautological<T64>(values.small.max));
+  EXPECT_TRUE(check_tautological<T64>(values.small_as_large.min));
+  EXPECT_TRUE(check_tautological<T64>(values.small_as_large.max));
+}
+
+TEST(TestCheckedCast, unsigned_integers) {
+  using T32 = uint32_t;
+  using T64 = uint64_t;
+  using Values = TestCheckedCastIntegerValues<T32, T64>;
+  const Values& values = Values::values;
+
+  EXPECT_FALSE(check_normal<T32>(values.large.minus_one));
+  EXPECT_TRUE(check_normal<T32>(values.large.zero));
+  EXPECT_TRUE(check_normal<T32>(values.large.one));
+  EXPECT_TRUE(check_normal<T32>(values.large.min));
+  EXPECT_FALSE(check_normal<T32>(values.large.max));
+  EXPECT_TRUE(check_normal<T32>(values.small_as_large.min));
+  EXPECT_TRUE(check_normal<T32>(values.small_as_large.min));
+
+  EXPECT_TRUE(check_tautological<T64>(values.small.minus_one));
+  EXPECT_TRUE(check_tautological<T64>(values.small.zero));
+  EXPECT_TRUE(check_tautological<T64>(values.small.one));
+  EXPECT_TRUE(check_tautological<T64>(values.small.min));
+  EXPECT_TRUE(check_tautological<T64>(values.small.max));
+  EXPECT_TRUE(check_tautological<T64>(values.small_as_large.min));
+  EXPECT_TRUE(check_tautological<T64>(values.small_as_large.max));
+}
+
+TEST(TestCheckedCast, unsigned_to_signed_integers) {
+  using T32 = int32_t;
+  using T64 = uint64_t;
+  using Values = TestCheckedCastIntegerValues<T32, T64>;
+  const Values& values = Values::values;
+
+  EXPECT_FALSE(check_normal<T32>(values.large.minus_one));
+  EXPECT_TRUE(check_normal<T32>(values.large.zero));
+  EXPECT_TRUE(check_normal<T32>(values.large.one));
+  EXPECT_TRUE(check_normal<T32>(values.large.min));
+  EXPECT_FALSE(check_normal<T32>(values.large.max));
+  EXPECT_FALSE(check_normal<T32>(values.small_as_large.min));
+  EXPECT_TRUE(check_normal<T32>(values.small_as_large.max));
+}
+
+TEST(TestCheckedCast, signed_to_unsigned_integers) {
+  using T32 = uint32_t;
+  using T64 = int64_t;
+  using Values = TestCheckedCastIntegerValues<T32, T64>;
+  const Values& values = Values::values;
+
+  EXPECT_FALSE(check_normal<T32>(values.large.minus_one));
+  EXPECT_TRUE(check_normal<T32>(values.large.zero));
+  EXPECT_TRUE(check_normal<T32>(values.large.one));
+  EXPECT_FALSE(check_normal<T32>(values.large.min));
+  EXPECT_FALSE(check_normal<T32>(values.large.max));
+  EXPECT_TRUE(check_normal<T32>(values.small_as_large.min));
+  EXPECT_TRUE(check_normal<T32>(values.small_as_large.max));
+}
+
+TEST(TestCheckedCast, unsigned_to_wide_signed_integers) {
+  using T32 = uint32_t;
+  using T64 = int64_t;
+  using Values = TestCheckedCastIntegerValues<T32, T64>;
+  const Values& values = Values::values;
+
+  EXPECT_TRUE(check_tautological<T64>(values.small.minus_one));
+  EXPECT_TRUE(check_tautological<T64>(values.small.zero));
+  EXPECT_TRUE(check_tautological<T64>(values.small.one));
+  EXPECT_TRUE(check_tautological<T64>(values.small.min));
+  EXPECT_TRUE(check_tautological<T64>(values.small.max));
+  EXPECT_TRUE(check_tautological<T64>(values.small_as_large.min));
+  EXPECT_TRUE(check_tautological<T64>(values.small_as_large.max));
+}
+
+TEST(TestCheckedCast, signed_to_wide_unsigned_integers) {
+  using T32 = int32_t;
+  using T64 = uint64_t;
+  using Values = TestCheckedCastIntegerValues<T32, T64>;
+  const Values& values = Values::values;
+
+  EXPECT_FALSE(check_normal<T64>(values.small.minus_one));
+  EXPECT_TRUE(check_normal<T64>(values.small.zero));
+  EXPECT_TRUE(check_normal<T64>(values.small.one));
+  EXPECT_FALSE(check_normal<T64>(values.small.min));
+  EXPECT_TRUE(check_normal<T64>(values.small.max));
+  EXPECT_TRUE(check_tautological<T64>(values.small_as_large.min));
+  EXPECT_TRUE(check_tautological<T64>(values.small_as_large.max));
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Checked casts from enum to integral.
+
+TEST(TestCheckedCast, enums) {
+  using I = int;
+  enum class TestEnum : I {};
+  using Values = TestCheckedCastValues<I>;
+  const Values& values = Values::values;
+
+  EXPECT_TRUE(check_normal<I>(static_cast<TestEnum>(values.minus_one)));
+  EXPECT_TRUE(check_normal<I>(static_cast<TestEnum>(values.zero)));
+  EXPECT_TRUE(check_normal<I>(static_cast<TestEnum>(values.one)));
+  EXPECT_TRUE(check_normal<I>(static_cast<TestEnum>(values.min)));
+  EXPECT_TRUE(check_normal<I>(static_cast<TestEnum>(values.max)));
+}


### PR DESCRIPTION
Please review this improvement to the `checked_cast` utility.

checked_cast was added by JDK-8255544 to permit silencing of certain compiler
warnings (such as from gcc's -Wconversion) for narrowing conversions when the
value is "known" to be safely convertible.  It provides debug-only runtime
verification that the conversion preserves the value while changing the type.

There has been a recent effort to apply checked_cast to eliminate -Wconversion
warnings, with the eventual goal of turning on such warnings by default - see
JDK-8135181.

The existing implementation checks that the value is unchanged by a round-trip
conversion, and has no restrictions on the arguments.  There are several
problems with this.

(1) There are some cases where conversion of an integral value to a different
integral type may pass the check, even though the value isn't in the range of
the destination type.

(2) Floating point to integral conversions are often intended to discard the
fractional part.  But that won't pass the round-trip conversion test, making
checked_cast mostly useless for such conversions.

(3) Integral to floating point conversions are often intended to be
indifferent to loss of precision.  But again, that won't pass the round-trip
conversion test, making checked_cast mostly useless for such conversions.

This change to checked_cast supports integral to integral conversions, but not
conversions involving floating point types.  The intent is that we'll use
"-Wconversion -Wno-float-conversion" instead of -Wconversion alone.  If/when
we later want to enable -Wfloat-conversion, we can either extend checked_cast
for that purpose, or probably better, add new functions tailored for the
various use-cases.

It also supports enum to integral conversions, mostly for compatibility with
old code that uses class-scoped enums instead of class-scoped static const
integral members, to work around ancient broken compilers.  We still have a
lot of such code.

This new checked_cast ensures (in debugging builds) that the value being
converted is in the range of the destination type.  It does so while avoiding
tautological comparisons, as some versions of some compilers may warn about
such.  Note that this means it can also be used to suppress -Wsign-conversion
warnings (which are not included in -Wconversion when compiling C++), which we
might explore enabling in the future.

It also verifies a runtime check is needed, producing a compile-time error if
not.  Unnecessary checked_casts make the code harder to understand.  This will
alert a developer that a change is rendering a checked_cast unnecessary, so it
can be removed.  This compile-time check can be suppressed on a per-call
basis, as there are cases where a runtime check might only sometimes be needed.

Aside: Using C++17 if-constexpr would eliminate the metaprogramming needed to
implement the tautological comparison avoidance and the unnecessary
checked_cast error.  The resulting implementation would be less than 1/3 the
size from this proposal, and easier to understand.  Maybe later...

This change removes a small number of unnecessary checked_casts, found by the
check for such.  It also suppresses that check in a few call sites where
that's needed.  Finally, it removes a call involving floating point.

Testing:
New gtests for checked_cast.
mach5 tier1-5
OpenJDK GHA Sanity Checks

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/xml/jaxp/datatype/8033980/JDK9_XMLGregorianCalendar.ser)

### Issue
 * [JDK-8314258](https://bugs.openjdk.org/browse/JDK-8314258): checked_cast doesn't properly check some cases (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16005/head:pull/16005` \
`$ git checkout pull/16005`

Update a local copy of the PR: \
`$ git checkout pull/16005` \
`$ git pull https://git.openjdk.org/jdk.git pull/16005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16005`

View PR using the GUI difftool: \
`$ git pr show -t 16005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16005.diff">https://git.openjdk.org/jdk/pull/16005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16005#issuecomment-1763590853)