### PR TITLE
JDK-8317959: Check return values of malloc in native java.base coding

### DIFF
--- a/src/java.base/aix/native/libnio/MappedMemoryUtils.c
+++ b/src/java.base/aix/native/libnio/MappedMemoryUtils.c
@@ -158,6 +158,11 @@ static void check_aix_einval(JNIEnv* env, void* end_address)
     FILE* proc_file;
     {
         char* fname = (char*) malloc(sizeof(char) * PFNAME_LEN);
+        if (fname == NULL) {
+            JNU_ThrowOutOfMemoryError(env, NULL);
+            return;
+        }
+
         pid_t the_pid = getpid();
         jio_snprintf(fname, PFNAME_LEN, "/proc/%d/map", the_pid);
         proc_file = fopen(fname, "r");
@@ -170,6 +175,11 @@ static void check_aix_einval(JNIEnv* env, void* end_address)
     }
     {
         prmap_t* map_entry = (prmap_t*) malloc(sizeof(prmap_t));
+        if (map_entry == NULL) {
+            JNU_ThrowOutOfMemoryError(env, NULL);
+            fclose(proc_file);
+            return;
+        }
         check_proc_map_array(env, proc_file, map_entry, end_address);
         free(map_entry);
     }

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -238,6 +238,11 @@ static int ParseLocale(JNIEnv* env, int cat, char ** std_language, char ** std_s
         *std_language = "en";
         if (language != NULL && mapLookup(language_names, language, std_language) == 0) {
             *std_language = malloc(strlen(language)+1);
+            if (*std_language == NULL) {
+                free(encoding_variant);
+                JNU_ThrowOutOfMemoryError(env, NULL);
+                return 0;
+            }
             strcpy(*std_language, language);
         }
     }
@@ -246,6 +251,11 @@ static int ParseLocale(JNIEnv* env, int cat, char ** std_language, char ** std_s
     if (std_country != NULL && country != NULL) {
         if (mapLookup(country_names, country, std_country) == 0) {
             *std_country = malloc(strlen(country)+1);
+            if (*std_country == NULL) {
+                free(encoding_variant);
+                JNU_ThrowOutOfMemoryError(env, NULL);
+                return 0;
+            }
             strcpy(*std_country, country);
         }
     }

--- a/src/java.base/windows/native/libjli/cmdtoargs.c
+++ b/src/java.base/windows/native/libjli/cmdtoargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -324,6 +324,7 @@ public:
     bool check() {
         // "pgmname" rest of cmdline ie. pgmname + 2 double quotes + space + cmdline from windows
         char* cptr = (char*) malloc(strlen(argv[0]) + sizeof(char) * 3 + strlen(cmdline) + 1);
+        if (cptr == NULL) return false;
         _snprintf(cptr, MAX_PATH, "\"%s\" %s", argv[0], cmdline);
         JLI_CmdToArgs(cptr);
         free(cptr);

--- a/src/java.base/windows/native/libjli/cmdtoargs.c
+++ b/src/java.base/windows/native/libjli/cmdtoargs.c
@@ -324,7 +324,10 @@ public:
     bool check() {
         // "pgmname" rest of cmdline ie. pgmname + 2 double quotes + space + cmdline from windows
         char* cptr = (char*) malloc(strlen(argv[0]) + sizeof(char) * 3 + strlen(cmdline) + 1);
-        if (cptr == NULL) return false;
+        if (cptr == NULL) {
+            printf("*** cannot allocate memory\n");
+            doabort();
+        }
         _snprintf(cptr, MAX_PATH, "\"%s\" %s", argv[0], cmdline);
         JLI_CmdToArgs(cptr);
         free(cptr);

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -118,6 +118,9 @@ Java_sun_nio_ch_UnixDomainSockets_init(JNIEnv *env, jclass cl)
     if (result == SOCKET_ERROR) {
         if (GetLastError() == WSAENOBUFS) {
             infoPtr = (LPWSAPROTOCOL_INFOW)malloc(len);
+            if (infoPtr == NULL) {
+                return JNI_FALSE;
+            }
             result = WSAEnumProtocolsW(0, infoPtr, &len);
             if (result == SOCKET_ERROR) {
                 free(infoPtr);


### PR DESCRIPTION
There are a few remaining places in java.base where the return value NULL-check of malloc is missing. This should better be adjusted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317959](https://bugs.openjdk.org/browse/JDK-8317959): Check return values of malloc in native java.base coding (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16160/head:pull/16160` \
`$ git checkout pull/16160`

Update a local copy of the PR: \
`$ git checkout pull/16160` \
`$ git pull https://git.openjdk.org/jdk.git pull/16160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16160`

View PR using the GUI difftool: \
`$ git pr show -t 16160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16160.diff">https://git.openjdk.org/jdk/pull/16160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16160#issuecomment-1759139129)