### PR TITLE
8316959: Improve InlineCacheBuffer pending queue management

### DIFF
--- a/src/hotspot/share/code/icBuffer.cpp
+++ b/src/hotspot/share/code/icBuffer.cpp
@@ -261,7 +261,7 @@ void InlineCacheBuffer::release_pending_icholders() {
 }
 
 // Enqueue this icholder for release during the next safepoint.  It's
-// not safe to free them until them since they might be visible to
+// not safe to free them until then since they might be visible to
 // another thread.
 void InlineCacheBuffer::queue_for_release(CompiledICHolder* icholder) {
   CompiledICHolder* old = Atomic::load(&_pending_released);

--- a/src/hotspot/share/code/icBuffer.cpp
+++ b/src/hotspot/share/code/icBuffer.cpp
@@ -34,6 +34,7 @@
 #include "memory/resourceArea.hpp"
 #include "oops/method.hpp"
 #include "oops/oop.inline.hpp"
+#include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/mutexLocker.hpp"
@@ -44,8 +45,8 @@ DEF_STUB_INTERFACE(ICStub);
 
 StubQueue* InlineCacheBuffer::_buffer    = nullptr;
 
-CompiledICHolder* InlineCacheBuffer::_pending_released = nullptr;
-int InlineCacheBuffer::_pending_count = 0;
+CompiledICHolder* volatile InlineCacheBuffer::_pending_released = nullptr;
+volatile int InlineCacheBuffer::_pending_count = 0;
 
 #ifdef ASSERT
 ICRefillVerifier::ICRefillVerifier()
@@ -247,26 +248,38 @@ void* InlineCacheBuffer::cached_value_for(CompiledIC *ic) {
 // Free CompiledICHolder*s that are no longer in use
 void InlineCacheBuffer::release_pending_icholders() {
   assert(SafepointSynchronize::is_at_safepoint(), "should only be called during a safepoint");
-  CompiledICHolder* holder = _pending_released;
-  _pending_released = nullptr;
+  CompiledICHolder* holder = Atomic::xchg(&_pending_released, (CompiledICHolder*)nullptr, memory_order_relaxed);
+  int count = 0;
   while (holder != nullptr) {
     CompiledICHolder* next = holder->next();
     delete holder;
     holder = next;
-    _pending_count--;
+    count++;
   }
-  assert(_pending_count == 0, "wrong count");
+  assert(pending_icholder_count() == count, "wrong count");
+  Atomic::store(&_pending_count, 0);
 }
 
 // Enqueue this icholder for release during the next safepoint.  It's
 // not safe to free them until them since they might be visible to
 // another thread.
 void InlineCacheBuffer::queue_for_release(CompiledICHolder* icholder) {
-  MutexLocker mex(InlineCacheBuffer_lock, Mutex::_no_safepoint_check_flag);
-  icholder->set_next(_pending_released);
-  _pending_released = icholder;
-  _pending_count++;
+  CompiledICHolder* old = Atomic::load(&_pending_released);
+  for (;;) {
+    icholder->set_next(old);
+    CompiledICHolder* cur = Atomic::cmpxchg(&_pending_released, old, icholder, memory_order_relaxed);
+    if (cur == old) {
+      break;
+    }
+    old = cur;
+  }
+  Atomic::inc(&_pending_count, memory_order_relaxed);
+
   if (TraceICBuffer) {
     tty->print_cr("enqueueing icholder " INTPTR_FORMAT " to be freed", p2i(icholder));
   }
+}
+
+int InlineCacheBuffer::pending_icholder_count() {
+  return Atomic::load(&_pending_count);
 }

--- a/src/hotspot/share/code/icBuffer.hpp
+++ b/src/hotspot/share/code/icBuffer.hpp
@@ -146,8 +146,8 @@ class InlineCacheBuffer: public AllStatic {
 
   static StubQueue* _buffer;
 
-  static CompiledICHolder* _pending_released;
-  static int _pending_count;
+  static CompiledICHolder* volatile _pending_released;
+  static volatile int _pending_count;
 
   static StubQueue* buffer()                         { return _buffer;         }
 
@@ -176,7 +176,7 @@ class InlineCacheBuffer: public AllStatic {
 
   static void release_pending_icholders();
   static void queue_for_release(CompiledICHolder* icholder);
-  static int pending_icholder_count() { return _pending_count; }
+  static int pending_icholder_count();
 
   // New interface
   static bool    create_transition_stub(CompiledIC *ic, void* cached_value, address entry);

--- a/src/hotspot/share/oops/compiledICHolder.cpp
+++ b/src/hotspot/share/oops/compiledICHolder.cpp
@@ -32,7 +32,7 @@ volatile int CompiledICHolder::_live_not_claimed_count;
 #endif
 
 CompiledICHolder::CompiledICHolder(Metadata* metadata, Klass* klass, bool is_method)
-  : _holder_metadata(metadata), _holder_klass(klass), _is_metadata_method(is_method) {
+  : _holder_metadata(metadata), _holder_klass(klass), _next(nullptr), _is_metadata_method(is_method) {
 #ifdef ASSERT
   Atomic::inc(&_live_count);
   Atomic::inc(&_live_not_claimed_count);


### PR DESCRIPTION
Hi all,

  please review this change that makes enqueuing `CompiledICHolder`s into the `InlineCacheBuffer::_pending_list` lock free. This reduces time clearing IC call sites when unlinking during parallel code cache unloading by 40% (at 16 threads, with 60k unloaded nmethods) affecting G1, Shenandoah. 

I do not expect any noticeable difference for other collectors unloading serially (an uncontended mutex should be similar in performance than the CAS).

The implementation is fairly straightforward, some comments:
* I do not know why the previous implementation used `InlineCacheBuffer_lock` for guarding access to the pending list. This and the other user do not share any of the affected variables.
* managing the pending count using atomic increments is as problematic wrt to consistency with other code reading from it as before as the readers did not take the lock either. Code review showed that the time of when the code is executed seem to be disjoint enough (i.e. inside/outside safepoint, after synchronization). As mentioned, no difference here.
* `InlineCacheBuffer::release_pending_icholders` is as unguarded wrt to races with `queue_for_release` as before.

Note that there can be a performance/pause time problem with ZGC wrt to `InlineCacheBuffer::release_pending_icholders`: releasing (a lot of them) in the safepoint used for it can take a few ms alone (In my stress test 6-7ms) which might break some guarantees (otoh it's strictly speaking not the GC taking such a long stw pause). This also did not change to before.

Testing: tier1-5, code unloading stress testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316959](https://bugs.openjdk.org/browse/JDK-8316959): Improve InlineCacheBuffer pending queue management (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16059/head:pull/16059` \
`$ git checkout pull/16059`

Update a local copy of the PR: \
`$ git checkout pull/16059` \
`$ git pull https://git.openjdk.org/jdk.git pull/16059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16059`

View PR using the GUI difftool: \
`$ git pr show -t 16059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16059.diff">https://git.openjdk.org/jdk/pull/16059.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16059#issuecomment-1750136041)