### PR TITLE
8317963: Serial: Remove unused GenerationIsInReservedClosure

### DIFF
--- a/src/hotspot/share/gc/serial/generation.cpp
+++ b/src/hotspot/share/gc/serial/generation.cpp
@@ -94,18 +94,6 @@ void Generation::print_summary_info_on(outputStream* st) {
 
 // Utility iterator classes
 
-class GenerationIsInReservedClosure : public SpaceClosure {
- public:
-  const void* _p;
-  Space* sp;
-  virtual void do_space(Space* s) {
-    if (sp == nullptr) {
-      if (s->is_in_reserved(_p)) sp = s;
-    }
-  }
-  GenerationIsInReservedClosure(const void* p) : _p(p), sp(nullptr) {}
-};
-
 class GenerationIsInClosure : public SpaceClosure {
  public:
   const void* _p;


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317963](https://bugs.openjdk.org/browse/JDK-8317963): Serial: Remove unused GenerationIsInReservedClosure (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16153/head:pull/16153` \
`$ git checkout pull/16153`

Update a local copy of the PR: \
`$ git checkout pull/16153` \
`$ git pull https://git.openjdk.org/jdk.git pull/16153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16153`

View PR using the GUI difftool: \
`$ git pr show -t 16153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16153.diff">https://git.openjdk.org/jdk/pull/16153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16153#issuecomment-1757969451)