### PR TITLE
8317802: jmh tests fail with Unable to find the resource: /META-INF/BenchmarkList after JDK-8306819

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -84,7 +84,9 @@ $(eval $(call SetupJavaCompilation, BUILD_INDIFY, \
 #### Compile Targets
 
 # Building microbenchmark requires the jdk.unsupported and java.management modules.
-# sun.security.util is required to compile Cache benchmark
+# sun.security.util is required to compile Cache benchmark.
+# jmh uses annotation processors to generate the benchmark jar and thus
+# requires the use of -proc option during benchmark compilation.
 
 # Build microbenchmark suite for the current JDK
 $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
@@ -106,7 +108,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
         --add-exports java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.vm=ALL-UNNAMED \
         --add-exports java.base/jdk.internal.event=ALL-UNNAMED \
-        --enable-preview, \
+        --enable-preview -proc:full, \
     JAVA_FLAGS := --add-modules jdk.unsupported --limit-modules java.management \
         --add-exports java.base/jdk.internal.vm=ALL-UNNAMED \
         --enable-preview, \


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix jmh test launch failures noted in https://bugs.openjdk.org/browse/JDK-8317802?

jmh apparently relies on annotation processors during compilation of a benchmark. When annotation processing is disabled, the generated benchmark jar is unusable when the benchmark is launched and fails with:

```console
Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
	at org.openjdk.jmh.runner.AbstractResourceReader.getReaders(AbstractResourceReader.java:98)
	at org.openjdk.jmh.runner.BenchmarkList.find(BenchmarkList.java:124)
	at org.openjdk.jmh.runner.Runner.internalRun(Runner.java:252)
	at org.openjdk.jmh.runner.Runner.run(Runner.java:208)
	at org.openjdk.jmh.Main.main(Main.java:71)
```
After the integration of https://bugs.openjdk.org/browse/JDK-8306819 recently in JDK mainline, `javac` no longer runs annotation processors by default. These jmh tests that are compiled as part of the JDK build will now have to enable annotation processing explicitly.

The commit in this PR enables annotation processing by setting `-proc:full` (implying run annotation processors as well as compile the files) when compiling the benchmarks.

I tested this change locally. Without this change, the following command fails:

```console
make test TEST="micro:java.lang.ArraysSort"                                                               
...
Test selection 'micro:java.lang.ArraysSort', will run:
* micro:java.lang.ArraysSort

Running test 'micro:java.lang.ArraysSort'
Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
	at org.openjdk.jmh.runner.AbstractResourceReader.getReaders(AbstractResourceReader.java:98)
	at org.openjdk.jmh.runner.BenchmarkList.find(BenchmarkList.java:124)
	at org.openjdk.jmh.runner.Runner.internalRun(Runner.java:252)
	at org.openjdk.jmh.runner.Runner.run(Runner.java:208)
	at org.openjdk.jmh.Main.main(Main.java:71)
Finished running test 'micro:java.lang.ArraysSort'

```

After the change in this PR, the same command works fine and the jmh benchmark is run.