### PR TITLE
JDK-6690019: JOptionPane obscured behind an always on top JFrame hangs UI

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -996,6 +996,7 @@ public class JOptionPane extends JComponent implements Accessible
             }
         }
         dialog.pack();
+        dialog.setAlwaysOnTop(true);
         dialog.setLocationRelativeTo(parentComponent);
 
         final PropertyChangeListener listener = new PropertyChangeListener() {

--- a/test/jdk/javax/swing/JOptionPane/TestJOptionPaneAlwaysOnTopBug.java
+++ b/test/jdk/javax/swing/JOptionPane/TestJOptionPaneAlwaysOnTopBug.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6690019
+ * @key headful
+ * @summary  Verifies if JOptionPane obscured behind an always on top JFrame
+ *           hangs UI
+ * @run main TestJOptionPaneAlwaysOnTopBug
+ */
+
+import java.awt.Dimension;
+import java.awt.KeyboardFocusManager;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.JOptionPane;
+
+public class TestJOptionPaneAlwaysOnTopBug {
+    static JFrame alwaysOnTopFrame;
+    static JFrame normalFrame;
+
+    public static void main(String[] args) throws Exception {
+        Robot robot = new Robot();
+        try {	
+            SwingUtilities.invokeAndWait(() -> {
+                alwaysOnTopFrame = new JFrame("Test JOptionPane");
+                alwaysOnTopFrame.setSize(600, 400);
+                centreFrame(alwaysOnTopFrame);
+                alwaysOnTopFrame.setAlwaysOnTop(true);
+                alwaysOnTopFrame.setVisible(true);
+
+                normalFrame = new JFrame();
+                normalFrame.setSize(800, 600);
+                centreFrame(normalFrame);
+                normalFrame.setVisible(true);
+
+                new Thread() {
+                    public void run() {
+                        robot.waitForIdle();
+                        robot.delay(3000);
+                        robot.keyPress(KeyEvent.VK_ENTER);
+                        robot.keyRelease(KeyEvent.VK_ENTER);
+                        System.out.println("always-on-top: " +  
+                            KeyboardFocusManager.getCurrentKeyboardFocusManager().
+                                           getFocusedWindow().isAlwaysOnTop());
+                        if (KeyboardFocusManager.getCurrentKeyboardFocusManager().
+                                    getFocusedWindow() instanceof JDialog dialog) {
+                            if (!dialog.isAlwaysOnTop()) {
+                                throw new RuntimeException("Dialog not on top");
+                            }
+                        }			
+                    }
+                }.start();
+                JOptionPane option = new JOptionPane();
+                option.showMessageDialog(normalFrame, "Can't you see me?");
+            });
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (alwaysOnTopFrame != null) {		    
+                    alwaysOnTopFrame.dispose();
+                }
+                if (normalFrame != null) {
+                    normalFrame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void centreFrame(JFrame myFrame)  {
+        Dimension d = Toolkit.getDefaultToolkit().getScreenSize();
+        int x = (d.width - myFrame.getWidth()) / 2;
+        int y = (d.height - myFrame.getHeight()) / 2;
+        myFrame.setLocation(new Point(x, y));
+    }
+}
+

--- a/test/jdk/javax/swing/JOptionPane/TestJOptionPaneAlwaysOnTopBug.java
+++ b/test/jdk/javax/swing/JOptionPane/TestJOptionPaneAlwaysOnTopBug.java
@@ -47,7 +47,7 @@ public class TestJOptionPaneAlwaysOnTopBug {
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
-        try {	
+        try {
             SwingUtilities.invokeAndWait(() -> {
                 alwaysOnTopFrame = new JFrame("Test JOptionPane");
                 alwaysOnTopFrame.setSize(600, 400);
@@ -66,7 +66,7 @@ public class TestJOptionPaneAlwaysOnTopBug {
                         robot.delay(3000);
                         robot.keyPress(KeyEvent.VK_ENTER);
                         robot.keyRelease(KeyEvent.VK_ENTER);
-                        System.out.println("always-on-top: " +  
+                        System.out.println("always-on-top: " +
                             KeyboardFocusManager.getCurrentKeyboardFocusManager().
                                            getFocusedWindow().isAlwaysOnTop());
                         if (KeyboardFocusManager.getCurrentKeyboardFocusManager().
@@ -74,7 +74,7 @@ public class TestJOptionPaneAlwaysOnTopBug {
                             if (!dialog.isAlwaysOnTop()) {
                                 throw new RuntimeException("Dialog not on top");
                             }
-                        }			
+                        }
                     }
                 }.start();
                 JOptionPane option = new JOptionPane();
@@ -82,7 +82,7 @@ public class TestJOptionPaneAlwaysOnTopBug {
             });
         } finally {
             SwingUtilities.invokeAndWait(() -> {
-                if (alwaysOnTopFrame != null) {		    
+                if (alwaysOnTopFrame != null) {
                     alwaysOnTopFrame.dispose();
                 }
                 if (normalFrame != null) {


### PR DESCRIPTION
A JOptionPane message dialog owned by a JFrame which is not always on top can be obscured behind an `"always on top" JFrame`. Since the option pane is modal, one can't move the "always on top frame" to reveal it, so the application effectively hangs as we cannot dismiss the option pane dialog
Fix is to make sure the option pane dialog is always on top....

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6690019](https://bugs.openjdk.org/browse/JDK-6690019): JOptionPane obscured behind an always on top JFrame hangs UI (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16060/head:pull/16060` \
`$ git checkout pull/16060`

Update a local copy of the PR: \
`$ git checkout pull/16060` \
`$ git pull https://git.openjdk.org/jdk.git pull/16060/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16060`

View PR using the GUI difftool: \
`$ git pr show -t 16060`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16060.diff">https://git.openjdk.org/jdk/pull/16060.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16060#issuecomment-1749302080)