### PR TITLE
8317343: GC: Make TestHeapFreeRatio use createTestJvm

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
+++ b/test/hotspot/jtreg/gc/arguments/TestHeapFreeRatio.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package gc.arguments;
  * @test TestHeapFreeRatio
  * @bug 8025661
  * @summary Test parsing of -Xminf and -Xmaxf
+ * @requires vm.opt.x.Xminf == null & vm.opt.x.Xmaxf == null & vm.opt.MinHeapFreeRatio == null & vm.opt.MaxHeapFreeRatio == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -47,7 +48,7 @@ public class TestHeapFreeRatio {
   }
 
   private static void testMinMaxFreeRatio(String min, String max, Validation type) throws Exception {
-    ProcessBuilder pb = GCArguments.createJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createTestJvm(
         "-Xminf" + min,
         "-Xmaxf" + max,
         "-version");


### PR DESCRIPTION
This fix is implicitly dependent on https://github.com/openjdk/jdk/pull/15986/files for `@requires opt.x` support. Initial testing passes, but I will do more (tier) testing before pushing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317343](https://bugs.openjdk.org/browse/JDK-8317343): GC: Make TestHeapFreeRatio use createTestJvm (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16007/head:pull/16007` \
`$ git checkout pull/16007`

Update a local copy of the PR: \
`$ git checkout pull/16007` \
`$ git pull https://git.openjdk.org/jdk.git pull/16007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16007`

View PR using the GUI difftool: \
`$ git pr show -t 16007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16007.diff">https://git.openjdk.org/jdk/pull/16007.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16007#issuecomment-1742739794)