### PR TITLE
8317873: Add @sealedGraph to IllegalFormatException

### DIFF
--- a/src/java.base/share/classes/java/util/IllegalFormatException.java
+++ b/src/java.base/share/classes/java/util/IllegalFormatException.java
@@ -31,6 +31,7 @@ package java.util;
  * explicit subtypes of this exception which correspond to specific errors
  * should be instantiated.
  *
+ * @sealedGraph
  * @since 1.5
  */
 public sealed class IllegalFormatException extends IllegalArgumentException


### PR DESCRIPTION
This PR proposes to add @sealedGraph to `IllegalFormatException`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317873](https://bugs.openjdk.org/browse/JDK-8317873): Add @<!---->sealedGraph to IllegalFormatException (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16140/head:pull/16140` \
`$ git checkout pull/16140`

Update a local copy of the PR: \
`$ git checkout pull/16140` \
`$ git pull https://git.openjdk.org/jdk.git pull/16140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16140`

View PR using the GUI difftool: \
`$ git pr show -t 16140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16140.diff">https://git.openjdk.org/jdk/pull/16140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16140#issuecomment-1757079437)