### PR TITLE
8317422: [JVMCI] concurrency issue in MethodData creation

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -843,9 +843,7 @@ class CompileReplay : public StackObj {
     // method to be rewritten (number of arguments at a call for instance)
     method->method_holder()->link_class(CHECK);
     assert(method->method_data() == nullptr, "Should only be initialized once");
-    ClassLoaderData* loader_data = method->method_holder()->class_loader_data();
-    MethodData* method_data = MethodData::allocate(loader_data, methodHandle(THREAD, method), CHECK);
-    method->set_method_data(method_data);
+    method->build_profiling_method_data(methodHandle(THREAD, method), CHECK);
 
     // collect and record all the needed information for later
     ciMethodDataRecord* rec = new_ciMethodData(method);

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -102,7 +102,7 @@ Method::Method(ConstMethod* xconst, AccessFlags access_flags, Symbol* name) {
   set_constMethod(xconst);
   set_access_flags(access_flags);
   set_intrinsic_id(vmIntrinsics::_none);
-  set_method_data(nullptr);
+  clear_method_data();
   clear_method_counters();
   set_vtable_index(Method::garbage_vtable_index);
 
@@ -127,7 +127,7 @@ void Method::deallocate_contents(ClassLoaderData* loader_data) {
   MetadataFactory::free_metadata(loader_data, constMethod());
   set_constMethod(nullptr);
   MetadataFactory::free_metadata(loader_data, method_data());
-  set_method_data(nullptr);
+  clear_method_data();
   MetadataFactory::free_metadata(loader_data, method_counters());
   clear_method_counters();
   // The nmethod will be gone when we get here.
@@ -1179,7 +1179,7 @@ void Method::unlink_method() {
   }
   NOT_PRODUCT(set_compiled_invocation_count(0);)
 
-  set_method_data(nullptr);
+  clear_method_data();
   clear_method_counters();
   remove_unshareable_flags();
 }

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -308,7 +308,7 @@ class Method : public Metadata {
     return _method_data;
   }
 
-  void set_method_data(MethodData* data);
+  void clear_method_data();
 
   MethodCounters* method_counters() const {
     return _method_counters;

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -308,8 +308,6 @@ class Method : public Metadata {
     return _method_data;
   }
 
-  void clear_method_data();
-
   MethodCounters* method_counters() const {
     return _method_counters;
   }
@@ -360,6 +358,10 @@ class Method : public Metadata {
 private:
   // Either called with CompiledMethod_lock held or from constructor.
   void clear_code();
+
+  void clear_method_data() {
+    _method_data = nullptr;
+  }
 
 public:
   static void set_code(const methodHandle& mh, CompiledMethod* code);

--- a/src/hotspot/share/oops/method.inline.hpp
+++ b/src/hotspot/share/oops/method.inline.hpp
@@ -39,11 +39,8 @@ inline address Method::from_interpreted_entry() const {
   return Atomic::load_acquire(&_from_interpreted_entry);
 }
 
-inline void Method::set_method_data(MethodData* data) {
-  // The store into method must be released. On platforms without
-  // total store order (TSO) the reference may become visible before
-  // the initialization of data otherwise.
-  Atomic::release_store(&_method_data, data);
+inline void Method::clear_method_data() {
+  _method_data = nullptr;
 }
 
 inline CompiledMethod* Method::code() const {

--- a/src/hotspot/share/oops/method.inline.hpp
+++ b/src/hotspot/share/oops/method.inline.hpp
@@ -39,10 +39,6 @@ inline address Method::from_interpreted_entry() const {
   return Atomic::load_acquire(&_from_interpreted_entry);
 }
 
-inline void Method::clear_method_data() {
-  _method_data = nullptr;
-}
-
 inline CompiledMethod* Method::code() const {
   assert( check_code(), "" );
   return Atomic::load_acquire(&_code);


### PR DESCRIPTION
`Method::build_profiling_method_data` is the safe way to create `MethodData` for a `Method` - it uses an atomic to do the write.
This PR updates `c2v_getFailedSpeculationAddress` and `c2v_reprofile` to use `Method::build_profiling_method_data`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317422](https://bugs.openjdk.org/browse/JDK-8317422): [JVMCI] concurrency issue in MethodData creation (**Bug** - P2)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [fda052d4](https://git.openjdk.org/jdk/pull/16026/files/fda052d4394d3a57f7fa16fca13c409bc14a78b0)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16026/head:pull/16026` \
`$ git checkout pull/16026`

Update a local copy of the PR: \
`$ git checkout pull/16026` \
`$ git pull https://git.openjdk.org/jdk.git pull/16026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16026`

View PR using the GUI difftool: \
`$ git pr show -t 16026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16026.diff">https://git.openjdk.org/jdk/pull/16026.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16026#issuecomment-1746430605)