### PR TITLE
8317874: Add @sealedGraph to StringTemplate.Processor.Linkage

### DIFF
--- a/src/java.base/share/classes/java/lang/StringTemplate.java
+++ b/src/java.base/share/classes/java/lang/StringTemplate.java
@@ -595,6 +595,7 @@ public interface StringTemplate {
          *
          * @implNote This interface is sealed to only allow standard processors.
          *
+         * @sealedGraph
          * @since 21
          */
         @PreviewFeature(feature=PreviewFeature.Feature.STRING_TEMPLATES)


### PR DESCRIPTION
This PR proposes to Add @sealedGraph to `StringTemplate.Processor.Linkage`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317874](https://bugs.openjdk.org/browse/JDK-8317874): Add @<!---->sealedGraph to StringTemplate.Processor.Linkage (**Sub-task** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16141/head:pull/16141` \
`$ git checkout pull/16141`

Update a local copy of the PR: \
`$ git checkout pull/16141` \
`$ git pull https://git.openjdk.org/jdk.git pull/16141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16141`

View PR using the GUI difftool: \
`$ git pr show -t 16141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16141.diff">https://git.openjdk.org/jdk/pull/16141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16141#issuecomment-1757108201)