### PR TITLE
8317839: Exclude java/nio/channels/Channels/SocketChannelStreams.java on AIX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -560,6 +560,8 @@ java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc6
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
+java/nio/channels/Channels/SocketChannelStreams.java            8317838 aix-ppc64
+
 java/nio/channels/DatagramChannel/AdaptorMulticasting.java      8308807 aix-ppc64
 java/nio/channels/DatagramChannel/AfterDisconnect.java          8308807 aix-ppc64
 java/nio/channels/DatagramChannel/ManySourcesAndTargets.java    8264385 macosx-aarch64


### PR DESCRIPTION
The test java/nio/channels/Channels/SocketChannelStreams.java often times out on AIX and should be excluded.
