### PR TITLE
8317514: Ensure MemorySegment is initialized before touching NativeMemorySegmentImpl

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -41,9 +41,8 @@ import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
-import jdk.internal.foreign.HeapMemorySegmentImpl;
 import jdk.internal.foreign.MemorySessionImpl;
-import jdk.internal.foreign.NativeMemorySegmentImpl;
+import jdk.internal.foreign.SegmentFactories;
 import jdk.internal.foreign.StringSupport;
 import jdk.internal.foreign.Utils;
 import jdk.internal.javac.Restricted;
@@ -1209,7 +1208,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a heap memory segment backed by a byte array.
      */
     static MemorySegment ofArray(byte[] byteArray) {
-        return HeapMemorySegmentImpl.OfByte.fromArray(byteArray);
+        return SegmentFactories.fromArray(byteArray);
     }
 
     /**
@@ -1221,7 +1220,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a heap memory segment backed by a char array.
      */
     static MemorySegment ofArray(char[] charArray) {
-        return HeapMemorySegmentImpl.OfChar.fromArray(charArray);
+        return SegmentFactories.fromArray(charArray);
     }
 
     /**
@@ -1233,7 +1232,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a heap memory segment backed by a short array.
      */
     static MemorySegment ofArray(short[] shortArray) {
-        return HeapMemorySegmentImpl.OfShort.fromArray(shortArray);
+        return SegmentFactories.fromArray(shortArray);
     }
 
     /**
@@ -1245,7 +1244,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a heap memory segment backed by an int array.
      */
     static MemorySegment ofArray(int[] intArray) {
-        return HeapMemorySegmentImpl.OfInt.fromArray(intArray);
+        return SegmentFactories.fromArray(intArray);
     }
 
     /**
@@ -1257,7 +1256,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a heap memory segment backed by a float array.
      */
     static MemorySegment ofArray(float[] floatArray) {
-        return HeapMemorySegmentImpl.OfFloat.fromArray(floatArray);
+        return SegmentFactories.fromArray(floatArray);
     }
 
     /**
@@ -1269,7 +1268,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a heap memory segment backed by a long array.
      */
     static MemorySegment ofArray(long[] longArray) {
-        return HeapMemorySegmentImpl.OfLong.fromArray(longArray);
+        return SegmentFactories.fromArray(longArray);
     }
 
     /**
@@ -1281,13 +1280,13 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a heap memory segment backed by a double array.
      */
     static MemorySegment ofArray(double[] doubleArray) {
-        return HeapMemorySegmentImpl.OfDouble.fromArray(doubleArray);
+        return SegmentFactories.fromArray(doubleArray);
     }
 
     /**
      * A zero-length native segment modelling the {@code NULL} address.
      */
-    MemorySegment NULL = new NativeMemorySegmentImpl();
+    MemorySegment NULL = MemorySegment.ofAddress(0L);
 
     /**
      * Creates a zero-length native segment from the given {@linkplain #address() address value}.
@@ -1301,7 +1300,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @return a zero-length native segment with the given address.
      */
     static MemorySegment ofAddress(long address) {
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(address, 0);
+        return SegmentFactories.makeNativeSegmentUnchecked(address, 0);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1284,7 +1284,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     }
 
     /**
-     * A zero-length native segment modelling the {@code NULL} address.
+     * A zero-length native segment modelling the {@code NULL} address. Equivalent to {@code MemorySegment.ofAddress(0L)}.
      */
     MemorySegment NULL = MemorySegment.ofAddress(0L);
 

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -151,9 +151,9 @@ public abstract sealed class AbstractMemorySegmentImpl
         }
         if (!isNative()) throw new UnsupportedOperationException("Not a native segment");
         Runnable action = cleanup != null ?
-                () -> cleanup.accept(NativeMemorySegmentImpl.makeNativeSegmentUnchecked(address(), newSize)) :
+                () -> cleanup.accept(SegmentFactories.makeNativeSegmentUnchecked(address(), newSize)) :
                 null;
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(address(), newSize,
+        return SegmentFactories.makeNativeSegmentUnchecked(address(), newSize,
                 (MemorySessionImpl)scope, action);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
@@ -52,7 +52,7 @@ public final class ArenaImpl implements Arena {
 
     public MemorySegment allocateNoInit(long byteSize, long byteAlignment) {
         Utils.checkAllocationSizeAndAlign(byteSize, byteAlignment);
-        return NativeMemorySegmentImpl.makeNativeSegmentNoZeroing(byteSize, byteAlignment, session, shouldReserveMemory);
+        return SegmentFactories.allocateSegment(byteSize, byteAlignment, session, shouldReserveMemory);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -26,7 +26,6 @@
 
 package jdk.internal.foreign;
 
-import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.util.Objects;
@@ -48,7 +47,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * using sharper types would require use of type-conversions, which in turn would inhibit some C2 optimizations,
  * such as the elimination of store barriers in methods like {@link HeapMemorySegmentImpl#dup(long, long, boolean, MemorySessionImpl)}.
  */
-public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
+abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
     private static final int BYTE_ARR_BASE = UNSAFE.arrayBaseOffset(byte[].class);
@@ -110,13 +109,6 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             return (byte[])Objects.requireNonNull(base);
         }
 
-        public static MemorySegment fromArray(byte[] arr) {
-            Objects.requireNonNull(arr);
-            long byteSize = (long)arr.length * Unsafe.ARRAY_BYTE_INDEX_SCALE;
-            return new OfByte(Unsafe.ARRAY_BYTE_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
-        }
-
         @Override
         public long maxAlignMask() {
             return MAX_ALIGN_1;
@@ -142,13 +134,6 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         @Override
         public char[] unsafeGetBase() {
             return (char[])Objects.requireNonNull(base);
-        }
-
-        public static MemorySegment fromArray(char[] arr) {
-            Objects.requireNonNull(arr);
-            long byteSize = (long)arr.length * Unsafe.ARRAY_CHAR_INDEX_SCALE;
-            return new OfChar(Unsafe.ARRAY_CHAR_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
         }
 
         @Override
@@ -178,13 +163,6 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             return (short[])Objects.requireNonNull(base);
         }
 
-        public static MemorySegment fromArray(short[] arr) {
-            Objects.requireNonNull(arr);
-            long byteSize = (long)arr.length * Unsafe.ARRAY_SHORT_INDEX_SCALE;
-            return new OfShort(Unsafe.ARRAY_SHORT_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
-        }
-
         @Override
         public long maxAlignMask() {
             return MAX_ALIGN_2;
@@ -210,13 +188,6 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         @Override
         public int[] unsafeGetBase() {
             return (int[])Objects.requireNonNull(base);
-        }
-
-        public static MemorySegment fromArray(int[] arr) {
-            Objects.requireNonNull(arr);
-            long byteSize = (long)arr.length * Unsafe.ARRAY_INT_INDEX_SCALE;
-            return new OfInt(Unsafe.ARRAY_INT_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
         }
 
         @Override
@@ -246,13 +217,6 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             return (long[])Objects.requireNonNull(base);
         }
 
-        public static MemorySegment fromArray(long[] arr) {
-            Objects.requireNonNull(arr);
-            long byteSize = (long)arr.length * Unsafe.ARRAY_LONG_INDEX_SCALE;
-            return new OfLong(Unsafe.ARRAY_LONG_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
-        }
-
         @Override
         public long maxAlignMask() {
             return MAX_ALIGN_8;
@@ -280,13 +244,6 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
             return (float[])Objects.requireNonNull(base);
         }
 
-        public static MemorySegment fromArray(float[] arr) {
-            Objects.requireNonNull(arr);
-            long byteSize = (long)arr.length * Unsafe.ARRAY_FLOAT_INDEX_SCALE;
-            return new OfFloat(Unsafe.ARRAY_FLOAT_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
-        }
-
         @Override
         public long maxAlignMask() {
             return MAX_ALIGN_4;
@@ -312,13 +269,6 @@ public abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegment
         @Override
         public double[] unsafeGetBase() {
             return (double[])Objects.requireNonNull(base);
-        }
-
-        public static MemorySegment fromArray(double[] arr) {
-            Objects.requireNonNull(arr);
-            long byteSize = (long)arr.length * Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
-            return new OfDouble(Unsafe.ARRAY_DOUBLE_BASE_OFFSET, arr, byteSize, false,
-                    MemorySessionImpl.heapSession(arr));
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -35,7 +35,7 @@ import jdk.internal.misc.ScopedMemoryAccess;
  * memory mapped segment, such as the file descriptor associated with the mapping. This information is crucial
  * in order to correctly reconstruct a byte buffer object from the segment (see {@link #makeByteBuffer()}).
  */
-public final class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
+final class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     private final UnmapperProxy unmapper;
 

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -51,17 +51,6 @@ sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl permits M
                 : min;
     }
 
-    /**
-     * This constructor should only be used when initializing {@link MemorySegment#NULL}. Note: because of the memory
-     * segment class hierarchy, it is possible to end up in a situation where this constructor is called
-     * when the static fields in this class are not yet initialized.
-     */
-    @ForceInline
-    public NativeMemorySegmentImpl() {
-        super(0L, false, new GlobalSession(null));
-        this.min = 0L;
-    }
-
     @Override
     public long address() {
         return min;

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -31,20 +31,13 @@ import java.nio.ByteBuffer;
 import java.util.Optional;
 
 import jdk.internal.misc.Unsafe;
-import jdk.internal.misc.VM;
 import jdk.internal.vm.annotation.ForceInline;
 
 /**
  * Implementation for native memory segments. A native memory segment is essentially a wrapper around
  * a native long address.
  */
-public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl permits MappedMemorySegmentImpl {
-
-    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
-
-    // The maximum alignment supported by malloc - typically 16 bytes on
-    // 64-bit platforms and 8 bytes on 32-bit platforms.
-    private static final long MAX_MALLOC_ALIGN = Unsafe.ADDRESS_SIZE == 4 ? 8 : 16;
+sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl permits MappedMemorySegmentImpl {
 
     final long min;
 
@@ -109,73 +102,5 @@ public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl pe
     @Override
     public long maxAlignMask() {
         return 0;
-    }
-
-    // factories
-
-    public static MemorySegment makeNativeSegmentNoZeroing(long byteSize, long byteAlignment, MemorySessionImpl sessionImpl,
-                                                  boolean shouldReserve) {
-        sessionImpl.checkValidState();
-        if (VM.isDirectMemoryPageAligned()) {
-            byteAlignment = Math.max(byteAlignment, NIO_ACCESS.pageSize());
-        }
-        long alignedSize = Math.max(1L, byteAlignment > MAX_MALLOC_ALIGN ?
-                byteSize + (byteAlignment - 1) :
-                byteSize);
-
-        if (shouldReserve) {
-            NIO_ACCESS.reserveMemory(alignedSize, byteSize);
-        }
-
-        long buf = allocateMemoryWrapper(alignedSize);
-        long alignedBuf = Utils.alignUp(buf, byteAlignment);
-        AbstractMemorySegmentImpl segment = new NativeMemorySegmentImpl(buf, alignedSize,
-                false, sessionImpl);
-        sessionImpl.addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
-            @Override
-            public void cleanup() {
-                UNSAFE.freeMemory(buf);
-                if (shouldReserve) {
-                    NIO_ACCESS.unreserveMemory(alignedSize, byteSize);
-                }
-            }
-        });
-        if (alignedSize != byteSize) {
-            long delta = alignedBuf - buf;
-            segment = segment.asSlice(delta, byteSize);
-        }
-        return segment;
-    }
-
-    private static long allocateMemoryWrapper(long size) {
-        try {
-            return UNSAFE.allocateMemory(size);
-        } catch (IllegalArgumentException ex) {
-            throw new OutOfMemoryError();
-        }
-    }
-
-    // Unsafe native segment factories. These are used by the implementation code, to skip the sanity checks
-    // associated with MemorySegment::ofAddress.
-
-    @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, MemorySessionImpl sessionImpl, Runnable action) {
-        if (action == null) {
-            sessionImpl.checkValidState();
-        } else {
-            sessionImpl.addCloseAction(action);
-        }
-        return new NativeMemorySegmentImpl(min, byteSize, false, sessionImpl);
-    }
-
-    @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, MemorySessionImpl sessionImpl) {
-        sessionImpl.checkValidState();
-        return new NativeMemorySegmentImpl(min, byteSize, false, sessionImpl);
-    }
-
-    @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize) {
-        return new NativeMemorySegmentImpl(min, byteSize, false, new GlobalSession(null));
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package jdk.internal.foreign;
 
 import jdk.internal.access.foreign.UnmapperProxy;

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -1,0 +1,186 @@
+package jdk.internal.foreign;
+
+import jdk.internal.access.foreign.UnmapperProxy;
+import jdk.internal.foreign.HeapMemorySegmentImpl.OfByte;
+import jdk.internal.foreign.HeapMemorySegmentImpl.OfChar;
+import jdk.internal.foreign.HeapMemorySegmentImpl.OfDouble;
+import jdk.internal.foreign.HeapMemorySegmentImpl.OfFloat;
+import jdk.internal.foreign.HeapMemorySegmentImpl.OfInt;
+import jdk.internal.foreign.HeapMemorySegmentImpl.OfLong;
+import jdk.internal.foreign.HeapMemorySegmentImpl.OfShort;
+import jdk.internal.misc.Unsafe;
+import jdk.internal.misc.VM;
+import jdk.internal.vm.annotation.ForceInline;
+
+import java.lang.foreign.MemorySegment;
+import java.util.Objects;
+
+/**
+ * This class is used to retrieve concrete memory segment implementations, while making sure that classes
+ * are initialized in the right order (that is, that {@code MemorySegment} is always initialized first).
+ * See {@link SegmentFactories#ensureInitialized()}.
+ */
+public class SegmentFactories {
+
+    // The maximum alignment supported by malloc - typically 16 bytes on
+    // 64-bit platforms and 8 bytes on 32-bit platforms.
+    private static final long MAX_MALLOC_ALIGN = Unsafe.ADDRESS_SIZE == 4 ? 8 : 16;
+
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    // Unsafe native segment factories. These are used by the implementation code, to skip the sanity checks
+    // associated with MemorySegment::ofAddress.
+
+    @ForceInline
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, MemorySessionImpl sessionImpl, Runnable action) {
+        ensureInitialized();
+        if (action == null) {
+            sessionImpl.checkValidState();
+        } else {
+            sessionImpl.addCloseAction(action);
+        }
+        return new NativeMemorySegmentImpl(min, byteSize, false, sessionImpl);
+    }
+
+    @ForceInline
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, MemorySessionImpl sessionImpl) {
+        ensureInitialized();
+        sessionImpl.checkValidState();
+        return new NativeMemorySegmentImpl(min, byteSize, false, sessionImpl);
+    }
+
+    @ForceInline
+    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize) {
+        ensureInitialized();
+        return new NativeMemorySegmentImpl(min, byteSize, false, new GlobalSession(null));
+    }
+
+    public static MemorySegment fromArray(byte[] arr) {
+        ensureInitialized();
+        Objects.requireNonNull(arr);
+        long byteSize = (long)arr.length * Unsafe.ARRAY_BYTE_INDEX_SCALE;
+        return new OfByte(Unsafe.ARRAY_BYTE_BASE_OFFSET, arr, byteSize, false,
+                MemorySessionImpl.heapSession(arr));
+    }
+
+    public static MemorySegment fromArray(short[] arr) {
+        ensureInitialized();
+        Objects.requireNonNull(arr);
+        long byteSize = (long)arr.length * Unsafe.ARRAY_SHORT_INDEX_SCALE;
+        return new OfShort(Unsafe.ARRAY_SHORT_BASE_OFFSET, arr, byteSize, false,
+                MemorySessionImpl.heapSession(arr));
+    }
+
+    public static MemorySegment fromArray(int[] arr) {
+        ensureInitialized();
+        Objects.requireNonNull(arr);
+        long byteSize = (long)arr.length * Unsafe.ARRAY_INT_INDEX_SCALE;
+        return new OfInt(Unsafe.ARRAY_INT_BASE_OFFSET, arr, byteSize, false,
+                MemorySessionImpl.heapSession(arr));
+    }
+
+    public static MemorySegment fromArray(char[] arr) {
+        ensureInitialized();
+        Objects.requireNonNull(arr);
+        long byteSize = (long)arr.length * Unsafe.ARRAY_CHAR_INDEX_SCALE;
+        return new OfChar(Unsafe.ARRAY_CHAR_BASE_OFFSET, arr, byteSize, false,
+                MemorySessionImpl.heapSession(arr));
+    }
+
+    public static MemorySegment fromArray(float[] arr) {
+        ensureInitialized();
+        Objects.requireNonNull(arr);
+        long byteSize = (long)arr.length * Unsafe.ARRAY_FLOAT_INDEX_SCALE;
+        return new OfFloat(Unsafe.ARRAY_FLOAT_BASE_OFFSET, arr, byteSize, false,
+                MemorySessionImpl.heapSession(arr));
+    }
+
+    public static MemorySegment fromArray(double[] arr) {
+        ensureInitialized();
+        Objects.requireNonNull(arr);
+        long byteSize = (long)arr.length * Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
+        return new OfDouble(Unsafe.ARRAY_DOUBLE_BASE_OFFSET, arr, byteSize, false,
+                MemorySessionImpl.heapSession(arr));
+    }
+
+    public static MemorySegment fromArray(long[] arr) {
+        ensureInitialized();
+        Objects.requireNonNull(arr);
+        long byteSize = (long)arr.length * Unsafe.ARRAY_LONG_INDEX_SCALE;
+        return new OfLong(Unsafe.ARRAY_LONG_BASE_OFFSET, arr, byteSize, false,
+                MemorySessionImpl.heapSession(arr));
+    }
+
+    public static MemorySegment allocateSegment(long byteSize, long byteAlignment, MemorySessionImpl sessionImpl,
+                                                  boolean shouldReserve) {
+        ensureInitialized();
+        sessionImpl.checkValidState();
+        if (VM.isDirectMemoryPageAligned()) {
+            byteAlignment = Math.max(byteAlignment, AbstractMemorySegmentImpl.NIO_ACCESS.pageSize());
+        }
+        long alignedSize = Math.max(1L, byteAlignment > MAX_MALLOC_ALIGN ?
+                byteSize + (byteAlignment - 1) :
+                byteSize);
+
+        if (shouldReserve) {
+            AbstractMemorySegmentImpl.NIO_ACCESS.reserveMemory(alignedSize, byteSize);
+        }
+
+        long buf = allocateMemoryWrapper(alignedSize);
+        long alignedBuf = Utils.alignUp(buf, byteAlignment);
+        AbstractMemorySegmentImpl segment = new NativeMemorySegmentImpl(buf, alignedSize,
+                false, sessionImpl);
+        sessionImpl.addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
+            @Override
+            public void cleanup() {
+                UNSAFE.freeMemory(buf);
+                if (shouldReserve) {
+                    AbstractMemorySegmentImpl.NIO_ACCESS.unreserveMemory(alignedSize, byteSize);
+                }
+            }
+        });
+        if (alignedSize != byteSize) {
+            long delta = alignedBuf - buf;
+            segment = segment.asSlice(delta, byteSize);
+        }
+        return segment;
+    }
+
+    private static long allocateMemoryWrapper(long size) {
+        try {
+            return UNSAFE.allocateMemory(size);
+        } catch (IllegalArgumentException ex) {
+            throw new OutOfMemoryError();
+        }
+    }
+
+    public static MemorySegment mapSegment(long size, UnmapperProxy unmapper, boolean readOnly, MemorySessionImpl sessionImpl) {
+        ensureInitialized();
+        if (unmapper != null) {
+            AbstractMemorySegmentImpl segment =
+                    new MappedMemorySegmentImpl(unmapper.address(), unmapper, size,
+                            readOnly, sessionImpl);
+            MemorySessionImpl.ResourceList.ResourceCleanup resource =
+                    new MemorySessionImpl.ResourceList.ResourceCleanup() {
+                        @Override
+                        public void cleanup() {
+                            unmapper.unmap();
+                        }
+                    };
+            sessionImpl.addOrCleanupIfFail(resource);
+            return segment;
+        } else {
+            return new MappedMemorySegmentImpl(0, null, 0, readOnly, sessionImpl);
+        }
+    }
+
+    // The method below needs to be called before any concrete subclass of MemorySegment
+    // is instantiated. This is to make sure that we cannot have an initialization deadlock
+    // where one thread attempts to initialize e.g. MemorySegment (and then NativeMemorySegmentImpl, via
+    // the MemorySegment.NULL field) while another thread is attempting to initialize
+    // NativeMemorySegmentImpl (and then MemorySegment, the super-interface).
+    @ForceInline
+    private static void ensureInitialized() {
+        MemorySegment segment = MemorySegment.NULL;
+    }
+}

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -148,7 +148,7 @@ public final class Utils {
         if (!isAligned(addr, align)) {
             throw new IllegalArgumentException("Invalid alignment constraint for address: " + addr);
         }
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(addr, size);
+        return SegmentFactories.makeNativeSegmentUnchecked(addr, size);
     }
 
     @ForceInline
@@ -156,7 +156,7 @@ public final class Utils {
         if (!isAligned(addr, align)) {
             throw new IllegalArgumentException("Invalid alignment constraint for address: " + addr);
         }
-        return NativeMemorySegmentImpl.makeNativeSegmentUnchecked(addr, size, scope);
+        return SegmentFactories.makeNativeSegmentUnchecked(addr, size, scope);
     }
 
     @ForceInline

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -50,9 +50,8 @@ import java.util.Objects;
 
 import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.foreign.AbstractMemorySegmentImpl;
-import jdk.internal.foreign.MappedMemorySegmentImpl;
 import jdk.internal.foreign.MemorySessionImpl;
+import jdk.internal.foreign.SegmentFactories;
 import jdk.internal.misc.Blocker;
 import jdk.internal.misc.ExtendedMapMode;
 import jdk.internal.misc.Unsafe;
@@ -1335,22 +1334,7 @@ public class FileChannelImpl
         if (mode == MapMode.READ_ONLY) {
             readOnly = true;
         }
-        if (unmapper != null) {
-            AbstractMemorySegmentImpl segment =
-                new MappedMemorySegmentImpl(unmapper.address(), unmapper, size,
-                                            readOnly, sessionImpl);
-            MemorySessionImpl.ResourceList.ResourceCleanup resource =
-                new MemorySessionImpl.ResourceList.ResourceCleanup() {
-                    @Override
-                    public void cleanup() {
-                        unmapper.unmap();
-                    }
-                };
-            sessionImpl.addOrCleanupIfFail(resource);
-            return segment;
-        } else {
-            return new MappedMemorySegmentImpl(0, null, 0, readOnly, sessionImpl);
-        }
+        return SegmentFactories.mapSegment(size, unmapper, readOnly, sessionImpl);
     }
 
     private Unmapper mapInternal(MapMode mode, long position, long size, int prot, boolean isSync)

--- a/test/jdk/java/foreign/TestDeadlock.java
+++ b/test/jdk/java/foreign/TestDeadlock.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=Arena_allocateFrom
+ * @run main/othervm/timeout=5 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock Arena
+ */
+
+/*
+ * @test id=FileChannel_map
+ * @run main/othervm/timeout=5 --enable-native-access=ALL-UNNAMED -Xlog:class+init TestDeadlock FileChannel
+ */
+
+import java.lang.foreign.*;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.CountDownLatch;
+
+public class TestDeadlock {
+    public static void main(String[] args) throws Throwable {
+        CountDownLatch latch = new CountDownLatch(2);
+
+        Runnable tester = switch (args[0]) {
+            case "Arena" -> () -> {
+                Arena arena = Arena.global();
+                arena.scope(); // init ArenaImpl
+                ValueLayout.JAVA_INT.byteSize(); // init ValueLayout (and impls)
+                latch.countDown();
+                try {
+                    latch.await();
+                } catch(InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+
+                // Access ArenaImpl -> NativeMemorySegmentImpl -> MemorySegment
+                arena.allocateFrom(ValueLayout.JAVA_INT, 42);
+            };
+            case "FileChannel" -> () -> {
+                try {
+                    Arena arena = Arena.global();
+                    Path p = Files.createFile(Path.of("test.out"));
+
+                    try (FileChannel channel = FileChannel.open(p, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+                        channel.map(FileChannel.MapMode.READ_WRITE, 0, 4); // create MappedByteBuffer to initialize other things
+                        latch.countDown();
+                        latch.await();
+
+                        // Access MappedMemorySegmentImpl -> MemorySegment
+                        channel.map(FileChannel.MapMode.READ_WRITE, 0, 4, arena);
+                    }
+                } catch(InterruptedException | IOException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+            default -> throw new IllegalArgumentException("Unknown test selection: " + args[0]);
+        };
+
+        Thread t1 = Thread.ofPlatform().start(tester);
+        Thread t2 = Thread.ofPlatform().start(() -> {
+            latch.countDown();
+            try {
+                latch.await();
+            } catch(InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            // Access MemorySegment -> NativeMemorySegmentImpl
+            MemorySegment.ofAddress(42);
+        });
+
+        // wait for potential deadlock
+
+        t1.join();
+        t2.join();
+
+        // all good
+    }
+}

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -30,7 +30,6 @@
 
 import java.lang.foreign.*;
 
-import jdk.internal.foreign.NativeMemorySegmentImpl;
 import org.testng.annotations.*;
 
 import java.lang.foreign.Arena;
@@ -239,7 +238,7 @@ public class TestSegmentAllocators {
                 assertThrows(UnsupportedOperationException.class, segment::isLoaded);
                 assertThrows(UnsupportedOperationException.class, segment::force);
                 assertFalse(segment.isMapped());
-                assertEquals(segment.isNative(), segment instanceof NativeMemorySegmentImpl);
+                assertTrue(segment.isNative());
             }
         }
     }


### PR DESCRIPTION
This PR makes sure that `MemorySegment` is initialized *before* any of its subclasses.
This is done by centralizing all the memory segment factories in a single implementation class (`SegmentFactories`).
Doing so addresses a possible deadlock condition when using multiple threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317514](https://bugs.openjdk.org/browse/JDK-8317514): Ensure MemorySegment is initialized before touching NativeMemorySegmentImpl (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Contributors
 * Jorn Vernee `<jvernee@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16187/head:pull/16187` \
`$ git checkout pull/16187`

Update a local copy of the PR: \
`$ git checkout pull/16187` \
`$ git pull https://git.openjdk.org/jdk.git pull/16187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16187`

View PR using the GUI difftool: \
`$ git pr show -t 16187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16187.diff">https://git.openjdk.org/jdk/pull/16187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16187#issuecomment-1761736968)