### PR TITLE
8317975: [JVMCI] assert(pointee != nullptr) failed: invariant

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2436,6 +2436,16 @@ C2V_VMENTRY_0(jint, arrayIndexScale, (JNIEnv* env, jobject, jchar type_char))
   return type2aelembytes(type);
 C2V_END
 
+C2V_VMENTRY(void, clearOopHandle, (JNIEnv* env, jobject, jlong oop_handle))
+  if (oop_handle == 0L) {
+    JVMCI_THROW(NullPointerException);
+  }
+  // Assert before nulling out, for better debugging.
+  assert(JVMCIRuntime::is_oop_handle(oop_handle), "precondition");
+  oop* oop_ptr = (oop*) oop_handle;
+  NativeAccess<>::oop_store(oop_ptr, (oop) nullptr);
+C2V_END
+
 C2V_VMENTRY(void, releaseClearedOopHandles, (JNIEnv* env, jobject))
   JVMCIENV->runtime()->release_cleared_oop_handles();
 C2V_END
@@ -3260,6 +3270,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "readArrayElement",                             CC "(" OBJECTCONSTANT "I)Ljava/lang/Object;",                                         FN_PTR(readArrayElement)},
   {CC "arrayBaseOffset",                              CC "(C)I",                                                                            FN_PTR(arrayBaseOffset)},
   {CC "arrayIndexScale",                              CC "(C)I",                                                                            FN_PTR(arrayIndexScale)},
+  {CC "clearOopHandle",                               CC "(J)V",                                                                            FN_PTR(clearOopHandle)},
   {CC "releaseClearedOopHandles",                     CC "()V",                                                                             FN_PTR(releaseClearedOopHandles)},
   {CC "registerNativeMethods",                        CC "(" CLASS ")[J",                                                                   FN_PTR(registerNativeMethods)},
   {CC "isCurrentThreadAttached",                      CC "()Z",                                                                             FN_PTR(isCurrentThreadAttached)},

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -887,6 +887,13 @@ jlong JVMCIRuntime::make_oop_handle(const Handle& obj) {
   return reinterpret_cast<jlong>(ptr);
 }
 
+#ifdef ASSERT
+bool JVMCIRuntime::is_oop_handle(jlong handle) {
+  const oop* ptr = (oop*) handle;
+  return object_handles()->allocation_status(ptr) == OopStorage::ALLOCATED_ENTRY;
+}
+#endif
+
 int JVMCIRuntime::release_and_clear_oop_handles() {
   guarantee(_num_attached_threads == cannot_be_attached, "only call during JVMCI runtime shutdown");
   int released = release_cleared_oop_handles();

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -317,11 +317,12 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // used when creating an IndirectHotSpotObjectConstantImpl in the
   // shared library JavaVM.
   jlong make_oop_handle(const Handle& obj);
+#ifdef ASSERT
+  static bool is_oop_handle(jlong handle);
+#endif
 
   // Releases all the non-null entries in _oop_handles whose referent is null.
   // Returns the number of handles released by this call.
-  // The method also resets _last_found_oop_handle_index to -1
-  // and _null_oop_handles to 0.
   int release_cleared_oop_handles();
 
   // Allocation and management of metadata handles.

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1301,6 +1301,11 @@ final class CompilerToVM {
     native boolean isTrustedForIntrinsics(HotSpotResolvedObjectTypeImpl klass, long klassPointer);
 
     /**
+     * Clears the oop handle in {@code handle}.
+     */
+    native void clearOopHandle(long handle);
+
+    /**
      * Releases all oop handles whose referent is null.
      */
     native void releaseClearedOopHandles();

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/IndirectHotSpotObjectConstantImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/IndirectHotSpotObjectConstantImpl.java
@@ -155,10 +155,11 @@ final class IndirectHotSpotObjectConstantImpl extends HotSpotObjectConstantImpl 
 
     /**
      * Sets the referent of {@code handle} to 0 so that it will be reclaimed when calling
-     * {@link CompilerToVM#releaseClearedOopHandles}.
+     * {@link CompilerToVM#releaseClearedOopHandles}. This must be done with a VM call so
+     * that the JNI handle is cleared at a safepoint.
      */
     static void clearHandle(long handle) {
-        UNSAFE.putLong(handle, 0);
+        runtime().compilerToVm.clearOopHandle(handle);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes the clearing of a JNI handle help by libjvmci such that it is done at a safepoint. This is achieved by making a VM call to do the clearing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317975](https://bugs.openjdk.org/browse/JDK-8317975): [JVMCI] assert(pointee != nullptr) failed: invariant (**Bug** - P3)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16158/head:pull/16158` \
`$ git checkout pull/16158`

Update a local copy of the PR: \
`$ git checkout pull/16158` \
`$ git pull https://git.openjdk.org/jdk.git pull/16158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16158`

View PR using the GUI difftool: \
`$ git pr show -t 16158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16158.diff">https://git.openjdk.org/jdk/pull/16158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16158#issuecomment-1761080528)