### PR TITLE
8317432: Async UL: Use memcpy instead of strcpy in Message ctr

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -49,7 +49,7 @@ const LogDecorations& AsyncLogWriter::None = LogDecorations(LogLevel::Warning, L
                                       LogDecorators::None);
 
 bool AsyncLogWriter::Buffer::push_back(LogFileStreamOutput* output, const LogDecorations& decorations, const char* msg) {
-  size_t len = strlen(msg);
+  const size_t len = strlen(msg);
   const size_t sz = Message::calc_size(len);
   const bool is_token = output == nullptr;
   // Always leave headroom for the flush token. Pushing a token must succeed.

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -48,13 +48,14 @@ const LogDecorations& AsyncLogWriter::None = LogDecorations(LogLevel::Warning, L
                                       LogDecorators::None);
 
 bool AsyncLogWriter::Buffer::push_back(LogFileStreamOutput* output, const LogDecorations& decorations, const char* msg) {
-  const size_t sz = Message::calc_size(strlen(msg));
+  size_t len = strlen(msg);
+  const size_t sz = Message::calc_size(len);
   const bool is_token = output == nullptr;
   // Always leave headroom for the flush token. Pushing a token must succeed.
   const size_t headroom = (!is_token) ? Message::calc_size(0) : 0;
 
   if (_pos + sz <= (_capacity - headroom)) {
-    new(_buf + _pos) Message(output, decorations, msg);
+    new(_buf + _pos) Message(output, decorations, msg, len);
     _pos += sz;
     return true;
   }

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -95,7 +95,7 @@ class AsyncLogWriter : public NonJavaThread {
 
     // Calculate the size for a prospective Message object depending on its message length including the trailing zero
     static constexpr size_t calc_size(size_t message_len) {
-      return align_up(sizeof(Message) + message_len + 1, sizeof(void*));
+      return align_up(sizeof(Message) + message_len + 1, sizeof(Message));
     }
 
     size_t size() const {
@@ -116,6 +116,8 @@ class AsyncLogWriter : public NonJavaThread {
    public:
     Buffer(size_t capacity) :  _pos(0), _capacity(capacity) {
       _buf = NEW_C_HEAP_ARRAY(char, capacity, mtLogging);
+      // Ensure _pos is Message-aligned
+      _pos += align_up(_buf, sizeof(Message)) - _buf;
       assert(capacity >= Message::calc_size(0), "capcity must be great a token size");
     }
 

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -118,7 +118,7 @@ class AsyncLogWriter : public NonJavaThread {
     Buffer(size_t capacity) :  _pos(0), _capacity(capacity) {
       _buf = NEW_C_HEAP_ARRAY(char, capacity, mtLogging);
       // Ensure _pos is Message-aligned
-      _pos += align_up(_buf, alignof(Message)) - _buf;
+      _pos = align_up(_buf, alignof(Message)) - _buf;
       assert(capacity >= Message::calc_size(0), "capcity must be great a token size");
     }
 
@@ -129,7 +129,10 @@ class AsyncLogWriter : public NonJavaThread {
     void push_flush_token();
     bool push_back(LogFileStreamOutput* output, const LogDecorations& decorations, const char* msg);
 
-    void reset() { _pos = 0; }
+    void reset() {
+      // Ensure _pos is Message-aligned
+      _pos = align_up(_buf, alignof(Message)) - _buf;
+    }
 
     class Iterator {
       const Buffer& _buf;


### PR DESCRIPTION
Hi,

This change does three things:

1. At construction of message we used to compute `strlen` and then `strcpy`, we change this to do only one `strlen` and then a `memcpy` instead.
2. A `strlen` used to be required to calculate the size when finding the next message in the iterator. We instead store the previously computed message length and so the `strlen` is no longer necessary. The cost of this is 8 bytes extra per message (64 -> 72 bytes).
3. There's also some code which alters the alignment to explicitly handle the alignment of `Message` and ensure that `_pos` starts at a `Message`-aligned pointer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317432](https://bugs.openjdk.org/browse/JDK-8317432): Async UL: Use memcpy instead of strcpy in Message ctr (**Enhancement** - P4)


### Reviewers
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16029/head:pull/16029` \
`$ git checkout pull/16029`

Update a local copy of the PR: \
`$ git checkout pull/16029` \
`$ git pull https://git.openjdk.org/jdk.git pull/16029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16029`

View PR using the GUI difftool: \
`$ git pr show -t 16029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16029.diff">https://git.openjdk.org/jdk/pull/16029.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16029#issuecomment-1746472454)