### PR TITLE
Enum codegen experiment

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/EnumInitializer.java
+++ b/src/java.base/share/classes/java/lang/runtime/EnumInitializer.java
@@ -1,0 +1,47 @@
+package java.lang.runtime;
+
+import jdk.internal.misc.Unsafe;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * A class for initializing enums.
+ */
+public final class EnumInitializer {
+
+    /**
+     * A method for initializing enums.
+     *
+     * @param enumClassLU the lookup
+     */
+    public static void initializeEnumClass(MethodHandles.Lookup enumClassLU) {
+        if (!enumClassLU.hasFullPrivilegeAccess()) {
+            throw new IllegalArgumentException();
+        }
+        @SuppressWarnings("rawtypes")
+        Class<? extends Enum> ec = enumClassLU.lookupClass().asSubclass(Enum.class);
+        Unsafe unsafe = Unsafe.getUnsafe();
+        try {
+            // TODO - guarantee the creator method name doesn't clash, and pass in the name of the generated method
+            Method enumMemberCreator = ec.getDeclaredMethod("enumMemberCreator$", int.class);
+            enumMemberCreator.setAccessible(true);
+            int ordinal = 0;
+            for (Field f : ec.getDeclaredFields()) {  //order significant here
+                if (f.isEnumConstant()) {
+                    Object e = enumMemberCreator.invoke(null, ordinal++);
+                    long offset = unsafe.staticFieldOffset(f);
+                    assert unsafe.getReference(enumClassLU.lookupClass(), offset) == null; //caller resp.
+                    unsafe.putReference(enumClassLU.lookupClass(), offset, e);
+                }
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new LinkageError(e.getMessage(), e);
+        }
+    }
+
+    private EnumInitializer() {
+    }
+}


### PR DESCRIPTION
This is not ready for review, it is a prototype for discussion.

See https://mail.openjdk.org/pipermail/compiler-dev/2023-October/024456.html

---

```java
import java.util.Arrays;

enum E {
  ONE,
  TWO,
  THREE;

  public static void main(String[] args) {
    System.err.println(E.THREE);
  }
}
```

```
Classfile /Users/cushon/src/jdk/E.class
  Last modified Oct 13, 2023; size 1698 bytes
  SHA-256 checksum 7893ee386ed8936f1b0e914ad6dc123dfbd96ca1cb622c463dc1233c1acd0960
  Compiled from "E.java"
final class E extends java.lang.Enum<E>
  minor version: 0
  major version: 66
  flags: (0x4030) ACC_FINAL, ACC_SUPER, ACC_ENUM
  this_class: #1                          // E
  super_class: #32                        // java/lang/Enum
  interfaces: 0, fields: 4, methods: 8, attributes: 3
Constant pool:
   #1 = Class              #2             // E
   #2 = Utf8               E
   #3 = String             #4             // ONE
   #4 = Utf8               ONE
   #5 = Methodref          #1.#6          // E."<init>":(Ljava/lang/String;I)V
   #6 = NameAndType        #7:#8          // "<init>":(Ljava/lang/String;I)V
   #7 = Utf8               <init>
   #8 = Utf8               (Ljava/lang/String;I)V
   #9 = String             #10            // TWO
  #10 = Utf8               TWO
  #11 = String             #12            // THREE
  #12 = Utf8               THREE
  #13 = Class              #14            // java/lang/MatchException
  #14 = Utf8               java/lang/MatchException
  #15 = Methodref          #13.#16        // java/lang/MatchException."<init>":(Ljava/lang/String;Ljava/lang/Throwable;)V
  #16 = NameAndType        #7:#17         // "<init>":(Ljava/lang/String;Ljava/lang/Throwable;)V
  #17 = Utf8               (Ljava/lang/String;Ljava/lang/Throwable;)V
  #18 = Methodref          #1.#19         // E.enumMemberCreator$0:(I)LE;
  #19 = NameAndType        #20:#21        // enumMemberCreator$0:(I)LE;
  #20 = Utf8               enumMemberCreator$0
  #21 = Utf8               (I)LE;
  #22 = Fieldref           #1.#23         // E.$VALUES:[LE;
  #23 = NameAndType        #24:#25        // $VALUES:[LE;
  #24 = Utf8               $VALUES
  #25 = Utf8               [LE;
  #26 = Methodref          #27.#28        // "[LE;".clone:()Ljava/lang/Object;
  #27 = Class              #25            // "[LE;"
  #28 = NameAndType        #29:#30        // clone:()Ljava/lang/Object;
  #29 = Utf8               clone
  #30 = Utf8               ()Ljava/lang/Object;
  #31 = Methodref          #32.#33        // java/lang/Enum.valueOf:(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;
  #32 = Class              #34            // java/lang/Enum
  #33 = NameAndType        #35:#36        // valueOf:(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;
  #34 = Utf8               java/lang/Enum
  #35 = Utf8               valueOf
  #36 = Utf8               (Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;
  #37 = Methodref          #32.#6         // java/lang/Enum."<init>":(Ljava/lang/String;I)V
  #38 = Fieldref           #39.#40        // java/lang/System.err:Ljava/io/PrintStream;
  #39 = Class              #41            // java/lang/System
  #40 = NameAndType        #42:#43        // err:Ljava/io/PrintStream;
  #41 = Utf8               java/lang/System
  #42 = Utf8               err
  #43 = Utf8               Ljava/io/PrintStream;
  #44 = Fieldref           #1.#45         // E.THREE:LE;
  #45 = NameAndType        #12:#46        // THREE:LE;
  #46 = Utf8               LE;
  #47 = Methodref          #48.#49        // java/io/PrintStream.println:(Ljava/lang/Object;)V
  #48 = Class              #50            // java/io/PrintStream
  #49 = NameAndType        #51:#52        // println:(Ljava/lang/Object;)V
  #50 = Utf8               java/io/PrintStream
  #51 = Utf8               println
  #52 = Utf8               (Ljava/lang/Object;)V
  #53 = Methodref          #1.#54         // E.$values:()[LE;
  #54 = NameAndType        #55:#56        // $values:()[LE;
  #55 = Utf8               $values
  #56 = Utf8               ()[LE;
  #57 = Methodref          #58.#59        // java/lang/invoke/MethodHandles.lookup:()Ljava/lang/invoke/MethodHandles$Lookup;
  #58 = Class              #60            // java/lang/invoke/MethodHandles
  #59 = NameAndType        #61:#62        // lookup:()Ljava/lang/invoke/MethodHandles$Lookup;
  #60 = Utf8               java/lang/invoke/MethodHandles
  #61 = Utf8               lookup
  #62 = Utf8               ()Ljava/lang/invoke/MethodHandles$Lookup;
  #63 = Methodref          #64.#65        // java/lang/runtime/EnumInitializer.initializeEnumClass:(Ljava/lang/invoke/MethodHandles$Lookup;)V
  #64 = Class              #66            // java/lang/runtime/EnumInitializer
  #65 = NameAndType        #67:#68        // initializeEnumClass:(Ljava/lang/invoke/MethodHandles$Lookup;)V
  #66 = Utf8               java/lang/runtime/EnumInitializer
  #67 = Utf8               initializeEnumClass
  #68 = Utf8               (Ljava/lang/invoke/MethodHandles$Lookup;)V
  #69 = Utf8               values
  #70 = Utf8               Code
  #71 = Utf8               LineNumberTable
  #72 = Utf8               (Ljava/lang/String;)LE;
  #73 = Utf8               MethodParameters
  #74 = Utf8               Signature
  #75 = Utf8               ()V
  #76 = Utf8               main
  #77 = Utf8               ([Ljava/lang/String;)V
  #78 = Utf8               StackMapTable
  #79 = Utf8               enumMemberCreator$
  #80 = Utf8               <clinit>
  #81 = Utf8               Ljava/lang/Enum<LE;>;
  #82 = Utf8               SourceFile
  #83 = Utf8               E.java
  #84 = Utf8               InnerClasses
  #85 = Class              #86            // java/lang/invoke/MethodHandles$Lookup
  #86 = Utf8               java/lang/invoke/MethodHandles$Lookup
  #87 = Utf8               Lookup
{
  public static final E ONE;
    descriptor: LE;
    flags: (0x4019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL, ACC_ENUM

  public static final E TWO;
    descriptor: LE;
    flags: (0x4019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL, ACC_ENUM

  public static final E THREE;
    descriptor: LE;
    flags: (0x4019) ACC_PUBLIC, ACC_STATIC, ACC_FINAL, ACC_ENUM

  private static final E[] $VALUES;
    descriptor: [LE;
    flags: (0x101a) ACC_PRIVATE, ACC_STATIC, ACC_FINAL, ACC_SYNTHETIC

  public static E[] values();
    descriptor: ()[LE;
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC
    Code:
      stack=1, locals=0, args_size=0
         0: getstatic     #22                 // Field $VALUES:[LE;
         3: invokevirtual #26                 // Method "[LE;".clone:()Ljava/lang/Object;
         6: checkcast     #27                 // class "[LE;"
         9: areturn
      LineNumberTable:
        line 3: 0

  public static E valueOf(java.lang.String);
    descriptor: (Ljava/lang/String;)LE;
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC
    Code:
      stack=2, locals=1, args_size=1
         0: ldc           #1                  // class E
         2: aload_0
         3: invokestatic  #31                 // Method java/lang/Enum.valueOf:(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;
         6: checkcast     #1                  // class E
         9: areturn
      LineNumberTable:
        line 3: 0
    MethodParameters:
      Name                           Flags
      <no name>                      mandated

  private E();
    descriptor: (Ljava/lang/String;I)V
    flags: (0x0002) ACC_PRIVATE
    Code:
      stack=3, locals=3, args_size=3
         0: aload_0
         1: aload_1
         2: iload_2
         3: invokespecial #37                 // Method java/lang/Enum."<init>":(Ljava/lang/String;I)V
         6: return
      LineNumberTable:
        line 3: 0
    MethodParameters:
      Name                           Flags
      <no name>                      synthetic
      <no name>                      synthetic
    Signature: #75                          // ()V

  public static void main(java.lang.String[]);
    descriptor: ([Ljava/lang/String;)V
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC
    Code:
      stack=2, locals=1, args_size=1
         0: getstatic     #38                 // Field java/lang/System.err:Ljava/io/PrintStream;
         3: getstatic     #44                 // Field THREE:LE;
         6: invokevirtual #47                 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
         9: return
      LineNumberTable:
        line 9: 0
        line 10: 9

  private static E enumMemberCreator$0(int);
    descriptor: (I)LE;
    flags: (0x100a) ACC_PRIVATE, ACC_STATIC, ACC_SYNTHETIC
    Code:
      stack=4, locals=1, args_size=1
         0: iload_0
         1: tableswitch   { // 0 to 2
                       0: 28
                       1: 39
                       2: 50
                 default: 61
            }
        28: new           #1                  // class E
        31: dup
        32: ldc           #3                  // String ONE
        34: iconst_0
        35: invokespecial #5                  // Method "<init>":(Ljava/lang/String;I)V
        38: areturn
        39: new           #1                  // class E
        42: dup
        43: ldc           #9                  // String TWO
        45: iconst_1
        46: invokespecial #5                  // Method "<init>":(Ljava/lang/String;I)V
        49: areturn
        50: new           #1                  // class E
        53: dup
        54: ldc           #11                 // String THREE
        56: iconst_2
        57: invokespecial #5                  // Method "<init>":(Ljava/lang/String;I)V
        60: areturn
        61: new           #13                 // class java/lang/MatchException
        64: dup
        65: aconst_null
        66: aconst_null
        67: invokespecial #15                 // Method java/lang/MatchException."<init>":(Ljava/lang/String;Ljava/lang/Throwable;)V
        70: athrow
      LineNumberTable:
        line 3: 0
      StackMapTable: number_of_entries = 4
        frame_type = 28 /* same */
        frame_type = 10 /* same */
        frame_type = 10 /* same */
        frame_type = 10 /* same */
    MethodParameters:
      Name                           Flags
      <no name>                      synthetic

  private static E enumMemberCreator$(int);
    descriptor: (I)LE;
    flags: (0x100a) ACC_PRIVATE, ACC_STATIC, ACC_SYNTHETIC
    Code:
      stack=4, locals=1, args_size=1
         0: iload_0
         1: sipush        1000
         4: idiv
         5: lookupswitch  { // 1
                       0: 24
                 default: 29
            }
        24: iload_0
        25: invokestatic  #18                 // Method enumMemberCreator$0:(I)LE;
        28: areturn
        29: new           #13                 // class java/lang/MatchException
        32: dup
        33: aconst_null
        34: aconst_null
        35: invokespecial #15                 // Method java/lang/MatchException."<init>":(Ljava/lang/String;Ljava/lang/Throwable;)V
        38: athrow
      LineNumberTable:
        line 3: 0
      StackMapTable: number_of_entries = 2
        frame_type = 24 /* same */
        frame_type = 4 /* same */
    MethodParameters:
      Name                           Flags
      <no name>                      synthetic

  private static E[] $values();
    descriptor: ()[LE;
    flags: (0x100a) ACC_PRIVATE, ACC_STATIC, ACC_SYNTHETIC
    Code:
      stack=1, locals=0, args_size=0
         0: iconst_0
         1: anewarray     #1                  // class E
         4: areturn
      LineNumberTable:
        line 3: 0

  static {};
    descriptor: ()V
    flags: (0x0008) ACC_STATIC
    Code:
      stack=1, locals=0, args_size=0
         0: invokestatic  #53                 // Method $values:()[LE;
         3: putstatic     #22                 // Field $VALUES:[LE;
         6: invokestatic  #57                 // Method java/lang/invoke/MethodHandles.lookup:()Ljava/lang/invoke/MethodHandles$Lookup;
         9: invokestatic  #63                 // Method java/lang/runtime/EnumInitializer.initializeEnumClass:(Ljava/lang/invoke/MethodHandles$Lookup;)V
        12: return
      LineNumberTable:
        line 3: 0
}
Signature: #81                          // Ljava/lang/Enum<LE;>;
SourceFile: "E.java"
InnerClasses:
  public static final #87= #85 of #58;    // Lookup=class java/lang/invoke/MethodHandles$Lookup of class java/lang/invoke/MethodHandles

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16191/head:pull/16191` \
`$ git checkout pull/16191`

Update a local copy of the PR: \
`$ git checkout pull/16191` \
`$ git pull https://git.openjdk.org/jdk.git pull/16191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16191`

View PR using the GUI difftool: \
`$ git pr show -t 16191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16191.diff">https://git.openjdk.org/jdk/pull/16191.diff</a>

</details>
