### PR TITLE
JDK-8317987: C2 recompilations cause high memory footprint

### DIFF
--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -118,6 +118,7 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
   bool do_superword = UseSuperWord;
 
   while (!env->failing()) {
+    ResourceMark rm;
     // Attempt to compile while subsuming loads into machine instructions.
     Options options(subsume_loads,
                     do_escape_analysis,


### PR DESCRIPTION
While playing with the new compiler memory statistic (https://github.com/openjdk/jdk/pull/16076), I saw that +StressRecompile causes a twofold increase in memory used during compilations. 

#### Baseline: 

highest peak during compilation is ~60 MB, caused by compilation of `java/lang/invoke/LambdaForm$Kind::<clinit>` with ~18k nodes.

`./images/jdk/bin/java -XX:CompileCommand='collectmemstat,*.*' -XX:-StressRecompilation -Xcomp -Xbatch -cp $REPROS_JAR de.stuefe.repros.Simple`

```
total     NA        RA        #nodes  time    type  #rc thread              method
(3/1425)
59063K    13406K    40025K    18345   6,174   c2    2   0x00007fdc2c28e7b0  java/lang/invoke/LambdaForm$Kind::<clinit>(()V) 
```

#### +StressRecompile: 

highest peak during compilation is ~112 MB, same method, sameish node count.

`./images/jdk/bin/java -XX:CompileCommand='collectmemstat,*.*' -XX:+StressRecompilation -Xcomp -Xbatch -cp $REPROS_JAR de.stuefe.repros.Simple`

```
total     NA        RA        #nodes  time    type  #rc thread              method
(16/1434)
112M      13469K    94987K    18791   16,451  c2    2   0x00007f790428e7b0  java/lang/invoke/LambdaForm$Kind::<clinit>(()V) 

```
60M -> 112M. In both cases, a large part of the memory was allocated in resource areas. Its relative size compared to the total spike size increased. We accrue a lot of memory in ResourceArea over recompilations.

The solution is to wrap the `Compile` instantiation into a resource mark. Now we are at 61 MB, which is almost baseline:

```
total     NA        RA        #nodes  time    type  #rc thread              method
(3/1430)
61203K    13469K    40791K    18791   17,013  c2    2   0x00007fdf7428e7b0  java/lang/invoke/LambdaForm$Kind::<clinit>(()V) 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317987](https://bugs.openjdk.org/browse/JDK-8317987): C2 recompilations cause high memory footprint (**Bug** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16161/head:pull/16161` \
`$ git checkout pull/16161`

Update a local copy of the PR: \
`$ git checkout pull/16161` \
`$ git pull https://git.openjdk.org/jdk.git pull/16161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16161`

View PR using the GUI difftool: \
`$ git pr show -t 16161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16161.diff">https://git.openjdk.org/jdk/pull/16161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16161#issuecomment-1759688314)