### PR TITLE
8317687: (fs) FileStore.supportsFileAttributeView(posix) incorrectly returns 'true' for FAT32 volume on macOS

### DIFF
--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileStore.java
@@ -25,9 +25,10 @@
 
 package sun.nio.fs;
 
-import java.nio.file.attribute.FileAttributeView;
-import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.io.IOException;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.Arrays;
 
 /**
@@ -100,6 +101,10 @@ class BsdFileStore
             UnixPath dir = new UnixPath(file().getFileSystem(), entry().dir());
             return isExtendedAttributesEnabled(dir);
         }
+        // POSIX attributes not supported on FAT
+        if (type == PosixFileAttributeView.class &&
+            entry().fstype().equals("msdos"))
+            return false;
         return super.supportsFileAttributeView(type);
     }
 


### PR DESCRIPTION
Change `BsdFileStore.supportsFileAttributeView` to return false for POSIX attributes when the associated volume file system type is FAT32.