### PR TITLE
8317660: [BACKOUT] 8269393: store/load order not preserved when handling memory pool due to weakly ordered memory architecture of aarch64

### DIFF
--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -178,13 +178,8 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 }
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
-  size_t used;
-  size_t committed;
-  {
-    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    used = used_in_bytes();
-    committed = _codeHeap->capacity();
-  }
+  size_t used      = used_in_bytes();
+  size_t committed = _codeHeap->capacity();
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);
 
   return MemoryUsage(initial_size(), used, committed, maxSize);


### PR DESCRIPTION
Please review this clean backout of [JDK-8269393](https://bugs.openjdk.org/browse/JDK-8269393) because we see `Attempting to acquire lock CodeCache_lock/nosafepoint-2 out of order with lock Notification_lock/service -- possible deadlock` asserts with several tests.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317660](https://bugs.openjdk.org/browse/JDK-8317660): [BACKOUT] 8269393: store/load order not preserved when handling memory pool due to weakly ordered memory architecture of aarch64 (**Sub-task** - P1)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16071/head:pull/16071` \
`$ git checkout pull/16071`

Update a local copy of the PR: \
`$ git checkout pull/16071` \
`$ git pull https://git.openjdk.org/jdk.git pull/16071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16071`

View PR using the GUI difftool: \
`$ git pr show -t 16071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16071.diff">https://git.openjdk.org/jdk/pull/16071.diff</a>

</details>
