### PR TITLE
8318027: support alternative name to jdk.internal.vm.compiler

### DIFF
--- a/make/common/Modules.gmk
+++ b/make/common/Modules.gmk
@@ -64,6 +64,8 @@ ifeq ($(INCLUDE_JVMCI), false)
   MODULES_FILTER += jdk.internal.vm.ci
   MODULES_FILTER += jdk.internal.vm.compiler
   MODULES_FILTER += jdk.internal.vm.compiler.management
+  MODULES_FILTER += jdk.compiler.graal
+  MODULES_FILTER += jdk.compiler.graal.management
 endif
 
 # jpackage is only on windows, macosx, and linux

--- a/make/conf/module-loader-map.conf
+++ b/make/conf/module-loader-map.conf
@@ -62,6 +62,8 @@ UPGRADEABLE_PLATFORM_MODULES= \
     java.compiler \
     jdk.internal.vm.compiler \
     jdk.internal.vm.compiler.management \
+    jdk.compiler.graal \
+    jdk.compiler.graal.management \
     #
 
 PLATFORM_MODULES= \

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -167,16 +167,8 @@ grant codeBase "jrt:/jdk.internal.vm.compiler" {
     permission java.security.AllPermission;
 };
 
-grant codeBase "jrt:/jdk.internal.vm.compiler.management" {
-    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.vm.compiler.collections";
-    permission java.lang.RuntimePermission "accessClassInPackage.jdk.vm.ci.runtime";
-    permission java.lang.RuntimePermission "accessClassInPackage.jdk.vm.ci.services";
-    permission java.lang.RuntimePermission "accessClassInPackage.org.graalvm.compiler.core.common";
-    permission java.lang.RuntimePermission "accessClassInPackage.org.graalvm.compiler.debug";
-    permission java.lang.RuntimePermission "accessClassInPackage.org.graalvm.compiler.hotspot";
-    permission java.lang.RuntimePermission "accessClassInPackage.org.graalvm.compiler.options";
-    permission java.lang.RuntimePermission "accessClassInPackage.org.graalvm.compiler.phases.common.jmx";
-    permission java.lang.RuntimePermission "accessClassInPackage.org.graalvm.compiler.serviceprovider";
+grant codeBase "jrt:/jdk.compiler.graal" {
+    permission java.security.AllPermission;
 };
 
 grant codeBase "jrt:/jdk.jsobject" {

--- a/src/jdk.compiler.graal.management/share/classes/module-info.java
+++ b/src/jdk.compiler.graal.management/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,19 @@
  * questions.
  */
 
-module jdk.internal.vm.ci {
-    exports jdk.vm.ci.services to
-        jdk.internal.vm.compiler,
-        jdk.internal.vm.compiler.management,
-        jdk.compiler.graal,
-        jdk.compiler.graal.management;
-    exports jdk.vm.ci.runtime to
-        jdk.internal.vm.compiler,
-        jdk.internal.vm.compiler.management,
-        jdk.compiler.graal,
-        jdk.compiler.graal.management;
-    exports jdk.vm.ci.meta to jdk.internal.vm.compiler, jdk.compiler.graal;
-    exports jdk.vm.ci.code to jdk.internal.vm.compiler, jdk.compiler.graal;
-    exports jdk.vm.ci.hotspot to jdk.internal.vm.compiler, jdk.compiler.graal;
-
-    uses jdk.vm.ci.services.JVMCIServiceLocator;
-    uses jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory;
-
-    provides jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory with
-        jdk.vm.ci.hotspot.aarch64.AArch64HotSpotJVMCIBackendFactory,
-        jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory,
-        jdk.vm.ci.hotspot.riscv64.RISCV64HotSpotJVMCIBackendFactory;
+/**
+ * Registers JVMCI compiler specific management interfaces for the JVM.
+ *
+ * This is an empty and upgradeable module that is a placeholder for an
+ * external implementation of a JVMCI compiler. It must be upgradeable so
+ * that it can be replaced when jlinking a new JDK image without failing
+ * the hash check for the qualified exports in jdk.internal.vm.ci's
+ * module descriptor.
+ *
+ * @moduleGraph
+ * @since 22
+ */
+module jdk.compiler.graal.management {
+    requires jdk.internal.vm.ci;
 }
+

--- a/src/jdk.compiler.graal/share/classes/module-info.java
+++ b/src/jdk.compiler.graal/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,26 +23,19 @@
  * questions.
  */
 
-module jdk.internal.vm.ci {
-    exports jdk.vm.ci.services to
-        jdk.internal.vm.compiler,
-        jdk.internal.vm.compiler.management,
-        jdk.compiler.graal,
-        jdk.compiler.graal.management;
-    exports jdk.vm.ci.runtime to
-        jdk.internal.vm.compiler,
-        jdk.internal.vm.compiler.management,
-        jdk.compiler.graal,
-        jdk.compiler.graal.management;
-    exports jdk.vm.ci.meta to jdk.internal.vm.compiler, jdk.compiler.graal;
-    exports jdk.vm.ci.code to jdk.internal.vm.compiler, jdk.compiler.graal;
-    exports jdk.vm.ci.hotspot to jdk.internal.vm.compiler, jdk.compiler.graal;
+/**
+  * JVMCI compiler implementation for the JVM.
+  *
+  * This is an empty and upgradeable module that is a placeholder for an
+  * external implementation of a JVMCI compiler. It must be upgradeable so
+  * that it can be replaced when jlinking a new JDK image without failing
+  * the hash check for the qualified exports in jdk.internal.vm.ci's
+  * module descriptor.
+  *
+  * @moduleGraph
+  * @since 22
+  */
 
-    uses jdk.vm.ci.services.JVMCIServiceLocator;
-    uses jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory;
-
-    provides jdk.vm.ci.hotspot.HotSpotJVMCIBackendFactory with
-        jdk.vm.ci.hotspot.aarch64.AArch64HotSpotJVMCIBackendFactory,
-        jdk.vm.ci.hotspot.amd64.AMD64HotSpotJVMCIBackendFactory,
-        jdk.vm.ci.hotspot.riscv64.RISCV64HotSpotJVMCIBackendFactory;
+module jdk.compiler.graal {
+    requires jdk.internal.vm.ci;
 }

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsCompilableTest.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/IsCompilableTest.java
@@ -27,7 +27,6 @@
  * @requires vm.graal.enabled & vm.compMode == "Xmixed"
  * @library /test/lib /
  * @library ../common/patches
- * @modules jdk.internal.vm.compiler
  * @modules java.base/jdk.internal.misc
  * @modules java.base/jdk.internal.org.objectweb.asm
  *          java.base/jdk.internal.org.objectweb.asm.tree

--- a/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
+++ b/test/jdk/java/lang/Class/getDeclaredField/FieldSetAccessibleTest.java
@@ -311,12 +311,12 @@ public class FieldSetAccessibleTest {
 
             Set<String> mods = Set.of(
                     // All JVMCI packages other than jdk.vm.ci.services are dynamically
-                    // exported to jdk.internal.vm.compiler
-                    "jdk.internal.vm.compiler", "jdk.internal.vm.compiler.management"
+                    // exported to Graal
+                    "jdk.internal.vm.compiler", "jdk.internal.vm.compiler.management",
+                    "jdk.compiler.graal", "jdk.compiler.graal.management"
             );
-            // Filters all modules that directly or indirectly require jdk.internal.vm.compiler
-            // and jdk.internal.vm.compiler.management, as these are upgradeable and
-            // also provide APIs to add qualified exports dynamically
+            // Filters all modules that directly or indirectly require Graal modules
+            // as these are upgradeable and also provide APIs to add qualified exports dynamically
             Set<String> filters = mods.stream().flatMap(mn -> findDeps(mn, inverseDeps).stream())
                                       .collect(Collectors.toSet());
             System.out.println("Filtered modules: " + filters);

--- a/test/jdk/jdk/modules/etc/UpgradeableModules.java
+++ b/test/jdk/jdk/modules/etc/UpgradeableModules.java
@@ -45,7 +45,9 @@ public class UpgradeableModules {
     private static final List<String> UPGRADEABLE_MODULES =
         List.of("java.compiler",
                 "jdk.internal.vm.compiler",
-                "jdk.internal.vm.compiler.management");
+                "jdk.internal.vm.compiler.management",
+                "jdk.compiler.graal",
+                "jdk.compiler.graal.management");
 
 
     public static void main(String... args) {

--- a/test/jdk/tools/jimage/VerifyJimage.java
+++ b/test/jdk/tools/jimage/VerifyJimage.java
@@ -196,8 +196,8 @@ public class VerifyJimage {
     }
 
     // All JVMCI packages other than jdk.vm.ci.services are dynamically
-    // exported to jdk.internal.vm.compiler
-    private static Set<String> EXCLUDED_MODULES = Set.of("jdk.internal.vm.compiler");
+    // exported to jdk.compiler.graal
+    private static Set<String> EXCLUDED_MODULES = Set.of("jdk.internal.vm.compiler", "jdk.compiler.graal");
 
     private boolean accept(String entry) {
         int index = entry.indexOf('/', 1);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318027](https://bugs.openjdk.org/browse/JDK-8318027): Support alternative name to jdk.internal.vm.compiler (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16182/head:pull/16182` \
`$ git checkout pull/16182`

Update a local copy of the PR: \
`$ git checkout pull/16182` \
`$ git pull https://git.openjdk.org/jdk.git pull/16182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16182`

View PR using the GUI difftool: \
`$ git pr show -t 16182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16182.diff">https://git.openjdk.org/jdk/pull/16182.diff</a>

</details>
