### PR TITLE
JDK-8317502 Add asserts to check for non-null in ciInstance::java_lang_Class_klass

### DIFF
--- a/src/hotspot/share/ci/ciInstance.cpp
+++ b/src/hotspot/share/ci/ciInstance.cpp
@@ -136,5 +136,6 @@ void ciInstance::print_impl(outputStream* st) {
 
 ciKlass* ciInstance::java_lang_Class_klass() {
   VM_ENTRY_MARK;
+  assert(java_lang_Class::as_Klass(get_oop()) != nullptr, "klass is null");
   return CURRENT_ENV->get_metadata(java_lang_Class::as_Klass(get_oop()))->as_klass();
 }

--- a/src/hotspot/share/ci/ciTypeArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciTypeArrayKlass.cpp
@@ -53,5 +53,6 @@ ciTypeArrayKlass* ciTypeArrayKlass::make_impl(BasicType t) {
 //
 // Make an array klass corresponding to the specified primitive type.
 ciTypeArrayKlass* ciTypeArrayKlass::make(BasicType t) {
+  assert(make_impl(t) != nullptr, "array klass is null");
   GUARDED_VM_ENTRY(return make_impl(t);)
 }

--- a/src/hotspot/share/ci/ciTypeArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciTypeArrayKlass.cpp
@@ -45,6 +45,7 @@ ciTypeArrayKlass::ciTypeArrayKlass(Klass* k) : ciArrayKlass(k) {
 // Implementation of make.
 ciTypeArrayKlass* ciTypeArrayKlass::make_impl(BasicType t) {
   Klass* k = Universe::typeArrayKlassObj(t);
+  assert(CURRENT_ENV->get_type_array_klass(k) != nullptr, "array klass is null");
   return CURRENT_ENV->get_type_array_klass(k);
 }
 
@@ -53,6 +54,5 @@ ciTypeArrayKlass* ciTypeArrayKlass::make_impl(BasicType t) {
 //
 // Make an array klass corresponding to the specified primitive type.
 ciTypeArrayKlass* ciTypeArrayKlass::make(BasicType t) {
-  assert(make_impl(t) != nullptr, "array klass is null");
   GUARDED_VM_ENTRY(return make_impl(t);)
 }

--- a/src/hotspot/share/ci/ciTypeArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciTypeArrayKlass.cpp
@@ -45,7 +45,6 @@ ciTypeArrayKlass::ciTypeArrayKlass(Klass* k) : ciArrayKlass(k) {
 // Implementation of make.
 ciTypeArrayKlass* ciTypeArrayKlass::make_impl(BasicType t) {
   Klass* k = Universe::typeArrayKlassObj(t);
-  assert(CURRENT_ENV->get_type_array_klass(k) != nullptr, "array klass is null");
   return CURRENT_ENV->get_type_array_klass(k);
 }
 


### PR DESCRIPTION
`ciInstance::java_lang_Class_klass` and `ciTypeArrayKlass::make_impl` could potentially return a `null` pointer (solely based on the code). A static code analyzer found out that in other places in the code this could potentially lead to a null pointer dereferencing. However we know that this will never happen: `java_lang_Class::as_Klass(get_oop())` cannot be null and neither can `Universe::typeArrayKlassObj(t)` (there is already an explicit assert in `typeArrayKlassObj`).

So, this change adds an assert in `ciInstance::java_lang_Class_klass` ensuring that `java_lang_Class::as_Klass(get_oop())` don't return `nullptr` (no assert in `ciTypeArrayKlass::make_impl` as `Universe::typeArrayKlassObj(t)`already includes one for `_typeArrayKlassObjs[t] != nullptr`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317502](https://bugs.openjdk.org/browse/JDK-8317502): Add asserts to check for non-null in ciInstance::java_lang_Class_klass (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16038/head:pull/16038` \
`$ git checkout pull/16038`

Update a local copy of the PR: \
`$ git checkout pull/16038` \
`$ git pull https://git.openjdk.org/jdk.git pull/16038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16038`

View PR using the GUI difftool: \
`$ git pr show -t 16038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16038.diff">https://git.openjdk.org/jdk/pull/16038.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16038#issuecomment-1748382996)