### PR TITLE
8318126: Refresh manpages

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -530,26 +530,27 @@ The value \[dq]disabled\[dq] disables finalization, so that no
 finalizers are invoked.
 .TP
 \f[V]--module-path\f[R] \f[I]modulepath\f[R]... or \f[V]-p\f[R] \f[I]modulepath\f[R]
-Specifies where to find application modules with a list of path elements.
-The elements of a module path can be a file path to a module or a directory
-containing modules. Each module is either a modular JAR or an
-exploded-module directory.
+Specifies where to find application modules with a list of path
+elements.
+The elements of a module path can be a file path to a module or a
+directory containing modules.
+Each module is either a modular JAR or an exploded-module directory.
 .RS
 .PP
-On Windows, semicolons (\f[V];\f[R]) separate path elements in this list;
-on other platforms it is a colon (\f[V]:\f[R]).
+On Windows, semicolons (\f[V];\f[R]) separate path elements in this
+list; on other platforms it is a colon (\f[V]:\f[R]).
 .RE
 .TP
 \f[V]--upgrade-module-path\f[R] \f[I]modulepath\f[R]...
-Specifies where to find module replacements of upgradeable modules in the
-runtime image with a list of path elements.
-The elements of a module path can be a file path to a module or a directory
-containing modules. Each module is either a modular JAR or an
-exploded-module directory.
+Specifies where to find module replacements of upgradeable modules in
+the runtime image with a list of path elements.
+The elements of a module path can be a file path to a module or a
+directory containing modules.
+Each module is either a modular JAR or an exploded-module directory.
 .RS
 .PP
-On Windows, semicolons (\f[V];\f[R]) separate path elements in this list;
-on other platforms it is a colon (\f[V]:\f[R]).
+On Windows, semicolons (\f[V];\f[R]) separate path elements in this
+list; on other platforms it is a colon (\f[V]:\f[R]).
 .RE
 .TP
 \f[V]--add-modules\f[R] \f[I]module\f[R][\f[V],\f[R]\f[I]module\f[R]...]
@@ -1304,6 +1305,7 @@ By default this option is disabled.
 .TP
 \f[V]-XX:FlightRecorderOptions=\f[R]\f[I]parameter\f[R]\f[V]=\f[R]\f[I]value\f[R] (or) \f[V]-XX:FlightRecorderOptions:\f[R]\f[I]parameter\f[R]\f[V]=\f[R]\f[I]value\f[R]
 Sets the parameters that control the behavior of JFR.
+Multiple parameters can be specified by separating them with a comma.
 .RS
 .PP
 The following list contains the available JFR
@@ -1369,9 +1371,6 @@ By default, the local buffer size is set to 8 kilobytes, with a minimum
 value of 4 kilobytes.
 Overriding this parameter could reduce performance and is not
 recommended.
-.PP
-You can specify values for multiple parameters by separating them with a
-comma.
 .RE
 .TP
 \f[V]-XX:LargePageSizeInBytes=\f[R]\f[I]size\f[R]
@@ -1658,6 +1657,9 @@ written when the recording is stopped, for example:
 \f[V]/home/user/recordings/recording.jfr\f[R]
 .IP \[bu] 2
 \f[V]c:\[rs]recordings\[rs]recording.jfr\f[R]
+.PP
+If %p and/or %t is specified in the filename, it expands to the
+JVM\[aq]s PID and the current timestamp, respectively.
 .RE
 .TP
 \f[V]name=\f[R]\f[I]identifier\f[R]
@@ -1810,19 +1812,6 @@ Use \f[V]-Xlog:os+container=trace\f[R] for maximum logging of container
 information.
 See \f[B]Enable Logging with the JVM Unified Logging Framework\f[R] for
 a description of using Unified Logging.
-.RE
-.TP
-\f[V]-XX:+UseHugeTLBFS\f[R]
-\f[B]Linux only:\f[R] This option is the equivalent of specifying
-\f[V]-XX:+UseLargePages\f[R].
-This option is disabled by default.
-This option pre-allocates all large pages up-front, when memory is
-reserved; consequently the JVM can\[aq]t dynamically grow or shrink
-large pages memory areas; see \f[V]-XX:UseTransparentHugePages\f[R] if
-you want this behavior.
-.RS
-.PP
-See \f[B]Large Pages\f[R].
 .RE
 .TP
 \f[V]-XX:+UseLargePages\f[R]
@@ -2172,37 +2161,16 @@ unlocks diagnostic JVM options.
 Sets the list of methods (separated by commas) to which compilation
 should be restricted.
 Only the specified methods are compiled.
-Specify each method with the full class name (including the packages and
-subpackages).
-For example, to compile only the \f[V]length()\f[R] method of the
-\f[V]String\f[R] class and the \f[V]size()\f[R] method of the
-\f[V]List\f[R] class, use the following:
-.RS
 .RS
 .PP
-\f[V]-XX:CompileOnly=java/lang/String.length,java/util/List.size\f[R]
-.RE
-.PP
-Note that the full class name is specified, including all packages and
-subpackages separated by a slash (\f[V]/\f[R]).
-For easier cut and paste operations, it\[aq]s also possible to use the
-method name format produced by the \f[V]-XX:+PrintCompilation\f[R] and
-\f[V]-XX:+LogCompilation\f[R] options:
-.RS
-.PP
-\f[V]-XX:CompileOnly=java.lang.String::length,java.util.List::size\f[R]
-.RE
-.PP
-Although wildcards aren\[aq]t supported, you can specify only the class
-or package name to compile all methods in that class or package, as well
-as specify just the method to compile methods with this name in any
-class:
+\f[V]-XX:CompileOnly=method1,method2,...,methodN\f[R] is an alias for:
 .IP
 .nf
 \f[CB]
--XX:CompileOnly=java/lang/String
--XX:CompileOnly=java/lang
--XX:CompileOnly=.length
+-XX:CompileCommand=compileonly,method1
+-XX:CompileCommand=compileonly,method2
+\&...
+-XX:CompileCommand=compileonly,methodN
 \f[R]
 .fi
 .RE
@@ -3655,14 +3623,6 @@ This is generally the best choice for small and simple applications that
 don\[aq]t require any special functionality from garbage collection.
 By default, this option is disabled and the default collector is used.
 .TP
-\f[V]-XX:+UseSHM\f[R]
-\f[B]Linux only:\f[R] Enables the JVM to use shared memory to set up
-large pages.
-.RS
-.PP
-See \f[B]Large Pages\f[R] for setting up large pages.
-.RE
-.TP
 \f[V]-XX:+UseStringDeduplication\f[R]
 Enables string deduplication.
 By default, this option is disabled.
@@ -3815,6 +3775,19 @@ Controlled \f[I]relaxed strong encapsulation\f[R], as defined in
 This option was deprecated in JDK 16 by \f[B]JEP 396\f[R]
 [https://openjdk.org/jeps/396] and made obsolete in JDK 17 by \f[B]JEP
 403\f[R] [https://openjdk.org/jeps/403].
+.TP
+\f[V]-XX:+UseHugeTLBFS\f[R]
+\f[B]Linux only:\f[R] This option is the equivalent of specifying
+\f[V]-XX:+UseLargePages\f[R].
+This option is disabled by default.
+This option pre-allocates all large pages up-front, when memory is
+reserved; consequently the JVM can\[aq]t dynamically grow or shrink
+large pages memory areas; see \f[V]-XX:UseTransparentHugePages\f[R] if
+you want this behavior.
+.TP
+\f[V]-XX:+UseSHM\f[R]
+\f[B]Linux only:\f[R] Enables the JVM to use shared memory to set up
+large pages.
 .SH REMOVED JAVA OPTIONS
 .PP
 No documented java options have been removed in JDK 22.
@@ -4915,20 +4888,6 @@ login as \f[V]root\f[R] and run:
 It is always recommended to check the value of \f[V]nr_hugepages\f[R]
 after the request to make sure the kernel was able to allocate the
 requested number of large pages.
-.PP
-When using the option \f[V]-XX:+UseSHM\f[R] to enable large pages you
-also need to make sure the \f[V]SHMMAX\f[R] parameter is configured to
-allow large enough shared memory segments to be allocated.
-To allow a maximum shared segment of 8 GB, login as \f[V]root\f[R] and
-run:
-.RS
-.PP
-\f[V]# echo 8589934592 > /proc/sys/kernel/shmmax\f[R]
-.RE
-.PP
-In some environments this is not needed since the default value is large
-enough, but it is important to make sure the value is large enough to
-fit the amount of memory intended to be backed by large pages.
 .RS
 .PP
 \f[B]Note:\f[R] The values contained in \f[V]/proc\f[R] and

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -453,6 +453,8 @@ If no filename is given, a filename is generated from the PID and the
 current date.
 The filename may also be a directory in which case, the filename is
 generated from the PID and the current date in the specified directory.
+If %p and/or %t is specified in the filename, it expands to the
+JVM\[aq]s PID and the current timestamp, respectively.
 (STRING, no default value)
 .IP \[bu] 2
 \f[V]maxage\f[R]: (Optional) Length of time for dumping the flight
@@ -521,6 +523,8 @@ current date and is placed in the directory where the process was
 started.
 The filename may also be a directory in which case, the filename is
 generated from the PID and the current date in the specified directory.
+If %p and/or %t is specified in the filename, it expands to the
+JVM\[aq]s PID and the current timestamp, respectively.
 (STRING, no default value)
 .IP \[bu] 2
 \f[V]maxage\f[R]: (Optional) Maximum time to keep the recorded data on
@@ -612,6 +616,8 @@ If no parameters are entered, then no recording is stopped.
 .IP \[bu] 2
 \f[V]filename\f[R]: (Optional) Name of the file to which the recording
 is written when the recording is stopped.
+If %p and/or %t is specified in the filename, it expands to the
+JVM\[aq]s PID and the current timestamp, respectively.
 If no path is provided, the data from the recording is discarded.
 (STRING, no default value)
 .IP \[bu] 2

--- a/src/jdk.jdeps/share/man/jdeps.1
+++ b/src/jdk.jdeps/share/man/jdeps.1
@@ -244,10 +244,6 @@ This option filters the list of classes to be analyzed.
 It can be used together with \f[V]-p\f[R] and \f[V]-e\f[R], which apply
 the pattern to the dependencies.
 .TP
-\f[V]-P\f[R] or \f[V]-profile\f[R]
-Shows the profile containing a package.
-This option is deprecated and may be removed in a future release.
-.TP
 \f[V]-R\f[R] or \f[V]--recursive\f[R]
 Recursively traverses all run-time dependences.
 The \f[V]-R\f[R] option implies \f[V]-filter:none\f[R].

--- a/src/jdk.jfr/share/man/jfr.1
+++ b/src/jdk.jfr/share/man/jfr.1
@@ -221,7 +221,7 @@ Use \f[V]jfr --help view\f[R] to see a list of available views.
 <\f[I]file\f[R]>
 Location of the recording file (.jfr)
 .PP
-The parameter can be an event type name.
+The <\f[I]view\f[R]> parameter can be an event type name.
 Use the \f[V]jfr view types <file>\f[R] to see a list.
 To display all views, use \f[V]jfr view all-views <file>\f[R].
 To display all events, use \f[V]jfr view all-events <file>\f[R].
@@ -258,8 +258,9 @@ To see available options, use \f[V]jfr help configure\f[R]
 .TP
 \f[I]event-setting=value\f[R]
 The event setting value to modify.
-Use the form: <\f[I]event-name>#=<value\f[R]> To add a new event
-setting, prefix the event name with \[aq]+\[aq].
+Use the form:
+<\f[I]event-name\f[R]>#<\f[I]setting-name\f[R]>=<\f[I]value\f[R]> To add
+a new event setting, prefix the event name with \[aq]+\[aq].
 .PP
 The whitespace delimiter can be omitted for timespan values, i.e.
 20ms.
@@ -316,7 +317,7 @@ The syntax is:
 [--exclude-events <\f[I]filter\f[R]>] [--include-categories
 <\f[I]filter\f[R]>] [--exclude-categories <\f[I]filter\f[R]>]
 [--include-threads <\f[I]filter\f[R]>] [--exclude-threads
-<\f[I]filter\f[R]>] <\f[I]input-file\f[R]> []
+<\f[I]filter\f[R]>] <\f[I]input-file\f[R]> [<\f[I]output-file\f[R]>]
 .TP
 \f[V]--include-events\f[R] <\f[I]filter\f[R]>
 Select events matching an event name.
@@ -335,8 +336,9 @@ Select events matching a thread name.
 .TP
 \f[V]--exclude-threads\f[R] <\f[I]filter\f[R]>
 Exclude events matching a thread name.
-.PP
-<\f[I]input-file\f[R]> :The input file to read events from.
+.TP
+<\f[I]input-file\f[R]>
+The input file to read events from.
 .TP
 <\f[I]output-file\f[R]>
 The output file to write filter events to.
@@ -346,7 +348,7 @@ input file, but with \[dq]-scrubbed\[dq] appended to the filename.
 The filter is a comma-separated list of names, simple and/or qualified,
 and/or quoted glob patterns.
 If multiple filters are used, they are applied in the specified order.
-.SS jfr \f[V]assemble\f[R] subcommand
+.SS \f[V]jfr assemble\f[R] subcommand
 .PP
 Use jfr \f[V]assemble\f[R] to assemble chunk files into a recording
 file.


### PR DESCRIPTION
The open nroff manpage files are out of sync with their closed markdown sources and need to be refreshed.

The changes to apply are coming from:

- [JDK-8288158](https://bugs.openjdk.org/browse/JDK-8288158): Add an anchor to each subcommand option on jfr html page
- [JDK-8273131](https://bugs.openjdk.org/browse/JDK-8273131): Update the java manpage markdown source for JFR filename expansion
- [JDK-8221633](https://bugs.openjdk.org/browse/JDK-8221633): StartFlightRecording: consider moving mention of multiple comma-separated parameters to the front
- [JDK-8308662](https://bugs.openjdk.org/browse/JDK-8308662): Update the "java" tool specification for CompileOnly
- [JDK-8317565](https://bugs.openjdk.org/browse/JDK-8317565): Update Manpage for obsoletion of UseSHM
- [JDK-8310460](https://bugs.openjdk.org/browse/JDK-8310460): Remove jdeps -profile option

There are also some simple line break changes, likely due to using different versions of the pandoc tool.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318126](https://bugs.openjdk.org/browse/JDK-8318126): Refresh manpages (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16196/head:pull/16196` \
`$ git checkout pull/16196`

Update a local copy of the PR: \
`$ git checkout pull/16196` \
`$ git pull https://git.openjdk.org/jdk.git pull/16196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16196`

View PR using the GUI difftool: \
`$ git pr show -t 16196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16196.diff">https://git.openjdk.org/jdk/pull/16196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16196#issuecomment-1763589047)