### PR TITLE
8316918: Optimize conversions duplicated across phi nodes

### DIFF
--- a/src/hotspot/share/opto/convertnode.hpp
+++ b/src/hotspot/share/opto/convertnode.hpp
@@ -42,193 +42,190 @@ class Conv2BNode : public Node {
   virtual uint  ideal_reg() const { return Op_RegI; }
 };
 
+class ConvertNode : public TypeNode {
+protected:
+  ConvertNode(const Type* t, Node* input) : TypeNode(t, 2) {
+    init_class_id(Class_Convert);
+    init_req(1, input);
+  }
+public:
+  virtual const Type* in_type() const = 0;
+  virtual uint ideal_reg() const;
+
+  // Create a convert node for a given input and output type.
+  // Conversions to and from half float are specified via T_SHORT.
+  static Node* create_convert(BasicType source, BasicType target, Node* input);
+};
+
 // The conversions operations are all Alpha sorted.  Please keep it that way!
 //------------------------------ConvD2FNode------------------------------------
 // Convert double to float
-class ConvD2FNode : public Node {
+class ConvD2FNode : public ConvertNode {
   public:
-  ConvD2FNode( Node *in1 ) : Node(0,in1) {}
+  ConvD2FNode(Node* in1) : ConvertNode(Type::FLOAT,in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::FLOAT; }
+  virtual const Type* in_type() const { return Type::DOUBLE; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  virtual uint  ideal_reg() const { return Op_RegF; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 //------------------------------ConvD2INode------------------------------------
 // Convert Double to Integer
-class ConvD2INode : public Node {
+class ConvD2INode : public ConvertNode {
   public:
-  ConvD2INode( Node *in1 ) : Node(0,in1) {}
+  ConvD2INode(Node* in1) : ConvertNode(TypeInt::INT,in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeInt::INT; }
+  virtual const Type* in_type() const { return Type::DOUBLE; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  virtual uint  ideal_reg() const { return Op_RegI; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 //------------------------------ConvD2LNode------------------------------------
 // Convert Double to Long
-class ConvD2LNode : public Node {
+class ConvD2LNode : public ConvertNode {
   public:
-  ConvD2LNode( Node *dbl ) : Node(0,dbl) {}
+  ConvD2LNode(Node* in1) : ConvertNode(TypeLong::LONG, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeLong::LONG; }
+  virtual const Type* in_type() const { return Type::DOUBLE; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  virtual uint ideal_reg() const { return Op_RegL; }
-};
-
-class RoundDNode : public Node {
-  public:
-  RoundDNode( Node *dbl ) : Node(0,dbl) {}
-  virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeLong::LONG; }
-  virtual uint ideal_reg() const { return Op_RegL; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 //------------------------------ConvF2DNode------------------------------------
 // Convert Float to a Double.
-class ConvF2DNode : public Node {
+class ConvF2DNode : public ConvertNode {
   public:
-  ConvF2DNode( Node *in1 ) : Node(0,in1) {}
+  ConvF2DNode(Node* in1) : ConvertNode(Type::DOUBLE,in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::DOUBLE; }
+  virtual const Type* in_type() const { return Type::FLOAT; }
   virtual const Type* Value(PhaseGVN* phase) const;
-  virtual uint  ideal_reg() const { return Op_RegD; }
 };
 
 //------------------------------ConvF2HFNode------------------------------------
 // Convert Float to Halffloat
-class ConvF2HFNode : public Node {
+class ConvF2HFNode : public ConvertNode {
   public:
-  ConvF2HFNode( Node *in1 ) : Node(0,in1) {}
+  ConvF2HFNode(Node* in1) : ConvertNode(TypeInt::SHORT, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeInt::SHORT; }
+  virtual const Type* in_type() const { return TypeInt::FLOAT; }
   virtual const Type* Value(PhaseGVN* phase) const;
-  virtual uint  ideal_reg() const { return Op_RegI; }
 };
 
 //------------------------------ConvF2INode------------------------------------
 // Convert float to integer
-class ConvF2INode : public Node {
-  public:
-  ConvF2INode( Node *in1 ) : Node(0,in1) {}
+class ConvF2INode : public ConvertNode {
+public:
+  ConvF2INode(Node* in1) : ConvertNode(TypeInt::INT, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeInt::INT; }
+  virtual const Type* in_type() const { return TypeInt::FLOAT; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  virtual uint  ideal_reg() const { return Op_RegI; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
-
 
 //------------------------------ConvF2LNode------------------------------------
 // Convert float to long
-class ConvF2LNode : public Node {
-  public:
-  ConvF2LNode( Node *in1 ) : Node(0,in1) {}
+class ConvF2LNode : public ConvertNode {
+public:
+  ConvF2LNode(Node* in1) : ConvertNode(TypeLong::LONG, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeLong::LONG; }
+  virtual const Type* in_type() const { return TypeInt::FLOAT; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
-  virtual uint  ideal_reg() const { return Op_RegL; }
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
 };
 
 //------------------------------ConvHF2FNode------------------------------------
 // Convert Halffloat to float
-class ConvHF2FNode : public Node {
-  public:
-  ConvHF2FNode( Node *in1 ) : Node(0,in1) {}
+class ConvHF2FNode : public ConvertNode {
+public:
+  ConvHF2FNode(Node* in1) : ConvertNode(Type::FLOAT, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::FLOAT; }
+  virtual const Type* in_type() const { return TypeInt::SHORT; }
   virtual const Type* Value(PhaseGVN* phase) const;
-  virtual uint  ideal_reg() const { return Op_RegF; }
 };
 
 //------------------------------ConvI2DNode------------------------------------
 // Convert Integer to Double
-class ConvI2DNode : public Node {
-  public:
-  ConvI2DNode( Node *in1 ) : Node(0,in1) {}
+class ConvI2DNode : public ConvertNode {
+public:
+  ConvI2DNode(Node* in1) : ConvertNode(Type::DOUBLE, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::DOUBLE; }
+  virtual const Type* in_type() const { return TypeInt::INT; }
   virtual const Type* Value(PhaseGVN* phase) const;
-  virtual uint  ideal_reg() const { return Op_RegD; }
 };
 
 //------------------------------ConvI2FNode------------------------------------
 // Convert Integer to Float
-class ConvI2FNode : public Node {
-  public:
-  ConvI2FNode( Node *in1 ) : Node(0,in1) {}
+class ConvI2FNode : public ConvertNode {
+public:
+  ConvI2FNode(Node* in1) : ConvertNode(Type::FLOAT, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::FLOAT; }
+  virtual const Type* in_type() const { return TypeInt::INT; }
   virtual const Type* Value(PhaseGVN* phase) const;
   virtual Node* Identity(PhaseGVN* phase);
-  virtual uint  ideal_reg() const { return Op_RegF; }
-};
-
-class RoundFNode : public Node {
-  public:
-  RoundFNode( Node *in1 ) : Node(0,in1) {}
-  virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return TypeInt::INT; }
-  virtual uint  ideal_reg() const { return Op_RegI; }
 };
 
 //------------------------------ConvI2LNode------------------------------------
 // Convert integer to long
-class ConvI2LNode : public TypeNode {
+class ConvI2LNode : public ConvertNode {
   public:
-  ConvI2LNode(Node *in1, const TypeLong* t = TypeLong::INT)
-  : TypeNode(t, 2)
-  { init_req(1, in1); }
+  ConvI2LNode(Node* in1, const TypeLong* t = TypeLong::INT) : ConvertNode(t, in1) {}
   virtual int Opcode() const;
+  virtual const Type* in_type() const { return TypeInt::INT; }
   virtual const Type* Value(PhaseGVN* phase) const;
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual Node* Identity(PhaseGVN* phase);
-  virtual uint  ideal_reg() const { return Op_RegL; }
 };
 
 //------------------------------ConvL2DNode------------------------------------
 // Convert Long to Double
-class ConvL2DNode : public Node {
-  public:
-  ConvL2DNode( Node *in1 ) : Node(0,in1) {}
+class ConvL2DNode : public ConvertNode {
+public:
+  ConvL2DNode(Node* in1) : ConvertNode(Type::DOUBLE, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::DOUBLE; }
+  virtual const Type* in_type() const { return TypeLong::LONG; }
   virtual const Type* Value(PhaseGVN* phase) const;
-  virtual uint ideal_reg() const { return Op_RegD; }
 };
 
 //------------------------------ConvL2FNode------------------------------------
 // Convert Long to Float
-class ConvL2FNode : public Node {
-  public:
-  ConvL2FNode( Node *in1 ) : Node(0,in1) {}
+class ConvL2FNode : public ConvertNode {
+public:
+  ConvL2FNode(Node* in1) : ConvertNode(Type::FLOAT, in1) {}
   virtual int Opcode() const;
-  virtual const Type *bottom_type() const { return Type::FLOAT; }
+  virtual const Type* in_type() const { return TypeLong::LONG; }
   virtual const Type* Value(PhaseGVN* phase) const;
-  virtual uint  ideal_reg() const { return Op_RegF; }
 };
 
 //------------------------------ConvL2INode------------------------------------
 // Convert long to integer
-class ConvL2INode : public TypeNode {
+class ConvL2INode : public ConvertNode {
   public:
-  ConvL2INode(Node *in1, const TypeInt* t = TypeInt::INT)
-  : TypeNode(t, 2) {
-    init_req(1, in1);
-  }
+  ConvL2INode(Node* in1, const TypeInt* t = TypeInt::INT) : ConvertNode(t, in1) {}
   virtual int Opcode() const;
+  virtual const Type* in_type() const { return TypeLong::LONG; }
   virtual Node* Identity(PhaseGVN* phase);
   virtual const Type* Value(PhaseGVN* phase) const;
-  virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
+  virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
+};
+
+class RoundDNode : public Node {
+public:
+  RoundDNode(Node* in1) : Node(nullptr, in1) {}
+  virtual int Opcode() const;
+  virtual const Type* bottom_type() const { return TypeLong::LONG; }
+  virtual uint ideal_reg() const { return Op_RegL; }
+};
+
+class RoundFNode : public Node {
+public:
+  RoundFNode(Node* in1) : Node(nullptr, in1) {}
+  virtual int Opcode() const;
+  virtual const Type* bottom_type() const { return TypeInt::INT; }
   virtual uint  ideal_reg() const { return Op_RegI; }
 };
 

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -70,6 +70,7 @@ class CodeBuffer;
 class ConstraintCastNode;
 class ConNode;
 class ConINode;
+class ConvertNode;
 class CompareAndSwapNode;
 class CompareAndExchangeNode;
 class CountedLoopNode;
@@ -731,6 +732,7 @@ public:
       DEFINE_CLASS_ID(Con, Type, 8)
           DEFINE_CLASS_ID(ConI, Con, 0)
       DEFINE_CLASS_ID(SafePointScalarMerge, Type, 9)
+      DEFINE_CLASS_ID(Convert, Type, 10)
 
 
     DEFINE_CLASS_ID(Proj,  Node, 3)
@@ -889,6 +891,7 @@ public:
   DEFINE_CLASS_QUERY(ClearArray)
   DEFINE_CLASS_QUERY(CMove)
   DEFINE_CLASS_QUERY(Cmp)
+  DEFINE_CLASS_QUERY(Convert)
   DEFINE_CLASS_QUERY(CountedLoop)
   DEFINE_CLASS_QUERY(CountedLoopEnd)
   DEFINE_CLASS_QUERY(DecodeNarrowPtr)

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1493,6 +1493,7 @@
   declare_c2_type(CastPPNode, ConstraintCastNode)                         \
   declare_c2_type(CheckCastPPNode, TypeNode)                              \
   declare_c2_type(Conv2BNode, Node)                                       \
+  declare_c2_type(ConvertNode, TypeNode)                                  \
   declare_c2_type(ConvD2FNode, Node)                                      \
   declare_c2_type(ConvD2INode, Node)                                      \
   declare_c2_type(ConvD2LNode, Node)                                      \

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPhiDuplicatedConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPhiDuplicatedConversion.java
@@ -114,13 +114,13 @@ public class TestPhiDuplicatedConversion {
     }
 
     @Test
-    @IR(counts = {IRNode.CONV, "1"})
+    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     public static short float2HalfFloat(boolean c, float a, float b) {
         return c ? Float.floatToFloat16(a) : Float.floatToFloat16(b);
     }
 
     @Test
-    @IR(counts = {IRNode.CONV, "1"})
+    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
     public static float halfFloat2Float(boolean c, short a, short b) {
         return c ? Float.float16ToFloat(a) : Float.float16ToFloat(b);
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPhiDuplicatedConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPhiDuplicatedConversion.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/*
+ * @test
+ * @summary Test that patterns involving duplicated conversion nodes behind phi are properly optimized.
+ * @bug 8316918
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.irTests.TestPhiDuplicatedConversion
+ */
+public class TestPhiDuplicatedConversion {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static float int2Float(boolean c, int a, int b) {
+        return c ? a : b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static double int2Double(boolean c, int a, int b) {
+        return c ? a : b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static long int2Long(boolean c, int a, int b) {
+        return c ? a : b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static int float2Int(boolean c, float a, float b) {
+        return c ? (int)a : (int)b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static double float2Double(boolean c, float a, float b) {
+        return c ? (double)a : (double)b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static long float2Long(boolean c, float a, float b) {
+        return c ? (long)a : (long)b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static int double2Int(boolean c, double a, double b) {
+        return c ? (int)a : (int)b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static float double2Float(boolean c, double a, double b) {
+        return c ? (float)a : (float)b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static long double2Long(boolean c, double a, double b) {
+        return c ? (long)a : (long)b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static float long2Float(boolean c, long a, long b) {
+        return c ? a : b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static double long2Double(boolean c, long a, long b) {
+        return c ? a : b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static int long2Int(boolean c, long a, long b) {
+        return c ? (int)a : (int)b;
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static short float2HalfFloat(boolean c, float a, float b) {
+        return c ? Float.floatToFloat16(a) : Float.floatToFloat16(b);
+    }
+
+    @Test
+    @IR(counts = {IRNode.CONV, "1"})
+    public static float halfFloat2Float(boolean c, short a, short b) {
+        return c ? Float.float16ToFloat(a) : Float.float16ToFloat(b);
+    }
+
+    @Run(test = {"int2Float", "int2Double", "int2Long",
+                 "float2Int", "float2Double", "float2Long",
+                 "double2Int", "double2Float", "double2Long",
+                 "long2Float", "long2Double", "long2Int",
+                 "float2HalfFloat", "halfFloat2Float"})
+    public void runTests() {
+        assertResults(true, 10, 20, 3.14f, -1.6f, 3.1415, -1.618, 30L, 400L, Float.floatToFloat16(10.5f), Float.floatToFloat16(20.5f));
+        assertResults(false, 10, 20, 3.14f, -1.6f, 3.1415, -1.618, 30L, 400L, Float.floatToFloat16(10.5f), Float.floatToFloat16(20.5f));
+    }
+
+    @DontCompile
+    public void assertResults(boolean c, int intA, int intB, float floatA, float floatB, double doubleA, double doubleB, long longA, long longB, short halfFloatA, short halfFloatB) {
+        Asserts.assertEQ(c ? (float)intA : (float)intB, int2Float(c, intA, intB));
+        Asserts.assertEQ(c ? (double)intA : (double)intB, int2Double(c, intA, intB));
+        Asserts.assertEQ(c ? (long)intA : (long)intB, int2Long(c, intA, intB));
+        Asserts.assertEQ(c ? (int)floatA : (int)floatB, float2Int(c, floatA, floatB));
+        Asserts.assertEQ(c ? (double)floatA : (double)floatB, float2Double(c, floatA, floatB));
+        Asserts.assertEQ(c ? (long)floatA : (long)floatB, float2Long(c, floatA, floatB));
+        Asserts.assertEQ(c ? (int)doubleA : (int)doubleB, double2Int(c, doubleA, doubleB));
+        Asserts.assertEQ(c ? (float)doubleA : (float)doubleB, double2Float(c, doubleA, doubleB));
+        Asserts.assertEQ(c ? (long)doubleA : (long)doubleB, double2Long(c, doubleA, doubleB));
+        Asserts.assertEQ(c ? (float)longA : (float)longB, long2Float(c, longA, longB));
+        Asserts.assertEQ(c ? (double)longA : (double)longB, long2Double(c, longA, longB));
+        Asserts.assertEQ(c ? (int)longA : (int)longB, long2Int(c, longA, longB));
+        Asserts.assertEQ(c ? Float.floatToFloat16(floatA) : Float.floatToFloat16(floatB), float2HalfFloat(c, floatA, floatB));
+        Asserts.assertEQ(c ? Float.float16ToFloat(halfFloatA) : Float.float16ToFloat(halfFloatB), halfFloat2Float(c, halfFloatA, halfFloatB));
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -442,6 +442,11 @@ public class IRNode {
         beforeMatchingNameRegex(COMPRESS_BITS, "CompressBits");
     }
 
+    public static final String CONV = PREFIX + "CONV" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(CONV, "Conv");
+    }
+
     public static final String CONV_I2L = PREFIX + "CONV_I2L" + POSTFIX;
     static {
         beforeMatchingNameRegex(CONV_I2L, "ConvI2L");

--- a/test/micro/org/openjdk/bench/vm/compiler/PhiDuplicatedConversion.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/PhiDuplicatedConversion.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Measurement(iterations = 4, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+public class PhiDuplicatedConversion {
+    public static final int SIZE = 300;
+
+    // Ints
+
+    @Benchmark
+    public void testInt2Float(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(i2f(state.bools[i], state.ints[i], state.ints[SIZE - 1 - i]));
+        }
+    }
+
+    @Benchmark
+    public void testInt2Double(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(i2d(state.bools[i], state.ints[i], state.ints[SIZE - 1 - i]));
+        }
+    }
+
+    @Benchmark
+    public void testInt2Long(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(i2l(state.bools[i], state.ints[i], state.ints[SIZE - 1 - i]));
+        }
+    }
+
+    // Floats
+
+    @Benchmark
+    public void testFloat2Int(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(f2i(state.bools[i], state.floats[i], state.floats[SIZE - 1 - i]));
+        }
+    }
+
+    @Benchmark
+    public void testFloat2Double(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(f2d(state.bools[i], state.floats[i], state.floats[SIZE - 1 - i]));
+        }
+    }
+
+    @Benchmark
+    public void testFloat2Long(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(f2l(state.bools[i], state.floats[i], state.floats[SIZE - 1 - i]));
+        }
+    }
+
+    // Doubles
+
+    @Benchmark
+    public void testDouble2Int(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(d2i(state.bools[i], state.doubles[i], state.doubles[SIZE - 1 - i]));
+        }
+    }
+
+    @Benchmark
+    public void testDouble2Float(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(d2f(state.bools[i], state.doubles[i], state.doubles[SIZE - 1 - i]));
+        }
+    }
+
+    @Benchmark
+    public void testDouble2Long(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(d2l(state.bools[i], state.doubles[i], state.doubles[SIZE - 1 - i]));
+        }
+    }
+
+    // Longs
+
+    @Benchmark
+    public void testLong2Float(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(l2f(state.bools[i], state.longs[i], state.longs[SIZE - 1 - i]));
+        }
+    }
+
+    @Benchmark
+    public void testLong2Double(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(l2d(state.bools[i], state.longs[i], state.longs[SIZE - 1 - i]));
+        }
+    }
+
+    @Benchmark
+    public void testLong2Int(Blackhole blackhole, BenchState state) {
+        for (int i = 0; i < SIZE; i++) {
+            blackhole.consume(l2i(state.bools[i], state.longs[i], state.longs[SIZE - 1 - i]));
+        }
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static float i2f(boolean c, int a, int b) {
+        return c ? a : b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static double i2d(boolean c, int a, int b) {
+        return c ? a : b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static long i2l(boolean c, int a, int b) {
+        return c ? a : b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static int f2i(boolean c, float a, float b) {
+        return c ? (int)a : (int)b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static double f2d(boolean c, float a, float b) {
+        return c ? (double)a : (double)b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static long f2l(boolean c, float a, float b) {
+        return c ? (long)a : (long)b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static int d2i(boolean c, double a, double b) {
+        return c ? (int)a : (int)b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static float d2f(boolean c, double a, double b) {
+        return c ? (float)a : (float)b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static long d2l(boolean c, double a, double b) {
+        return c ? (long)a : (long)b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static float l2f(boolean c, long a, long b) {
+        return c ? a : b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static double l2d(boolean c, long a, long b) {
+        return c ? a : b;
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static int l2i(boolean c, long a, long b) {
+        return c ? (int)a : (int)b;
+    }
+
+    @State(Scope.Benchmark)
+    public static class BenchState {
+        public boolean[] bools;
+        public int[] ints;
+        public long[] longs;
+        public float[] floats;
+        public double[] doubles;
+        public BenchState() {
+
+        }
+
+        @Setup(Level.Iteration)
+        public void setup() {
+            Random random = new Random(1000);
+            bools = new boolean[SIZE];
+            ints = new int[SIZE];
+            longs = new long[SIZE];
+            floats = new float[SIZE];
+            doubles = new double[SIZE];
+
+            for (int i = 0; i < SIZE; i++) {
+                bools[i] = random.nextBoolean();
+                ints[i] = random.nextInt(100);
+                longs[i] = random.nextLong(100);
+                floats[i] = random.nextFloat(100);
+                doubles[i] = random.nextDouble(100);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

I've created this changeset which introduces a minor optimization that de-duplicates primitive type conversion nodes when behind a phi, by replacing it with a single conversion that follows after the phi. In addition, it cleans up the conversion node classes by introducing a common superclass to host shared behavior. This transformation is beneficial as it reduces the size of the IR and the generated code, and is a fairly frequent pattern. Most notably, array creation with a non-constant size parameter contains a duplicated ConvI2L in a branch, and when this transformation is applied the entire branch is able to be removed as the transformation has allowed it to realize that there is only one unique input. In the future, I would like to do this transformation more generally with other types of pure operations with shared inputs, but I figured that this is a good starting point.

Here are some performance benchmarks from my (Zen 3) machine:
```
                                                          Baseline                     Patch          Improvement
Benchmark                                 Mode   Cnt  Score    Error  Units      Score    Error  Units
PhiDuplicatedConversion.testDouble2Float  avgt   12  679.987 ± 29.678 ns/op  /  592.162 ± 11.354 ns/op  + 12.9%
PhiDuplicatedConversion.testDouble2Int    avgt   12  737.388 ± 24.690 ns/op  /  651.517 ± 12.950 ns/op  + 11.6%
PhiDuplicatedConversion.testDouble2Long   avgt   12  685.582 ± 24.236 ns/op  /  662.577 ± 16.498 ns/op  + 3.3%
PhiDuplicatedConversion.testFloat2Double  avgt   12  670.812 ± 22.945 ns/op  /  641.940 ± 15.954 ns/op  + 4.3%
PhiDuplicatedConversion.testFloat2Int     avgt   12  703.796 ± 21.627 ns/op  /  652.882 ± 14.300 ns/op  + 7.2%
PhiDuplicatedConversion.testFloat2Long    avgt   12  682.821 ± 22.023 ns/op  /  651.343 ± 13.281 ns/op  + 4.6%
PhiDuplicatedConversion.testInt2Double    avgt   12  694.062 ± 15.567 ns/op  /  637.920 ±  8.959 ns/op  + 8.0%
PhiDuplicatedConversion.testInt2Float     avgt   12  709.544 ± 20.454 ns/op  /  637.696 ±  7.011 ns/op  + 10.1%
PhiDuplicatedConversion.testInt2Long      avgt   12  660.117 ± 22.712 ns/op  /  637.106 ± 10.776 ns/op  + 3.4%
PhiDuplicatedConversion.testLong2Double   avgt   12  666.147 ± 18.828 ns/op  /  635.747 ±  6.524 ns/op  + 4.5%
PhiDuplicatedConversion.testLong2Float    avgt   12  675.239 ± 16.210 ns/op  /  640.328 ±  6.551 ns/op  + 5.1%
PhiDuplicatedConversion.testLong2Int      avgt   12  665.644 ± 13.507 ns/op  /  637.952 ± 10.948 ns/op  + 4.1%
```

Testing: tier1-3, linux x86_64

Reviews and comments would be appreciated!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316918](https://bugs.openjdk.org/browse/JDK-8316918): Optimize conversions duplicated across phi nodes (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16036/head:pull/16036` \
`$ git checkout pull/16036`

Update a local copy of the PR: \
`$ git checkout pull/16036` \
`$ git pull https://git.openjdk.org/jdk.git pull/16036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16036`

View PR using the GUI difftool: \
`$ git pr show -t 16036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16036.diff">https://git.openjdk.org/jdk/pull/16036.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16036#issuecomment-1745892220)