### PR TITLE
8317971: RISC-V: implement copySignF/D and signumF/D intrinsics

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1653,6 +1653,41 @@ void C2_MacroAssembler::round_double_mode(FloatRegister dst, FloatRegister src, 
   bind(done);
 }
 
+// According to Java SE specification, for floating-point signum operations, if
+// on input we have NaN or +/-0.0 value we should return it,
+// otherwise return +/- 1.0 using sign of input.
+// tmp1 - used to store result of fclass operation,
+// one - gives us a floating-point 1.0 (got from matching rule)
+// bool single_precision - specififes single or double precision operations will be used.
+void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister src, FloatRegister one, Register tmp1, bool is_double) {
+  assert_different_registers(dst, src, one);
+
+  Label done, special_val;
+
+  is_double ? fclass_d(tmp1, src)
+            : fclass_s(tmp1, src);
+
+  //bitmask 0b1100011000 specifies this bits:
+  // 3 - src is -0
+  // 4 - src is +0
+  // 8 - src is signaling NaN
+  // 9 - src is a quiet NaN
+  andi(tmp1, tmp1, 0b1100011000);
+
+  bnez(tmp1, special_val);
+
+  // use floating-point 1.0 with a sign of input
+  is_double ? fsgnj_d(dst, one, src)
+            : fsgnj_s(dst, one, src);
+  j(done);
+
+  bind(special_val);
+  is_double ? fmv_d(dst, src)
+            : fmv_s(dst, src);
+
+  bind(done);
+}
+
 void C2_MacroAssembler::element_compare(Register a1, Register a2, Register result, Register cnt, Register tmp1, Register tmp2,
                                         VectorRegister vr1, VectorRegister vr2, VectorRegister vrs, bool islatin, Label &DONE) {
   Label loop;

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1656,11 +1656,9 @@ void C2_MacroAssembler::round_double_mode(FloatRegister dst, FloatRegister src, 
 // According to Java SE specification, for floating-point signum operations, if
 // on input we have NaN or +/-0.0 value we should return it,
 // otherwise return +/- 1.0 using sign of input.
-// tmp1 - alias for t0 register,
 // one - gives us a floating-point 1.0 (got from matching rule)
 // bool is_double - specififes single or double precision operations will be used.
 void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister src, FloatRegister one, bool is_double) {
-  assert_different_registers(dst, src, one);
   Register tmp1 = t0;
 
   Label done, special_val;

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1657,7 +1657,7 @@ void C2_MacroAssembler::round_double_mode(FloatRegister dst, FloatRegister src, 
 // on input we have NaN or +/-0.0 value we should return it,
 // otherwise return +/- 1.0 using sign of input.
 // one - gives us a floating-point 1.0 (got from matching rule)
-// bool is_double - specififes single or double precision operations will be used.
+// bool is_double - specifies single or double precision operations will be used.
 void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister src, FloatRegister one, bool is_double) {
   Register tmp1 = t0;
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1656,11 +1656,12 @@ void C2_MacroAssembler::round_double_mode(FloatRegister dst, FloatRegister src, 
 // According to Java SE specification, for floating-point signum operations, if
 // on input we have NaN or +/-0.0 value we should return it,
 // otherwise return +/- 1.0 using sign of input.
-// tmp1 - used to store result of fclass operation,
+// tmp1 - alias for t0 register,
 // one - gives us a floating-point 1.0 (got from matching rule)
-// bool single_precision - specififes single or double precision operations will be used.
-void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister src, FloatRegister one, Register tmp1, bool is_double) {
+// bool is_double - specififes single or double precision operations will be used.
+void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister src, FloatRegister one, bool is_double) {
   assert_different_registers(dst, src, one);
+  Register tmp1 = t0;
 
   Label done, special_val;
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1661,10 +1661,13 @@ void C2_MacroAssembler::round_double_mode(FloatRegister dst, FloatRegister src, 
 void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister src, FloatRegister one, bool is_double) {
   Register tmp1 = t0;
 
-  Label done, special_val;
+  Label done;
 
   is_double ? fclass_d(tmp1, src)
             : fclass_s(tmp1, src);
+
+  is_double ? fmv_d(dst, src)
+            : fmv_s(dst, src);
 
   //bitmask 0b1100011000 specifies this bits:
   // 3 - src is -0
@@ -1673,16 +1676,11 @@ void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister src, FloatReg
   // 9 - src is a quiet NaN
   andi(tmp1, tmp1, 0b1100011000);
 
-  bnez(tmp1, special_val);
+  bnez(tmp1, done);
 
   // use floating-point 1.0 with a sign of input
   is_double ? fsgnj_d(dst, one, src)
             : fsgnj_s(dst, one, src);
-  j(done);
-
-  bind(special_val);
-  is_double ? fmv_d(dst, src)
-            : fmv_s(dst, src);
 
   bind(done);
 }

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -158,7 +158,7 @@
                          Register tmp1, Register tmp2, Register tmp3);
 
   void signum_fp(FloatRegister dst, FloatRegister src, FloatRegister one,
-                 Register tmp1, bool is_double);
+                 bool is_double);
 
   // intrinsic methods implemented by rvv instructions
   void string_equals_v(Register r1, Register r2,

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -157,6 +157,9 @@
   void round_double_mode(FloatRegister dst, FloatRegister src, int round_mode,
                          Register tmp1, Register tmp2, Register tmp3);
 
+  void signum_fp(FloatRegister dst, FloatRegister src, FloatRegister one,
+                 Register tmp1, bool is_double);
+
   // intrinsic methods implemented by rvv instructions
   void string_equals_v(Register r1, Register r2,
                        Register result, Register cnt1,

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7534,7 +7534,6 @@ instruct copySignF_reg(fRegF dst, fRegF src1, fRegF src2) %{
 
 instruct signumD_reg(fRegD dst, fRegD src, immD zero, fRegD one) %{
   match(Set dst (SignumD src (Binary zero one)));
-  effect(TEMP_DEF dst, USE src, USE one);
   format %{ "signumD  $dst, $src" %}
   ins_encode %{
     __ signum_fp(as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg),
@@ -7545,7 +7544,6 @@ instruct signumD_reg(fRegD dst, fRegD src, immD zero, fRegD one) %{
 
 instruct signumF_reg(fRegF dst, fRegF src, immF zero, fRegF one) %{
   match(Set dst (SignumF src (Binary zero one)));
-  effect(TEMP_DEF dst, USE src, USE one);
   format %{ "signumF  $dst, $src" %}
   ins_encode %{
     __ signum_fp(as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg),

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7517,7 +7517,7 @@ instruct copySignD_reg(fRegD dst, fRegD src1, fRegD src2, immD zero) %{
                   src2 = as_FloatRegister($src2$$reg);
     __ fsgnj_d(dst, src1, src2);
   %}
-  ins_pipe(fp_uop_d);
+  ins_pipe(fp_dop_reg_reg_d);
 %}
 
 instruct copySignF_reg(fRegF dst, fRegF src1, fRegF src2) %{
@@ -7529,7 +7529,7 @@ instruct copySignF_reg(fRegF dst, fRegF src1, fRegF src2) %{
                   src2 = as_FloatRegister($src2$$reg);
     __ fsgnj_s(dst, src1, src2);
   %}
-  ins_pipe(fp_uop_d);
+  ins_pipe(fp_dop_reg_reg_s);
 %}
 
 instruct signumD_reg(fRegD dst, fRegD src, immD zero, fRegD one) %{

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7508,9 +7508,8 @@ instruct roundD_reg(fRegD dst, fRegD src, immI rmode, iRegLNoSp tmp1, iRegLNoSp 
 
 // Copysign and signum intrinsics
 
-instruct copySignD_reg(fRegD dst, fRegD src1, fRegD src2, immD0 zero) %{
+instruct copySignD_reg(fRegD dst, fRegD src1, fRegD src2, immD zero) %{
   match(Set dst (CopySignD src1 (Binary src2 zero)));
-  effect(TEMP_DEF dst, USE src1, USE src2);
   format %{ "CopySignD  $dst $src1 $src2" %}
   ins_encode %{
     FloatRegister dst = as_FloatRegister($dst$$reg),
@@ -7523,7 +7522,6 @@ instruct copySignD_reg(fRegD dst, fRegD src1, fRegD src2, immD0 zero) %{
 
 instruct copySignF_reg(fRegF dst, fRegF src1, fRegF src2) %{
   match(Set dst (CopySignF src1 src2));
-  effect(TEMP_DEF dst, USE src1, USE src2);
   format %{ "CopySignF  $dst $src1 $src2" %}
   ins_encode %{
     FloatRegister dst = as_FloatRegister($dst$$reg),
@@ -7534,24 +7532,24 @@ instruct copySignF_reg(fRegF dst, fRegF src1, fRegF src2) %{
   ins_pipe(fp_uop_d);
 %}
 
-instruct signumD_reg(fRegD dst, fRegD src, fRegD zero, fRegD one, iRegINoSp tmp1) %{
+instruct signumD_reg(fRegD dst, fRegD src, immD zero, fRegD one) %{
   match(Set dst (SignumD src (Binary zero one)));
-  effect(TEMP_DEF dst, USE src, USE one, TEMP tmp1);
+  effect(TEMP_DEF dst, USE src, USE one);
   format %{ "signumD  $dst, $src" %}
   ins_encode %{
     __ signum_fp(as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg),
-                 as_FloatRegister($one$$reg), $tmp1$$Register, true /* is_double */);
+                 as_FloatRegister($one$$reg), true /* is_double */);
   %}
   ins_pipe(pipe_class_default);
 %}
 
-instruct signumF_reg(fRegF dst, fRegF src, fRegF zero, fRegF one, iRegINoSp tmp1) %{
+instruct signumF_reg(fRegF dst, fRegF src, immF zero, fRegF one) %{
   match(Set dst (SignumF src (Binary zero one)));
-  effect(TEMP_DEF dst, USE src, USE one, TEMP tmp1);
+  effect(TEMP_DEF dst, USE src, USE one);
   format %{ "signumF  $dst, $src" %}
   ins_encode %{
     __ signum_fp(as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg),
-                 as_FloatRegister($one$$reg), $tmp1$$Register, false /* is_double */);
+                 as_FloatRegister($one$$reg), false /* is_double */);
   %}
   ins_pipe(pipe_class_default);
 %}

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7506,6 +7506,56 @@ instruct roundD_reg(fRegD dst, fRegD src, immI rmode, iRegLNoSp tmp1, iRegLNoSp 
   ins_pipe(pipe_class_default);
 %}
 
+// Copysign and signum intrinsics
+
+instruct copySignD_reg(fRegD dst, fRegD src1, fRegD src2, immD0 zero) %{
+  match(Set dst (CopySignD src1 (Binary src2 zero)));
+  effect(TEMP_DEF dst, USE src1, USE src2);
+  format %{ "CopySignD  $dst $src1 $src2" %}
+  ins_encode %{
+    FloatRegister dst = as_FloatRegister($dst$$reg),
+                  src1 = as_FloatRegister($src1$$reg),
+                  src2 = as_FloatRegister($src2$$reg);
+    __ fsgnj_d(dst, src1, src2);
+  %}
+  ins_pipe(fp_uop_d);
+%}
+
+instruct copySignF_reg(fRegF dst, fRegF src1, fRegF src2) %{
+  match(Set dst (CopySignF src1 src2));
+  effect(TEMP_DEF dst, USE src1, USE src2);
+  format %{ "CopySignF  $dst $src1 $src2" %}
+  ins_encode %{
+    FloatRegister dst = as_FloatRegister($dst$$reg),
+                  src1 = as_FloatRegister($src1$$reg),
+                  src2 = as_FloatRegister($src2$$reg);
+    __ fsgnj_s(dst, src1, src2);
+  %}
+  ins_pipe(fp_uop_d);
+%}
+
+instruct signumD_reg(fRegD dst, fRegD src, fRegD zero, fRegD one, iRegINoSp tmp1) %{
+  match(Set dst (SignumD src (Binary zero one)));
+  effect(TEMP_DEF dst, USE src, USE one, TEMP tmp1);
+  format %{ "signumD  $dst, $src" %}
+  ins_encode %{
+    __ signum_fp(as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg),
+                 as_FloatRegister($one$$reg), $tmp1$$Register, true /* is_double */);
+  %}
+  ins_pipe(pipe_class_default);
+%}
+
+instruct signumF_reg(fRegF dst, fRegF src, fRegF zero, fRegF one, iRegINoSp tmp1) %{
+  match(Set dst (SignumF src (Binary zero one)));
+  effect(TEMP_DEF dst, USE src, USE one, TEMP tmp1);
+  format %{ "signumF  $dst, $src" %}
+  ins_encode %{
+    __ signum_fp(as_FloatRegister($dst$$reg), as_FloatRegister($src$$reg),
+                 as_FloatRegister($one$$reg), $tmp1$$Register, false /* is_double */);
+  %}
+  ins_pipe(pipe_class_default);
+%}
+
 // Arithmetic Instructions End
 
 // ============================================================================

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -191,6 +191,14 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, true);
   }
 
+  if (FLAG_IS_DEFAULT(UseCopySignIntrinsic)) {
+      FLAG_SET_DEFAULT(UseCopySignIntrinsic, true);
+  }
+
+  if (FLAG_IS_DEFAULT(UseSignumIntrinsic)) {
+      FLAG_SET_DEFAULT(UseSignumIntrinsic, true);
+  }
+
   if (UseRVV) {
     if (!ext_V.enabled()) {
       warning("RVV is not supported on this CPU");

--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -471,7 +471,7 @@ public class MathBench {
     }
 
     @Benchmark
-    public double  sigNumDouble() {
+    public double  signumDouble() {
         return  Math.signum(double4Dot1);
     }
 


### PR DESCRIPTION
Hi all, please review this changes into risc-v floating point copysign and signum intrinsics.
CopySign - returns first argument with the sign of second. On risc-v we have `fsgnj.x` instruction, which can implement this intrinsic.
Signum - returns input value if it is +/- 0.0 or NaN, otherwise 1.0 with the sign of input value returned.  On risc-v we can use `fclass.x` to specify type of input value and return appropriate value.

Tests:
Performance tests on t-head board:
With intrinsics:
```
Benchmark                 (seed)   Mode  Cnt      Score      Error   Units
MathBench.copySignDouble       0  thrpt    8  34156.580 ±   76.272  ops/ms
MathBench.copySignFloat        0  thrpt    8  34181.731 ±   38.182  ops/ms
MathBench.signumDouble         0  thrpt    8  31977.258 ± 1122.327  ops/ms
MathBench.signumFloat          0  thrpt    8  31836.852 ±   56.013  ops/ms
```
Intrinsics turned off (`-XX:+UnlockDiagnosticVMOptions -XX:-UseCopySignIntrinsic -XX:-UseSignumIntrinsic`):
```
Benchmark                 (seed)   Mode  Cnt      Score      Error   Units
MathBench.copySignDouble       0  thrpt    8  31000.996 ±  943.094  ops/ms
MathBench.copySignFloat        0  thrpt    8  30678.016 ±   28.087  ops/ms
MathBench.signumDouble         0  thrpt    8  25435.010 ± 2047.085  ops/ms
MathBench.signumFloat          0  thrpt    8  25257.058 ±   79.175  ops/ms
```
Regression tests: tier1, hotspot:tier2 on risc-v board.

Also, changed name of one micro test: before we had: `sigNumDouble` and `signumFloat` tests, they does not matches to `signum` or `sigNum`. Now we have similar part: `signum`.
Performance tests has been changed a bit, to check intrinsics result better, diff to modify tests:
```
diff --git a/test/micro/org/openjdk/bench/java/lang/MathBench.java b/test/micro/org/openjdk/bench/java/lang/MathBench.java
index 6cd1353907e..0bee25366bf 100644
--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -143,12 +143,12 @@ public double  ceilDouble() {
 
     @Benchmark
     public double  copySignDouble() {
-        return  Math.copySign(double81, doubleNegative12);
+        return  Math.copySign(double81, doubleNegative12) + Math.copySign(double81, double2) + Math.copySign(double4Dot1, doubleNegative12);
     }
 
     @Benchmark
     public float  copySignFloat() {
-        return  Math.copySign(floatNegative99, float1);
+        return  Math.copySign(floatNegative99, float1) + Math.copySign(eFloat, float1) + Math.copySign(eFloat, floatNegative99);
     }
 
     @Benchmark
@@ -472,12 +472,12 @@ public float  scalbFloatInt() {
 
     @Benchmark
     public double  sigNumDouble() {
-        return  Math.signum(double4Dot1);
+        return  Math.signum(double4Dot1) + Math.signum(doubleNegative12) + Math.signum(double81);
     }
 
     @Benchmark
     public double  signumFloat() {
-        return  Math.signum(floatNegative99);
+        return  Math.signum(floatNegative99) + Math.signum(float2) + Math.signum(float7);
     }
 
     @Benchmark
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317971](https://bugs.openjdk.org/browse/JDK-8317971): RISC-V: implement copySignF/D and signumF/D intrinsics (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [867d6e8e](https://git.openjdk.org/jdk/pull/16186/files/867d6e8ea2a53ae71fb8fd341892e8f88347ec07)
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - Committer) ⚠️ Review applies to [867d6e8e](https://git.openjdk.org/jdk/pull/16186/files/867d6e8ea2a53ae71fb8fd341892e8f88347ec07)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16186/head:pull/16186` \
`$ git checkout pull/16186`

Update a local copy of the PR: \
`$ git checkout pull/16186` \
`$ git pull https://git.openjdk.org/jdk.git pull/16186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16186`

View PR using the GUI difftool: \
`$ git pr show -t 16186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16186.diff">https://git.openjdk.org/jdk/pull/16186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16186#issuecomment-1761729988)