### PR TITLE
8317870: Add @sealedGraph to Thread.Builder

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -869,6 +869,7 @@ public class Thread implements Runnable {
      *
      * @see Thread#ofPlatform()
      * @see Thread#ofVirtual()
+     * @sealedGraph
      * @since 21
      */
     public sealed interface Builder


### PR DESCRIPTION
This PR proposes to Add @sealedGraph to `Thread.Builder`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317870](https://bugs.openjdk.org/browse/JDK-8317870): Add @<!---->sealedGraph to Thread.Builder (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16138/head:pull/16138` \
`$ git checkout pull/16138`

Update a local copy of the PR: \
`$ git checkout pull/16138` \
`$ git pull https://git.openjdk.org/jdk.git pull/16138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16138`

View PR using the GUI difftool: \
`$ git pr show -t 16138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16138.diff">https://git.openjdk.org/jdk/pull/16138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16138#issuecomment-1757066940)