### PR TITLE
JDK-8317919: pthread_attr_init handle return value and destroy pthread_attr_t object

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -769,7 +769,8 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
 
   // Init thread attributes.
   pthread_attr_t attr;
-  pthread_attr_init(&attr);
+  int rslt = pthread_attr_init(&attr);
+  guarantee(rslt == 0, "pthread_attr_init has to return 0");
   guarantee(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) == 0, "???");
 
   // Make sure we run in 1:1 kernel-user-thread mode.
@@ -803,6 +804,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
                             stack_size / K);
     thread->set_osthread(nullptr);
     delete osthread;
+    pthread_attr_destroy(&attr);
     return false;
   }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -911,7 +911,12 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
 
   // init thread attributes
   pthread_attr_t attr;
-  pthread_attr_init(&attr);
+  int rslt = pthread_attr_init(&attr);
+  if (rslt != 0) {
+    thread->set_osthread(nullptr);
+    delete osthread;
+    return false;
+  }
   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
   // Calculate stack size if it's not specified by caller.
@@ -960,6 +965,7 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
                             stack_size / K);
     thread->set_osthread(nullptr);
     delete osthread;
+    pthread_attr_destroy(&attr);
     return false;
   }
 

--- a/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
+++ b/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
@@ -273,8 +273,10 @@ SplashCreateThread(Splash * splash) {
     pthread_attr_t attr;
     int rc;
 
-    pthread_attr_init(&attr);
+    int rslt = pthread_attr_init(&attr);
+    if (rslt != 0) return;
     rc = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    pthread_attr_destroy(&attr);
 }
 
 void

--- a/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
+++ b/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
@@ -773,8 +773,10 @@ SplashCreateThread(Splash * splash) {
     pthread_attr_t attr;
     int rc;
 
-    pthread_attr_init(&attr);
+    int rslt = pthread_attr_init(&attr);
+    if (rslt != 0) return;
     rc = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    pthread_attr_destroy(&attr);
 }
 
 void


### PR DESCRIPTION
Seems we miss on AIX and Linux the handling of pthread_attr_init return value and sometimes in special cases destroying the related pthread_attr_t object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317919](https://bugs.openjdk.org/browse/JDK-8317919): pthread_attr_init handle return value and destroy pthread_attr_t object (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [2861da45](https://git.openjdk.org/jdk/pull/16147/files/2861da45c492ec5ad348a563bfaa5b002b4c46af)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16147/head:pull/16147` \
`$ git checkout pull/16147`

Update a local copy of the PR: \
`$ git checkout pull/16147` \
`$ git pull https://git.openjdk.org/jdk.git pull/16147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16147`

View PR using the GUI difftool: \
`$ git pr show -t 16147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16147.diff">https://git.openjdk.org/jdk/pull/16147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16147#issuecomment-1757539433)