### PR TITLE
8317803: Exclude java/net/Socket/asyncClose/Race.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -554,6 +554,8 @@ java/net/MulticastSocket/Test.java                              7145658,8308807 
 
 java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
 
+java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc64
+
 ############################################################################
 
 # jdk_nio


### PR DESCRIPTION
Test java/net/Socket/asyncClose/Race.java should be excluded until [JDK-8317801](https://bugs.openjdk.org/browse/JDK-8317801) is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317803](https://bugs.openjdk.org/browse/JDK-8317803): Exclude java/net/Socket/asyncClose/Race.java on AIX (**Sub-task** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16121/head:pull/16121` \
`$ git checkout pull/16121`

Update a local copy of the PR: \
`$ git checkout pull/16121` \
`$ git pull https://git.openjdk.org/jdk.git pull/16121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16121`

View PR using the GUI difftool: \
`$ git pr show -t 16121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16121.diff">https://git.openjdk.org/jdk/pull/16121.diff</a>

</details>
