### PR TITLE
8318015: Lock inflation not needed for OSR or Deopt for new locking modes

### DIFF
--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -66,7 +66,7 @@ void BasicLock::move_to(oop obj, BasicLock* dest) {
   // is small (given the support for inflated fast-path locking in the fast_lock, etc)
   // we'll leave that optimization for another time.
 
-  if (displaced_header().is_neutral()) {
+  if (LockingMode == LM_LEGACY && displaced_header().is_neutral()) {
     // The object is locked and the resulting ObjectMonitor* will also be
     // locked so it can't be async deflated until ownership is dropped.
     ObjectSynchronizer::inflate_helper(obj);

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3258,7 +3258,7 @@ JRT_LEAF(intptr_t*, SharedRuntime::OSR_migration_begin( JavaThread *current) )
     if (kptr2->obj() != nullptr) {         // Avoid 'holes' in the monitor array
       BasicLock *lock = kptr2->lock();
       // Inflate so the object's header no longer refers to the BasicLock.
-      if (lock->displaced_header().is_unlocked()) {
+      if (LockingMode == LM_LEGACY && lock->displaced_header().is_unlocked()) {
         // The object is locked and the resulting ObjectMonitor* will also be
         // locked so it can't be async deflated until ownership is dropped.
         // See the big comment in basicLock.cpp: BasicLock::move_to().


### PR DESCRIPTION
Only LockingMode "LM_LEGACY" requires inflation before lock transfers because it is the only one which uses stack addresses in the mark word.