### PR TITLE
8316814: NMT: A separate script or Java program is needed to analyze and make useful reports ouf of JMH benchmarks outputs.

### DIFF
--- a/test/micro/org/openjdk/bench/vm/runtime/NMTAnalyze.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTAnalyze.java
@@ -134,18 +134,18 @@ class NMTAnalyze {
     }
     fileName = args[0];
     System.out.println(args[0]);
-		try (BufferedReader reader = new BufferedReader(new FileReader(fileName))) {
+    try (BufferedReader reader = new BufferedReader(new FileReader(fileName))) {
       System.out.println("file name " + fileName);
 
       skipUntilReport(reader);
       readRecords(reader);
       analyzeRecords(reader);
 
-			reader.close();
-		} catch (IOException ioe) {
+      reader.close();
+    } catch (IOException ioe) {
       ioe.printStackTrace();
       System.out.println(ioe.getMessage());
-		} finally {
+    } finally {
     }
 
   }

--- a/test/micro/org/openjdk/bench/vm/runtime/NMTAnalyze.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTAnalyze.java
@@ -40,15 +40,15 @@ class NMTAnalyze {
     public String units;
   }
   public static class BenchmarkFields {
-    static int NMT_METHOD = 0;
-    static int N = 1;
-    static int THREADS = 2;
-    static int MODE = 3;
-    static int CNT = 4;
-    static int SCORE = 5;
+    static int NMT_METHOD    = 0;
+    static int N             = 1;
+    static int THREADS       = 2;
+    static int MODE          = 3;
+    static int CNT           = 4;
+    static int SCORE         = 5;
     static int QUESTION_MARK = 6;
-    static int ERROR = 7;
-    static int UNITS = 8;
+    static int ERROR         = 7;
+    static int UNITS         = 8;
   }
   public static BufferedReader reader;
   public static String fileName;
@@ -96,23 +96,35 @@ class NMTAnalyze {
     }
   }
   private static void analyzeRecords() {
-    String NMT_OFF = "NMTOff";
-    String NMT_DETAIL = "NMTDetail";
+    String NMT_OFF     = "NMTOff";
+    String NMT_DETAIL  = "NMTDetail";
     String NMT_SUMMARY = "NMTSummary";
     int[] threads = {0, 4};
     String [] methods = {"mixAallocateFreeMemory", "mixAllocateReallocateMemory", "onlyAllocateMemory"};
-    System.out.printf("\n%40s %6s %6s %6s %6s\n","Method", "Threads", "  Off ", "Summary", "Detail");
+
+    System.out.printf("\n%40s %6s %9s %6s %15s %6s %24s %6s\n","Method", "Threads", " ", "Off ", " ", "Summary", " ", "Detail");
     for(String m: methods) {
       for (int t: threads) {
-        List <BenchmarkRecord> mtd_thrd = records.stream()
-                                            .filter(r -> r.jmh_method.contains(m) && r.threads == t)
-                                            .collect(Collectors.toList());
-        Double nmt_off = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_OFF)).collect(Collectors.toList()).get(0).score;
-        Double nmt_summary = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_SUMMARY)).collect(Collectors.toList()).get(0).score;
-        Double nmt_detail = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_DETAIL)).collect(Collectors.toList()).get(0).score;
-        System.out.printf("%40s %5d    %6.2f %6.2f  %6.2f\n", m, t, nmt_off, nmt_summary, nmt_detail);
-        System.out.printf("%56s %6.2f%% %6.2f%%\n", " ", (nmt_summary - nmt_off)/nmt_off * 100.0,
-                          (nmt_detail - nmt_off) / nmt_off * 100.0);
+        List<BenchmarkRecord> mtd_thrd = records.stream()
+                                        .filter(r -> r.jmh_method.contains(m) && r.threads == t)
+                                        .collect(Collectors.toList());
+        BenchmarkRecord off_rec     = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_OFF))    .collect(Collectors.toList()).get(0);
+        BenchmarkRecord summary_rec = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_SUMMARY)).collect(Collectors.toList()).get(0);
+        BenchmarkRecord detail_rec  = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_DETAIL)) .collect(Collectors.toList()).get(0);
+
+        Double nmt_off         = off_rec    .score;
+        Double nmt_summary     = summary_rec.score;
+        Double nmt_detail      = detail_rec .score;
+
+        Double nmt_off_err     = off_rec    .error;
+        Double nmt_summary_err = summary_rec.error;
+        Double nmt_detail_err  = detail_rec .error;
+
+        System.out.printf("%40s %5d    %7.3f (± %6.3f)    %7.3f (± %6.3f) %7.3f%%   %7.3f (± %6.3f) %7.3f%%\n",
+                          m, t,
+                          nmt_off, nmt_off_err,
+                          nmt_summary, nmt_summary_err, (nmt_summary - nmt_off) / nmt_off * 100.0,
+                          nmt_detail, nmt_detail_err, (nmt_detail - nmt_off) / nmt_off * 100.0);
       }
     }
 

--- a/test/micro/org/openjdk/bench/vm/runtime/NMTAnalyze.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTAnalyze.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class NMTAnalyze {
+  public static class BenchmarkRecord {
+    public String jmh_method;
+    public int N, threads, cnt;
+    public double score, error;
+    public String mode;
+    public String units;
+  }
+  public static class BenchmarkFields {
+    static int NMT_METHOD = 0;
+    static int N = 1;
+    static int THREADS = 2;
+    static int MODE = 3;
+    static int CNT = 4;
+    static int SCORE = 5;
+    static int QUESTION_MARK = 6;
+    static int ERROR = 7;
+    static int UNITS = 8;
+  }
+  public static BufferedReader reader;
+  public static String fileName;
+  public static List<BenchmarkRecord> records = new ArrayList<>();
+  private static void skipUntilReport() {
+    try {
+      String line = reader.readLine();
+      while (line != null) {
+        String ReportStartKeyword = "Benchmark";
+        if (!line.startsWith(ReportStartKeyword) || line.contains("#")) {
+          line = reader.readLine();
+          continue;
+        } else {
+          break;
+        }
+      }
+    } catch (IOException ioe) {
+      System.out.println(ioe.getMessage());
+    }
+  }
+  private static void readRecords() {
+    try {
+      do {
+        String line = reader.readLine();
+        if (line == null) break;
+        if (!line.startsWith("NMTBenchmark"))
+          continue;
+        String[] _fields= line.split(" ");
+        BenchmarkRecord rec = new BenchmarkRecord();
+        List<String> __fields = Arrays.asList(_fields);
+        String[] fields = __fields.stream().filter(f -> f.length() > 0).collect(Collectors.toList()).toArray(new String[0]);
+
+        rec.jmh_method  =                    fields[BenchmarkFields.NMT_METHOD];
+        rec.N           =   Integer.parseInt(fields[BenchmarkFields.N         ]);
+        rec.threads     =   Integer.parseInt(fields[BenchmarkFields.THREADS   ]);
+        rec.cnt         =   Integer.parseInt(fields[BenchmarkFields.CNT       ]);
+        rec.mode        =                    fields[BenchmarkFields.MODE      ];
+        rec.units       =                    fields[BenchmarkFields.UNITS     ];
+        rec.score       = Double.parseDouble(fields[BenchmarkFields.SCORE     ]);
+        rec.error       = Double.parseDouble(fields[BenchmarkFields.ERROR     ]);
+        records.add(rec);
+      } while (true);
+    } catch (IOException ioe) {
+      System.out.println(ioe.getMessage());
+    }
+  }
+  private static void analyzeRecords() {
+    String NMT_OFF = "NMTOff";
+    String NMT_DETAIL = "NMTDetail";
+    String NMT_SUMMARY = "NMTSummary";
+    int[] threads = {0, 4};
+    String [] methods = {"mixAallocateFreeMemory", "mixAllocateReallocateMemory", "onlyAllocateMemory"};
+    System.out.printf("\n%40s %6s %6s %6s %6s\n","Method", "Threads", "  Off ", "Summary", "Detail");
+    for(String m: methods) {
+      for (int t: threads) {
+        List <BenchmarkRecord> mtd_thrd = records.stream()
+                                            .filter(r -> r.jmh_method.contains(m) && r.threads == t)
+                                            .collect(Collectors.toList());
+        Double nmt_off = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_OFF)).collect(Collectors.toList()).get(0).score;
+        Double nmt_summary = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_SUMMARY)).collect(Collectors.toList()).get(0).score;
+        Double nmt_detail = mtd_thrd.stream().filter(r->r.jmh_method.contains(NMT_DETAIL)).collect(Collectors.toList()).get(0).score;
+        System.out.printf("%40s %5d    %6.2f %6.2f  %6.2f\n", m, t, nmt_off, nmt_summary, nmt_detail);
+        System.out.printf("%56s %6.2f%% %6.2f%%\n", " ", (nmt_summary - nmt_off)/nmt_off * 100.0,
+                          (nmt_detail - nmt_off) / nmt_off * 100.0);
+      }
+    }
+
+  }
+  public static void main(String[] args) {
+    if (args.length < 1) {
+      System.out.println("Usage: java NMTAnalyze.java <benchmark-results-filename>");
+      System.exit(1);
+    }
+    fileName = args[0];
+    System.out.println(args[0]);
+		try {
+      System.out.println("file name " + fileName);
+			reader = new BufferedReader(new FileReader(fileName));
+      skipUntilReport();
+      readRecords();
+      analyzeRecords();
+			reader.close();
+		} catch (IOException ioe) {
+      ioe.printStackTrace();
+      System.out.println(ioe.getMessage());
+		} finally {
+    }
+
+  }
+}

--- a/test/micro/org/openjdk/bench/vm/runtime/NMTAnalyze.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTAnalyze.java
@@ -145,8 +145,6 @@ class NMTAnalyze {
     } catch (IOException ioe) {
       ioe.printStackTrace();
       System.out.println(ioe.getMessage());
-    } finally {
     }
-
   }
 }


### PR DESCRIPTION
It reads the benchmark report file whose path is given as command line. Then extract percentage of overhead of NMT modes for different methods used in benchmarks.
Locally tested with some sample report files.
From an input benchmark report like this: 
```
# JMH version: 1.37
# VM version: JDK 22-internal, OpenJDK 64-Bit Server VM,......in...
# VM invoker:.....
# VM options: -XX:NativeMemoryTracking=detail --add-exports java.base/jdk.internal.misc=ALL-UNNAMED -Djava.library.path=...
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 1 s each
# Measurement: 5 iterations, 1 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.openjdk.bench.vm.runtime.NMTBenchmark.NMTDetail.mixAallocateFreeMemory
# Parameters: (N = 100000, THREADS = 4)

.
.
.


Benchmark                                               (N)  (THREADS)  Mode  Cnt    Score    Error  Units
NMTBenchmark.NMTDetail.mixAallocateFreeMemory        100000          0  avgt   10   87.010 ? 10.630  ms/op
NMTBenchmark.NMTDetail.mixAallocateFreeMemory        100000          4  avgt   10    2.473 ?  0.728  ms/op
NMTBenchmark.NMTDetail.mixAllocateReallocateMemory   100000          0  avgt   10  225.054 ?  4.381  ms/op
NMTBenchmark.NMTDetail.mixAllocateReallocateMemory   100000          4  avgt   10    2.247 ?  0.599  ms/op
NMTBenchmark.NMTDetail.onlyAllocateMemory            100000          0  avgt   10  147.346 ?  8.226  ms/op
NMTBenchmark.NMTDetail.onlyAllocateMemory            100000          4  avgt   10    2.285 ?  0.611  ms/op
NMTBenchmark.NMTOff.mixAallocateFreeMemory           100000          0  avgt   10   40.405 ?  8.115  ms/op
NMTBenchmark.NMTOff.mixAallocateFreeMemory           100000          4  avgt   10    2.299 ?  0.658  ms/op
NMTBenchmark.NMTOff.mixAllocateReallocateMemory      100000          0  avgt   10  158.700 ? 10.750  ms/op
NMTBenchmark.NMTOff.mixAllocateReallocateMemory      100000          4  avgt   10    2.282 ?  0.723  ms/op
NMTBenchmark.NMTOff.onlyAllocateMemory               100000          0  avgt   10  113.949 ? 21.257  ms/op
NMTBenchmark.NMTOff.onlyAllocateMemory               100000          4  avgt   10    2.155 ?  0.682  ms/op
NMTBenchmark.NMTSummary.mixAallocateFreeMemory       100000          0  avgt   10   50.436 ?  4.576  ms/op
NMTBenchmark.NMTSummary.mixAallocateFreeMemory       100000          4  avgt   10    2.192 ?  0.737  ms/op
NMTBenchmark.NMTSummary.mixAllocateReallocateMemory  100000          0  avgt   10  170.408 ?  4.556  ms/op
NMTBenchmark.NMTSummary.mixAllocateReallocateMemory  100000          4  avgt   10    2.344 ?  0.645  ms/op
NMTBenchmark.NMTSummary.onlyAllocateMemory           100000          0  avgt   10  117.480 ?  8.846  ms/op
NMTBenchmark.NMTSummary.onlyAllocateMemory           100000          4  avgt   10    2.367 ?  0.694  ms/op
```

it creates summary like this:
```

                                  Method Threads   Off  Summary Detail
                  mixAallocateFreeMemory     0     40.41  50.44   87.01
                                                          24.83% 115.34%
                  mixAallocateFreeMemory     4      2.30   2.19    2.47
                                                          -4.65%   7.57%
             mixAllocateReallocateMemory     0    158.70 170.41  225.05
                                                           7.38%  41.81%
             mixAllocateReallocateMemory     4      2.28   2.34    2.25
                                                           2.72%  -1.53%
                      onlyAllocateMemory     0    113.95 117.48  147.35
                                                           3.10%  29.31%
                      onlyAllocateMemory     4      2.16   2.37    2.29
                                                           9.84%   6.03%
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316814](https://bugs.openjdk.org/browse/JDK-8316814): NMT: A separate script or Java program is needed to analyze and make useful reports ouf of JMH benchmarks outputs. (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [bbe147ab](https://git.openjdk.org/jdk/pull/16070/files/bbe147ab6cfa8bdc7172ea4e5dfc8fcaa135c8a3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16070/head:pull/16070` \
`$ git checkout pull/16070`

Update a local copy of the PR: \
`$ git checkout pull/16070` \
`$ git pull https://git.openjdk.org/jdk.git pull/16070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16070`

View PR using the GUI difftool: \
`$ git pr show -t 16070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16070.diff">https://git.openjdk.org/jdk/pull/16070.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16070#issuecomment-1772395666)