### PR TITLE
8317443: StackOverflowError on calling ListFormat::getInstance() for Norwegian locales

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -849,19 +849,20 @@ public class LocaleResources {
         ResourceReference data = cache.get(cacheKey);
 
         if (data == null || ((lpArray = (String[]) data.get()) == null)) {
-            ResourceBundle rb = localeData.getDateFormatData(locale);
-            lpArray = rb.getStringArray("ListPatterns_" + typeStr + (style == ListFormat.Style.FULL ? "" : "-" + styleStr));
+            var rbKey = "ListPatterns_" + typeStr + (style == ListFormat.Style.FULL ? "" : "-" + styleStr);
+            lpArray = localeData.getDateFormatData(locale).getStringArray(rbKey);
 
             if (lpArray[0].isEmpty() || lpArray[1].isEmpty() || lpArray[2].isEmpty()) {
-                var adapter = LocaleProviderAdapter.forType(LocaleProviderAdapter.Type.CLDR);
-                if (adapter instanceof ResourceBundleBasedAdapter rbba) {
+                if (LocaleProviderAdapter.forType(LocaleProviderAdapter.Type.CLDR)
+                        instanceof ResourceBundleBasedAdapter rbba) {
                     var candList = rbba.getCandidateLocales("", locale);
-                    // make sure there is at least one parent locale
-                    if (candList.size() >= 2) {
-                        var parentPatterns = adapter.getLocaleResources(candList.get(1)).getListPatterns(type, style);
-                        for (int i = 0; i < 3; i++) { // exclude optional ones, ie, "two"/"three"
-                            if (lpArray[i].isEmpty()) {
-                                lpArray[i] = parentPatterns[i];
+                    if (!candList.isEmpty()) {
+                        for (var p : candList.subList(1, candList.size())) {
+                            var parentPatterns = localeData.getDateFormatData(p).getStringArray(rbKey);
+                            for (int i = 0; i < 3; i++) { // exclude optional ones, ie, "two"/"three"
+                                if (lpArray[i].isEmpty()) {
+                                    lpArray[i] = parentPatterns[i];
+                                }
                             }
                         }
                     }

--- a/test/jdk/java/text/Format/ListFormat/TestListFormat.java
+++ b/test/jdk/java/text/Format/ListFormat/TestListFormat.java
@@ -316,10 +316,11 @@ public class TestListFormat {
         // English ("en") has Oxford-comma "end" pattern. Thus missing "standard"/"middle"
         // should be inherited from "en", but "end" should stay non-Oxford for "en-001"
         // Note that this test depends on a particular version of CLDR data.
+        var world = Locale.forLanguageTag("en-001");
         assertEquals("""
-            ListFormat [locale: "English (world)", start: "{0}, {1}", middle: "{0}, {1}", end: "{0} and {1}", two: "{0} and {1}", three: "{0}, {1} and {2}"]
-            """,
-            ListFormat.getInstance(Locale.forLanguageTag("en-001"), ListFormat.Type.STANDARD, ListFormat.Style.FULL).toString());
+            ListFormat [locale: "%s", start: "{0}, {1}", middle: "{0}, {1}", end: "{0} and {1}", two: "{0} and {1}", three: "{0}, {1} and {2}"]
+            """.formatted(world.getDisplayName()),
+            ListFormat.getInstance(world, ListFormat.Type.STANDARD, ListFormat.Style.FULL).toString());
     }
 
     private static void compareResult(ListFormat f, List<String> input, String expected, boolean roundTrip) throws ParseException {


### PR DESCRIPTION
Please review the fix to the subject issue. This was found during upgrading CLDR to v44, in which some list patterns are missing (thus to be inherited from parents) in Norwegian locales which could end up with infinite parent lookup. Avoiding the recursive call and changing it to a plain loop fixes the issue.
Not related to this issue, the test case has been corrected to work with any locale. Currently, it assumes English.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317443](https://bugs.openjdk.org/browse/JDK-8317443): StackOverflowError on calling ListFormat::getInstance() for Norwegian locales (**Bug** - P3)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16042/head:pull/16042` \
`$ git checkout pull/16042`

Update a local copy of the PR: \
`$ git checkout pull/16042` \
`$ git pull https://git.openjdk.org/jdk.git pull/16042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16042`

View PR using the GUI difftool: \
`$ git pr show -t 16042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16042.diff">https://git.openjdk.org/jdk/pull/16042.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16042#issuecomment-1747340112)