### PR TITLE
8317808: HTTP/2 stream cancelImpl may leave subscriber registered

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpClientImpl.java
@@ -578,8 +578,9 @@ final class HttpClientImpl extends HttpClient implements Trackable {
                         if (debug.on()) {
                             debug.log("body subscriber registered: " + count);
                         }
+                        return true;
                     }
-                    return true;
+                    return false;
                 }
             } finally {
                 selmgr.unlock();

--- a/test/jdk/java/net/httpclient/ReferenceTracker.java
+++ b/test/jdk/java/net/httpclient/ReferenceTracker.java
@@ -115,6 +115,14 @@ public class ReferenceTracker {
                 "outstanding operations or unreleased resources", true);
     }
 
+    public AssertionError checkFinished(Tracker tracker, long graceDelayMs) {
+        Predicate<Tracker> hasOperations = (t) -> t.getOutstandingOperations() > 0;
+        Predicate<Tracker> hasSubscribers = (t) -> t.getOutstandingSubscribers() > 0;
+        return check(tracker, graceDelayMs,
+                hasOperations.or(hasSubscribers),
+                "outstanding operations or unreleased resources", false);
+    }
+
     public AssertionError check(long graceDelayMs) {
         Predicate<Tracker> hasOperations = (t) -> t.getOutstandingOperations() > 0;
         Predicate<Tracker> hasSubscribers = (t) -> t.getOutstandingSubscribers() > 0;


### PR DESCRIPTION
Some of the ThrowingSubscriberXxx tests (typically those that use a streaming body) have been observed failing intermittently (though rarely) in timeout. The error message printed at the end showed that some HTTP/2 stream subscribers had not been properly deregistered when an exception was thrown in GET_BODY.

The issue appears to be a race condition between `cancelImpl` and `schedule` where the scheduler `sched` may get stopped before the subscriber is exceptionally completed.

A simple fix is to ensure that `cancelImpl` will complete the subscriber, if needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317808](https://bugs.openjdk.org/browse/JDK-8317808): HTTP/2 stream cancelImpl may leave subscriber registered (**Bug** - P4)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16144/head:pull/16144` \
`$ git checkout pull/16144`

Update a local copy of the PR: \
`$ git checkout pull/16144` \
`$ git pull https://git.openjdk.org/jdk.git pull/16144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16144`

View PR using the GUI difftool: \
`$ git pr show -t 16144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16144.diff">https://git.openjdk.org/jdk/pull/16144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16144#issuecomment-1757364166)