### PR TITLE
8318101: Additional test cases for CSSAttributeEqualityBug

### DIFF
--- a/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
+++ b/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
@@ -70,6 +70,8 @@ public class CSSAttributeEqualityBug {
             "background-position: 0 0",
             "background-position: 1cm 2cm",
             "background-position: 1em 2em",
+
+            "border-width: medium",
     };
 
     /**
@@ -86,6 +88,14 @@ public class CSSAttributeEqualityBug {
             {"margin-top: 100%", "margin-top: 50%"},
     };
 
+    private static final String[][] EQUALS_WITH_SPACE = {
+            {"font-size: 42px", "font-size: 42 px"},
+            {"font-size: 100%", "font-size: 100 %"},
+
+            {"width: 42px", "width: 42 px"},
+            {"width: 100%", "width: 100 %"},
+    };
+
     public static void main(String[] args) {
         final List<String> failures = new ArrayList<>();
 
@@ -97,10 +107,14 @@ public class CSSAttributeEqualityBug {
               .map(CSSAttributeEqualityBug::negativeTest)
               .filter(Objects::nonNull)
               .forEach(failures::add);
+        Arrays.stream(EQUALS_WITH_SPACE)
+              .map(CSSAttributeEqualityBug::positiveTest)
+              .filter(Objects::nonNull)
+              .forEach(failures::add);
 
         if (!failures.isEmpty()) {
             failures.forEach(System.err::println);
-            throw new RuntimeException(failures.size()
+            throw new RuntimeException("The test failed: " + failures.size()
                                        + " failure(s) detected: "
                                        + failures.get(0));
         }
@@ -111,6 +125,15 @@ public class CSSAttributeEqualityBug {
 
         AttributeSet a = ss.getDeclaration(cssDeclaration);
         AttributeSet b = ss.getDeclaration(cssDeclaration);
+
+        return assertEquals(a, b);
+    }
+
+    private static String positiveTest(String[] cssDeclaration) {
+        StyleSheet ss = new StyleSheet();
+
+        AttributeSet a = ss.getDeclaration(cssDeclaration[0]);
+        AttributeSet b = ss.getDeclaration(cssDeclaration[1]);
 
         return assertEquals(a, b);
     }
@@ -145,4 +168,3 @@ public class CSSAttributeEqualityBug {
     }
 
 }
-


### PR DESCRIPTION
Adds additional test cases to `javax/swing/text/html/CSS/CSSAttributeEqualityBug.java`.

Currently, CSS parser in Java allows space between the number and the unit or percent. This is what the additional test cases verify.

There's also one additional case for `border-width: medium`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318101](https://bugs.openjdk.org/browse/JDK-8318101): Additional test cases for CSSAttributeEqualityBug (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16193/head:pull/16193` \
`$ git checkout pull/16193`

Update a local copy of the PR: \
`$ git checkout pull/16193` \
`$ git pull https://git.openjdk.org/jdk.git pull/16193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16193`

View PR using the GUI difftool: \
`$ git pr show -t 16193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16193.diff">https://git.openjdk.org/jdk/pull/16193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16193#issuecomment-1762159214)