### PR TITLE
8318322: Update IANA Language Subtag Registry to Version 2023-10-16

### DIFF
--- a/src/java.base/share/data/lsrdata/language-subtag-registry.txt
+++ b/src/java.base/share/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2023-08-02
+File-Date: 2023-10-16
 %%
 Type: language
 Subtag: aa
@@ -44880,6 +44880,11 @@ Description: Cherokee
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Chis
+Description: Chisoi
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Chrs
 Description: Chorasmian
 Added: 2019-09-11
@@ -44975,6 +44980,11 @@ Description: Ge'ez
 Added: 2005-10-16
 %%
 Type: script
+Subtag: Gara
+Description: Garay
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Geok
 Description: Khutsuri (Asomtavruli and Nuskhuri)
 Added: 2005-10-16
@@ -45018,6 +45028,11 @@ Type: script
 Subtag: Gujr
 Description: Gujarati
 Added: 2005-10-16
+%%
+Type: script
+Subtag: Gukh
+Description: Gurung Khema
+Added: 2023-10-16
 %%
 Type: script
 Subtag: Guru
@@ -45188,6 +45203,11 @@ Type: script
 Subtag: Kpel
 Description: Kpelle
 Added: 2010-04-10
+%%
+Type: script
+Subtag: Krai
+Description: Kirat Rai
+Added: 2023-10-16
 %%
 Type: script
 Subtag: Kthi
@@ -45437,6 +45457,11 @@ Description: Santali
 Added: 2006-07-21
 %%
 Type: script
+Subtag: Onao
+Description: Ol Onal
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Orkh
 Description: Old Turkic
 Description: Orkhon Runic
@@ -45616,6 +45641,11 @@ Description: Siddhamātṛkā
 Added: 2013-12-02
 %%
 Type: script
+Subtag: Sidt
+Description: Sidetic
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Sind
 Description: Khudawadi
 Description: Sindhi
@@ -45719,6 +45749,11 @@ Description: Tai Viet
 Added: 2007-12-05
 %%
 Type: script
+Subtag: Tayo
+Description: Tai Yo
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Telu
 Description: Telugu
 Added: 2005-10-16
@@ -45767,9 +45802,24 @@ Description: Tangsa
 Added: 2021-03-05
 %%
 Type: script
+Subtag: Todr
+Description: Todhri
+Added: 2023-10-16
+%%
+Type: script
+Subtag: Tols
+Description: Tolong Siki
+Added: 2023-10-16
+%%
+Type: script
 Subtag: Toto
 Description: Toto
 Added: 2020-05-12
+%%
+Type: script
+Subtag: Tutg
+Description: Tulu-Tigalari
+Added: 2023-10-16
 %%
 Type: script
 Subtag: Ugar

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @bug 8025703 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
- *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702
+ *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702 8318322
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2023-08-02) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2023-10-16) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
This change updates the IANA subtag registry to the update released on 2023-10-16.

Announcement -> https://mm.icann.org/pipermail/ietf-languages-announcements/2023-October/000089.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318322](https://bugs.openjdk.org/browse/JDK-8318322): Update IANA Language Subtag Registry to Version 2023-10-16 (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Steven Loomis](https://openjdk.org/census#srl) (@srl295 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16227/head:pull/16227` \
`$ git checkout pull/16227`

Update a local copy of the PR: \
`$ git checkout pull/16227` \
`$ git pull https://git.openjdk.org/jdk.git pull/16227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16227`

View PR using the GUI difftool: \
`$ git pr show -t 16227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16227.diff">https://git.openjdk.org/jdk/pull/16227.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16227#issuecomment-1767099545)