### PR TITLE
8316585: [REDO] runtime/InvocationTests spend a lot of time on dependency verification

### DIFF
--- a/test/hotspot/jtreg/runtime/InvocationTests/shared/AbstractGenerator.java
+++ b/test/hotspot/jtreg/runtime/InvocationTests/shared/AbstractGenerator.java
@@ -35,6 +35,7 @@ public abstract class AbstractGenerator {
     protected final boolean dumpClasses;
     protected final boolean executeTests;
     private static int testNum = 0;
+    private static int classesBeforeGC = 0;
 
     protected AbstractGenerator(String[] args) {
         List<String> params = new ArrayList<String>(Arrays.asList(args));
@@ -95,6 +96,14 @@ public abstract class AbstractGenerator {
         boolean isPassed = true;
 
         testNum++;
+
+        // Every N-th classes, force a GC to kick out the loaded classes from previous tests.
+        // Different tests come in with different number of classes, so testNum is not reliable.
+        classesBeforeGC -= classes.size();
+        if (classesBeforeGC <= 0) {
+            System.gc();
+            classesBeforeGC = 1024;
+        }
 
         String caseDescription = String.format("%4d| %s", testNum, description);
 


### PR DESCRIPTION
This is another (hopefully better) attempt at fixing the issue described by [JDK-8315932](https://bugs.openjdk.org/browse/JDK-8315932). The previous attempt tried to tune the Metaspace parameters, hoping for a more frequent GCs. This patch just does the GCs explicitly in the tests.

```
# Testing with CONF=linux-x86_64-server-fastdebug make test TEST=runtime/InvocationTests/  

# Current run time
4487.61s user 93.63s system 372% cpu 20:28.42 total

# GC every 2048 classes
3171.62s user 116.97s system 492% cpu 11:07.38 total

# GC every 1024 classes
3112.66s user 114.94s system 506% cpu 10:37.35 total

# GC every 512 classes
3180.21s user 122.11s system 508% cpu 10:48.85 total

# GC every 128 classes
3628.81s user 90.54s system 481% cpu 12:52.88 total
```