### PR TITLE
8316923: Add DEF_STATIC_JNI_OnLoad for librmi

### DIFF
--- a/src/java.rmi/share/native/librmi/GC.c
+++ b/src/java.rmi/share/native/librmi/GC.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.rmi/share/native/librmi/GC.c
+++ b/src/java.rmi/share/native/librmi/GC.c
@@ -25,8 +25,13 @@
 
 #include <jni.h>
 #include <jvm.h>
+#include "jni_util.h"
 #include "sun_rmi_transport_GC.h"
 
+/*
+ * Declare library specific JNI_Onload entry if static build
+ */
+DEF_STATIC_JNI_OnLoad
 
 JNIEXPORT jlong JNICALL
 Java_sun_rmi_transport_GC_maxObjectInspectionAge(JNIEnv *env, jclass cls)


### PR DESCRIPTION
Please help review this trivial change that adds missing DEF_STATIC_JNI_OnLoad for librmi.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316923](https://bugs.openjdk.org/browse/JDK-8316923): Add DEF_STATIC_JNI_OnLoad for librmi (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [f51209fb](https://git.openjdk.org/jdk/pull/16020/files/f51209fb32575eb6b1671da4ff981ae8257afee7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16020/head:pull/16020` \
`$ git checkout pull/16020`

Update a local copy of the PR: \
`$ git checkout pull/16020` \
`$ git pull https://git.openjdk.org/jdk.git pull/16020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16020`

View PR using the GUI difftool: \
`$ git pr show -t 16020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16020.diff">https://git.openjdk.org/jdk/pull/16020.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16020#issuecomment-1744064363)