### PR TITLE
8318160: javac does not reject private method reference with type-variable receiver

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -180,14 +180,7 @@ public class Types {
      * suitable for a method lookup.
      */
     public Type skipTypeVars(Type site, boolean capture) {
-        return skipTypeVars(site, capture, false);
-    }
-
-    /* same as above but with an additional parameter to specify if only captured type variables should be
-     * skipped
-     */
-    public Type skipTypeVars(Type site, boolean capture, boolean capturedOnly) {
-        while (!capturedOnly ? site.hasTag(TYPEVAR) : site.hasTag(TYPEVAR) && ((TypeVar)site).isCaptured()) {
+        while (site.hasTag(TYPEVAR)) {
             site = site.getUpperBound();
         }
         return capture ? capture(site) : site;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -180,7 +180,14 @@ public class Types {
      * suitable for a method lookup.
      */
     public Type skipTypeVars(Type site, boolean capture) {
-        while (site.hasTag(TYPEVAR)) {
+        return skipTypeVars(site, capture, false);
+    }
+
+    /* same as above but with an additional parameter to specify if only captured type variables should be
+     * skipped
+     */
+    public Type skipTypeVars(Type site, boolean capture, boolean capturedOnly) {
+        while (!capturedOnly ? site.hasTag(TYPEVAR) : site.hasTag(TYPEVAR) && ((TypeVar)site).isCaptured()) {
             site = site.getUpperBound();
         }
         return capture ? capture(site) : site;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3552,7 +3552,7 @@ public class Resolve {
 
         MethodReferenceLookupHelper(JCMemberReference referenceTree, Name name, Type site,
                 List<Type> argtypes, List<Type> typeargtypes, MethodResolutionPhase maxPhase) {
-            super(referenceTree, name, types.skipTypeVars(site, true), argtypes, typeargtypes, maxPhase);
+            super(referenceTree, name, types.skipTypeVars(site, true, true), argtypes, typeargtypes, maxPhase);
             this.originalSite = site;
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3621,7 +3621,7 @@ public class Resolve {
             super(referenceTree, name, site, argtypes.tail, typeargtypes, maxPhase);
             if (site.isRaw() && !argtypes.head.hasTag(NONE)) {
                 Type asSuperSite = types.asSuper(argtypes.head, site.tsym);
-                this.site = types.skipTypeVars(asSuperSite, true);
+                this.site = types.skipTypeVars(asSuperSite, true, true);
             }
         }
 

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
@@ -12,7 +12,7 @@ class PrivateMethodReferenceWithTypeVarTest {
         return "bar";
     }
 
-    private String asString2() {
+    private String asString2(Object o) {
         return "bar";
     }
 

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
@@ -1,0 +1,18 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8318160
+ * @summary javac does not reject private method reference with type-variable receiver
+ * @compile/fail/ref=PrivateMethodReferenceWithTypeVarTest.out -XDrawDiagnostics PrivateMethodReferenceWithTypeVarTest.java
+ */
+
+import java.util.function.*;
+
+class PrivateMethodReferenceWithTypeVarTest {
+    private String asString() {
+        return "bar";
+    }
+
+    static <T extends Test> Function<T, String> foo() {
+        return T::asString;
+    }
+}

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
@@ -12,7 +12,15 @@ class PrivateMethodReferenceWithTypeVarTest {
         return "bar";
     }
 
-    static <T extends Test> Function<T, String> foo() {
+    private String asString2() {
+        return "bar";
+    }
+
+    static <T extends Test> Function<T, String> m1() {
         return T::asString;
+    }
+
+    static <T extends Test> Function<T, String> m2(T t) {
+        return t::asString2;
     }
 }

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
@@ -16,11 +16,11 @@ class PrivateMethodReferenceWithTypeVarTest {
         return "bar";
     }
 
-    static <T extends Test> Function<T, String> m1() {
+    static <T extends PrivateMethodReferenceWithTypeVarTest> Function<T, String> m1() {
         return T::asString;
     }
 
-    static <T extends Test> Function<T, String> m2(T t) {
+    static <T extends PrivateMethodReferenceWithTypeVarTest> Function<T, String> m2(T t) {
         return t::asString2;
     }
 }

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.java
@@ -8,6 +8,10 @@
 import java.util.function.*;
 
 class PrivateMethodReferenceWithTypeVarTest {
+    class Foo<X> {
+        X get() { return null; }
+    }
+
     private String asString() {
         return "bar";
     }
@@ -22,5 +26,9 @@ class PrivateMethodReferenceWithTypeVarTest {
 
     static <T extends PrivateMethodReferenceWithTypeVarTest> Function<T, String> m2(T t) {
         return t::asString2;
+    }
+
+    static Function<?, String> m2(Foo<? extends PrivateMethodReferenceWithTypeVarTest> foo) {
+        return foo.get()::asString2;
     }
 }

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
@@ -1,4 +1,4 @@
-PrivateMethodReferenceWithTypeVarTest.java:24:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
-PrivateMethodReferenceWithTypeVarTest.java:28:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString2, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
-PrivateMethodReferenceWithTypeVarTest.java:32:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString2, , java.lang.Object, (compiler.misc.location: kindname.type.variable.bound, compiler.misc.type.captureof: 1, ? extends PrivateMethodReferenceWithTypeVarTest, null))
+PrivateMethodReferenceWithTypeVarTest.java:24:16: compiler.err.report.access: asString(), private, PrivateMethodReferenceWithTypeVarTest
+PrivateMethodReferenceWithTypeVarTest.java:28:16: compiler.err.report.access: asString2(java.lang.Object), private, PrivateMethodReferenceWithTypeVarTest
+PrivateMethodReferenceWithTypeVarTest.java:32:16: compiler.err.report.access: asString2(java.lang.Object), private, PrivateMethodReferenceWithTypeVarTest
 3 errors

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
@@ -1,3 +1,4 @@
-PrivateMethodReferenceWithTypeVarTest.java:20:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
-PrivateMethodReferenceWithTypeVarTest.java:24:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString2, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
-2 errors
+PrivateMethodReferenceWithTypeVarTest.java:24:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
+PrivateMethodReferenceWithTypeVarTest.java:28:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString2, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
+PrivateMethodReferenceWithTypeVarTest.java:32:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString2, , java.lang.Object, (compiler.misc.location: kindname.type.variable.bound, compiler.misc.type.captureof: 1, ? extends PrivateMethodReferenceWithTypeVarTest, null))
+3 errors

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
@@ -1,5 +1,3 @@
-PrivateMethodReferenceWithTypeVarTest.java:19:23: compiler.err.cant.resolve.location: kindname.class, Test, , , (compiler.misc.location: kindname.class, PrivateMethodReferenceWithTypeVarTest, null)
-PrivateMethodReferenceWithTypeVarTest.java:23:23: compiler.err.cant.resolve.location: kindname.class, Test, , , (compiler.misc.location: kindname.class, PrivateMethodReferenceWithTypeVarTest, null)
 PrivateMethodReferenceWithTypeVarTest.java:20:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
 PrivateMethodReferenceWithTypeVarTest.java:24:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString2, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
-4 errors
+2 errors

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
@@ -1,0 +1,3 @@
+PrivateMethodReferenceWithTypeVarTest.java:15:23: compiler.err.cant.resolve.location: kindname.class, Test, , , (compiler.misc.location: kindname.class, PrivateMethodReferenceWithTypeVarTest, null)
+PrivateMethodReferenceWithTypeVarTest.java:16:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
+2 errors

--- a/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
+++ b/test/langtools/tools/javac/lambda/methodReference/PrivateMethodReferenceWithTypeVarTest.out
@@ -1,3 +1,5 @@
-PrivateMethodReferenceWithTypeVarTest.java:15:23: compiler.err.cant.resolve.location: kindname.class, Test, , , (compiler.misc.location: kindname.class, PrivateMethodReferenceWithTypeVarTest, null)
-PrivateMethodReferenceWithTypeVarTest.java:16:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
-2 errors
+PrivateMethodReferenceWithTypeVarTest.java:19:23: compiler.err.cant.resolve.location: kindname.class, Test, , , (compiler.misc.location: kindname.class, PrivateMethodReferenceWithTypeVarTest, null)
+PrivateMethodReferenceWithTypeVarTest.java:23:23: compiler.err.cant.resolve.location: kindname.class, Test, , , (compiler.misc.location: kindname.class, PrivateMethodReferenceWithTypeVarTest, null)
+PrivateMethodReferenceWithTypeVarTest.java:20:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
+PrivateMethodReferenceWithTypeVarTest.java:24:16: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, asString2, , T, (compiler.misc.location: kindname.type.variable.bound, T, null))
+4 errors


### PR DESCRIPTION
Please review this PR which is fixing a long standing regression in javac. Basically javac is accepting code like:

```
import java.util.function.*;

class Test {
    private String asString() {
        return "bar";
    }

    static <T extends Test> Function<T, String> foo() {
        return T::asString;
    }
}
```

this code should be rejected on the grounds that ::asString is a private method in class `Test` and thus not a member of type variable `T`

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8318203](https://bugs.openjdk.org/browse/JDK-8318203) to be approved

### Issues
 * [JDK-8318160](https://bugs.openjdk.org/browse/JDK-8318160): javac does not reject private method reference with type-variable receiver (**Bug** - P3)
 * [JDK-8318203](https://bugs.openjdk.org/browse/JDK-8318203): javac does not reject private method reference with type-variable receiver (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16210/head:pull/16210` \
`$ git checkout pull/16210`

Update a local copy of the PR: \
`$ git checkout pull/16210` \
`$ git pull https://git.openjdk.org/jdk.git pull/16210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16210`

View PR using the GUI difftool: \
`$ git pr show -t 16210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16210.diff">https://git.openjdk.org/jdk/pull/16210.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16210#issuecomment-1765473836)