### PR TITLE
8317689: [JVMCI] include error message when CreateJavaVM in libgraal fails

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -2203,7 +2203,9 @@ void CompileBroker::invoke_compiler_on_method(CompileTask* task) {
     } else {
       JVMCIEnv env(thread, &compile_state, __FILE__, __LINE__);
       if (env.init_error() != JNI_OK) {
-        failure_reason = os::strdup(err_msg("Error attaching to libjvmci (err: %d)", env.init_error()), mtJVMCI);
+        const char* msg = env.init_error_msg();
+        failure_reason = os::strdup(err_msg("Error attaching to libjvmci (err: %d, %s)",
+                                    env.init_error(), msg == nullptr ? "unknown" : msg), mtJVMCI);
         bool reason_on_C_heap = true;
         // In case of JNI_ENOMEM, there's a good chance a subsequent attempt to create libjvmci or attach to it
         // might succeed. Other errors most likely indicate a non-recoverable error in the JVMCI runtime.

--- a/src/hotspot/share/jvmci/jvmciEnv.hpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.hpp
@@ -172,6 +172,7 @@ class JVMCIEnv : public ResourceObj {
   int              _init_error;  // JNI code returned when creating or attaching to a libjvmci isolate.
                                  // If not JNI_OK, the JVMCIEnv is invalid and should not be used apart from
                                  // calling init_error().
+  const char*  _init_error_msg;  // Message for _init_error if available. C heap allocated.
 
   // Translates an exception on the HotSpot heap (i.e., hotspot_env) to an exception on
   // the shared library heap (i.e., jni_env). The translation includes the stack and cause(s) of `throwable`.
@@ -215,6 +216,12 @@ public:
   // this JVMCIEnv context was created for.
   int init_error() {
     return _init_error;
+  }
+
+  // Gets a message describing a non-zero init_error().
+  // Valid as long as this JVMCIEnv is valid.
+  const char* init_error_msg() {
+    return _init_error_msg;
   }
 
   // Checks the value of init_error() and throws an exception in `JVMCI_TRAPS`

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1246,7 +1246,7 @@ bool JVMCIRuntime::detach_thread(JavaThread* thread, const char* reason, bool ca
   return destroyed_javavm;
 }
 
-JNIEnv* JVMCIRuntime::init_shared_library_javavm(int* create_JavaVM_err) {
+JNIEnv* JVMCIRuntime::init_shared_library_javavm(int* create_JavaVM_err, const char** err_msg) {
   MutexLocker locker(_lock);
   JavaVM* javaVM = _shared_library_javavm;
   if (javaVM == nullptr) {
@@ -1273,7 +1273,7 @@ JNIEnv* JVMCIRuntime::init_shared_library_javavm(int* create_JavaVM_err) {
     JavaVMInitArgs vm_args;
     vm_args.version = JNI_VERSION_1_2;
     vm_args.ignoreUnrecognized = JNI_TRUE;
-    JavaVMOption options[5];
+    JavaVMOption options[6];
     jlong javaVM_id = 0;
 
     // Protocol: JVMCI shared library JavaVM should support a non-standard "_javavm_id"
@@ -1290,6 +1290,8 @@ JNIEnv* JVMCIRuntime::init_shared_library_javavm(int* create_JavaVM_err) {
     options[3].extraInfo = (void*) _fatal;
     options[4].optionString = (char*) "_fatal_log";
     options[4].extraInfo = (void*) _fatal_log;
+    options[5].optionString = (char*) "_strerror";
+    options[5].extraInfo = (void*) err_msg;
 
     vm_args.version = JNI_VERSION_1_2;
     vm_args.options = options;

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1290,7 +1290,7 @@ JNIEnv* JVMCIRuntime::init_shared_library_javavm(int* create_JavaVM_err, const c
     options[3].extraInfo = (void*) _fatal;
     options[4].optionString = (char*) "_fatal_log";
     options[4].extraInfo = (void*) _fatal_log;
-    options[5].optionString = (char*) "_strerror";
+    options[5].optionString = (char*) "_createvm_errorstr";
     options[5].extraInfo = (void*) err_msg;
 
     vm_args.version = JNI_VERSION_1_2;

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -280,8 +280,10 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // If the JavaVM was created by this call, then the thread-local JNI
   // interface pointer for the JavaVM is returned otherwise null is returned.
   // If this method tried to create the JavaVM but failed, the error code returned
-  // by JNI_CreateJavaVM is returned in create_JavaVM_err.
-  JNIEnv* init_shared_library_javavm(int* create_JavaVM_err);
+  // by JNI_CreateJavaVM is returned in create_JavaVM_err and, if available, an
+  // error message is malloc'ed and assigned to err_msg. The caller is responsible
+  // for freeing err_msg.
+  JNIEnv* init_shared_library_javavm(int* create_JavaVM_err, const char** err_msg);
 
   // Determines if the JVMCI shared library JavaVM exists for this runtime.
   bool has_shared_library_javavm() { return _shared_library_javavm != nullptr; }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -381,7 +381,7 @@ WB_ENTRY(jboolean, WB_IsGCSupportedByJVMCICompiler(JNIEnv* env, jobject o, jint 
   if (EnableJVMCI) {
     // Enter the JVMCI env that will be used by the CompileBroker.
     JVMCIEnv jvmciEnv(thread, __FILE__, __LINE__);
-    return jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name);
+    return jvmciEnv.init_error() == JNI_OK && jvmciEnv.runtime()->is_gc_supported(&jvmciEnv, (CollectedHeap::Name)name);
   }
 #endif
   return false;


### PR DESCRIPTION
Creating a new libgraal isolate can fail for a number of reasons. Currently, all that one sees on such a failure is a numeric error code. For example:

```
   2096 20291       4       java.lang.CharacterData::of (136 bytes)
   2096 20291       4       java.lang.CharacterData::of (136 bytes)   COMPILE SKIPPED: Error attaching to libjvmci (err: -1000000024)
```

Native Image has been [enhanced](https://github.com/oracle/graal/blob/14ca57efd35941a3b60c6224285ad8153f77059c/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jni/functions/JNIInvocationInterface.java#L209-L214) to return an error message along with an error code by a non-standard `_createvm_errorstr` argument passed to the `CreateJavaVM` JNI invocation interface function:

```
 |--------------------|-----------------------------------------------------------------------------------|
 | _createvm_errorstr | extraInfo is a "const char**" value.                                              |
 |                    | If CreateJavaVM returns non-zero, then extraInfo is assigned a newly malloc'ed    |
 |                    | 0-terminated C string describing the error if a description is available,         |
 |                    | otherwise extraInfo is set to null.                                               |
 |--------------------|-----------------------------------------------------------------------------------|
```

This PR updates JVMCI to take advantage of this Native Image enhancement.

This is sample `-XX:+PrintCompilation` output from testing this PR on libgraal:
```
   2096 20291       4       java.lang.CharacterData::of (136 bytes)
   2096 20291       4       java.lang.CharacterData::of (136 bytes)   COMPILE SKIPPED: Error attaching to libjvmci (err: -1000000024, Image page size is incompatible with run-time page size. Rebuild image with -H:PageSize=[pagesize] to set appropriately.)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317689](https://bugs.openjdk.org/browse/JDK-8317689): [JVMCI] include error message when CreateJavaVM in libgraal fails (**Enhancement** - P4)


### Reviewers
 * [Peter Hofer](https://openjdk.org/census#phofer) (@peter-hofer - no project role)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16086/head:pull/16086` \
`$ git checkout pull/16086`

Update a local copy of the PR: \
`$ git checkout pull/16086` \
`$ git pull https://git.openjdk.org/jdk.git pull/16086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16086`

View PR using the GUI difftool: \
`$ git pr show -t 16086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16086.diff">https://git.openjdk.org/jdk/pull/16086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16086#issuecomment-1751660525)