### PR TITLE
8317446: ProblemList gc/arguments/TestNewSizeFlags.java on macosx-aarch64 in Xcomp

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -43,3 +43,5 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_a/TestDescription.java 
 vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 8308367 windows-x64
 
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64
+
+gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -45,3 +45,4 @@ vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 83
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64
 
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
+compiler/interpreter/TestVerifyStackAfterDeopt.java 8316392 macosx-aarch64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -134,6 +134,8 @@ serviceability/sa/ClhsdbDumpclass.java 8316342 generic-all
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
+serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java 8315980 linux-all,windows-x64
+
 #############################################################################
 
 # :hotspot_misc


### PR DESCRIPTION
Trivial fixes to ProblemList noisy tests in the JDK22 CI;

[JDK-8317446](https://bugs.openjdk.org/browse/JDK-8317446) ProblemList gc/arguments/TestNewSizeFlags.java on macosx-aarch64 in Xcomp
[JDK-8317448](https://bugs.openjdk.org/browse/JDK-8317448) ProblemList compiler/interpreter/TestVerifyStackAfterDeopt.java on macosx-aarch64 in Xcomp
[JDK-8317449](https://bugs.openjdk.org/browse/JDK-8317449) ProblemList serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java on several platforms

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8317446](https://bugs.openjdk.org/browse/JDK-8317446): ProblemList gc/arguments/TestNewSizeFlags.java on macosx-aarch64 in Xcomp (**Sub-task** - P4)
 * [JDK-8317448](https://bugs.openjdk.org/browse/JDK-8317448): ProblemList compiler/interpreter/TestVerifyStackAfterDeopt.java on macosx-aarch64 in Xcomp (**Sub-task** - P2)
 * [JDK-8317449](https://bugs.openjdk.org/browse/JDK-8317449): ProblemList serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java on several platforms (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16031/head:pull/16031` \
`$ git checkout pull/16031`

Update a local copy of the PR: \
`$ git checkout pull/16031` \
`$ git pull https://git.openjdk.org/jdk.git pull/16031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16031`

View PR using the GUI difftool: \
`$ git pr show -t 16031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16031.diff">https://git.openjdk.org/jdk/pull/16031.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16031#issuecomment-1745505273)