### PR TITLE
8318328: DHKEM should check XDH name in case-insensitive mode

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DHKEM.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHKEM.java
@@ -353,9 +353,9 @@ public class DHKEM implements KEMSpi {
             }
         } else if (k instanceof XECKey xkey
                 && xkey.getParams() instanceof NamedParameterSpec ns) {
-            if (ns.getName().equals("X25519")) {
+            if (ns.getName().equalsIgnoreCase("X25519")) {
                 return Params.X25519;
-            } else if (ns.getName().equals("X448")) {
+            } else if (ns.getName().equalsIgnoreCase("X448")) {
                 return Params.X448;
             }
         }

--- a/src/java.base/share/classes/sun/security/ec/XDHPrivateKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/ec/XDHPrivateKeyImpl.java
@@ -103,7 +103,7 @@ public final class XDHPrivateKeyImpl extends PKCS8Key implements XECPrivateKey {
 
     @Override
     public PublicKey calculatePublicKey() {
-        XECParameters params = paramSpec.getName().equals("X25519")
+        XECParameters params = paramSpec.getName().equalsIgnoreCase("X25519")
                 ? XECParameters.X25519
                 : XECParameters.X448;
         try {

--- a/test/jdk/com/sun/crypto/provider/DHKEM/NameSensitiveness.java
+++ b/test/jdk/com/sun/crypto/provider/DHKEM/NameSensitiveness.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8318328
+ * @summary DHKEM should check XDH name in case-insensitive mode
+ * @library /test/lib
+ * @modules java.base/com.sun.crypto.provider
+ */
+import javax.crypto.KEM;
+import java.math.BigInteger;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.XECPublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.NamedParameterSpec;
+
+public class NameSensitiveness {
+    public static void main(String[] args) throws Exception {
+        var g = KeyPairGenerator.getInstance("XDH");
+        g.initialize(NamedParameterSpec.X25519);
+        var pk1 = (XECPublicKey) g.generateKeyPair().getPublic();
+        var pk2 = new XECPublicKey() {
+            public BigInteger getU() {
+                return pk1.getU();
+            }
+            public AlgorithmParameterSpec getParams() {
+                return new NamedParameterSpec("x25519"); // lowercase!!!
+            }
+            public String getAlgorithm() {
+                return pk1.getAlgorithm();
+            }
+            public String getFormat() {
+                return pk1.getFormat();
+            }
+            public byte[] getEncoded() {
+                return pk1.getEncoded();
+            }
+        };
+        var kem = KEM.getInstance("DHKEM");
+        kem.newEncapsulator(pk2);
+    }
+}


### PR DESCRIPTION
The comparison should have been done in case-insensitive mode.

The new test confirms the change inside `DHKEM.java`. The one in `XDHPrivateKeyImpl.java` is not easy to confirm. The SUN provider's implementation always got the name "correct".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318328](https://bugs.openjdk.org/browse/JDK-8318328): DHKEM should check XDH name in case-insensitive mode (**Bug** - P4)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16225/head:pull/16225` \
`$ git checkout pull/16225`

Update a local copy of the PR: \
`$ git checkout pull/16225` \
`$ git pull https://git.openjdk.org/jdk.git pull/16225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16225`

View PR using the GUI difftool: \
`$ git pr show -t 16225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16225.diff">https://git.openjdk.org/jdk/pull/16225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16225#issuecomment-1766924992)