### PR TITLE
8316452: java/lang/instrument/modules/AppendToClassPathModuleTest.java ignores VM flags

### DIFF
--- a/test/jdk/java/lang/instrument/modules/AppendToClassPathModuleTest.java
+++ b/test/jdk/java/lang/instrument/modules/AppendToClassPathModuleTest.java
@@ -24,6 +24,7 @@
 /**
  * @test
  * @bug 8169909
+ * @requires vm.flagless
  * @library src /test/lib
  * @build test/*
  * @run shell AppendToClassPathModuleTest.sh


### PR DESCRIPTION
The test uses specific classpath, and jar and is intended to test modules. So I marked is as flagless,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316452](https://bugs.openjdk.org/browse/JDK-8316452): java/lang/instrument/modules/AppendToClassPathModuleTest.java ignores VM flags (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16080/head:pull/16080` \
`$ git checkout pull/16080`

Update a local copy of the PR: \
`$ git checkout pull/16080` \
`$ git pull https://git.openjdk.org/jdk.git pull/16080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16080`

View PR using the GUI difftool: \
`$ git pr show -t 16080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16080.diff">https://git.openjdk.org/jdk/pull/16080.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16080#issuecomment-1751346646)