### PR TITLE
8317262: LockStack::contains(oop) fails "assert(t->is_Java_thread()) failed: incorrect cast to JavaThread"

### DIFF
--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -47,10 +47,14 @@ inline bool LockStack::can_push() const {
 }
 
 inline bool LockStack::is_owning_thread() const {
-  JavaThread* thread = JavaThread::current();
-  bool is_owning = &thread->lock_stack() == this;
-  assert(is_owning == (get_thread() == thread), "is_owning sanity");
-  return is_owning;
+  Thread* current = Thread::current();
+  if (current->is_Java_thread()) {
+    JavaThread* thread = JavaThread::cast(current);
+    bool is_owning = &thread->lock_stack() == this;
+    assert(is_owning == (get_thread() == thread), "is_owning sanity");
+    return is_owning;
+  }
+  return false;
 }
 
 inline void LockStack::push(oop o) {

--- a/test/hotspot/jtreg/runtime/lockStack/TestStackWalk.java
+++ b/test/hotspot/jtreg/runtime/lockStack/TestStackWalk.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8317262
+ * @library /testlibrary /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+HandshakeALot -XX:GuaranteedSafepointInterval=1 TestStackWalk
+ */
+
+import jvmti.JVMTIUtils;
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+import java.util.concurrent.CountDownLatch;
+
+public class TestStackWalk {
+    static Thread worker1;
+    static Thread worker2;
+    static volatile boolean done;
+    static volatile int counter = 0;
+    static Object lock = new Object();
+
+    public static void main(String... args) throws Exception {
+        worker1 = new Thread(() -> syncedWorker());
+        worker1.start();
+        worker2 = new Thread(() -> syncedWorker());
+        worker2.start();
+        Thread worker3 = new Thread(() -> stackWalker());
+        worker3.start();
+
+        worker1.join();
+        worker2.join();
+        worker3.join();
+    }
+
+    public static void syncedWorker() {
+        synchronized (lock) {
+            while (!done) {
+                counter++;
+            }
+        }
+    }
+
+    public static void stackWalker() {
+        // Suspend workers so the one looping waiting for "done"
+        // doesn't execute the handshake below, increasing the
+        // chances the VMThread will do it.
+        suspendWorkers();
+
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        long end = System.currentTimeMillis() + 20000;
+        while (end > System.currentTimeMillis()) {
+            wb.handshakeWalkStack(worker1, false /* all_threads */);
+            wb.handshakeWalkStack(worker2, false /* all_threads */);
+        }
+
+        resumeWorkers();
+        done = true;
+    }
+
+    static void suspendWorkers() {
+        try {
+            JVMTIUtils.suspendThread(worker1);
+            JVMTIUtils.suspendThread(worker2);
+        } catch (JVMTIUtils.JvmtiException e) {
+            if (e.getCode() != JVMTIUtils.JVMTI_ERROR_THREAD_NOT_ALIVE
+                && e.getCode() != JVMTIUtils.JVMTI_ERROR_WRONG_PHASE) {
+                throw e;
+            }
+        }
+    }
+
+    static void resumeWorkers() {
+        try {
+            JVMTIUtils.resumeThread(worker1);
+            JVMTIUtils.resumeThread(worker2);
+        } catch (JVMTIUtils.JvmtiException e) {
+            if (e.getCode() != JVMTIUtils.JVMTI_ERROR_THREAD_NOT_ALIVE
+                && e.getCode() != JVMTIUtils.JVMTI_ERROR_WRONG_PHASE) {
+                throw e;
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/lockStack/TestStackWalk.java
+++ b/test/hotspot/jtreg/runtime/lockStack/TestStackWalk.java
@@ -82,26 +82,12 @@ public class TestStackWalk {
     }
 
     static void suspendWorkers() {
-        try {
-            JVMTIUtils.suspendThread(worker1);
-            JVMTIUtils.suspendThread(worker2);
-        } catch (JVMTIUtils.JvmtiException e) {
-            if (e.getCode() != JVMTIUtils.JVMTI_ERROR_THREAD_NOT_ALIVE
-                && e.getCode() != JVMTIUtils.JVMTI_ERROR_WRONG_PHASE) {
-                throw e;
-            }
-        }
+        JVMTIUtils.suspendThread(worker1);
+        JVMTIUtils.suspendThread(worker2);
     }
 
     static void resumeWorkers() {
-        try {
-            JVMTIUtils.resumeThread(worker1);
-            JVMTIUtils.resumeThread(worker2);
-        } catch (JVMTIUtils.JvmtiException e) {
-            if (e.getCode() != JVMTIUtils.JVMTI_ERROR_THREAD_NOT_ALIVE
-                && e.getCode() != JVMTIUtils.JVMTI_ERROR_WRONG_PHASE) {
-                throw e;
-            }
-        }
+        JVMTIUtils.resumeThread(worker1);
+        JVMTIUtils.resumeThread(worker2);
     }
 }


### PR DESCRIPTION
Please review this simple fix to `LockStack::is_owning_thread()` that allows it to be called by a non-JavaThread. Thanks to @pchilano  for the regression test.

Testing:
- new regression test
- runtime/handshake/MixedHandshakeWalkStackTest.java
- tiers 1-3 sanity

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317262](https://bugs.openjdk.org/browse/JDK-8317262): LockStack::contains(oop) fails "assert(t-&gt;is_Java_thread()) failed: incorrect cast to JavaThread" (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Contributors
 * Patricio Chilano Mateo `<pchilanomate@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16047/head:pull/16047` \
`$ git checkout pull/16047`

Update a local copy of the PR: \
`$ git checkout pull/16047` \
`$ git pull https://git.openjdk.org/jdk.git pull/16047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16047`

View PR using the GUI difftool: \
`$ git pr show -t 16047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16047.diff">https://git.openjdk.org/jdk/pull/16047.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16047#issuecomment-1747923504)