### PR TITLE
8317266: Move nmethod::check_all_dependencies to codeCache.cpp and mark it NOT_PRODUCT

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1251,6 +1251,54 @@ void CodeCache::cleanup_inline_caches_whitebox() {
 // Keeps track of time spent for checking dependencies
 NOT_PRODUCT(static elapsedTimer dependentCheckTime;)
 
+#ifndef PRODUCT
+// Check if any of live methods dependencies have been invalidated.
+// (this is expensive!)
+static void check_live_nmethods_dependencies(DepChange& changes) {
+  // Checked dependencies are allocated into this ResourceMark
+  ResourceMark rm;
+
+  // Turn off dependency tracing while actually testing dependencies.
+  FlagSetting fs(Dependencies::_verify_in_progress, true);
+
+  typedef ResourceHashtable<DependencySignature, int, 11027,
+                            AnyObj::RESOURCE_AREA, mtInternal,
+                            &DependencySignature::hash,
+                            &DependencySignature::equals> DepTable;
+
+  DepTable* table = new DepTable();
+
+  // Iterate over live nmethods and check dependencies of all nmethods that are not
+  // marked for deoptimization. A particular dependency is only checked once.
+  NMethodIterator iter(NMethodIterator::only_not_unloading);
+  while(iter.next()) {
+    nmethod* nm = iter.method();
+    // Only notify for live nmethods
+    if (!nm->is_marked_for_deoptimization()) {
+      for (Dependencies::DepStream deps(nm); deps.next(); ) {
+        // Construct abstraction of a dependency.
+        DependencySignature* current_sig = new DependencySignature(deps);
+
+        // Determine if dependency is already checked. table->put(...) returns
+        // 'true' if the dependency is added (i.e., was not in the hashtable).
+        if (table->put(*current_sig, 1)) {
+          if (deps.check_dependency() != nullptr) {
+            // Dependency checking failed. Print out information about the failed
+            // dependency and finally fail with an assert. We can fail here, since
+            // dependency checking is never done in a product build.
+            tty->print_cr("Failed dependency:");
+            changes.print();
+            nm->print();
+            nm->print_dependencies_on(tty);
+            assert(false, "Should have been marked for deoptimization");
+          }
+        }
+      }
+    }
+  }
+}
+#endif
+
 void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, KlassDepChange& changes) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
@@ -1272,7 +1320,7 @@ void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, KlassD
     // Object pointers are used as unique identifiers for dependency arguments. This
     // is only possible if no safepoint, i.e., GC occurs during the verification code.
     dependentCheckTime.start();
-    nmethod::check_all_dependencies(changes);
+    check_live_nmethods_dependencies(changes);
     dependentCheckTime.stop();
   }
 #endif

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -677,10 +677,6 @@ public:
   virtual int compile_id() const { return _compile_id; }
   const char* compile_kind() const;
 
-  // tells if any of this method's dependencies have been invalidated
-  // (this is expensive!)
-  static void check_all_dependencies(DepChange& changes);
-
   // tells if this compiled method is dependent on the given changes,
   // and the changes have invalidated it
   bool check_dependency_on(DepChange& changes);


### PR DESCRIPTION
`nmethod::check_all_dependencies` goes over live nmethods and checks if any of nmethod's dependencies have been invalidated. It is public static and does not use any private/protected members of nmethod. There are no other uses of `nmethod::check_all_dependencies` but in `CodeCache::mark_for_deoptimization` of codeCache.cpp. The use is in NOT_PRODUCT code. The function has not-product code which disables logging dependencies. In a release build, the code will not be available and there will be significant performance impact. See https://bugs.openjdk.org/browse/JDK-7194669 for details.

As the function is only used in debug builds, depends on not-product code, does not use any specifics of nmethods and has only one use, it is reasonable to move it to codeCache.cpp and to make it a standalone static function guarded by `#ifndef PRODUCT`

Tested with fastdebug and release builds:
- [x] gtest
- [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8317266](https://bugs.openjdk.org/browse/JDK-8317266): Move nmethod::check_all_dependencies to codeCache.cpp and mark it NOT_PRODUCT (**Enhancement** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16152/head:pull/16152` \
`$ git checkout pull/16152`

Update a local copy of the PR: \
`$ git checkout pull/16152` \
`$ git pull https://git.openjdk.org/jdk.git pull/16152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16152`

View PR using the GUI difftool: \
`$ git pr show -t 16152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16152.diff">https://git.openjdk.org/jdk/pull/16152.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16152#issuecomment-1757804790)