### PR TITLE
8316693: Simplify at-requires checkDockerSupport()

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -602,9 +602,10 @@ public class VMProps implements Callable<Map<String, String>> {
 
     private boolean checkDockerSupport() throws IOException, InterruptedException {
         log("checkDockerSupport(): entering");
-        ProcessBuilder pb = new ProcessBuilder(Container.ENGINE_COMMAND, "ps");
-        Map<String, String> logFileNames = redirectOutputToLogFile("checkDockerSupport(): <container> ps",
-                                                      pb, "container-ps");
+        ProcessBuilder pb = new ProcessBuilder("which", Container.ENGINE_COMMAND);
+        Map<String, String> logFileNames =
+            redirectOutputToLogFile("checkDockerSupport(): which <container-engine>",
+                                                      pb, "which-container");
         Process p = pb.start();
         p.waitFor(10, TimeUnit.SECONDS);
         int exitValue = p.exitValue();


### PR DESCRIPTION
Please review this simple change.

Currently JTReg @requires extension test/jtreg-ext/requires/VMProps.java checkDockerSupport() uses "<CONTAINER_ENGINE> ps" command to check whether test host/environment allows for container testing. With this change proposing to switch it to "which <CONTAINER_ENGINE>":
  - the "ps" command could be heavy-weight in some environments, taking longer time then expected
  - it may not apply to all container engine types

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316693](https://bugs.openjdk.org/browse/JDK-8316693): Simplify at-requires checkDockerSupport() (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16111/head:pull/16111` \
`$ git checkout pull/16111`

Update a local copy of the PR: \
`$ git checkout pull/16111` \
`$ git pull https://git.openjdk.org/jdk.git pull/16111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16111`

View PR using the GUI difftool: \
`$ git pr show -t 16111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16111.diff">https://git.openjdk.org/jdk/pull/16111.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16111#issuecomment-1754105026)