### PR TITLE
8316464: 3 sun/tools tests ignore VM flags

### DIFF
--- a/test/jdk/sun/tools/jcmd/TestProcessHelper.java
+++ b/test/jdk/sun/tools/jcmd/TestProcessHelper.java
@@ -50,8 +50,9 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @test
  * @bug 8205654
  * @summary Unit test for sun.tools.ProcessHelper class. The test launches Java processes with different Java options
- * and checks that sun.tools.ProcessHelper.getMainClass(pid) method returns a correct main class.                                                                                                                               return a .
+ * and checks that sun.tools.ProcessHelper.getMainClass(pid) method returns a correct main class.
  *
+ * @requires vm.flagless
  * @requires os.family == "linux"
  * @modules jdk.jcmd/sun.tools.common:+open
  *          java.base/jdk.internal.classfile

--- a/test/jdk/sun/tools/jinfo/JInfoTest.java
+++ b/test/jdk/sun/tools/jinfo/JInfoTest.java
@@ -38,7 +38,6 @@ import jdk.test.lib.apps.LingeredApp;
  * @test
  * @summary Unit test for jinfo utility
  *
- * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -61,9 +60,8 @@ public class JInfoTest {
         LingeredApp app1 = new JInfoTestLingeredApp();
         LingeredApp app2 = new JInfoTestLingeredApp();
         try {
-            String[] params = new String[0];;
-            LingeredApp.startAppExactJvmOpts(app1, params);
-            LingeredApp.startAppExactJvmOpts(app2, params);
+            LingeredApp.startApp(app1);
+            LingeredApp.startApp(app2);
             OutputAnalyzer output = jinfo("-flag", "MinHeapFreeRatio=1", "JInfoTestLingeredApp");
             output.shouldHaveExitValue(0);
             output = jinfo("-flag", "MinHeapFreeRatio", "JInfoTestLingeredApp");
@@ -90,9 +88,8 @@ public class JInfoTest {
         LingeredApp app1 = new JInfoTestLingeredApp();
         LingeredApp app2 = new JInfoTestLingeredApp();
         try {
-            String[] params = new String[0];
-            LingeredApp.startAppExactJvmOpts(app1, params);
-            LingeredApp.startAppExactJvmOpts(app2, params);
+            LingeredApp.startApp(app1);
+            LingeredApp.startApp(app2);
             OutputAnalyzer output = jinfo("JInfoTestLingeredApp");
             output.shouldHaveExitValue(0);
             // "Runtime Environment" written once per proc

--- a/test/jdk/sun/tools/jinfo/JInfoTest.java
+++ b/test/jdk/sun/tools/jinfo/JInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import jdk.test.lib.apps.LingeredApp;
  * @test
  * @summary Unit test for jinfo utility
  *
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/jdk/sun/tools/jstat/JStatInterval.java
+++ b/test/jdk/sun/tools/jstat/JStatInterval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8035668
+ * @requires vm.flagless
  * @library /test/lib
  * @summary Test checks case when target application finishes execution and jstat didn't complete work.
             jstat is started with interval = 100 (jstat -compiler 100) and monitored application finishes
@@ -60,9 +61,7 @@ public class JStatInterval {
         }
     }
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
-            "-cp",
-            System.getProperty("test.class.path"),
+        ProcessBuilder pb = ProcessTools.createTestJvm(
             "-XX:+UsePerfData",
             Application.class.getName()
         );


### PR DESCRIPTION
I marked tests 
sun/tools/jcmd/TestProcessHelper.java
sun/tools/jinfo/JInfoTest.java
as headless. They used different specific VM options and are not worth executing with other VM flags. 
And fixed 
sun/tools/jstat/JStatInterval.java
Tested with tier1, local execution of tests, and running sun/tools/jstat/JStatInterval.java with different options.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316464](https://bugs.openjdk.org/browse/JDK-8316464): 3 sun/tools tests ignore VM flags (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16078/head:pull/16078` \
`$ git checkout pull/16078`

Update a local copy of the PR: \
`$ git checkout pull/16078` \
`$ git pull https://git.openjdk.org/jdk.git pull/16078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16078`

View PR using the GUI difftool: \
`$ git pr show -t 16078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16078.diff">https://git.openjdk.org/jdk/pull/16078.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16078#issuecomment-1751312279)