### PR TITLE
Optimization for Integer.parseInt and Long.parseLong

### DIFF
--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -27,6 +27,7 @@ package java.lang;
 
 import jdk.internal.misc.CDS;
 import jdk.internal.misc.VM;
+import jdk.internal.util.DecimalDigits;
 import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.Stable;
@@ -551,13 +552,11 @@ public final class Integer extends Number
         }
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         int len = s.length();
@@ -621,13 +620,11 @@ public final class Integer extends Number
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         /*
@@ -682,6 +679,35 @@ public final class Integer extends Number
      *               parsable integer.
      */
     public static int parseInt(String s) throws NumberFormatException {
+        if (s != null && s.coder() == String.LATIN1) {
+            final byte[] value = s.value();
+            final int len = value.length;
+            if (len == 0) {
+                throw new NumberFormatException("");
+            }
+            int digit = ~0xFF;
+            int i = 0;
+            byte firstChar = value[i++];
+            if (firstChar != '-' && firstChar != '+') {
+                digit = DecimalDigits.digit(firstChar);
+            }
+            if (digit >= 0 || digit == ~0xFF && len > 1) {
+                int limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
+                final int multmin = -214748364; // actual limit / 10;
+                int result = -(digit & 0xFF);
+                boolean inRange = true;
+                /* Accumulating negatively avoids surprises near MAX_VALUE */
+                while (i < len && (digit = DecimalDigits.digit(value[i++])) >= 0
+                        && (inRange = result > multmin
+                        || result == multmin && digit <= multmin * 10 - limit)) {
+                    result = 10 * result - digit;
+                }
+                if (inRange && i == len && digit >= 0) {
+                    return firstChar != '-' ? -result : result;
+                }
+            }
+            throw NumberFormatException.forInputString(s, 10);
+        }
         return parseInt(s, 10);
     }
 
@@ -735,13 +761,11 @@ public final class Integer extends Number
         }
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         int len = s.length();
@@ -751,8 +775,7 @@ public final class Integer extends Number
         int i = 0;
         char firstChar = s.charAt(i++);
         if (firstChar == '-') {
-            throw new NumberFormatException(String.format(
-                "Illegal leading minus sign on unsigned string %s.", s));
+            throw NumberFormatException.forUnsign(s);
         }
         int digit = ~0xFF;
         if (firstChar != '+') {
@@ -775,8 +798,7 @@ public final class Integer extends Number
         if (digit < 0) {
             throw NumberFormatException.forInputString(s, radix);
         }
-        throw new NumberFormatException(String.format(
-            "String value %s exceeds range of unsigned int.", s));
+        throw NumberFormatException.forUnsignInt(s);
     }
 
     /**
@@ -812,13 +834,11 @@ public final class Integer extends Number
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         /*
@@ -833,8 +853,7 @@ public final class Integer extends Number
         int i = beginIndex;
         char firstChar = s.charAt(i++);
         if (firstChar == '-') {
-            throw new NumberFormatException(
-                "Illegal leading minus sign on unsigned string " + s + ".");
+            throw NumberFormatException.forUnsign(s);
         }
         int digit = ~0xFF;
         if (firstChar != '+') {
@@ -858,8 +877,7 @@ public final class Integer extends Number
             throw NumberFormatException.forCharSequence(s, beginIndex,
                 endIndex, i - (digit < -1 ? 0 : 1));
         }
-        throw new NumberFormatException(String.format(
-            "String value %s exceeds range of unsigned int.", s));
+        throw NumberFormatException.forUnsignInt(s);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -38,6 +38,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 import java.util.Optional;
 
+import static java.lang.Character.digit;
 import static java.lang.String.COMPACT_STRINGS;
 import static java.lang.String.LATIN1;
 import static java.lang.String.UTF16;
@@ -538,8 +539,7 @@ public final class Integer extends Number
      *             does not contain a parsable {@code int}.
      */
     public static int parseInt(String s, int radix)
-                throws NumberFormatException
-    {
+                throws NumberFormatException {
         /*
          * WARNING: This method may be invoked early during VM initialization
          * before IntegerCache is initialized. Care must be taken to not use
@@ -551,52 +551,41 @@ public final class Integer extends Number
         }
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException("radix " + radix +
-                                            " less than Character.MIN_RADIX");
+            throw new NumberFormatException(String.format(
+                "radix %d less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException("radix " + radix +
-                                            " greater than Character.MAX_RADIX");
+            throw new NumberFormatException(String.format(
+                "radix %d greater than Character.MAX_RADIX", radix));
         }
 
-        boolean negative = false;
-        int i = 0, len = s.length();
-        int limit = -Integer.MAX_VALUE;
-
-        if (len > 0) {
-            char firstChar = s.charAt(0);
-            if (firstChar < '0') { // Possible leading "+" or "-"
-                if (firstChar == '-') {
-                    negative = true;
-                    limit = Integer.MIN_VALUE;
-                } else if (firstChar != '+') {
-                    throw NumberFormatException.forInputString(s, radix);
-                }
-
-                if (len == 1) { // Cannot have lone "+" or "-"
-                    throw NumberFormatException.forInputString(s, radix);
-                }
-                i++;
-            }
+        int len = s.length();
+        if (len == 0) {
+            throw new NumberFormatException("");
+        }
+        int digit = ~0xFF;
+        int i = 0;
+        char firstChar = s.charAt(i++);
+        if (firstChar != '-' && firstChar != '+') {
+            digit = digit(firstChar, radix);
+        }
+        if (digit >= 0 || digit == ~0xFF && len > 1) {
+            int limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
             int multmin = limit / radix;
-            int result = 0;
-            while (i < len) {
-                // Accumulating negatively avoids surprises near MAX_VALUE
-                int digit = Character.digit(s.charAt(i++), radix);
-                if (digit < 0 || result < multmin) {
-                    throw NumberFormatException.forInputString(s, radix);
-                }
-                result *= radix;
-                if (result < limit + digit) {
-                    throw NumberFormatException.forInputString(s, radix);
-                }
-                result -= digit;
+            int result = -(digit & 0xFF);
+            boolean inRange = true;
+            /* Accumulating negatively avoids surprises near MAX_VALUE */
+            while (i < len && (digit = digit(s.charAt(i++), radix)) >= 0
+                    && (inRange = result > multmin
+                        || result == multmin && digit <= radix * multmin - limit)) {
+                result = radix * result - digit;
             }
-            return negative ? result : -result;
-        } else {
-            throw NumberFormatException.forInputString(s, radix);
+            if (inRange && i == len && digit >= 0) {
+                return firstChar != '-' ? -result : result;
+            }
         }
+        throw NumberFormatException.forInputString(s, radix);
     }
 
     /**
@@ -632,55 +621,47 @@ public final class Integer extends Number
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException("radix " + radix +
-                                            " less than Character.MIN_RADIX");
+            throw new NumberFormatException(String.format(
+                "radix %d less than Character.MIN_RADIX", radix));
         }
+
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException("radix " + radix +
-                                            " greater than Character.MAX_RADIX");
+            throw new NumberFormatException(String.format(
+                "radix %d greater than Character.MAX_RADIX", radix));
         }
 
-        boolean negative = false;
+        /*
+         * While s can be concurrently modified, it is ensured that each
+         * of its characters is read at most once, from lower to higher indices.
+         * This is obtained by reading them using the pattern s.charAt(i++),
+         * and by not updating i anywhere else.
+         */
+        if (beginIndex == endIndex) {
+            throw new NumberFormatException("");
+        }
+        int digit = ~0xFF;
         int i = beginIndex;
-        int limit = -Integer.MAX_VALUE;
-
-        if (i < endIndex) {
-            char firstChar = s.charAt(i);
-            if (firstChar < '0') { // Possible leading "+" or "-"
-                if (firstChar == '-') {
-                    negative = true;
-                    limit = Integer.MIN_VALUE;
-                } else if (firstChar != '+') {
-                    throw NumberFormatException.forCharSequence(s, beginIndex,
-                            endIndex, i);
-                }
-                i++;
-                if (i == endIndex) { // Cannot have lone "+" or "-"
-                    throw NumberFormatException.forCharSequence(s, beginIndex,
-                            endIndex, i);
-                }
-            }
-            int multmin = limit / radix;
-            int result = 0;
-            while (i < endIndex) {
-                // Accumulating negatively avoids surprises near MAX_VALUE
-                int digit = Character.digit(s.charAt(i), radix);
-                if (digit < 0 || result < multmin) {
-                    throw NumberFormatException.forCharSequence(s, beginIndex,
-                            endIndex, i);
-                }
-                result *= radix;
-                if (result < limit + digit) {
-                    throw NumberFormatException.forCharSequence(s, beginIndex,
-                            endIndex, i);
-                }
-                i++;
-                result -= digit;
-            }
-            return negative ? result : -result;
-        } else {
-            throw NumberFormatException.forInputString("", radix);
+        char firstChar = s.charAt(i++);
+        if (firstChar != '-' && firstChar != '+') {
+            digit = digit(firstChar, radix);
         }
+        if (digit >= 0 || digit == ~0xFF && endIndex - beginIndex > 1) {
+            int limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
+            int multmin = limit / radix;
+            int result = -(digit & 0xFF);
+            boolean inRange = true;
+            /* Accumulating negatively avoids surprises near MAX_VALUE */
+            while (i < endIndex && (digit = digit(s.charAt(i++), radix)) >= 0
+                    && (inRange = result > multmin
+                        || result == multmin && digit <= radix * multmin - limit)) {
+                result = radix * result - digit;
+            }
+            if (inRange && i == endIndex && digit >= 0) {
+                return firstChar != '-' ? -result : result;
+            }
+        }
+        throw NumberFormatException.forCharSequence(s, beginIndex,
+            endIndex, i - (digit < -1 ? 0 : 1));
     }
 
     /**
@@ -701,7 +682,7 @@ public final class Integer extends Number
      *               parsable integer.
      */
     public static int parseInt(String s) throws NumberFormatException {
-        return parseInt(s,10);
+        return parseInt(s, 10);
     }
 
     /**
@@ -753,31 +734,49 @@ public final class Integer extends Number
             throw new NumberFormatException("Cannot parse null string");
         }
 
+        if (radix < Character.MIN_RADIX) {
+            throw new NumberFormatException(String.format(
+                "radix %d less than Character.MIN_RADIX", radix));
+        }
+
+        if (radix > Character.MAX_RADIX) {
+            throw new NumberFormatException(String.format(
+                "radix %d greater than Character.MAX_RADIX", radix));
+        }
+
         int len = s.length();
-        if (len > 0) {
-            char firstChar = s.charAt(0);
-            if (firstChar == '-') {
-                throw new
-                    NumberFormatException(String.format("Illegal leading minus sign " +
-                                                       "on unsigned string %s.", s));
-            } else {
-                if (len <= 5 || // Integer.MAX_VALUE in Character.MAX_RADIX is 6 digits
-                    (radix == 10 && len <= 9) ) { // Integer.MAX_VALUE in base 10 is 10 digits
-                    return parseInt(s, radix);
-                } else {
-                    long ell = Long.parseLong(s, radix);
-                    if ((ell & 0xffff_ffff_0000_0000L) == 0) {
-                        return (int) ell;
-                    } else {
-                        throw new
-                            NumberFormatException(String.format("String value %s exceeds " +
-                                                                "range of unsigned int.", s));
-                    }
-                }
-            }
-        } else {
+        if (len == 0) {
             throw NumberFormatException.forInputString(s, radix);
         }
+        int i = 0;
+        char firstChar = s.charAt(i++);
+        if (firstChar == '-') {
+            throw new NumberFormatException(String.format(
+                "Illegal leading minus sign on unsigned string %s.", s));
+        }
+        int digit = ~0xFF;
+        if (firstChar != '+') {
+            digit = digit(firstChar, radix);
+        }
+        if (digit >= 0 || digit == ~0xFF && len > 1) {
+            int multmax = divideUnsigned(-1, radix);  // -1 is max unsigned int
+            int result = digit & 0xFF;
+            boolean inRange = true;
+            /* Use MIN_VALUE + x < MIN_VALUE + y as unsigned x < y comparison */
+            while (i < len && (digit = digit(s.charAt(i++), radix)) >= 0
+                    && (inRange = MIN_VALUE + result < MIN_VALUE + multmax
+                        || result == multmax && digit < -radix * multmax)) {
+                result = radix * result + digit;
+            }
+            if (inRange && i == len && digit >= 0) {
+                return result;
+            }
+        }
+        if (digit < 0) {
+            throw NumberFormatException.forInputString(s, radix);
+        }
+        throw new NumberFormatException(String.format(
+            "String value %s exceeds range of unsigned int.", s));
     }
 
     /**
@@ -812,32 +811,55 @@ public final class Integer extends Number
         Objects.requireNonNull(s);
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
-        int start = beginIndex, len = endIndex - beginIndex;
+        if (radix < Character.MIN_RADIX) {
+            throw new NumberFormatException(String.format(
+                "radix %d less than Character.MIN_RADIX", radix));
+        }
 
-        if (len > 0) {
-            char firstChar = s.charAt(start);
-            if (firstChar == '-') {
-                throw new
-                    NumberFormatException(String.format("Illegal leading minus sign " +
-                                                       "on unsigned string %s.", s));
-            } else {
-                if (len <= 5 || // Integer.MAX_VALUE in Character.MAX_RADIX is 6 digits
-                        (radix == 10 && len <= 9)) { // Integer.MAX_VALUE in base 10 is 10 digits
-                    return parseInt(s, start, start + len, radix);
-                } else {
-                    long ell = Long.parseLong(s, start, start + len, radix);
-                    if ((ell & 0xffff_ffff_0000_0000L) == 0) {
-                        return (int) ell;
-                    } else {
-                        throw new
-                            NumberFormatException(String.format("String value %s exceeds " +
-                                                                "range of unsigned int.", s));
-                    }
-                }
-            }
-        } else {
+        if (radix > Character.MAX_RADIX) {
+            throw new NumberFormatException(String.format(
+                "radix %d greater than Character.MAX_RADIX", radix));
+        }
+
+        /*
+         * While s can be concurrently modified, it is ensured that each
+         * of its characters is read at most once, from lower to higher indices.
+         * This is obtained by reading them using the pattern s.charAt(i++),
+         * and by not updating i anywhere else.
+         */
+        if (beginIndex == endIndex) {
             throw new NumberFormatException("");
         }
+        int i = beginIndex;
+        char firstChar = s.charAt(i++);
+        if (firstChar == '-') {
+            throw new NumberFormatException(
+                "Illegal leading minus sign on unsigned string " + s + ".");
+        }
+        int digit = ~0xFF;
+        if (firstChar != '+') {
+            digit = digit(firstChar, radix);
+        }
+        if (digit >= 0 || digit == ~0xFF && endIndex - beginIndex > 1) {
+            int multmax = divideUnsigned(-1, radix);  // -1 is max unsigned int
+            int result = digit & 0xFF;
+            boolean inRange = true;
+            /* Use MIN_VALUE + x < MIN_VALUE + y as unsigned x < y comparison */
+            while (i < endIndex && (digit = digit(s.charAt(i++), radix)) >= 0
+                    && (inRange = MIN_VALUE + result < MIN_VALUE + multmax
+                        || result == multmax && digit < -radix * multmax)) {
+                result = radix * result + digit;
+            }
+            if (inRange && i == endIndex && digit >= 0) {
+                return result;
+            }
+        }
+        if (digit < 0) {
+            throw NumberFormatException.forCharSequence(s, beginIndex,
+                endIndex, i - (digit < -1 ? 0 : 1));
+        }
+        throw new NumberFormatException(String.format(
+            "String value %s exceeds range of unsigned int.", s));
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -552,12 +552,12 @@ public final class Integer extends Number
 
         if (radix < Character.MIN_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d less than Character.MIN_RADIX", radix));
+                "radix %s less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d greater than Character.MAX_RADIX", radix));
+                "radix %s greater than Character.MAX_RADIX", radix));
         }
 
         int len = s.length();
@@ -622,12 +622,12 @@ public final class Integer extends Number
 
         if (radix < Character.MIN_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d less than Character.MIN_RADIX", radix));
+                "radix %s less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d greater than Character.MAX_RADIX", radix));
+                "radix %s greater than Character.MAX_RADIX", radix));
         }
 
         /*
@@ -736,12 +736,12 @@ public final class Integer extends Number
 
         if (radix < Character.MIN_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d less than Character.MIN_RADIX", radix));
+                "radix %s less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d greater than Character.MAX_RADIX", radix));
+                "radix %s greater than Character.MAX_RADIX", radix));
         }
 
         int len = s.length();
@@ -813,12 +813,12 @@ public final class Integer extends Number
 
         if (radix < Character.MIN_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d less than Character.MIN_RADIX", radix));
+                "radix %s less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d greater than Character.MAX_RADIX", radix));
+                "radix %s greater than Character.MAX_RADIX", radix));
         }
 
         /*

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -38,6 +38,7 @@ import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 import jdk.internal.vm.annotation.Stable;
 
+import static java.lang.Character.digit;
 import static java.lang.String.COMPACT_STRINGS;
 import static java.lang.String.LATIN1;
 import static java.lang.String.UTF16;
@@ -574,58 +575,47 @@ public final class Long extends Number
      *             parsable {@code long}.
      */
     public static long parseLong(String s, int radix)
-              throws NumberFormatException
-    {
+                throws NumberFormatException {
         if (s == null) {
             throw new NumberFormatException("Cannot parse null string");
         }
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException("radix " + radix +
-                                            " less than Character.MIN_RADIX");
+            throw new NumberFormatException(String.format(
+                "radix %d less than Character.MIN_RADIX", radix));
         }
+
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException("radix " + radix +
-                                            " greater than Character.MAX_RADIX");
+            throw new NumberFormatException(String.format(
+                "radix %d greater than Character.MAX_RADIX", radix));
         }
 
-        boolean negative = false;
-        int i = 0, len = s.length();
-        long limit = -Long.MAX_VALUE;
-
-        if (len > 0) {
-            char firstChar = s.charAt(0);
-            if (firstChar < '0') { // Possible leading "+" or "-"
-                if (firstChar == '-') {
-                    negative = true;
-                    limit = Long.MIN_VALUE;
-                } else if (firstChar != '+') {
-                    throw NumberFormatException.forInputString(s, radix);
-                }
-
-                if (len == 1) { // Cannot have lone "+" or "-"
-                    throw NumberFormatException.forInputString(s, radix);
-                }
-                i++;
-            }
+        int len = s.length();
+        if (len == 0) {
+            throw new NumberFormatException("");
+        }
+        int digit = ~0xFF;
+        int i = 0;
+        char firstChar = s.charAt(i++);
+        if (firstChar != '-' && firstChar != '+') {
+            digit = digit(firstChar, radix);
+        }
+        if (digit >= 0 || digit == ~0xFF && len > 1) {
+            long limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
             long multmin = limit / radix;
-            long result = 0;
-            while (i < len) {
-                // Accumulating negatively avoids surprises near MAX_VALUE
-                int digit = Character.digit(s.charAt(i++),radix);
-                if (digit < 0 || result < multmin) {
-                    throw NumberFormatException.forInputString(s, radix);
-                }
-                result *= radix;
-                if (result < limit + digit) {
-                    throw NumberFormatException.forInputString(s, radix);
-                }
-                result -= digit;
+            long result = -(digit & 0xFF);
+            boolean inRange = true;
+            /* Accumulating negatively avoids surprises near MAX_VALUE */
+            while (i < len && (digit = digit(s.charAt(i++), radix)) >= 0
+                    && (inRange = result > multmin
+                        || result == multmin && digit <= (int) (radix * multmin - limit))) {
+                result = radix * result - digit;
             }
-            return negative ? result : -result;
-        } else {
-            throw NumberFormatException.forInputString(s, radix);
+            if (inRange && i == len && digit >= 0) {
+                return firstChar != '-' ? -result : result;
+            }
         }
+        throw NumberFormatException.forInputString(s, radix);
     }
 
     /**
@@ -661,55 +651,47 @@ public final class Long extends Number
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException("radix " + radix +
-                    " less than Character.MIN_RADIX");
+            throw new NumberFormatException(String.format(
+                "radix %d less than Character.MIN_RADIX", radix));
         }
+
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException("radix " + radix +
-                    " greater than Character.MAX_RADIX");
+            throw new NumberFormatException(String.format(
+                "radix %d greater than Character.MAX_RADIX", radix));
         }
 
-        boolean negative = false;
-        int i = beginIndex;
-        long limit = -Long.MAX_VALUE;
-
-        if (i < endIndex) {
-            char firstChar = s.charAt(i);
-            if (firstChar < '0') { // Possible leading "+" or "-"
-                if (firstChar == '-') {
-                    negative = true;
-                    limit = Long.MIN_VALUE;
-                } else if (firstChar != '+') {
-                    throw NumberFormatException.forCharSequence(s, beginIndex,
-                            endIndex, i);
-                }
-                i++;
-            }
-            if (i >= endIndex) { // Cannot have lone "+", "-" or ""
-                throw NumberFormatException.forCharSequence(s, beginIndex,
-                        endIndex, i);
-            }
-            long multmin = limit / radix;
-            long result = 0;
-            while (i < endIndex) {
-                // Accumulating negatively avoids surprises near MAX_VALUE
-                int digit = Character.digit(s.charAt(i), radix);
-                if (digit < 0 || result < multmin) {
-                    throw NumberFormatException.forCharSequence(s, beginIndex,
-                            endIndex, i);
-                }
-                result *= radix;
-                if (result < limit + digit) {
-                    throw NumberFormatException.forCharSequence(s, beginIndex,
-                            endIndex, i);
-                }
-                i++;
-                result -= digit;
-            }
-            return negative ? result : -result;
-        } else {
+        /*
+         * While s can be concurrently modified, it is ensured that each
+         * of its characters is read at most once, from lower to higher indices.
+         * This is obtained by reading them using the pattern s.charAt(i++),
+         * and by not updating i anywhere else.
+         */
+        if (beginIndex == endIndex) {
             throw new NumberFormatException("");
         }
+        int digit = ~0xFF;  // ~0xFF means firstChar char is sign
+        int i = beginIndex;
+        char firstChar = s.charAt(i++);
+        if (firstChar != '-' && firstChar != '+') {
+            digit = digit(firstChar, radix);
+        }
+        if (digit >= 0 || digit == ~0xFF && endIndex - beginIndex > 1) {
+            long limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
+            long multmin = limit / radix;
+            long result = -(digit & 0xFF);
+            boolean inRange = true;
+            /* Accumulating negatively avoids surprises near MAX_VALUE */
+            while (i < endIndex && (digit = digit(s.charAt(i++), radix)) >= 0
+                    && (inRange = result > multmin
+                        || result == multmin && digit <= (int) (radix * multmin - limit))) {
+                result = radix * result - digit;
+            }
+            if (inRange && i == endIndex && digit >= 0) {
+                return firstChar != '-' ? -result : result;
+            }
+        }
+        throw NumberFormatException.forCharSequence(s, beginIndex,
+            endIndex, i - (digit < -1 ? 0 : 1));
     }
 
     /**
@@ -789,87 +771,49 @@ public final class Long extends Number
             throw new NumberFormatException("Cannot parse null string");
         }
 
+        if (radix < Character.MIN_RADIX) {
+            throw new NumberFormatException(String.format(
+                "radix %d less than Character.MIN_RADIX", radix));
+        }
+
+        if (radix > Character.MAX_RADIX) {
+            throw new NumberFormatException(String.format(
+                "radix %d greater than Character.MAX_RADIX", radix));
+        }
+
         int len = s.length();
-        if (len > 0) {
-            char firstChar = s.charAt(0);
-            if (firstChar == '-') {
-                throw new
-                    NumberFormatException(String.format("Illegal leading minus sign " +
-                                                       "on unsigned string %s.", s));
-            } else {
-                if (len <= 12 || // Long.MAX_VALUE in Character.MAX_RADIX is 13 digits
-                    (radix == 10 && len <= 18) ) { // Long.MAX_VALUE in base 10 is 19 digits
-                    return parseLong(s, radix);
-                }
-
-                // No need for range checks on len due to testing above.
-                long first = parseLong(s, 0, len - 1, radix);
-                int second = Character.digit(s.charAt(len - 1), radix);
-                if (second < 0) {
-                    throw new NumberFormatException("Bad digit at end of " + s);
-                }
-                long result = first * radix + second;
-
-                /*
-                 * Test leftmost bits of multiprecision extension of first*radix
-                 * for overflow. The number of bits needed is defined by
-                 * GUARD_BIT = ceil(log2(Character.MAX_RADIX)) + 1 = 7. Then
-                 * int guard = radix*(int)(first >>> (64 - GUARD_BIT)) and
-                 * overflow is tested by splitting guard in the ranges
-                 * guard < 92, 92 <= guard < 128, and 128 <= guard, where
-                 * 92 = 128 - Character.MAX_RADIX. Note that guard cannot take
-                 * on a value which does not include a prime factor in the legal
-                 * radix range.
-                 */
-                int guard = radix * (int) (first >>> 57);
-                if (guard >= 128 ||
-                    (result >= 0 && guard >= 128 - Character.MAX_RADIX)) {
-                    /*
-                     * For purposes of exposition, the programmatic statements
-                     * below should be taken to be multi-precision, i.e., not
-                     * subject to overflow.
-                     *
-                     * A) Condition guard >= 128:
-                     * If guard >= 128 then first*radix >= 2^7 * 2^57 = 2^64
-                     * hence always overflow.
-                     *
-                     * B) Condition guard < 92:
-                     * Define left7 = first >>> 57.
-                     * Given first = (left7 * 2^57) + (first & (2^57 - 1)) then
-                     * result <= (radix*left7)*2^57 + radix*(2^57 - 1) + second.
-                     * Thus if radix*left7 < 92, radix <= 36, and second < 36,
-                     * then result < 92*2^57 + 36*(2^57 - 1) + 36 = 2^64 hence
-                     * never overflow.
-                     *
-                     * C) Condition 92 <= guard < 128:
-                     * first*radix + second >= radix*left7*2^57 + second
-                     * so that first*radix + second >= 92*2^57 + 0 > 2^63
-                     *
-                     * D) Condition guard < 128:
-                     * radix*first <= (radix*left7) * 2^57 + radix*(2^57 - 1)
-                     * so
-                     * radix*first + second <= (radix*left7) * 2^57 + radix*(2^57 - 1) + 36
-                     * thus
-                     * radix*first + second < 128 * 2^57 + 36*2^57 - radix + 36
-                     * whence
-                     * radix*first + second < 2^64 + 2^6*2^57 = 2^64 + 2^63
-                     *
-                     * E) Conditions C, D, and result >= 0:
-                     * C and D combined imply the mathematical result
-                     * 2^63 < first*radix + second < 2^64 + 2^63. The lower
-                     * bound is therefore negative as a signed long, but the
-                     * upper bound is too small to overflow again after the
-                     * signed long overflows to positive above 2^64 - 1. Hence
-                     * result >= 0 implies overflow given C and D.
-                     */
-                    throw new NumberFormatException(String.format("String value %s exceeds " +
-                                                                  "range of unsigned long.", s));
-                }
-                return result;
-            }
-        } else {
+        if (len == 0) {
             throw NumberFormatException.forInputString(s, radix);
         }
+        int i = 0;
+        char firstChar = s.charAt(i++);
+        if (firstChar == '-') {
+            throw new NumberFormatException(String.format(
+                "Illegal leading minus sign on unsigned string %s.", s));
+        }
+        int digit = ~0xFF;
+        if (firstChar != '+') {
+            digit = digit(firstChar, radix);
+        }
+        if (digit >= 0 || digit == ~0xFF && len > 1) {
+            long multmax = divideUnsigned(-1L, radix);  // -1L is max unsigned long
+            long result = digit & 0xFF;
+            boolean inRange = true;
+            /* Use MIN_VALUE + x < MIN_VALUE + y as unsigned x < y comparison */
+            while (i < len && (digit = digit(s.charAt(i++), radix)) >= 0
+                    && (inRange = MIN_VALUE + result < MIN_VALUE + multmax
+                        || result == multmax && digit < (int) (-radix * multmax))) {
+                result = radix * result + digit;
+            }
+            if (inRange && i == len && digit >= 0) {
+                return result;
+            }
+        }
+        if (digit < 0) {
+            throw NumberFormatException.forInputString(s, radix);
+        }
+        throw new NumberFormatException(String.format(
+            "String value %s exceeds range of unsigned long.", s));
     }
 
     /**
@@ -904,88 +848,55 @@ public final class Long extends Number
         Objects.requireNonNull(s);
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
-        int start = beginIndex, len = endIndex - beginIndex;
+        if (radix < Character.MIN_RADIX) {
+            throw new NumberFormatException(String.format(
+                "radix %d less than Character.MIN_RADIX", radix));
+        }
 
-        if (len > 0) {
-            char firstChar = s.charAt(start);
-            if (firstChar == '-') {
-                throw new NumberFormatException(String.format("Illegal leading minus sign " +
-                        "on unsigned string %s.", s.subSequence(start, start + len)));
-            } else {
-                if (len <= 12 || // Long.MAX_VALUE in Character.MAX_RADIX is 13 digits
-                    (radix == 10 && len <= 18) ) { // Long.MAX_VALUE in base 10 is 19 digits
-                    return parseLong(s, start, start + len, radix);
-                }
+        if (radix > Character.MAX_RADIX) {
+            throw new NumberFormatException(String.format(
+                "radix %d greater than Character.MAX_RADIX", radix));
+        }
 
-                // No need for range checks on end due to testing above.
-                long first = parseLong(s, start, start + len - 1, radix);
-                int second = Character.digit(s.charAt(start + len - 1), radix);
-                if (second < 0) {
-                    throw new NumberFormatException("Bad digit at end of " +
-                            s.subSequence(start, start + len));
-                }
-                long result = first * radix + second;
-
-                /*
-                 * Test leftmost bits of multiprecision extension of first*radix
-                 * for overflow. The number of bits needed is defined by
-                 * GUARD_BIT = ceil(log2(Character.MAX_RADIX)) + 1 = 7. Then
-                 * int guard = radix*(int)(first >>> (64 - GUARD_BIT)) and
-                 * overflow is tested by splitting guard in the ranges
-                 * guard < 92, 92 <= guard < 128, and 128 <= guard, where
-                 * 92 = 128 - Character.MAX_RADIX. Note that guard cannot take
-                 * on a value which does not include a prime factor in the legal
-                 * radix range.
-                 */
-                int guard = radix * (int) (first >>> 57);
-                if (guard >= 128 ||
-                        (result >= 0 && guard >= 128 - Character.MAX_RADIX)) {
-                    /*
-                     * For purposes of exposition, the programmatic statements
-                     * below should be taken to be multi-precision, i.e., not
-                     * subject to overflow.
-                     *
-                     * A) Condition guard >= 128:
-                     * If guard >= 128 then first*radix >= 2^7 * 2^57 = 2^64
-                     * hence always overflow.
-                     *
-                     * B) Condition guard < 92:
-                     * Define left7 = first >>> 57.
-                     * Given first = (left7 * 2^57) + (first & (2^57 - 1)) then
-                     * result <= (radix*left7)*2^57 + radix*(2^57 - 1) + second.
-                     * Thus if radix*left7 < 92, radix <= 36, and second < 36,
-                     * then result < 92*2^57 + 36*(2^57 - 1) + 36 = 2^64 hence
-                     * never overflow.
-                     *
-                     * C) Condition 92 <= guard < 128:
-                     * first*radix + second >= radix*left7*2^57 + second
-                     * so that first*radix + second >= 92*2^57 + 0 > 2^63
-                     *
-                     * D) Condition guard < 128:
-                     * radix*first <= (radix*left7) * 2^57 + radix*(2^57 - 1)
-                     * so
-                     * radix*first + second <= (radix*left7) * 2^57 + radix*(2^57 - 1) + 36
-                     * thus
-                     * radix*first + second < 128 * 2^57 + 36*2^57 - radix + 36
-                     * whence
-                     * radix*first + second < 2^64 + 2^6*2^57 = 2^64 + 2^63
-                     *
-                     * E) Conditions C, D, and result >= 0:
-                     * C and D combined imply the mathematical result
-                     * 2^63 < first*radix + second < 2^64 + 2^63. The lower
-                     * bound is therefore negative as a signed long, but the
-                     * upper bound is too small to overflow again after the
-                     * signed long overflows to positive above 2^64 - 1. Hence
-                     * result >= 0 implies overflow given C and D.
-                     */
-                    throw new NumberFormatException(String.format("String value %s exceeds " +
-                            "range of unsigned long.", s.subSequence(start, start + len)));
-                }
+        /*
+         * While s can be concurrently modified, it is ensured that each
+         * of its characters is read at most once, from lower to higher indices.
+         * This is obtained by reading them using the pattern s.charAt(i++),
+         * and by not updating i anywhere else.
+         */
+        if (beginIndex == endIndex) {
+            throw new NumberFormatException("");
+        }
+        int i = beginIndex;
+        char firstChar = s.charAt(i++);
+        if (firstChar == '-') {
+            throw new NumberFormatException(
+                "Illegal leading minus sign on unsigned string " + s + ".");
+        }
+        int digit = ~0xFF;
+        if (firstChar != '+') {
+            digit = digit(firstChar, radix);
+        }
+        if (digit >= 0 || digit == ~0xFF && endIndex - beginIndex > 1) {
+            long multmax = divideUnsigned(-1L, radix);  // -1L is max unsigned long
+            long result = digit & 0xFF;
+            boolean inRange = true;
+            /* Use MIN_VALUE + x < MIN_VALUE + y as unsigned x < y comparison */
+            while (i < endIndex && (digit = digit(s.charAt(i++), radix)) >= 0
+                    && (inRange = MIN_VALUE + result < MIN_VALUE + multmax
+                        || result == multmax && digit < (int) (-radix * multmax))) {
+                result = radix * result + digit;
+            }
+            if (inRange && i == endIndex && digit >= 0) {
                 return result;
             }
-        } else {
-            throw NumberFormatException.forInputString("", radix);
         }
+        if (digit < 0) {
+            throw NumberFormatException.forCharSequence(s, beginIndex,
+                endIndex, i - (digit < -1 ? 0 : 1));
+        }
+        throw new NumberFormatException(String.format(
+            "String value %s exceeds range of unsigned long.", s));
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -582,12 +582,12 @@ public final class Long extends Number
 
         if (radix < Character.MIN_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d less than Character.MIN_RADIX", radix));
+                "radix %s less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d greater than Character.MAX_RADIX", radix));
+                "radix %s greater than Character.MAX_RADIX", radix));
         }
 
         int len = s.length();
@@ -652,12 +652,12 @@ public final class Long extends Number
 
         if (radix < Character.MIN_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d less than Character.MIN_RADIX", radix));
+                "radix %s less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d greater than Character.MAX_RADIX", radix));
+                "radix %s greater than Character.MAX_RADIX", radix));
         }
 
         /*
@@ -773,12 +773,12 @@ public final class Long extends Number
 
         if (radix < Character.MIN_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d less than Character.MIN_RADIX", radix));
+                "radix %s less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d greater than Character.MAX_RADIX", radix));
+                "radix %s greater than Character.MAX_RADIX", radix));
         }
 
         int len = s.length();
@@ -850,12 +850,12 @@ public final class Long extends Number
 
         if (radix < Character.MIN_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d less than Character.MIN_RADIX", radix));
+                "radix %s less than Character.MIN_RADIX", radix));
         }
 
         if (radix > Character.MAX_RADIX) {
             throw new NumberFormatException(String.format(
-                "radix %d greater than Character.MAX_RADIX", radix));
+                "radix %s greater than Character.MAX_RADIX", radix));
         }
 
         /*

--- a/src/java.base/share/classes/java/lang/NumberFormatException.java
+++ b/src/java.base/share/classes/java/lang/NumberFormatException.java
@@ -82,4 +82,28 @@ public class NumberFormatException extends IllegalArgumentException {
                 + (errorIndex - beginIndex) + " in: \""
                 + s.subSequence(beginIndex, endIndex) + "\"");
     }
+
+    static NumberFormatException forUnsign(CharSequence s) {
+        return new NumberFormatException("Illegal leading minus sign on unsigned string " + s + ".");
+    }
+
+    static NumberFormatException forUnsignLong(CharSequence s) {
+        return new NumberFormatException(String.format(
+                "String value %s exceeds range of unsigned long.", s));
+    }
+
+    static NumberFormatException forUnsignInt(CharSequence s) {
+        return new NumberFormatException(String.format(
+                "String value %s exceeds range of unsigned int.", s));
+    }
+
+    static NumberFormatException forMinRadix(int radix) {
+        return new NumberFormatException(String.format(
+                "radix %s greater than Character.MIN_RADIX", radix));
+    }
+
+    static NumberFormatException forMaxRadix(int radix) {
+        return new NumberFormatException(String.format(
+                "radix %s greater than Character.MAX_RADIX", radix));
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -35,6 +35,21 @@ import jdk.internal.vm.annotation.Stable;
  * @since 21
  */
 public final class DecimalDigits implements Digits {
+    @Stable
+    private static final byte[] DIGITS_LATIN1 = new byte[] {
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
 
     /**
      * Each element of the array represents the packaging of two ascii characters based on little endian:<p>
@@ -158,5 +173,18 @@ public final class DecimalDigits implements Digits {
      */
     public static short digitPair(int i) {
         return DIGITS[i];
+    }
+
+
+    /**
+     * Returns the numeric value of the character {@code ch}
+     * <p>
+     * if the value of {@code ch} is not a valid digit, {@code -1} is returned.
+     *
+     * @param   ch      the character to be converted.
+     * @return  the numeric value represented by the character.
+     */
+    public static int digit(byte ch) {
+        return DIGITS_LATIN1[ch & 0xFF];
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -54,6 +54,7 @@ public class Integers {
 
     private int bound;
     private String[] strings;
+    private String[] stringsUnsigned;
     private int[] intsTiny;
     private int[] intsSmall;
     private int[] intsBig;
@@ -63,13 +64,16 @@ public class Integers {
     public void setup() {
         Random r  = new Random(0);
         bound = 50;
+        stringsUnsigned  = new String[size];
         strings   = new String[size];
         intsTiny  = new int[size];
         intsSmall = new int[size];
         intsBig   = new int[size];
         res       = new int[size];
         for (int i = 0; i < size; i++) {
-            strings[i] = "" + (r.nextInt(10000) - (5000));
+            int nextInt = r.nextInt(10000) - (5000);
+            strings[i] = Integer.toString(nextInt);
+            stringsUnsigned[i] = Integer.toString(Math.abs(nextInt));
             intsTiny[i] = r.nextInt(99);
             intsSmall[i] = 100 * i + i + 103;
             intsBig[i] = ((100 * i + i) << 24) + 4543 + i * 4;
@@ -80,6 +84,27 @@ public class Integers {
     public void parseInt(Blackhole bh) {
         for (String s : strings) {
             bh.consume(Integer.parseInt(s));
+        }
+    }
+
+    @Benchmark
+    public void parseIntCharSequence(Blackhole bh) {
+        for (String s : strings) {
+            bh.consume(Integer.parseInt(s, 0, s.length(), 10));
+        }
+    }
+
+    @Benchmark
+    public void parseUnisgnedInt(Blackhole bh) {
+        for (String s : stringsUnsigned) {
+            bh.consume(Integer.parseUnsignedInt(s));
+        }
+    }
+
+    @Benchmark
+    public void parseUnisgnedIntCharSequence(Blackhole bh) {
+        for (String s : stringsUnsigned) {
+            bh.consume(Integer.parseUnsignedInt(s, 0, s.length(), 10));
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -52,6 +52,7 @@ public class Longs {
     private long bound;
     private long[] res;
     private String[] strings;
+    private String[] stringsUnsigned;
     private long[] longArraySmall;
     private long[] longArrayBig;
 
@@ -60,11 +61,14 @@ public class Longs {
         var random = ThreadLocalRandom.current();
         bound = 20000L;
         strings = new String[size];
+        stringsUnsigned = new String[size];
         res = new long[size];
         longArraySmall = new long[size];
         longArrayBig = new long[size];
         for (int i = 0; i < size; i++) {
-            strings[i] = "" + (random.nextLong(10000) - 5000);
+            long nextLong = random.nextLong(10000) - 5000;
+            strings[i] = Long.toString(nextLong);
+            stringsUnsigned[i] = Long.toString(Math.abs(nextLong));
             longArraySmall[i] = 100L * i + i + 103L;
             longArrayBig[i] = ((100L * i + i) << 32) + 4543 + i * 4L;
         }
@@ -82,6 +86,34 @@ public class Longs {
     public void decode(Blackhole bh) {
         for (String s : strings) {
             bh.consume(Long.decode(s));
+        }
+    }
+
+    @Benchmark
+    public void parseLong(Blackhole bh) {
+        for (String s : strings) {
+            bh.consume(Long.parseLong(s));
+        }
+    }
+
+    @Benchmark
+    public void parseLongCharSequence(Blackhole bh) {
+        for (String s : strings) {
+            bh.consume(Long.parseLong(s, 0, s.length(), 10));
+        }
+    }
+
+    @Benchmark
+    public void parseUnsignedLong(Blackhole bh) {
+        for (String s : stringsUnsigned) {
+            bh.consume(Long.parseUnsignedLong(s));
+        }
+    }
+
+    @Benchmark
+    public void parseUnsignedLongCharSequence(Blackhole bh) {
+        for (String s : stringsUnsigned) {
+            bh.consume(Long.parseUnsignedLong(s, 0, s.length(), 10));
         }
     }
 


### PR DESCRIPTION
Refactoring the code related to exception handling can make the code smaller and easier to be inlined. The code for constructing exceptions in these methods is encapsulated into methods and can be easily maintained together.

By extracting the code that creates the exception, the CodeSize of these methods is less than the default FreqInlineSize 325.
```
codeSize 350 bytes -> 269 bytes
public static int parseUnsignedInt(CharSequence s, int beginIndex, int endIndex, int radix)

codeSize 327 bytes -> 289 bytes
public static long parseLong(CharSequence s, int beginIndex, int endIndex, int radix)

codeSize 362 bytes -> 281 bytes
public static long parseUnsignedLong(CharSequence s, int beginIndex, int endIndex, int radix)
```

For the scenario where the most commonly used radix is 10 and the coder is LATIN1, fast-path optimization is done, which improves the performance of parseInt(String)/parseLong(String) by about 10%.

Performance numbers running on MacBook M1 Pro:
```diff
-Benchmark                              (size)  Mode  Cnt  Score   Error  Units
-Integers.parseInt                         500  avgt   15  2.676 ? 0.003  us/op
-Integers.parseIntCharSequence             500  avgt   15  2.731 ? 0.009  us/op
-Integers.parseUnisgnedInt                 500  avgt   15  2.422 ? 0.035  us/op
-Integers.parseUnisgnedIntCharSequence     500  avgt   15  4.096 ? 0.028  us/op
-Longs.parseLong                           500  avgt   15  2.995 ? 0.022  us/op
-Longs.parseLongCharSequence               500  avgt   15  4.213 ? 0.041  us/op
-Longs.parseLongUnsigned                   500  avgt   15  2.677 ? 0.031  us/op
-Longs.parseLongUnsignedCharSequence       500  avgt   15  4.388 ? 0.149  us/op

+Benchmark                              (size)  Mode  Cnt  Score   Error  Units
+Integers.parseInt                         500  avgt   15  2.352 ? 0.014  us/op (+13.78)
+Integers.parseIntCharSequence             500  avgt   15  2.655 ? 0.020  us/op (+2.87)
+Integers.parseUnisgnedInt                 500  avgt   15  2.411 ? 0.021  us/op (+0.46)
+Integers.parseUnisgnedIntCharSequence     500  avgt   15  2.401 ? 0.013  us/op (+70.60)
+Longs.parseLong                           500  avgt   15  2.592 ? 0.006  us/op (+15.55)
+Longs.parseLongCharSequence               500  avgt   15  2.885 ? 0.024  us/op (+46.04)
+Longs.parseLongUnsigned                   500  avgt   15  2.464 ? 0.022  us/op (+8.65)
+Longs.parseLongUnsignedCharSequence       500  avgt   15  2.484 ? 0.039  us/op (+76.66)
```