### PR TITLE
8316447: 8 sun/management/jmxremote tests ignore VM flags

### DIFF
--- a/test/jdk/sun/management/jdp/DynamicLauncher.java
+++ b/test/jdk/sun/management/jdp/DynamicLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public abstract class DynamicLauncher {
 
     protected OutputAnalyzer runVM() throws Exception {
         String[] options = this.options();
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(options);
+        ProcessBuilder pb = ProcessTools.createTestJvm(options);
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
         System.out.println(out.getStdout());
         System.err.println(out.getStderr());

--- a/test/jdk/sun/management/jdp/DynamicLauncher.java
+++ b/test/jdk/sun/management/jdp/DynamicLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public abstract class DynamicLauncher {
 
     protected OutputAnalyzer runVM() throws Exception {
         String[] options = this.options();
-        ProcessBuilder pb = ProcessTools.createTestJvm(options);
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(options);
         OutputAnalyzer out = ProcessTools.executeProcess(pb);
         System.out.println(out.getStdout());
         System.err.println(out.getStderr());

--- a/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
@@ -173,8 +173,7 @@ public abstract class AbstractFilePermissionTest {
             command.add(className);
 
 
-            ProcessBuilder processBuilder = ProcessTools.createTestJvm(
-                    command.toArray(new String[command.size()]));
+            ProcessBuilder processBuilder = ProcessTools.createTestJvm(command);
 
             System.out.println("test cmdline: " + Arrays.toString(processBuilder.command().toArray()).replace(",", ""));
             OutputAnalyzer output = ProcessTools.executeProcess(processBuilder);

--- a/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ public abstract class AbstractFilePermissionTest {
             command.add(className);
 
 
-            ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(
+            ProcessBuilder processBuilder = ProcessTools.createTestJvm(
                     command.toArray(new String[command.size()]));
 
             System.out.println("test cmdline: " + Arrays.toString(processBuilder.command().toArray()).replace(",", ""));

--- a/test/jdk/sun/management/jmxremote/bootstrap/CustomLauncherTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/CustomLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,7 @@ public class CustomLauncherTest {
             System.out.println("  PID           : " + serverPrc.pid());
             System.out.println("  shutdown port : " + port.get());
 
-            ProcessBuilder client = ProcessTools.createJavaProcessBuilder(
+            ProcessBuilder client = ProcessTools.createTestJvm(
                 "-cp",
                 Utils.TEST_CLASS_PATH,
                 "--add-exports", "jdk.management.agent/jdk.internal.agent=ALL-UNNAMED",

--- a/test/jdk/sun/management/jmxremote/bootstrap/CustomLauncherTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/CustomLauncherTest.java
@@ -96,8 +96,6 @@ public class CustomLauncherTest {
             System.out.println("  shutdown port : " + port.get());
 
             ProcessBuilder client = ProcessTools.createTestJvm(
-                "-cp",
-                Utils.TEST_CLASS_PATH,
                 "--add-exports", "jdk.management.agent/jdk.internal.agent=ALL-UNNAMED",
                 "TestManager",
                 String.valueOf(serverPrc.pid()),

--- a/test/jdk/sun/management/jmxremote/bootstrap/JMXAgentInterfaceBinding.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/JMXAgentInterfaceBinding.java
@@ -230,7 +230,6 @@ public class JMXAgentInterfaceBinding {
         private static final String EXP_TERM_MSG_REG = "Exit: ([0-9]+)";
         private static final Pattern EXIT_PATTERN = Pattern.compile(EXP_TERM_MSG_REG);
         private static final String COOP_EXIT = "MainThread: Cooperative Exit";
-        private static final int WAIT_FOR_JMX_AGENT_TIMEOUT_MS = 20_000;
         private final String addr;
         private final int jmxPort;
         private final int rmiPort;
@@ -269,19 +268,11 @@ public class JMXAgentInterfaceBinding {
             JMXConnectorThread connectionTester = new JMXConnectorThread(
                     addr, jmxPort, rmiPort, useSSL, latch);
             connectionTester.start();
-            boolean expired = false;
             try {
-                expired = !latch.await(WAIT_FOR_JMX_AGENT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                System.out.println(
-                        "MainThread: Finished waiting for JMX agent to become available: expired == "
-                                + expired);
-                jmxAgentStarted = !expired;
+                latch.await();
+                System.out.println("MainThread: Finished waiting for JMX agent to become available.");
             } catch (InterruptedException e) {
                 throw new RuntimeException("Test failed", e);
-            }
-            if (!jmxAgentStarted) {
-                throw new RuntimeException(
-                        "Test failed. JMX server agents not becoming available.");
             }
             if (connectionTester.isFailed()
                     || !connectionTester.jmxConnectionWorked()

--- a/test/jdk/sun/management/jmxremote/bootstrap/JMXAgentInterfaceBinding.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/JMXAgentInterfaceBinding.java
@@ -234,7 +234,6 @@ public class JMXAgentInterfaceBinding {
         private final int jmxPort;
         private final int rmiPort;
         private final boolean useSSL;
-        private boolean jmxAgentStarted = false;
         private volatile Exception excptn;
 
         private MainThread(InetAddress bindAddress, int jmxPort, int rmiPort, boolean useSSL) {

--- a/test/jdk/sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/JMXInterfaceBindingTest.java
@@ -42,7 +42,7 @@ import jdk.test.lib.process.ProcessTools;
  * @modules java.management.rmi
  *
  * @build JMXAgentInterfaceBinding
- * @run main/timeout=60 JMXInterfaceBindingTest
+ * @run main JMXInterfaceBindingTest
  */
 public class JMXInterfaceBindingTest {
 
@@ -65,7 +65,6 @@ public class JMXInterfaceBindingTest {
                                                 "ssl" +
                                                 File.separator +
                                                 "truststore";
-    public static final String TEST_CLASSPATH = System.getProperty("test.classes", ".");
 
     public void run(List<InetAddress> addrs) {
         System.out.println("DEBUG: Running tests with plain sockets.");
@@ -198,8 +197,6 @@ public class JMXInterfaceBindingTest {
                             " == (%s,%d,%d)", address, jmxPort, rmiPort);
             System.out.println(msg);
             List<String> args = new ArrayList<>();
-            args.add("-classpath");
-            args.add(TEST_CLASSPATH);
             args.add("-Dcom.sun.management.jmxremote.host=" + address);
             args.add("-Dcom.sun.management.jmxremote.port=" + jmxPort);
             args.add("-Dcom.sun.management.jmxremote.rmi.port=" + rmiPort);
@@ -221,7 +218,7 @@ public class JMXInterfaceBindingTest {
             args.add(Boolean.toString(useSSL));
 
             try {
-                ProcessBuilder builder = ProcessTools.createJavaProcessBuilder(args.toArray(new String[]{}));
+                ProcessBuilder builder = ProcessTools.createTestJvm(args.toArray(new String[]{}));
                 System.out.println(ProcessTools.getCommandLine(builder));
                 Process process = builder.start();
                 output = new OutputAnalyzer(process);

--- a/test/jdk/sun/management/jmxremote/bootstrap/LocalManagementTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/LocalManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public class LocalManagementTest {
             args.add(arg);
         }
         args.add("TestApplication");
-        ProcessBuilder server = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder server = ProcessTools.createTestJvm(
             args.toArray(new String[args.size()])
         );
 
@@ -133,7 +133,7 @@ public class LocalManagementTest {
             System.out.println("  PID           : " + serverPrc.pid());
             System.out.println("  shutdown port : " + port.get());
 
-            ProcessBuilder client = ProcessTools.createJavaProcessBuilder(
+            ProcessBuilder client = ProcessTools.createTestJvm(
                 "-cp",
                 TEST_CLASSPATH,
                 "--add-exports", "jdk.management.agent/jdk.internal.agent=ALL-UNNAMED",

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
@@ -188,7 +188,7 @@ public class RmiRegistrySslTest {
             command.add(TEST_CLASS_PATH);
             command.add(className);
 
-            ProcessBuilder processBuilder = ProcessTools.createTestJvm(command.toArray(new String[command.size()]));
+            ProcessBuilder processBuilder = ProcessTools.createTestJvm(command);
 
             OutputAnalyzer output = ProcessTools.executeProcess(processBuilder);
 

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,7 +188,7 @@ public class RmiRegistrySslTest {
             command.add(TEST_CLASS_PATH);
             command.add(className);
 
-            ProcessBuilder processBuilder = ProcessTools.createJavaProcessBuilder(command.toArray(new String[command.size()]));
+            ProcessBuilder processBuilder = ProcessTools.createTestJvm(command.toArray(new String[command.size()]));
 
             OutputAnalyzer output = ProcessTools.executeProcess(processBuilder);
 

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
@@ -391,8 +391,6 @@ public class JMXStartStopTest {
     private static TestAppRun doTest(String name, String ... args)
             throws Exception {
         List<String> pbArgs = new ArrayList<>(Arrays.asList(
-                "-cp",
-                System.getProperty("test.class.path"),
                 "-Duser.language=en",
                 "-Duser.country=US",
                 "-XX:+UsePerfData"
@@ -400,9 +398,7 @@ public class JMXStartStopTest {
         pbArgs.addAll(Arrays.asList(args));
         pbArgs.add(TEST_APP_NAME);
 
-        ProcessBuilder pb = ProcessTools.createTestJvm(
-                pbArgs.toArray(new String[pbArgs.size()])
-        );
+        ProcessBuilder pb = ProcessTools.createTestJvm(pbArgs);
         TestAppRun s = new TestAppRun(pb, name);
         s.start();
         return s;

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
@@ -400,7 +400,7 @@ public class JMXStartStopTest {
         pbArgs.addAll(Arrays.asList(args));
         pbArgs.add(TEST_APP_NAME);
 
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJvm(
                 pbArgs.toArray(new String[pbArgs.size()])
         );
         TestAppRun s = new TestAppRun(pb, name);

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public class JMXStatusPerfCountersTest {
 
     @BeforeClass
     public static void setupClass() throws Exception {
-        testAppPb = ProcessTools.createJavaProcessBuilder(
+        testAppPb = ProcessTools.createTestJvm(
             "-XX:+UsePerfData",
             "-cp", System.getProperty("test.class.path"),
             TEST_APP_NAME

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java
@@ -61,7 +61,6 @@ public class JMXStatusPerfCountersTest {
     public static void setupClass() throws Exception {
         testAppPb = ProcessTools.createTestJvm(
             "-XX:+UsePerfData",
-            "-cp", System.getProperty("test.class.path"),
             TEST_APP_NAME
         );
     }

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
@@ -89,7 +89,7 @@ abstract public class JMXStatusTest {
         args.add("-XX:+UsePerfData");
         args.addAll(getCustomVmArgs());
         args.add(TEST_APP_NAME);
-        testAppPb = ProcessTools.createJavaProcessBuilder(args.toArray(new String[args.size()]));
+        testAppPb = ProcessTools.createTestJvm(args.toArray(new String[args.size()]));
 
         jcmd = new ManagementAgentJcmd(TEST_APP_NAME, false);
     }

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
@@ -84,12 +84,10 @@ abstract public class JMXStatusTest {
     @BeforeTest
     public final void setup() throws Exception {
         List<String> args = new ArrayList<>();
-        args.add("-cp");
-        args.add(System.getProperty("test.class.path"));
         args.add("-XX:+UsePerfData");
         args.addAll(getCustomVmArgs());
         args.add(TEST_APP_NAME);
-        testAppPb = ProcessTools.createTestJvm(args.toArray(new String[args.size()]));
+        testAppPb = ProcessTools.createTestJvm(args);
 
         jcmd = new ManagementAgentJcmd(TEST_APP_NAME, false);
     }


### PR DESCRIPTION
Updated test to use createTesJvm.
Removed internal timeout to not fail when Xcomp is used and also to get more info if the test times out.,

Tested by running tier1, hs-tier5 and executing test with various VM flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316447](https://bugs.openjdk.org/browse/JDK-8316447): 8 sun/management/jmxremote tests ignore VM flags (**Sub-task** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [b8ddc215](https://git.openjdk.org/jdk/pull/16048/files/b8ddc215bf558f8eab0658a4ab8d6e995ceb9a67)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16048/head:pull/16048` \
`$ git checkout pull/16048`

Update a local copy of the PR: \
`$ git checkout pull/16048` \
`$ git pull https://git.openjdk.org/jdk.git pull/16048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16048`

View PR using the GUI difftool: \
`$ git pr show -t 16048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16048.diff">https://git.openjdk.org/jdk/pull/16048.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16048#issuecomment-1748086516)