### PR TITLE
JDK-8249832: java/util/zip/DataDescriptorSignatureMissing.java uses @ignore w/o bug-id

### DIFF
--- a/test/jdk/java/util/zip/DataDescriptorSignatureMissing.java
+++ b/test/jdk/java/util/zip/DataDescriptorSignatureMissing.java
@@ -37,7 +37,7 @@
  * No way to adapt the technique in this test to get a ZIP64 zip file
  * without data descriptors was found.
  *
- * @ignore This test has brittle dependencies on an external working python.
+ * @ignore 8303920 This test has brittle dependencies on an external working python.
  */
 
 import java.io.*;

--- a/test/jdk/java/util/zip/DataDescriptorSignatureMissing.java
+++ b/test/jdk/java/util/zip/DataDescriptorSignatureMissing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google, Inc.  All Rights Reserved.
+ * Copyright 2012 Google, Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/zip/DataDescriptorSignatureMissing.java
+++ b/test/jdk/java/util/zip/DataDescriptorSignatureMissing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Google, Inc.  All Rights Reserved.
+ * Copyright 2023 Google, Inc.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this PR as a fix of [JDK-8249832](https://bugs.openjdk.org/browse/JDK-8249832). I have added the bug with after @ignore annotation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8249832](https://bugs.openjdk.org/browse/JDK-8249832): java/util/zip/DataDescriptorSignatureMissing.java uses @<!---->ignore w/o bug-id (**Sub-task** - P4)


### Reviewers
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16073/head:pull/16073` \
`$ git checkout pull/16073`

Update a local copy of the PR: \
`$ git checkout pull/16073` \
`$ git pull https://git.openjdk.org/jdk.git pull/16073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16073`

View PR using the GUI difftool: \
`$ git pr show -t 16073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16073.diff">https://git.openjdk.org/jdk/pull/16073.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16073#issuecomment-1759106062)