### PR TITLE
8318365: Test runtime/cds/appcds/sharedStrings/InternSharedString.java fails after JDK-8311538

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/InternSharedString.java
@@ -26,7 +26,9 @@
  * @test
  * @summary Test shared strings together with string intern operation
  * @requires vm.cds.write.archived.java.heap
- * @requires vm.gc == null & !vm.opt.UseLargePages
+ * @requires vm.gc == null
+ * @comment CDS archive heap mapping is not supported with large pages
+ * @requires vm.opt.UseLargePages == null | !vm.opt.UseLargePages
  * @library /test/hotspot/jtreg/runtime/cds/appcds /test/lib
  * @compile InternStringTest.java
  * @build jdk.test.whitebox.WhiteBox


### PR DESCRIPTION
Please review this simple test fix for the requires clause.

The test runs and passes with no flags set; is skipped with -XX:+UseLargePages; and runs and passes with -XX:-UseLargePages.

Sanity testing tiers 1-3 in progress

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318365](https://bugs.openjdk.org/browse/JDK-8318365): Test runtime/cds/appcds/sharedStrings/InternSharedString.java fails after JDK-8311538 (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16229/head:pull/16229` \
`$ git checkout pull/16229`

Update a local copy of the PR: \
`$ git checkout pull/16229` \
`$ git pull https://git.openjdk.org/jdk.git pull/16229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16229`

View PR using the GUI difftool: \
`$ git pr show -t 16229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16229.diff">https://git.openjdk.org/jdk/pull/16229.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16229#issuecomment-1767276595)