### PR TITLE
8317677: Specialize Vtablestubs::entry_for() for VtableBlob

### DIFF
--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -565,9 +565,7 @@ bool CompiledIC::is_icholder_entry(address entry) {
   if (cb->is_adapter_blob()) {
     return true;
   } else if (cb->is_vtable_blob()) {
-    VtableStub* s = VtableStubs::entry_point_for_vtable_blob(entry);
-    // itable stubs also use CompiledICHolder
-    return s->is_itable_stub();
+    return VtableStubs::is_icholder_entry(entry);
   }
   return false;
 }

--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -559,15 +559,16 @@ void CompiledIC::compute_monomorphic_entry(const methodHandle& method,
 
 bool CompiledIC::is_icholder_entry(address entry) {
   CodeBlob* cb = CodeCache::find_blob(entry);
-  if (cb != nullptr && cb->is_adapter_blob()) {
+  if (cb == nullptr) {
+    return false;
+  }
+  if (cb->is_adapter_blob()) {
     return true;
+  } else if (cb->is_vtable_blob()) {
+    VtableStub* s = VtableStubs::entry_point_for_vtable_blob(entry);
+    // itable stubs also use CompiledICHolder
+    return s->is_itable_stub();
   }
-  // itable stubs also use CompiledICHolder
-  if (cb != nullptr && cb->is_vtable_blob()) {
-    VtableStub* s = VtableStubs::entry_point(entry);
-    return (s != nullptr) && s->is_itable_stub();
-  }
-
   return false;
 }
 

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -284,6 +284,12 @@ VtableStub* VtableStubs::entry_point(address pc) {
   return (s == stub) ? s : nullptr;
 }
 
+VtableStub* VtableStubs::entry_point_for_vtable_blob(address pc) {
+  VtableStub* stub = (VtableStub*)(pc - VtableStub::entry_offset());
+  assert(contains(pc), "must contain all vtable blobs");
+  return stub;
+}
+
 bool VtableStubs::contains(address pc) {
   // simple solution for now - we may want to use
   // a faster way if this function is called often

--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -284,10 +284,11 @@ VtableStub* VtableStubs::entry_point(address pc) {
   return (s == stub) ? s : nullptr;
 }
 
-VtableStub* VtableStubs::entry_point_for_vtable_blob(address pc) {
-  VtableStub* stub = (VtableStub*)(pc - VtableStub::entry_offset());
+bool VtableStubs::is_icholder_entry(address pc) {
   assert(contains(pc), "must contain all vtable blobs");
-  return stub;
+  VtableStub* stub = (VtableStub*)(pc - VtableStub::entry_offset());
+  // itable stubs use CompiledICHolder.
+  return stub->is_itable_stub();
 }
 
 bool VtableStubs::contains(address pc) {

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -106,6 +106,7 @@ class VtableStubs : AllStatic {
   static address     find_itable_stub(int itable_index) { return find_stub(false, itable_index); }
 
   static VtableStub* entry_point(address pc);                        // vtable stub entry point for a pc
+  static VtableStub* entry_point_for_vtable_blob(address pc);        // vtable stub entry point for a pc
   static bool        contains(address pc);                           // is pc within any stub?
   static VtableStub* stub_containing(address pc);                    // stub containing pc or nullptr
   static int         number_of_vtable_stubs() { return _number_of_vtable_stubs; }

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -106,7 +106,7 @@ class VtableStubs : AllStatic {
   static address     find_itable_stub(int itable_index) { return find_stub(false, itable_index); }
 
   static VtableStub* entry_point(address pc);                        // vtable stub entry point for a pc
-  static VtableStub* entry_point_for_vtable_blob(address pc);        // vtable stub entry point for a pc
+  static bool        is_icholder_entry(address pc);                  // is the blob containing pc (which must be a vtable blob) an icholder?
   static bool        contains(address pc);                           // is pc within any stub?
   static VtableStub* stub_containing(address pc);                    // stub containing pc or nullptr
   static int         number_of_vtable_stubs() { return _number_of_vtable_stubs; }


### PR DESCRIPTION
Hi all,

  please review this change that specializes the call to `Vtablestubs::entry_for` for vtable blob.

This kind of code blobs must always be in the `Vtablestubs` table (they are only created by the `Vtablestubs` class), so trying to find that stub there using it is unnecessary. For verification I added an assert that verifies it's found.

Given that `Vtablestubs::entry_point()` would take a lock this removal of the lock results in a large speedup (https://bugs.openjdk.org/browse/JDK-8317527) in MT situations and is an even better change than that mentioned CR - and also worth the extra code (I did not retest performance since the `Vtablestubs` table lookup should be fairly fast).

Fwiw, the first commit contains a different variant of this change, keeping the decision out of `Vtablestubs`, but I liked the current one better for it encapsulating that decision more. I am fine with reverting the second commit.

Testing: tier1-7, gha, stress testing

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317677](https://bugs.openjdk.org/browse/JDK-8317677): Specialize Vtablestubs::entry_for() for VtableBlob (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16099/head:pull/16099` \
`$ git checkout pull/16099`

Update a local copy of the PR: \
`$ git checkout pull/16099` \
`$ git pull https://git.openjdk.org/jdk.git pull/16099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16099`

View PR using the GUI difftool: \
`$ git pr show -t 16099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16099.diff">https://git.openjdk.org/jdk/pull/16099.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16099#issuecomment-1752804778)