### PR TITLE
8310673: [JVMCI] batch compilation for libgraal should work the same way as for C2

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1700,8 +1700,11 @@ void CompileBroker::wait_for_completion(CompileTask* task) {
   bool free_task;
 #if INCLUDE_JVMCI
   AbstractCompiler* comp = compiler(task->comp_level());
-  if (comp->is_jvmci() && !task->should_wait_for_compilation()) {
+  if (!UseJVMCINativeLibrary && comp->is_jvmci() && !task->should_wait_for_compilation()) {
     // It may return before compilation is completed.
+    // Note that libjvmci should not pre-emptively unblock
+    // a thread waiting for a compilation as it does not call
+    // Java code and so is not deadlock prone like jarjvmci.
     free_task = wait_for_jvmci_completion((JVMCICompiler*) comp, task, thread);
   } else
 #endif


### PR DESCRIPTION
There's extra logic in the CompileBroker for waiting for blocking JVMCI compilations to try and prevent deadlock ([JDK-8148507](https://bugs.openjdk.org/browse/JDK-8148507)). However, this is not relevant for libgraal which does not run Java code that can be accessing locks used by other threads.

However, over time, this logic was extended to unblock a blocking compilation when a libgraal internal deadlock is detected. It turns out that this hides deadlocks or long compilations that should be solved in libgraal itself.

This PR makes blocking compilation with libgraal the same as blocking compilations for C1 and C2.

Testing: This has been tested for about 3 months against libgraal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310673](https://bugs.openjdk.org/browse/JDK-8310673): [JVMCI] batch compilation for libgraal should work the same way as for C2 (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16197/head:pull/16197` \
`$ git checkout pull/16197`

Update a local copy of the PR: \
`$ git checkout pull/16197` \
`$ git pull https://git.openjdk.org/jdk.git pull/16197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16197`

View PR using the GUI difftool: \
`$ git pr show -t 16197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16197.diff">https://git.openjdk.org/jdk/pull/16197.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16197#issuecomment-1763913063)