### PR TITLE
8318028: Remove unused class="centered" from FocusCycle.svg

### DIFF
--- a/src/java.desktop/share/classes/java/awt/doc-files/FocusCycle.svg
+++ b/src/java.desktop/share/classes/java/awt/doc-files/FocusCycle.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,6 @@
     <text
             x="300"
             y="50"
-            class="centered"
     >A</text>
 
     <use


### PR DESCRIPTION
**Cleanup**

A trivial modification which removes `class="centered"` from one of the `<text>` elements. It's a remnant from a previous version of the image.

Classes aren't used, all `<text>` elements are centered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318028](https://bugs.openjdk.org/browse/JDK-8318028): Remove unused class="centered" from FocusCycle.svg (**Bug** - P5)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16168/head:pull/16168` \
`$ git checkout pull/16168`

Update a local copy of the PR: \
`$ git checkout pull/16168` \
`$ git pull https://git.openjdk.org/jdk.git pull/16168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16168`

View PR using the GUI difftool: \
`$ git pr show -t 16168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16168.diff">https://git.openjdk.org/jdk/pull/16168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16168#issuecomment-1760040309)