### PR TITLE
JDK-8317772: NMT: Make peak values available in release builds

### DIFF
--- a/src/hotspot/share/services/mallocTracker.cpp
+++ b/src/hotspot/share/services/mallocTracker.cpp
@@ -45,7 +45,6 @@
 
 size_t MallocMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(MallocMemorySnapshot, size_t)];
 
-#ifdef ASSERT
 void MemoryCounter::update_peak(size_t size, size_t cnt) {
   size_t peak_sz = peak_size();
   while (peak_sz < size) {
@@ -59,7 +58,6 @@ void MemoryCounter::update_peak(size_t size, size_t cnt) {
     }
   }
 }
-#endif // ASSERT
 
 // Total malloc'd memory used by arenas
 size_t MallocMemorySnapshot::total_arena() const {

--- a/src/hotspot/share/services/mallocTracker.hpp
+++ b/src/hotspot/share/services/mallocTracker.hpp
@@ -46,25 +46,20 @@ class MemoryCounter {
   volatile size_t   _count;
   volatile size_t   _size;
 
-#ifdef ASSERT
   // Peak size and count. Note: Peak count is the count at the point
   // peak size was reached, not the absolute highest peak count.
   volatile size_t _peak_count;
   volatile size_t _peak_size;
   void update_peak(size_t size, size_t cnt);
-#endif // ASSERT
 
  public:
-  MemoryCounter() : _count(0), _size(0) {
-    DEBUG_ONLY(_peak_count = 0;)
-    DEBUG_ONLY(_peak_size  = 0;)
-  }
+  MemoryCounter() : _count(0), _size(0), _peak_count(0), _peak_size(0) {}
 
   inline void allocate(size_t sz) {
     size_t cnt = Atomic::add(&_count, size_t(1), memory_order_relaxed);
     if (sz > 0) {
       size_t sum = Atomic::add(&_size, sz, memory_order_relaxed);
-      DEBUG_ONLY(update_peak(sum, cnt);)
+      update_peak(sum, cnt);
     }
   }
 
@@ -81,7 +76,7 @@ class MemoryCounter {
     if (sz != 0) {
       assert(sz >= 0 || size() >= size_t(-sz), "Must be");
       size_t sum = Atomic::add(&_size, size_t(sz), memory_order_relaxed);
-      DEBUG_ONLY(update_peak(sum, _count);)
+      update_peak(sum, _count);
     }
   }
 
@@ -89,11 +84,11 @@ class MemoryCounter {
   inline size_t size()  const { return Atomic::load(&_size);  }
 
   inline size_t peak_count() const {
-    return DEBUG_ONLY(Atomic::load(&_peak_count)) NOT_DEBUG(0);
+    return Atomic::load(&_peak_count);
   }
 
   inline size_t peak_size() const {
-    return DEBUG_ONLY(Atomic::load(&_peak_size)) NOT_DEBUG(0);
+    return Atomic::load(&_peak_size);
   }
 };
 

--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -246,7 +246,7 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
 
      // report malloc'd memory
     if (amount_in_current_scale(malloc_memory->malloc_size()) > 0
-        DEBUG_ONLY(|| amount_in_current_scale(malloc_memory->malloc_peak_size()) > 0)) {
+        || amount_in_current_scale(malloc_memory->malloc_peak_size()) > 0) {
       print_malloc_line(malloc_memory->malloc_counter());
     }
 


### PR DESCRIPTION
We added peak counts to NMT with [JDK-8297958](https://bugs.openjdk.org/browse/JDK-8297958). That feature is *extremely* helpful in analyzing native memory footprints since it gives you a glance into the past. For instance, it makes libc memory retention easier to explain.

Initially, I restricted this feature to debug JVMs out of vague concerns about performance when running with NMT. However, after measuring, it turns out that the increase in cost is very small. This makes sense since we only update the peak values when we actually reach a peak. 

Since the payoff is huge, it makes sense to have this feature always enabled. We don't need a new switch for that. As a side effect, NMT code becomes a bit clearer since we can lose a number of assert ifdefs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317772](https://bugs.openjdk.org/browse/JDK-8317772): NMT: Make peak values available in release builds (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16119/head:pull/16119` \
`$ git checkout pull/16119`

Update a local copy of the PR: \
`$ git checkout pull/16119` \
`$ git pull https://git.openjdk.org/jdk.git pull/16119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16119`

View PR using the GUI difftool: \
`$ git pr show -t 16119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16119.diff">https://git.openjdk.org/jdk/pull/16119.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16119#issuecomment-1755709857)