### PR TITLE
8317433: Async UL: Only grab lock once when write():ing

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -157,8 +157,8 @@ void AsyncLogWriter::run() {
       while (!_data_available) {
         _lock.wait(0/* no timeout */);
       }
-      // lock protection. This guarantees I/O jobs don't block logsites.
-
+      // Only doing a swap and statistics under the lock to
+      // guarantee that I/O jobs don't block logsites.
       _buffer_staging->reset();
       swap(_buffer, _buffer_staging);
 

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -135,7 +135,7 @@ void AsyncLogWriter::write(AsyncLogMap<AnyObj::C_HEAP>& snapshot) {
     if (counter > 0) {
       stringStream ss;
       ss.print(UINT32_FORMAT_W(6) " messages dropped due to async logging", counter);
-      output->write_blocking(decorations, ss.as_string(false));
+      output->write_blocking(decorations, ss.freeze());
     }
     return true;
   });

--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -115,7 +115,7 @@ AsyncLogWriter::AsyncLogWriter()
   }
 }
 
-void AsyncLogWriter::write(AsyncLogMap<AnyObj::C_HEAP>& snapshot) {
+void AsyncLogWriter::write(AsyncLogMap<AnyObj::RESOURCE_AREA>& snapshot) {
   int req = 0;
   auto it = _buffer_staging->iterator();
   while (it.hasNext()) {
@@ -149,7 +149,8 @@ void AsyncLogWriter::write(AsyncLogMap<AnyObj::C_HEAP>& snapshot) {
 
 void AsyncLogWriter::run() {
   while (true) {
-    AsyncLogMap<AnyObj::C_HEAP> snapshot;
+    ResourceMark rm;
+    AsyncLogMap<AnyObj::RESOURCE_AREA> snapshot;
     {
       AsyncLogLocker locker;
 

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -167,7 +167,7 @@ class AsyncLogWriter : public NonJavaThread {
 
   AsyncLogWriter();
   void enqueue_locked(LogFileStreamOutput* output, const LogDecorations& decorations, const char* msg);
-  void write(AsyncLogMap<AnyObj::C_HEAP>& snapshot);
+  void write(AsyncLogMap<AnyObj::RESOURCE_AREA>& snapshot);
   void run() override;
   void pre_run() override {
     NonJavaThread::pre_run();

--- a/src/hotspot/share/logging/logAsyncWriter.hpp
+++ b/src/hotspot/share/logging/logAsyncWriter.hpp
@@ -166,7 +166,7 @@ class AsyncLogWriter : public NonJavaThread {
 
   AsyncLogWriter();
   void enqueue_locked(LogFileStreamOutput* output, const LogDecorations& decorations, const char* msg);
-  void write();
+  void write(AsyncLogMap<AnyObj::C_HEAP>& snapshot);
   void run() override;
   void pre_run() override {
     NonJavaThread::pre_run();


### PR DESCRIPTION
Hi,

The writer thread used to await for `_data_available` to become true through using the async log lock as a condition variable. When data is available it'd let go of the lock and then call `AsyncLogWriter::write()`, which would immediately try to acquire that same lock. We can remove this second instance by moving the work needed to be done under lock to `run`.

Thank you for considering this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317433](https://bugs.openjdk.org/browse/JDK-8317433): Async UL: Only grab lock once when write():ing (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16030/head:pull/16030` \
`$ git checkout pull/16030`

Update a local copy of the PR: \
`$ git checkout pull/16030` \
`$ git pull https://git.openjdk.org/jdk.git pull/16030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16030`

View PR using the GUI difftool: \
`$ git pr show -t 16030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16030.diff">https://git.openjdk.org/jdk/pull/16030.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16030#issuecomment-1746472648)