### PR TITLE
8317634: Introduce the ability to exclude modules from dedup-legal-notices plugin of jlink

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -74,25 +74,27 @@ compress.warn.argumentdeprecated=\
 Warning: The {0} argument for --compress is deprecated and may be removed in a future release
 
 
-dedup-legal-notices.argument=[error-if-not-same-content]\
-  |[exclude-modules=comma separated list of module names]\
-  |[error-if-not-same-content:exclude-modules=comma separated list of module names]
+dedup-legal-notices.argument=[error-if-not-same-content]|[exclude-modules=<module names>]\
+|[error-if-not-same-content:exclude-modules=<module names>]
 
 dedup-legal-notices.description=\
 De-duplicate all legal notices.  If error-if-not-same-content is\n\
 specified then it will be an error if two files of the same filename\n\
-are different.
+are different.\n\
+exclude-modules is a comma separated list of module names whose legal\n\
+notices will not be de-duplicated.
 
 dedup-legal-notices.usage=\
-\  --dedup-legal-notices [error-if-not-same-content]\
-\  |[exclude-modules=comma separated list of module names]\
-\  |[error-if-not-same-content:exclude-modules=comma separated list of module names]\n\
+\  --dedup-legal-notices [error-if-not-same-content]\n\
+\                        |[exclude-modules=<module names>]\n\
+\                        |[error-if-not-same-content:exclude-modules=<module names>]\n\
 \                            De-duplicate all legal notices.\n\
 \                            If error-if-not-same-content is specified then\n\
 \                            it will be an error if two files of the same\n\
 \                            filename are different.\n\
-\                            If exclude-modules is specified then the\n\
-\                            legal notices of those modules will not be de-duplicated.
+\                            exclude-modules is a comma separated list\n\
+\                            of module names whose legal notices will not\n\
+\                            be de-duplicated.
 
 exclude-files.argument=<pattern-list> of files to exclude
 

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/resources/plugins.properties
@@ -74,7 +74,9 @@ compress.warn.argumentdeprecated=\
 Warning: The {0} argument for --compress is deprecated and may be removed in a future release
 
 
-dedup-legal-notices.argument=[error-if-not-same-content]
+dedup-legal-notices.argument=[error-if-not-same-content]\
+  |[exclude-modules=comma separated list of module names]\
+  |[error-if-not-same-content:exclude-modules=comma separated list of module names]
 
 dedup-legal-notices.description=\
 De-duplicate all legal notices.  If error-if-not-same-content is\n\
@@ -82,11 +84,15 @@ specified then it will be an error if two files of the same filename\n\
 are different.
 
 dedup-legal-notices.usage=\
-\  --dedup-legal-notices [error-if-not-same-content]\n\
+\  --dedup-legal-notices [error-if-not-same-content]\
+\  |[exclude-modules=comma separated list of module names]\
+\  |[error-if-not-same-content:exclude-modules=comma separated list of module names]\n\
 \                            De-duplicate all legal notices.\n\
 \                            If error-if-not-same-content is specified then\n\
 \                            it will be an error if two files of the same\n\
-\                            filename are different.
+\                            filename are different.\n\
+\                            If exclude-modules is specified then the\n\
+\                            legal notices of those modules will not be de-duplicated.
 
 exclude-files.argument=<pattern-list> of files to exclude
 


### PR DESCRIPTION
Can I please get a review of this change which proposes to implement the enhancement request noted in https://bugs.openjdk.org/browse/JDK-8317634?

The change in this commit introduces a new `exclude-modules` argument to the `dedup-legal-notices` jlink plugin. This optional argument takes a comma separated values of module names. These module names are then excluded from the de-duplication of license notice files during image generation.

(Edited to add some context) The motivation for this change is discussed here https://github.com/openjdk/jdk/pull/13686#issuecomment-1747301865

Two new test methods have been added to the existing `LegalFilePluginTest` jtreg test case to verify this implementation. Existing tests in `test/jdk/tools/jlink` continue to pass. tier testing is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 22 to be approved (needs to be created)

### Issue
 * [JDK-8317634](https://bugs.openjdk.org/browse/JDK-8317634): Introduce the ability to exclude modules from dedup-legal-notices plugin of jlink (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16066/head:pull/16066` \
`$ git checkout pull/16066`

Update a local copy of the PR: \
`$ git checkout pull/16066` \
`$ git pull https://git.openjdk.org/jdk.git pull/16066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16066`

View PR using the GUI difftool: \
`$ git pr show -t 16066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16066.diff">https://git.openjdk.org/jdk/pull/16066.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16066#issuecomment-1749876058)