### PR TITLE
8170817: G1: Returning MinTLABSize from unsafe_max_tlab_alloc causes TLAB flapping

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -191,11 +191,14 @@ size_t G1Allocator::unsafe_max_tlab_alloc() {
   uint node_index = current_node_index();
   HeapRegion* hr = mutator_alloc_region(node_index)->get();
   size_t max_tlab = _g1h->max_tlab_size() * wordSize;
-  if (hr == nullptr) {
+
+  if (hr == nullptr || hr->free() < MinTLABSize) {
+    // The next TLAB allocation will most probably happen in a new region,
+    // therefore we can attempt to allocate the maximum allowed TLAB size.
     return max_tlab;
-  } else {
-    return clamp(hr->free(), MinTLABSize, max_tlab);
   }
+
+  return MIN2(hr->free(), max_tlab);
 }
 
 size_t G1Allocator::used_in_alloc_regions() {


### PR DESCRIPTION
Hi all,

Please review this small change to return the maximum allowed TLAB size from `unsafe_max_tlab_alloc` in case the current region does not have enough free space to allocate MinTLABSize. We assume that the next TLAB allocation will happen in a new region.

Testing: Tier 1-3.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8170817](https://bugs.openjdk.org/browse/JDK-8170817): G1: Returning MinTLABSize from unsafe_max_tlab_alloc causes TLAB flapping (**Enhancement** - P3)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16102/head:pull/16102` \
`$ git checkout pull/16102`

Update a local copy of the PR: \
`$ git checkout pull/16102` \
`$ git pull https://git.openjdk.org/jdk.git pull/16102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16102`

View PR using the GUI difftool: \
`$ git pr show -t 16102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16102.diff">https://git.openjdk.org/jdk/pull/16102.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16102#issuecomment-1753218467)