### PR TITLE
8317886: Add @sealedGraph to ByteBuffer

### DIFF
--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -279,6 +279,9 @@ import jdk.internal.util.ArraysSupport;
  *
  * @author Mark Reinhold
  * @author JSR-51 Expert Group
+#if[byte]
+ * @sealedGraph
+#end[byte]
  * @since 1.4
  */
 


### PR DESCRIPTION
This PR proposed to Add @sealedGraph to `ByteBuffer`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317886](https://bugs.openjdk.org/browse/JDK-8317886): Add @<!---->sealedGraph to ByteBuffer (**Sub-task** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16142/head:pull/16142` \
`$ git checkout pull/16142`

Update a local copy of the PR: \
`$ git checkout pull/16142` \
`$ git pull https://git.openjdk.org/jdk.git pull/16142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16142`

View PR using the GUI difftool: \
`$ git pr show -t 16142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16142.diff">https://git.openjdk.org/jdk/pull/16142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16142#issuecomment-1757214150)