### PR TITLE
8316462: sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java ignores VM flags

### DIFF
--- a/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
+++ b/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
@@ -308,7 +308,6 @@ public final class MonitorVmStartTerminate {
 
         private void executeJava() throws Throwable {
             String className = JavaProcess.class.getName();
-            String classPath = System.getProperty("test.classes");
             ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-Dtest.timeout.factor=" + System.getProperty("test.timeout.factor", "1.0"),
                 className, mainArgsIdentifier);

--- a/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
+++ b/test/jdk/sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -309,9 +309,9 @@ public final class MonitorVmStartTerminate {
         private void executeJava() throws Throwable {
             String className = JavaProcess.class.getName();
             String classPath = System.getProperty("test.classes");
-            ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+            ProcessBuilder pb = ProcessTools.createTestJvm(
                 "-Dtest.timeout.factor=" + System.getProperty("test.timeout.factor", "1.0"),
-                "-cp", classPath, className, mainArgsIdentifier);
+                className, mainArgsIdentifier);
             OutputAnalyzer ob = ProcessTools.executeProcess(pb);
             System.out.println("Java Process " + getMainArgsIdentifier() + " stderr:"
                     + ob.getStderr());


### PR DESCRIPTION
Test fixed to accept vm  flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316462](https://bugs.openjdk.org/browse/JDK-8316462): sun/jvmstat/monitor/MonitoredVm/MonitorVmStartTerminate.java ignores VM flags (**Sub-task** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [da6d3647](https://git.openjdk.org/jdk/pull/16081/files/da6d3647538d25a8a180854e420195ab17b359ce)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [da6d3647](https://git.openjdk.org/jdk/pull/16081/files/da6d3647538d25a8a180854e420195ab17b359ce)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16081/head:pull/16081` \
`$ git checkout pull/16081`

Update a local copy of the PR: \
`$ git checkout pull/16081` \
`$ git pull https://git.openjdk.org/jdk.git pull/16081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16081`

View PR using the GUI difftool: \
`$ git pr show -t 16081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16081.diff">https://git.openjdk.org/jdk/pull/16081.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16081#issuecomment-1751393330)