### PR TITLE
JDK-8038244: (fs) Check return value of malloc in Java_sun_nio_fs_AixNativeDispatcher_getmntctl()

### DIFF
--- a/src/java.base/aix/native/libnio/fs/AixNativeDispatcher.c
+++ b/src/java.base/aix/native/libnio/fs/AixNativeDispatcher.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,10 @@ Java_sun_nio_fs_AixNativeDispatcher_getmntctl(JNIEnv* env, jclass this)
         }
         buffer_size *= 8;
         buffer = malloc(buffer_size);
+        if (buffer == NULL) {
+            throwUnixException(env, errno);
+            return NULL;
+        }
         must_free_buf = 1;
     }
     /* Treat zero entries like errors. */


### PR DESCRIPTION
There's a call to malloc() in Java_sun_nio_fs_AixNativeDispatcher_getmntctl() where we don't check for a potentially NULL return value (i.e. out of memory).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8038244](https://bugs.openjdk.org/browse/JDK-8038244): (fs) Check return value of malloc in Java_sun_nio_fs_AixNativeDispatcher_getmntctl() (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16151/head:pull/16151` \
`$ git checkout pull/16151`

Update a local copy of the PR: \
`$ git checkout pull/16151` \
`$ git pull https://git.openjdk.org/jdk.git pull/16151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16151`

View PR using the GUI difftool: \
`$ git pr show -t 16151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16151.diff">https://git.openjdk.org/jdk/pull/16151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16151#issuecomment-1757727656)