### PR TITLE
8318180: Memory model reference from foreign package-info is broken

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/package-info.java
+++ b/src/java.base/share/classes/java/lang/foreign/package-info.java
@@ -135,8 +135,8 @@
  * type must not be null, and any null argument will elicit a {@code NullPointerException}.  This fact is not individually
  * documented for methods of this API.
  *
- * @apiNote Usual memory model guarantees, for example stated in {@jls 6.6} and {@jls 10.4}, do not apply
- * when accessing native memory segments as these segments are backed by off-heap regions of memory.
+ * @apiNote Usual memory model guarantees (see {@jls 17.4}) do not apply when accessing native memory segments as
+ * these segments are backed by off-heap regions of memory.
  *
  * @implNote
  * In the reference implementation, access to restricted methods can be granted to specific modules using the command line option


### PR DESCRIPTION
This PR fixes a wrong reference to the JLS memory model section.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318180](https://bugs.openjdk.org/browse/JDK-8318180): Memory model reference from foreign package-info is broken (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16204/head:pull/16204` \
`$ git checkout pull/16204`

Update a local copy of the PR: \
`$ git checkout pull/16204` \
`$ git pull https://git.openjdk.org/jdk.git pull/16204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16204`

View PR using the GUI difftool: \
`$ git pr show -t 16204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16204.diff">https://git.openjdk.org/jdk/pull/16204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16204#issuecomment-1764857947)