### PR TITLE
8317763: Follow-up to AVX512 intrinsics for Arrays.sort() PR

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -227,7 +227,7 @@ ifeq ($(ENABLE_FALLBACK_LINKER), true)
       NAME := fallbackLinker, \
       CFLAGS := $(CFLAGS_JDKLIB) $(LIBFFI_CFLAGS), \
       LDFLAGS := $(LDFLAGS_JDKLIB) \
-                  $(call SET_SHARED_LIBRARY_ORIGIN), \
+                 $(call SET_SHARED_LIBRARY_ORIGIN), \
       LIBS := $(LIBFFI_LIBS), \
       LIBS_windows := $(LIBFFI_LIBS) ws2_32.lib, \
   ))

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4173,7 +4173,7 @@ void StubGenerator::generate_compiler_stubs() {
   }
 
   // Load x86_64_sort library on supported hardware to enable avx512 sort and partition intrinsics
-  if (VM_Version::is_intel() && UseAVX > 2 && VM_Version::supports_avx512dq()) {
+  if (VM_Version::is_intel() && VM_Version::supports_avx512dq()) {
     void *libsimdsort = nullptr;
     char ebuf_[1024];
     char dll_name_simd_sort[JVM_MAXPATHLEN];

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4173,7 +4173,7 @@ void StubGenerator::generate_compiler_stubs() {
   }
 
   // Load x86_64_sort library on supported hardware to enable avx512 sort and partition intrinsics
-  if (UseAVX > 2 && VM_Version::supports_avx512dq()) {
+  if (VM_Version::is_intel() && UseAVX > 2 && VM_Version::supports_avx512dq()) {
     void *libsimdsort = nullptr;
     char ebuf_[1024];
     char dll_name_simd_sort[JVM_MAXPATHLEN];

--- a/src/java.base/linux/native/libsimdsort/avx512-common-qsort.h
+++ b/src/java.base/linux/native/libsimdsort/avx512-common-qsort.h
@@ -57,8 +57,17 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <immintrin.h>
 #include <limits>
+
+/*
+Workaround for the bug in GCC12 (that was fixed in GCC 12.3.1).
+More details are available at: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593
+*/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#include <immintrin.h>
+#pragma GCC diagnostic pop
 
 #define X86_SIMD_SORT_INFINITY std::numeric_limits<double>::infinity()
 #define X86_SIMD_SORT_INFINITYF std::numeric_limits<float>::infinity()

--- a/src/java.base/share/classes/java/util/DualPivotQuicksort.java
+++ b/src/java.base/share/classes/java/util/DualPivotQuicksort.java
@@ -166,9 +166,9 @@ final class DualPivotQuicksort {
         /**
          * Partitions the specified range of the array using the given pivots.
          *
-         * @param a the array to be sorted
-         * @param low the index of the first element, inclusive, to be sorted
-         * @param high the index of the last element, exclusive, to be sorted
+         * @param a the array to be partitioned
+         * @param low the index of the first element, inclusive, to be partitioned
+         * @param high the index of the last element, exclusive, to be partitioned
          * @param pivotIndex1 the index of pivot1, the first pivot
          * @param pivotIndex2 the index of pivot2, the second pivot
          */
@@ -178,13 +178,13 @@ final class DualPivotQuicksort {
     /**
      * Partitions the specified range of the array using the two pivots provided.
      *
-     * @param elemType the class of the array to be sorted
-     * @param array the array to be sorted
+     * @param elemType the class of the array to be partitioned
+     * @param array the array to be partitioned
      * @param offset the relative offset, in bytes, from the base address of
      * the array to partition, otherwise if the array is {@code null},an absolute
      * address pointing to the first element to partition from.
-     * @param low the index of the first element, inclusive, to be sorted
-     * @param high the index of the last element, exclusive, to be sorted
+     * @param low the index of the first element, inclusive, to be partitioned
+     * @param high the index of the last element, exclusive, to be partitioned
      * @param pivotIndex1 the index of pivot1, the first pivot
      * @param pivotIndex2 the index of pivot2, the second pivot
      * @param po the method reference for the fallback implementation

--- a/src/java.base/share/classes/java/util/DualPivotQuicksort.java
+++ b/src/java.base/share/classes/java/util/DualPivotQuicksort.java
@@ -569,6 +569,7 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
+    @ForceInline
     private static void mixedInsertionSort(int[] a, int low, int high) {
         int size = high - low;
         int end = high - 3 * ((size >> 5) << 3);
@@ -684,6 +685,7 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
+    @ForceInline
     private static void insertionSort(int[] a, int low, int high) {
         for (int i, k = low; ++k < high; ) {
             int ai = a[i = k];
@@ -1371,6 +1373,7 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
+    @ForceInline
     private static void mixedInsertionSort(long[] a, int low, int high) {
         int size = high - low;
         int end = high - 3 * ((size >> 5) << 3);
@@ -1486,6 +1489,7 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
+    @ForceInline
     private static void insertionSort(long[] a, int low, int high) {
         for (int i, k = low; ++k < high; ) {
             long ai = a[i = k];
@@ -2959,6 +2963,7 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
+    @ForceInline
     private static void mixedInsertionSort(float[] a, int low, int high) {
         int size = high - low;
         int end = high - 3 * ((size >> 5) << 3);
@@ -3074,6 +3079,7 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
+    @ForceInline
     private static void insertionSort(float[] a, int low, int high) {
         for (int i, k = low; ++k < high; ) {
             float ai = a[i = k];
@@ -3812,6 +3818,7 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
+    @ForceInline
     private static void mixedInsertionSort(double[] a, int low, int high) {
         int size = high - low;
         int end = high - 3 * ((size >> 5) << 3);
@@ -3927,6 +3934,7 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
+    @ForceInline
     private static void insertionSort(double[] a, int low, int high) {
         for (int i, k = low; ++k < high; ) {
             double ai = a[i = k];

--- a/src/java.base/share/classes/java/util/DualPivotQuicksort.java
+++ b/src/java.base/share/classes/java/util/DualPivotQuicksort.java
@@ -569,7 +569,6 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
-    @ForceInline
     private static void mixedInsertionSort(int[] a, int low, int high) {
         int size = high - low;
         int end = high - 3 * ((size >> 5) << 3);
@@ -685,7 +684,6 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
-    @ForceInline
     private static void insertionSort(int[] a, int low, int high) {
         for (int i, k = low; ++k < high; ) {
             int ai = a[i = k];
@@ -1373,7 +1371,6 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
-    @ForceInline
     private static void mixedInsertionSort(long[] a, int low, int high) {
         int size = high - low;
         int end = high - 3 * ((size >> 5) << 3);
@@ -1489,7 +1486,6 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
-    @ForceInline
     private static void insertionSort(long[] a, int low, int high) {
         for (int i, k = low; ++k < high; ) {
             long ai = a[i = k];
@@ -2963,7 +2959,6 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
-    @ForceInline
     private static void mixedInsertionSort(float[] a, int low, int high) {
         int size = high - low;
         int end = high - 3 * ((size >> 5) << 3);
@@ -3079,7 +3074,6 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
-    @ForceInline
     private static void insertionSort(float[] a, int low, int high) {
         for (int i, k = low; ++k < high; ) {
             float ai = a[i = k];
@@ -3818,7 +3812,6 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
-    @ForceInline
     private static void mixedInsertionSort(double[] a, int low, int high) {
         int size = high - low;
         int end = high - 3 * ((size >> 5) << 3);
@@ -3934,7 +3927,6 @@ final class DualPivotQuicksort {
      * @param low the index of the first element, inclusive, to be sorted
      * @param high the index of the last element, exclusive, to be sorted
      */
-    @ForceInline
     private static void insertionSort(double[] a, int low, int high) {
         for (int i, k = low; ++k < high; ) {
             double ai = a[i = k];


### PR DESCRIPTION
The goal of this PR is to address the follow-up comments to the SIMD accelerated sort PR (#14227) which implemented AVX512 intrinsics for Arrays.sort() methods.
The proposed changes are:

1) Restriction of the AVX512 sort acceleration to only Intel CPUs. A performance regression (due to micro-architectural differences) was reported for AMD Zen4 CPUs in the comments section of PR.
2) Addressing the build failure due to a bug in GCC 12 (which was fixed in version 12.3.1). The details of the bug are at: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105593
3) Minor changes in Javadoc strings

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8317763](https://bugs.openjdk.org/browse/JDK-8317763): Follow-up to AVX512 intrinsics for Arrays.sort() PR (**Task** - P4)


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**) ⚠️ Review applies to [1138dc38](https://git.openjdk.org/jdk/pull/16124/files/1138dc3883123b0331e535ca651505588463c60d)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to [1de07fb7](https://git.openjdk.org/jdk/pull/16124/files/1de07fb7cd8293481813a2c2b79aa5aac07b561a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16124/head:pull/16124` \
`$ git checkout pull/16124`

Update a local copy of the PR: \
`$ git checkout pull/16124` \
`$ git pull https://git.openjdk.org/jdk.git pull/16124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16124`

View PR using the GUI difftool: \
`$ git pr show -t 16124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16124.diff">https://git.openjdk.org/jdk/pull/16124.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16124#issuecomment-1755855766)