### PR TITLE
8317706: Exclude java/awt/Graphics2D/DrawString/RotTransText.java on linux

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -454,6 +454,7 @@ java/awt/Robot/Delay/InterruptOfDelay.java 8265986 macosx-all
 java/awt/MenuBar/TestNoScreenMenuBar.java 8265987 macosx-all
 
 java/awt/Graphics2D/DrawString/DrawRotatedStringUsingRotatedFont.java 8266283 generic-all
+java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all
 java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java 8257529 windows-x64
 
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64


### PR DESCRIPTION
This test is failing on several Linux configurations (SLES 15), so it should be excluded.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317706](https://bugs.openjdk.org/browse/JDK-8317706): Exclude java/awt/Graphics2D/DrawString/RotTransText.java on linux (**Sub-task** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16096/head:pull/16096` \
`$ git checkout pull/16096`

Update a local copy of the PR: \
`$ git checkout pull/16096` \
`$ git pull https://git.openjdk.org/jdk.git pull/16096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16096`

View PR using the GUI difftool: \
`$ git pr show -t 16096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16096.diff">https://git.openjdk.org/jdk/pull/16096.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16096#issuecomment-1752420510)