### PR TITLE
8313621: test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal should use RandomFactory

### DIFF
--- a/test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java
+++ b/test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java
@@ -26,6 +26,10 @@ import jdk.internal.math.FloatingDecimal;
 
 import jdk.test.lib.RandomFactory;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /*
 OldFloatingDecimalForTest
 
@@ -59,51 +63,35 @@ public class jdk.internal.math.FloatingDecimal {
 /**
  * @test
  * @bug 7032154
- * @summary unit tests of FloatingDecimal (use -Dseed=X to set PRNG seed)
+ * @summary unit tests of FloatingDecimal (use -Dseed=X to set PRANDOM seed)
  * @modules java.base/jdk.internal.math
  * @library ..
  * @library /test/lib
  * @library /java/lang/Math
  * @build jdk.test.lib.RandomFactory
  * @build DoubleConsts FloatConsts
- * @run main TestFloatingDecimal
+ * @run junit TestFloatingDecimal
  * @author Brian Burkhalter
  * @key randomness
  */
 public class TestFloatingDecimal {
-    private static enum ResultType {
-        RESULT_EXCEPTION,
-        RESULT_PRINT
-    }
-
-    private static final ResultType RESULT_TYPE = ResultType.RESULT_PRINT;
     private static final int NUM_RANDOM_TESTS = 100000;
 
     private static final Random RANDOM = RandomFactory.getRandom();
-
-    private static void result(String message) {
-        switch (RESULT_TYPE) {
-            case RESULT_EXCEPTION:
-                throw new RuntimeException(message);
-            case RESULT_PRINT:
-                System.err.println(message);
-                break;
-            default:
-                assert false;
-        }
-    }
 
     private static int check(String test, Object expected, Object actual) {
         int failures = 0;
         if(!actual.equals(expected)) {
             failures++;
-            result("Test "+test+" expected "+expected+" but obtained "+actual);
+            System.err.println("Test " + test +
+                               " expected " + expected +
+                               " but obtained " + actual);
         }
         return failures;
     }
 
-    private static int testAppendToDouble() {
-        System.out.println("  testAppendToDouble");
+    @Test
+    public void testAppendToDouble() {
         int failures = 0;
 
         for(int i = 0; i < NUM_RANDOM_TESTS; i++) {
@@ -124,11 +112,11 @@ public class TestFloatingDecimal {
             }
         }
 
-        return failures;
+        assertTrue(failures == 0);
     }
 
-    private static int testAppendToFloat() {
-        System.out.println("  testAppendToFloat");
+    @Test
+    public void testAppendToFloat() {
         int failures = 0;
 
         for(int i = 0; i < NUM_RANDOM_TESTS; i++) {
@@ -149,21 +137,11 @@ public class TestFloatingDecimal {
             }
         }
 
-        return failures;
+        assertTrue(failures == 0);
     }
 
-    private static int testAppendTo() {
-        System.out.println("testAppendTo");
-        int failures = 0;
-
-        failures += testAppendToDouble();
-        failures += testAppendToFloat();
-
-        return failures;
-    }
-
-    private static int testParseDouble() {
-        System.out.println("  testParseDouble");
+    @Test
+    public void testParseDouble() {
         int failures = 0;
 
         for(int i = 0; i < NUM_RANDOM_TESTS; i++) {
@@ -182,11 +160,11 @@ public class TestFloatingDecimal {
             }
         }
 
-        return failures;
+        assertTrue(failures == 0);
     }
 
-    private static int testParseFloat() {
-        System.out.println("  testParseFloat");
+    @Test
+    public void testParseFloat() {
         int failures = 0;
 
         for(int i = 0; i < NUM_RANDOM_TESTS; i++) {
@@ -205,21 +183,11 @@ public class TestFloatingDecimal {
             }
         }
 
-        return failures;
+        assertTrue(failures == 0);
     }
 
-    private static int testParse() {
-        System.out.println("testParse");
-        int failures = 0;
-
-        failures += testParseDouble();
-        failures += testParseFloat();
-
-        return failures;
-    }
-
-    private static int testToJavaFormatStringDoubleFixed() {
-        System.out.println("    testToJavaFormatStringDoubleFixed");
+    @Test
+    public void testToJavaFormatStringDoubleFixed() {
         int failures = 0;
 
         double[] d = new double [] {
@@ -233,11 +201,11 @@ public class TestFloatingDecimal {
             failures += check("testToJavaFormatStringDoubleFixed", ofd.toJavaFormatString(), FloatingDecimal.toJavaFormatString(d[i]));
         }
 
-        return failures;
+        assertTrue(failures == 0);
     }
 
-    private static int testToJavaFormatStringDoubleRandom() {
-        System.out.println("    testToJavaFormatStringDoubleRandom");
+    @Test
+    public void testToJavaFormatStringDoubleRandom() {
         int failures = 0;
 
         for(int i = 0; i < NUM_RANDOM_TESTS; i++) {
@@ -252,19 +220,11 @@ public class TestFloatingDecimal {
             }
         }
 
-        return failures;
+        assertTrue(failures == 0);
     }
 
-    private static int testToJavaFormatStringDouble() {
-        System.out.println("  testToJavaFormatStringDouble");
-        int failures = 0;
-        failures += testToJavaFormatStringDoubleFixed();
-        failures += testToJavaFormatStringDoubleRandom();
-        return failures;
-    }
-
-    private static int testToJavaFormatStringFloatFixed() {
-        System.out.println("    testToJavaFormatStringFloatFixed");
+    @Test
+    public void testToJavaFormatStringFloatFixed() {
         int failures = 0;
 
         float[] f = new float[] {
@@ -278,11 +238,11 @@ public class TestFloatingDecimal {
             failures += check("testToJavaFormatStringFloatFixed", ofd.toJavaFormatString(), FloatingDecimal.toJavaFormatString(f[i]));
         }
 
-        return failures;
+        assertTrue(failures == 0);
     }
 
-    private static int testToJavaFormatStringFloatRandom() {
-        System.out.println("    testToJavaFormatStringFloatRandom");
+    @Test
+    public void testToJavaFormatStringFloatRandom() {
         int failures = 0;
 
         for(int i = 0; i < NUM_RANDOM_TESTS; i++) {
@@ -297,38 +257,6 @@ public class TestFloatingDecimal {
             }
         }
 
-        return failures;
-    }
-
-    private static int testToJavaFormatStringFloat() {
-        System.out.println("  testToJavaFormatStringFloat");
-        int failures = 0;
-
-        failures += testToJavaFormatStringFloatFixed();
-        failures += testToJavaFormatStringFloatRandom();
-
-        return failures;
-    }
-
-    private static int testToJavaFormatString() {
-        System.out.println("testToJavaFormatString");
-        int failures = 0;
-
-        failures += testToJavaFormatStringDouble();
-        failures += testToJavaFormatStringFloat();
-
-        return failures;
-    }
-
-    public static void main(String[] args) {
-        int failures = 0;
-
-        failures += testAppendTo();
-        failures += testParse();
-        failures += testToJavaFormatString();
-
-        if (failures != 0) {
-            throw new RuntimeException("" + failures + " failures while testing FloatingDecimal");
-        }
+        assertTrue(failures == 0);
     }
 }

--- a/test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java
+++ b/test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java
@@ -75,7 +75,7 @@ public class jdk.internal.math.FloatingDecimal {
  * @key randomness
  */
 public class TestFloatingDecimal {
-    private static final int NUM_RANDOM_TESTS = 100000;
+    private static final int NUM_RANDOM_TESTS = 100_000;
 
     private static final Random RANDOM = RandomFactory.getRandom();
 

--- a/test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java
+++ b/test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java
@@ -28,7 +28,7 @@ import jdk.test.lib.RandomFactory;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /*
 OldFloatingDecimalForTest
@@ -112,7 +112,7 @@ public class TestFloatingDecimal {
             }
         }
 
-        assertTrue(failures == 0);
+        assertEquals(0, failures);
     }
 
     @Test
@@ -137,7 +137,7 @@ public class TestFloatingDecimal {
             }
         }
 
-        assertTrue(failures == 0);
+        assertEquals(0, failures);
     }
 
     @Test
@@ -160,7 +160,7 @@ public class TestFloatingDecimal {
             }
         }
 
-        assertTrue(failures == 0);
+        assertEquals(0, failures);
     }
 
     @Test
@@ -183,7 +183,7 @@ public class TestFloatingDecimal {
             }
         }
 
-        assertTrue(failures == 0);
+        assertEquals(0, failures);
     }
 
     @Test
@@ -201,7 +201,7 @@ public class TestFloatingDecimal {
             failures += check("testToJavaFormatStringDoubleFixed", ofd.toJavaFormatString(), FloatingDecimal.toJavaFormatString(d[i]));
         }
 
-        assertTrue(failures == 0);
+        assertEquals(0, failures);
     }
 
     @Test
@@ -220,7 +220,7 @@ public class TestFloatingDecimal {
             }
         }
 
-        assertTrue(failures == 0);
+        assertEquals(0, failures);
     }
 
     @Test
@@ -238,7 +238,7 @@ public class TestFloatingDecimal {
             failures += check("testToJavaFormatStringFloatFixed", ofd.toJavaFormatString(), FloatingDecimal.toJavaFormatString(f[i]));
         }
 
-        assertTrue(failures == 0);
+        assertEquals(0, failures);
     }
 
     @Test
@@ -257,6 +257,6 @@ public class TestFloatingDecimal {
             }
         }
 
-        assertTrue(failures == 0);
+        assertEquals(0, failures);
     }
 }

--- a/test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java
+++ b/test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,8 @@
 
 import java.util.Random;
 import jdk.internal.math.FloatingDecimal;
+
+import jdk.test.lib.RandomFactory;
 
 /*
 OldFloatingDecimalForTest
@@ -57,9 +59,12 @@ public class jdk.internal.math.FloatingDecimal {
 /**
  * @test
  * @bug 7032154
- * @summary unit tests of FloatingDecimal
+ * @summary unit tests of FloatingDecimal (use -Dseed=X to set PRNG seed)
  * @modules java.base/jdk.internal.math
+ * @library ..
+ * @library /test/lib
  * @library /java/lang/Math
+ * @build jdk.test.lib.RandomFactory
  * @build DoubleConsts FloatConsts
  * @run main TestFloatingDecimal
  * @author Brian Burkhalter
@@ -74,7 +79,7 @@ public class TestFloatingDecimal {
     private static final ResultType RESULT_TYPE = ResultType.RESULT_PRINT;
     private static final int NUM_RANDOM_TESTS = 100000;
 
-    private static final Random RANDOM = new Random();
+    private static final Random RANDOM = RandomFactory.getRandom();
 
     private static void result(String message) {
         switch (RESULT_TYPE) {


### PR DESCRIPTION
Change test to use `RandomFactory` instead of `new Random()` and convert it to JUnit 5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313621](https://bugs.openjdk.org/browse/JDK-8313621): test/jdk/jdk/internal/math/FloatingDecimal/TestFloatingDecimal should use RandomFactory (**Bug** - P5)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16130/head:pull/16130` \
`$ git checkout pull/16130`

Update a local copy of the PR: \
`$ git checkout pull/16130` \
`$ git pull https://git.openjdk.org/jdk.git pull/16130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16130`

View PR using the GUI difftool: \
`$ git pr show -t 16130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16130.diff">https://git.openjdk.org/jdk/pull/16130.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16130#issuecomment-1756461176)