### PR TITLE
8317545: AIX PPC64: Implementation of Foreign Function & Memory API

### DIFF
--- a/src/hotspot/cpu/ppc/foreignGlobals_ppc.cpp
+++ b/src/hotspot/cpu/ppc/foreignGlobals_ppc.cpp
@@ -47,11 +47,7 @@ bool ABIDescriptor::is_volatile_reg(FloatRegister reg) const {
 }
 
 bool ForeignGlobals::is_foreign_linker_supported() {
-#ifdef LINUX
   return true;
-#else
-  return false;
-#endif
 }
 
 // Stubbed out, implement later

--- a/src/java.base/share/classes/jdk/internal/foreign/CABI.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/CABI.java
@@ -39,6 +39,7 @@ public enum CABI {
     LINUX_AARCH_64,
     MAC_OS_AARCH_64,
     WIN_AARCH_64,
+    AIX_PPC_64,
     LINUX_PPC_64,
     LINUX_PPC_64_LE,
     LINUX_RISCV_64,
@@ -78,6 +79,8 @@ public enum CABI {
             } else if (arch.equals("ppc64")) {
                 if (OperatingSystem.isLinux()) {
                     return LINUX_PPC_64;
+                } else if (OperatingSystem.isAix()) {
+                    return AIX_PPC_64;
                 }
             } else if (arch.equals("ppc64le")) {
                 if (OperatingSystem.isLinux()) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -233,12 +233,12 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
         }
     }
 
-    private static void checkSupported(ValueLayout valueLayout) {
+    private void checkSupported(ValueLayout valueLayout) {
         valueLayout = valueLayout.withoutName();
         if (valueLayout instanceof AddressLayout addressLayout) {
             valueLayout = addressLayout.withoutTargetLayout();
         }
-        if (!SUPPORTED_LAYOUTS.contains(valueLayout.withoutName())) {
+        if (!supportedLayouts().contains(valueLayout.withoutName())) {
             throw new IllegalArgumentException("Unsupported layout: " + valueLayout);
         }
     }
@@ -275,7 +275,7 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
                 .orElseGet(() -> FunctionDescriptor.ofVoid(stripNames(function.argumentLayouts())));
     }
 
-    private static final Set<MemoryLayout> SUPPORTED_LAYOUTS = Set.of(
+    protected static final Set<MemoryLayout> DEFAULT_LAYOUTS = Set.of(
             ValueLayout.JAVA_BOOLEAN,
             ValueLayout.JAVA_BYTE,
             ValueLayout.JAVA_CHAR,
@@ -284,7 +284,10 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
             ValueLayout.JAVA_FLOAT,
             ValueLayout.JAVA_LONG,
             ValueLayout.JAVA_DOUBLE,
-            ValueLayout.ADDRESS,
-            ValueLayout.JAVA_DOUBLE.withByteAlignment(4) // used by AIX
+            ValueLayout.ADDRESS
     );
+
+    protected Set<MemoryLayout> supportedLayouts() {
+        return DEFAULT_LAYOUTS;
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/AbstractLinker.java
@@ -30,6 +30,7 @@ import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.windows.WindowsAArch64Linker;
 import jdk.internal.foreign.abi.fallback.FallbackLinker;
+import jdk.internal.foreign.abi.ppc64.aix.AixPPC64Linker;
 import jdk.internal.foreign.abi.ppc64.linux.LinuxPPC64Linker;
 import jdk.internal.foreign.abi.ppc64.linux.LinuxPPC64leLinker;
 import jdk.internal.foreign.abi.riscv64.linux.LinuxRISCV64Linker;
@@ -61,7 +62,7 @@ import java.util.Set;
 
 public abstract sealed class AbstractLinker implements Linker permits LinuxAArch64Linker, MacOsAArch64Linker,
                                                                       SysVx64Linker, WindowsAArch64Linker,
-                                                                      Windowsx64Linker,
+                                                                      Windowsx64Linker, AixPPC64Linker,
                                                                       LinuxPPC64Linker, LinuxPPC64leLinker,
                                                                       LinuxRISCV64Linker, LinuxS390Linker,
                                                                       FallbackLinker {
@@ -283,6 +284,7 @@ public abstract sealed class AbstractLinker implements Linker permits LinuxAArch
             ValueLayout.JAVA_FLOAT,
             ValueLayout.JAVA_LONG,
             ValueLayout.JAVA_DOUBLE,
-            ValueLayout.ADDRESS
+            ValueLayout.ADDRESS,
+            ValueLayout.JAVA_DOUBLE.withByteAlignment(4) // used by AIX
     );
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -33,6 +33,7 @@ import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.windows.WindowsAArch64Linker;
 import jdk.internal.foreign.abi.fallback.FallbackLinker;
+import jdk.internal.foreign.abi.ppc64.aix.AixPPC64Linker;
 import jdk.internal.foreign.abi.ppc64.linux.LinuxPPC64Linker;
 import jdk.internal.foreign.abi.ppc64.linux.LinuxPPC64leLinker;
 import jdk.internal.foreign.abi.riscv64.linux.LinuxRISCV64Linker;
@@ -242,6 +243,7 @@ public final class SharedUtils {
             case LINUX_AARCH_64 -> LinuxAArch64Linker.getInstance();
             case MAC_OS_AARCH_64 -> MacOsAArch64Linker.getInstance();
             case WIN_AARCH_64 -> WindowsAArch64Linker.getInstance();
+            case AIX_PPC_64 -> AixPPC64Linker.getInstance();
             case LINUX_PPC_64 -> LinuxPPC64Linker.getInstance();
             case LINUX_PPC_64_LE -> LinuxPPC64leLinker.getInstance();
             case LINUX_RISCV_64 -> LinuxRISCV64Linker.getInstance();

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/TypeClass.java
@@ -112,8 +112,8 @@ public enum TypeClass {
         return true;
     }
 
-    private static TypeClass classifyStructType(MemoryLayout layout, boolean useABIv2) {
-        if (isHomogeneousFloatAggregate(layout, useABIv2)) {
+    private static TypeClass classifyStructType(MemoryLayout layout, boolean useABIv2, boolean isAIX) {
+        if (!isAIX && isHomogeneousFloatAggregate(layout, useABIv2)) {
             return TypeClass.STRUCT_HFA;
         }
         return TypeClass.STRUCT_REGISTER;
@@ -124,11 +124,11 @@ public enum TypeClass {
         return isHomogeneousFloatAggregate(layout, true) || isReturnRegisterAggregate(layout);
     }
 
-    public static TypeClass classifyLayout(MemoryLayout type, boolean useABIv2) {
+    public static TypeClass classifyLayout(MemoryLayout type, boolean useABIv2, boolean isAIX) {
         if (type instanceof ValueLayout) {
             return classifyValueType((ValueLayout) type);
         } else if (type instanceof GroupLayout) {
-            return classifyStructType(type, useABIv2);
+            return classifyStructType(type, useABIv2, isAIX);
         } else {
             throw new IllegalArgumentException("Unhandled type " + type);
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixCallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixCallArranger.java
@@ -28,7 +28,7 @@ package jdk.internal.foreign.abi.ppc64.aix;
 import jdk.internal.foreign.abi.ppc64.CallArranger;
 
 /**
- * PPC64 CallArranger specialized for ABI v1.
+ * PPC64 CallArranger specialized for AIX.
  */
 public class AixCallArranger extends CallArranger {
 

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixCallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixCallArranger.java
@@ -23,15 +23,22 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.internal.foreign.abi.ppc64;
+package jdk.internal.foreign.abi.ppc64.aix;
+
+import jdk.internal.foreign.abi.ppc64.CallArranger;
 
 /**
  * PPC64 CallArranger specialized for ABI v1.
  */
-public class ABIv1CallArranger extends CallArranger {
+public class AixCallArranger extends CallArranger {
 
     @Override
     protected boolean useABIv2() {
         return false;
+    }
+
+    @Override
+    protected boolean isAIX() {
+        return true;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64Linker.java
@@ -30,9 +30,12 @@ import jdk.internal.foreign.abi.LinkerOptions;
 import jdk.internal.foreign.abi.ppc64.CallArranger;
 
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
 import java.nio.ByteOrder;
+import java.util.Set;
 
 public final class AixPPC64Linker extends AbstractLinker {
 
@@ -61,5 +64,23 @@ public final class AixPPC64Linker extends AbstractLinker {
     @Override
     protected ByteOrder linkerByteOrder() {
         return ByteOrder.BIG_ENDIAN;
+    }
+
+    protected static final Set<MemoryLayout> AIX_LAYOUTS = Set.of(
+            ValueLayout.JAVA_BOOLEAN,
+            ValueLayout.JAVA_BYTE,
+            ValueLayout.JAVA_CHAR,
+            ValueLayout.JAVA_SHORT,
+            ValueLayout.JAVA_INT,
+            ValueLayout.JAVA_FLOAT,
+            ValueLayout.JAVA_LONG,
+            ValueLayout.JAVA_DOUBLE,
+            ValueLayout.ADDRESS,
+            ValueLayout.JAVA_DOUBLE.withByteAlignment(4)
+    );
+
+    @Override
+    protected Set<MemoryLayout> supportedLayouts() {
+        return AIX_LAYOUTS;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64Linker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64Linker.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.foreign.abi.ppc64.aix;
+
+import jdk.internal.foreign.abi.AbstractLinker;
+import jdk.internal.foreign.abi.LinkerOptions;
+import jdk.internal.foreign.abi.ppc64.CallArranger;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.nio.ByteOrder;
+
+public final class AixPPC64Linker extends AbstractLinker {
+
+    public static AixPPC64Linker getInstance() {
+        final class Holder {
+            private static final AixPPC64Linker INSTANCE = new AixPPC64Linker();
+        }
+
+        return Holder.INSTANCE;
+    }
+
+    private AixPPC64Linker() {
+        // Ensure there is only one instance
+    }
+
+    @Override
+    protected MethodHandle arrangeDowncall(MethodType inferredMethodType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.AIX.arrangeDowncall(inferredMethodType, function, options);
+    }
+
+    @Override
+    protected UpcallStubFactory arrangeUpcall(MethodType targetType, FunctionDescriptor function, LinkerOptions options) {
+        return CallArranger.AIX.arrangeUpcall(targetType, function, options);
+    }
+
+    @Override
+    protected ByteOrder linkerByteOrder() {
+        return ByteOrder.BIG_ENDIAN;
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/linux/ABIv1CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/linux/ABIv1CallArranger.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023 SAP SE. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.foreign.abi.ppc64.linux;
+
+import jdk.internal.foreign.abi.ppc64.CallArranger;
+
+/**
+ * PPC64 CallArranger specialized for ABI v1.
+ */
+public class ABIv1CallArranger extends CallArranger {
+
+    @Override
+    protected boolean useABIv2() {
+        return false;
+    }
+
+    @Override
+    protected boolean isAIX() {
+        return false;
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/linux/ABIv2CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/linux/ABIv2CallArranger.java
@@ -23,7 +23,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.internal.foreign.abi.ppc64;
+package jdk.internal.foreign.abi.ppc64.linux;
+
+import jdk.internal.foreign.abi.ppc64.CallArranger;
 
 /**
  * PPC64 CallArranger specialized for ABI v2.
@@ -33,5 +35,10 @@ public class ABIv2CallArranger extends CallArranger {
     @Override
     protected boolean useABIv2() {
         return true;
+    }
+
+    @Override
+    protected boolean isAIX() {
+        return false;
     }
 }

--- a/test/jdk/java/foreign/NativeTestHelper.java
+++ b/test/jdk/java/foreign/NativeTestHelper.java
@@ -54,6 +54,7 @@ import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 
 public class NativeTestHelper {
 
+    public static final boolean IS_AIX = System.getProperty("os.name").startsWith("AIX");
     public static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
 
     private static final MethodHandle MH_SAVER;
@@ -116,7 +117,8 @@ public class NativeTestHelper {
     /**
      * The layout for the {@code double} C type
      */
-    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
+    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE.withByteAlignment(IS_AIX ? 4 : 8);
+
     /**
      * The {@code T*} native type.
      */

--- a/test/jdk/java/foreign/callarranger/platform/PlatformLayouts.java
+++ b/test/jdk/java/foreign/callarranger/platform/PlatformLayouts.java
@@ -201,6 +201,7 @@ public final class PlatformLayouts {
      * This class defines layout constants modelling standard primitive types supported by the PPC64 ABI.
      */
     public static final class PPC64 {
+        public static final boolean IS_AIX = System.getProperty("os.name").startsWith("AIX");
 
         private PPC64() {
             //just the one
@@ -244,7 +245,7 @@ public final class PlatformLayouts {
         /**
          * The {@code double} native type.
          */
-        public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
+        public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE.withByteAlignment(IS_AIX ? 4 : 8);
 
         /**
          * The {@code T*} native type.

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
@@ -33,6 +33,7 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 
 public class CLayouts {
+    private static final boolean IS_AIX = System.getProperty("os.name").startsWith("AIX");
 
     // the constants below are useful aliases for C types. The type/carrier association is only valid for 64-bit platforms.
 
@@ -64,7 +65,8 @@ public class CLayouts {
     /**
      * The layout for the {@code double} C type
      */
-    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE;
+    public static final ValueLayout.OfDouble C_DOUBLE = ValueLayout.JAVA_DOUBLE.withByteAlignment(IS_AIX ? 4 : 8);
+
     /**
      * The {@code T*} native type.
      */

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/NativeType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/NativeType.java
@@ -29,6 +29,7 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
 
 public sealed abstract class NativeType<X> {
+    private static final boolean IS_AIX = System.getProperty("os.name").startsWith("AIX");
 
     public abstract MemoryLayout layout();
 
@@ -63,7 +64,7 @@ public sealed abstract class NativeType<X> {
     public static final OfDouble<Double> C_DOUBLE = new OfDouble<>() {
         @Override
         public ValueLayout.OfDouble layout() {
-            return ValueLayout.JAVA_DOUBLE;
+            return ValueLayout.JAVA_DOUBLE.withByteAlignment(IS_AIX ? 4 : 8);
         }
     };
 


### PR DESCRIPTION
The AIX linker has a few minor diffs to the linux ABIv1 linker. In addition, double values have only 4 Byte alignment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317545](https://bugs.openjdk.org/browse/JDK-8317545): AIX PPC64: Implementation of Foreign Function &amp; Memory API (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16043/head:pull/16043` \
`$ git checkout pull/16043`

Update a local copy of the PR: \
`$ git checkout pull/16043` \
`$ git pull https://git.openjdk.org/jdk.git pull/16043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16043`

View PR using the GUI difftool: \
`$ git pr show -t 16043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16043.diff">https://git.openjdk.org/jdk/pull/16043.diff</a>

</details>
