### PR TITLE
8317824: Beef up javadoc for base offset in var handles derived from layouts (mainline)

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -77,7 +77,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * The above declaration can be modelled using a layout object, as follows:
  *
  * {@snippet lang=java :
- * SequenceLayout taggedValues = MemoryLayout.sequenceLayout(5,
+ * SequenceLayout TAGGED_VALUES = MemoryLayout.sequenceLayout(5,
  *     MemoryLayout.structLayout(
  *         ValueLayout.JAVA_BYTE.withName("kind"),
  *         MemoryLayout.paddingLayout(3),
@@ -132,13 +132,13 @@ import jdk.internal.vm.annotation.ForceInline;
  * For instance, given the {@code taggedValues} sequence layout constructed above, we can obtain the offset,
  * in bytes, of the member layout named <code>value</code> in the <em>first</em> sequence element, as follows:
  * {@snippet lang=java :
- * long valueOffset = taggedValues.byteOffset(PathElement.sequenceElement(0),
+ * long valueOffset = TAGGED_VALUES.byteOffset(PathElement.sequenceElement(0),
  *                                           PathElement.groupElement("value")); // yields 4
  * }
  *
  * Similarly, we can select the member layout named {@code value}, as follows:
  * {@snippet lang=java :
- * MemoryLayout value = taggedValues.select(PathElement.sequenceElement(),
+ * MemoryLayout value = TAGGED_VALUES.select(PathElement.sequenceElement(),
  *                                          PathElement.groupElement("value"));
  * }
  *
@@ -151,10 +151,13 @@ import jdk.internal.vm.annotation.ForceInline;
  * the open elements in the path:
  *
  * {@snippet lang=java :
- * VarHandle valueHandle = taggedValues.varHandle(PathElement.sequenceElement(),
+ * VarHandle valueHandle = TAGGED_VALUES.varHandle(PathElement.sequenceElement(),
  *                                                PathElement.groupElement("value"));
- * MemorySegment valuesSegment = ...
- * int val = (int) valueHandle.get(valuesSegment, 2); // reads the "value" field of the third struct in the array
+ * MemorySegment taggedValues = ...
+ * // reads the "value" field of the third struct in the array (taggedValues[2].value)
+ * int val = (int) valueHandle.get(taggedValues,
+ *         0L,  // base offset
+ *         2L); // sequence index
  * }
  *
  * <p>
@@ -164,10 +167,10 @@ import jdk.internal.vm.annotation.ForceInline;
  * of the sequence element whose offset is to be computed:
  *
  * {@snippet lang=java :
- * MethodHandle offsetHandle = taggedValues.byteOffsetHandle(PathElement.sequenceElement(),
+ * MethodHandle offsetHandle = TAGGED_VALUES.byteOffsetHandle(PathElement.sequenceElement(),
  *                                                           PathElement.groupElement("kind"));
- * long offset1 = (long) offsetHandle.invokeExact(1L); // 8
- * long offset2 = (long) offsetHandle.invokeExact(2L); // 16
+ * long offset1 = (long) offsetHandle.invokeExact(0L, 1L); // 0 + (1 * 8) = 8
+ * long offset2 = (long) offsetHandle.invokeExact(0L, 2L); // 0 + (2 * 8) = 16
  * }
  *
  * <h3 id="deref-path-elements">Dereference path elements</h3>
@@ -205,7 +208,10 @@ import jdk.internal.vm.annotation.ForceInline;
  * );
  *
  * MemorySegment rect = ...
- * int rect_y_4 = (int) rectPointYs.get(rect, 2); // rect.points[2]->y
+ * // dereferences the third point struct in the "points" array, and reads its "y" coordinate (rect.points[2]->y)
+ * int rect_y_2 = (int) rectPointYs.get(rect,
+ *     0L,  // base offset
+ *     2L); // sequence index
  * }
  *
  * <h3 id="well-formedness">Layout path well-formedness</h3>
@@ -268,6 +274,67 @@ import jdk.internal.vm.annotation.ForceInline;
  * access size {@code S}, that is, if {@code A < S}. An unaligned var handle only supports the {@code get} and {@code set}
  * access modes. All other access modes will result in {@link UnsupportedOperationException} being thrown. Moreover,
  * while supported, access modes {@code get} and {@code set} might lead to word tearing.
+ *
+ * <h2 id="variable-length">Working with variable-length structs</h2>
+ *
+ * Memory layouts allow clients to describe the contents of a region of memory whose size is known <em>statically</em>.
+ * There are, however, cases, where the size of a region of memory is only known <em>dynamically</em>, as it depends
+ * on the value of one or more struct fields. Consider the following struct declaration in C:
+ *
+ * {@snippet lang=c :
+ * typedef struct {
+ *     int size;
+ *     struct {
+ *         int x;
+ *         int y;
+ *     } points[];
+ * } Polygon;
+ * }
+ *
+ * In the above code, a polygon is modelled as a size (the number of edges in the polygon) and an array of points
+ * (one for each vertex in the polygon). The number of vertices depends on the number of edges in the polygon. As such,
+ * the size of the {@code points} array is left <em>unspecified</em> in the C declaration, using a <em>Flexible Array Member</em>
+ * (a feature standardized in C99).
+ * <p>
+ * Memory layouts do not support sequence layouts whose size is unknown. As such, it is not possible to model
+ * the above struct directly. That said, clients can still enjoy structured access provided by memory layouts, as
+ * demonstrated below:
+ *
+ * {@snippet lang=java :
+ * StructLayout POINT = MemoryLayout.structLayout(
+ *             ValueLayout.JAVA_INT.withName("x"),
+ *             ValueLayout.JAVA_INT.withName("y")
+ * );
+ *
+ * StructLayout POLYGON = MemoryLayout.structLayout(
+ *             ValueLayout.JAVA_INT.withName("size"),
+ *             MemoryLayout.sequenceLayout(0, POINT).withName("points")
+ * );
+ *
+ * VarHandle POLYGON_SIZE = POLYGON.varHandle(0, PathElement.groupElement("size"));
+ * VarHandle POINT_X = POINT.varHandle(PathElement.groupElement("x"));
+ * long POINTS_OFFSET = POLYGON.byteOffset(PathElement.groupElement("points"));
+ * }
+ *
+ * Note how we have split the polygon struct in two. The {@code POLYGON} layout contains a sequence layout
+ * of size <em>zero</em>. The element layout of the sequence layout is the {@code POINT} layout, which defines
+ * the {@code x} and {@code y} coordinates, accordingly. The first layout is used to obtain a var handle
+ * that provides access to the polygon size; the second layout is used to obtain a var handle that provides
+ * access to the {@code x} coordinate of a point struct. Finally, an offset to the start of the variable-length
+ * {@code points} array is also obtained.
+ * <p>
+ * The {@code x} coordinates of all the points in a polygon can then be accessed as follows:
+ * {@snippet lang=java :
+ * MemorySegment polygon = ...
+ * int size = POLYGON_SIZE.get(polygon, 0L);
+ * for (int i = 0 ; i < size ; i++) {
+ *     int x = POINT_X.get(polygon, POINT.scaleOffset(POINTS_OFFSET, i));
+ * }
+ *  }
+ * Here, we first obtain the polygon size, using the {@code POLYGON_SIZE} var handle. Then, in a loop, we read
+ * the {@code x} coordinates of all the points in the polygon. This is done by providing a custom base offset to
+ * the {@code POINT_X} var handle. The custom offset is computed as {@code POINTS_OFFSET + (i * POINT.byteSize())}, where
+ * {@code i} is the loop induction variable.
  *
  * @implSpec
  * Implementations of this interface are immutable, thread-safe and <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.


### PR DESCRIPTION
Port of: https://github.com/openjdk/panama-foreign/pull/901

Original PR body:

> This PR adds more javadoc to explain how base offsets in var handles obtained from layouts can be used.
> 
> First, a number of examples in the main `MemoryLayout` javadoc is rectified, as such examples did not use the additional base offset parameter (and were hence incorrect).
> 
> Second, the var handles part in the `MemorySegment` section on "accessing memory segment" has been rewritten to avoid duplication with the concepts exposed in `MemoryLayout`. Now we show how `MemorySegment::get` and `MemorySegment::getAtIndex` can be obtained using basic var handles and combinators. We mention that more complex var handles can be obtained using layout paths, but we now just reference the layout path section.
> 
> Last, I've added a new section on the `MemoryLayout` javadoc, with an example on how to deal with variable-length structs. This example showcases how var handles can be used in intricate situations, and combined with the new `scaleOffset` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317824](https://bugs.openjdk.org/browse/JDK-8317824): Beef up javadoc for base offset in var handles derived from layouts (mainline) (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Contributors
 * Maurizio Cimadamore `<mcimadamore@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16127/head:pull/16127` \
`$ git checkout pull/16127`

Update a local copy of the PR: \
`$ git checkout pull/16127` \
`$ git pull https://git.openjdk.org/jdk.git pull/16127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16127`

View PR using the GUI difftool: \
`$ git pr show -t 16127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16127.diff">https://git.openjdk.org/jdk/pull/16127.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16127#issuecomment-1760324365)