### PR TITLE
8317738: CodeCacheFullCountTest failed with "VirtualMachineError: Out of space in CodeCache for method handle intrinsic"

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/CodeCacheFullCountTest.java
@@ -67,7 +67,7 @@ public class CodeCacheFullCountTest {
           "-XX:ReservedCodeCacheSize=2496k", "-XX:-UseCodeCacheFlushing", "-XX:-MethodFlushing", "CodeCacheFullCountTest", "WasteCodeCache");
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         // Ignore adapter creation failures
-        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache for adapters")) {
+        if (oa.getExitValue() != 0 && !oa.getOutput().contains("Out of space in CodeCache")) {
             oa.reportDiagnosticSummary();
             throw new RuntimeException("VM finished with exit code " + oa.getExitValue());
         }


### PR DESCRIPTION
The test fails because VM startup throws a VirtualMachineError with "Out of space in CodeCache for method handle intrinsic" instead of the expected "Out of space in CodeCache for adapters". Both messages are expected and should be handled.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317738](https://bugs.openjdk.org/browse/JDK-8317738): CodeCacheFullCountTest failed with "VirtualMachineError: Out of space in CodeCache for method handle intrinsic" (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16113/head:pull/16113` \
`$ git checkout pull/16113`

Update a local copy of the PR: \
`$ git checkout pull/16113` \
`$ git pull https://git.openjdk.org/jdk.git pull/16113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16113`

View PR using the GUI difftool: \
`$ git pr show -t 16113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16113.diff">https://git.openjdk.org/jdk/pull/16113.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16113#issuecomment-1754621924)