### PR TITLE
JDK-8317633: Modernize text.testlib.HexDumpReader

### DIFF
--- a/test/jdk/java/text/testlib/HexDumpReader.java
+++ b/test/jdk/java/text/testlib/HexDumpReader.java
@@ -21,15 +21,15 @@
  * questions.
  */
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
+import java.nio.file.Files;
+import java.util.HexFormat;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * HexDumpReader provides utility methods to read a hex dump text file
@@ -41,80 +41,30 @@ import java.util.List;
 public final class HexDumpReader {
 
     // Utility class should not be instantiated
-    private HexDumpReader() {}
+    private HexDumpReader() {
+    }
 
+    // Converts a Hex dump file (String) into an InputStream containing bytes
     public static InputStream getStreamFromHexDump(String fileName) {
         return getStreamFromHexDump(new File(System.getProperty("test.src", "."),
-                                             fileName));
+                fileName));
     }
 
+    // Converts a Hex dump file (File) into an InputStream containing bytes
     public static InputStream getStreamFromHexDump(File hexFile) {
-        ByteArrayBuilder bab = new ByteArrayBuilder();
-        int lineNo = 0;
-        try (BufferedReader reader
-                 = new BufferedReader(new InputStreamReader(new FileInputStream(hexFile),
-                StandardCharsets.US_ASCII))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                lineNo++;
-                line = line.trim();
-                // Skip blank and comment lines.
-                if (line.length() == 0) {
-                    continue;
-                }
-                int x = line.indexOf('#');
-                if (x == 0) {
-                    continue;
-                }
-                if (x > 0) {
-                    line = line.substring(0, x).trim();
-                }
-                int len = line.length();
-                for (int i = 0; i < len; i += 2) {
-                    bab.put((byte)Integer.parseInt(line, i, i + 2, 16));
-                }
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(hexFile.getName() + ":error:" + lineNo + ": " + e, e);
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(hexFile.toPath(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Utility class HexDumpReader" +
+                    " threw %s when trying to read the file %s", e, hexFile.getName()));
         }
-        return new ByteArrayInputStream(bab.toArray());
+        // Grab all non-empty lines up until a '#' if one exists
+        String hexString = lines.stream().map(String::trim)
+                .map(s -> (s.contains("#")) ? s.substring(0, s.indexOf("#")).trim() : s)
+                .filter(s -> !s.isEmpty()).collect(Collectors.joining());
+        // Iterate the hex string and convert it to bytes
+        byte[] bArray = HexFormat.of().parseHex(hexString);
+        return new ByteArrayInputStream(bArray);
     }
-
-
-    private static class ByteArrayBuilder {
-        private static final int BUFFER_SIZE = 4096;
-
-        private int size;
-        private List<byte[]> bytes;
-        private byte[] current;
-        private int offset;
-
-        ByteArrayBuilder() {
-            bytes = new ArrayList<>();
-            current = new byte[BUFFER_SIZE];
-        }
-
-        void put(byte b) {
-            if (offset == BUFFER_SIZE) {
-                bytes.add(current);
-                current = new byte[BUFFER_SIZE];
-                offset = 0;
-            }
-            current[offset++] = b;
-            size++;
-        }
-
-        byte[] toArray() {
-            byte[] buf = new byte[size];
-            int ptr = 0;
-            for (byte[] ba : bytes) {
-                System.arraycopy(ba, 0, buf, ptr, ba.length);
-                ptr += ba.length;
-            }
-            System.arraycopy(current, 0, buf, ptr, offset);
-            assert ptr + offset == size;
-            return buf;
-        }
-    }
-
 }


### PR DESCRIPTION
Please review this PR which cleans up the static test utility class _HexDumpReader_.

This cleans up the code by replacing the nested _ByteArrayBuilder_ class with _HexFormat_, and simplifies the File processing by using a stream. Changes were tested to ensure that the _text_ tests are still getting equivalent ByteArrayInputStreams as before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317633](https://bugs.openjdk.org/browse/JDK-8317633): Modernize text.testlib.HexDumpReader (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16075/head:pull/16075` \
`$ git checkout pull/16075`

Update a local copy of the PR: \
`$ git checkout pull/16075` \
`$ git pull https://git.openjdk.org/jdk.git pull/16075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16075`

View PR using the GUI difftool: \
`$ git pr show -t 16075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16075.diff">https://git.openjdk.org/jdk/pull/16075.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16075#issuecomment-1751159344)