### PR TITLE
8317761: Combine two versions of print_statistics() in java.cpp

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -284,10 +284,7 @@ void print_statistics() {
     print_method_invocation_histogram();
   }
 
-  if (NOT_PRODUCT(true) PRODUCT_ONLY(PrintMethodData)) {
-    // TODO: why is this unconditional in non-product builds?
-    print_method_profiling_data();
-  }
+  print_method_profiling_data();
 
   if (TimeOopMap) {
     GenerateOopMap::print_time();

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -225,6 +225,13 @@ void print_bytecode_count() {
   }
 }
 
+#else
+
+void print_method_invocation_histogram() {}
+void print_bytecode_count() {}
+
+#endif // PRODUCT
+
 
 // General statistics printing (profiling ...)
 void print_statistics() {
@@ -277,7 +284,10 @@ void print_statistics() {
     print_method_invocation_histogram();
   }
 
-  print_method_profiling_data();
+  if (NOT_PRODUCT(true) PRODUCT_ONLY(PrintMethodData)) {
+    // TODO: why is this unconditional in non-product builds?
+    print_method_profiling_data();
+  }
 
   if (TimeOopMap) {
     GenerateOopMap::print_time();
@@ -336,56 +346,6 @@ void print_statistics() {
 
   ThreadsSMRSupport::log_statistics();
 }
-
-#else // PRODUCT MODE STATISTICS
-
-void print_statistics() {
-
-  if (PrintMethodData) {
-    print_method_profiling_data();
-  }
-
-  if (CITime) {
-    CompileBroker::print_times();
-  }
-
-#ifdef COMPILER2_OR_JVMCI
-  if ((LogVMOutput || LogCompilation) && UseCompiler) {
-    // Only print the statistics to the log file
-    FlagSetting fs(DisplayVMOutput, false);
-    Deoptimization::print_statistics();
-  }
-#endif /* COMPILER2 || INCLUDE_JVMCI */
-
-  if (PrintCodeCache) {
-    MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    CodeCache::print();
-  }
-
-  // CodeHeap State Analytics.
-  if (PrintCodeHeapAnalytics) {
-    CompileBroker::print_heapinfo(nullptr, "all", 4096); // details
-  }
-
-#ifdef COMPILER2
-  if (PrintPreciseRTMLockingStatistics) {
-    OptoRuntime::print_named_counters();
-  }
-#endif
-
-  // Native memory tracking data
-  if (PrintNMTStatistics) {
-    MemTracker::final_report(tty);
-  }
-
-  if (PrintMetaspaceStatisticsAtExit) {
-    MetaspaceUtils::print_basic_report(tty, 0);
-  }
-
-  ThreadsSMRSupport::log_statistics();
-}
-
-#endif
 
 // Note: before_exit() can be executed only once, if more than one threads
 //       are trying to shutdown the VM at the same time, only one thread

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -575,10 +575,11 @@ class SharedRuntime: AllStatic {
   static address nof_interface_calls_addr()             { return (address)&_nof_interface_calls; }
   static address nof_inlined_interface_calls_addr()     { return (address)&_nof_inlined_interface_calls; }
   static void print_call_statistics(uint64_t comp_total);
-  static void print_statistics();
   static void print_ic_miss_histogram();
 
 #endif // PRODUCT
+
+  static void print_statistics() PRODUCT_RETURN;
 };
 
 


### PR DESCRIPTION
The non-product version of `print_statistics()` can be compiled in the product build as well, so there's no need to keep two different versions.

BTW, for some reason `print_method_profiling_data()` is called unconditionally in non-product builds, but is guarded by `PrintMethodData` in product builds. I made the behavior the same as before in this PR. This can probably be cleaned up in a future PR.

I verified that:

- All functions call by the original product version are also called by the non-product version (but could be in different order).
- For functions that are called by the non-product version but not call by the original product version: all such calls are guarded by non-product flags (e.g. `TimeOopMap`), or the function itself does nothing (e.g., declared as `PRODUCT_RETURN`)

Testing: tier1, tier2, build-tiers5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317761](https://bugs.openjdk.org/browse/JDK-8317761): Combine two versions of print_statistics() in java.cpp (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16110/head:pull/16110` \
`$ git checkout pull/16110`

Update a local copy of the PR: \
`$ git checkout pull/16110` \
`$ git pull https://git.openjdk.org/jdk.git pull/16110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16110`

View PR using the GUI difftool: \
`$ git pr show -t 16110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16110.diff">https://git.openjdk.org/jdk/pull/16110.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16110#issuecomment-1754047556)