### PR TITLE
8317698: Optimization for URLEncoder

### DIFF
--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -123,7 +123,7 @@ public class URLEncoder {
          *
          */
         DONT_NEED_ENCODING_FLAGS_0_WITHOUT_SPACE
-                = (1L << '*') // ASCII 45
+                = (1L << '*') // ASCII 42
                 | (1L << '-') // ASCII 45
                 | (1L << '.') // ASCII 46
                 | (1L << '0') // ASCII 48

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -141,19 +141,20 @@ public class URLEncoder {
         DONT_NEED_ENCODING_FLAGS_0_WITH_SPACE
                 = DONT_NEED_ENCODING_FLAGS_0_WITHOUT_SPACE
                 | (1L << ' '); // ASCII 32 encoding a space to a + is done in the encode() method
-
-//        long flags1 = 0;
-//        // ASCII 65 - 90
-//        for (int i = 'A'; i <= 'Z'; ++i) {
-//            flags1 |= 1L << (i - 64);
-//        }
-//        flags1 |= 1L << ('_' - 64); // ASCII 95
-//        // ASCII 97 - 122
-//        for (int i = 'a'; i <= 'z'; ++i) {
-//            flags1 |= 1L << (i - 64);
-//        }
-//        DONT_NEED_ENCODING_FLAGS_1 = flags1;
-        DONT_NEED_ENCODING_FLAGS_1 = 0x7FFFFFE87FFFFFEL; // really 1L << ([A-Z_a-z] - 64)
+        /*
+         * long flags1 = 0;
+         * // ASCII 65 - 90
+         * for (int i = 'A'; i <= 'Z'; ++i) {
+         *     flags1 |= 1L << (i - 64);
+         * }
+         * flags1 |= 1L << ('_' - 64); // ASCII 95
+         * // ASCII 97 - 122
+         * for (int i = 'a'; i <= 'z'; ++i) {
+         *     flags1 |= 1L << (i - 64);
+         * }
+         * DONT_NEED_ENCODING_FLAGS_1 = flags1;
+         */
+        DONT_NEED_ENCODING_FLAGS_1 = 0x7FFFFFE87FFFFFEL; // really : 1L << ([A-Z_a-z] - 64)
     }
 
     /**


### PR DESCRIPTION
@cl4es and @Glavo have already made some very good optimizations to URLEncoder, but we can continue to improve.

The current URLEncoder's Predicate for DONT_NEED_ENCODING is based on BitSet, which is actually a table lookup. The actual performance may not be as good as microbench. 

The character value range of DONT_NEED_ENCODING is between [45-122]. We can construct two long type constants to do the work of BitSet. This can improve performance by about 7% to 30%.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317698](https://bugs.openjdk.org/browse/JDK-8317698): Optimization for URLEncoder (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16082/head:pull/16082` \
`$ git checkout pull/16082`

Update a local copy of the PR: \
`$ git checkout pull/16082` \
`$ git pull https://git.openjdk.org/jdk.git pull/16082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16082`

View PR using the GUI difftool: \
`$ git pr show -t 16082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16082.diff">https://git.openjdk.org/jdk/pull/16082.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16082#issuecomment-1751887864)