### PR TITLE
8318150: StaticProxySelector.select should not throw NullPointerExceptions

### DIFF
--- a/src/java.base/share/classes/java/net/ProxySelector.java
+++ b/src/java.base/share/classes/java/net/ProxySelector.java
@@ -178,7 +178,8 @@ public abstract class ProxySelector {
 
     /**
      * Returns a ProxySelector which uses the given proxy address for all HTTP
-     * and HTTPS requests. If proxy is {@code null} then proxying is disabled.
+     * and HTTPS requests. If {@code proxyAddress} is {@code null}
+     * then proxying is disabled.
      *
      * @param proxyAddress
      *        The address of the proxy
@@ -211,8 +212,15 @@ public abstract class ProxySelector {
         }
 
         @Override
-        public synchronized List<Proxy> select(URI uri) {
-            String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+        public List<Proxy> select(URI uri) {
+            if (uri == null) {
+                throw new IllegalArgumentException("URI can't be null");
+            }
+            String scheme = uri.getScheme();
+            if (scheme == null) {
+                throw new IllegalArgumentException("protocol can't be null");
+            }
+            scheme = scheme.toLowerCase(Locale.ROOT);
             if (scheme.equals("http") || scheme.equals("https")) {
                 return list;
             } else {

--- a/src/java.base/share/classes/java/net/ProxySelector.java
+++ b/src/java.base/share/classes/java/net/ProxySelector.java
@@ -208,6 +208,9 @@ public abstract class ProxySelector {
 
         @Override
         public void connectFailed(URI uri, SocketAddress sa, IOException e) {
+            if (uri == null || sa == null || e == null) {
+                throw new IllegalArgumentException("Arguments can't be null.");
+            }
             /* ignore */
         }
 

--- a/src/java.base/share/classes/java/net/ProxySelector.java
+++ b/src/java.base/share/classes/java/net/ProxySelector.java
@@ -27,7 +27,6 @@ package java.net;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
 
 import sun.security.util.SecurityConstants;
 
@@ -223,8 +222,7 @@ public abstract class ProxySelector {
             if (scheme == null) {
                 throw new IllegalArgumentException("protocol can't be null");
             }
-            scheme = scheme.toLowerCase(Locale.ROOT);
-            if (scheme.equals("http") || scheme.equals("https")) {
+            if (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https")) {
                 return list;
             } else {
                 return NO_PROXY_LIST;


### PR DESCRIPTION
`ProxySelector.select` and `connectFailed` methods should throw `IllegalArgumentException`s on null parameters.

Additionally, the `select` method doesn't need to be synchronized - the selector is immutable.

Tier2 green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8318164](https://bugs.openjdk.org/browse/JDK-8318164) to be approved

### Issues
 * [JDK-8318150](https://bugs.openjdk.org/browse/JDK-8318150): StaticProxySelector.select should not throw NullPointerExceptions (**Bug** - P4)
 * [JDK-8318164](https://bugs.openjdk.org/browse/JDK-8318164): StaticProxySelector.select should not throw NullPointerExceptions (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [6ed6a983](https://git.openjdk.org/jdk/pull/16199/files/6ed6a983ac4c63a38bc87ac24b157996a1b146c6)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [6ed6a983](https://git.openjdk.org/jdk/pull/16199/files/6ed6a983ac4c63a38bc87ac24b157996a1b146c6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16199/head:pull/16199` \
`$ git checkout pull/16199`

Update a local copy of the PR: \
`$ git checkout pull/16199` \
`$ git pull https://git.openjdk.org/jdk.git pull/16199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16199`

View PR using the GUI difftool: \
`$ git pr show -t 16199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16199.diff">https://git.openjdk.org/jdk/pull/16199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16199#issuecomment-1764182987)