### PR TITLE
JDK-8318176: C2: dont assert in ~GraphKit if compilation had been interrupted

### DIFF
--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -82,7 +82,7 @@ class GraphKit : public Phase {
 
 #ifdef ASSERT
   ~GraphKit() {
-    assert(!has_exceptions(), "user must call transfer_exceptions_into_jvms");
+    assert(Compile::current()->failing() || !has_exceptions(), "user must call transfer_exceptions_into_jvms");
   }
 #endif
 


### PR DESCRIPTION
If compilation had been interrupted, which may have happened e.g. due to reaching the node limit check, the using code may not have called `GraphKit::transfer_exceptions_into_jvms()` yet; in that case, we should not assert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318176](https://bugs.openjdk.org/browse/JDK-8318176): C2: dont assert in ~GraphKit if compilation had been interrupted (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16203/head:pull/16203` \
`$ git checkout pull/16203`

Update a local copy of the PR: \
`$ git checkout pull/16203` \
`$ git pull https://git.openjdk.org/jdk.git pull/16203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16203`

View PR using the GUI difftool: \
`$ git pr show -t 16203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16203.diff">https://git.openjdk.org/jdk/pull/16203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16203#issuecomment-1765107924)