### PR TITLE
8317742: ISO Standard Date Format implementation consistency on DateTimeFormatter and String.format

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -54,8 +54,11 @@ import java.util.regex.Pattern;
 
 import java.time.DateTimeException;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
@@ -4495,7 +4498,13 @@ public final class Formatter implements Closeable, Flushable {
                 }
                 case DateTime.ISO_STANDARD_DATE: { // 'F' (%Y-%m-%d)
                     char sep = '-';
-                    int year = t.get(ChronoField.YEAR);
+                    ChronoField yearField;
+                    if (t instanceof ZonedDateTime || t instanceof LocalDateTime || t instanceof LocalDate) {
+                        yearField = ChronoField.YEAR;
+                    } else {
+                        yearField = ChronoField.YEAR_OF_ERA;
+                    }
+                    int year = t.get(yearField);
                     if (year < 0) {
                         sb.append(getMinusSign(l));
                         year = -year;

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -56,6 +56,7 @@ import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -4499,7 +4500,10 @@ public final class Formatter implements Closeable, Flushable {
                 case DateTime.ISO_STANDARD_DATE: { // 'F' (%Y-%m-%d)
                     char sep = '-';
                     ChronoField yearField;
-                    if (t instanceof ZonedDateTime || t instanceof LocalDateTime || t instanceof LocalDate) {
+                    if (t instanceof ZonedDateTime
+                            || t instanceof OffsetDateTime
+                            || t instanceof LocalDateTime
+                            || t instanceof LocalDate) {
                         yearField = ChronoField.YEAR;
                     } else {
                         yearField = ChronoField.YEAR_OF_ERA;

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -2050,6 +2050,11 @@ public final class Formatter implements Closeable, Flushable {
         return locale == null ? ',' : getDecimalFormatSymbols(locale).getGroupingSeparator();
     }
 
+    // Use minus sign from cached DecimalFormatSymbols.
+    private static char getMinusSign(Locale locale) {
+        return locale == null ? '-' : getDecimalFormatSymbols(locale).getMinusSign();
+    }
+
     private Appendable a;
     private final Locale l;
     private IOException lastException;
@@ -4492,7 +4497,7 @@ public final class Formatter implements Closeable, Flushable {
                     char sep = '-';
                     int year = t.get(ChronoField.YEAR);
                     if (year < 0) {
-                        sb.append(DecimalFormatSymbols.getInstance(l).getMinusSign());
+                        sb.append(getMinusSign(l));
                         year = -year;
                     } else if (year > 9999) {
                         sb.append('+');

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -54,12 +54,9 @@ import java.util.regex.Pattern;
 
 import java.time.DateTimeException;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.chrono.IsoChronology;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
@@ -4500,10 +4497,7 @@ public final class Formatter implements Closeable, Flushable {
                 case DateTime.ISO_STANDARD_DATE: { // 'F' (%Y-%m-%d)
                     char sep = '-';
                     ChronoField yearField;
-                    if (t instanceof ZonedDateTime
-                            || t instanceof OffsetDateTime
-                            || t instanceof LocalDateTime
-                            || t instanceof LocalDate) {
+                    if (t.query(TemporalQueries.chronology()) instanceof IsoChronology) {
                         yearField = ChronoField.YEAR;
                     } else {
                         yearField = ChronoField.YEAR_OF_ERA;

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4489,37 +4489,17 @@ public final class Formatter implements Closeable, Flushable {
                     break;
                 }
                 case DateTime.ISO_STANDARD_DATE: { // 'F' (%Y-%m-%d)
-                    // ISO_STANDARD_DATE does not need to deal with Locale
+                    char sep = '-';
                     int year = t.get(ChronoField.YEAR);
-                    int month = t.get(ChronoField.MONTH_OF_YEAR);
-                    int dayOfMonth = t.get(ChronoField.DAY_OF_MONTH);
-
                     if (year < 0) {
                         sb.append('-');
                         year = -year;
                     } else if (year > 9999) {
                         sb.append('+');
                     }
-                    if (year < 1000) {
-                        sb.append('0');
-                        if (year < 100) {
-                            sb.append('0');
-                            if (year < 10) {
-                                sb.append('0');
-                            }
-                        }
-                    }
-                    sb.append(year)
-                      .append('-');
-                    if (month < 10) {
-                        sb.append('0');
-                    }
-                    sb.append(month)
-                      .append('-');
-                    if (dayOfMonth < 10) {
-                        sb.append('0');
-                    }
-                    sb.append(dayOfMonth);
+                    sb.append(localizedMagnitude(fmt, null, year, Flags.ZERO_PAD, 4, l)).append(sep);
+                    print(fmt, sb, t, DateTime.MONTH, l).append(sep);
+                    print(fmt, sb, t, DateTime.DAY_OF_MONTH_0, l);
                     break;
                 }
                 default:

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4492,7 +4492,7 @@ public final class Formatter implements Closeable, Flushable {
                     char sep = '-';
                     int year = t.get(ChronoField.YEAR);
                     if (year < 0) {
-                        sb.append('-');
+                        sb.append(DecimalFormatSymbols.getInstance(l).getMinusSign());
                         year = -year;
                     } else if (year > 9999) {
                         sb.append('+');

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4489,7 +4489,7 @@ public final class Formatter implements Closeable, Flushable {
                     break;
                 }
                 case DateTime.ISO_STANDARD_DATE: { // 'F' (%Y-%m-%d)
-                    // ISO_STANDAR_DTE does not need to deal with Locale
+                    // ISO_STANDARD_DATE does not need to deal with Locale
                     int year = t.get(ChronoField.YEAR);
                     int month = t.get(ChronoField.MONTH_OF_YEAR);
                     int dayOfMonth = t.get(ChronoField.DAY_OF_MONTH);

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4416,7 +4416,8 @@ public final class Formatter implements Closeable, Flushable {
                     break;
                 }
                 case DateTime.CENTURY:                // 'C' (00 - 99)
-                case DateTime.YEAR_2:               {// 'y' (00 - 99)
+                case DateTime.YEAR_2:                 // 'y' (00 - 99)
+                case DateTime.YEAR_4:               { // 'Y' (0000 - 9999)
                     int i = t.get(ChronoField.YEAR_OF_ERA);
                     int size = 2;
                     switch (c) {
@@ -4425,27 +4426,6 @@ public final class Formatter implements Closeable, Flushable {
                         case DateTime.YEAR_4  -> size = 4;
                     }
                     sb.append(localizedMagnitude(fmt, null, i, Flags.ZERO_PAD, size, l));
-                    break;
-                }
-                case DateTime.YEAR_4:               { // 'Y' (0000 - 9999)
-                    int i = t.get(ChronoField.YEAR);
-                    if (i < 0) {
-                        sb.append('-');
-                        i = -i;
-                    } else if (i > 9999) {
-                        sb.append('+');
-                    }
-
-                    if (i < 1000) {
-                        sb.append('0');
-                        if (i < 100) {
-                            sb.append('0');
-                            if (i < 10) {
-                                sb.append('0');
-                            }
-                        }
-                    }
-                    sb.append(i);
                     break;
                 }
                 case DateTime.DAY_OF_MONTH_0:         // 'd' (01 - 31)
@@ -4509,10 +4489,37 @@ public final class Formatter implements Closeable, Flushable {
                     break;
                 }
                 case DateTime.ISO_STANDARD_DATE: { // 'F' (%Y-%m-%d)
-                    char sep = '-';
-                    print(fmt, sb, t, DateTime.YEAR_4, l).append(sep);
-                    print(fmt, sb, t, DateTime.MONTH, l).append(sep);
-                    print(fmt, sb, t, DateTime.DAY_OF_MONTH_0, l);
+                    // ISO_STANDAR_DTE does not need to deal with Locale
+                    int year = t.get(ChronoField.YEAR);
+                    int month = t.get(ChronoField.MONTH_OF_YEAR);
+                    int dayOfMonth = t.get(ChronoField.DAY_OF_MONTH);
+
+                    if (year < 0) {
+                        sb.append('-');
+                        year = -year;
+                    } else if (year > 9999) {
+                        sb.append('+');
+                    }
+                    if (year < 1000) {
+                        sb.append('0');
+                        if (year < 100) {
+                            sb.append('0');
+                            if (year < 10) {
+                                sb.append('0');
+                            }
+                        }
+                    }
+                    sb.append(year)
+                      .append('-');
+                    if (month < 10) {
+                        sb.append('0');
+                    }
+                    sb.append(month)
+                      .append('-');
+                    if (dayOfMonth < 10) {
+                        sb.append('0');
+                    }
+                    sb.append(dayOfMonth);
                     break;
                 }
                 default:

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4416,8 +4416,7 @@ public final class Formatter implements Closeable, Flushable {
                     break;
                 }
                 case DateTime.CENTURY:                // 'C' (00 - 99)
-                case DateTime.YEAR_2:                 // 'y' (00 - 99)
-                case DateTime.YEAR_4:               { // 'Y' (0000 - 9999)
+                case DateTime.YEAR_2:               {// 'y' (00 - 99)
                     int i = t.get(ChronoField.YEAR_OF_ERA);
                     int size = 2;
                     switch (c) {
@@ -4426,6 +4425,27 @@ public final class Formatter implements Closeable, Flushable {
                         case DateTime.YEAR_4  -> size = 4;
                     }
                     sb.append(localizedMagnitude(fmt, null, i, Flags.ZERO_PAD, size, l));
+                    break;
+                }
+                case DateTime.YEAR_4:               { // 'Y' (0000 - 9999)
+                    int i = t.get(ChronoField.YEAR);
+                    if (i < 0) {
+                        sb.append('-');
+                        i = -i;
+                    } else if (i > 9999) {
+                        sb.append('+');
+                    }
+
+                    if (i < 1000) {
+                        sb.append('0');
+                        if (i < 100) {
+                            sb.append('0');
+                            if (i < 10) {
+                                sb.append('0');
+                            }
+                        }
+                    }
+                    sb.append(i);
                     break;
                 }
                 case DateTime.DAY_OF_MONTH_0:         // 'd' (01 - 31)

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -466,10 +466,15 @@ public class BasicDateTime extends Basic {
         test("%tF", "-1234-10-03", LocalDate.of(-1234, 10, 3));
         test("%tF", "-12345-10-03", LocalDate.of(-12345, 10, 3));
 
-        Locale localeEuES = Locale.forLanguageTag("eu-ES");
-        test(localeEuES,
-                "%tF",
-                DecimalFormatSymbols.getInstance(localeEuES).getMinusSign() + "2023-01-13",
-                LocalDate.of(-2023, 1, 13));
+        // check minusSign
+        int year = 2023, month = 1, dayOfMonth = 13;
+        String specifier = "%tF";
+        for (Locale locale : Locale.getAvailableLocales()) {
+            char minusSign = DecimalFormatSymbols.getInstance(locale).getMinusSign();
+            String str = new Formatter(new StringBuilder(), locale)
+                    .format(specifier, LocalDate.of(year, month, dayOfMonth))
+                    .toString();
+            test(locale, specifier, minusSign + str, LocalDate.of(-year, month, dayOfMonth));
+        }
     }
 }

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -502,5 +502,15 @@ public class BasicDateTime extends Basic {
                         jpDate.get(ChronoField.MONTH_OF_YEAR),
                         jpDate.get(ChronoField.DAY_OF_MONTH)),
                 jpDate);
+
+        ChronoLocalDate jpDate1 = JapaneseChronology.INSTANCE.dateNow();
+        test(Locale.JAPANESE,
+                "%tF",
+                String.format(
+                        "%04d-%02d-%02d",
+                        jpDate1.get(ChronoField.YEAR_OF_ERA),
+                        jpDate1.get(ChronoField.MONTH_OF_YEAR),
+                        jpDate1.get(ChronoField.DAY_OF_MONTH)),
+                jpDate1);
     }
 }

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -36,6 +36,8 @@ import java.math.BigInteger;
 import java.text.DateFormatSymbols;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
+import java.time.chrono.*;
+import java.time.temporal.ChronoField;
 import java.util.*;
 
 import static java.util.Calendar.*;
@@ -476,5 +478,18 @@ public class BasicDateTime extends Basic {
                     .toString();
             test(locale, specifier, minusSign + str, LocalDate.of(-year, month, dayOfMonth));
         }
+
+        // ja-JP-u-ca-japanese
+        ChronoLocalDate jpDate = Chronology
+                .ofLocale(Locale.forLanguageTag("ja-JP-u-ca-japanese"))
+                .dateNow();
+        test(Locale.JAPANESE,
+                "%tF",
+                String.format(
+                        "%04d-%02d-%02d",
+                        jpDate.get(ChronoField.YEAR_OF_ERA),
+                        jpDate.get(ChronoField.MONTH_OF_YEAR),
+                        jpDate.get(ChronoField.DAY_OF_MONTH)),
+                now);
     }
 }

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -36,6 +36,10 @@ import java.math.BigInteger;
 import java.text.DateFormatSymbols;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneOffset;
 import java.time.chrono.*;
 import java.time.temporal.ChronoField;
 import java.util.*;
@@ -462,11 +466,18 @@ public class BasicDateTime extends Basic {
         test("%tF", "0012-10-03", LocalDate.of(12, 10, 3));
         test("%tF", "0123-10-03", LocalDate.of(123, 10, 3));
         test("%tF", "+12345-10-03", LocalDate.of(12345, 10, 3));
+        test("%tF", "+12345-10-03", LocalDateTime.of(12345, 10, 3, 0, 0, 0));
+        test("%tF", "+12345-10-03", OffsetDateTime.of(LocalDateTime.of(12345, 10, 3, 0, 0, 0), ZoneOffset.UTC));
+        test("%tF", "+12345-10-03", ZonedDateTime.of(LocalDateTime.of(12345, 10, 3, 0, 0, 0), ZoneOffset.UTC));
         test("%tF", "-0001-10-03", LocalDate.of(-1, 10, 3));
         test("%tF", "-0012-10-03", LocalDate.of(-12, 10, 3));
         test("%tF", "-0123-10-03", LocalDate.of(-123, 10, 3));
         test("%tF", "-1234-10-03", LocalDate.of(-1234, 10, 3));
         test("%tF", "-12345-10-03", LocalDate.of(-12345, 10, 3));
+        test("%tF", "-12345-10-03", LocalDate.of(-12345, 10, 3));
+        test("%tF", "-12345-10-03", LocalDateTime.of(-12345, 10, 3, 0, 0, 0));
+        test("%tF", "-12345-10-03", OffsetDateTime.of(LocalDateTime.of(-12345, 10, 3, 0, 0, 0), ZoneOffset.UTC));
+        test("%tF", "-12345-10-03", ZonedDateTime.of(LocalDateTime.of(-12345, 10, 3, 0, 0, 0), ZoneOffset.UTC));
 
         // check minusSign
         int year = 2023, month = 1, dayOfMonth = 13;
@@ -490,6 +501,6 @@ public class BasicDateTime extends Basic {
                         jpDate.get(ChronoField.YEAR_OF_ERA),
                         jpDate.get(ChronoField.MONTH_OF_YEAR),
                         jpDate.get(ChronoField.DAY_OF_MONTH)),
-                now);
+                jpDate);
     }
 }

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -464,12 +464,5 @@ public class BasicDateTime extends Basic {
         test("%tF", "-0123-10-03", LocalDate.of(-123, 10, 3));
         test("%tF", "-1234-10-03", LocalDate.of(-1234, 10, 3));
         test("%tF", "-12345-10-03", LocalDate.of(-12345, 10, 3));
-
-        // %tF No longer localize printed numbers
-        Locale locale = Locale.getDefault();
-        Locale.setDefault(
-                Locale.forLanguageTag("th-TH-u-nu-thai"));
-        test("%tF", "2023-01-13", LocalDate.of(2023, 1, 13));
-        Locale.setDefault(locale);
     }
 }

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -34,6 +34,7 @@ import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DateFormatSymbols;
+import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -464,5 +465,11 @@ public class BasicDateTime extends Basic {
         test("%tF", "-0123-10-03", LocalDate.of(-123, 10, 3));
         test("%tF", "-1234-10-03", LocalDate.of(-1234, 10, 3));
         test("%tF", "-12345-10-03", LocalDate.of(-12345, 10, 3));
+
+        Locale localeEuES = Locale.forLanguageTag("eu-ES");
+        test(localeEuES,
+                "%tF",
+                DecimalFormatSymbols.getInstance(localeEuES).getMinusSign() + "2023-01-13",
+                LocalDate.of(-2023, 1, 13));
     }
 }

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -453,11 +453,23 @@ public class BasicDateTime extends Basic {
         tryCatch("%<%", IllegalFormatFlagsException.class);
 
         // %tF LocalDate
+        test("%tF", "2023-01-13", LocalDate.of(2023, 1, 13));
         test("%tF", "2023-10-03", LocalDate.of(2023, 10, 3));
-        test("%tF", "-2023-10-03", LocalDate.of(-2023, 10, 3));
+        test("%tF", "0001-10-03", LocalDate.of(1, 10, 3));
+        test("%tF", "0012-10-03", LocalDate.of(12, 10, 3));
         test("%tF", "0123-10-03", LocalDate.of(123, 10, 3));
-        test("%tF", "-0123-10-03", LocalDate.of(-123, 10, 3));
         test("%tF", "+12345-10-03", LocalDate.of(12345, 10, 3));
+        test("%tF", "-0001-10-03", LocalDate.of(-1, 10, 3));
+        test("%tF", "-0012-10-03", LocalDate.of(-12, 10, 3));
+        test("%tF", "-0123-10-03", LocalDate.of(-123, 10, 3));
+        test("%tF", "-1234-10-03", LocalDate.of(-1234, 10, 3));
         test("%tF", "-12345-10-03", LocalDate.of(-12345, 10, 3));
+
+        // %tF No longer localize printed numbers
+        Locale locale = Locale.getDefault();
+        Locale.setDefault(
+                Locale.forLanguageTag("th-TH-u-nu-thai"));
+        test("%tF", "2023-01-13", LocalDate.of(2023, 1, 13));
+        Locale.setDefault(locale);
     }
 }

--- a/test/jdk/java/util/Formatter/BasicDateTime.java
+++ b/test/jdk/java/util/Formatter/BasicDateTime.java
@@ -34,6 +34,7 @@ import java.io.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DateFormatSymbols;
+import java.time.LocalDate;
 import java.util.*;
 
 import static java.util.Calendar.*;
@@ -450,5 +451,13 @@ public class BasicDateTime extends Basic {
         tryCatch("%%%", UnknownFormatConversionException.class);
         // perhaps an IllegalFormatArgumentIndexException should be defined?
         tryCatch("%<%", IllegalFormatFlagsException.class);
+
+        // %tF LocalDate
+        test("%tF", "2023-10-03", LocalDate.of(2023, 10, 3));
+        test("%tF", "-2023-10-03", LocalDate.of(-2023, 10, 3));
+        test("%tF", "0123-10-03", LocalDate.of(123, 10, 3));
+        test("%tF", "-0123-10-03", LocalDate.of(-123, 10, 3));
+        test("%tF", "+12345-10-03", LocalDate.of(12345, 10, 3));
+        test("%tF", "-12345-10-03", LocalDate.of(-12345, 10, 3));
     }
 }


### PR DESCRIPTION
j.u.Formatter now prints "%tF" (iso standard date) and the result is incorrect when processing year < 0 or year > 9999

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8317742](https://bugs.openjdk.org/browse/JDK-8317742): ISO Standard Date Format implementation consistency on DateTimeFormatter and String.format (**Bug** - P4)
 * [JDK-8317752](https://bugs.openjdk.org/browse/JDK-8317752): ISO Standard Date Format implementation consistency on DateTimeFormatter and String.format (**CSR**) (Withdrawn)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) ⚠️ Review applies to [47fc35f1](https://git.openjdk.org/jdk/pull/16033/files/47fc35f1907710f466292c4d3ad5be01856cb756)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [0fa1f882](https://git.openjdk.org/jdk/pull/16033/files/0fa1f882ded50ae3bd13c8600409d8d9f88fc724)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16033/head:pull/16033` \
`$ git checkout pull/16033`

Update a local copy of the PR: \
`$ git checkout pull/16033` \
`$ git pull https://git.openjdk.org/jdk.git pull/16033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16033`

View PR using the GUI difftool: \
`$ git pr show -t 16033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16033.diff">https://git.openjdk.org/jdk/pull/16033.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16033#issuecomment-1753493324)