### PR TITLE
8317977: update problemlist to include MacOS for sun/security/tools/keytool/NssTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -623,12 +623,12 @@ com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 
-sun/security/tools/keytool/NssTest.java                         8295343 linux-all
-sun/security/pkcs11/Signature/TestRSAKeyLength.java             8295343 linux-all
-sun/security/pkcs11/rsa/TestSignatures.java                     8295343 linux-all
-sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 linux-all
-sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 linux-all
-sun/security/pkcs11/KeyStore/Basic.java                         8295343 linux-all
+sun/security/tools/keytool/NssTest.java                         8295343 generic-all
+sun/security/pkcs11/Signature/TestRSAKeyLength.java             8295343 generic-all
+sun/security/pkcs11/rsa/TestSignatures.java                     8295343 generic-all
+sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 generic-all
+sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 generic-all
+sun/security/pkcs11/KeyStore/Basic.java                         8295343 generic-all
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183 linux-ppc64le
 
 ############################################################################


### PR DESCRIPTION
This test is now failing on MacOSX. Some of the other pkcs11 tests may also fail now, so I changed them all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317977](https://bugs.openjdk.org/browse/JDK-8317977): update problemlist to include MacOS for sun/security/tools/keytool/NssTest.java (**Bug** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16157/head:pull/16157` \
`$ git checkout pull/16157`

Update a local copy of the PR: \
`$ git checkout pull/16157` \
`$ git pull https://git.openjdk.org/jdk.git pull/16157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16157`

View PR using the GUI difftool: \
`$ git pr show -t 16157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16157.diff">https://git.openjdk.org/jdk/pull/16157.diff</a>

</details>
