### PR TITLE
8312475: org.jline.util.PumpReader signed byte problem

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/PumpReader.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/PumpReader.java
@@ -414,7 +414,7 @@ public class PumpReader extends Reader {
                 return EOF;
             }
 
-            return buffer.get();
+            return buffer.get() & 0xFF;
         }
 
         private boolean readUsingBuffer() throws IOException {


### PR DESCRIPTION
Added casting to `& 0xFF` to the InputStream read method return value.