### PR TITLE
8318296: Move Space::initialize to ContiguousSpace

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -46,24 +46,6 @@
 #include "gc/serial/defNewGeneration.hpp"
 #endif
 
-void Space::initialize(MemRegion mr,
-                       bool clear_space,
-                       bool mangle_space) {
-  HeapWord* bottom = mr.start();
-  HeapWord* end    = mr.end();
-  assert(Universe::on_page_boundary(bottom) && Universe::on_page_boundary(end),
-         "invalid space boundaries");
-  set_bottom(bottom);
-  set_end(end);
-  if (clear_space) clear(mangle_space);
-}
-
-void Space::clear(bool mangle_space) {
-  if (ZapUnusedHeapArea && mangle_space) {
-    mangle_unused_area();
-  }
-}
-
 ContiguousSpace::ContiguousSpace(): Space(),
   _compaction_top(nullptr),
   _next_compaction_space(nullptr),
@@ -79,15 +61,25 @@ void ContiguousSpace::initialize(MemRegion mr,
                                  bool clear_space,
                                  bool mangle_space)
 {
-  Space::initialize(mr, clear_space, mangle_space);
-  set_compaction_top(bottom());
+  HeapWord* bottom = mr.start();
+  HeapWord* end    = mr.end();
+  assert(Universe::on_page_boundary(bottom) && Universe::on_page_boundary(end),
+         "invalid space boundaries");
+  set_bottom(bottom);
+  set_end(end);
+  if (clear_space) {
+    clear(mangle_space);
+  }
+  set_compaction_top(bottom);
   _next_compaction_space = nullptr;
 }
 
 void ContiguousSpace::clear(bool mangle_space) {
   set_top(bottom());
   set_saved_mark();
-  Space::clear(mangle_space);
+  if (ZapUnusedHeapArea && mangle_space) {
+    mangle_unused_area();
+  }
   _compaction_top = bottom();
 }
 

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -112,17 +112,6 @@ class Space: public CHeapObj<mtGC> {
     return MemRegion(bottom(), saved_mark_word());
   }
 
-  // Initialization.
-  // "initialize" should be called once on a space, before it is used for
-  // any purpose.  The "mr" arguments gives the bounds of the space, and
-  // the "clear_space" argument should be true unless the memory in "mr" is
-  // known to be zeroed.
-  virtual void initialize(MemRegion mr, bool clear_space, bool mangle_space);
-
-  // The "clear" method must be called on a region that may have
-  // had allocation performed in it, but is now to be considered empty.
-  virtual void clear(bool mangle_space);
-
   // For detecting GC bugs.  Should only be called at GC boundaries, since
   // some unused space may be used as scratch space during GC's.
   // We also call this when expanding a space to satisfy an allocation
@@ -264,9 +253,16 @@ private:
   ContiguousSpace();
   ~ContiguousSpace();
 
-  void initialize(MemRegion mr, bool clear_space, bool mangle_space) override;
+  // Initialization.
+  // "initialize" should be called once on a space, before it is used for
+  // any purpose.  The "mr" arguments gives the bounds of the space, and
+  // the "clear_space" argument should be true unless the memory in "mr" is
+  // known to be zeroed.
+  void initialize(MemRegion mr, bool clear_space, bool mangle_space);
 
-  void clear(bool mangle_space) override;
+  // The "clear" method must be called on a region that may have
+  // had allocation performed in it, but is now to be considered empty.
+  virtual void clear(bool mangle_space);
 
   // Used temporarily during a compaction phase to hold the value
   // top should have when compaction is complete.


### PR DESCRIPTION
Simple refactoring of moving methods to subclass. (`clear` is also moved, as it is called inside `initialize`.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318296](https://bugs.openjdk.org/browse/JDK-8318296): Move Space::initialize to ContiguousSpace (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16219/head:pull/16219` \
`$ git checkout pull/16219`

Update a local copy of the PR: \
`$ git checkout pull/16219` \
`$ git pull https://git.openjdk.org/jdk.git pull/16219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16219`

View PR using the GUI difftool: \
`$ git pr show -t 16219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16219.diff">https://git.openjdk.org/jdk/pull/16219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16219#issuecomment-1766283702)