### PR TITLE
8317600: VtableStubs::stub_containing() table load not ordered wrt to stores

### DIFF
--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -95,8 +95,7 @@ void VtableStub::print() const { print_on(tty); }
 // hash value). Each list is anchored in a little hash _table, indexed
 // by that hash value.
 
-VtableStub* VtableStubs::_table[VtableStubs::N];
-int VtableStubs::_number_of_vtable_stubs = 0;
+VtableStub* volatile VtableStubs::_table[VtableStubs::N];
 int VtableStubs::_vtab_stub_size = 0;
 int VtableStubs::_itab_stub_size = 0;
 
@@ -126,13 +125,13 @@ int VtableStubs::_itab_stub_size = 0;
 
 
 void VtableStubs::initialize() {
+  assert(VtableStub::_receiver_location == VMRegImpl::Bad(), "initialized multiple times?");
+
   VtableStub::_receiver_location = SharedRuntime::name_for_receiver();
   {
     MutexLocker ml(VtableStubs_lock, Mutex::_no_safepoint_check_flag);
-    assert(_number_of_vtable_stubs == 0, "potential performance bug: VtableStubs initialized more than once");
-    assert(is_power_of_2(int(N)), "N must be a power of 2");
     for (int i = 0; i < N; i++) {
-      _table[i] = nullptr;
+      Atomic::store(&_table[i], (VtableStub*)nullptr);
     }
   }
 }
@@ -259,7 +258,7 @@ inline uint VtableStubs::hash(bool is_vtable_stub, int vtable_index){
 VtableStub* VtableStubs::lookup(bool is_vtable_stub, int vtable_index) {
   assert_lock_strong(VtableStubs_lock);
   unsigned hash = VtableStubs::hash(is_vtable_stub, vtable_index);
-  VtableStub* s = _table[hash];
+  VtableStub* s = Atomic::load(&_table[hash]);
   while( s && !s->matches(is_vtable_stub, vtable_index)) s = s->next();
   return s;
 }
@@ -269,10 +268,10 @@ void VtableStubs::enter(bool is_vtable_stub, int vtable_index, VtableStub* s) {
   assert_lock_strong(VtableStubs_lock);
   assert(s->matches(is_vtable_stub, vtable_index), "bad vtable stub");
   unsigned int h = VtableStubs::hash(is_vtable_stub, vtable_index);
-  // enter s at the beginning of the corresponding list
-  s->set_next(_table[h]);
-  _table[h] = s;
-  _number_of_vtable_stubs++;
+  // Insert s at the beginning of the corresponding list.
+  s->set_next(Atomic::load(&_table[h]));
+  // Make sure that concurrent readers not taking the mutex observe the writing of "next".
+  Atomic::release_store(&_table[h], s);
 }
 
 VtableStub* VtableStubs::entry_point(address pc) {
@@ -280,7 +279,7 @@ VtableStub* VtableStubs::entry_point(address pc) {
   VtableStub* stub = (VtableStub*)(pc - VtableStub::entry_offset());
   uint hash = VtableStubs::hash(stub->is_vtable_stub(), stub->index());
   VtableStub* s;
-  for (s = _table[hash]; s != nullptr && s != stub; s = s->next()) {}
+  for (s = Atomic::load(&_table[hash]); s != nullptr && s != stub; s = s->next()) {}
   return (s == stub) ? s : nullptr;
 }
 
@@ -292,11 +291,8 @@ bool VtableStubs::contains(address pc) {
 
 
 VtableStub* VtableStubs::stub_containing(address pc) {
-  // Note: No locking needed since any change to the data structure
-  //       happens with an atomic store into it (we don't care about
-  //       consistency with the _number_of_vtable_stubs counter).
   for (int i = 0; i < N; i++) {
-    for (VtableStub* s = _table[i]; s != nullptr; s = s->next()) {
+    for (VtableStub* s = Atomic::load_acquire(&_table[i]); s != nullptr; s = s->next()) {
       if (s->contains(pc)) return s;
     }
   }
@@ -308,11 +304,11 @@ void vtableStubs_init() {
 }
 
 void VtableStubs::vtable_stub_do(void f(VtableStub*)) {
-    for (int i = 0; i < N; i++) {
-        for (VtableStub* s = _table[i]; s != nullptr; s = s->next()) {
-            f(s);
-        }
+  for (int i = 0; i < N; i++) {
+    for (VtableStub* s = Atomic::load_acquire(&_table[i]); s != nullptr; s = s->next()) {
+      f(s);
     }
+  }
 }
 
 

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -80,10 +80,11 @@ class VtableStubs : AllStatic {
     mask = N - 1
   };
 
+  static_assert(is_power_of_2((int)N), "N must be a power of 2");
+
  private:
   friend class VtableStub;
-  static VtableStub* _table[N];                  // table of existing stubs
-  static int         _number_of_vtable_stubs;    // number of stubs created so far (for statistics)
+  static VtableStub* volatile _table[N];                  // table of existing stubs
   static int         _vtab_stub_size;            // current size estimate for vtable stub (quasi-constant)
   static int         _itab_stub_size;            // current size estimate for itable stub (quasi-constant)
 
@@ -108,7 +109,6 @@ class VtableStubs : AllStatic {
   static VtableStub* entry_point(address pc);                        // vtable stub entry point for a pc
   static bool        contains(address pc);                           // is pc within any stub?
   static VtableStub* stub_containing(address pc);                    // stub containing pc or nullptr
-  static int         number_of_vtable_stubs() { return _number_of_vtable_stubs; }
   static void        initialize();
   static void        vtable_stub_do(void f(VtableStub*));            // iterates over all vtable stubs
 };


### PR DESCRIPTION
Hi all,

  please review this change that makes sure that `Vtablestubs::stub_containing()` (and `::vtable_stub_do()` I noticed while implementing this) use proper memory fences to correctly observe the next pointers in the hash table buckets.

I assume that this memory ordering issue never occurs in the wild, there is probably always some additional memory fencing between the addition of the element to the given bucket to the iteration. However it is still the more correct code (I believe) to explicitly enforce memory ordering.

Testing: gha, class unloading stress test

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317600](https://bugs.openjdk.org/browse/JDK-8317600): VtableStubs::stub_containing() table load not ordered wrt to stores (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16056/head:pull/16056` \
`$ git checkout pull/16056`

Update a local copy of the PR: \
`$ git checkout pull/16056` \
`$ git pull https://git.openjdk.org/jdk.git pull/16056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16056`

View PR using the GUI difftool: \
`$ git pr show -t 16056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16056.diff">https://git.openjdk.org/jdk/pull/16056.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16056#issuecomment-1749092558)