### PR TITLE
8317956: Make jdk.internal.util.Architecture current architecture final

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Architecture.java
+++ b/src/java.base/share/classes/jdk/internal/util/Architecture.java
@@ -114,7 +114,7 @@ public enum Architecture {
     }
 
     // Initialize the architecture by mapping aliases and names to the enum values.
-    private static Architecture CURRENT_ARCH = initArch(PlatformProps.CURRENT_ARCH_STRING);
+    private static final Architecture CURRENT_ARCH = initArch(PlatformProps.CURRENT_ARCH_STRING);
 
     /**
      * {@return {@code true} if the current architecture is X64, Aka amd64}


### PR DESCRIPTION
The static for the current architecture should be final to allow some optimizations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317956](https://bugs.openjdk.org/browse/JDK-8317956): Make jdk.internal.util.Architecture current architecture final (**Bug** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - Committer)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16150/head:pull/16150` \
`$ git checkout pull/16150`

Update a local copy of the PR: \
`$ git checkout pull/16150` \
`$ git pull https://git.openjdk.org/jdk.git pull/16150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16150`

View PR using the GUI difftool: \
`$ git pr show -t 16150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16150.diff">https://git.openjdk.org/jdk/pull/16150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16150#issuecomment-1757713165)