### PR TITLE
8317868: Add @sealedGraph to MethodHandleDesc and descendants

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
@@ -46,7 +46,6 @@ import static java.lang.invoke.MethodHandleInfo.REF_putStatic;
  * {@link MethodHandle}.  A {@linkplain DirectMethodHandleDesc} corresponds to
  * a {@code Constant_MethodHandle_info} entry in the constant pool of a classfile.
  *
- * @sealedGraph
  * @since 12
  */
 public sealed interface DirectMethodHandleDesc

--- a/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ import static java.lang.invoke.MethodHandleInfo.REF_putStatic;
  * {@link MethodHandle}.  A {@linkplain DirectMethodHandleDesc} corresponds to
  * a {@code Constant_MethodHandle_info} entry in the constant pool of a classfile.
  *
+ * @sealedGraph
  * @since 12
  */
 public sealed interface DirectMethodHandleDesc

--- a/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/DirectMethodHandleDesc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/constant/MethodHandleDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/MethodHandleDesc.java
@@ -35,6 +35,7 @@ import static java.lang.constant.DirectMethodHandleDesc.Kind.CONSTRUCTOR;
  * A <a href="package-summary.html#nominal">nominal descriptor</a> for a
  * {@link MethodHandle} constant.
  *
+ * @sealedGraph
  * @since 12
  */
 public sealed interface MethodHandleDesc


### PR DESCRIPTION
This PR proposes to add  @sealedGraph to MethodHandleDesc and descendants.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317868](https://bugs.openjdk.org/browse/JDK-8317868): Add @<!---->sealedGraph to MethodHandleDesc and descendants (**Sub-task** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16137/head:pull/16137` \
`$ git checkout pull/16137`

Update a local copy of the PR: \
`$ git checkout pull/16137` \
`$ git pull https://git.openjdk.org/jdk.git pull/16137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16137`

View PR using the GUI difftool: \
`$ git pr show -t 16137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16137.diff">https://git.openjdk.org/jdk/pull/16137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16137#issuecomment-1757053348)