### PR TITLE
8317039 Enable specifying the JDK used to run jtreg

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -867,7 +867,7 @@ define SetupRunJtregTestBody
 	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
   $1_COMMAND_LINE := \
-      $$(JTREG_TOOL_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
+      $$(JTREG_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
           -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
           $$($1_JTREG_BASIC_OPTIONS) \
           -testjdk:$$(JDK_UNDER_TEST) \

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -867,7 +867,7 @@ define SetupRunJtregTestBody
 	$$(RM) -r $$($1_TEST_RESULTS_DIR)
 
   $1_COMMAND_LINE := \
-      $$(JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
+      $$(JTREG_TOOL_JAVA) $$($1_JTREG_LAUNCHER_OPTIONS) \
           -Dprogram=jtreg -jar $$(JT_HOME)/lib/jtreg.jar \
           $$($1_JTREG_BASIC_OPTIONS) \
           -testjdk:$$(JDK_UNDER_TEST) \

--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -122,6 +122,7 @@ $(eval $(call SetupVariable,JT_HOME))
 $(eval $(call SetupVariable,JDK_IMAGE_DIR,$(OUTPUTDIR)/images/jdk))
 $(eval $(call SetupVariable,TEST_IMAGE_DIR,$(OUTPUTDIR)/images/test))
 $(eval $(call SetupVariable,SYMBOLS_IMAGE_DIR,$(OUTPUTDIR)/images/symbols,NO_CHECK))
+$(eval $(call SetupVariable,JTREG_TOOL_JAVA,$(BOOT_JDK)/bin/java))
 
 # Provide default values for tools that we need
 $(eval $(call SetupVariable,MAKE,make,NO_CHECK))
@@ -248,6 +249,7 @@ $(call CreateNewSpec, $(NEW_SPEC), \
     TOPDIR := $(TOPDIR), \
     OUTPUTDIR := $(OUTPUTDIR), \
     BOOT_JDK := $(BOOT_JDK), \
+    JTREG_TOOL_JAVA := $(FIXPATH) $(JTREG_TOOL_JAVA), \
     JT_HOME := $(JT_HOME), \
     JDK_IMAGE_DIR := $(JDK_IMAGE_DIR), \
     JCOV_IMAGE_DIR := $(JCOV_IMAGE_DIR), \

--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -122,7 +122,7 @@ $(eval $(call SetupVariable,JT_HOME))
 $(eval $(call SetupVariable,JDK_IMAGE_DIR,$(OUTPUTDIR)/images/jdk))
 $(eval $(call SetupVariable,TEST_IMAGE_DIR,$(OUTPUTDIR)/images/test))
 $(eval $(call SetupVariable,SYMBOLS_IMAGE_DIR,$(OUTPUTDIR)/images/symbols,NO_CHECK))
-$(eval $(call SetupVariable,JTREG_TOOL_JAVA,$(BOOT_JDK)/bin/java))
+$(eval $(call SetupVariable,JTREG_JAVA,$(BOOT_JDK)/bin/java))
 
 # Provide default values for tools that we need
 $(eval $(call SetupVariable,MAKE,make,NO_CHECK))
@@ -249,7 +249,7 @@ $(call CreateNewSpec, $(NEW_SPEC), \
     TOPDIR := $(TOPDIR), \
     OUTPUTDIR := $(OUTPUTDIR), \
     BOOT_JDK := $(BOOT_JDK), \
-    JTREG_TOOL_JAVA := $(FIXPATH) $(JTREG_TOOL_JAVA), \
+    JTREG_JAVA := $(FIXPATH) $(JTREG_JAVA), \
     JT_HOME := $(JT_HOME), \
     JDK_IMAGE_DIR := $(JDK_IMAGE_DIR), \
     JCOV_IMAGE_DIR := $(JCOV_IMAGE_DIR), \

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -240,8 +240,8 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_JTREG],
       AC_MSG_ERROR([--with-jtreg-jdk needs a value])
     else
       JTREG_TOOL_JDK="${with_jtreg_jdk}"
+      AC_MSG_RESULT([$JTREG_TOOL_JDK])
       UTIL_FIXUP_PATH(JTREG_TOOL_JDK)
-      AC_MSG_CHECKING([jtreg java existence])
       if test ! -f "$JTREG_TOOL_JDK/bin/java"; then
         AC_MSG_ERROR([Could not find jtreg java at $JTREG_TOOL_JDK/bin/java])
       fi

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -239,22 +239,22 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_JTREG],
       AC_MSG_RESULT([not specified])
       AC_MSG_ERROR([--with-jtreg-jdk needs a value])
     else
-      JTREG_TOOL_JDK="${with_jtreg_jdk}"
-      AC_MSG_RESULT([$JTREG_TOOL_JDK])
-      UTIL_FIXUP_PATH(JTREG_TOOL_JDK)
-      if test ! -f "$JTREG_TOOL_JDK/bin/java"; then
-        AC_MSG_ERROR([Could not find jtreg java at $JTREG_TOOL_JDK/bin/java])
+      JTREG_JDK="${with_jtreg_jdk}"
+      AC_MSG_RESULT([$JTREG_JDK])
+      UTIL_FIXUP_PATH(JTREG_JDK)
+      if test ! -f "$JTREG_JDK/bin/java"; then
+        AC_MSG_ERROR([Could not find jtreg java at $JTREG_JDK/bin/java])
       fi
     fi
   else
-    JTREG_TOOL_JDK="${BOOT_JDK}"
+    JTREG_JDK="${BOOT_JDK}"
     AC_MSG_RESULT([no, using BOOT_JDK])
   fi
 
-  JTREG_TOOL_JAVA="$JTREG_TOOL_JDK/bin/java"
-  UTIL_FIXUP_PATH(JTREG_TOOL_JAVA)
-  JTREG_TOOL_JAVA="$FIXPATH $JTREG_TOOL_JAVA"
-  AC_SUBST([JTREG_TOOL_JAVA])
+  JTREG_JAVA="$JTREG_JDK/bin/java"
+  UTIL_FIXUP_PATH(JTREG_JAVA)
+  JTREG_JAVA="$FIXPATH $JTREG_JAVA"
+  AC_SUBST([JTREG_JAVA])
 
 
   # Verify jtreg version
@@ -267,7 +267,7 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_JTREG],
     AC_MSG_CHECKING([jtreg version number])
     # jtreg -version looks like this: "jtreg 6.1+1-19"
     # Extract actual version part ("6.1" in this case)
-    jtreg_version_full=$($JTREG_TOOL_JAVA -jar $JT_HOME/lib/jtreg.jar -version | $HEAD -n 1 | $CUT -d ' ' -f 2)
+    jtreg_version_full=$($JTREG_JAVA -jar $JT_HOME/lib/jtreg.jar -version | $HEAD -n 1 | $CUT -d ' ' -f 2)
 
     jtreg_version=${jtreg_version_full/%+*}
     AC_MSG_RESULT([$jtreg_version])

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -227,12 +227,48 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_JTREG],
   UTIL_FIXUP_PATH(JT_HOME)
   AC_SUBST(JT_HOME)
 
+  # Specify a JDK for running jtreg. Defaults to the BOOT_JDK.
+  AC_ARG_WITH(jtreg-jdk, [AS_HELP_STRING([--with-jdk],
+    [path to JDK for running jtreg @<:@BOOT_JDK@:>@])])
+
+  AC_MSG_CHECKING([for jtreg jdk])
+  if test "x${with_jtreg_jdk}" != x; then
+    if test "x${with_jtreg_jdk}" = xno; then
+      AC_MSG_RESULT([no, jtreg jdk not specified])
+    elif test "x${with_jtreg_jdk}" = xyes; then
+      AC_MSG_RESULT([not specified])
+      AC_MSG_ERROR([--with-jtreg-jdk needs a value])
+    else
+      JTREG_TOOL_JDK="${with_jtreg_jdk}"
+      UTIL_FIXUP_PATH(JTREG_TOOL_JDK)
+      AC_MSG_CHECKING([jtreg java existence])
+      if test ! -f "$JTREG_TOOL_JDK/bin/java"; then
+        AC_MSG_ERROR([Could not find jtreg java at $JTREG_TOOL_JDK/bin/java])
+      fi
+    fi
+  else
+    JTREG_TOOL_JDK="${BOOT_JDK}"
+    AC_MSG_RESULT([no, using BOOT_JDK])
+  fi
+
+  JTREG_TOOL_JAVA="$JTREG_TOOL_JDK/bin/java"
+  UTIL_FIXUP_PATH(JTREG_TOOL_JAVA)
+  JTREG_TOOL_JAVA="$FIXPATH $JTREG_TOOL_JAVA"
+  AC_SUBST([JTREG_TOOL_JAVA])
+
+
   # Verify jtreg version
   if test "x$JT_HOME" != x; then
+    AC_MSG_CHECKING([jtreg jar existence])
+    if test ! -f "$JT_HOME/lib/jtreg.jar"; then
+      AC_MSG_ERROR([Could not find jtreg jar at $JT_HOME/lib/jtreg.jar])
+    fi
+
     AC_MSG_CHECKING([jtreg version number])
     # jtreg -version looks like this: "jtreg 6.1+1-19"
     # Extract actual version part ("6.1" in this case)
-    jtreg_version_full=`$JAVA -jar $JT_HOME/lib/jtreg.jar -version | $HEAD -n 1 | $CUT -d ' ' -f 2`
+    jtreg_version_full=$($JTREG_TOOL_JAVA -jar $JT_HOME/lib/jtreg.jar -version | $HEAD -n 1 | $CUT -d ' ' -f 2)
+
     jtreg_version=${jtreg_version_full/%+*}
     AC_MSG_RESULT([$jtreg_version])
 

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -666,7 +666,7 @@ JAVA_FLAGS_SMALL:=@JAVA_FLAGS_SMALL@
 BUILDJDK_JAVA_FLAGS_SMALL:=@BUILDJDK_JAVA_FLAGS_SMALL@
 JAVA_TOOL_FLAGS_SMALL:=@JAVA_TOOL_FLAGS_SMALL@
 
-JTREG_TOOL_JAVA:=@JTREG_TOOL_JAVA@
+JTREG_JAVA:=@JTREG_JAVA@
 
 # The *_CMD variables are defined separately to be easily overridden in bootcycle-spec.gmk
 # for bootcycle-images build. Make sure to keep them in sync. Do not use the *_CMD

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -666,6 +666,8 @@ JAVA_FLAGS_SMALL:=@JAVA_FLAGS_SMALL@
 BUILDJDK_JAVA_FLAGS_SMALL:=@BUILDJDK_JAVA_FLAGS_SMALL@
 JAVA_TOOL_FLAGS_SMALL:=@JAVA_TOOL_FLAGS_SMALL@
 
+JTREG_TOOL_JAVA:=@JTREG_TOOL_JAVA@
+
 # The *_CMD variables are defined separately to be easily overridden in bootcycle-spec.gmk
 # for bootcycle-images build. Make sure to keep them in sync. Do not use the *_CMD
 # versions of the variables directly.


### PR DESCRIPTION
This pull request introduces changes in the build makefiles necessary to enable the user to specify a jdk to use when launching jtreg. It introduces a new configure flag, `--with-jtreg-jdk`, which takes a JDK path similar to the already existing `--with-boot-jdk`.

Before this pull request, boot-jdk was always used to launch jtreg. This pull request decouples the two, but still defaults to boot-jdk if no value is specified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317039](https://bugs.openjdk.org/browse/JDK-8317039): Enable specifying the JDK used to run jtreg (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16010/head:pull/16010` \
`$ git checkout pull/16010`

Update a local copy of the PR: \
`$ git checkout pull/16010` \
`$ git pull https://git.openjdk.org/jdk.git pull/16010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16010`

View PR using the GUI difftool: \
`$ git pr show -t 16010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16010.diff">https://git.openjdk.org/jdk/pull/16010.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16010#issuecomment-1742949582)