### PR TITLE
JDK-8317866: replace NET_SocketAvailable

### DIFF
--- a/src/java.base/share/native/libnet/net_util.h
+++ b/src/java.base/share/native/libnet/net_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,9 +160,6 @@ int NET_IsZeroAddr(jbyte* caddr);
  * These work just like the system calls, except that they may do some
  * platform-specific pre/post processing of the arguments and/or results.
  */
-
-JNIEXPORT int JNICALL
-NET_SocketAvailable(int fd, int *pbytes);
 
 JNIEXPORT int JNICALL
 NET_GetSockOpt(int fd, int level, int opt, void *result, int *len);

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -28,7 +28,6 @@
 #include <netinet/tcp.h> // defines TCP_NODELAY
 #include <stdlib.h>
 #include <string.h>
-#include <sys/ioctl.h>
 #include <sys/time.h>
 
 #if defined(__linux__)
@@ -50,18 +49,6 @@
 #if defined(__linux__) && !defined(IPV6_FLOWINFO_SEND)
 #define IPV6_FLOWINFO_SEND      33
 #endif
-
-#define RESTARTABLE(_cmd, _result) do { \
-    do { \
-        _result = _cmd; \
-    } while((_result == -1) && (errno == EINTR)); \
-} while(0)
-
-int NET_SocketAvailable(int s, int *pbytes) {
-    int result;
-    RESTARTABLE(ioctl(s, FIONREAD, pbytes), result);
-    return result;
-}
 
 void
 NET_ThrowByNameWithLastError(JNIEnv *env, const char *name,

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -24,6 +24,7 @@
  */
 
 #include <poll.h>
+#include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <string.h>
@@ -854,7 +855,10 @@ JNIEXPORT jint JNICALL
 Java_sun_nio_ch_Net_available(JNIEnv *env, jclass cl, jobject fdo)
 {
     int count = 0;
-    if (NET_SocketAvailable(fdval(env, fdo), &count) != 0) {
+    int result;
+    RESTARTABLE(ioctl(fdval(env, fdo), FIONREAD, &count), result);
+
+    if (result != 0) {
         handleSocketError(env, errno);
         return IOS_THROWN;
     }

--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -392,19 +392,8 @@ NET_GetSockOpt(int s, int level, int optname, void *optval,
     return rv;
 }
 
-JNIEXPORT int JNICALL
-NET_SocketAvailable(int s, int *pbytes) {
-    u_long arg;
-    if (ioctlsocket((SOCKET)s, FIONREAD, &arg) == SOCKET_ERROR) {
-        return -1;
-    } else {
-        *pbytes = (int) arg;
-        return 0;
-    }
-}
-
 /*
- * Sets SO_ECLUSIVEADDRUSE if SO_REUSEADDR is not already set.
+ * Sets SO_EXCLUSIVEADDRUSE if SO_REUSEADDR is not already set.
  */
 void setExclusiveBind(int fd) {
     int parg = 0;


### PR DESCRIPTION
When doing [JDK-8317603](https://bugs.openjdk.org/browse/JDK-8317603), it became clear that NET_SocketAvailable should be replaced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317866](https://bugs.openjdk.org/browse/JDK-8317866): replace NET_SocketAvailable (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16139/head:pull/16139` \
`$ git checkout pull/16139`

Update a local copy of the PR: \
`$ git checkout pull/16139` \
`$ git pull https://git.openjdk.org/jdk.git pull/16139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16139`

View PR using the GUI difftool: \
`$ git pr show -t 16139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16139.diff">https://git.openjdk.org/jdk/pull/16139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16139#issuecomment-1757079647)