### PR TITLE
8318104: macOS 10.13 check in TabButtonAccessibility.m can be removed

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TabButtonAccessibility.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/a11y/TabButtonAccessibility.m
@@ -84,10 +84,7 @@
 
 - (NSAccessibilitySubrole)accessibilitySubrole
 {
-    if (@available(macOS 10.13, *)) {
-        return NSAccessibilityTabButtonSubrole;
-    }
-    return NSAccessibilityUnknownSubrole;
+    return NSAccessibilityTabButtonSubrole;
 }
 
 - (id)accessibilityValue


### PR DESCRIPTION
Since[ JDK-8317970](https://bugs.openjdk.org/browse/JDK-8317970) is integrated to make macOS 11 the minimum version to build jdk, the 10.13 check is not needed and can be removed from TabButtonAccessibility.m file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318104](https://bugs.openjdk.org/browse/JDK-8318104): macOS 10.13 check in TabButtonAccessibility.m can be removed (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16218/head:pull/16218` \
`$ git checkout pull/16218`

Update a local copy of the PR: \
`$ git checkout pull/16218` \
`$ git pull https://git.openjdk.org/jdk.git pull/16218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16218`

View PR using the GUI difftool: \
`$ git pr show -t 16218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16218.diff">https://git.openjdk.org/jdk/pull/16218.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16218#issuecomment-1766257062)