### PR TITLE
8318240: [AIX] Cleaners.java test failure

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -104,6 +104,9 @@ public final class SunNativeProvider extends Provider {
                                         // Full path needed, DLL is in jre/bin
                                         StaticProperty.javaHome() + "\\bin\\sspi_bridge.dll",
                                 };
+                                case AIX -> new String[]{
+                                        "/opt/freeware/lib64/libgssapi_krb5.so",
+                                };
                                 default -> new String[0];
                             };
                         } else {


### PR DESCRIPTION
When the test sets the sun.security.jgss.native and sun.security.nativegss.debug as true, the test fails on AIX due to missing Kerberos GSS API dynamic library` libgssapi_krb5.so` 

JBS Issue : [JDK-8318240](https://bugs.openjdk.org/browse/JDK-8318240)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318240](https://bugs.openjdk.org/browse/JDK-8318240): [AIX] Cleaners.java test failure (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16212/head:pull/16212` \
`$ git checkout pull/16212`

Update a local copy of the PR: \
`$ git checkout pull/16212` \
`$ git pull https://git.openjdk.org/jdk.git pull/16212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16212`

View PR using the GUI difftool: \
`$ git pr show -t 16212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16212.diff">https://git.openjdk.org/jdk/pull/16212.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16212#issuecomment-1765842127)