### PR TITLE
8318038: ProblemList runtime/CompressedOops/CompressedClassPointers.java on two platforms

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -110,6 +110,8 @@ applications/jcstress/copy.java 8229852 linux-all
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-all
 
+runtime/CompressedOops/CompressedClassPointers.java 8317610 linux-x64,windows-x64
+
 #############################################################################
 
 # :hotspot_serviceability

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -175,3 +175,5 @@ vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 
 vmTestbase/nsk/monitoring/ThreadMXBean/ThreadInfo/Multi/Multi005/TestDescription.java 8076494 windows-x64
+
+vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/TestDescription.java 8310144 macosx-aarch64

--- a/test/jdk/ProblemList-generational-zgc.txt
+++ b/test/jdk/ProblemList-generational-zgc.txt
@@ -39,3 +39,4 @@ sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8307393   generic-all
 
 com/sun/jdi/ThreadMemoryLeakTest.java          8307402 generic-all
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8309218 generic-all
+java/nio/channels/vthread/BlockingChannelOps.java#direct-register 8315544 windows-x64


### PR DESCRIPTION
Trivial ProblemListing for some tests:

[JDK-8318038](https://bugs.openjdk.org/browse/JDK-8318038) ProblemList runtime/CompressedOops/CompressedClassPointers.java on two platforms
[JDK-8318040](https://bugs.openjdk.org/browse/JDK-8318040) ProblemList vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/TestDescription.java on macosx-aarch64
[JDK-8318042](https://bugs.openjdk.org/browse/JDK-8318042) ProblemList java/nio/channels/vthread/BlockingChannelOps.java#direct-register with GenZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8318038](https://bugs.openjdk.org/browse/JDK-8318038): ProblemList runtime/CompressedOops/CompressedClassPointers.java on two platforms (**Sub-task** - P3)
 * [JDK-8318040](https://bugs.openjdk.org/browse/JDK-8318040): ProblemList vmTestbase/nsk/monitoring/ThreadMXBean/findMonitorDeadlockedThreads/find006/TestDescription.java on macosx-aarch64 (**Sub-task** - P4)
 * [JDK-8318042](https://bugs.openjdk.org/browse/JDK-8318042): ProblemList java/nio/channels/vthread/BlockingChannelOps.java#direct-register with GenZGC (**Sub-task** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16172/head:pull/16172` \
`$ git checkout pull/16172`

Update a local copy of the PR: \
`$ git checkout pull/16172` \
`$ git pull https://git.openjdk.org/jdk.git pull/16172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16172`

View PR using the GUI difftool: \
`$ git pr show -t 16172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16172.diff">https://git.openjdk.org/jdk/pull/16172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16172#issuecomment-1760272998)