### PR TITLE
8312527: (ch) Re-examine use of sun.nio.ch.Invoker.myGroupAndInvokeCount

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/Invoker.java
+++ b/src/java.base/share/classes/sun/nio/ch/Invoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,12 +70,8 @@ class Invoker {
             handlerInvokeCount++;
         }
     }
-    private static final ThreadLocal<GroupAndInvokeCount> myGroupAndInvokeCount =
-        new ThreadLocal<GroupAndInvokeCount>() {
-            @Override protected GroupAndInvokeCount initialValue() {
-                return null;
-            }
-        };
+    private static final ThreadLocal<GroupAndInvokeCount> myGroupAndInvokeCount
+        = new ThreadLocal<GroupAndInvokeCount>();
 
     /**
      * Binds this thread to the given group


### PR DESCRIPTION
Initialize private static local variable `myGroupAndInvokeCount` to a `ThreadLocal` instead of to an anonymous class effectively identical to `ThreadLocal`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312527](https://bugs.openjdk.org/browse/JDK-8312527): (ch) Re-examine use of sun.nio.ch.Invoker.myGroupAndInvokeCount (**Bug** - P5)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16170/head:pull/16170` \
`$ git checkout pull/16170`

Update a local copy of the PR: \
`$ git checkout pull/16170` \
`$ git pull https://git.openjdk.org/jdk.git pull/16170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16170`

View PR using the GUI difftool: \
`$ git pr show -t 16170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16170.diff">https://git.openjdk.org/jdk/pull/16170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16170#issuecomment-1760237990)