### PR TITLE
8318078: ADLC: pass ASSERT and PRODUCT flags

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -135,7 +135,10 @@ ifeq ($(call check-jvm-feature, compiler2), true)
 
   # Set ASSERT, NDEBUG and PRODUCT flags just like in JvmFlags.gmk
   ifeq ($(DEBUG_LEVEL), release)
+    # release builds disable uses of assert macro from <assert.h>.
     ADLCFLAGS += -DNDEBUG
+    # For hotspot, release builds differ internally between "optimized" and "product"
+    # in that "optimize" does not define PRODUCT.
     ifneq ($(HOTSPOT_DEBUG_LEVEL), optimized)
       ADLCFLAGS += -DPRODUCT
     endif

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -133,6 +133,18 @@ ifeq ($(call check-jvm-feature, compiler2), true)
     ADLCFLAGS += -DARM=1
   endif
 
+  # Set ASSERT, NDEBUG and PRODUCT flags just like in JvmFlags.gmk
+  ifeq ($(DEBUG_LEVEL), release)
+    ADLCFLAGS += -DNDEBUG
+    ifneq ($(HOTSPOT_DEBUG_LEVEL), optimized)
+      ADLCFLAGS += -DPRODUCT
+    endif
+  else ifeq ($(DEBUG_LEVEL), fastdebug)
+    ADLCFLAGS += -DASSERT
+  else ifeq ($(DEBUG_LEVEL), slowdebug)
+    ADLCFLAGS += -DASSERT
+  endif
+
   ##############################################################################
   # Concatenate all ad source files into a single file, which will be fed to
   # adlc. Also include a #line directive at the start of every included file


### PR DESCRIPTION
@vnkozlov asked me to guard some debug AD file rules in `#ifdef ASSERT`. https://github.com/openjdk/jdk/pull/14785#discussion_r1349391130

We discovered that the `ASSERT` and `PRODUCT` are not yet passed to ADLC, and hence they are always considered `undefined`. Hence, all of these `ifdef` blocks would always be ignored.

**Solution**
I added the flags to `make/hotspot/gensrc/GensrcAdlc.gmk`, just like in `make/hotspot/lib/JvmFlags.gmk`.

As @erikj79 commented: we should probably unify this. But I leave that to the build team.

**Testing**
With this code you can see what flags are passed to ADLC:
```
--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -56,6 +56,11 @@ int main(int argc, char *argv[])
   // Check for proper arguments
   if( argc == 1 ) usage(AD);    // No arguments?  Then print usage
 
+  for( int i = 1; i < argc; i++ ) { // For all arguments
+    char *s = argv[i];          // Get option/filename
+    fprintf(stderr, "ARGV[%d] %s\n", i, s);
+  }
+
   // Read command line arguments and file names
   for( int i = 1; i < argc; i++ ) { // For all arguments
     char *s = argv[i];          // Get option/filename
```

On `linux-x64` I get:
```
ARGV[1] -q
ARGV[2] -T
ARGV[3] -DLINUX=1
ARGV[4] -D_GNU_SOURCE=1
ARGV[5] -g
ARGV[6] -DAMD64=1
ARGV[7] -D_LP64=1
ARGV[8] -DNDEBUG
ARGV[9] -DPRODUCT
```

And on `linux-x64-debug` I get:
```
ARGV[1] -q
ARGV[2] -T
ARGV[3] -DLINUX=1
ARGV[4] -D_GNU_SOURCE=1
ARGV[5] -g
ARGV[6] -DAMD64=1
ARGV[7] -D_LP64=1
ARGV[8] -DASSERT
```

I verified that the `#ifdef` work as expected, by adding this code to `src/hotspot/cpu/x86/x86.ad`:
```
#ifdef ASSERT
#ifdef PRODUCT
control
#endif
#endif

#ifdef ASSERT
xxx
#endif

#ifdef PRODUCT
yyy
#endif
```
When compiling, I get complaints for `yyy` on `linux-x64` and for `xxx` on `linux-x64-debug`. But since `ASSERT` and `PRODUCT` never occur together, we never get complaints about `control`.

**Tier1-3 and stress testing passed.**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8318078](https://bugs.openjdk.org/browse/JDK-8318078): ADLC: pass ASSERT and PRODUCT flags (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [b2875032](https://git.openjdk.org/jdk/pull/16178/files/b2875032bfb057dfe20beb08fb038da00c61c420)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16178/head:pull/16178` \
`$ git checkout pull/16178`

Update a local copy of the PR: \
`$ git checkout pull/16178` \
`$ git pull https://git.openjdk.org/jdk.git pull/16178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16178`

View PR using the GUI difftool: \
`$ git pr show -t 16178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16178.diff">https://git.openjdk.org/jdk/pull/16178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16178#issuecomment-1761260985)