### PR TITLE
JDK-8318154 : Improve stability of WheelModifier.java test

### DIFF
--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -26,7 +26,6 @@
    @key headful
    @bug 8041470
    @summary JButtons stay pressed after they have lost focus if you use the mouse wheel
-   @author Anton Nashatyrev
  */
 
 import java.awt.AWTEvent;
@@ -53,6 +52,7 @@ public class WheelModifier {
     CountDownLatch exitSema = new CountDownLatch(1);
     CountDownLatch releaseSema = new CountDownLatch(1);
     volatile CountDownLatch wheelSema;
+    
     private Point sLoc;
     private Dimension bSize;
 

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,20 @@
    @author Anton Nashatyrev
  */
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.AWTEvent;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.AWTEventListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.concurrent.CountDownLatch;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 
 public class WheelModifier {
 
@@ -43,6 +53,8 @@ public class WheelModifier {
     CountDownLatch exitSema = new CountDownLatch(1);
     CountDownLatch releaseSema = new CountDownLatch(1);
     volatile CountDownLatch wheelSema;
+    private Point sLoc;
+    private Dimension bSize;
 
     void createGui() {
         f = new JFrame("frame");
@@ -98,10 +110,13 @@ public class WheelModifier {
         r.waitForIdle();
         System.out.println("# Started");
 
-        Point sLoc = fb.getLocationOnScreen();
-        Dimension bSize = fb.getSize();
+        SwingUtilities.invokeAndWait(() -> {
+            sLoc = fb.getLocationOnScreen();
+            bSize = fb.getSize();
+        });
+
         r.mouseMove(sLoc.x + bSize.width / 2, sLoc.y + bSize.height / 2);
-        r.mousePress(MouseEvent.BUTTON1_MASK);
+        r.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
         pressSema.await();
         System.out.println("# Pressed");
 
@@ -119,7 +134,7 @@ public class WheelModifier {
         wheelSema.await();
         System.out.println("# Wheeled 2");
 
-        r.mouseRelease(MouseEvent.BUTTON1_MASK);
+        r.mouseRelease(MouseEvent.BUTTON1_DOWN_MASK);
         releaseSema.await();
         System.out.println("# Released!");
     }

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -53,8 +53,8 @@ public class WheelModifier {
     CountDownLatch releaseSema = new CountDownLatch(1);
     volatile CountDownLatch wheelSema;
     
-    private Point sLoc;
-    private Dimension bSize;
+    private volatile Point sLoc;
+    private volatile Dimension bSize;
 
     void createGui() {
         f = new JFrame("frame");

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -52,7 +52,7 @@ public class WheelModifier {
     CountDownLatch exitSema = new CountDownLatch(1);
     CountDownLatch releaseSema = new CountDownLatch(1);
     volatile CountDownLatch wheelSema;
-    
+
     private volatile Point sLoc;
     private volatile Dimension bSize;
 


### PR DESCRIPTION
Hi Revivers,

Part of stability improvement for the test case **WheelModifier.java** I have moved _getLocationOnScreen()_ and _getSize()_ into EDT, part of warning removal updated _BUTTON1_MASK_ with _BUTTON1_DOWN_MASK_

Please review and let me know your suggestions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318154](https://bugs.openjdk.org/browse/JDK-8318154): Improve stability of WheelModifier.java test (**Enhancement** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16185/head:pull/16185` \
`$ git checkout pull/16185`

Update a local copy of the PR: \
`$ git checkout pull/16185` \
`$ git pull https://git.openjdk.org/jdk.git pull/16185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16185`

View PR using the GUI difftool: \
`$ git pr show -t 16185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16185.diff">https://git.openjdk.org/jdk/pull/16185.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16185#issuecomment-1761700917)