### PR TITLE
8317560: Change to Xcode 14.3.1 for building on macOS at Oracle

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -367,7 +367,7 @@ to date at the time of writing.</p>
 </tr>
 <tr class="even">
 <td>macOS</td>
-<td>Mac OS X 10.13 (High Sierra)</td>
+<td>macOS 13 (Ventura)</td>
 </tr>
 <tr class="odd">
 <td>Windows</td>
@@ -464,9 +464,8 @@ this makes it difficult for a project such as the JDK to keep pace with
 a continuously updated machine running macOS. See the section on <a
 href="#apple-xcode">Apple Xcode</a> on some strategies to deal with
 this.</p>
-<p>It is recommended that you use at least Mac OS X 10.13 (High Sierra).
-At the time of writing, the JDK has been successfully compiled on macOS
-10.12 (Sierra).</p>
+<p>It is recommended that you use at least macOS 13 (Ventura) and Xcode
+14, but earlier versions may also work.</p>
 <p>The standard macOS environment contains the basic tooling needed to
 build, but for external libraries a package manager is recommended. The
 JDK uses <a href="https://brew.sh/">homebrew</a> in the examples, but
@@ -545,7 +544,7 @@ to compile successfully without issues.</p>
 </tr>
 <tr class="even">
 <td>macOS</td>
-<td>Apple Xcode 10.1 (using clang 10.0.0)</td>
+<td>Apple Xcode 14.3.1 (using clang 14.0.3)</td>
 </tr>
 <tr class="odd">
 <td>Windows</td>

--- a/doc/building.md
+++ b/doc/building.md
@@ -167,7 +167,7 @@ time of writing.
 | Operating system  | Vendor/version used                |
 | ----------------- | ---------------------------------- |
 | Linux             | Oracle Enterprise Linux 6.4 / 7.6  |
-| macOS             | Mac OS X 10.13 (High Sierra)       |
+| macOS             | macOS 13 (Ventura)                 |
 | Windows           | Windows Server 2012 R2             |
 
 The double version numbers for Linux are due to the hybrid model
@@ -270,8 +270,8 @@ difficult for a project such as the JDK to keep pace with a continuously updated
 machine running macOS. See the section on [Apple Xcode](#apple-xcode) on some
 strategies to deal with this.
 
-It is recommended that you use at least Mac OS X 10.13 (High Sierra). At the time
-of writing, the JDK has been successfully compiled on macOS 10.12 (Sierra).
+It is recommended that you use at least macOS 13 (Ventura) and Xcode
+14, but earlier versions may also work.
 
 The standard macOS environment contains the basic tooling needed to build, but
 for external libraries a package manager is recommended. The JDK uses
@@ -337,7 +337,7 @@ issues.
 | Operating system   | Toolchain version                          |
 | ------------------ | ------------------------------------------ |
 | Linux              | gcc 11.2.0                                 |
-| macOS              | Apple Xcode 10.1 (using clang 10.0.0)      |
+| macOS              | Apple Xcode 14.3.1 (using clang 14.0.3)    |
 | Windows            | Microsoft Visual Studio 2022 update 17.1.0 |
 
 All compilers are expected to be able to compile to the C99 language standard,

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1081,7 +1081,7 @@ var getJibProfilesDependencies = function (input, common) {
 
     var devkit_platform_revisions = {
         linux_x64: "gcc11.2.0-OL6.4+1.0",
-        macosx: "Xcode12.4+1.1",
+        macosx: "Xcode14.3.1+1.0",
         windows_x64: "VS2022-17.1.0+1.1",
         linux_aarch64: input.build_cpu == "x64" ? "gcc11.2.0-OL7.6+1.1" : "gcc11.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",

--- a/make/devkit/createMacosxDevkit.sh
+++ b/make/devkit/createMacosxDevkit.sh
@@ -106,8 +106,8 @@ for ex in $EXCLUDE_DIRS; do
 done
 
 echo "Copying Xcode.app..."
-echo rsync -rlH $INCLUDE_ARGS $EXCLUDE_ARGS "$XCODE_APP/." $DEVKIT_ROOT/Xcode.app/
-rsync -rlH $INCLUDE_ARGS $EXCLUDE_ARGS "$XCODE_APP/." $DEVKIT_ROOT/Xcode.app/
+echo rsync -rlH $INCLUDE_ARGS $EXCLUDE_ARGS "$XCODE_APP/." $DEVKIT_ROOT/Xcode
+rsync -rlH $INCLUDE_ARGS $EXCLUDE_ARGS "$XCODE_APP/." $DEVKIT_ROOT/Xcode
 
 ################################################################################
 
@@ -119,8 +119,8 @@ echo "Generating devkit.info..."
 rm -f $DEVKIT_ROOT/devkit.info
 echo-info "# This file describes to configure how to interpret the contents of this devkit"
 echo-info "DEVKIT_NAME=\"Xcode $XCODE_VERSION (devkit)\""
-echo-info "DEVKIT_TOOLCHAIN_PATH=\"\$DEVKIT_ROOT/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:\$DEVKIT_ROOT/Xcode.app/Contents/Developer/usr/bin\""
-echo-info "DEVKIT_SYSROOT=\"\$DEVKIT_ROOT/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/$SDK_VERSION.sdk\""
+echo-info "DEVKIT_TOOLCHAIN_PATH=\"\$DEVKIT_ROOT/Xcode/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin:\$DEVKIT_ROOT/Xcode/Contents/Developer/usr/bin\""
+echo-info "DEVKIT_SYSROOT=\"\$DEVKIT_ROOT/Xcode/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/$SDK_VERSION.sdk\""
 echo-info "DEVKIT_EXTRA_PATH=\"\$DEVKIT_TOOLCHAIN_PATH\""
 
 ################################################################################


### PR DESCRIPTION
This change bumps the version of Xcode used for building at Oracle to Xcode 14.3.1 and updates the docs accordingly. The change also updates the devkit creation logic to work around issues with macOS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317560](https://bugs.openjdk.org/browse/JDK-8317560): Change to Xcode 14.3.1 for building on macOS at Oracle (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16061/head:pull/16061` \
`$ git checkout pull/16061`

Update a local copy of the PR: \
`$ git checkout pull/16061` \
`$ git pull https://git.openjdk.org/jdk.git pull/16061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16061`

View PR using the GUI difftool: \
`$ git pr show -t 16061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16061.diff">https://git.openjdk.org/jdk/pull/16061.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16061#issuecomment-1749336179)