### PR TITLE
8317736: Stream::handleReset locks twice

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -622,7 +622,7 @@ class Stream<T> extends ExchangeImpl<T> {
                 }
                 closed = true;
             } finally {
-                stateLock.lock();
+                stateLock.unlock();
             }
             try {
                 int error = frame.getErrorCode();


### PR DESCRIPTION
Trivial one liner fix.

The fix for [JDK-8308310](https://bugs.openjdk.org/browse/JDK-8308310) introduced a reentrant `stateLock` but also a regression. In `Stream::handleReset` the lock is locked twice.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317736](https://bugs.openjdk.org/browse/JDK-8317736): Stream::handleReset locks twice (**Bug** - P3)


### Reviewers
 * [Conor Cleary](https://openjdk.org/census#ccleary) (@c-cleary - Committer)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16101/head:pull/16101` \
`$ git checkout pull/16101`

Update a local copy of the PR: \
`$ git checkout pull/16101` \
`$ git pull https://git.openjdk.org/jdk.git pull/16101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16101`

View PR using the GUI difftool: \
`$ git pr show -t 16101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16101.diff">https://git.openjdk.org/jdk/pull/16101.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16101#issuecomment-1753075945)