### PR TITLE
8318363: Foreign benchmarks fail to build on some platforms

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/libToCString.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libToCString.c
@@ -21,13 +21,14 @@
  * questions.
  */
 
+#include <jlong_md.h>
 #include <jni.h>
 #include <stdlib.h>
 #include <string.h>
 
 JNIEXPORT jlong JNICALL Java_org_openjdk_bench_java_lang_foreign_ToCStringTest_writeString(JNIEnv *const env, const jclass cls, const jstring text) {
     const char *str = (*env)->GetStringUTFChars(env, text, NULL);
-    jlong addr = (jlong)(void*)str;
+    jlong addr = ptr_to_jlong(str);
     (*env)->ReleaseStringUTFChars(env, text, str);
     return addr;
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libToJavaString.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libToJavaString.c
@@ -23,10 +23,11 @@
  * questions.
  */
 
+#include <jlong_md.h>
 #include <jni.h>
 #include <stdlib.h>
 #include <string.h>
 
 JNIEXPORT jstring JNICALL Java_org_openjdk_bench_java_lang_foreign_ToJavaStringTest_readString(JNIEnv *const env, const jclass cls, jlong addr) {
-    return (*env)->NewStringUTF(env, (char*)(void*)addr);
+    return (*env)->NewStringUTF(env, jlong_to_ptr(addr));
 }


### PR DESCRIPTION
Recent regression, see bug. The fix is to use the proper `jlong <-> ptr` converters.

Additional testing:
 - [x] Build now passes on ARM32
 - [x] Two affected JMH benchmarks still run