### PR TITLE
JDK-8317285: Misspellings in hprof test lib

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
@@ -261,7 +261,7 @@ public class VThreadInHeapDump {
     private static List<Root> findStackRoot(List<Root> roots, ThreadObject thread) {
         List<Root> result = new ArrayList<>();
         for (Root root: roots) {
-            if (root.getRefererId() == thread.getId()) {
+            if (root.getReferrerId() == thread.getId()) {
                 result.add(root);
             }
         }
@@ -286,7 +286,7 @@ public class VThreadInHeapDump {
             throw new RuntimeException("No root for " + className + " instance");
         }
         log("  root: " + root.getDescription());
-        JavaHeapObject referrer = root.getReferer();
+        JavaHeapObject referrer = root.getReferrer();
         log("  referrer: " + referrer);
     }
 

--- a/test/lib/jdk/test/lib/hprof/model/Root.java
+++ b/test/lib/jdk/test/lib/hprof/model/Root.java
@@ -46,11 +46,11 @@ import jdk.test.lib.hprof.util.Misc;
 public class Root {
 
     private long id;            // ID of the JavaThing we refer to
-    private long refererId;     // Thread or Class responsible for this, or 0
-    private int index = -1;             // Index in Snapshot.roots
+    private long referrerId;    // Thread or Class responsible for this, or 0
+    private int index = -1;     // Index in Snapshot.roots
     private int type;
     private String description;
-    private JavaHeapObject referer = null;
+    private JavaHeapObject referrer = null;
     private StackTrace stackTrace = null;
 
     // Values for type.  Higher values are more interesting -- see getType().
@@ -68,15 +68,15 @@ public class Root {
     public final static int JAVA_STATIC = 9;
 
 
-    public Root(long id, long refererId, int type, String description) {
-        this(id, refererId, type, description, null);
+    public Root(long id, long referrerId, int type, String description) {
+        this(id, referrerId, type, description, null);
     }
 
 
-    public Root(long id, long refererId, int type, String description,
+    public Root(long id, long referrerId, int type, String description,
                 StackTrace stackTrace) {
         this.id = id;
-        this.refererId = refererId;
+        this.referrerId = referrerId;
         this.type = type;
         this.description = description;
         this.stackTrace = stackTrace;
@@ -137,12 +137,12 @@ public class Root {
      * Get the object that's responsible for this root, if there is one.
      * This will be null, a Thread object, or a Class object.
      */
-    public JavaHeapObject getReferer() {
-        return referer;
+    public JavaHeapObject getReferrer() {
+        return referrer;
     }
 
-    public long getRefererId() {
-        return refererId;
+    public long getReferrerId() {
+        return referrerId;
     }
 
     /**
@@ -161,8 +161,8 @@ public class Root {
     }
 
     void resolve(Snapshot ss) {
-        if (refererId != 0) {
-            referer = ss.findThing(refererId);
+        if (referrerId != 0) {
+            referrer = ss.findThing(referrerId);
         }
         if (stackTrace != null) {
             stackTrace.resolve(ss);

--- a/test/lib/jdk/test/lib/hprof/model/Snapshot.java
+++ b/test/lib/jdk/test/lib/hprof/model/Snapshot.java
@@ -300,7 +300,7 @@ public class Snapshot implements AutoCloseable {
         }
         int count = 0;
         for (JavaHeapObject t : heapObjects.values()) {
-            t.setupReferers();
+            t.setupReferrers();
             ++count;
             if (calculateRefs && count % DOT_LIMIT == 0) {
                 System.out.print(".");
@@ -461,11 +461,11 @@ public class Snapshot implements AutoCloseable {
             if (curr.getRoot() != null) {
                 result.addElement(chain);
                 // Even though curr is in the rootset, we want to explore its
-                // referers, because they might be more interesting.
+                // referrers, because they might be more interesting.
             }
-            Enumeration<JavaThing> referers = curr.getReferers();
-            while (referers.hasMoreElements()) {
-                JavaHeapObject t = (JavaHeapObject) referers.nextElement();
+            Enumeration<JavaThing> referrers = curr.getReferrers();
+            while (referrers.hasMoreElements()) {
+                JavaHeapObject t = (JavaHeapObject)referrers.nextElement();
                 if (t != null && !visited.containsKey(t)) {
                     if (includeWeak || !t.refersOnlyWeaklyTo(this, curr)) {
                         visited.put(t, t);


### PR DESCRIPTION
The change fixes misspelled "referer" in test/lib/jdk/test/lib/hprof library
The only caller of changed public API is VThreadInHeapDump.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317285](https://bugs.openjdk.org/browse/JDK-8317285): Misspellings in hprof test lib (**Bug** - P5)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16174/head:pull/16174` \
`$ git checkout pull/16174`

Update a local copy of the PR: \
`$ git checkout pull/16174` \
`$ git pull https://git.openjdk.org/jdk.git pull/16174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16174`

View PR using the GUI difftool: \
`$ git pr show -t 16174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16174.diff">https://git.openjdk.org/jdk/pull/16174.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16174#issuecomment-1760629015)