### PR TITLE
8317790: Fix Bug entry for exclusion of runtime/jni/terminatedThread/TestTerminatedThread.java on AIX

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -91,7 +91,7 @@ gc/stress/TestStressG1Humongous.java 8286554 windows-x64
 
 # :hotspot_runtime
 
-runtime/jni/terminatedThread/TestTerminatedThread.java 8219652 aix-ppc64
+runtime/jni/terminatedThread/TestTerminatedThread.java 8317789 aix-ppc64
 runtime/handshake/HandshakeSuspendExitTest.java 8294313 generic-all
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#explicit-large-page-size 8267460 linux-aarch64


### PR DESCRIPTION
Bug for exclusion is wrong and refers to already fixed [JDK-8219652](https://bugs.openjdk.org/browse/JDK-8219652). It should better refer to [JDK-8317789](https://bugs.openjdk.org/browse/JDK-8317789).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317790](https://bugs.openjdk.org/browse/JDK-8317790): Fix Bug entry for exclusion of runtime/jni/terminatedThread/TestTerminatedThread.java on AIX (**Sub-task** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16114/head:pull/16114` \
`$ git checkout pull/16114`

Update a local copy of the PR: \
`$ git checkout pull/16114` \
`$ git pull https://git.openjdk.org/jdk.git pull/16114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16114`

View PR using the GUI difftool: \
`$ git pr show -t 16114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16114.diff">https://git.openjdk.org/jdk/pull/16114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16114#issuecomment-1755277151)