### PR TITLE
8317711: Exclude gtest/GTestWrapper.java on AIX

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -140,6 +140,7 @@ serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStr
 
 #############################################################################
 
+gtest/GTestWrapper.java 8306561 aix-ppc64
 gtest/NMTGtests.java#nmt-detail 8306561 aix-ppc64
 gtest/NMTGtests.java#nmt-summary 8306561 aix-ppc64
 


### PR DESCRIPTION
We see the failure reported in [JDK-8306561](https://bugs.openjdk.org/browse/JDK-8306561) for gtest/GTestWrapper.java as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317711](https://bugs.openjdk.org/browse/JDK-8317711): Exclude gtest/GTestWrapper.java on AIX (**Sub-task** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16098/head:pull/16098` \
`$ git checkout pull/16098`

Update a local copy of the PR: \
`$ git checkout pull/16098` \
`$ git pull https://git.openjdk.org/jdk.git pull/16098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16098`

View PR using the GUI difftool: \
`$ git pr show -t 16098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16098.diff">https://git.openjdk.org/jdk/pull/16098.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16098#issuecomment-1752420167)