### PR TITLE
8317819: Scope should reflect lifetime of underying resource (mainline)

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -219,7 +219,7 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      */
     static Arena global() {
         class Holder {
-            static final Arena GLOBAL = MemorySessionImpl.GLOBAL.asArena();
+            static final Arena GLOBAL = MemorySessionImpl.createGlobal().asArena();
         }
         return Holder.GLOBAL;
     }

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -365,7 +365,7 @@ import java.util.stream.Stream;
  *
  * The size of the segment returned by the {@code malloc} downcall method handle is
  * <a href="MemorySegment.html#wrapping-addresses">zero</a>. Moreover, the scope of the
- * returned segment is a fresh scope that is always alive. To provide safe access to the segment, we must,
+ * returned segment is a scope that is always alive. To provide safe access to the segment, we must,
  * unsafely, resize the segment to the desired size (100, in this case). It might also be desirable to
  * attach the segment to some existing {@linkplain Arena arena}, so that the lifetime of the region of memory
  * backing the segment can be managed automatically, as for any other native segment created directly from Java code.
@@ -602,7 +602,7 @@ public sealed interface Linker permits AbstractLinker {
      * upcall stub segment will be deallocated when the provided confined arena is {@linkplain Arena#close() closed}.
      * <p>
      * An upcall stub argument whose corresponding layout is an {@linkplain AddressLayout address layout}
-     * is a native segment associated with a fresh scope that is always alive.
+     * is a native segment associated with a scope that is always alive.
      * Under normal conditions, the size of this segment argument is {@code 0}.
      * However, if the address layout has a {@linkplain AddressLayout#targetLayout() target layout} {@code T}, then the size of the
      * segment argument is set to {@code T.byteSize()}.

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -460,7 +460,7 @@ public sealed interface MemoryLayout permits SequenceLayout, GroupLayout, Paddin
      * </ul>
      * <p>
      * If the selected layout is an {@linkplain AddressLayout address layout}, calling {@link VarHandle#get(Object...)}
-     * on the returned var handle will return a new memory segment. The segment is associated with a fresh scope that is
+     * on the returned var handle will return a new memory segment. The segment is associated with a scope that is
      * always alive. Moreover, the size of the segment depends on whether the address layout has a
      * {@linkplain AddressLayout#targetLayout() target layout}. More specifically:
      * <ul>

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -165,7 +165,7 @@ public interface SymbolLookup {
      * <p>
      * Libraries associated with a class loader are unloaded when the class loader becomes
      * <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>. The symbol lookup
-     * returned by this method is associated with a fresh {@linkplain MemorySegment.Scope scope} which keeps the caller's
+     * returned by this method is associated with a {@linkplain MemorySegment.Scope scope} which keeps the caller's
      * class loader reachable. Therefore, libraries associated with the caller's class loader are kept loaded
      * (and their symbols available) as long as a loader lookup for that class loader, or any of the segments
      * obtained by it, is reachable.
@@ -189,7 +189,7 @@ public interface SymbolLookup {
         if ((loader == null || loader instanceof BuiltinClassLoader)) {
             loaderArena = Arena.global();
         } else {
-            MemorySessionImpl session = MemorySessionImpl.heapSession(loader);
+            MemorySessionImpl session = MemorySessionImpl.createHeap(loader);
             loaderArena = session.asArena();
         }
         return name -> {

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -54,6 +54,7 @@ import jdk.internal.reflect.Reflection;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
+import sun.nio.ch.DirectBuffer;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 
@@ -537,7 +538,7 @@ public abstract sealed class AbstractMemorySegmentImpl
         if (bufferSegment != null) {
             bufferScope = bufferSegment.scope;
         } else {
-            bufferScope = MemorySessionImpl.heapSession(bb);
+            bufferScope = MemorySessionImpl.createHeap(bufferRef(bb));
         }
         if (base != null) {
             if (base instanceof byte[]) {
@@ -562,6 +563,17 @@ public abstract sealed class AbstractMemorySegmentImpl
         } else {
             // we can ignore scale factor here, a mapped buffer is always a byte buffer, so scaleFactor == 0.
             return new MappedMemorySegmentImpl(bbAddress + pos, unmapper, size, readOnly, bufferScope);
+        }
+    }
+
+    private static Object bufferRef(Buffer buffer) {
+        if (buffer instanceof DirectBuffer directBuffer) {
+            // direct buffer, return either the buffer attachment (for slices and views), or the buffer itself
+            return directBuffer.attachment() != null ?
+                    directBuffer.attachment() : directBuffer;
+        } else {
+            // heap buffer, return the underlying array
+            return NIO_ACCESS.getBufferBase(buffer);
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -114,7 +114,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             Objects.requireNonNull(arr);
             long byteSize = (long)arr.length * Unsafe.ARRAY_BYTE_INDEX_SCALE;
             return new OfByte(Unsafe.ARRAY_BYTE_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
+                    MemorySessionImpl.createHeap(arr));
         }
 
         @Override
@@ -148,7 +148,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             Objects.requireNonNull(arr);
             long byteSize = (long)arr.length * Unsafe.ARRAY_CHAR_INDEX_SCALE;
             return new OfChar(Unsafe.ARRAY_CHAR_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
+                    MemorySessionImpl.createHeap(arr));
         }
 
         @Override
@@ -182,7 +182,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             Objects.requireNonNull(arr);
             long byteSize = (long)arr.length * Unsafe.ARRAY_SHORT_INDEX_SCALE;
             return new OfShort(Unsafe.ARRAY_SHORT_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
+                    MemorySessionImpl.createHeap(arr));
         }
 
         @Override
@@ -216,7 +216,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             Objects.requireNonNull(arr);
             long byteSize = (long)arr.length * Unsafe.ARRAY_INT_INDEX_SCALE;
             return new OfInt(Unsafe.ARRAY_INT_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
+                    MemorySessionImpl.createHeap(arr));
         }
 
         @Override
@@ -250,7 +250,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             Objects.requireNonNull(arr);
             long byteSize = (long)arr.length * Unsafe.ARRAY_LONG_INDEX_SCALE;
             return new OfLong(Unsafe.ARRAY_LONG_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
+                    MemorySessionImpl.createHeap(arr));
         }
 
         @Override
@@ -284,7 +284,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             Objects.requireNonNull(arr);
             long byteSize = (long)arr.length * Unsafe.ARRAY_FLOAT_INDEX_SCALE;
             return new OfFloat(Unsafe.ARRAY_FLOAT_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
+                    MemorySessionImpl.createHeap(arr));
         }
 
         @Override
@@ -318,7 +318,7 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             Objects.requireNonNull(arr);
             long byteSize = (long)arr.length * Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
             return new OfDouble(Unsafe.ARRAY_DOUBLE_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
+                    MemorySessionImpl.createHeap(arr));
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -48,8 +48,7 @@ public final class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     @Override
     ByteBuffer makeByteBuffer() {
-        return NIO_ACCESS.newMappedByteBuffer(unmapper, min, (int)length, null,
-                scope == MemorySessionImpl.GLOBAL ? null : this);
+        return NIO_ACCESS.newMappedByteBuffer(unmapper, min, (int)length, null, this);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -33,6 +33,8 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.lang.ref.Cleaner;
 import java.util.Objects;
+
+import jdk.internal.foreign.GlobalSession.HeapSession;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -59,10 +61,10 @@ public abstract sealed class MemorySessionImpl
     static final VarHandle STATE;
     static final int MAX_FORKS = Integer.MAX_VALUE;
 
-    public static final MemorySessionImpl GLOBAL = new GlobalSession(null);
-
     static final ScopedMemoryAccess.ScopedAccessError ALREADY_CLOSED = new ScopedMemoryAccess.ScopedAccessError(MemorySessionImpl::alreadyClosed);
     static final ScopedMemoryAccess.ScopedAccessError WRONG_THREAD = new ScopedMemoryAccess.ScopedAccessError(MemorySessionImpl::wrongThread);
+    // This is the session of all zero-length memory segments
+    static final GlobalSession NATIVE_SESSION = new GlobalSession();
 
     final ResourceList resourceList;
     final Thread owner;
@@ -141,6 +143,14 @@ public abstract sealed class MemorySessionImpl
 
     public static MemorySessionImpl createImplicit(Cleaner cleaner) {
         return new ImplicitSession(cleaner);
+    }
+
+    public static MemorySessionImpl createGlobal() {
+        return new GlobalSession();
+    }
+
+    public static MemorySessionImpl createHeap(Object ref) {
+        return new HeapSession(ref);
     }
 
     public abstract void release0();
@@ -229,10 +239,6 @@ public abstract sealed class MemorySessionImpl
     }
 
     abstract void justClose();
-
-    public static MemorySessionImpl heapSession(Object ref) {
-        return new GlobalSession(ref);
-    }
 
     /**
      * A list of all cleanup actions associated with a memory session. Cleanup actions are modelled as instances

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -65,7 +65,7 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
      */
     @ForceInline
     public NativeMemorySegmentImpl() {
-        super(0L, false, new GlobalSession(null));
+        super(0L, false, MemorySessionImpl.NATIVE_SESSION);
         this.min = 0L;
     }
 
@@ -87,8 +87,7 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
 
     @Override
     ByteBuffer makeByteBuffer() {
-        return NIO_ACCESS.newDirectByteBuffer(min, (int) this.length, null,
-                scope == MemorySessionImpl.GLOBAL ? null : this);
+        return NIO_ACCESS.newDirectByteBuffer(min, (int) this.length, null, this);
     }
 
     @Override
@@ -176,6 +175,6 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
 
     @ForceInline
     public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize) {
-        return new NativeMemorySegmentImpl(min, byteSize, false, new GlobalSession(null));
+        return new NativeMemorySegmentImpl(min, byteSize, false, MemorySessionImpl.NATIVE_SESSION);
     }
 }

--- a/test/jdk/java/foreign/TestScope.java
+++ b/test/jdk/java/foreign/TestScope.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @run testng/othervm --enable-native-access=ALL-UNNAMED TestScope
+ */
+
+import org.testng.annotations.*;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+import static org.testng.Assert.*;
+
+public class TestScope {
+
+    static {
+        System.loadLibrary("LookupTest");
+    }
+
+    @Test
+    public void testDifferentArrayScope() {
+        MemorySegment.Scope scope1 = MemorySegment.ofArray(new byte[10]).scope();
+        MemorySegment.Scope scope2 = MemorySegment.ofArray(new byte[10]).scope();
+        assertNotEquals(scope1, scope2);
+    }
+
+    @Test
+    public void testDifferentBufferScope() {
+        MemorySegment.Scope scope1 = MemorySegment.ofBuffer(ByteBuffer.allocateDirect(10)).scope();
+        MemorySegment.Scope scope2 = MemorySegment.ofBuffer(ByteBuffer.allocateDirect(10)).scope();
+        assertNotEquals(scope1, scope2);
+    }
+
+    @Test
+    public void testDifferentArenaScope() {
+        MemorySegment.Scope scope1 = Arena.ofAuto().allocate(10).scope();
+        MemorySegment.Scope scope2 = Arena.ofAuto().allocate(10).scope();
+        assertNotEquals(scope1, scope2);
+    }
+
+    @Test
+    public void testSameArrayScope() {
+        byte[] arr = new byte[10];
+        assertEquals(MemorySegment.ofArray(arr).scope(), MemorySegment.ofArray(arr).scope());
+        ByteBuffer buf = ByteBuffer.wrap(arr);
+        assertEquals(MemorySegment.ofArray(arr).scope(), MemorySegment.ofBuffer(buf).scope());
+        testDerivedBufferScope(MemorySegment.ofArray(arr));
+    }
+
+    @Test
+    public void testSameBufferScope() {
+        ByteBuffer buf = ByteBuffer.allocateDirect(10);
+        assertEquals(MemorySegment.ofBuffer(buf).scope(), MemorySegment.ofBuffer(buf).scope());
+        testDerivedBufferScope(MemorySegment.ofBuffer(buf));
+    }
+
+    @Test
+    public void testSameArenaScope() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment1 = arena.allocate(10);
+            MemorySegment segment2 = arena.allocate(10);
+            assertEquals(segment1.scope(), segment2.scope());
+            testDerivedBufferScope(segment1);
+        }
+    }
+
+    @Test
+    public void testSameNativeScope() {
+        MemorySegment segment1 = MemorySegment.ofAddress(42);
+        MemorySegment segment2 = MemorySegment.ofAddress(43);
+        assertEquals(segment1.scope(), segment2.scope());
+        assertEquals(segment1.scope(), segment2.reinterpret(10).scope());
+        assertNotEquals(segment1.scope(), Arena.global().scope());
+        testDerivedBufferScope(segment1.reinterpret(10));
+    }
+
+    @Test
+    public void testSameLookupScope() {
+        SymbolLookup loaderLookup = SymbolLookup.loaderLookup();
+        MemorySegment segment1 = loaderLookup.find("f").get();
+        MemorySegment segment2 = loaderLookup.find("c").get();
+        assertEquals(segment1.scope(), segment2.scope());
+        testDerivedBufferScope(segment1.reinterpret(10));
+    }
+
+    void testDerivedBufferScope(MemorySegment segment) {
+        ByteBuffer buffer = segment.asByteBuffer();
+        MemorySegment.Scope expectedScope = segment.scope();
+        assertEquals(MemorySegment.ofBuffer(buffer).scope(), expectedScope);
+        // buffer slices should have same scope
+        ByteBuffer slice = buffer.slice(0, 2);
+        assertEquals(expectedScope, MemorySegment.ofBuffer(slice).scope());
+        // buffer views should have same scope
+        IntBuffer view = buffer.asIntBuffer();
+        assertEquals(expectedScope, MemorySegment.ofBuffer(view).scope());
+    }
+}


### PR DESCRIPTION
Port of: https://github.com/openjdk/panama-foreign/pull/898

Original PR body:

> 
> This patch addresses some issues with `MemorySegment.Scope::equals`. More specifically, when two segments are created from the same array/buffer, their underlying scope should be equal, but currently it is not, which is confusing.
> 
> This patch addesses that by adding a new subclass of `GlobalSession` (`HeapSession`) whose `equals`/`hashcode` methods are defined in terms of the heap reference it wraps. Note that the reference is deduped on construction - that is, we always try to find the "bottom" refrence that we should try to keep alive with the session, and we use that for comparisons (which avoid issues when comparing buffer slices and views).
> 
> As part of the changes, this patch also adds more javadoc on `MemorySegment.Scope` to document how equality works. And, this patch also makes all zero-length memory segments associate with the same "native" scope. This is a scope that is always alive, but is not the global scope (not to confuse with segments created by the global arena). While what the implementation does today is technically correct (a new fresh scope is returned with each new ZLMS), it seems also overkill given that the scope associated with segments originated outside Java code is not very interesting - if users really care about lifetime of such segments they should override the scope with `MemorySegment::reinterpret`. This leads to some changes in the javadoc of other methods where I replaced `fresh scope that is always alive` with just `scope that is always alive`, to avoid suggesting that a new scope should be created each time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8317820](https://bugs.openjdk.org/browse/JDK-8317820) to be approved

### Issues
 * [JDK-8317819](https://bugs.openjdk.org/browse/JDK-8317819): Scope should reflect lifetime of underying resource (mainline) (**Enhancement** - P2)
 * [JDK-8317820](https://bugs.openjdk.org/browse/JDK-8317820): Scope should reflect lifetime of underying resource (mainline) (**CSR**)


### Contributors
 * Maurizio Cimadamore `<mcimadamore@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16126/head:pull/16126` \
`$ git checkout pull/16126`

Update a local copy of the PR: \
`$ git checkout pull/16126` \
`$ git pull https://git.openjdk.org/jdk.git pull/16126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16126`

View PR using the GUI difftool: \
`$ git pr show -t 16126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16126.diff">https://git.openjdk.org/jdk/pull/16126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16126#issuecomment-1760309513)