### PR TITLE
8318049: C2: assert(!failure) failed: Missed optimization opportunity in PhaseIterGVN

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1600,12 +1600,12 @@ void PhaseIterGVN::add_users_to_worklist( Node *n ) {
     // ConstraintCast+ -> Phi
     // ConstraintCast+ -> Xor
     if (use->is_ConstraintCast()) {
-      auto push_phi_or_sub_uses_to_worklist = [&](Node* n){
+      auto push_the_uses_to_worklist = [&](Node* n){
         if (n->is_Phi() || n->is_Sub() || n->Opcode() == Op_XorI || n->Opcode() == Op_XorL) {
           _worklist.push(n);
         }
       };
-      ConstraintCastNode::visit_uncasted_uses(use, push_phi_or_sub_uses_to_worklist);
+      ConstraintCastNode::visit_uncasted_uses(use, push_the_uses_to_worklist);
     }
     // If changed LShift inputs, check RShift users for useless sign-ext
     if( use_op == Op_LShiftI ) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1594,13 +1594,14 @@ void PhaseIterGVN::add_users_to_worklist( Node *n ) {
       }
     }
 
-    // If changed Cast input, notify down for Phi and Sub - both do "uncast"
+    // If changed Cast input, notify down for Phi, Sub, and Xor - all do "uncast"
     // Patterns:
     // ConstraintCast+ -> Sub
     // ConstraintCast+ -> Phi
+    // ConstraintCast+ -> Xor
     if (use->is_ConstraintCast()) {
       auto push_phi_or_sub_uses_to_worklist = [&](Node* n){
-        if (n->is_Phi() || n->is_Sub()) {
+        if (n->is_Phi() || n->is_Sub() || n->Opcode() == Op_XorI || n->Opcode() == Op_XorL) {
           _worklist.push(n);
         }
       };

--- a/test/hotspot/jtreg/compiler/c2/TestNotifyCastToXor.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNotifyCastToXor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8318049
+ * @summary Test that xor nodes are properly notified when constraint casts change.
+ * @run main/othervm -Xbatch -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler.c2.TestNotifyCastToXor::test -XX:VerifyIterativeGVN=10 compiler.c2.TestNotifyCastToXor
+ */
+
+package compiler.c2;
+
+public class TestNotifyCastToXor {
+    public static long longField = 0L;
+
+    public static void test() {
+        int ind = -15;
+
+        ind %= ind;
+        for (int i = 0; i < 40; ++i) {
+            int j = 1;
+
+            do {
+                ind ^= (int)longField;
+
+                // Dead loop
+                for (int k = 1; k < 1; k++) {
+                }
+            } while (j++ < 10);
+        }
+    }
+
+    public static void main(String[] args) {
+        test();
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestNotifyCastToXor.java
+++ b/test/hotspot/jtreg/compiler/c2/TestNotifyCastToXor.java
@@ -25,7 +25,8 @@
  * @test
  * @bug 8318049
  * @summary Test that xor nodes are properly notified when constraint casts change.
- * @run main/othervm -Xbatch -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler.c2.TestNotifyCastToXor::test -XX:VerifyIterativeGVN=10 compiler.c2.TestNotifyCastToXor
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=compiler.c2.TestNotifyCastToXor::test
+                     -XX:+IgnoreUnrecognizedVMOptions -XX:VerifyIterativeGVN=10 compiler.c2.TestNotifyCastToXor
  */
 
 package compiler.c2;


### PR DESCRIPTION
This patch fixes [JDK-8318049](https://bugs.openjdk.org/browse/JDK-8318049) by informing XorI and XorL nodes in addition to sub and phi nodes when Cast nodes are updated during IGVN. 

The bug manifests when loop optimizations change the IR:
![image](https://github.com/openjdk/jdk/assets/25208576/5274f2cc-a6fb-4ce6-89f4-4a638577901c)

To the following form:
![image](https://github.com/openjdk/jdk/assets/25208576/07bcbec3-f0bb-4d6a-b312-6a459e6b8c0c)

XorI nodes check for that form in their `Value` call, to do the `x ^ x => 0` transformation, checking through casts. As the cast node didn't inform the Xor when it changes, the transformation doesn't have a chance to run.
https://github.com/openjdk/jdk/blob/5bd10521eb5e51e76b20e955addd45f76abba6f7/src/hotspot/share/opto/addnode.cpp#L947-L950

I've attached a reduced version of the test found in the bug. Reviews would be appreciated!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318049](https://bugs.openjdk.org/browse/JDK-8318049): C2: assert(!failure) failed: Missed optimization opportunity in PhaseIterGVN (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16214/head:pull/16214` \
`$ git checkout pull/16214`

Update a local copy of the PR: \
`$ git checkout pull/16214` \
`$ git pull https://git.openjdk.org/jdk.git pull/16214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16214`

View PR using the GUI difftool: \
`$ git pr show -t 16214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16214.diff">https://git.openjdk.org/jdk/pull/16214.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16214#issuecomment-1766147044)