### PR TITLE
8317846: Typo in API documentation of classes IdentityHashMap

### DIFF
--- a/src/java.base/share/classes/java/util/IdentityHashMap.java
+++ b/src/java.base/share/classes/java/util/IdentityHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/IdentityHashMap.java
+++ b/src/java.base/share/classes/java/util/IdentityHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,7 +267,7 @@ public class IdentityHashMap<K,V>
     }
 
     /**
-     * Constructs a new identity hash map containing the keys-value mappings
+     * Constructs a new identity hash map containing the key-value mappings
      * in the specified map.
      *
      * @param m the map whose mappings are to be placed into this map


### PR DESCRIPTION
Hello,

I have fixed the typo in the comment for the constructor IdentityHashMap(Map<? extends K,? extends V> m)

before: Constructs a new identity hash map containing the keys-value mappings in the specified map.
after: Constructs a new identity hash map containing the key-value mappings in the specified map.

Please review the change.

Regards,
Anupam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317846](https://bugs.openjdk.org/browse/JDK-8317846): Typo in API documentation of classes IdentityHashMap (**Bug** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16134/head:pull/16134` \
`$ git checkout pull/16134`

Update a local copy of the PR: \
`$ git checkout pull/16134` \
`$ git pull https://git.openjdk.org/jdk.git pull/16134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16134`

View PR using the GUI difftool: \
`$ git pr show -t 16134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16134.diff">https://git.openjdk.org/jdk/pull/16134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16134#issuecomment-1756813474)