### PR TITLE
8317265: ListFormat::format specification could be made clearer regarding handling IllegalArgumentException.

### DIFF
--- a/src/java.base/share/classes/java/text/ListFormat.java
+++ b/src/java.base/share/classes/java/text/ListFormat.java
@@ -353,8 +353,8 @@ public final class ListFormat extends Format {
      * @return       the string buffer passed in as {@code toAppendTo},
      *               with formatted text appended
      * @throws    NullPointerException if {@code obj} or {@code toAppendTo} is null
-     * @throws    IllegalArgumentException if the given object cannot
-     *               be formatted
+     * @throws    IllegalArgumentException if {@code obj} is neither a {@code List}
+     *               nor an array of {@code Object}s, or its length is zero.
      */
     @Override
     public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos) {


### PR DESCRIPTION
A simple clarification of the conditions for throwing an IAE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8317270](https://bugs.openjdk.org/browse/JDK-8317270) to be approved

### Issues
 * [JDK-8317265](https://bugs.openjdk.org/browse/JDK-8317265): ListFormat::format specification could be made clearer regarding handling IllegalArgumentException. (**Enhancement** - P3)
 * [JDK-8317270](https://bugs.openjdk.org/browse/JDK-8317270): ListFormat::format specification could be made clearer regarding handling IllegalArgumentException. (**CSR**)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16013/head:pull/16013` \
`$ git checkout pull/16013`

Update a local copy of the PR: \
`$ git checkout pull/16013` \
`$ git pull https://git.openjdk.org/jdk.git pull/16013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16013`

View PR using the GUI difftool: \
`$ git pr show -t 16013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16013.diff">https://git.openjdk.org/jdk/pull/16013.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16013#issuecomment-1743421674)