### PR TITLE
8317847: Typo in API documentation of class JPopupMenu

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
+++ b/src/java.desktop/share/classes/javax/swing/JPopupMenu.java
@@ -934,7 +934,7 @@ public class JPopupMenu extends JComponent implements Accessible,MenuElement {
 
     /**
      * Sets the invoker of this popup menu -- the component in which
-     * the popup menu menu is to be displayed.
+     * the popup menu is to be displayed.
      *
      * @param invoker the <code>Component</code> in which the popup
      *          menu is displayed


### PR DESCRIPTION
Hello,

I have fixed the typo in the comment for the method JPopupMenu.setInvoker(Component invoker)

before: Sets the invoker of this popup menu -- the component in which the popup menu menu is to be displayed.
after: Sets the invoker of this popup menu -- the component in which the popup menu is to be displayed.

Please review the change.

Regards,
Anupam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317847](https://bugs.openjdk.org/browse/JDK-8317847): Typo in API documentation of class JPopupMenu (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16135/head:pull/16135` \
`$ git checkout pull/16135`

Update a local copy of the PR: \
`$ git checkout pull/16135` \
`$ git pull https://git.openjdk.org/jdk.git pull/16135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16135`

View PR using the GUI difftool: \
`$ git pr show -t 16135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16135.diff">https://git.openjdk.org/jdk/pull/16135.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16135#issuecomment-1756820121)