### PR TITLE
4365952: Cannot disable JFileChooser

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaFileChooserUI.java
@@ -744,6 +744,10 @@ public class AquaFileChooserUI extends FileChooserUI {
         public void mouseClicked(final MouseEvent e) {
             if (e.getClickCount() != 2) return;
 
+            if (!getFileChooser().isEnabled()) {
+                return;
+            }
+
             final int index = list.locationToIndex(e.getPoint());
             if (index < 0) return;
 
@@ -1500,6 +1504,9 @@ public class AquaFileChooserUI extends FileChooserUI {
 
         // Instead of dragging, it selects which one to sort by
         public void setDraggedColumn(final TableColumn aColumn) {
+            if (!getFileChooser().isEnabled()) {
+                return;
+            }
             if (aColumn != null) {
                 final int colIndex = aColumn.getModelIndex();
                 if (colIndex != fSortColumn) {
@@ -1839,6 +1846,10 @@ public class AquaFileChooserUI extends FileChooserUI {
 
             // The autoscroller can generate drag events outside the Table's range.
             if ((column == -1) || (row == -1)) { return; }
+
+            if (!getFileChooser().isEnabled()) {
+                return;
+            }
 
             final File clickedFile = (File)(fFileList.getValueAt(row, 0));
 

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
@@ -435,6 +435,11 @@ class GTKFileChooserUI extends SynthFileChooserUI {
         }
 
         public void mouseClicked(MouseEvent e) {
+
+            if (!getFileChooser().isEnabled()) {
+                return;
+            }
+
             if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
                 int index = list.locationToIndex(e.getPoint());
                 if (index >= 0) {

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -2078,4 +2078,20 @@ public class JFileChooser extends JComponent implements Accessible {
             }
         }
     }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        setEnabled(this, enabled);
+    }
+
+    private static void setEnabled(Container container, boolean enabled) {
+        for (Component component : container.getComponents()) {
+            component.setEnabled(enabled);
+            if (component instanceof Container) {
+                setEnabled((Container) component, enabled);
+            }
+        }
+    }
+
 }

--- a/src/java.desktop/share/classes/javax/swing/JFileChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JFileChooser.java
@@ -2079,6 +2079,10 @@ public class JFileChooser extends JComponent implements Accessible {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * @param enabled {@inheritDoc}
+     */
     @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicFileChooserUI.java
@@ -643,6 +643,9 @@ public class BasicFileChooserUI extends FileChooserUI {
         public void mouseClicked(MouseEvent evt) {
             // Note: we can't depend on evt.getSource() because of backward
             // compatibility
+            if (!getFileChooser().isEnabled()) {
+                return;
+            }
             if (list != null &&
                 SwingUtilities.isLeftMouseButton(evt) &&
                 (evt.getClickCount()%2 == 0)) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
@@ -2228,7 +2228,7 @@ public abstract class BasicLookAndFeel extends LookAndFeel implements Serializab
                         src = (JComponent)
                             ((BasicSplitPaneDivider)c).getParent();
                     }
-                    if(src != null) {
+                    if(src != null && src.isEnabled()) {
                         JPopupMenu componentPopupMenu = src.getComponentPopupMenu();
                         if(componentPopupMenu != null) {
                             Point pt = src.getPopupLocation(me);

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollPaneUI.java
@@ -998,7 +998,8 @@ public class BasicScrollPaneUI
         //
         public void mouseWheelMoved(MouseWheelEvent e) {
             if (scrollpane.isWheelScrollingEnabled() &&
-                e.getWheelRotation() != 0) {
+                    scrollpane.isEnabled() &&
+                    e.getWheelRotation() != 0) {
                 JScrollBar toScroll = scrollpane.getVerticalScrollBar();
                 int direction = e.getWheelRotation() < 0 ? -1 : 1;
                 int orientation = SwingConstants.VERTICAL;

--- a/src/java.desktop/share/classes/sun/swing/FilePane.java
+++ b/src/java.desktop/share/classes/sun/swing/FilePane.java
@@ -1954,6 +1954,10 @@ public class FilePane extends JPanel implements PropertyChangeListener {
         public void mouseClicked(MouseEvent evt) {
             JComponent source = (JComponent)evt.getSource();
 
+            if(!source.isEnabled()) {
+                return;
+            }
+
             int index;
             if (source instanceof JList) {
                 index = SwingUtilities2.loc2IndexFileList(list, evt.getPoint());

--- a/src/java.desktop/share/classes/sun/swing/FilePane.java
+++ b/src/java.desktop/share/classes/sun/swing/FilePane.java
@@ -1954,7 +1954,7 @@ public class FilePane extends JPanel implements PropertyChangeListener {
         public void mouseClicked(MouseEvent evt) {
             JComponent source = (JComponent)evt.getSource();
 
-            if(!source.isEnabled()) {
+            if (!source.isEnabled()) {
                 return;
             }
 

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
@@ -371,6 +371,10 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
 
         viewMenuButton.addMouseListener(new MouseAdapter() {
             public void mousePressed(MouseEvent e) {
+                if(!getFileChooser().isEnabled()) {
+                    return;
+                }
+
                 if (SwingUtilities.isLeftMouseButton(e) && !viewMenuButton.isSelected()) {
                     viewMenuButton.setSelected(true);
 
@@ -380,6 +384,10 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
         });
         viewMenuButton.addKeyListener(new KeyAdapter() {
             public void keyPressed(KeyEvent e) {
+                if(!getFileChooser().isEnabled()) {
+                    return;
+                }
+
                 // Forbid keyboard actions if the button is not in rollover state
                 if (e.getKeyCode() == KeyEvent.VK_SPACE && viewMenuButton.getModel().isRollover()) {
                     viewMenuButton.setSelected(true);

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsFileChooserUI.java
@@ -371,7 +371,7 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
 
         viewMenuButton.addMouseListener(new MouseAdapter() {
             public void mousePressed(MouseEvent e) {
-                if(!getFileChooser().isEnabled()) {
+                if (!getFileChooser().isEnabled()) {
                     return;
                 }
 
@@ -384,7 +384,7 @@ public class WindowsFileChooserUI extends BasicFileChooserUI {
         });
         viewMenuButton.addKeyListener(new KeyAdapter() {
             public void keyPressed(KeyEvent e) {
-                if(!getFileChooser().isEnabled()) {
+                if (!getFileChooser().isEnabled()) {
                     return;
                 }
 

--- a/test/jdk/javax/swing/JFileChooser/FileChooserDisableTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserDisableTest.java
@@ -44,9 +44,10 @@ import java.util.function.Predicate;
  * @test
  * @bug 4365952
  * @key headful
- * @summary Test to check is File chooser can be Disabled
+ * @summary Test to check is JFilechooser can be Disabled
  * @run main FileChooserDisableTest
  */
+
 public class FileChooserDisableTest {
     static JFrame frame;
     static JFileChooser jfc;
@@ -68,7 +69,7 @@ public class FileChooserDisableTest {
                 buttonToolTip = "Open selected file";
             }
 
-            System.out.println("Testing LAF: " + laf.getClassName());
+            System.out.println("Testing LAF : " + laf.getClassName());
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
             try {
                 SwingUtilities.invokeAndWait(() -> {

--- a/test/jdk/javax/swing/JFileChooser/FileChooserDisableTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserDisableTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+
+import javax.swing.AbstractButton;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.WindowConstants;
+
+import java.util.function.Predicate;
+
+/*
+ * @test
+ * @bug 4365952
+ * @key headful
+ * @summary Test to check is File chooser can be Disabled
+ * @run main FileChooserDisableTest
+ */
+public class FileChooserDisableTest {
+    static Robot robot;
+    static JFrame frame;
+    static JFileChooser jfc;
+    static volatile Point movePoint;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+        try {
+
+            SwingUtilities.invokeAndWait(() -> {
+                initialize();
+            });
+            String defaultDirectory = jfc.getCurrentDirectory().toString();
+            robot.delay(1000);
+            robot.waitForIdle();
+            final AbstractButton[] desktopBtn = new AbstractButton[1];
+            SwingUtilities.invokeAndWait(() -> {
+                desktopBtn[0] = clickDetails();
+                movePoint = desktopBtn[0].getLocationOnScreen();
+            });
+            Dimension btnSize = desktopBtn[0].getSize();
+            robot.mouseMove(movePoint.x + btnSize.width / 2, movePoint.y + btnSize.height / 2);
+            robot.delay(2000);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(2000);
+            robot.waitForIdle();
+            String currentDirectory = jfc.getCurrentDirectory().toString();
+            if (!currentDirectory.equals(defaultDirectory)) {
+                throw new RuntimeException("File chooser disable failed");
+            }
+            System.out.println("Test Pass");
+
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static AbstractButton clickDetails() {
+        AbstractButton details = findDetailsButton(jfc);
+        if (details == null) {
+            throw new Error("Didn't find 'Home' button in JFileChooser");
+        }
+        return details;
+    }
+
+    private static Component findComponent(final Container container,
+                                           final Predicate<Component> predicate) {
+        for (Component child : container.getComponents()) {
+            if (predicate.test(child)) {
+                return child;
+            }
+            if (child instanceof Container cont && cont.getComponentCount() > 0) {
+                Component result = findComponent(cont, predicate);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static AbstractButton findDetailsButton(final Container container) {
+        Component result = findComponent(container,
+                c -> c instanceof JButton button
+                        && "Home".equals(button.getToolTipText()));
+        return (AbstractButton) result;
+    }
+
+    static void initialize() {
+        frame = new JFrame("JFileChooser Disable test");
+        jfc = new JFileChooser();
+        jfc.setEnabled(false);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.add(jfc, BorderLayout.CENTER);
+        frame.pack();
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JFileChooser/FileChooserDisableTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileChooserDisableTest.java
@@ -44,7 +44,7 @@ import java.util.function.Predicate;
  * @test
  * @bug 4365952
  * @key headful
- * @summary Test to check is JFilechooser can be Disabled
+ * @summary Test to check if JFileChooser can be disabled
  * @run main FileChooserDisableTest
  */
 


### PR DESCRIPTION
Invoking `setEnabled(false)` on an instance of `JFileChooser` the sub-components are unaffected since the sub-components didn't set/unset enabled explicitly. The fix address the issue and sets the Enabled flag to each sub-components. Along with setting the property to each sub components, the action listeners like mouseClick(Double too) and scroll actions has to be processed based on enabled/disabled property similar to other components. Since `JFilechooser` implementation varies based on LookAndFeel, the same had to be taken care for affected LookAndFeel also. 
Note: `JFrame` being top level container handles frame disable using native method which couldn't be the case for `JFileChooser`. For `showDialog/showOpenDialog/showSaveDialog` the fix could be to set the one the enabled property for created single Dialog. But when an instance of `JFileChooser` is created and added to Frame (Without Dialog been created), disabling the `FileChooser` alone had to be done by handling each sub-components and listeners separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8318024](https://bugs.openjdk.org/browse/JDK-8318024) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-4365952](https://bugs.openjdk.org/browse/JDK-4365952): Cannot disable JFileChooser (**Bug** - P4)
 * [JDK-8318024](https://bugs.openjdk.org/browse/JDK-8318024): Cannot disable JFileChooser (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16068/head:pull/16068` \
`$ git checkout pull/16068`

Update a local copy of the PR: \
`$ git checkout pull/16068` \
`$ git pull https://git.openjdk.org/jdk.git pull/16068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16068`

View PR using the GUI difftool: \
`$ git pr show -t 16068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16068.diff">https://git.openjdk.org/jdk/pull/16068.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16068#issuecomment-1749998170)