### PR TITLE
JDK-8317603: Improve exception messages thrown by sun.nio.ch.Net native methods (win)

### DIFF
--- a/src/java.base/windows/native/libnio/ch/DatagramChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/DatagramChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/ch/DatagramChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/DatagramChannelImpl.c
@@ -89,7 +89,7 @@ Java_sun_nio_ch_DatagramChannelImpl_disconnect0(JNIEnv *env, jclass clazz,
 
     rv = connect((SOCKET)fd, &sa.sa, sa_len);
     if (rv == SOCKET_ERROR) {
-        handleSocketError(env, WSAGetLastError());
+        NET_ThrowNew(env, WSAGetLastError(), "connect");
     } else {
         /* Disable WSAECONNRESET errors as socket is no longer connected */
         BOOL enable = FALSE;
@@ -136,7 +136,10 @@ Java_sun_nio_ch_DatagramChannelImpl_receive0(JNIEnv *env, jclass clazz,
                 }
             } else if (theErr == WSAEWOULDBLOCK) {
                 return IOS_UNAVAILABLE;
-            } else return handleSocketError(env, theErr);
+            } else {
+                NET_ThrowNew(env, theErr, "recvfrom");
+                return IOS_THROWN;
+            }
         }
     } while (retry);
 
@@ -160,7 +163,8 @@ Java_sun_nio_ch_DatagramChannelImpl_send0(JNIEnv *env, jclass clazz,
         if (theErr == WSAEWOULDBLOCK) {
             return IOS_UNAVAILABLE;
         }
-        return handleSocketError(env, (jint)WSAGetLastError());
+        NET_ThrowNew(env, (jint)WSAGetLastError(), "sendto");
+        return IOS_THROWN;
     }
     return rv;
 }

--- a/src/java.base/windows/native/libnio/ch/IOUtil.c
+++ b/src/java.base/windows/native/libnio/ch/IOUtil.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/ch/IOUtil.c
+++ b/src/java.base/windows/native/libnio/ch/IOUtil.c
@@ -149,8 +149,7 @@ Java_sun_nio_ch_IOUtil_configureBlocking(JNIEnv *env, jclass clazz,
     }
     result = ioctlsocket(fd, FIONBIO, &argp);
     if (result == SOCKET_ERROR) {
-        int error = WSAGetLastError();
-        handleSocketError(env, (jint)error);
+        NET_ThrowNew(env, WSAGetLastError(), "ioctlsocket");
     }
 }
 

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -523,7 +523,6 @@ Java_sun_nio_ch_Net_joinOrDrop6(JNIEnv *env, jobject this, jboolean join, jobjec
 {
     struct ipv6_mreq mreq6;
     int n;
-    char* error_message = "setsockopt";
 
     if (source == NULL) {
         int opt = (join) ? IPV6_ADD_MEMBERSHIP : IPV6_DROP_MEMBERSHIP;
@@ -534,11 +533,11 @@ Java_sun_nio_ch_Net_joinOrDrop6(JNIEnv *env, jobject this, jboolean join, jobjec
     } else {
         int opt = (join) ? MCAST_JOIN_SOURCE_GROUP : MCAST_LEAVE_SOURCE_GROUP;
         n = setGroupSourceReqOption(env, fdo, opt, group, index, source);
-        error_message = "setsockopt with group source request";
+
     }
 
     if (n == SOCKET_ERROR) {
-        NET_ThrowNew(env, WSAGetLastError(), error_message);
+        NET_ThrowNew(env, WSAGetLastError(), "setsockopt");
     }
     return 0;
 }
@@ -723,7 +722,7 @@ Java_sun_nio_ch_Net_pollConnect(JNIEnv* env, jclass this, jobject fdo, jlong tim
                 NET_ThrowNew(env, lastError, "getsockopt");
             }
         } else if (optError != NO_ERROR) {
-            NET_ThrowNew(env, optError, "getsockopt issue with option value");
+            NET_ThrowNew(env, optError, "getsockopt");
         }
         return JNI_FALSE;
     }

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -633,7 +633,7 @@ Java_sun_nio_ch_Net_available(JNIEnv *env, jclass cl, jobject fdo)
 {
     u_long arg;
     if (ioctlsocket((SOCKET) fdval(env, fdo), FIONREAD, &arg) == SOCKET_ERROR) {
-        NET_ThrowNew(env, WSAGetLastError(), "ioctlsocket);
+        NET_ThrowNew(env, WSAGetLastError(), "ioctlsocket");
         return IOS_THROWN;
     }
     return (jint) arg;

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -533,7 +533,6 @@ Java_sun_nio_ch_Net_joinOrDrop6(JNIEnv *env, jobject this, jboolean join, jobjec
     } else {
         int opt = (join) ? MCAST_JOIN_SOURCE_GROUP : MCAST_LEAVE_SOURCE_GROUP;
         n = setGroupSourceReqOption(env, fdo, opt, group, index, source);
-
     }
 
     if (n == SOCKET_ERROR) {

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -550,11 +550,7 @@ Java_sun_nio_ch_Net_blockOrUnblock6(JNIEnv *env, jobject this, jboolean block, j
     int opt = (block) ? MCAST_BLOCK_SOURCE : MCAST_UNBLOCK_SOURCE;
     int n = setGroupSourceReqOption(env, fdo, opt, group, index, source);
     if (n == SOCKET_ERROR) {
-        if (block) {
-            NET_ThrowNew(env, WSAGetLastError(), "setsocketopt to block source");
-        } else {
-            NET_ThrowNew(env, WSAGetLastError(), "setsocketopt to unblock source");
-        }
+        NET_ThrowNew(env, WSAGetLastError(), "setsocketopt to block or unblock source");
     }
     return 0;
 }

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -586,7 +586,7 @@ Java_sun_nio_ch_Net_getInterface4(JNIEnv* env, jobject this, jobject fdo)
 
     n = getsockopt(fdval(env, fdo), IPPROTO_IP, IP_MULTICAST_IF, (void*)&in, &arglen);
     if (n == SOCKET_ERROR) {
-        NET_ThrowNew(env, WSAGetLastError(), "setsockopt");
+        NET_ThrowNew(env, WSAGetLastError(), "getsockopt");
         return IOS_THROWN;
     }
     return ntohl(in.s_addr);
@@ -729,7 +729,7 @@ Java_sun_nio_ch_Net_pollConnect(JNIEnv* env, jclass this, jobject fdo, jlong tim
                 NET_ThrowNew(env, lastError, "getsockopt");
             }
         } else if (optError != NO_ERROR) {
-            NET_ThrowNew(env, optError, "getsockopt");
+            NET_ThrowNew(env, optError, "getsockopt issue with option value");
         }
         return JNI_FALSE;
     }

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -158,7 +158,8 @@ Java_sun_nio_ch_UnixDomainSockets_socket0(JNIEnv *env, jclass cl)
 {
     SOCKET s = WSASocketW(PF_UNIX, SOCK_STREAM, 0, &provider, 0, WSA_FLAG_OVERLAPPED);
     if (s == INVALID_SOCKET) {
-        return handleSocketError(env, WSAGetLastError());
+        NET_ThrowNew(env, WSAGetLastError(), "WSASocketW");
+        return IOS_THROWN;
     }
     SetHandleInformation((HANDLE)s, HANDLE_FLAG_INHERIT, 0);
     return (int)s;

--- a/src/java.base/windows/native/libnio/ch/nio_util.h
+++ b/src/java.base/windows/native/libnio/ch/nio_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/windows/native/libnio/ch/nio_util.h
+++ b/src/java.base/windows/native/libnio/ch/nio_util.h
@@ -46,7 +46,6 @@ jlong handleval(JNIEnv *env, jobject fdo);
 jint convertReturnVal(JNIEnv *env, jint n, jboolean r);
 jlong convertLongReturnVal(JNIEnv *env, jlong n, jboolean r);
 jboolean purgeOutstandingICMP(JNIEnv *env, jclass clazz, jint fd);
-jint handleSocketError(JNIEnv *env, int errorValue);
 
 #ifdef _WIN64
 


### PR DESCRIPTION
On Windows, we miss a handleSocketErrorWithMessage function that provides an additional message showing what went wrong in the Net.c coding.  On Unix we have this function. 
This leads sometimes to exceptions like

MSG RTE: javax.naming.CommunicationException: example.com:1234 [Root exception is java.net.ConnectException: Connection timed out: no further information]

see https://bugs.openjdk.org/browse/JDK-8317307

It would be better to have a message explaining the reason instead of "no further information" .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317603](https://bugs.openjdk.org/browse/JDK-8317603): Improve exception messages thrown by sun.nio.ch.Net native methods (win) (**Enhancement** - P4)


### Reviewers
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [c3b7e85d](https://git.openjdk.org/jdk/pull/16057/files/c3b7e85d2ab29b2827848dac879e945d0bfbbc4d)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [a4175aa1](https://git.openjdk.org/jdk/pull/16057/files/a4175aa1d9b8e5dce43208aed1fc736ff38f8b6c)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16057/head:pull/16057` \
`$ git checkout pull/16057`

Update a local copy of the PR: \
`$ git checkout pull/16057` \
`$ git pull https://git.openjdk.org/jdk.git pull/16057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16057`

View PR using the GUI difftool: \
`$ git pr show -t 16057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16057.diff">https://git.openjdk.org/jdk/pull/16057.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16057#issuecomment-1749123432)