### PR TITLE
JDK-8318415: Adjust describing comment of os_getChildren after 8315026

### DIFF
--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -47,13 +47,21 @@
 void os_initNative(JNIEnv *env, jclass clazz) {}
 
 /*
- * Returns the children of the requested pid and optionally each parent.
- *
- * Use sysctl to accumulate any process whose parent pid is zero or matches.
- * The resulting pids are stored into the array of longs.
+ * Return pids of active processes, and optionally parent pids and
+ * start times for each process.
+ * For a specific non-zero pid jpid, only the direct children are returned.
+ * If the pid jpid is zero, all active processes are returned.
+ * Uses sysctl to accumulates any process following the rules above.
+ * The resulting pids are stored into an array of longs named jarray.
  * The number of pids is returned if they all fit.
- * If the parentArray is non-null, store the parent pid.
- * If the array is too short, excess pids are not stored and
+ * If the parentArray is non-null, store also the parent pid.
+ * In this case the parentArray must have the same length as the result pid array.
+ * Of course in the case of a given non-zero pid all entries in the parentArray
+ * will contain this pid, so this array does only make sense in the case of a given
+ * zero pid.
+ * If the jstimesArray is non-null, store also the start time of the pid.
+ * In this case the jstimesArray must have the same length as the result pid array.
+ * If the array(s) (is|are) too short, excess pids are not stored and
  * the desired length is returned.
  */
 jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
@@ -485,7 +485,7 @@ void unix_getUserInfo(JNIEnv* env, jobject jinfo, uid_t uid) {
 }
 
 /*
- * The following functions are common on Solaris, Linux and AIX.
+ * The following functions are for Linux
  */
 
 #if defined (__linux__)


### PR DESCRIPTION
8315026 adjusted and improved the describings comments already for AIX/Linux. But macOS was not adjusted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318415](https://bugs.openjdk.org/browse/JDK-8318415): Adjust describing comment of os_getChildren after 8315026 (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16236/head:pull/16236` \
`$ git checkout pull/16236`

Update a local copy of the PR: \
`$ git checkout pull/16236` \
`$ git pull https://git.openjdk.org/jdk.git pull/16236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16236`

View PR using the GUI difftool: \
`$ git pr show -t 16236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16236.diff">https://git.openjdk.org/jdk/pull/16236.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16236#issuecomment-1767975385)