### PR TITLE
8316975: Memory leak in MTLSurfaceData

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceData.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -296,6 +296,11 @@ Java_sun_java2d_metal_MTLSurfaceData_initOps
     BMTLSDOps *bmtlsdo = (BMTLSDOps *)SurfaceData_InitOps(env, mtlsd, sizeof(BMTLSDOps));
     MTLSDOps *mtlsdo = (MTLSDOps *)malloc(sizeof(MTLSDOps));
 
+    if (mtlsdo == NULL) {
+        JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
+        return;
+    }
+
     J2dTraceLn1(J2D_TRACE_INFO, "MTLSurfaceData_initOps p=%p", bmtlsdo);
     J2dTraceLn1(J2D_TRACE_INFO, "  pPeerData=%p", jlong_to_ptr(pPeerData));
     J2dTraceLn1(J2D_TRACE_INFO, "  layerPtr=%p", jlong_to_ptr(layerPtr));
@@ -303,12 +308,7 @@ Java_sun_java2d_metal_MTLSurfaceData_initOps
 
     gc = (*env)->NewGlobalRef(env, gc);
     if (gc == NULL) {
-        JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
-        return;
-    }
-
-    if (mtlsdo == NULL) {
-        (*env)->DeleteGlobalRef(env, gc);
+        free(mtlsdo);
         JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
         return;
     }


### PR DESCRIPTION
In MTLSurfaceData_initOps() we return if "(gc == NULL)" but we don't free already allocated "mtlsdo" using (MTLSDOps *)malloc(sizeof(MTLSDOps)) which is of 40 bytes.

We need to free(mtlsdo) before we return from MTLSurfaceData_initOps() for any reasons. Moved (mtlsdo == NULL) check right after we allocate it and added logic to delete mtlsdo(40 bytes) at appropriate places.

There is no regression test because to reproduce this issue we need to exhaust system memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316975](https://bugs.openjdk.org/browse/JDK-8316975): Memory leak in MTLSurfaceData (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16117/head:pull/16117` \
`$ git checkout pull/16117`

Update a local copy of the PR: \
`$ git checkout pull/16117` \
`$ git pull https://git.openjdk.org/jdk.git pull/16117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16117`

View PR using the GUI difftool: \
`$ git pr show -t 16117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16117.diff">https://git.openjdk.org/jdk/pull/16117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16117#issuecomment-1755255690)