### PR TITLE
8317592: Serial: Remove Space::toContiguousSpace

### DIFF
--- a/src/hotspot/share/gc/serial/cardTableRS.cpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.cpp
@@ -53,7 +53,7 @@
 class DirtyCardToOopClosure: public MemRegionClosure {
 protected:
   OopIterateClosure* _cl;
-  Space* _sp;
+  TenuredSpace* _sp;
   HeapWord* _min_done;          // Need a downwards traversal to compensate
                                 // imprecise write barrier; this is the
                                 // lowest location already done (or,
@@ -88,7 +88,7 @@ protected:
                                HeapWord* bottom, HeapWord* top,
                                OopIterateClosure* cl);
 public:
-  DirtyCardToOopClosure(Space* sp, OopIterateClosure* cl) :
+  DirtyCardToOopClosure(TenuredSpace* sp, OopIterateClosure* cl) :
     _cl(cl), _sp(sp), _min_done(nullptr) {
     NOT_PRODUCT(_last_bottom = nullptr);
   }
@@ -98,7 +98,7 @@ public:
 
 HeapWord* DirtyCardToOopClosure::get_actual_top(HeapWord* top,
                                                 HeapWord* top_obj) {
-  if (top_obj != nullptr && top_obj < (_sp->toContiguousSpace())->top()) {
+  if (top_obj != nullptr && top_obj < _sp->top()) {
     if (cast_to_oop(top_obj)->is_objArray() || cast_to_oop(top_obj)->is_typeArray()) {
       // An arrayOop is starting on the dirty card - since we do exact
       // store checks for objArrays we are done.
@@ -111,7 +111,7 @@ HeapWord* DirtyCardToOopClosure::get_actual_top(HeapWord* top,
       top = top_obj + cast_to_oop(top_obj)->size();
     }
   } else {
-    top = (_sp->toContiguousSpace())->top();
+    top = _sp->top();
   }
   return top;
 }

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -211,12 +211,6 @@ class Space: public CHeapObj<mtGC> {
   virtual void print_short() const;
   virtual void print_short_on(outputStream* st) const;
 
-
-  // IF "this" is a ContiguousSpace, return it, else return null.
-  virtual ContiguousSpace* toContiguousSpace() {
-    return nullptr;
-  }
-
   // Debugging
   virtual void verify() const = 0;
 };
@@ -414,11 +408,6 @@ private:
   HeapWord** end_addr() { return &_end; }
 
   void print_on(outputStream* st) const override;
-
-  // Checked dynamic downcasts.
-  ContiguousSpace* toContiguousSpace() override {
-    return this;
-  }
 
   // Debugging
   void verify() const override;


### PR DESCRIPTION
Simple removing unnecessary abstraction after using more precise type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317592](https://bugs.openjdk.org/browse/JDK-8317592): Serial: Remove Space::toContiguousSpace (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16054/head:pull/16054` \
`$ git checkout pull/16054`

Update a local copy of the PR: \
`$ git checkout pull/16054` \
`$ git pull https://git.openjdk.org/jdk.git pull/16054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16054`

View PR using the GUI difftool: \
`$ git pr show -t 16054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16054.diff">https://git.openjdk.org/jdk/pull/16054.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16054#issuecomment-1748813974)