### PR TITLE
8314199: Initial size PBEKeyFactory#validTypes is not up-to-date

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
@@ -31,8 +31,8 @@ import java.security.spec.InvalidKeySpecException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactorySpi;
 import javax.crypto.spec.PBEKeySpec;
-import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * This class implements a key factory for PBE keys according to PKCS#5,
@@ -46,7 +46,7 @@ import java.util.Locale;
 abstract class PBEKeyFactory extends SecretKeyFactorySpi {
 
     private String type;
-    private static HashSet<String> validTypes;
+    private static final Set<String> validTypes;
 
     /**
      * Simple constructor
@@ -56,29 +56,28 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
     }
 
     static {
-        validTypes = HashSet.newHashSet(21);
-        validTypes.add("PBEWithMD5AndDES".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithSHA1AndDESede".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithSHA1AndRC2_40".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithSHA1AndRC2_128".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithSHA1AndRC4_40".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithSHA1AndRC4_128".toUpperCase(Locale.ENGLISH));
-        // Proprietary algorithm.
-        validTypes.add("PBEWithMD5AndTripleDES".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA1AndAES_128".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA224AndAES_128".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA256AndAES_128".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA384AndAES_128".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA512AndAES_128".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA512/224AndAES_128".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA512/256AndAES_128".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA1AndAES_256".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA224AndAES_256".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA256AndAES_256".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA384AndAES_256".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA512AndAES_256".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA512/224AndAES_256".toUpperCase(Locale.ENGLISH));
-        validTypes.add("PBEWithHmacSHA512/256AndAES_256".toUpperCase(Locale.ENGLISH));
+        validTypes = Set.of("PBEWithMD5AndDES".toUpperCase(Locale.ENGLISH),
+                "PBEWithSHA1AndDESede".toUpperCase(Locale.ENGLISH),
+                "PBEWithSHA1AndRC2_40".toUpperCase(Locale.ENGLISH),
+                "PBEWithSHA1AndRC2_128".toUpperCase(Locale.ENGLISH),
+                "PBEWithSHA1AndRC4_40".toUpperCase(Locale.ENGLISH),
+                "PBEWithSHA1AndRC4_128".toUpperCase(Locale.ENGLISH),
+                // Proprietary algorithm.
+                "PBEWithMD5AndTripleDES".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA1AndAES_128".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA224AndAES_128".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA256AndAES_128".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA384AndAES_128".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA512AndAES_128".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA512/224AndAES_128".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA512/256AndAES_128".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA1AndAES_256".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA224AndAES_256".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA256AndAES_256".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA384AndAES_256".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA512AndAES_256".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA512/224AndAES_256".toUpperCase(Locale.ENGLISH),
+                "PBEWithHmacSHA512/256AndAES_256".toUpperCase(Locale.ENGLISH));
     }
 
     public static final class PBEWithMD5AndDES extends PBEKeyFactory {

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
@@ -56,7 +56,7 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
     }
 
     static {
-        validTypes = HashSet.newHashSet(17);
+        validTypes = HashSet.newHashSet(21);
         validTypes.add("PBEWithMD5AndDES".toUpperCase(Locale.ENGLISH));
         validTypes.add("PBEWithSHA1AndDESede".toUpperCase(Locale.ENGLISH));
         validTypes.add("PBEWithSHA1AndRC2_40".toUpperCase(Locale.ENGLISH));

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
@@ -31,6 +31,7 @@ import java.security.spec.InvalidKeySpecException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactorySpi;
 import javax.crypto.spec.PBEKeySpec;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
@@ -46,7 +47,7 @@ import java.util.Set;
 abstract class PBEKeyFactory extends SecretKeyFactorySpi {
 
     private String type;
-    private static final Set<String> validTypes;
+    private static final HashSet<String> validTypes;
 
     /**
      * Simple constructor
@@ -56,7 +57,8 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
     }
 
     static {
-        validTypes = Set.of("PBEWithMD5AndDES".toUpperCase(Locale.ENGLISH),
+        validTypes = new HashSet(
+                Set.of("PBEWithMD5AndDES".toUpperCase(Locale.ENGLISH),
                 "PBEWithSHA1AndDESede".toUpperCase(Locale.ENGLISH),
                 "PBEWithSHA1AndRC2_40".toUpperCase(Locale.ENGLISH),
                 "PBEWithSHA1AndRC2_128".toUpperCase(Locale.ENGLISH),
@@ -77,7 +79,7 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
                 "PBEWithHmacSHA384AndAES_256".toUpperCase(Locale.ENGLISH),
                 "PBEWithHmacSHA512AndAES_256".toUpperCase(Locale.ENGLISH),
                 "PBEWithHmacSHA512/224AndAES_256".toUpperCase(Locale.ENGLISH),
-                "PBEWithHmacSHA512/256AndAES_256".toUpperCase(Locale.ENGLISH));
+                "PBEWithHmacSHA512/256AndAES_256".toUpperCase(Locale.ENGLISH)));
     }
 
     public static final class PBEWithMD5AndDES extends PBEKeyFactory {

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKeyFactory.java
@@ -57,7 +57,7 @@ abstract class PBEKeyFactory extends SecretKeyFactorySpi {
     }
 
     static {
-        validTypes = new HashSet(
+        validTypes = new HashSet<String>(
                 Set.of("PBEWithMD5AndDES".toUpperCase(Locale.ENGLISH),
                 "PBEWithSHA1AndDESede".toUpperCase(Locale.ENGLISH),
                 "PBEWithSHA1AndRC2_40".toUpperCase(Locale.ENGLISH),


### PR DESCRIPTION
fixes [JDK-8314199](https://bugs.openjdk.org/browse/JDK-8314199) by initializing the HashSet with a more accurate number

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314199](https://bugs.openjdk.org/browse/JDK-8314199): Initial size PBEKeyFactory#validTypes is not up-to-date (**Bug** - P5)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**) ⚠️ Review applies to [1f6d7281](https://git.openjdk.org/jdk/pull/16103/files/1f6d7281118048ccb9701f2adc6ea9f660fd5f17)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16103/head:pull/16103` \
`$ git checkout pull/16103`

Update a local copy of the PR: \
`$ git checkout pull/16103` \
`$ git pull https://git.openjdk.org/jdk.git pull/16103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16103`

View PR using the GUI difftool: \
`$ git pr show -t 16103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16103.diff">https://git.openjdk.org/jdk/pull/16103.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16103#issuecomment-1753338505)