### PR TITLE
8309621: [XWayland][Screencast] screen capture failure with sun.java2d.uiScale other than 1

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/screencast/ScreencastHelper.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/ScreencastHelper.java
@@ -26,11 +26,14 @@
 package sun.awt.screencast;
 
 import sun.awt.UNIXToolkit;
+import sun.java2d.pipe.Region;
 import sun.security.action.GetPropertyAction;
 
+import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
+import java.awt.geom.AffineTransform;
 import java.security.AccessController;
 import java.util.Arrays;
 import java.util.List;
@@ -109,9 +112,20 @@ public class ScreencastHelper {
                 .stream(GraphicsEnvironment
                         .getLocalGraphicsEnvironment()
                         .getScreenDevices())
-                .map(graphicsDevice ->
-                        graphicsDevice.getDefaultConfiguration().getBounds()
-                ).toList();
+                .map(graphicsDevice -> {
+                    GraphicsConfiguration gc =
+                            graphicsDevice.getDefaultConfiguration();
+                    Rectangle screen = gc.getBounds();
+                    AffineTransform tx = gc.getDefaultTransform();
+
+                    return new Rectangle(
+                            Region.clipRound(screen.x * tx.getScaleX()),
+                            Region.clipRound(screen.y * tx.getScaleY()),
+                            Region.clipRound(screen.width * tx.getScaleX()),
+                            Region.clipRound(screen.height * tx.getScaleY())
+                    );
+                })
+                .toList();
     }
 
     private static synchronized native void closeSession();

--- a/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
@@ -369,6 +369,17 @@ final class TokenStorage {
             System.out.println("// getTokens same sizes 2. " + result);
         }
 
+        // 3. add tokens with the same or greater number of screens
+        // This is useful if we once received a token with one screen resolution
+        // and the same screen was later scaled in the system.
+        // In that case, the token is still valid.
+
+        allTokenItems
+                .stream()
+                .filter(t ->
+                        t.allowedScreensBounds.size() >= affectedScreenBounds.size())
+                .forEach(result::add);
+
         return result;
     }
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -319,6 +319,10 @@ GtkApi* gtk3_load(JNIEnv *env, const char* lib_name)
 
         /* Pixbuf */
         fp_gdk_pixbuf_new = dl_symbol("gdk_pixbuf_new");
+        fp_gdk_pixbuf_new_from_data = dl_symbol("gdk_pixbuf_new_from_data");
+        fp_gdk_pixbuf_scale_simple = dl_symbol("gdk_pixbuf_scale_simple");
+        fp_gdk_pixbuf_copy_area = dl_symbol("gdk_pixbuf_copy_area");
+
         fp_gdk_pixbuf_new_from_file =
                 dl_symbol("gdk_pixbuf_new_from_file");
         fp_gdk_pixbuf_get_from_drawable =
@@ -3123,4 +3127,10 @@ static void gtk3_init(GtkApi* gtk) {
     gtk->g_main_context_iteration = fp_g_main_context_iteration;
     gtk->g_error_free = fp_g_error_free;
     gtk->g_unix_fd_list_get = fp_g_unix_fd_list_get;
+
+    gtk->gdk_pixbuf_new = fp_gdk_pixbuf_new;
+    gtk->gdk_pixbuf_new_from_data = fp_gdk_pixbuf_new_from_data;
+    gtk->gdk_pixbuf_scale_simple = fp_gdk_pixbuf_scale_simple;
+    gtk->gdk_pixbuf_get_pixels = fp_gdk_pixbuf_get_pixels;
+    gtk->gdk_pixbuf_copy_area = fp_gdk_pixbuf_copy_area;
 }

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
@@ -528,6 +528,30 @@ static void (*fp_gdk_draw_rectangle)(GdkDrawable*, GdkGC*, gboolean,
         gint, gint, gint, gint);
 static GdkPixbuf *(*fp_gdk_pixbuf_new)(GdkColorspace colorspace,
         gboolean has_alpha, int bits_per_sample, int width, int height);
+
+static GdkPixbuf *(*fp_gdk_pixbuf_new_from_data)(
+        const guchar *data,
+        GdkColorspace colorspace,
+        gboolean has_alpha,
+        int bits_per_sample,
+        int width,
+        int height,
+        int rowstride,
+        GdkPixbufDestroyNotify destroy_fn,
+        gpointer destroy_fn_data
+);
+
+static void (*fp_gdk_pixbuf_copy_area) (
+        const GdkPixbuf* src_pixbuf,
+        int src_x,
+        int src_y,
+        int width,
+        int height,
+        GdkPixbuf* dest_pixbuf,
+        int dest_x,
+        int dest_y
+);
+
 static void (*fp_gdk_drawable_get_size)(GdkDrawable *drawable,
         gint* width, gint* height);
 static gboolean (*fp_gtk_init_check)(int* argc, char** argv);

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk_interface.h
@@ -532,6 +532,8 @@ typedef void (*GClosureNotify)(gpointer data, GClosure *closure);
 typedef void (*GDestroyNotify)(gpointer data);
 typedef void (*GCallback)(void);
 
+typedef void GdkPixbuf;
+typedef void (* GdkPixbufDestroyNotify) (guchar *pixels, gpointer data);
 
 typedef struct GtkApi {
     int version;
@@ -796,6 +798,46 @@ typedef struct GtkApi {
     gint (*g_unix_fd_list_get)(GUnixFDList *list,
                                gint index_,
                                GError **error);
+
+    GdkPixbuf *(*gdk_pixbuf_new)(GdkColorspace colorspace,
+                                 gboolean has_alpha,
+                                 int bits_per_sample,
+                                 int width,
+                                 int height);
+
+
+    GdkPixbuf *(*gdk_pixbuf_new_from_data)(
+            const guchar *data,
+            GdkColorspace colorspace,
+            gboolean has_alpha,
+            int bits_per_sample,
+            int width,
+            int height,
+            int rowstride,
+            GdkPixbufDestroyNotify destroy_fn,
+            gpointer destroy_fn_data
+    );
+
+
+    GdkPixbuf *(*gdk_pixbuf_scale_simple)(GdkPixbuf *src,
+                                          int dest_width,
+                                          int dest_heigh,
+                                          GdkInterpType interp_type
+    );
+
+    guchar* (*gdk_pixbuf_get_pixels) (const GdkPixbuf* pixbuf);
+
+
+    void (*gdk_pixbuf_copy_area) (
+            const GdkPixbuf* src_pixbuf,
+            int src_x,
+            int src_y,
+            int width,
+            int height,
+            GdkPixbuf* dest_pixbuf,
+            int dest_x,
+            int dest_y
+    );
 
     /* </for screencast, used only with GTK3>  */
 } GtkApi;

--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.h
@@ -48,7 +48,7 @@ struct ScreenProps {
     GdkRectangle captureArea;
     struct PwStreamData *data;
 
-    gchar *captureData;
+    GdkPixbuf *captureDataPixbuf;
     volatile gboolean shouldCapture;
     volatile gboolean captureDataReady;
 };

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
+++ b/test/jdk/java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
@@ -32,7 +32,6 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
-import javax.swing.UIManager;
 import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
@@ -54,6 +53,12 @@ public class ScreenCaptureGtkTest {
             Color.GREEN, Color.BLUE, Color.ORANGE, Color.RED};
 
     public static void main(String[] args) throws Exception {
+        if ("2".equals(System.getProperty("jdk.gtk.version"))
+                && System.getenv("WAYLAND_DISPLAY") != null) {
+            // screen capture is not supported with gtk2 on Wayland
+            return;
+        }
+
         final int topOffset = 50;
         final int leftOffset = 50;
 


### PR DESCRIPTION
The current implementation of screen capture with ScreenCast has some shortcomings in handling ui scale.

This changeset includes:

* sun.java2d.uiScale value is now taken into account
* screen data streams from ScreenCast are provided in native screen resolution regardless of the scale set in the system.
Now we take that into account and resize the image accordingly.
* We are now trying all available `restore_token`, since it is is tied to the display, but not to its resolution.
* Skips the gtk2 part of the ScreenCaptureGtkTest as it is not supported.

Following tests are no longer failing on Wayland:
java/awt/Robot/HiDPIScreenCapture/HiDPIRobotScreenCaptureTest.java
java/awt/Robot/HiDPIScreenCapture/ScreenCaptureGtkTest.java
java/awt/Robot/HiDPIScreenCapture/ScreenCaptureTest.java

Other testing also looks good, including manual testing with various scales set in the system(including fractional scaling).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309621](https://bugs.openjdk.org/browse/JDK-8309621): [XWayland][Screencast] screen capture failure with sun.java2d.uiScale other than 1 (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [da786357](https://git.openjdk.org/jdk/pull/16027/files/da786357f541f2282b76146f0d3c962b3bf4103f)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [da786357](https://git.openjdk.org/jdk/pull/16027/files/da786357f541f2282b76146f0d3c962b3bf4103f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16027/head:pull/16027` \
`$ git checkout pull/16027`

Update a local copy of the PR: \
`$ git checkout pull/16027` \
`$ git pull https://git.openjdk.org/jdk.git pull/16027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16027`

View PR using the GUI difftool: \
`$ git pr show -t 16027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16027.diff">https://git.openjdk.org/jdk/pull/16027.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16027#issuecomment-1744699217)