### PR TITLE
JDK-8317612: ChoiceFormat and MessageFormat constructors call non-final public method

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -412,6 +412,10 @@ public class ChoiceFormat extends NumberFormat {
 
     /**
      * Set the choices to be used in formatting.
+     *
+     * @implSpec {@link #ChoiceFormat(double[], String[])} may invoke this method.
+     * Therefore, any changes made to the {@code setChoices} method in subclasses
+     * may be reflected in the constructor as well.
      * @param limits contains the top value that you want
      * parsed with that format, and should be in ascending sorted order. When
      * formatting X, the choice will be the i, where

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -231,9 +231,9 @@ public class ChoiceFormat extends NumberFormat {
      * for the ChoiceFormat pattern can be seen in the {@linkplain ##patterns
      * Patterns} section.
      *
-     * @implSpec {@link ChoiceFormat#ChoiceFormat(String)} invokes this method.
-     * Therefore, any changes made to the applyPattern method in subclasses
-     * will be reflected in the constructor as well.
+     * @implSpec {@link #ChoiceFormat(String)} may invoke this method.
+     * Therefore, any changes made to the {@code applyPattern} method in subclasses
+     * may be reflected in the constructor as well.
      * @param newPattern a pattern string
      * @throws    NullPointerException if {@code newPattern}
      *            is {@code null}

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -231,6 +231,9 @@ public class ChoiceFormat extends NumberFormat {
      * for the ChoiceFormat pattern can be seen in the {@linkplain ##patterns
      * Patterns} section.
      *
+     * @implSpec {@link ChoiceFormat#ChoiceFormat(String)} invokes this method.
+     * Therefore, any changes made to the applyPattern method in subclasses
+     * will be reflected in the constructor as well.
      * @param newPattern a pattern string
      * @throws    NullPointerException if {@code newPattern}
      *            is {@code null}

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -231,9 +231,6 @@ public class ChoiceFormat extends NumberFormat {
      * for the ChoiceFormat pattern can be seen in the {@linkplain ##patterns
      * Patterns} section.
      *
-     * @implSpec {@link #ChoiceFormat(String)} may invoke this method.
-     * Therefore, any changes made to the {@code applyPattern} method in subclasses
-     * may be reflected in the constructor as well.
      * @param newPattern a pattern string
      * @throws    NullPointerException if {@code newPattern}
      *            is {@code null}
@@ -242,6 +239,17 @@ public class ChoiceFormat extends NumberFormat {
      * @see #ChoiceFormat(String)
      */
     public void applyPattern(String newPattern) {
+        applyPatternImpl(newPattern);
+    }
+
+    /**
+     * Implementation of applying a pattern to this ChoiceFormat.
+     * This method processes a String pattern in accordance with the ChoiceFormat
+     * pattern syntax and populates the internal {@code limits} and {@code formats}
+     * array variables. See the {@linkplain ##patterns} section for
+     * further understanding of certain special characters: "#", "<", "\u2264", "|".
+     */
+    private void applyPatternImpl(String newPattern) {
         StringBuilder[] segments = new StringBuilder[2];
         for (int i = 0; i < segments.length; ++i) {
             segments[i] = new StringBuilder();
@@ -322,8 +330,8 @@ public class ChoiceFormat extends NumberFormat {
     }
 
     /**
-     * {@return a pattern {@code string} that represents the the limits and formats
-     * of this ChoiceFormat object}
+     * {@return a pattern {@code string} that represents the {@code limits} and
+     * {@code formats} of this ChoiceFormat object}
      *
      * The {@code string} returned is not guaranteed to be the same input
      * {@code string} passed to either {@link #applyPattern(String)} or
@@ -392,7 +400,7 @@ public class ChoiceFormat extends NumberFormat {
      * @see #applyPattern
      */
     public ChoiceFormat(String newPattern)  {
-        applyPattern(newPattern);
+        applyPatternImpl(newPattern);
     }
 
     /**
@@ -407,15 +415,12 @@ public class ChoiceFormat extends NumberFormat {
      * @see #setChoices
      */
     public ChoiceFormat(double[] limits, String[] formats) {
-        setChoices(limits, formats);
+        setChoicesImpl(limits, formats);
     }
 
     /**
      * Set the choices to be used in formatting.
      *
-     * @implSpec {@link #ChoiceFormat(double[], String[])} may invoke this method.
-     * Therefore, any changes made to the {@code setChoices} method in subclasses
-     * may be reflected in the constructor as well.
      * @param limits contains the top value that you want
      * parsed with that format, and should be in ascending sorted order. When
      * formatting X, the choice will be the i, where
@@ -429,6 +434,14 @@ public class ChoiceFormat extends NumberFormat {
      *            and {@code formats} are not equal
      */
     public void setChoices(double[] limits, String[] formats) {
+        setChoicesImpl(limits, formats);
+    }
+
+    /**
+     * Implementation of populating the {@code limits} and
+     * {@code formats} of this ChoiceFormat. Defensive copies are made.
+     */
+    private void setChoicesImpl(double[] limits, String[] formats) {
         if (limits.length != formats.length) {
             throw new IllegalArgumentException(
                     "Input arrays must be of the same length.");
@@ -441,16 +454,14 @@ public class ChoiceFormat extends NumberFormat {
      * {@return the limits of this ChoiceFormat}
      */
     public double[] getLimits() {
-        double[] newLimits = Arrays.copyOf(choiceLimits, choiceLimits.length);
-        return newLimits;
+        return Arrays.copyOf(choiceLimits, choiceLimits.length);
     }
 
     /**
      * {@return the formats of this ChoiceFormat}
      */
     public Object[] getFormats() {
-        Object[] newFormats = Arrays.copyOf(choiceFormats, choiceFormats.length);
-        return newFormats;
+        return Arrays.copyOf(choiceFormats, choiceFormats.length);
     }
 
     // Overrides
@@ -546,7 +557,7 @@ public class ChoiceFormat extends NumberFormat {
      * @return the least double value greater than {@code d}
      * @see #previousDouble
      */
-    public static final double nextDouble (double d) {
+    public static double nextDouble (double d) {
         return Math.nextUp(d);
     }
 
@@ -561,7 +572,7 @@ public class ChoiceFormat extends NumberFormat {
      * @return the greatest double value less than {@code d}
      * @see #nextDouble
      */
-    public static final double previousDouble (double d) {
+    public static double previousDouble (double d) {
         return Math.nextDown(d);
     }
 

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -557,7 +557,7 @@ public class ChoiceFormat extends NumberFormat {
      * @return the least double value greater than {@code d}
      * @see #previousDouble
      */
-    public static double nextDouble (double d) {
+    public static final double nextDouble (double d) {
         return Math.nextUp(d);
     }
 
@@ -572,7 +572,7 @@ public class ChoiceFormat extends NumberFormat {
      * @return the greatest double value less than {@code d}
      * @see #nextDouble
      */
-    public static double previousDouble (double d) {
+    public static final double previousDouble (double d) {
         return Math.nextDown(d);
     }
 

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -451,8 +451,8 @@ public class MessageFormat extends Format {
      *
      * @implSpec {@link #MessageFormat(String)} and
      * {@link #MessageFormat(String, Locale)} may invoke this method.
-     * Therefore, any changes made to the applyPattern method in subclasses
-     * may be reflected in the constructors as well.
+     * Therefore, any changes made to the {@code applyPattern} method in
+     * subclasses may be reflected in the constructors as well.
      * @param pattern the pattern for this message format
      * @throws    IllegalArgumentException if the pattern is invalid
      * @throws    NullPointerException if {@code pattern} is

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -371,7 +371,7 @@ public class MessageFormat extends Format {
      * The constructor first sets the locale, then parses the pattern and
      * creates a list of subformats for the format elements contained in it.
      * Patterns and their interpretation are specified in the
-     * <a href="#patterns">class description</a>.
+     * {@linkplain ##patterns class description}.
      *
      * @param pattern the pattern for this message format
      * @throws    IllegalArgumentException if the pattern is invalid
@@ -389,7 +389,7 @@ public class MessageFormat extends Format {
      * The constructor first sets the locale, then parses the pattern and
      * creates a list of subformats for the format elements contained in it.
      * Patterns and their interpretation are specified in the
-     * <a href="#patterns">class description</a>.
+     * {@linkplain ##patterns class description}.
      *
      * @implSpec The default implementation throws a
      * {@code NullPointerException} if {@code locale} is {@code null}
@@ -447,7 +447,7 @@ public class MessageFormat extends Format {
      * The method parses the pattern and creates a list of subformats
      * for the format elements contained in it.
      * Patterns and their interpretation are specified in the
-     * <a href="#patterns">class description</a>.
+     * {@linkplain ##patterns class description}.
      *
      * @param pattern the pattern for this message format
      * @throws    IllegalArgumentException if the pattern is invalid
@@ -461,9 +461,12 @@ public class MessageFormat extends Format {
     /**
      * Implementation of applying a pattern to this MessageFormat.
      * This method processes a String pattern in accordance with the MessageFormat
-     * pattern syntax and sets the internal {@code pattern} variable. See the
-     * {@linkplain ##patterns} section for further understanding of certain special
-     * characters: "{", "}", ",".
+     * pattern syntax and sets the internal {@code pattern} variable as well as
+     * populating the {@code formats} array with the subformats defined in the
+     * pattern. See the {@linkplain ##patterns} section for further understanding
+     * of certain special characters: "{", "}", ",". See {@linkplain
+     * ##makeFormat(int, int, StringBuilder[])} for the implementation of setting
+     * a subformat.
      */
     @SuppressWarnings("fallthrough") // fallthrough in switch is expected, suppress it
     private void applyPatternImpl(String pattern) {
@@ -520,6 +523,7 @@ public class MessageFormat extends Format {
                         case '}':
                             if (braceStack == 0) {
                                 part = SEG_RAW;
+                                // Set the subformat
                                 makeFormat(i, formatNumber, segments);
                                 formatNumber++;
                                 // throw away other segments

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -449,10 +449,10 @@ public class MessageFormat extends Format {
      * Patterns and their interpretation are specified in the
      * <a href="#patterns">class description</a>.
      *
-     * @implSpec {@link MessageFormat#MessageFormat(String)} and
-     * {@link MessageFormat#MessageFormat(String, Locale)} invoke this method.
+     * @implSpec {@link #MessageFormat(String)} and
+     * {@link #MessageFormat(String, Locale)} may invoke this method.
      * Therefore, any changes made to the applyPattern method in subclasses
-     * will be reflected in the constructors as well.
+     * may be reflected in the constructors as well.
      * @param pattern the pattern for this message format
      * @throws    IllegalArgumentException if the pattern is invalid
      * @throws    NullPointerException if {@code pattern} is

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -380,7 +380,7 @@ public class MessageFormat extends Format {
      */
     public MessageFormat(String pattern) {
         this.locale = Locale.getDefault(Locale.Category.FORMAT);
-        applyPattern(pattern);
+        applyPatternImpl(pattern);
     }
 
     /**
@@ -408,7 +408,7 @@ public class MessageFormat extends Format {
      */
     public MessageFormat(String pattern, Locale locale) {
         this.locale = locale;
-        applyPattern(pattern);
+        applyPatternImpl(pattern);
     }
 
     /**
@@ -449,17 +449,24 @@ public class MessageFormat extends Format {
      * Patterns and their interpretation are specified in the
      * <a href="#patterns">class description</a>.
      *
-     * @implSpec {@link #MessageFormat(String)} and
-     * {@link #MessageFormat(String, Locale)} may invoke this method.
-     * Therefore, any changes made to the {@code applyPattern} method in
-     * subclasses may be reflected in the constructors as well.
      * @param pattern the pattern for this message format
      * @throws    IllegalArgumentException if the pattern is invalid
      * @throws    NullPointerException if {@code pattern} is
      *            {@code null}
      */
-    @SuppressWarnings("fallthrough") // fallthrough in switch is expected, suppress it
     public void applyPattern(String pattern) {
+        applyPatternImpl(pattern);
+    }
+
+    /**
+     * Implementation of applying a pattern to this MessageFormat.
+     * This method processes a String pattern in accordance with the MessageFormat
+     * pattern syntax and sets the internal {@code pattern} variable. See the
+     * {@linkplain ##patterns} section for further understanding of certain special
+     * characters: "{", "}", ",".
+     */
+    @SuppressWarnings("fallthrough") // fallthrough in switch is expected, suppress it
+    private void applyPatternImpl(String pattern) {
             StringBuilder[] segments = new StringBuilder[4];
             // Allocate only segments[SEG_RAW] here. The rest are
             // allocated on demand.
@@ -1596,7 +1603,7 @@ public class MessageFormat extends Format {
         formats[offsetNumber] = newFormat;
     }
 
-    private static final int findKeyword(String s, String[] list) {
+    private static int findKeyword(String s, String[] list) {
         for (int i = 0; i < list.length; ++i) {
             if (s.equals(list[i]))
                 return i;
@@ -1613,8 +1620,8 @@ public class MessageFormat extends Format {
         return -1;
     }
 
-    private static final void copyAndFixQuotes(String source, int start, int end,
-                                               StringBuilder target) {
+    private static void copyAndFixQuotes(String source, int start, int end,
+                                         StringBuilder target) {
         boolean quoted = false;
 
         for (int i = start; i < end; ++i) {

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -449,6 +449,10 @@ public class MessageFormat extends Format {
      * Patterns and their interpretation are specified in the
      * <a href="#patterns">class description</a>.
      *
+     * @implSpec {@link MessageFormat#MessageFormat(String)} and
+     * {@link MessageFormat#MessageFormat(String, Locale)} invoke this method.
+     * Therefore, any changes made to the applyPattern method in subclasses
+     * will be reflected in the constructors as well.
      * @param pattern the pattern for this message format
      * @throws    IllegalArgumentException if the pattern is invalid
      * @throws    NullPointerException if {@code pattern} is


### PR DESCRIPTION
Please review this PR which updates ChoiceFormat and MessageFormat to no longer call overridable methods in their constructors.

The overridable methods called in the constructors are: _ChoiceFormat::applyPattern_, _ChoiceFormat::setChoices_, and _MessageFormat::applyPattern_. The code should be updated so that both the methods and constructors call a separate private method. Some other drive-by cleanup changes were included in the change as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8317630](https://bugs.openjdk.org/browse/JDK-8317630) to be approved

### Issues
 * [JDK-8317612](https://bugs.openjdk.org/browse/JDK-8317612): ChoiceFormat and MessageFormat constructors call non-final public method (**Bug** - P4)
 * [JDK-8317630](https://bugs.openjdk.org/browse/JDK-8317630): ChoiceFormat and MessageFormat constructors call non-final public method (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16064/head:pull/16064` \
`$ git checkout pull/16064`

Update a local copy of the PR: \
`$ git checkout pull/16064` \
`$ git pull https://git.openjdk.org/jdk.git pull/16064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16064`

View PR using the GUI difftool: \
`$ git pr show -t 16064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16064.diff">https://git.openjdk.org/jdk/pull/16064.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16064#issuecomment-1751153493)