### PR TITLE
8317967: Enhance test/jdk/javax/net/ssl/TLSCommon/SSLEngineTestCase.java to handle default cases

### DIFF
--- a/test/jdk/javax/net/ssl/TLSCommon/SSLEngineTestCase.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/SSLEngineTestCase.java
@@ -134,7 +134,7 @@ abstract public class SSLEngineTestCase {
      * e.g. "TLSv1", "TLSv1.1", "TLSv1.2", "DTLSv1.0", "DTLSv1.2".
      */
     public static final String TESTED_SECURITY_PROTOCOL
-            = System.getProperty("test.security.protocol", "TLS");
+            = System.getProperty("test.security.protocol");
     /**
      * Test mode: "norm", "norm_sni" or "krb".
      * Modes "norm" and "norm_sni" are used to run

--- a/test/jdk/javax/net/ssl/TLSCommon/SSLEngineTestCase.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/SSLEngineTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -738,13 +738,18 @@ abstract public class SSLEngineTestCase {
                     case "TLSv1.1":
                         runTests(Ciphers.SUPPORTED_NON_KRB_NON_SHA_CIPHERS);
                         break;
+                    case "DTLS":
                     case "DTLSv1.1":
+                    case "TLS":
                     case "TLSv1.2":
                         runTests(Ciphers.SUPPORTED_NON_KRB_CIPHERS);
                         break;
                     case "TLSv1.3":
                         runTests(Ciphers.TLS13_CIPHERS);
                         break;
+                    default:
+                        throw new Error("Test error: Unsupported test " +
+                                "security protocol: " + TESTED_SECURITY_PROTOCOL);
                 }
                 break;
             case "krb":

--- a/test/jdk/javax/net/ssl/TLSCommon/SSLEngineTestCase.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/SSLEngineTestCase.java
@@ -739,7 +739,7 @@ abstract public class SSLEngineTestCase {
                         runTests(Ciphers.SUPPORTED_NON_KRB_NON_SHA_CIPHERS);
                         break;
                     case "DTLS":
-                    case "DTLSv1.1":
+                    case "DTLSv1.2":
                     case "TLS":
                     case "TLSv1.2":
                         runTests(Ciphers.SUPPORTED_NON_KRB_CIPHERS);


### PR DESCRIPTION
Template is updated to handle default cases and will also throw an Error on not supported test protocols.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317967](https://bugs.openjdk.org/browse/JDK-8317967): Enhance test/jdk/javax/net/ssl/TLSCommon/SSLEngineTestCase.java to handle default cases (**Bug** - P2)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16156/head:pull/16156` \
`$ git checkout pull/16156`

Update a local copy of the PR: \
`$ git checkout pull/16156` \
`$ git pull https://git.openjdk.org/jdk.git pull/16156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16156`

View PR using the GUI difftool: \
`$ git pr show -t 16156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16156.diff">https://git.openjdk.org/jdk/pull/16156.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16156#issuecomment-1758230911)