### PR TITLE
8318096: Introduce AsymmetricKey interface with a getParams method

### DIFF
--- a/src/java.base/share/classes/java/security/AsymmetricKey.java
+++ b/src/java.base/share/classes/java/security/AsymmetricKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,36 +25,29 @@
 
 package java.security;
 
+import java.security.spec.AlgorithmParameterSpec;
+
 /**
- * <p>A public key. This interface contains no methods or constants.
- * It merely serves to group (and provide type safety for) all public key
- * interfaces.
+ * An asymmetric key, which can be either a public key or a private key.
+ * This interface contains methods that are common to either a public key or
+ * a private key.
  *
- * Note: The specialized public key interfaces extend this interface.
- * See, for example, the DSAPublicKey interface in
- * {@code java.security.interfaces}.
- *
- * @since 1.1
- * @see Key
- * @see PrivateKey
- * @see java.security.cert.Certificate
- * @see Signature#initVerify
- * @see java.security.interfaces.DSAPublicKey
- * @see java.security.interfaces.RSAPublicKey
- *
+ * @since 22
  */
 
-public non-sealed interface PublicKey extends AsymmetricKey {
-    // Declare serialVersionUID to be compatible with JDK1.1
+public sealed interface AsymmetricKey extends Key permits PrivateKey, PublicKey {
     /**
-     * The class fingerprint that is set to indicate serialization
-     * compatibility with a previous version of the class.
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
      *
-     * @deprecated A {@code serialVersionUID} field in an interface is
-     * ineffectual. Do not use; no replacement.
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be {@code null}
      */
-    @Deprecated
-    @SuppressWarnings("serial")
-    @java.io.Serial
-    long serialVersionUID = 7187392471159151072L;
+    default AlgorithmParameterSpec getParams() {
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/AsymmetricKey.java
+++ b/src/java.base/share/classes/java/security/AsymmetricKey.java
@@ -34,8 +34,7 @@ import java.security.spec.AlgorithmParameterSpec;
  *
  * @since 22
  */
-
-public sealed interface AsymmetricKey extends Key permits PrivateKey, PublicKey {
+public interface AsymmetricKey extends Key {
     /**
      * Returns the parameters associated with this key.
      * The parameters are optional and may be either

--- a/src/java.base/share/classes/java/security/PrivateKey.java
+++ b/src/java.base/share/classes/java/security/PrivateKey.java
@@ -83,10 +83,10 @@ public interface PrivateKey extends Key, javax.security.auth.Destroyable {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default AlgorithmParameterSpec getParams(){
+    default AlgorithmParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/PrivateKey.java
+++ b/src/java.base/share/classes/java/security/PrivateKey.java
@@ -25,8 +25,6 @@
 
 package java.security;
 
-import java.security.spec.AlgorithmParameterSpec;
-
 /**
  * A private key.
  * The purpose of this interface is to group (and provide type safety
@@ -59,7 +57,7 @@ import java.security.spec.AlgorithmParameterSpec;
  * @since 1.1
  */
 
-public interface PrivateKey extends Key, javax.security.auth.Destroyable {
+public non-sealed interface PrivateKey extends AsymmetricKey, javax.security.auth.Destroyable {
 
     // Declare serialVersionUID to be compatible with JDK1.1
     /**
@@ -73,20 +71,4 @@ public interface PrivateKey extends Key, javax.security.auth.Destroyable {
     @SuppressWarnings("serial")
     @java.io.Serial
     long serialVersionUID = 6034044314589513430L;
-
-    /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
-     *
-     * @implSpec
-     * The default implementation returns {@code null}.
-     *
-     * @return the associated parameters, may be {@code null}
-     * @since 22
-     */
-    default AlgorithmParameterSpec getParams() {
-        return null;
-    }
 }

--- a/src/java.base/share/classes/java/security/PrivateKey.java
+++ b/src/java.base/share/classes/java/security/PrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.security;
+
+import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * A private key.
@@ -71,4 +73,20 @@ public interface PrivateKey extends Key, javax.security.auth.Destroyable {
     @SuppressWarnings("serial")
     @java.io.Serial
     long serialVersionUID = 6034044314589513430L;
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default AlgorithmParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/PrivateKey.java
+++ b/src/java.base/share/classes/java/security/PrivateKey.java
@@ -57,7 +57,7 @@ package java.security;
  * @since 1.1
  */
 
-public non-sealed interface PrivateKey extends AsymmetricKey, javax.security.auth.Destroyable {
+public interface PrivateKey extends AsymmetricKey, javax.security.auth.Destroyable {
 
     // Declare serialVersionUID to be compatible with JDK1.1
     /**

--- a/src/java.base/share/classes/java/security/PublicKey.java
+++ b/src/java.base/share/classes/java/security/PublicKey.java
@@ -44,7 +44,7 @@ package java.security;
  *
  */
 
-public non-sealed interface PublicKey extends AsymmetricKey {
+public interface PublicKey extends AsymmetricKey {
     // Declare serialVersionUID to be compatible with JDK1.1
     /**
      * The class fingerprint that is set to indicate serialization

--- a/src/java.base/share/classes/java/security/PublicKey.java
+++ b/src/java.base/share/classes/java/security/PublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.security;
+
+import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * <p>A public key. This interface contains no methods or constants.
@@ -57,4 +59,20 @@ public interface PublicKey extends Key {
     @SuppressWarnings("serial")
     @java.io.Serial
     long serialVersionUID = 7187392471159151072L;
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default AlgorithmParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/PublicKey.java
+++ b/src/java.base/share/classes/java/security/PublicKey.java
@@ -69,10 +69,10 @@ public interface PublicKey extends Key {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default AlgorithmParameterSpec getParams(){
+    default AlgorithmParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/DSAParams.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.security.interfaces;
 
 import java.math.BigInteger;
+import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * Interface to a DSA-specific set of key parameters, which defines a
@@ -40,7 +41,7 @@ import java.math.BigInteger;
  * @author Josh Bloch
  * @since 1.1
  */
-public interface DSAParams {
+public interface DSAParams extends AlgorithmParameterSpec {
 
     /**
      * Returns the prime, {@code p}.

--- a/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
@@ -72,10 +72,10 @@ public interface DSAPrivateKey extends DSAKey, java.security.PrivateKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default DSAParams getParams(){
+    default DSAParams getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,4 +62,20 @@ public interface DSAPrivateKey extends DSAKey, java.security.PrivateKey {
      * @return the value of the private key, {@code x}.
      */
     BigInteger getX();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default DSAParams getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
@@ -64,17 +64,15 @@ public interface DSAPrivateKey extends DSAKey, java.security.PrivateKey {
     BigInteger getX();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default DSAParams getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
@@ -72,10 +72,10 @@ public interface DSAPublicKey extends DSAKey, java.security.PublicKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default DSAParams getParams(){
+    default DSAParams getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
@@ -64,17 +64,15 @@ public interface DSAPublicKey extends DSAKey, java.security.PublicKey {
     BigInteger getY();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default DSAParams getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,4 +62,20 @@ public interface DSAPublicKey extends DSAKey, java.security.PublicKey {
      * @return the value of the public key, {@code y}.
      */
     BigInteger getY();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default DSAParams getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
@@ -67,10 +67,10 @@ public interface ECPrivateKey extends PrivateKey, ECKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default ECParameterSpec getParams(){
+    default ECParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
@@ -59,17 +59,15 @@ public interface ECPrivateKey extends PrivateKey, ECKey {
     BigInteger getS();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default ECParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package java.security.interfaces;
 
 import java.math.BigInteger;
 import java.security.PrivateKey;
+import java.security.spec.ECParameterSpec;
 
 /**
  * The interface to an elliptic curve (EC) private key.
@@ -56,4 +57,20 @@ public interface ECPrivateKey extends PrivateKey, ECKey {
      * @return the private value S.
      */
     BigInteger getS();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default ECParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
@@ -69,10 +69,10 @@ public interface ECPublicKey extends PublicKey, ECKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default ECParameterSpec getParams(){
+    default ECParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
@@ -61,17 +61,15 @@ public interface ECPublicKey extends PublicKey, ECKey {
     ECPoint getW();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default ECParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package java.security.interfaces;
 
 import java.security.PublicKey;
+import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 
 /**
@@ -58,4 +59,20 @@ public interface ECPublicKey extends PublicKey, ECKey {
      * @return the public point W.
      */
     ECPoint getW();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default ECParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
@@ -55,17 +55,15 @@ public interface EdECPrivateKey extends EdECKey, PrivateKey {
     Optional<byte[]> getBytes();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default NamedParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
@@ -63,10 +63,10 @@ public interface EdECPrivateKey extends EdECKey, PrivateKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default NamedParameterSpec getParams(){
+    default NamedParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package java.security.interfaces;
 
 import java.security.PrivateKey;
+import java.security.spec.NamedParameterSpec;
 import java.util.Optional;
 
 /**
@@ -52,4 +53,20 @@ public interface EdECPrivateKey extends EdECKey, PrivateKey {
      * If the key is not available, then an empty {@code Optional}.
      */
     Optional<byte[]> getBytes();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default NamedParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
@@ -58,10 +58,10 @@ public interface EdECPublicKey extends EdECKey, PublicKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default NamedParameterSpec getParams(){
+    default NamedParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package java.security.interfaces;
 
 import java.security.PublicKey;
 import java.security.spec.EdECPoint;
+import java.security.spec.NamedParameterSpec;
 
 /**
  * An interface for an elliptic curve public key as defined by
@@ -47,4 +48,20 @@ public interface EdECPublicKey extends EdECKey, PublicKey {
      * @return the {@code EdECPoint} representing the public key.
      */
     EdECPoint getPoint();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default NamedParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
@@ -50,17 +50,15 @@ public interface EdECPublicKey extends EdECKey, PublicKey {
     EdECPoint getPoint();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default NamedParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
@@ -62,17 +62,15 @@ public interface RSAPrivateKey extends java.security.PrivateKey, RSAKey
     BigInteger getPrivateExponent();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default AlgorithmParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
@@ -70,10 +70,10 @@ public interface RSAPrivateKey extends java.security.PrivateKey, RSAKey
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default AlgorithmParameterSpec getParams(){
+    default AlgorithmParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.security.interfaces;
 
 import java.math.BigInteger;
+import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * The interface to an RSA private key.
@@ -59,4 +60,20 @@ public interface RSAPrivateKey extends java.security.PrivateKey, RSAKey
      * @return the private exponent
      */
     BigInteger getPrivateExponent();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default AlgorithmParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.security.interfaces;
 
 import java.math.BigInteger;
+import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * The interface to an RSA public key.
@@ -56,4 +57,20 @@ public interface RSAPublicKey extends java.security.PublicKey, RSAKey
      * @return the public exponent
      */
     BigInteger getPublicExponent();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default AlgorithmParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
@@ -67,10 +67,10 @@ public interface RSAPublicKey extends java.security.PublicKey, RSAKey
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default AlgorithmParameterSpec getParams(){
+    default AlgorithmParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
@@ -59,17 +59,15 @@ public interface RSAPublicKey extends java.security.PublicKey, RSAKey
     BigInteger getPublicExponent();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default AlgorithmParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
@@ -56,17 +56,15 @@ public interface XECPrivateKey extends XECKey, PrivateKey {
     Optional<byte[]> getScalar();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default AlgorithmParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
@@ -64,10 +64,10 @@ public interface XECPrivateKey extends XECKey, PrivateKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default AlgorithmParameterSpec getParams(){
+    default AlgorithmParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package java.security.interfaces;
 
 import java.security.PrivateKey;
+import java.security.spec.AlgorithmParameterSpec;
 import java.util.Optional;
 
 /**
@@ -53,5 +54,21 @@ public interface XECPrivateKey extends XECKey, PrivateKey {
      *     and the private key is not allowed to leave the crypto boundary).
      */
     Optional<byte[]> getScalar();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default AlgorithmParameterSpec getParams(){
+        return null;
+    }
 }
 

--- a/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
@@ -62,10 +62,10 @@ public interface XECPublicKey extends XECKey, PublicKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default AlgorithmParameterSpec getParams(){
+    default AlgorithmParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
@@ -54,17 +54,15 @@ public interface XECPublicKey extends XECKey, PublicKey {
     BigInteger getU();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default AlgorithmParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package java.security.interfaces;
 
 import java.math.BigInteger;
 import java.security.PublicKey;
+import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * An interface for an elliptic curve public key as defined by RFC 7748.
@@ -52,5 +53,20 @@ public interface XECPublicKey extends XECKey, PublicKey {
      */
     BigInteger getU();
 
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default AlgorithmParameterSpec getParams(){
+        return null;
+    }
 }
 

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.crypto.interfaces;
 
+import javax.crypto.spec.DHParameterSpec;
 import java.math.BigInteger;
 
 /**
@@ -56,4 +57,20 @@ public interface DHPrivateKey extends DHKey, java.security.PrivateKey {
      * @return the private value, <code>x</code>
      */
     BigInteger getX();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default DHParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
@@ -67,10 +67,10 @@ public interface DHPrivateKey extends DHKey, java.security.PrivateKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default DHParameterSpec getParams(){
+    default DHParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
@@ -59,17 +59,15 @@ public interface DHPrivateKey extends DHKey, java.security.PrivateKey {
     BigInteger getX();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default DHParameterSpec getParams() {
         return null;
     }

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javax.crypto.interfaces;
 
+import javax.crypto.spec.DHParameterSpec;
 import java.math.BigInteger;
 
 /**
@@ -56,4 +57,20 @@ public interface DHPublicKey extends DHKey, java.security.PublicKey {
      * @return the public value, <code>y</code>
      */
     BigInteger getY();
+
+    /**
+     * Returns the parameters associated with this key.
+     * The parameters are optional and may be either
+     * explicitly specified or implicitly created during
+     * key pair generation.
+     *
+     * @implSpec
+     * The default implementation returns {@code null}.
+     *
+     * @return the associated parameters, may be null
+     * @since 22
+     */
+    default DHParameterSpec getParams(){
+        return null;
+    }
 }

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
@@ -67,10 +67,10 @@ public interface DHPublicKey extends DHKey, java.security.PublicKey {
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be null
+     * @return the associated parameters, may be {@code null}
      * @since 22
      */
-    default DHParameterSpec getParams(){
+    default DHParameterSpec getParams() {
         return null;
     }
 }

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
@@ -59,17 +59,15 @@ public interface DHPublicKey extends DHKey, java.security.PublicKey {
     BigInteger getY();
 
     /**
-     * Returns the parameters associated with this key.
-     * The parameters are optional and may be either
-     * explicitly specified or implicitly created during
-     * key pair generation.
+     * {@inheritDoc java.security.AsymmetricKey}
      *
      * @implSpec
      * The default implementation returns {@code null}.
      *
-     * @return the associated parameters, may be {@code null}
+     * @return {@inheritDoc java.security.AsymmetricKey}
      * @since 22
      */
+    @Override
     default DHParameterSpec getParams() {
         return null;
     }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -899,7 +899,7 @@ abstract class P11Key implements Key, Length {
             params = new DSAParameterSpec(res[0], res[1], res[2]);
         }
 
-        protected DSAParams getParams() {
+        public DSAParams getParams() {
             fetchValues();
             return params;
         }
@@ -1202,7 +1202,7 @@ abstract class P11Key implements Key, Length {
             }
         }
 
-        protected ECParameterSpec getParams() {
+        public ECParameterSpec getParams() {
             fetchValues();
             return params;
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -899,6 +899,7 @@ abstract class P11Key implements Key, Length {
             params = new DSAParameterSpec(res[0], res[1], res[2]);
         }
 
+        @Override
         public DSAParams getParams() {
             fetchValues();
             return params;
@@ -1202,6 +1203,7 @@ abstract class P11Key implements Key, Length {
             }
         }
 
+        @Override
         public ECParameterSpec getParams() {
             fetchValues();
             return params;

--- a/test/jdk/java/security/AsymmetricKey/GetParams.java
+++ b/test/jdk/java/security/AsymmetricKey/GetParams.java
@@ -29,13 +29,12 @@ import java.security.KeyPairGenerator;
 import java.security.interfaces.DSAParams;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECParameterSpec;
-import java.security.spec.EdDSAParameterSpec;
 import java.security.spec.NamedParameterSpec;
 
 /**
  * @test
  * @bug 8318096
- * @summary Add getParams method in PublicKey and PrivateKey
+ * @summary Introduce AsymmetricKey interface with a getParams method
  * @library /test/lib
  */
 

--- a/test/jdk/java/security/Signature/GetParams.java
+++ b/test/jdk/java/security/Signature/GetParams.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.Asserts;
+
+import javax.crypto.spec.DHParameterSpec;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.DSAParams;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.EdDSAParameterSpec;
+import java.security.spec.NamedParameterSpec;
+
+/**
+ * @test
+ * @bug 8318096
+ * @summary Add getParams method in PublicKey and PrivateKey
+ * @library /test/lib
+ */
+
+public class GetParams {
+    public static void main(String[] args) throws Exception {
+        test("DSA", DSAParams.class);
+        test("RSA", AlgorithmParameterSpec.class);
+        test("RSASSA-PSS", AlgorithmParameterSpec.class);
+        test("EC", ECParameterSpec.class);
+        test("DH", DHParameterSpec.class);
+        test("EdDSA", NamedParameterSpec.class);
+        test("XDH", NamedParameterSpec.class);
+    }
+
+    static void test(String alg, Class<? extends AlgorithmParameterSpec> clazz)
+            throws Exception {
+        KeyPairGenerator g = KeyPairGenerator.getInstance(alg);
+        KeyPair kp = g.generateKeyPair();
+        AlgorithmParameterSpec spec1 = kp.getPrivate().getParams();
+        Asserts.assertTrue(spec1 == null || clazz.isAssignableFrom(spec1.getClass()));
+        AlgorithmParameterSpec spec2 = kp.getPublic().getParams();
+        Asserts.assertTrue(spec2 == null || clazz.isAssignableFrom(spec2.getClass()));
+    }
+}


### PR DESCRIPTION
Create a parent interface `AsymmetricKey` for `PublicKey` and `PrivateKey` and add a `getParams` method there. This makes it available to all current and future public and private keys.

No test. Might add one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))
- [x] Change requires CSR request [JDK-8318108](https://bugs.openjdk.org/browse/JDK-8318108) to be approved

### Issues
 * [JDK-8318096](https://bugs.openjdk.org/browse/JDK-8318096): Introduce AsymmetricKey interface with a getParams method (**Enhancement** - P3)
 * [JDK-8318108](https://bugs.openjdk.org/browse/JDK-8318108): Introduce AsymmetricKey interface with a getParams method (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [096b95a1](https://git.openjdk.org/jdk/pull/16222/files/096b95a151b62e6529e34930085b69ae566c5b27)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16222/head:pull/16222` \
`$ git checkout pull/16222`

Update a local copy of the PR: \
`$ git checkout pull/16222` \
`$ git pull https://git.openjdk.org/jdk.git pull/16222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16222`

View PR using the GUI difftool: \
`$ git pr show -t 16222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16222.diff">https://git.openjdk.org/jdk/pull/16222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16222#issuecomment-1766677562)