### PR TITLE
8317471: ListFormat::parseObject() spec can be improved on parsePosition valid values

### DIFF
--- a/src/java.base/share/classes/java/text/ListFormat.java
+++ b/src/java.base/share/classes/java/text/ListFormat.java
@@ -416,6 +416,8 @@ public final class ListFormat extends Format {
      * @return A list of string parsed from the {@code source}.
      *            In case of error, returns null.
      * @throws NullPointerException if {@code source} or {@code parsePos} is null.
+     * @throws IndexOutOfBoundsException if the starting index given by
+     *            {@code parsePos} is outside {@code source}.
      */
     @Override
     public Object parseObject(String source, ParsePosition parsePos) {


### PR DESCRIPTION
Adding IOOBE clause to clarify the behavior on an invalid `parsePos` argument on calling `ListFormat::parseObject()`. A corresponding CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8317546](https://bugs.openjdk.org/browse/JDK-8317546) to be approved

### Issues
 * [JDK-8317471](https://bugs.openjdk.org/browse/JDK-8317471): ListFormat::parseObject()  spec can be improved on parsePosition valid values (**Enhancement** - P3)
 * [JDK-8317546](https://bugs.openjdk.org/browse/JDK-8317546): ListFormat::parseObject()  spec can be improved on parsePosition valid values (**CSR**)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16063/head:pull/16063` \
`$ git checkout pull/16063`

Update a local copy of the PR: \
`$ git checkout pull/16063` \
`$ git pull https://git.openjdk.org/jdk.git pull/16063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16063`

View PR using the GUI difftool: \
`$ git pr show -t 16063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16063.diff">https://git.openjdk.org/jdk/pull/16063.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16063#issuecomment-1749403237)