### PR TITLE
8317287: [macos14] InterJVMGetDropSuccessTest.java: Child VM: abnormal termination

### DIFF
--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -266,6 +266,7 @@ class Child {
 
             Robot robot = new Robot();
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
+            robot.waitForIdle();
             robot.mousePress(InputEvent.BUTTON1_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);
                  p.translate(Util.sign(targetPoint.x - p.x),
@@ -287,6 +288,7 @@ class Child {
 
             dragSourceListener.reset();
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
+            robot.waitForIdle();
             robot.mousePress(InputEvent.BUTTON1_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);
                  p.translate(Util.sign(targetPoint.x - p.x),


### PR DESCRIPTION
Fix the bug [macos14] InterJVMGetDropSuccessTest.java: Child VM: abnormal termination

JBS issue : [JDK-8317287](https://bugs.openjdk.org/browse/JDK-8317287)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8317287](https://bugs.openjdk.org/browse/JDK-8317287): [macos14] InterJVMGetDropSuccessTest.java: Child VM: abnormal termination (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16040/head:pull/16040` \
`$ git checkout pull/16040`

Update a local copy of the PR: \
`$ git checkout pull/16040` \
`$ git pull https://git.openjdk.org/jdk.git pull/16040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16040`

View PR using the GUI difftool: \
`$ git pr show -t 16040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16040.diff">https://git.openjdk.org/jdk/pull/16040.diff</a>

</details>
