### PR TITLE
JDK-8318085: ProblemList jdk/jfr/api/consumer/recordingstream/TestOnEvent.java on linux-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -761,7 +761,7 @@ jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc6
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
-jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
+jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64,linux-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
In order to reduce the noise in the JDK21 and JDK22 CIs,
I'm ProblemListing:

jdk/jfr/api/consumer/recordingstream/TestOnEvent.java

on linux-aarch64.  Same has been done for linux-x64 where the timeouts were seen too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318085](https://bugs.openjdk.org/browse/JDK-8318085): ProblemList jdk/jfr/api/consumer/recordingstream/TestOnEvent.java on linux-aarch64 (**Sub-task** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16180/head:pull/16180` \
`$ git checkout pull/16180`

Update a local copy of the PR: \
`$ git checkout pull/16180` \
`$ git pull https://git.openjdk.org/jdk.git pull/16180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16180`

View PR using the GUI difftool: \
`$ git pr show -t 16180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16180.diff">https://git.openjdk.org/jdk/pull/16180.diff</a>

</details>
