### PR TITLE
8317594: G1: Refactor find_empty_from_idx_reverse

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.hpp
@@ -106,7 +106,7 @@ class HeapRegionManager: public CHeapObj<mtGC> {
 
   void assert_contiguous_range(uint start, uint num_regions) NOT_DEBUG_RETURN;
 
-  // Finds the next sequence of empty regions starting from start_idx, going backwards in
+  // Finds the next sequence of empty regions starting from start_idx (exclusive), going backwards in
   // the heap. Returns the length of the sequence found. If this value is zero, no
   // sequence could be found, otherwise res_idx contains the start index of this range.
   uint find_empty_from_idx_reverse(uint start_idx, uint* res_idx) const;


### PR DESCRIPTION
Simple range boundary value adjustment to remove some redundant operations inside/around this method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317594](https://bugs.openjdk.org/browse/JDK-8317594): G1: Refactor find_empty_from_idx_reverse (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16055/head:pull/16055` \
`$ git checkout pull/16055`

Update a local copy of the PR: \
`$ git checkout pull/16055` \
`$ git pull https://git.openjdk.org/jdk.git pull/16055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16055`

View PR using the GUI difftool: \
`$ git pr show -t 16055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16055.diff">https://git.openjdk.org/jdk/pull/16055.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16055#issuecomment-1748824332)