### PR TITLE
JDK-8317661: [REDO] store/load order not preserved when handling memory pool due to weakly ordered memory architecture of aarch64

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -573,6 +573,8 @@ CodeBlob* CodeCache::allocate(int size, CodeBlobType code_blob_type, bool handle
         CompileBroker::handle_full_code_cache(orig_code_blob_type);
       }
       return nullptr;
+    } else {
+      OrderAccess::release(); // ensure heap expansion is visible to an asynchronous observer (e.g. CodeHeapPool::get_memory_usage())
     }
     if (PrintCodeCacheExtension) {
       ResourceMark rm;

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -553,7 +553,8 @@ int CodeHeap::allocated_segments() const {
 
 size_t CodeHeap::allocated_capacity() const {
   // size of used heap - size on freelist
-  return segments_to_size(Atomic::load_acquire(&_next_segment) - _freelist_segments);
+  size_t next_segment = Atomic::load_acquire(&_next_segment);
+  return segments_to_size(next_segment - _freelist_segments);
 }
 
 // Returns size of the unallocated heap block

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -553,8 +553,7 @@ int CodeHeap::allocated_segments() const {
 
 size_t CodeHeap::allocated_capacity() const {
   // size of used heap - size on freelist
-  size_t next_segment = Atomic::load_acquire(&_next_segment);
-  return segments_to_size(next_segment - _freelist_segments);
+  return segments_to_size(Atomic::load_acquire(&_next_segment) - _freelist_segments);
 }
 
 // Returns size of the unallocated heap block

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -303,7 +303,7 @@ void* CodeHeap::allocate(size_t instance_size) {
     mark_segmap_as_used(_next_segment, _next_segment + number_of_segments, false);
     block = block_at(_next_segment);
     block->initialize(number_of_segments);
-    _next_segment += number_of_segments;
+    Atomic::release_store(&_next_segment, _next_segment + number_of_segments);
     guarantee((char*) block >= _memory.low_boundary() && (char*) block < _memory.high(),
               "The newly allocated block " PTR_FORMAT " is not within the heap "
               "starting with "  PTR_FORMAT " and ending with " PTR_FORMAT,
@@ -553,7 +553,7 @@ int CodeHeap::allocated_segments() const {
 
 size_t CodeHeap::allocated_capacity() const {
   // size of used heap - size on freelist
-  return segments_to_size(_next_segment - _freelist_segments);
+  return segments_to_size(Atomic::load_acquire(&_next_segment) - _freelist_segments);
 }
 
 // Returns size of the unallocated heap block

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -303,7 +303,7 @@ void* CodeHeap::allocate(size_t instance_size) {
     mark_segmap_as_used(_next_segment, _next_segment + number_of_segments, false);
     block = block_at(_next_segment);
     block->initialize(number_of_segments);
-    Atomic::release_store(&_next_segment, _next_segment + number_of_segments);
+    _next_segment += number_of_segments;
     guarantee((char*) block >= _memory.low_boundary() && (char*) block < _memory.high(),
               "The newly allocated block " PTR_FORMAT " is not within the heap "
               "starting with "  PTR_FORMAT " and ending with " PTR_FORMAT,
@@ -553,7 +553,7 @@ int CodeHeap::allocated_segments() const {
 
 size_t CodeHeap::allocated_capacity() const {
   // size of used heap - size on freelist
-  return segments_to_size(Atomic::load_acquire(&_next_segment) - _freelist_segments);
+  return segments_to_size(_next_segment - _freelist_segments);
 }
 
 // Returns size of the unallocated heap block

--- a/src/hotspot/share/services/memoryPool.cpp
+++ b/src/hotspot/share/services/memoryPool.cpp
@@ -179,6 +179,7 @@ CodeHeapPool::CodeHeapPool(CodeHeap* codeHeap, const char* name, bool support_us
 
 MemoryUsage CodeHeapPool::get_memory_usage() {
   size_t used      = used_in_bytes();
+  OrderAccess::acquire(); // ensure possible cache expansion in CodeCache::allocate is seen
   size_t committed = _codeHeap->capacity();
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);
 


### PR DESCRIPTION
# Issue
An intermittent _Memory Pool not found_ error has been noticed when running  a few tests (_vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java_, _vmTestbase/vm/mlvm/meth/stress/compiler/sequences/Test.java_) on _macosx\_aarch64_ (production build) with non-segmented code cache.

## Origin
The issue originates from the fact that aarch64 architecture is a weakly ordered memory architecture, i.e. it _permits the observation and completion of memory accesses in a different order from the program order_.

More precisely: while calling `CodeHeapPool::get_memory_usage`, the `used` and `committed` variables are retrieved
https://github.com/openjdk/jdk/blob/138542de7889e8002df0e15a79e31d824c6a0473/src/hotspot/share/services/memoryPool.cpp#L181-L182
and these are computed based on different variables saved in memory in `CodeCache::allocate` (during `heap->allocate` and `heap->expand_by` to be precise) .https://github.com/openjdk/jdk/blob/138542de7889e8002df0e15a79e31d824c6a0473/src/hotspot/share/code/codeCache.cpp#L535-L537
The problem happens when first `heap->expand_by` gets called (which _increases_ `committed`) and then `heap->allocate` gets called in a second loop pass (which _increases_ `used`). Although stores in `CodeCache::allocate` happen in the this order, when reading from memory in `CodeHeapPool::get_memory_usage` it can happen that `used` has the newly computed value, while `committed` is still "old" (because of ARM’s weak memory order). This is a problem, since `committed` must be > than `used`.

# Solution

To avoid this situation we must assure that values used to calculate `committed` are actually saved before the values used to calculate `used` and that the opposite be true for reading. To enforce this explicit barriers are introduced: `OrderAccess::release` in `CodeCache::allocate` if we need to expand the heap, to ensure heap expansion is visible before we allocate, and `OrderAccess::acquire` before calculating `committed` in `CodeHeapPool::get_memory_usage` to make sure that the cache expansion is seen.

Acquiring a `CodeCache_lock` has been attempted in #15819 but resulted in deadlocks (that seem to be unavoidable).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317661](https://bugs.openjdk.org/browse/JDK-8317661): [REDO] store/load order not preserved when handling memory pool due to weakly ordered memory architecture of aarch64 (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16143/head:pull/16143` \
`$ git checkout pull/16143`

Update a local copy of the PR: \
`$ git checkout pull/16143` \
`$ git pull https://git.openjdk.org/jdk.git pull/16143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16143`

View PR using the GUI difftool: \
`$ git pr show -t 16143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16143.diff">https://git.openjdk.org/jdk/pull/16143.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16143#issuecomment-1766260302)