### PR TITLE
8317795: Add an ImmutableBitSetPredicate variant for bitsets <= 128 elements

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -81,19 +81,13 @@ public class ImmutableBitSetPredicate implements IntPredicate {
      */
     public static IntPredicate of(BitSet original) {
         if (original.size() <= 128) {
-            return new SmallImmutableBitSetPredicate(original);
+            long[] array = original.toLongArray();
+            return new SmallImmutableBitSetPredicate(array[0], array.length == 2 ? array[1] : 0L);
         }
         return new ImmutableBitSetPredicate(original);
     }
 
-    public static class SmallImmutableBitSetPredicate implements IntPredicate {
-        private final long first;
-        private final long second;
-        private SmallImmutableBitSetPredicate(BitSet original) {
-            long[] array = original.toLongArray();
-            first = array[0];
-            second = array.length == 2 ? array[1] : 0L;
-        }
+    public record SmallImmutableBitSetPredicate(long first, long second) implements IntPredicate {
         @Override
         public boolean test(int bitIndex) {
             if (bitIndex < 0)

--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -48,11 +48,22 @@ public class ImmutableBitSetPredicate implements IntPredicate {
         this.words = original.toLongArray();
     }
 
+
     @Override
     public boolean test(int bitIndex) {
-        int wordIndex = bitIndex >> 6;
+        if (bitIndex < 0)
+            throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
+
+        int wordIndex = wordIndex(bitIndex);
         return (wordIndex < words.length)
                 && ((words[wordIndex] & (1L << bitIndex)) != 0);
+    }
+
+    /**
+     * Given a bit index, return word index containing it.
+     */
+    private static int wordIndex(int bitIndex) {
+        return bitIndex >> 6;
     }
 
     /**
@@ -89,8 +100,11 @@ public class ImmutableBitSetPredicate implements IntPredicate {
         }
         @Override
         public boolean test(int bitIndex) {
+            if (bitIndex < 0)
+                throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
+
             int wordIndex = bitIndex >> 6;
-            if (bitIndex < 0 || wordIndex > 1) {
+            if (wordIndex > 1) {
                 return false;
             }
             long bits = wordIndex == 0 ? first : second;

--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -82,11 +82,18 @@ public class ImmutableBitSetPredicate implements IntPredicate {
     public static IntPredicate of(BitSet original) {
         if (original.size() <= 128) {
             long[] array = original.toLongArray();
-            return new SmallImmutableBitSetPredicate(array[0], array.length == 2 ? array[1] : 0L);
+            return new SmallImmutableBitSetPredicate(
+                    array.length > 0 ? array[0] : 0L,
+                    array.length > 1 ? array[1] : 0L);
         }
         return new ImmutableBitSetPredicate(original);
     }
 
+    /**
+     * Specialization for small sets of 128 bits or less.
+     * @param first
+     * @param second
+     */
     public record SmallImmutableBitSetPredicate(long first, long second) implements IntPredicate {
         @Override
         public boolean test(int bitIndex) {

--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -90,10 +90,6 @@ public class ImmutableBitSetPredicate implements IntPredicate {
         private final long first;
         private final long second;
         private SmallImmutableBitSetPredicate(BitSet original) {
-            // If this class is made public, we need to do
-            // a defensive array copy as certain BitSet implementations
-            // may return a shared array. The spec says the array should be _new_ though but
-            // the consequences might be unspecified for a malicious BitSet.
             long[] array = original.toLongArray();
             first = array[0];
             second = array.length == 2 ? array[1] : 0L;

--- a/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
+++ b/src/java.base/share/classes/jdk/internal/util/ImmutableBitSetPredicate.java
@@ -48,22 +48,19 @@ public class ImmutableBitSetPredicate implements IntPredicate {
         this.words = original.toLongArray();
     }
 
-
+    /**
+     * @param bitIndex the bit index to test
+     * @return true if the bit is in the range of the BitSet and the bit is set, otherwise false
+     */
     @Override
     public boolean test(int bitIndex) {
-        if (bitIndex < 0)
-            throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
+        if (bitIndex < 0) {
+            return false;
+        }
 
-        int wordIndex = wordIndex(bitIndex);
+        int wordIndex = bitIndex >> 6;
         return (wordIndex < words.length)
                 && ((words[wordIndex] & (1L << bitIndex)) != 0);
-    }
-
-    /**
-     * Given a bit index, return word index containing it.
-     */
-    private static int wordIndex(int bitIndex) {
-        return bitIndex >> 6;
     }
 
     /**
@@ -90,15 +87,21 @@ public class ImmutableBitSetPredicate implements IntPredicate {
     }
 
     /**
-     * Specialization for small sets of 128 bits or less.
-     * @param first
-     * @param second
+     * Specialization for small sets of 128 bits or less
+     * @param first - bits index 0 through 63, inclusive
+     * @param second - bits index 64 through 127, inclusive
      */
     public record SmallImmutableBitSetPredicate(long first, long second) implements IntPredicate {
+
+        /**
+         * @param bitIndex the bit index to test
+         * @return true if the bit is in the range of the BitSet and the bit is set, otherwise false
+         */
         @Override
         public boolean test(int bitIndex) {
-            if (bitIndex < 0)
-                throw new IndexOutOfBoundsException("bitIndex < 0: " + bitIndex);
+            if (bitIndex < 0) {
+                return false;
+            }
 
             int wordIndex = bitIndex >> 6;
             if (wordIndex > 1) {

--- a/test/jdk/java/util/BitSet/ImmutableBitSet.java
+++ b/test/jdk/java/util/BitSet/ImmutableBitSet.java
@@ -49,20 +49,17 @@ public class ImmutableBitSet {
 
     @Test
     void negativeIndex() {
-        BitSet bs = new BitSet();
-        IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
-        assertFalse(ibs.test(-1));
-        assertFalse(ibs.test(Integer.MIN_VALUE));
-
-        bs = new BitSet(1024);
-        ibs = ImmutableBitSetPredicate.of(bs);
-        assertFalse(ibs.test(-1));
-        assertFalse(ibs.test(Integer.MIN_VALUE));
+        IntStream.of(0, 127, 128, 143, 4711).forEach(k -> {
+                    BitSet bs = new BitSet(k);
+                    IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
+                    assertFalse(ibs.test(-1));
+                    assertFalse(ibs.test(Integer.MIN_VALUE));
+                });
     }
 
     @Test
     void basic() {
-        IntStream.of(0, 16, 143, 4711).forEach(k -> basic(k));
+        IntStream.of(0, 16, 127, 128, 143, 4711).forEach(k -> basic(k));
     }
 
     void basic(int length) {
@@ -73,7 +70,7 @@ public class ImmutableBitSet {
 
     @Test
     void clearedAtTheTail() {
-        IntStream.of(0, 143, 4711).forEach(k -> {
+        IntStream.of(0, 16, 127, 128, 143, 4711).forEach(k -> {
             for (int i = Long.BYTES - 1; i < Long.BYTES + 2; i++) {
                 BitSet bs = createReference(k + i);
                 for (int j = bs.length() - 1; j > Long.BYTES - 1; j++) {
@@ -92,7 +89,7 @@ public class ImmutableBitSet {
     }
 
     private static BitSet createReference(int length) {
-        BitSet result = new BitSet();
+        BitSet result = new BitSet(length);
         Random random = new Random(length);
         for (int i = 0; i < length; i++) {
             result.set(i, random.nextBoolean());

--- a/test/jdk/java/util/BitSet/ImmutableBitSet.java
+++ b/test/jdk/java/util/BitSet/ImmutableBitSet.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.BitSet;
 import java.util.Random;
 import java.util.function.IntPredicate;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -50,28 +51,38 @@ public class ImmutableBitSet {
     void negativeIndex() {
         BitSet bs = new BitSet();
         IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
-        assertThrows(IndexOutOfBoundsException.class, () -> {
-            ibs.test(-1);
-        });
+        assertFalse(ibs.test(-1));
+        assertFalse(ibs.test(Integer.MIN_VALUE));
+
+        bs = new BitSet(1024);
+        ibs = ImmutableBitSetPredicate.of(bs);
+        assertFalse(ibs.test(-1));
+        assertFalse(ibs.test(Integer.MIN_VALUE));
     }
 
     @Test
     void basic() {
-        BitSet bs = createReference(147);
+        IntStream.of(0, 16, 143, 4711).forEach(k -> basic(k));
+    }
+
+    void basic(int length) {
+        BitSet bs = createReference(length);
         IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
         test(bs, ibs);
     }
 
     @Test
     void clearedAtTheTail() {
-        for (int i = Long.BYTES - 1; i < Long.BYTES + 2; i++) {
-            BitSet bs = createReference(i);
-            for (int j = bs.length() - 1; j > Long.BYTES - 1; j++) {
-                bs.clear(j);
+        IntStream.of(0, 143, 4711).forEach(k -> {
+            for (int i = Long.BYTES - 1; i < Long.BYTES + 2; i++) {
+                BitSet bs = createReference(k + i);
+                for (int j = bs.length() - 1; j > Long.BYTES - 1; j++) {
+                    bs.clear(j);
+                }
+                IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
+                test(bs, ibs);
             }
-            IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
-            test(bs, ibs);
-        }
+        });
     }
 
     static void test(BitSet expected, IntPredicate actual) {

--- a/test/jdk/java/util/BitSet/ImmutableBitSet.java
+++ b/test/jdk/java/util/BitSet/ImmutableBitSet.java
@@ -49,7 +49,7 @@ public class ImmutableBitSet {
 
     @Test
     void negativeIndex() {
-        IntStream.of(0, 127, 128, 143, 4711).forEach(k -> {
+        IntStream.of(0, 127, 128, 129, 143, 4711).forEach(k -> {
                     BitSet bs = new BitSet(k);
                     IntPredicate ibs = ImmutableBitSetPredicate.of(bs);
                     assertFalse(ibs.test(-1));
@@ -59,7 +59,7 @@ public class ImmutableBitSet {
 
     @Test
     void basic() {
-        IntStream.of(0, 16, 127, 128, 143, 4711).forEach(k -> basic(k));
+        IntStream.of(0, 16, 127, 128, 129, 143, 4711).forEach(k -> basic(k));
     }
 
     void basic(int length) {
@@ -70,10 +70,10 @@ public class ImmutableBitSet {
 
     @Test
     void clearedAtTheTail() {
-        IntStream.of(0, 16, 127, 128, 143, 4711).forEach(k -> {
+        IntStream.of(0, 16, 127, 128, 129, 143, 4711).forEach(k -> {
             for (int i = Long.BYTES - 1; i < Long.BYTES + 2; i++) {
                 BitSet bs = createReference(k + i);
-                for (int j = bs.length() - 1; j > Long.BYTES - 1; j++) {
+                for (int j = bs.length() - 1; j > Long.BYTES - 1; j--) {
                     bs.clear(j);
                 }
                 IntPredicate ibs = ImmutableBitSetPredicate.of(bs);


### PR DESCRIPTION
Alternative to #16082
```
Name                             (unchanged) Cnt  Base   Error   Test   Error  Unit  Change
URLEncodeDecode.testEncodeLatin1           0  15 2,066 ± 0,104  1,899 ± 0,007 ms/op   1,09x (p = 0,000*)
URLEncodeDecode.testEncodeLatin1          75  15 0,934 ± 0,017  0,811 ± 0,014 ms/op   1,15x (p = 0,000*)
URLEncodeDecode.testEncodeLatin1         100  15 0,433 ± 0,060  0,389 ± 0,007 ms/op   1,11x (p = 0,008*)
  * = significant
  ```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317795](https://bugs.openjdk.org/browse/JDK-8317795): Add an ImmutableBitSetPredicate variant for bitsets &lt;= 128 elements (**Enhancement** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer) ⚠️ Review applies to [bdcde89d](https://git.openjdk.org/jdk/pull/16094/files/bdcde89dc9261d396ee6542acb7ff2c970bbb6e5)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16094/head:pull/16094` \
`$ git checkout pull/16094`

Update a local copy of the PR: \
`$ git checkout pull/16094` \
`$ git pull https://git.openjdk.org/jdk.git pull/16094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16094`

View PR using the GUI difftool: \
`$ git pr show -t 16094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16094.diff">https://git.openjdk.org/jdk/pull/16094.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16094#issuecomment-1755128787)