### PR TITLE
8318058: Notify the jvm when the direct memory is oom

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -468,6 +468,12 @@ UNSAFE_LEAF (void, Unsafe_WriteBackPostSync0(JNIEnv *env, jobject unsafe)) {
   doWriteBackSync0(false);
 } UNSAFE_END
 
+
+UNSAFE_LEAF (void, Unsafe_ReportJavaOutOfMemory0(JNIEnv *env, jobject unsafe,jstring message)) {
+        char *utf_message = java_lang_String::as_utf8_string(JNIHandles::resolve_non_null(message));
+        report_java_out_of_memory(utf_message);
+} UNSAFE_END
+
 ////// Random queries
 
 static jlong find_field_offset(jclass clazz, jstring name, TRAPS) {
@@ -904,6 +910,7 @@ static JNINativeMethod jdk_internal_misc_Unsafe_methods[] = {
     {CC "shouldBeInitialized0", CC "(" CLS ")Z",         FN_PTR(Unsafe_ShouldBeInitialized0)},
 
     {CC "fullFence",          CC "()V",                  FN_PTR(Unsafe_FullFence)},
+    {CC "reportJavaOutOfMemory0", CC "(" LANG "String;)V",                  FN_PTR(Unsafe_ReportJavaOutOfMemory0)},
 };
 
 #undef CC

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -3837,6 +3837,7 @@ public final class Unsafe {
     private native int arrayIndexScale0(Class<?> arrayClass);
     private native int getLoadAverage0(double[] loadavg, int nelems);
 
+    public native void reportJavaOutOfMemory0(String message);
 
     /**
      * Invokes the given direct byte buffer's cleaner, if any.

--- a/test/hotspot/jtreg/runtime/ErrorHandling/TestExitOnDirectOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/TestExitOnDirectOutOfMemoryError.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test TestExitOnDirectOutOfMemoryError
+ * @summary Test using -XX:ExitOnOutOfMemoryError
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @requires vm.flagless
+ * @run driver TestExitOnDirectOutOfMemoryError
+ * @bug 8138745
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+import java.nio.ByteBuffer;
+public class TestExitOnDirectOutOfMemoryError {
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            // This should guarantee to throw:
+            // java.lang.OutOfMemoryError: Cannot reserve 2147483647 bytes of direct buffer memory (allocated: 0, limit: 20971520)
+            try {
+               ByteBuffer byteBuffer = ByteBuffer.allocateDirect(Integer.MAX_VALUE);
+            } catch (OutOfMemoryError err) {
+                throw new Error("OOME didn't terminate JVM!");
+            }
+        }
+
+        // else this is the main test
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-XX:+ExitOnOutOfMemoryError",
+                "-Xmx20m","-Djdk.nio.reportOomOnDirectMemoryOom=true", TestExitOnDirectOutOfMemoryError.class.getName(), "throwOOME");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+        /*
+         * Actual output should look like this:
+         * Terminating due to java.lang.OutOfMemoryError: Cannot reserve 2147483647 bytes of direct buffer memory (allocated: 0, limit: 20971520)
+         */
+        output.shouldHaveExitValue(3);
+        output.stdoutShouldNotBeEmpty();
+        output.shouldContain("Terminating due to java.lang.OutOfMemoryError: Cannot reserve 2147483647 bytes of direct" +
+                " buffer memory (allocated: 0, limit: 20971520)");
+        System.out.println("PASSED");
+    }
+}


### PR DESCRIPTION
Big data processes often experience situations where the direct memory oom process is alive but not serving properly. If the direct memory is oom, code can notify the jvm. Can bring the following benefits:
1. Analysis of direct memory Java. Nio. DirectByteBuffer need heapdumps reference relations. Can be used directly HeapDumpOnOutOfMemoryError.
2. In container environment, ExitOnOutOfMemoryError can be used to let the process that cannot provide services exit, so that the container can quickly pull up a new pod

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318058](https://bugs.openjdk.org/browse/JDK-8318058): Notify the jvm when the direct memory is oom (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16176/head:pull/16176` \
`$ git checkout pull/16176`

Update a local copy of the PR: \
`$ git checkout pull/16176` \
`$ git pull https://git.openjdk.org/jdk.git pull/16176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16176`

View PR using the GUI difftool: \
`$ git pr show -t 16176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16176.diff">https://git.openjdk.org/jdk/pull/16176.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16176#issuecomment-1760708168)