### PR TITLE
JDK-8272337: Refactor LocaleProvidersRun tests

### DIFF
--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 6336885 7196799 7197573 7198834 8000245 8000615 8001440 8008577
  *      8010666 8013086 8013233 8013903 8015960 8028771 8054482 8062006
  *      8150432 8215913 8220227 8228465 8232871 8232860 8236495 8245241
- *      8246721 8248695 8257964 8261919
+ *      8246721 8248695 8257964 8261919 8268379
  * @summary tests for "java.locale.providers" system property
  * @library /test/lib
  * @build LocaleProviders
@@ -34,42 +34,80 @@
  *        providersrc.spi.src.tznp8013086
  * @modules java.base/sun.util.locale
  *          java.base/sun.util.locale.provider
- * @run main/othervm -Djdk.lang.Process.allowAmbiguousCommands=false LocaleProvidersRun
+ * @run junit/othervm -Djdk.lang.Process.allowAmbiguousCommands=false LocaleProvidersRun
  */
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import jdk.test.lib.JDKToolLauncher;
-import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
 
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/*
+ * This class serves as a test runner that launches LocaleProvider related
+ * tests with a new JVM, so that different providers can be set at the command line.
+ * To add a new test, add the method implementation to LocaleProviders,
+ * then add a test to this class which simply invokes the actual test method.
+ * As this test has shown to cause intermittent issues, each test method is set with
+ * a timeout of 10 seconds, so that the test class itself can recover if a test
+ * method times out.
+ */
+@Timeout(10)
 public class LocaleProvidersRun {
-    public static void main(String[] args) throws Throwable {
-        //get the platform default locales
-        Locale platDefLoc = Locale.getDefault(Locale.Category.DISPLAY);
-        String defLang = platDefLoc.getLanguage();
-        String defCtry = platDefLoc.getCountry();
-        System.out.println("DEFLANG = " + defLang);
-        System.out.println("DEFCTRY = " + defCtry);
 
-        Locale platDefFormat = Locale.getDefault(Locale.Category.FORMAT);
-        String defFmtLang = platDefFormat.getLanguage();
-        String defFmtCtry = platDefFormat.getCountry();
-        System.out.println("DEFFMTLANG = " + defFmtLang);
-        System.out.println("DEFFMTCTRY = " + defFmtCtry);
+    // Locale DISPLAY values
+    private static String defLang;
+    private static String defCtry;
+    // Locale FORMAT values
+    private static String defFmtLang;
+    private static String defFmtCtry;
 
-        //Run Test
-        //testing HOST is selected for the default locale,
+    // Store the language and country of the Locale.Category.DISPLAY and FORMAT,
+    // which are used in various data providers.
+    @BeforeAll
+    static void getLocaleValues() {
+        var platDefLoc = Locale.getDefault(Locale.Category.DISPLAY);
+        defLang = platDefLoc.getLanguage();
+        defCtry = platDefLoc.getCountry();
+        var platDefFormat = Locale.getDefault(Locale.Category.FORMAT);
+        defFmtLang = platDefFormat.getLanguage();
+        defFmtCtry = platDefFormat.getCountry();
+    }
+
+
+    // Ensure that the correct adapter can be loaded when expected
+    @ParameterizedTest
+    @MethodSource
+    public void adapterTest(String provider, String testName,
+                            String param1, String param2, String param3) {
+            launchTest(provider, testName, param1, param2, param3);
+    }
+
+    // Variety of different ordered locale providers/fallbacks to ensure
+    // the adapters are well tested and are correctly returned
+    static Arguments[] adapterTest() {
+        // Run Test
+        // testing HOST is selected for the default locale,
         // if specified on Windows or MacOSX
         String osName = System.getProperty("os.name");
         String param1 = "JRE";
-        if(osName.startsWith("Windows") || osName.startsWith("Mac")) {
+        if (osName.startsWith("Windows") || osName.startsWith("Mac")) {
             param1 = "HOST";
         }
-        testRun("HOST,JRE", "adapterTest", param1, defLang, defCtry);
 
-        //testing HOST is NOT selected for the non-default locale, if specified
-        //Try to find the locale JRE supports which is not the platform default
+        // Testing HOST is NOT selected for the non-default locale, if specified
+        // Try to find the locale JRE supports which is not the platform default
         // (HOST supports that one)
         String param2;
         String param3;
@@ -83,119 +121,220 @@ public class LocaleProvidersRun {
             param2 = "zh";
             param3 = "CN";
         }
-        testRun("HOST,JRE", "adapterTest", "JRE", param2, param3);
+        return new Arguments[] {
+                arguments("HOST,JRE", "adapterTest", param1, defLang, defCtry),
+                arguments("HOST,JRE", "adapterTest", "JRE", param2, param3),
+                // Testing SPI is NOT selected, as there is none.
+                arguments("SPI,JRE", "adapterTest", "JRE", "en", "US"),
+                arguments("SPI,COMPAT", "adapterTest", "JRE", "en", "US"),
+                // Testing the order, variant #1. This assumes en_GB DateFormat data are
+                // available both in JRE & CLDR
+                arguments("CLDR,JRE", "adapterTest", "CLDR", "en", "GB"),
+                arguments("CLDR,COMPAT", "adapterTest", "CLDR", "en", "GB"),
+                // Testing the order, variant #2. This assumes en_GB DateFormat data are
+                // available both in JRE & CLDR
+                arguments("JRE,CLDR", "adapterTest", "JRE", "en", "GB"),
+                arguments("COMPAT,CLDR", "adapterTest", "JRE", "en", "GB"),
+                // Testing the order, variant #3 for non-existent locale in JRE
+                // assuming "haw" is not in JRE.
+                arguments("JRE,CLDR", "adapterTest", "CLDR", "haw", ""),
+                arguments("COMPAT,CLDR", "adapterTest", "CLDR", "haw", ""),
+                // Testing the order, variant #4 for the bug 7196799. CLDR's "zh" data
+                // should be used in "zh_CN"
+                arguments("CLDR", "adapterTest", "CLDR", "zh", "CN"),
+                // Testing FALLBACK provider. SPI and invalid one cases.
+                arguments("SPI", "adapterTest", "FALLBACK", "en", "US"),
+                arguments("FOO", "adapterTest", "CLDR", "en", "US"),
+                arguments("BAR,SPI", "adapterTest", "FALLBACK", "en", "US")
 
-        //testing SPI is NOT selected, as there is none.
-        testRun("SPI,JRE", "adapterTest", "JRE", "en", "US");
-        testRun("SPI,COMPAT", "adapterTest", "JRE", "en", "US");
-
-        //testing the order, variant #1. This assumes en_GB DateFormat data are
-        // available both in JRE & CLDR
-        testRun("CLDR,JRE", "adapterTest", "CLDR", "en", "GB");
-        testRun("CLDR,COMPAT", "adapterTest", "CLDR", "en", "GB");
-
-        //testing the order, variant #2. This assumes en_GB DateFormat data are
-        // available both in JRE & CLDR
-        testRun("JRE,CLDR", "adapterTest", "JRE", "en", "GB");
-        testRun("COMPAT,CLDR", "adapterTest", "JRE", "en", "GB");
-
-        //testing the order, variant #3 for non-existent locale in JRE
-        // assuming "haw" is not in JRE.
-        testRun("JRE,CLDR", "adapterTest", "CLDR", "haw", "");
-        testRun("COMPAT,CLDR", "adapterTest", "CLDR", "haw", "");
-
-        //testing the order, variant #4 for the bug 7196799. CLDR's "zh" data
-        // should be used in "zh_CN"
-        testRun("CLDR", "adapterTest", "CLDR", "zh", "CN");
-
-        //testing FALLBACK provider. SPI and invalid one cases.
-        testRun("SPI", "adapterTest", "FALLBACK", "en", "US");
-        testRun("FOO", "adapterTest", "CLDR", "en", "US");
-        testRun("BAR,SPI", "adapterTest", "FALLBACK", "en", "US");
-
-        //testing 7198834 fix.
-        testRun("HOST", "bug7198834Test", "", "", "");
-
-        //testing 8000245 fix.
-        testRun("JRE", "tzNameTest", "Europe/Moscow", "", "");
-        testRun("COMPAT", "tzNameTest", "Europe/Moscow", "", "");
-
-        //testing 8000615 fix.
-        testRun("JRE", "tzNameTest", "America/Los_Angeles", "", "");
-        testRun("COMPAT", "tzNameTest", "America/Los_Angeles", "", "");
-
-        //testing 8001440 fix.
-        testRun("CLDR", "bug8001440Test", "", "", "");
-
-        //testing 8010666 fix.
-        if (defLang.equals("en")) {
-            testRun("HOST", "bug8010666Test", "", "", "");
-        }
-
-        //testing 8013086 fix.
-        testRun("JRE,SPI", "bug8013086Test", "ja", "JP", "");
-        testRun("COMPAT,SPI", "bug8013086Test", "ja", "JP", "");
-
-        //testing 8013903 fix. (Windows only)
-        testRun("HOST,JRE", "bug8013903Test", "", "", "");
-        testRun("HOST", "bug8013903Test", "", "", "");
-        testRun("HOST,COMPAT", "bug8013903Test", "", "", "");
-
-        //testing 8027289 fix, if the platform format default is zh_CN
-        // this assumes Windows' currency symbol for zh_CN is \u00A5, the yen
-        // (yuan) sign.
-        if (defFmtLang.equals("zh") && defFmtCtry.equals("CN")) {
-            testRun("JRE,HOST", "bug8027289Test", "FFE5", "", "");
-            testRun("COMPAT,HOST", "bug8027289Test", "FFE5", "", "");
-            testRun("HOST", "bug8027289Test", "00A5", "", "");
-        }
-
-        //testing 8220227 fix. (Windows only)
-        if (!defLang.equals("en")) {
-            testRun("HOST", "bug8220227Test", "", "", "");
-        }
-
-        //testing 8228465 fix. (Windows only)
-        testRun("HOST", "bug8228465Test", "", "", "");
-
-        //testing 8232871 fix. (macOS only)
-        testRun("HOST", "bug8232871Test", "", "", "");
-
-        //testing 8232860 fix. (macOS/Windows only)
-        testRun("HOST", "bug8232860Test", "", "", "");
-
-        //testing 8245241 fix.
-        //jdk.lang.Process.allowAmbiguousCommands=false is needed for properly escaping
-        //double quotes in the string argument.
-        testRun("FOO", "bug8245241Test",
-            "Invalid locale provider adapter \"FOO\" ignored.", "", "");
-
-        //testing 8248695 fix.
-        testRun("HOST", "bug8248695Test", "", "", "");
-
-        //testing 8257964 fix. (macOS/Windows only)
-        testRun("HOST", "bug8257964Test", "", "", "");
+        };
     }
 
-    private static void testRun(String prefList, String methodName,
-            String param1, String param2, String param3) throws Throwable{
+    // Ensure the Windows HOST adapter is not appending extra spaces for date patterns
+    @Test
+    public void bug7198834Test() {
+        // Testing 7198834 fix.
+        launchTest("HOST", "bug7198834Test");
+    }
+
+    // Ensure TimeZoneNameProvider returns expected output
+    @ParameterizedTest
+    @MethodSource
+    public void tzNameTest(String provider, String testName, String param) {
+        launchTest(provider, testName, param);
+    }
+
+    // Various locale providers to test for correct timezone name
+    static Arguments[] tzNameTest() {
+        return new Arguments[]{
+                // Testing 8000245 fix.
+                arguments("JRE", "tzNameTest", "Europe/Moscow"),
+                arguments("COMPAT", "tzNameTest", "Europe/Moscow"),
+                // Testing 8000615 fix.
+                arguments("JRE", "tzNameTest", "America/Los_Angeles"),
+                arguments("COMPAT", "tzNameTest", "America/Los_Angeles")
+        };
+    }
+
+    // Ensure invalid number extension does not cause exception in NumberFormat.format()
+    @Test
+    public void bug8001440Test() {
+        // Testing 8001440 fix.
+        launchTest("CLDR", "bug8001440Test");
+    }
+
+    // Implement Currency/LocaleNameProvider in Windows Host LocaleProviderAdapter
+    @Test
+    public void bug8010666Test() {
+        // Testing 8010666 fix.
+        if (defLang.equals("en")) {
+            launchTest("HOST", "bug8010666Test");
+        }
+    }
+
+    // Ensure NPE not thrown by SimpleDateFormat.parse() with custom impl
+    // of TimeZoneNameProvider
+    @ParameterizedTest
+    @MethodSource
+    public void bug8013086Test(String provider, String param1, String param2) {
+        launchTest(provider, "bug8013086Test", param1, param2);
+    }
+
+    // Providers with SPI fallback, create Japanese locale
+    static Arguments[] bug8013086Test() {
+        return new Arguments[]{
+                // Testing 8013086 fix.
+                arguments("JRE,SPI", "ja", "JP"),
+                arguments("COMPAT,SPI", "ja", "JP")
+        };
+    }
+
+
+    // Ensure HOST Windows produces correct Japanese era, date, and month for SDfmt
+    @ParameterizedTest
+    @MethodSource
+    public void bug8013903Test(String provider) {
+        launchTest(provider, "bug8013903Test");
+    }
+
+    // Various providers/fallbacks
+    static Arguments[] bug8013903Test() {
+        return new Arguments[]{
+                // Testing 8013903 fix. (Windows only)
+                arguments("HOST"),
+                arguments("HOST, JRE"),
+                arguments("HOST, COMPAT")
+            };
+    }
+
+    // Ensure expected currency symbol for Window's zh_CN. Testing 8027289 fix.
+    @ParameterizedTest
+    @MethodSource
+    public void bug8027289Test(String provider, String param) {
+        if (defFmtLang.equals("zh") && defFmtCtry.equals("CN")) {
+            launchTest(provider, "bug8027289Test", param);
+        }
+    }
+
+    // Combos of locale providers and fallbacks with expected symbol
+    static Arguments[] bug8027289Test() {
+        // If the platform format default is zh_CN, this assumes Windows' currency
+        // symbol for zh_CN is \u00A5, the yen (yuan) sign.
+        return new Arguments[]{
+                arguments("JRE,HOST", "FFE5"),
+                arguments("COMPAT,HOST", "FFE5"),
+                arguments("HOST", "00A5")
+            };
+    }
+
+    // Ensure Locale.getDisplayCountry() does not throw error message
+    // for non-English Windows 10
+    @Test
+    public void bug8220227Test() {
+        // Testing 8220227 fix. (Windows only)
+        if (!defLang.equals("en")) {
+            launchTest("HOST", "bug8220227Test");
+        }
+    }
+
+    // Ensure correct hera name for GregorianCalendar with US locale
+    @Test
+    public void bug8228465Test() {
+        // Testing 8228465 fix. (Windows only)
+        launchTest("HOST", "bug8228465Test");
+    }
+
+    // Ensure Japanese returned for Host Locale Provider on Mac
+    @Test
+    public void bug8232871Test() {
+        // Testing 8232871 fix. (macOS only)
+        launchTest("HOST", "bug8232871Test");
+    }
+
+    // Ensure correctly formatted values for MessageFormat.format() under HOST
+    @Test
+    public void bug8232860Test() {
+        // Testing 8232860 fix. (macOS/Windows only)
+        launchTest("HOST", "bug8232860Test");
+    }
+
+    // Ensure that an incorrect locale provider is logged to user
+    @Test
+    public void bug8245241Test() {
+        // Testing 8245241 fix.
+        // jdk.lang.Process.allowAmbiguousCommands=false is needed for properly
+        // escaping double quotes in the string argument.
+        launchTest("FOO", "bug8245241Test",
+                "Invalid locale provider adapter \"FOO\" ignored.");
+    }
+
+    // Ensure HostLocaleProviderAdapterImpl provides correct date-only
+    @Test
+    public void bug8248695Test() {
+        // Testing 8248695 fix.
+        launchTest("HOST", "bug8248695Test");
+    }
+
+    // Tests that Calendar.getMinimalDaysInFirstWeek works for HOST
+    @Test
+    public void bug8257964Test() {
+        // Testing 8257964 fix. (macOS/Windows only)
+        launchTest("HOST", "bug8257964Test");
+    }
+
+    /*
+     * Launches a test in a new JVM which can be any method found in LocaleProviders.
+     * These tests have access to sun.util.locale.provider and are passed the
+     * desired locale provider(s) (e.g. "HOST").
+     */
+    private static void launchTest(String providers, String methodName, String... params) {
+        System.out.printf("$$$ Launching test LocaleProviders::%s, with Djava.locale.providers=%s," +
+                " and params:%s $$$%n", methodName, providers, Arrays.toString(params));
+
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
+        launcher.addToolArg("-ea") // Enable assertions
+                .addToolArg("-esa") // Enable system assertions
                 .addToolArg("-cp")
                 .addToolArg(Utils.TEST_CLASS_PATH)
+                // Used for bug 8245241
                 .addToolArg("-Djava.util.logging.config.class=LocaleProviders$LogConfig")
-                .addToolArg("-Djava.locale.providers=" + prefList)
+                .addToolArg("-Djava.locale.providers=" + providers)
                 .addToolArg("--add-exports=java.base/sun.util.locale.provider=ALL-UNNAMED")
                 .addToolArg("LocaleProviders")
-                .addToolArg(methodName)
-                .addToolArg(param1)
-                .addToolArg(param2)
-                .addToolArg(param3);
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                .getExitValue();
-        if (exitCode != 0) {
-            throw new RuntimeException("Unexpected exit code: " + exitCode);
+                .addToolArg(methodName);
+
+        // Add parameters if required by the desired test method
+        for (String param : params) {
+            launcher.addToolArg(param);
+        }
+
+        // Launch the test
+        try {
+            int exitCode = ProcessTools.executeCommand(launcher.getCommand())
+                    .getExitValue();
+            assertEquals(0, exitCode, "Unexpected exit code: " + exitCode);
+        } catch (Throwable t) {
+            throw new RuntimeException("Launched test failed with: "+ t);
         }
     }
 }


### PR DESCRIPTION
This change splits up the intermittently failing test `LocaleProvidersRun` into multiple test methods, as opposed to all the tests ran under main, to prevent the 1920 second time out.

This way, if a launched test method from `LocaleProviders` times out, the rest of the tests can continue with execution. As the entire test class completes under 3 seconds, each test method is given 10 seconds before being considered as a timeout and failing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272337](https://bugs.openjdk.org/browse/JDK-8272337): Refactor LocaleProvidersRun tests (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16173/head:pull/16173` \
`$ git checkout pull/16173`

Update a local copy of the PR: \
`$ git checkout pull/16173` \
`$ git pull https://git.openjdk.org/jdk.git pull/16173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16173`

View PR using the GUI difftool: \
`$ git pr show -t 16173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16173.diff">https://git.openjdk.org/jdk/pull/16173.diff</a>

</details>
