### PR TITLE
8318086: [jvmci] RISC-V: Reuse target config from TargetDescription

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotJVMCIBackendFactory.java
@@ -99,7 +99,7 @@ public class RISCV64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFac
     }
 
     private static RegisterConfig createRegisterConfig(RISCV64HotSpotVMConfig config, TargetDescription target) {
-        return new RISCV64HotSpotRegisterConfig(target, config.useCompressedOops, config.linuxOs);
+        return new RISCV64HotSpotRegisterConfig(target, config.useCompressedOops, target.linuxOs);
     }
 
     protected HotSpotCodeCacheProvider createCodeCache(HotSpotJVMCIRuntime runtime, TargetDescription target, RegisterConfig regConfig) {

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
@@ -24,7 +24,6 @@ package jdk.vm.ci.hotspot.riscv64;
 
 import jdk.vm.ci.hotspot.HotSpotVMConfigAccess;
 import jdk.vm.ci.hotspot.HotSpotVMConfigStore;
-import jdk.vm.ci.services.Services;
 import jdk.internal.util.OperatingSystem;
 
 /**
@@ -37,8 +36,6 @@ class RISCV64HotSpotVMConfig extends HotSpotVMConfigAccess {
     RISCV64HotSpotVMConfig(HotSpotVMConfigStore config) {
         super(config);
     }
-
-    final boolean linuxOs = OperatingSystem.isLinux();
 
     final boolean useCompressedOops = getFlag("UseCompressedOops", Boolean.class);
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/riscv64/RISCV64HotSpotVMConfig.java
@@ -24,7 +24,6 @@ package jdk.vm.ci.hotspot.riscv64;
 
 import jdk.vm.ci.hotspot.HotSpotVMConfigAccess;
 import jdk.vm.ci.hotspot.HotSpotVMConfigStore;
-import jdk.internal.util.OperatingSystem;
 
 /**
  * Used to access native configuration details.


### PR DESCRIPTION
Hi, please review this cleanup. 

[JDK-8262901](https://bugs.openjdk.org/browse/JDK-8262901) moved `linuxOs` and `macOs` from AArch64HotSpotVMConfig.java into TargetDescription.java, we can reuse `linuxOs` for RISC-V.

Testing:

- [x] `compiler/jvmci` with linux-riscv release build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318086](https://bugs.openjdk.org/browse/JDK-8318086): [jvmci] RISC-V: Reuse target config from TargetDescription (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16181/head:pull/16181` \
`$ git checkout pull/16181`

Update a local copy of the PR: \
`$ git checkout pull/16181` \
`$ git pull https://git.openjdk.org/jdk.git pull/16181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16181`

View PR using the GUI difftool: \
`$ git pr show -t 16181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16181.diff">https://git.openjdk.org/jdk/pull/16181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16181#issuecomment-1761436492)