### PR TITLE
8317998: Temporarily disable malformed control flow assert to reduce noise in testing

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4009,8 +4009,6 @@ bool Compile::final_graph_reshaping() {
 
       // Recheck with a better notion of 'required_outcnt'
       if (n->outcnt() != required_outcnt) {
-        DEBUG_ONLY( n->dump_bfs(1, 0, "-"); );
-        assert(false, "malformed control flow");
         record_method_not_compilable("malformed control flow");
         return true;            // Not all targets reachable!
       }


### PR DESCRIPTION
[JDK-8303951](https://bugs.openjdk.org/browse/JDK-8303951) added a "malformed control flow" assert before a harmless but unexpected compilation bailout in C2. It now triggers quite frequently (see [JDK-8308392](https://bugs.openjdk.org/browse/JDK-8308392) and linked bugs). Let's disable it temporarily to reduce noise in our testing. The issues can still be reproduced/investigated by checking for the corresponding compilation bailout.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317998](https://bugs.openjdk.org/browse/JDK-8317998): Temporarily disable malformed control flow assert to reduce noise in testing (**Sub-task** - P2)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16163/head:pull/16163` \
`$ git checkout pull/16163`

Update a local copy of the PR: \
`$ git checkout pull/16163` \
`$ git pull https://git.openjdk.org/jdk.git pull/16163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16163`

View PR using the GUI difftool: \
`$ git pr show -t 16163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16163.diff">https://git.openjdk.org/jdk/pull/16163.diff</a>

</details>
