### PR TITLE
JDK-8317635: Improve GetClassFields test to verify correctness of field order

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,8 +119,13 @@ abstract class OuterClass4 extends OuterClass3 implements OuterInterface2 {
     }
 }
 
+// class with multiple fields to verify correctness of the field order
 class OuterClass5 extends OuterClass4 {
     int fld_i1 = 1;
+    String fld_s1 = "str";
+    int fld_i2 = 2;
+    String fld_s2 = "str2";
+
     public int meth_i1() {
         return 1;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007.java
@@ -79,14 +79,15 @@ public class getclfld007 {
 
 
     static void check(Class cls) throws Exception {
-        List<String> fields = FieldExplorer.get(cls);
+        FieldExplorer explorer = new FieldExplorer(cls);
+        List<String> fields = explorer.get();
         check(cls, fields.toArray(new String[0]));
     }
 
-    // helper class to get list of the class field
+    // helper class to get list of the class fields
     // in the order they appear in the class file
     static class FieldExplorer extends ClassVisitor {
-        private Class cls;
+        private final Class cls;
         private List<String> fieldNameAndSig = new ArrayList<>();
         private FieldExplorer(Class cls) {
             super(Opcodes.ASM7);
@@ -101,21 +102,20 @@ public class getclfld007 {
             return super.visitField(access, name, descriptor, signature, value);
         }
 
-        InputStream getClassBytes() throws Exception {
+        private InputStream getClassBytes() throws Exception {
             String clsName = cls.getName();
             String clsPath = clsName.replace('.', '/') + ".class";
             return cls.getClassLoader().getResourceAsStream(clsPath);
         }
 
         // each field is represented by 2 Strings in the list: name and type descriptor
-        static List<String> get(Class cls) throws Exception {
+        public List<String> get() throws Exception {
             System.out.println("Class " + cls.getName());
-            FieldExplorer explorer = new FieldExplorer(cls);
-            try (InputStream classBytes = explorer.getClassBytes()) {
+            try (InputStream classBytes = getClassBytes()) {
                 ClassReader classReader = new ClassReader(classBytes);
-                classReader.accept(explorer, 0);
+                classReader.accept(this, 0);
             }
-            return explorer.fieldNameAndSig;
+            return fieldNameAndSig;
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,9 @@
  * DESCRIPTION
  *     The test exercises JVMTI function
  *         GetClassFields(clazz, fieldCountPtr, fieldsPtr).
- *     The test checks if the function returns the expected list of fields.
- *     That is the field list contains only directly declared (not inherited)
- *     fields.
+ *     The test checks if the function returns the expected list of fields:
+ *         - the list contains only directly declared (not inherited) fields;
+ *         - fields are returned in the order they occur in the class file.
  * COMMENTS
  *     Ported from JVMDI.
  *     Test fixed due to test bug:
@@ -45,6 +45,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm/native -agentlib:getclfld007 nsk.jvmti.GetClassFields.getclfld007
+ * @run main/othervm/native -agentlib:getclfld007=printdump nsk.jvmti.GetClassFields.getclfld007
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/TestDescription.java
@@ -45,6 +45,7 @@
  *
  * @library /vmTestbase
  *          /test/lib
- * @run main/othervm/native -agentlib:getclfld007=printdump nsk.jvmti.GetClassFields.getclfld007
+ * @modules java.base/jdk.internal.org.objectweb.asm
+ * @run main/othervm/native -agentlib:getclfld007 nsk.jvmti.GetClassFields.getclfld007
  */
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/getclfld007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/getclfld007.cpp
@@ -33,72 +33,25 @@ extern "C" {
 #define PASSED 0
 #define STATUS_FAILED 2
 
-typedef struct {
-    const char *name;
-    const char *sig;
-} fld_info;
-
-typedef struct {
-    const char *name;
-    jint fcount;
-    fld_info *flds;
-} class_info;
-
 static jvmtiEnv *jvmti = NULL;
 static jint result = PASSED;
-static jboolean printdump = JNI_FALSE;
 
-static fld_info f0[] = {
-    { "fld_1", "Ljava/lang/String;" }
-};
 
-static fld_info f1[] = {
-    { "fld_n1", "I" }
-};
-
-static fld_info f2[] = {
-    { "fld_n2", "I" }
-};
-
-static fld_info f4[] = {
-    { "fld_o2", "I" }
-};
-
-static fld_info f5[] = {
-    { "fld_o3", "I" }
-};
-
-static fld_info f6[] = {
-    { "fld_i1", "I" }
-};
-
-static fld_info f7[] = {
-    { "fld_i2", "I" }
-};
-
-static fld_info f8[] = {
-    { "fld_i2", "I" }
-};
-
-static fld_info f9[] = {
-    { "fld_i1", "I" },
-    { "fld_s1", "Ljava/lang/String;" },
-    { "fld_i2", "I" },
-    { "fld_s2", "Ljava/lang/String;" }
-};
-
-static class_info classes[] = {
-    { "InnerClass1", 1, f0 },
-    { "InnerInterface", 1, f1 },
-    { "InnerClass2", 1, f2 },
-    { "OuterClass1", 0, NULL },
-    { "OuterClass2", 1, f4 },
-    { "OuterClass3", 1, f5 },
-    { "OuterInterface1", 1, f6 },
-    { "OuterInterface2", 1, f7 },
-    { "OuterClass4", 1, f8 },
-    { "OuterClass5", 4, f9 }
-};
+// compares 'value' with jobject_arr[index]
+static bool equals_str(JNIEnv *env, const char *value, jobjectArray jobject_arr, jint index) {
+    jstring jstr = (jstring)env->GetObjectArrayElement(jobject_arr, index);
+    const char* utf = env->GetStringUTFChars(jstr, NULL);
+    bool res = false;
+    if (utf != NULL) {
+        res = strcmp(value, utf) == 0;
+        env->ReleaseStringUTFChars(jstr, utf);
+    } else {
+        printf("GetStringUTFChars failed\n");
+        result = STATUS_FAILED;
+    }
+    env->DeleteLocalRef(jstr);
+    return res;
+}
 
 #ifdef STATIC_BUILD
 JNIEXPORT jint JNICALL Agent_OnLoad_getclfld007(JavaVM *jvm, char *options, void *reserved) {
@@ -114,10 +67,6 @@ JNIEXPORT jint JNI_OnLoad_getclfld007(JavaVM *jvm, char *options, void *reserved
 jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res;
 
-    if (options != NULL && strcmp(options, "printdump") == 0) {
-        printdump = JNI_TRUE;
-    }
-
     res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == NULL) {
         printf("Wrong result of a valid call to GetEnv!\n");
@@ -128,61 +77,61 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 }
 
 JNIEXPORT void JNICALL
-Java_nsk_jvmti_GetClassFields_getclfld007_check(JNIEnv *env, jclass cls, jint i, jclass clazz) {
+Java_nsk_jvmti_GetClassFields_getclfld007_check(JNIEnv *env, jclass cls, jclass clazz, jobjectArray fieldArr) {
     jvmtiError err;
     jint fcount;
     jfieldID *fields;
-    char *name, *sig, *generic;
+    char *name, *sig;
     int j;
 
     if (jvmti == NULL) {
         printf("JVMTI client was not properly loaded!\n");
+        fflush(0);
         result = STATUS_FAILED;
         return;
     }
 
-    if (printdump == JNI_TRUE) {
-        printf(">>> %s:\n", classes[i].name);
-    }
+    // fieldArr contains 2 elements for each field
+    jint field_count = env->GetArrayLength(fieldArr) / 2;
 
     err = jvmti->GetClassFields(clazz, &fcount, &fields);
     if (err != JVMTI_ERROR_NONE) {
-        printf("(GetClassFields#%d) unexpected error: %s (%d)\n",
-               i, TranslateError(err), err);
+        printf("GetClassFields unexpected error: %s (%d)\n",
+               TranslateError(err), err);
+        fflush(0);
         result = STATUS_FAILED;
         return;
     }
 
-    if (fcount != classes[i].fcount) {
-        printf("(%d) wrong number of fields: %d, expected: %d\n",
-               i, fcount, classes[i].fcount);
+    if (fcount != field_count) {
+        printf("wrong number of fields: %d, expected: %d\n",
+               fcount, field_count);
         result = STATUS_FAILED;
     }
     for (j = 0; j < fcount; j++) {
         if (fields[j] == NULL) {
-            printf("(%d:%d) fieldID = null\n", i, j);
+            printf("(%d) fieldID = null\n", j);
+            result = STATUS_FAILED;
         } else {
-            err = jvmti->GetFieldName(clazz, fields[j],
-                &name, &sig, &generic);
+            err = jvmti->GetFieldName(clazz, fields[j], &name, &sig, NULL);
             if (err != JVMTI_ERROR_NONE) {
-                printf("(GetFieldName#%d:%d) unexpected error: %s (%d)\n",
-                       i, j, TranslateError(err), err);
+                printf("(GetFieldName#%d) unexpected error: %s (%d)\n",
+                       j, TranslateError(err), err);
             } else {
-                if (printdump == JNI_TRUE) {
-                    printf(">>>   [%d]: %s, sig = \"%s\"\n", j, name, sig);
-                }
-                if ((j < classes[i].fcount) &&
+                printf(">>>   [%d]: %s, sig = \"%s\"\n", j, name, sig);
+                if ((j < field_count) &&
                        (name == NULL || sig == NULL ||
-                        strcmp(name, classes[i].flds[j].name) != 0 ||
-                        strcmp(sig, classes[i].flds[j].sig) != 0)) {
-                    printf("(%d:%d) wrong field: \"%s%s\"", i, j, name, sig);
-                    printf(", expected: \"%s%s\"\n",
-                           classes[i].flds[j].name, classes[i].flds[j].sig);
+                        !equals_str(env, name, fieldArr, j * 2) ||
+                        !equals_str(env, sig, fieldArr, j * 2 + 1))) {
+                    printf("(%d) wrong field: \"%s%s\"", j, name, sig);
                     result = STATUS_FAILED;
                 }
+                jvmti->Deallocate((unsigned char *)name);
+                jvmti->Deallocate((unsigned char *)sig);
             }
         }
     }
+    fflush(0);
 }
 
 JNIEXPORT int JNICALL

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/getclfld007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/getclfld007.cpp
@@ -112,24 +112,25 @@ Java_nsk_jvmti_GetClassFields_getclfld007_check(JNIEnv *env, jclass cls, jclass 
         if (fields[j] == NULL) {
             printf("(%d) fieldID = null\n", j);
             result = STATUS_FAILED;
-        } else {
-            err = jvmti->GetFieldName(clazz, fields[j], &name, &sig, NULL);
-            if (err != JVMTI_ERROR_NONE) {
-                printf("(GetFieldName#%d) unexpected error: %s (%d)\n",
-                       j, TranslateError(err), err);
-            } else {
-                printf(">>>   [%d]: %s, sig = \"%s\"\n", j, name, sig);
-                if ((j < field_count) &&
-                       (name == NULL || sig == NULL ||
-                        !equals_str(env, name, fieldArr, j * 2) ||
-                        !equals_str(env, sig, fieldArr, j * 2 + 1))) {
-                    printf("(%d) wrong field: \"%s%s\"", j, name, sig);
-                    result = STATUS_FAILED;
-                }
-                jvmti->Deallocate((unsigned char *)name);
-                jvmti->Deallocate((unsigned char *)sig);
-            }
+            continue;
         }
+        err = jvmti->GetFieldName(clazz, fields[j], &name, &sig, NULL);
+        if (err != JVMTI_ERROR_NONE) {
+            printf("(GetFieldName#%d) unexpected error: %s (%d)\n",
+                   j, TranslateError(err), err);
+            result = STATUS_FAILED;
+            continue;
+        }
+        printf(">>>   [%d]: %s, sig = \"%s\"\n", j, name, sig);
+        if ((j < field_count) &&
+               (name == NULL || sig == NULL ||
+                !equals_str(env, name, fieldArr, j * 2) ||
+                !equals_str(env, sig, fieldArr, j * 2 + 1))) {
+            printf("(%d) wrong field: \"%s%s\"", j, name, sig);
+            result = STATUS_FAILED;
+        }
+        jvmti->Deallocate((unsigned char *)name);
+        jvmti->Deallocate((unsigned char *)sig);
     }
     fflush(0);
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/getclfld007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/getclfld007.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,10 @@ static fld_info f8[] = {
 };
 
 static fld_info f9[] = {
-    { "fld_i1", "I" }
+    { "fld_i1", "I" },
+    { "fld_s1", "Ljava/lang/String;" },
+    { "fld_i2", "I" },
+    { "fld_s2", "Ljava/lang/String;" }
 };
 
 static class_info classes[] = {
@@ -94,7 +97,7 @@ static class_info classes[] = {
     { "OuterInterface1", 1, f6 },
     { "OuterInterface2", 1, f7 },
     { "OuterClass4", 1, f8 },
-    { "OuterClass5", 1, f9 }
+    { "OuterClass5", 4, f9 }
 };
 
 #ifdef STATIC_BUILD


### PR DESCRIPTION
All test cases in getclfld007 had 1 (or 0) field in test classes/interfaces.
The change adds several fields in one of the test classes to verify order of the returned fields (as described by GetClassFields spec: "in the order they occur in the class file").
Field order in the class file is not guaranteed to be the same as in the source, so information about expected fields and expected order is extracted by ASM (it parses class file sequentially).
This allows to drop hardcoded field name/type in native part.

Additionally did some test cleanup:
- dropped "printdump" stuff (the test always logs reported fields);
- removed unused `generic` in native check() method, added deallocation of `name` and `sig`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317635](https://bugs.openjdk.org/browse/JDK-8317635): Improve GetClassFields test to verify correctness of field order (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [bd48a0b0](https://git.openjdk.org/jdk/pull/16131/files/bd48a0b0814050846bb4b24baadeded0828898f8)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16131/head:pull/16131` \
`$ git checkout pull/16131`

Update a local copy of the PR: \
`$ git checkout pull/16131` \
`$ git pull https://git.openjdk.org/jdk.git pull/16131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16131`

View PR using the GUI difftool: \
`$ git pr show -t 16131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16131.diff">https://git.openjdk.org/jdk/pull/16131.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16131#issuecomment-1756535475)