### PR TITLE
8318200: String::newStringNoRepl and String::getBytesNoRepl does not throw CharacterCodingException

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -769,21 +769,8 @@ public final class String
         return new String(dst, UTF16);
     }
 
-    static String newStringNoRepl(byte[] src, Charset cs) throws CharacterCodingException {
-        try {
-            return newStringNoRepl1(src, cs);
-        } catch (IllegalArgumentException e) {
-            //newStringNoRepl1 throws IAE with MalformedInputException or CCE as the cause
-            Throwable cause = e.getCause();
-            if (cause instanceof MalformedInputException mie) {
-                throw mie;
-            }
-            throw (CharacterCodingException)cause;
-        }
-    }
-
     @SuppressWarnings("removal")
-    private static String newStringNoRepl1(byte[] src, Charset cs) {
+    static String newStringNoRepl(byte[] src, Charset cs) {
         int len = src.length;
         if (len == 0) {
             return "";
@@ -941,23 +928,11 @@ public final class String
         return !StringCoding.hasNegatives(src, 0, src.length);
     }
 
-    /*
-     * Throws CCE, instead of replacing, if unmappable.
-     */
-    static byte[] getBytesNoRepl(String s, Charset cs) throws CharacterCodingException {
-        try {
-            return getBytesNoRepl1(s, cs);
-        } catch (IllegalArgumentException e) {
-            //getBytesNoRepl1 throws IAE with UnmappableCharacterException or CCE as the cause
-            Throwable cause = e.getCause();
-            if (cause instanceof UnmappableCharacterException) {
-                throw (UnmappableCharacterException)cause;
-            }
-            throw (CharacterCodingException)cause;
-        }
+    private static byte[] getBytesNoRepl1(String s, Charset cs) {
+        return getBytesNoRepl1(s, cs);
     }
 
-    private static byte[] getBytesNoRepl1(String s, Charset cs) {
+    static byte[] getBytesNoRepl(String s, Charset cs) {
         byte[] val = s.value();
         byte coder = s.coder();
         if (cs == UTF_8.INSTANCE) {

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -928,10 +928,6 @@ public final class String
         return !StringCoding.hasNegatives(src, 0, src.length);
     }
 
-    private static byte[] getBytesNoRepl1(String s, Charset cs) {
-        return getBytesNoRepl1(s, cs);
-    }
-
     static byte[] getBytesNoRepl(String s, Charset cs) {
         byte[] val = s.value();
         byte coder = s.coder();

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -48,7 +48,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.channels.Channel;
 import java.nio.channels.spi.SelectorProvider;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -2473,13 +2472,13 @@ public final class System {
             public int countPositives(byte[] bytes, int offset, int length) {
                 return StringCoding.countPositives(bytes, offset, length);
             }
-            public String newStringNoRepl(byte[] bytes, Charset cs) throws CharacterCodingException  {
+            public String newStringNoRepl(byte[] bytes, Charset cs) {
                 return String.newStringNoRepl(bytes, cs);
             }
             public char getUTF16Char(byte[] bytes, int index) {
                 return StringUTF16.getChar(bytes, index);
             }
-            public byte[] getBytesNoRepl(String s, Charset cs) throws CharacterCodingException {
+            public byte[] getBytesNoRepl(String s, Charset cs) {
                 return String.getBytesNoRepl(s, cs);
             }
 

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -40,6 +40,7 @@ import java.io.Writer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
@@ -3351,7 +3352,14 @@ public final class Files {
         byte[] ba = readAllBytes(path);
         if (path.getClass().getModule() != Object.class.getModule())
             ba = ba.clone();
-        return JLA.newStringNoRepl(ba, cs);
+        try {
+            return JLA.newStringNoRepl(ba, cs);
+        } catch (IllegalArgumentException e) {
+            if (e.getCause() instanceof CharacterCodingException cause) {
+                throw cause;
+            }
+            throw e;
+        }
     }
 
     /**
@@ -3713,7 +3721,15 @@ public final class Files {
         Objects.requireNonNull(csq);
         Objects.requireNonNull(cs);
 
-        byte[] bytes = JLA.getBytesNoRepl(String.valueOf(csq), cs);
+        byte[] bytes;
+        try {
+            bytes = JLA.getBytesNoRepl(String.valueOf(csq), cs);
+        } catch (IllegalArgumentException e) {
+            if (e.getCause() instanceof CharacterCodingException cause) {
+                throw cause;
+            }
+            throw e;
+        }
         if (path.getClass().getModule() != Object.class.getModule())
             bytes = bytes.clone();
         write(path, bytes, options);

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -3355,10 +3355,7 @@ public final class Files {
         try {
             return JLA.newStringNoRepl(ba, cs);
         } catch (IllegalArgumentException e) {
-            if (e.getCause() instanceof CharacterCodingException cause) {
-                throw cause;
-            }
-            throw e;
+            throw (CharacterCodingException) e.getCause();
         }
     }
 
@@ -3725,10 +3722,7 @@ public final class Files {
         try {
             bytes = JLA.getBytesNoRepl(String.valueOf(csq), cs);
         } catch (IllegalArgumentException e) {
-            if (e.getCause() instanceof CharacterCodingException cause) {
-                throw cause;
-            }
-            throw e;
+            throw (CharacterCodingException) e.getCause();
         }
         if (path.getClass().getModule() != Object.class.getModule())
             bytes = bytes.clone();

--- a/src/java.base/share/classes/java/util/HexFormat.java
+++ b/src/java.base/share/classes/java/util/HexFormat.java
@@ -32,7 +32,6 @@ import jdk.internal.util.HexDigits;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.CharBuffer;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -465,12 +464,8 @@ public final class HexFormat {
             // Delimiter formatting not to a single byte
             return null;
         }
-        try {
-            // Return a new string using the bytes without making a copy
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        // Return a new string using the bytes without making a copy
+        return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
     }
 
     /**
@@ -700,11 +695,7 @@ public final class HexFormat {
         byte[] rep = new byte[2];
         rep[0] = (byte)toHighHexDigit(value);
         rep[1] = (byte)toLowHexDigit(value);
-        try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
     }
 
     /**
@@ -736,11 +727,7 @@ public final class HexFormat {
         rep[2] = (byte)toHighHexDigit((byte)value);
         rep[3] = (byte)toLowHexDigit((byte)value);
 
-        try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
     }
 
     /**
@@ -764,11 +751,7 @@ public final class HexFormat {
         rep[6] = (byte)toHighHexDigit((byte)value);
         rep[7] = (byte)toLowHexDigit((byte)value);
 
-        try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
     }
 
     /**
@@ -800,11 +783,7 @@ public final class HexFormat {
         rep[14] = (byte)toHighHexDigit((byte)value);
         rep[15] = (byte)toLowHexDigit((byte)value);
 
-        try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
     }
 
     /**
@@ -828,11 +807,7 @@ public final class HexFormat {
             rep[i] = (byte)toLowHexDigit((byte)(value));
             value = value >>> 4;
         }
-        try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -25,7 +25,6 @@
 
 package java.util;
 
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 
@@ -499,11 +498,7 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
                 32,
                 HexDigits.packDigits(((int) lsb) >> 8, (int) lsb));
 
-        try {
-            return jla.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
-        } catch (CharacterCodingException cce) {
-            throw new AssertionError(cce);
-        }
+        return jla.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -316,8 +316,7 @@ class ZipCoder {
                     return Comparison.NO_MATCH;
                 }
             } catch (IllegalArgumentException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof CharacterCodingException) {
+                if (e.getCause() instanceof CharacterCodingException) {
                     return Comparison.NO_MATCH;
                 }
                 throw e;

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -315,7 +315,7 @@ class ZipCoder {
                 } else {
                     return Comparison.NO_MATCH;
                 }
-            } catch (CharacterCodingException e) {
+            } catch (IllegalArgumentException e) {
                 return Comparison.NO_MATCH;
             }
         }

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -316,7 +316,11 @@ class ZipCoder {
                     return Comparison.NO_MATCH;
                 }
             } catch (IllegalArgumentException e) {
-                return Comparison.NO_MATCH;
+                Throwable cause = e.getCause();
+                if (cause instanceof CharacterCodingException) {
+                    return Comparison.NO_MATCH;
+                }
+                throw e;
             }
         }
     }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -34,7 +34,6 @@ import java.lang.module.ModuleDescriptor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.security.AccessControlContext;
 import java.security.ProtectionDomain;
@@ -314,9 +313,9 @@ public interface JavaLangAccess {
      * @param bytes the byte array source
      * @param cs the Charset
      * @return the newly created string
-     * @throws CharacterCodingException for malformed or unmappable bytes
+     * @throws IllegalArgumentException for malformed or unmappable bytes
      */
-    String newStringNoRepl(byte[] bytes, Charset cs) throws CharacterCodingException;
+    String newStringNoRepl(byte[] bytes, Charset cs);
 
     /**
      * Encode the given string into a sequence of bytes using the specified Charset.
@@ -324,15 +323,15 @@ public interface JavaLangAccess {
      * This method avoids copying the String's internal representation if the input
      * is ASCII.
      *
-     * This method throws CharacterCodingException instead of replacing when
+     * This method throws IllegalArgumentException instead of replacing when
      * malformed input or unmappable characters are encountered.
      *
      * @param s the string to encode
      * @param cs the charset
      * @return the encoded bytes
-     * @throws CharacterCodingException for malformed input or unmappable characters
+     * @throws IllegalArgumentException for malformed input or unmappable characters
      */
-    byte[] getBytesNoRepl(String s, Charset cs) throws CharacterCodingException;
+    byte[] getBytesNoRepl(String s, Charset cs);
 
     /**
      * Returns a new string by decoding from the given utf8 bytes array.

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -27,7 +27,6 @@ package sun.nio.fs;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.CharacterCodingException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.InvalidPathException;
 import java.nio.file.LinkOption;
@@ -127,7 +126,7 @@ class UnixPath implements Path {
         input = fs.normalizeNativePath(input);
         try {
             return JLA.getBytesNoRepl(input, Util.jnuEncoding());
-        } catch (CharacterCodingException cce) {
+        } catch (IllegalArgumentException iae) {
             throw new InvalidPathException(input,
                 "Malformed input or input contains unmappable characters");
         }

--- a/test/jdk/java/lang/String/NoReplTest.java
+++ b/test/jdk/java/lang/String/NoReplTest.java
@@ -60,8 +60,7 @@ public class NoReplTest {
                             .withUpperCase()
                             .formatHex(read.getBytes(UTF_16)));
         } catch (IllegalArgumentException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof CharacterCodingException) {
+            if (e.getCause() instanceof CharacterCodingException) {
                 // success
             } else {
                 throw e;

--- a/test/jdk/java/lang/String/NoReplTest.java
+++ b/test/jdk/java/lang/String/NoReplTest.java
@@ -59,8 +59,13 @@ public class NoReplTest {
                             .withPrefix("x")
                             .withUpperCase()
                             .formatHex(read.getBytes(UTF_16)));
-        } catch (CharacterCodingException cce) {
-            // success
+        } catch (IllegalArgumentException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof CharacterCodingException) {
+                // success
+            } else {
+                throw e;
+            }
         } finally {
             Files.delete(f);
         }
@@ -76,8 +81,13 @@ public class NoReplTest {
         try {
             Files.writeString(f, MALFORMED_WINDOWS_1252, WINDOWS_1252);
             throw new RuntimeException("Exception should be thrown");
-        } catch (CharacterCodingException cce) {
-            // success
+        } catch (IllegalArgumentException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof CharacterCodingException) {
+                // success
+            } else {
+                throw e;
+            }
         } finally {
             Files.delete(f);
         }

--- a/test/jdk/java/lang/String/NoReplTest.java
+++ b/test/jdk/java/lang/String/NoReplTest.java
@@ -59,12 +59,8 @@ public class NoReplTest {
                             .withPrefix("x")
                             .withUpperCase()
                             .formatHex(read.getBytes(UTF_16)));
-        } catch (IllegalArgumentException e) {
-            if (e.getCause() instanceof CharacterCodingException) {
-                // success
-            } else {
-                throw e;
-            }
+        } catch (CharacterCodingException cce) {
+            // success
         } finally {
             Files.delete(f);
         }
@@ -80,13 +76,8 @@ public class NoReplTest {
         try {
             Files.writeString(f, MALFORMED_WINDOWS_1252, WINDOWS_1252);
             throw new RuntimeException("Exception should be thrown");
-        } catch (IllegalArgumentException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof CharacterCodingException) {
-                // success
-            } else {
-                throw e;
-            }
+        } catch (CharacterCodingException cce) {
+            // success
         } finally {
             Files.delete(f);
         }


### PR DESCRIPTION
When calling String::newStringNoRepl and String::getBytesNoRepl, we need to use try...catch to handle CharacterCodingException and throw IllegalArgumentException instead of CharacterCodingException to make the calling code cleaner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8318200](https://bugs.openjdk.org/browse/JDK-8318200): String::newStringNoRepl and String::getBytesNoRepl does not throw CharacterCodingException (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16209/head:pull/16209` \
`$ git checkout pull/16209`

Update a local copy of the PR: \
`$ git checkout pull/16209` \
`$ git pull https://git.openjdk.org/jdk.git pull/16209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16209`

View PR using the GUI difftool: \
`$ git pr show -t 16209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16209.diff">https://git.openjdk.org/jdk/pull/16209.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16209#issuecomment-1765375772)