### PR TITLE
6681958: Maximization state of JInternalFrames is corrupted by WindowsDesktopManager

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java
@@ -78,9 +78,7 @@ public class WindowsDesktopManager extends DefaultDesktopManager
                         if (f.isMaximizable()) {
                             if (!f.isMaximum()) {
                                 f.setMaximum(true);
-                                System.out.println("f.setmaximum true");
                             } else if (f.isMaximum() && f.isIcon()) {
-                                System.out.println("f.setIcon false");
                                 f.setIcon(false);
                             }
                         }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java
@@ -75,14 +75,13 @@ public class WindowsDesktopManager extends DefaultDesktopManager
                     //frame instead of minimizing the icon via the minimize
                     //icon.
                     if (!currentFrame.isIcon()) {
-                        currentFrame.setMaximum(false);
                         if (f.isMaximizable()) {
                             if (!f.isMaximum()) {
                                 f.setMaximum(true);
+                                System.out.println("f.setmaximum true");
                             } else if (f.isMaximum() && f.isIcon()) {
+                                System.out.println("f.setIcon false");
                                 f.setIcon(false);
-                            } else {
-                                f.setMaximum(false);
                             }
                         }
                     }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java
@@ -75,6 +75,7 @@ public class WindowsDesktopManager extends DefaultDesktopManager
                     //frame instead of minimizing the icon via the minimize
                     //icon.
                     if (!currentFrame.isIcon()) {
+                        currentFrame.setMaximum(false);
                         if (f.isMaximizable()) {
                             if (!f.isMaximum()) {
                                 f.setMaximum(true);


### PR DESCRIPTION
Issue is if one internal frame is open and maximized and another internal frame is created which is initialized with setMaximum(true) then after opening the second internal frame both internal frames are non-maximized
It can also be seen with SwingSet2 JInternalFrameDemo in WIndowsLookAndFeel i.e. when Frame 0 is maximised, and then Frame1 is maximised and then minimised, Frame0 should remain maximised but it is now unmaximised

Issues seen with JInternalFrame in WindowsLookAndFeel are
- Frame 0 maximised
 - Frame 4 maximised, when minimised, Frame0 is seen to be restored to normal size with Frame4 minimised
 - Frame 0 is again maximised
 - Frame 4 maximised from minimised, instead of maximising, it restores both Frame0 and Frame4

The fix makes sure the maximised internal frame remains maximised when the 2nd internal frame is maximised
This code seems to be added for [JDK-5036083](https://bugs.openjdk.org/browse/JDK-5036083) which expects 
`When a frame is maximized and then minimized, the next frame should NOT be maximized.`

It still honours that fix as the  test mentioned in JDK-5036083 works as expected as mentioned above

Also it is mentioned 
https://github.com/openjdk/jdk/blob/dc4bc4f0844b768e83406f44f2a9ee50686b1d9d/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsDesktopManager.java#L69-L70

It can be seen it is still honored. In SwingSet2 JInternalFrameDemo in WindowsL&F, if Frame0 is maximised and then Frame1 is activated/selected, it becomes maximised
Also, it doesn't cause any regression with our existing closed/open tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6681958](https://bugs.openjdk.org/browse/JDK-6681958): Maximization state of JInternalFrames is corrupted by WindowsDesktopManager (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16097/head:pull/16097` \
`$ git checkout pull/16097`

Update a local copy of the PR: \
`$ git checkout pull/16097` \
`$ git pull https://git.openjdk.org/jdk.git pull/16097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16097`

View PR using the GUI difftool: \
`$ git pr show -t 16097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16097.diff">https://git.openjdk.org/jdk/pull/16097.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16097#issuecomment-1752364753)