### PR TITLE
8266242: java/awt/GraphicsDevice/CheckDisplayModes.java failing on macOS 11 ARM

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -37,7 +37,7 @@
 
 static NSInteger architecture = -1;
 /*
- * Convert the mode string to the more convinient bits per pixel value
+ * Convert the mode string to the more convenient bits per pixel value
  */
 static int getBPPFromModeString(CFStringRef mode)
 {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -75,7 +75,6 @@ static BOOL isValidDisplayMode(CGDisplayModeRef mode) {
 
 static CFMutableArrayRef getAllValidDisplayModes(jint displayID){
     // CGDisplayCopyAllDisplayModes can return NULL if displayID is invalid
-
     CFArrayRef allModes = CGDisplayCopyAllDisplayModes(displayID, NULL);
     CFMutableArrayRef validModes = nil;
     if (allModes) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CGraphicsDevice.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,9 @@
 #define DEFAULT_DEVICE_HEIGHT 768
 #define DEFAULT_DEVICE_DPI 72
 
+static NSInteger architecture = -1;
 /*
- * Convert the mode string to the more convenient bits per pixel value
+ * Convert the mode string to the more convinient bits per pixel value
  */
 static int getBPPFromModeString(CFStringRef mode)
 {
@@ -58,12 +59,23 @@ static int getBPPFromModeString(CFStringRef mode)
     return 0;
 }
 
-static BOOL isValidDisplayMode(CGDisplayModeRef mode){
+static BOOL isValidDisplayMode(CGDisplayModeRef mode) {
+    // Workaround for apple bug FB13261205, since it only affects arm based macs
+    // and arm support started with macOS 11 ignore the workaround for previous versions
+    if (@available(macOS 11, *)) {
+        if (architecture == -1) {
+            architecture = [[NSRunningApplication currentApplication] executableArchitecture];
+        }
+        if (architecture == NSBundleExecutableArchitectureARM64) {
+            return (CGDisplayModeGetPixelWidth(mode) >= 800);
+        }
+    }
     return (1 < CGDisplayModeGetWidth(mode) && 1 < CGDisplayModeGetHeight(mode));
 }
 
 static CFMutableArrayRef getAllValidDisplayModes(jint displayID){
     // CGDisplayCopyAllDisplayModes can return NULL if displayID is invalid
+
     CFArrayRef allModes = CGDisplayCopyAllDisplayModes(displayID, NULL);
     CFMutableArrayRef validModes = nil;
     if (allModes) {

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -462,7 +462,6 @@ java/awt/KeyboardFocusmanager/TypeAhead/MenuItemActivatedTest/MenuItemActivatedT
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
 java/awt/dnd/BadSerializationTest/BadSerializationTest.java 8277817 linux-x64,windows-x64
-java/awt/GraphicsDevice/CheckDisplayModes.java 8266242 macosx-aarch64
 java/awt/GraphicsDevice/DisplayModes/UnknownRefrshRateTest.java 8286436 macosx-aarch64
 java/awt/image/multiresolution/MultiresolutionIconTest.java 8291979 linux-x64,windows-all
 java/awt/event/SequencedEvent/MultipleContextsFunctionalTest.java 8305061 macosx-x64


### PR DESCRIPTION
As a workaround changing the method that filters out valid resolutions to not allow resolutions unsupported by Apple m1/m2 chips to be reported back to Java side.

Also removing test from problem list as it should pass again now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8266242](https://bugs.openjdk.org/browse/JDK-8266242): java/awt/GraphicsDevice/CheckDisplayModes.java failing on macOS 11 ARM (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16169/head:pull/16169` \
`$ git checkout pull/16169`

Update a local copy of the PR: \
`$ git checkout pull/16169` \
`$ git pull https://git.openjdk.org/jdk.git pull/16169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16169`

View PR using the GUI difftool: \
`$ git pr show -t 16169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16169.diff">https://git.openjdk.org/jdk/pull/16169.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16169#issuecomment-1760112024)