### PR TITLE
8317609: Classfile API fails to verify /jdk.jcmd/sun/tools/jstat/Alignment.class

### DIFF
--- a/test/jdk/tools/lib/tests/JImageValidator.java
+++ b/test/jdk/tools/lib/tests/JImageValidator.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import jdk.internal.classfile.ClassHierarchyResolver;
 
 import jdk.internal.classfile.Classfile;
 import jdk.internal.jimage.BasicImageReader;
@@ -222,7 +223,10 @@ public class JImageValidator {
     }
 
     public static void readClass(byte[] clazz) throws IOException{
-        var errors = Classfile.of().parse(clazz).verify(null);
+        var errors = Classfile.of().parse(clazz).verify(
+                //resolution of all classes as interfaces cancels assignability verification
+                cls -> ClassHierarchyResolver.ClassHierarchyInfo.ofInterface(),
+                null);
         if (!errors.isEmpty()) {
             var itr = errors.iterator();
             var thrown = itr.next();


### PR DESCRIPTION
JImageValidator has been recently converted to use ClassFile API and original weak validation of class files was replaced with full class verification.
Unfortunately full class verification is too strong as it includes class assignability verification according to class hierarchy resolution.
This patch relaxes class assignability verification from JImageValidator by mocking ClassHierarchyResolver.
Resolution of all classes as interfaces during verification effectively cancels the assignability verification (as interface assignability is not verified).

Please review this pull request.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317609](https://bugs.openjdk.org/browse/JDK-8317609): Classfile API fails to verify /jdk.jcmd/sun/tools/jstat/Alignment.class (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16123/head:pull/16123` \
`$ git checkout pull/16123`

Update a local copy of the PR: \
`$ git checkout pull/16123` \
`$ git pull https://git.openjdk.org/jdk.git pull/16123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16123`

View PR using the GUI difftool: \
`$ git pr show -t 16123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16123.diff">https://git.openjdk.org/jdk/pull/16123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16123#issuecomment-1756917127)