### PR TITLE
8316967: Correct the scope of vmtimer in UnregisteredClasses::load_class

### DIFF
--- a/src/hotspot/share/cds/unregisteredClasses.cpp
+++ b/src/hotspot/share/cds/unregisteredClasses.cpp
@@ -46,6 +46,10 @@ InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path, T
   assert(name != nullptr, "invariant");
   assert(DumpSharedSpaces, "this function is only used with -Xshare:dump");
 
+  PerfClassTraceTime vmtimer(ClassLoader::perf_sys_class_lookup_time(),
+                             THREAD->get_thread_stat()->perf_timers_addr(),
+                             PerfClassTraceTime::CLASS_LOAD);
+
   Symbol* path_symbol = SymbolTable::new_symbol(path);
   Handle url_classloader = get_url_classloader(path_symbol, CHECK_NULL);
   Handle ext_class_name = java_lang_String::externalize_classname(name, CHECK_NULL);

--- a/src/hotspot/share/cds/unregisteredClasses.cpp
+++ b/src/hotspot/share/cds/unregisteredClasses.cpp
@@ -46,7 +46,7 @@ InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path, T
   assert(name != nullptr, "invariant");
   assert(DumpSharedSpaces, "this function is only used with -Xshare:dump");
 
-  PerfClassTraceTime vmtimer(ClassLoader::perf_sys_class_lookup_time(),
+  PerfClassTraceTime vmtimer(ClassLoader::perf_app_classload_time(),
                              THREAD->get_thread_stat()->perf_timers_addr(),
                              PerfClassTraceTime::CLASS_LOAD);
 

--- a/src/hotspot/share/cds/unregisteredClasses.cpp
+++ b/src/hotspot/share/cds/unregisteredClasses.cpp
@@ -46,12 +46,6 @@ InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path, T
   assert(name != nullptr, "invariant");
   assert(DumpSharedSpaces, "this function is only used with -Xshare:dump");
 
-  {
-    PerfClassTraceTime vmtimer(ClassLoader::perf_sys_class_lookup_time(),
-                               THREAD->get_thread_stat()->perf_timers_addr(),
-                               PerfClassTraceTime::CLASS_LOAD);
-  }
-
   Symbol* path_symbol = SymbolTable::new_symbol(path);
   Handle url_classloader = get_url_classloader(path_symbol, CHECK_NULL);
   Handle ext_class_name = java_lang_String::externalize_classname(name, CHECK_NULL);

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -123,7 +123,6 @@ PerfCounter*    ClassLoader::_perf_class_verify_selftime = nullptr;
 PerfCounter*    ClassLoader::_perf_classes_linked = nullptr;
 PerfCounter*    ClassLoader::_perf_class_link_time = nullptr;
 PerfCounter*    ClassLoader::_perf_class_link_selftime = nullptr;
-PerfCounter*    ClassLoader::_perf_sys_class_lookup_time = nullptr;
 PerfCounter*    ClassLoader::_perf_shared_classload_time = nullptr;
 PerfCounter*    ClassLoader::_perf_sys_classload_time = nullptr;
 PerfCounter*    ClassLoader::_perf_app_classload_time = nullptr;
@@ -1377,7 +1376,6 @@ void ClassLoader::initialize(TRAPS) {
     NEWPERFEVENTCOUNTER(_perf_classes_linked, SUN_CLS, "linkedClasses");
     NEWPERFEVENTCOUNTER(_perf_classes_verified, SUN_CLS, "verifiedClasses");
 
-    NEWPERFTICKCOUNTER(_perf_sys_class_lookup_time, SUN_CLS, "lookupSysClassTime");
     NEWPERFTICKCOUNTER(_perf_shared_classload_time, SUN_CLS, "sharedClassLoadTime");
     NEWPERFTICKCOUNTER(_perf_sys_classload_time, SUN_CLS, "sysClassLoadTime");
     NEWPERFTICKCOUNTER(_perf_app_classload_time, SUN_CLS, "appClassLoadTime");

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -454,13 +454,6 @@ class PerfClassTraceTime {
     initialize();
   }
 
-  inline PerfClassTraceTime(PerfLongCounter* timep,     /* counter incremented with inclusive time */
-                            elapsedTimer* timers,       /* thread-local timer array */
-                            int type                    /* event type */ ) :
-      _timep(timep), _selftimep(nullptr), _eventp(nullptr), _recursion_counters(nullptr), _timers(timers), _event_type(type) {
-    initialize();
-  }
-
   ~PerfClassTraceTime();
   void initialize();
 };

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -289,7 +289,6 @@ class ClassLoader: AllStatic {
   static PerfCounter* perf_classes_linked()           { return _perf_classes_linked; }
   static PerfCounter* perf_class_link_time()          { return _perf_class_link_time; }
   static PerfCounter* perf_class_link_selftime()      { return _perf_class_link_selftime; }
-  static PerfCounter* perf_sys_class_lookup_time()    { return _perf_sys_class_lookup_time; }
   static PerfCounter* perf_shared_classload_time()    { return _perf_shared_classload_time; }
   static PerfCounter* perf_sys_classload_time()       { return _perf_sys_classload_time; }
   static PerfCounter* perf_app_classload_time()       { return _perf_app_classload_time; }

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -168,7 +168,6 @@ class ClassLoader: AllStatic {
   static PerfCounter* _perf_classes_linked;
   static PerfCounter* _perf_class_link_time;
   static PerfCounter* _perf_class_link_selftime;
-  static PerfCounter* _perf_sys_class_lookup_time;
   static PerfCounter* _perf_shared_classload_time;
   static PerfCounter* _perf_sys_classload_time;
   static PerfCounter* _perf_app_classload_time;

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -454,6 +454,13 @@ class PerfClassTraceTime {
     initialize();
   }
 
+  inline PerfClassTraceTime(PerfLongCounter* timep,     /* counter incremented with inclusive time */
+                            elapsedTimer* timers,       /* thread-local timer array */
+                            int type                    /* event type */ ) :
+      _timep(timep), _selftimep(nullptr), _eventp(nullptr), _recursion_counters(nullptr), _timers(timers), _event_type(type) {
+    initialize();
+  }
+
   ~PerfClassTraceTime();
   void initialize();
 };


### PR DESCRIPTION
Simple fix for removing the vmtimer from `UnregisteredClasses::load_class` and the corresponding `PerfClassTraceTime` constructor.

Passed tier1 testing.
--------------------
Update: correct the scope of the vmtimer instead of removing it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316967](https://bugs.openjdk.org/browse/JDK-8316967): Correct the scope of vmtimer in UnregisteredClasses::load_class (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**) ⚠️ Review applies to [321bde57](https://git.openjdk.org/jdk/pull/16046/files/321bde57b76074d6f3d4602e81c9158e85dd94ee)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16046/head:pull/16046` \
`$ git checkout pull/16046`

Update a local copy of the PR: \
`$ git checkout pull/16046` \
`$ git pull https://git.openjdk.org/jdk.git pull/16046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16046`

View PR using the GUI difftool: \
`$ git pr show -t 16046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16046.diff">https://git.openjdk.org/jdk/pull/16046.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16046#issuecomment-1747792601)