### PR TITLE
8315484: java/awt/dnd/RejectDragDropActionTest.java timed out

### DIFF
--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -100,7 +100,7 @@ public class RejectDragDropActionTest {
             for (Point p = new Point(startPoint);
                  !p.equals(endPoint) && !incorrectActionDetected;
                  p.translate(sign(endPoint.x - p.x),
-                         sign(endPoint.y - p.y))) {
+                             sign(endPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);
             }
 

--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -98,7 +98,7 @@ public class RejectDragDropActionTest {
             robot.mouseMove(startPoint.x, startPoint.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             for (Point p = new Point(startPoint);
-                 !p.equals(endPoint) || incorrectActionDetected;
+                 !p.equals(endPoint) && incorrectActionDetected;
                  p.translate(sign(endPoint.x - p.x),
                          sign(endPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);

--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -27,10 +27,10 @@
   @summary tests that DropTargetDragEvent.getDropAction() returns correct value
            after DropTargetDragEvent.rejectDrag()
   @key headful
-  @run main RejectDragDropActionTest
+  @run main/timeout=300 RejectDragDropActionTest
 */
 
-import java.awt.AWTException;
+import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Point;
@@ -46,14 +46,13 @@ import java.awt.dnd.DropTargetDragEvent;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.dnd.DropTargetListener;
 import java.awt.event.InputEvent;
-import java.lang.reflect.InvocationTargetException;
 
 
 public class RejectDragDropActionTest {
 
     private static volatile boolean incorrectActionDetected = false;
 
-    private static final int FRAME_ACTIVATION_TIMEOUT = 3000;
+    private static final int DELAY_TIME = 1000;
 
     private static Frame frame;
     private static DragSource ds;
@@ -74,26 +73,30 @@ public class RejectDragDropActionTest {
         };
     private final DropTarget dt = new DropTarget(frame, dtl);
 
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException, AWTException {
+    public static void main(String[] args) throws Exception {
         EventQueue.invokeAndWait(() -> {
             frame = new Frame("RejectDragDropActionTest");
             ds = DragSource.getDefaultDragSource();
             dgl = dge -> dge.startDrag(null, new StringSelection("OOKK"));
-            dgr = ds.createDefaultDragGestureRecognizer(frame, DnDConstants.ACTION_COPY, dgl);
-            frame.setBounds(100, 100, 200, 200);
+            dgr = ds.createDefaultDragGestureRecognizer(frame,
+                    DnDConstants.ACTION_COPY, dgl);
+            frame.setPreferredSize(new Dimension(200, 200));
+            frame.pack();
+            frame.setLocationRelativeTo(null);
             frame.setVisible(true);
         });
 
         try {
             Robot robot = new Robot();
             robot.waitForIdle();
-            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+            robot.delay(DELAY_TIME);
 
             Point startPoint = frame.getLocationOnScreen();
             Point endPoint = new Point(startPoint);
             startPoint.translate(50, 50);
             endPoint.translate(150, 150);
+
+            robot.delay(DELAY_TIME);
 
             robot.mouseMove(startPoint.x, startPoint.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);

--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -51,7 +51,7 @@ public class RejectDragDropActionTest {
 
     private static volatile boolean incorrectActionDetected = false;
 
-    private static final int DELAY_TIME = 1000;
+    private static final int DELAY_TIME = 500;
 
     private static Frame frame;
     private static DragSource ds;
@@ -95,15 +95,16 @@ public class RejectDragDropActionTest {
             startPoint.translate(50, 50);
             endPoint.translate(150, 150);
 
-            robot.delay(DELAY_TIME);
-
             robot.mouseMove(startPoint.x, startPoint.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             for (Point p = new Point(startPoint); !p.equals(endPoint);
                  p.translate(sign(endPoint.x - p.x),
                          sign(endPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);
-                robot.delay(50);
+                if (incorrectActionDetected) {
+                    System.err.println("Incorrect action during loop");
+                    break;
+                }
             }
 
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);

--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -98,7 +98,7 @@ public class RejectDragDropActionTest {
             robot.mouseMove(startPoint.x, startPoint.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             for (Point p = new Point(startPoint);
-                 !p.equals(endPoint) && incorrectActionDetected;
+                 !p.equals(endPoint) && !incorrectActionDetected;
                  p.translate(sign(endPoint.x - p.x),
                          sign(endPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);
@@ -112,6 +112,8 @@ public class RejectDragDropActionTest {
                 }
             });
         }
+
+        Thread.dumpStack();
 
         if (incorrectActionDetected) {
             throw new RuntimeException("User action reported incorrectly.");

--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -97,14 +97,11 @@ public class RejectDragDropActionTest {
 
             robot.mouseMove(startPoint.x, startPoint.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-            for (Point p = new Point(startPoint); !p.equals(endPoint);
+            for (Point p = new Point(startPoint);
+                 !p.equals(endPoint) || incorrectActionDetected;
                  p.translate(sign(endPoint.x - p.x),
                          sign(endPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);
-                if (incorrectActionDetected) {
-                    System.err.println("Incorrect action during loop");
-                    break;
-                }
             }
 
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);

--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -30,7 +30,6 @@
   @run main/timeout=300 RejectDragDropActionTest
 */
 
-import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Point;
@@ -80,8 +79,7 @@ public class RejectDragDropActionTest {
             dgl = dge -> dge.startDrag(null, new StringSelection("OOKK"));
             dgr = ds.createDefaultDragGestureRecognizer(frame,
                     DnDConstants.ACTION_COPY, dgl);
-            frame.setPreferredSize(new Dimension(200, 200));
-            frame.pack();
+            frame.setSize(200, 200);
             frame.setLocationRelativeTo(null);
             frame.setVisible(true);
         });

--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -86,6 +86,7 @@ public class RejectDragDropActionTest {
 
         try {
             Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
             robot.waitForIdle();
             robot.delay(DELAY_TIME);
 

--- a/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
+++ b/test/jdk/java/awt/dnd/RejectDragDropActionTest.java
@@ -113,8 +113,6 @@ public class RejectDragDropActionTest {
             });
         }
 
-        Thread.dumpStack();
-
         if (incorrectActionDetected) {
             throw new RuntimeException("User action reported incorrectly.");
         }


### PR DESCRIPTION
This test intermittently fails by timeout. Increasing the timeout alone doesn't solve the failure as it still fails in about 400 runs. Adding another delay and reducing the delay amount to 1000ms. Now, the test passes after 2 sets of 500 repeats on all OS's without a timeout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315484](https://bugs.openjdk.org/browse/JDK-8315484): java/awt/dnd/RejectDragDropActionTest.java timed out (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [db1ac5cf](https://git.openjdk.org/jdk/pull/16018/files/db1ac5cfbe62d36dcc3467ed7c0b4d7b6926b93a)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16018/head:pull/16018` \
`$ git checkout pull/16018`

Update a local copy of the PR: \
`$ git checkout pull/16018` \
`$ git pull https://git.openjdk.org/jdk.git pull/16018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16018`

View PR using the GUI difftool: \
`$ git pr show -t 16018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16018.diff">https://git.openjdk.org/jdk/pull/16018.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16018#issuecomment-1743902522)