### PR TITLE
8317562: [JFR] Compilation queue statistics

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -330,6 +330,10 @@ void CompileQueue::add(CompileTask* task) {
     _last = task;
   }
   ++_size;
+  ++_total_added;
+  if (_size > _peak_size) {
+    _peak_size = _size;
+  }
 
   // Mark the method as being in the compile queue.
   task->method()->set_queued_for_compilation();
@@ -486,6 +490,7 @@ void CompileQueue::remove(CompileTask* task) {
     _last = task->prev();
   }
   --_size;
+  ++_total_removed;
 }
 
 void CompileQueue::remove_and_mark_stale(CompileTask* task) {
@@ -513,6 +518,14 @@ CompileQueue* CompileBroker::compile_queue(int comp_level) {
   if (is_c2_compile(comp_level)) return _c2_compile_queue;
   if (is_c1_compile(comp_level)) return _c1_compile_queue;
   return nullptr;
+}
+
+CompileQueue* CompileBroker::c1_compile_queue() {
+  return _c1_compile_queue;
+}
+
+CompileQueue* CompileBroker::c2_compile_queue() {
+  return _c2_compile_queue;
 }
 
 void CompileBroker::print_compile_queues(outputStream* st) {

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -88,9 +88,9 @@ class CompileQueue : public CHeapObj<mtCompiler> {
   CompileTask* _first_stale;
 
   int _size;
-  int _total_added;
-  int _total_removed;
   int _peak_size;
+  uint _total_added;
+  uint _total_removed;
 
   void purge_stale_tasks();
  public:

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -119,8 +119,8 @@ class CompileQueue : public CHeapObj<mtCompiler> {
   int          size()     const                  { return _size;          }
 
   int         get_peak_size()     const          { return _peak_size; }
-  int         get_total_added()   const          { return _total_added; }
-  int         get_total_removed() const          { return _total_removed; }
+  uint        get_total_added()   const          { return _total_added; }
+  uint        get_total_removed() const          { return _total_removed; }
 
   // Redefine Classes support
   void mark_on_stack();

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -88,6 +88,9 @@ class CompileQueue : public CHeapObj<mtCompiler> {
   CompileTask* _first_stale;
 
   int _size;
+  int _total_added;
+  int _total_removed;
+  int _peak_size;
 
   void purge_stale_tasks();
  public:
@@ -96,6 +99,9 @@ class CompileQueue : public CHeapObj<mtCompiler> {
     _first = nullptr;
     _last = nullptr;
     _size = 0;
+    _total_added = 0;
+    _total_removed = 0;
+    _peak_size = 0;
     _first_stale = nullptr;
   }
 
@@ -112,6 +118,9 @@ class CompileQueue : public CHeapObj<mtCompiler> {
   bool         is_empty() const                  { return _first == nullptr; }
   int          size()     const                  { return _size;          }
 
+  int         get_peak_size()     const          { return _peak_size; }
+  int         get_total_added()   const          { return _total_added; }
+  int         get_total_removed() const          { return _total_removed; }
 
   // Redefine Classes support
   void mark_on_stack();
@@ -302,6 +311,9 @@ public:
                                  int hot_count,
                                  CompileTask::CompileReason compile_reason,
                                  TRAPS);
+  static CompileQueue* c1_compile_queue();
+  static CompileQueue* c2_compile_queue();
+
 private:
   static nmethod* compile_method(const methodHandle& method,
                                    int osr_bci,
@@ -399,6 +411,8 @@ public:
 
   static CompileLog* get_log(CompilerThread* ct);
 
+  static int get_c1_thread_count() {                return _compilers[0]->num_compiler_threads(); }
+  static int get_c2_thread_count() {                return _compilers[1]->num_compiler_threads(); }
   static int get_total_compile_count() {            return _total_compile_count; }
   static int get_total_bailout_count() {            return _total_bailout_count; }
   static int get_total_invalidated_count() {        return _total_invalidated_count; }

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -848,6 +848,19 @@
     <Field type="float" contentType="hertz" name="switchRate" label="Switch Rate" description="Number of context switches per second" />
   </Event>
 
+  <Event name="CompilerQueueUtilization" category="Java Virtual Machine, Compiler" label="Compiler Queue Utilization" period="everyChunk">
+    <Field type="CompilerType" name="compiler" label="Compiler" />
+    <Field type="long" contentType="hertz" name="ingress" label="Ingress" description="Number of added requests per second"/>
+    <Field type="long" contentType="hertz" name="egress" label="Egress" description="Number of removed requests per second"/>
+    <Field type="long" contentType="count" name="size" label="Size" description="Current queue size"/>
+    <Field type="long" contentType="count" name="peak" label="Peak Size" description="Peak queue size"/>
+    <Field type="long" contentType="count" name="added" label="Added" description="Added requests"/>
+    <Field type="long" contentType="count" name="removed" label="Removed" description="Removed requests"/>
+    <Field type="long" contentType="count" name="totalAdded" label="Total Added" description="Total requests"/>
+    <Field type="long" contentType="count" name="totalRemoved" label="Total Removed" description="Total removed requests"/>
+    <Field type="int" name="compilerThreadCount" label="Number of Compiler Threads for this queue" />
+  </Event>
+
   <Event name="NetworkUtilization" category="Operating System, Network" label="Network Utilization" period="everyChunk">
     <Field type="NetworkInterfaceName" name="networkInterface" label="Network Interface" description="Network Interface Name"/>
     <Field type="long" contentType="bits-per-second" name="readRate" label="Read Rate" description="Number of incoming bits per second"/>

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -858,7 +858,7 @@
     <Field type="long" contentType="count" name="removed" label="Removed" description="Removed requests"/>
     <Field type="long" contentType="count" name="totalAdded" label="Total Added" description="Total requests"/>
     <Field type="long" contentType="count" name="totalRemoved" label="Total Removed" description="Total removed requests"/>
-    <Field type="int" name="compilerThreadCount" label="Number of Compiler Threads for this queue" />
+    <Field type="int" name="compilerThreadCount" label="Number of Compiler Threads for this queue"/>
   </Event>
 
   <Event name="NetworkUtilization" category="Operating System, Network" label="Network Utilization" period="everyChunk">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -850,15 +850,15 @@
 
   <Event name="CompilerQueueUtilization" category="Java Virtual Machine, Compiler" label="Compiler Queue Utilization" period="everyChunk">
     <Field type="CompilerType" name="compiler" label="Compiler" />
-    <Field type="long" contentType="hertz" name="ingress" label="Ingress" description="Number of added requests per second"/>
-    <Field type="long" contentType="hertz" name="egress" label="Egress" description="Number of removed requests per second"/>
-    <Field type="long" name="size" label="Size"/>
-    <Field type="long" name="peak" label="Peak Size"/>
-    <Field type="long" name="added" label="Added"/>
-    <Field type="long" name="removed" label="Removed"/>
-    <Field type="long" name="totalAdded" label="Total Added"/>
-    <Field type="long" name="totalRemoved" label="Total Removed"/>
-    <Field type="int" name="compilerThreadCount" label="Number of Compiler Threads for this queue"/>
+    <Field type="long" contentType="hertz" name="addedRate" label="Requets Added Rate" description="Requests added per second"/>
+    <Field type="long" contentType="hertz" name="removedRate" label="Requests Removed Rate" description="Requests removed per second"/>
+    <Field type="long" name="queueSize" label="Queue Size"/>
+    <Field type="long" name="peakQueueSize" label="Peak Queue Size"/>
+    <Field type="long" name="addedCount" label="Requests Added"/>
+    <Field type="long" name="removedCount" label="Requests Removed"/>
+    <Field type="long" name="totalAddedCount" label="Total Requests Added"/>
+    <Field type="long" name="totalRemovedCount" label="Total Requests Removed"/>
+    <Field type="int" name="compilerThreadCount" label="Compiler Thread Count"/>
   </Event>
 
   <Event name="NetworkUtilization" category="Operating System, Network" label="Network Utilization" period="everyChunk">

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -852,12 +852,12 @@
     <Field type="CompilerType" name="compiler" label="Compiler" />
     <Field type="long" contentType="hertz" name="ingress" label="Ingress" description="Number of added requests per second"/>
     <Field type="long" contentType="hertz" name="egress" label="Egress" description="Number of removed requests per second"/>
-    <Field type="long" contentType="count" name="size" label="Size" description="Current queue size"/>
-    <Field type="long" contentType="count" name="peak" label="Peak Size" description="Peak queue size"/>
-    <Field type="long" contentType="count" name="added" label="Added" description="Added requests"/>
-    <Field type="long" contentType="count" name="removed" label="Removed" description="Removed requests"/>
-    <Field type="long" contentType="count" name="totalAdded" label="Total Added" description="Total requests"/>
-    <Field type="long" contentType="count" name="totalRemoved" label="Total Removed" description="Total removed requests"/>
+    <Field type="long" name="size" label="Size"/>
+    <Field type="long" name="peak" label="Peak Size"/>
+    <Field type="long" name="added" label="Added"/>
+    <Field type="long" name="removed" label="Removed"/>
+    <Field type="long" name="totalAdded" label="Total Added"/>
+    <Field type="long" name="totalRemoved" label="Total Removed"/>
     <Field type="int" name="compilerThreadCount" label="Number of Compiler Threads for this queue"/>
   </Event>
 

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
@@ -47,7 +47,7 @@ static uint64_t rate_per_second(uint64_t current, uint64_t old, const JfrTickspa
 void JfrCompilerQueueUtilization::send_events() {
   static CompilerQueueEntry compilerQueueEntries[2] = {
     {CompileBroker::c1_compile_queue(), 1, 0, 0},
-    {CompileBroker::c2_compile_queue(), 2, 0,0}};
+    {CompileBroker::c2_compile_queue(), 2, 0, 0}};
 
   const JfrTicks cur_time = JfrTicks::now();
   static JfrTicks last_sample_instant;

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
@@ -53,8 +53,6 @@ static uint64_t rate_per_second(uint64_t current, uint64_t old, const JfrTickspa
   return ((current - old) * NANOSECS_PER_SEC) / interval.nanoseconds();
 }
 
-
-
 void JfrCompilerQueueUtilization::send_events() {
   static CompilerQueueEntry compilerQueueEntries[num_compiler_queues] = {
     {CompileBroker::c1_compile_queue(), c1_compiler_queue_id, &CompileBroker::get_c1_thread_count, 0, 0},
@@ -63,11 +61,9 @@ void JfrCompilerQueueUtilization::send_events() {
   const JfrTicks cur_time = JfrTicks::now();
   static JfrTicks last_sample_instant;
   const JfrTickspan interval = cur_time - last_sample_instant;
-  for(int i = 0; i < num_compiler_queues; i ++)
-  {
+  for (int i = 0; i < num_compiler_queues; i ++) {
     CompilerQueueEntry* entry = &compilerQueueEntries[i];
-    if (entry->compilerQueue != NULL)
-    {
+    if (entry->compilerQueue != NULL) {
       const uint64_t current_added = entry->compilerQueue->get_total_added();
       const uint64_t current_removed = entry->compilerQueue->get_total_removed();
       const uint64_t ingress = rate_per_second(current_added, entry->added, interval);

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
@@ -63,7 +63,7 @@ void JfrCompilerQueueUtilization::send_events() {
   const JfrTickspan interval = cur_time - last_sample_instant;
   for (int i = 0; i < num_compiler_queues; i ++) {
     CompilerQueueEntry* entry = &compilerQueueEntries[i];
-    if (entry->compilerQueue != NULL) {
+    if (entry->compilerQueue != nullptr) {
       const uint64_t current_added = entry->compilerQueue->get_total_added();
       const uint64_t current_removed = entry->compilerQueue->get_total_removed();
       const uint64_t ingress = rate_per_second(current_added, entry->added, interval);

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
@@ -34,7 +34,7 @@ struct CompilerQueueEntry {
   uint64_t removed;
 };
 
-// If current counters are less than previous we assume the interface has been reset
+// If current counters are less than previous, we assume the interface has been reset
 // If no bytes have been either sent or received, we'll also skip the event
 static uint64_t rate_per_second(uint64_t current, uint64_t old, const JfrTickspan& interval) {
   assert(interval.value() > 0, "invariant");

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
@@ -46,7 +46,7 @@ static uint64_t rate_per_second(uint64_t current, uint64_t old, const JfrTickspa
 
 void JfrCompilerQueueUtilization::send_events() {
   static CompilerQueueEntry compilerQueueEntries[2] = {
-    {CompileBroker::c1_compile_queue(), 1, 0,0},
+    {CompileBroker::c1_compile_queue(), 1, 0, 0},
     {CompileBroker::c2_compile_queue(), 2, 0,0}};
 
   const JfrTicks cur_time = JfrTicks::now();

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
@@ -66,19 +66,19 @@ void JfrCompilerQueueUtilization::send_events() {
     if (entry->compilerQueue != nullptr) {
       const uint64_t current_added = entry->compilerQueue->get_total_added();
       const uint64_t current_removed = entry->compilerQueue->get_total_removed();
-      const uint64_t ingress = rate_per_second(current_added, entry->added, interval);
-      const uint64_t egress = rate_per_second(current_removed, entry->removed, interval);
+      const uint64_t addedRate = rate_per_second(current_added, entry->added, interval);
+      const uint64_t removedRate = rate_per_second(current_removed, entry->removed, interval);
 
       EventCompilerQueueUtilization event;
       event.set_compiler(entry->compiler_queue_id);
-      event.set_ingress(ingress);
-      event.set_egress(egress);
-      event.set_size(entry->compilerQueue->size());
-      event.set_peak(entry->compilerQueue->get_peak_size());
-      event.set_added(current_added - entry->added);
-      event.set_removed(current_removed - entry->removed);
-      event.set_totalAdded(current_added);
-      event.set_totalRemoved(current_removed);
+      event.set_addedRate(addedRate);
+      event.set_removedRate(removedRate);
+      event.set_queueSize(entry->compilerQueue->size());
+      event.set_peakQueueSize(entry->compilerQueue->get_peak_size());
+      event.set_addedCount(current_added - entry->added);
+      event.set_removedCount(current_removed - entry->removed);
+      event.set_totalAddedCount(current_added);
+      event.set_totalRemovedCount(current_removed);
       event.set_compilerThreadCount(entry->get_compiler_thread_count());
       event.commit();
 

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "compiler/compileBroker.hpp"
+#include "jfr/jfrEvents.hpp"
+#include "jfr/periodic/jfrCompilerQueueUtilization.hpp"
+
+struct CompilerQueueEntry {
+  CompileQueue* compilerQueue;
+  u8 compiler;
+  uint64_t added;
+  uint64_t removed;
+};
+
+// If current counters are less than previous we assume the interface has been reset
+// If no bytes have been either sent or received, we'll also skip the event
+static uint64_t rate_per_second(uint64_t current, uint64_t old, const JfrTickspan& interval) {
+  assert(interval.value() > 0, "invariant");
+  if (current <= old) {
+    return 0;
+  }
+  return ((current - old) * NANOSECS_PER_SEC) / interval.nanoseconds();
+}
+
+void JfrCompilerQueueUtilization::send_events() {
+  static CompilerQueueEntry compilerQueueEntries[2] = {
+    {CompileBroker::c1_compile_queue(), 1, 0,0},
+    {CompileBroker::c2_compile_queue(), 2, 0,0}};
+
+  const JfrTicks cur_time = JfrTicks::now();
+  static JfrTicks last_sample_instant;
+  const JfrTickspan interval = cur_time - last_sample_instant;
+  for(int i = 0; i < 2; i ++)
+  {
+    CompilerQueueEntry* entry = &compilerQueueEntries[i];
+    if (entry->compilerQueue != NULL)
+    {
+      const uint64_t current_added = entry->compilerQueue->get_total_added();
+      const uint64_t current_removed = entry->compilerQueue->get_total_removed();
+      const uint64_t ingress = rate_per_second(current_added, entry->added, interval);
+      const uint64_t egress = rate_per_second(current_removed, entry->removed, interval);
+
+      EventCompilerQueueUtilization event;
+      event.set_compiler(entry->compiler);
+      event.set_compilerThreadCount((i == 0) ? CompileBroker::get_c1_thread_count() : CompileBroker::get_c2_thread_count());
+      event.set_ingress(ingress);
+      event.set_egress(egress);
+      event.set_size(entry->compilerQueue->size());
+      event.set_peak(entry->compilerQueue->get_peak_size());
+      event.set_added(current_added - entry->added);
+      event.set_removed(current_removed - entry->removed);
+      event.set_totalAdded(current_added);
+      event.set_totalRemoved(current_removed);
+      event.commit();
+
+      entry->added = current_added;
+      entry->removed = current_removed;
+    }
+
+    last_sample_instant = cur_time;
+  }
+}

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.hpp
+++ b/src/hotspot/share/jfr/periodic/jfrCompilerQueueUtilization.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_JFR_PERIODIC_JFRCOMPILERQUEUEUTILIZATION_HPP
+#define SHARE_JFR_PERIODIC_JFRCOMPILERQUEUEUTILIZATION_HPP
+
+#include "memory/allStatic.hpp"
+
+class JfrCompilerQueueUtilization : public AllStatic {
+public:
+  static void send_events();
+};
+
+#endif // SHARE_JFR_PERIODIC_JFRCOMPILERQUEUEUTILIZATION_HPP

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -36,6 +36,7 @@
 #include "gc/shared/gcVMOperations.hpp"
 #include "gc/shared/objectCountEventSender.hpp"
 #include "jfr/jfrEvents.hpp"
+#include "jfr/periodic/jfrCompilerQueueUtilization.hpp"
 #include "jfr/periodic/jfrFinalizerStatisticsEvent.hpp"
 #include "jfr/periodic/jfrModuleEvent.hpp"
 #include "jfr/periodic/jfrOSInterface.hpp"
@@ -219,6 +220,10 @@ TRACE_REQUEST_FUNC(CPULoad) {
 
 TRACE_REQUEST_FUNC(ThreadCPULoad) {
   JfrThreadCPULoadEvent::send_events();
+}
+
+TRACE_REQUEST_FUNC(CompilerQueueUtilization) {
+  JfrCompilerQueueUtilization::send_events();
 }
 
 TRACE_REQUEST_FUNC(NetworkUtilization) {

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -663,6 +663,11 @@
       <setting name="period">5 s</setting>
     </event>
 
+    <event name="jdk.CompilerQueueUtilization">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 s</setting>
+    </event>
+
     <event name="jdk.InitialEnvironmentVariable">
       <setting name="enabled">true</setting>
       <setting name="period">beginChunk</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -663,6 +663,11 @@
       <setting name="period">5 s</setting>
     </event>
 
+    <event name="jdk.CompilerQueueUtilization">
+      <setting name="enabled">true</setting>
+      <setting name="period">5 s</setting>
+    </event>
+
     <event name="jdk.InitialEnvironmentVariable">
       <setting name="enabled">true</setting>
       <setting name="period">beginChunk</setting>

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerQueueUtilization.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerQueueUtilization.java
@@ -52,14 +52,14 @@ public class TestCompilerQueueUtilization {
             for (RecordedEvent event : events) {
                 System.out.println("Event:" + event);
                 Events.assertField(event, "compiler").notEmpty();
-                Events.assertField(event, "ingress").atLeast(0L);
-                Events.assertField(event, "egress").atLeast(0L);
-                Events.assertField(event, "size").atLeast(0L);
-                Events.assertField(event, "peak").atLeast(0L);
-                Events.assertField(event, "added").atLeast(0L);
-                Events.assertField(event, "removed").atLeast(0L);
-                Events.assertField(event, "totalAdded").atLeast(0L);
-                Events.assertField(event, "totalRemoved").atLeast(0L);
+                Events.assertField(event, "addedRate").atLeast(0L);
+                Events.assertField(event, "removedRate").atLeast(0L);
+                Events.assertField(event, "queueSize").atLeast(0L);
+                Events.assertField(event, "peakQueueSize").atLeast(0L);
+                Events.assertField(event, "addedCount").atLeast(0L);
+                Events.assertField(event, "removedCount").atLeast(0L);
+                Events.assertField(event, "totalAddedCount").atLeast(0L);
+                Events.assertField(event, "totalRemovedCount").atLeast(0L);
                 Events.assertField(event, "compilerThreadCount").atLeast(0);
             }
         }

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerQueueUtilization.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerQueueUtilization.java
@@ -34,6 +34,7 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
+ * @requires vm.compMode!="Xint"
  * @library /test/lib
  * @run main/othervm jdk.jfr.event.compiler.TestCompilerQueueUtilization
  */

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerQueueUtilization.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerQueueUtilization.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.compiler;
+
+import java.util.List;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+
+/**
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.event.compiler.TestCompilerQueueUtilization
+ */
+public class TestCompilerQueueUtilization {
+    private final static String EVENT_NAME = EventNames.CompilerQueueUtilization;
+
+    public static void main(String[] args) throws Exception {
+        Recording recording = new Recording();
+        recording.enable(EVENT_NAME);
+        recording.start();
+        recording.stop();
+
+        List<RecordedEvent> events = Events.fromRecording(recording);
+        Events.hasEvents(events);
+        for (RecordedEvent event : events) {
+            System.out.println("Event:" + event);
+            Events.assertField(event, "compiler").notEmpty();
+            Events.assertField(event, "ingress").atLeast(0L);
+            Events.assertField(event, "egress").atLeast(0L);
+            Events.assertField(event, "size").atLeast(0L);
+            Events.assertField(event, "peak").atLeast(0L);
+            Events.assertField(event, "added").atLeast(0L);
+            Events.assertField(event, "removed").atLeast(0L);
+            Events.assertField(event, "totalAdded").atLeast(0L);
+            Events.assertField(event, "totalRemoved").atLeast(0L);
+            Events.assertField(event, "compilerThreadCount").atLeast(0);
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerQueueUtilization.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerQueueUtilization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,25 +42,26 @@ public class TestCompilerQueueUtilization {
     private final static String EVENT_NAME = EventNames.CompilerQueueUtilization;
 
     public static void main(String[] args) throws Exception {
-        Recording recording = new Recording();
-        recording.enable(EVENT_NAME);
-        recording.start();
-        recording.stop();
+        try (Recording recording = new Recording()) {
+            recording.enable(EVENT_NAME);
+            recording.start();
+            recording.stop();
 
-        List<RecordedEvent> events = Events.fromRecording(recording);
-        Events.hasEvents(events);
-        for (RecordedEvent event : events) {
-            System.out.println("Event:" + event);
-            Events.assertField(event, "compiler").notEmpty();
-            Events.assertField(event, "ingress").atLeast(0L);
-            Events.assertField(event, "egress").atLeast(0L);
-            Events.assertField(event, "size").atLeast(0L);
-            Events.assertField(event, "peak").atLeast(0L);
-            Events.assertField(event, "added").atLeast(0L);
-            Events.assertField(event, "removed").atLeast(0L);
-            Events.assertField(event, "totalAdded").atLeast(0L);
-            Events.assertField(event, "totalRemoved").atLeast(0L);
-            Events.assertField(event, "compilerThreadCount").atLeast(0);
+            List<RecordedEvent> events = Events.fromRecording(recording);
+            Events.hasEvents(events);
+            for (RecordedEvent event : events) {
+                System.out.println("Event:" + event);
+                Events.assertField(event, "compiler").notEmpty();
+                Events.assertField(event, "ingress").atLeast(0L);
+                Events.assertField(event, "egress").atLeast(0L);
+                Events.assertField(event, "size").atLeast(0L);
+                Events.assertField(event, "peak").atLeast(0L);
+                Events.assertField(event, "added").atLeast(0L);
+                Events.assertField(event, "removed").atLeast(0L);
+                Events.assertField(event, "totalAdded").atLeast(0L);
+                Events.assertField(event, "totalRemoved").atLeast(0L);
+                Events.assertField(event, "compilerThreadCount").atLeast(0);
+            }
         }
     }
 }

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -160,6 +160,7 @@ public class EventNames {
     public static final String CompilerPhase = PREFIX + "CompilerPhase";
     public static final String CompilationFailure = PREFIX + "CompilationFailure";
     public static final String CompilerInlining = PREFIX + "CompilerInlining";
+    public static final String CompilerQueueUtilization = PREFIX + "CompilerQueueUtilization";
     public static final String CompilerStatistics = PREFIX + "CompilerStatistics";
     public static final String CompilerConfiguration = PREFIX + "CompilerConfiguration";
     public static final String CodeCacheStatistics = PREFIX + "CodeCacheStatistics";


### PR DESCRIPTION
Adding a new periodic jfr event to monitor and output statistics for the compiler queues.  You will see one event per compiler queue (c1 and c2)

Passes tier1 on linux (x86) and mac (aarch64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317562](https://bugs.openjdk.org/browse/JDK-8317562): [JFR] Compilation queue statistics (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [6c0b1670](https://git.openjdk.org/jdk/pull/16211/files/6c0b16702c7ba73fd8f88d24e413f6afc7b6f6d4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16211/head:pull/16211` \
`$ git checkout pull/16211`

Update a local copy of the PR: \
`$ git checkout pull/16211` \
`$ git pull https://git.openjdk.org/jdk.git pull/16211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16211`

View PR using the GUI difftool: \
`$ git pr show -t 16211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16211.diff">https://git.openjdk.org/jdk/pull/16211.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16211#issuecomment-1768736923)