### PR TITLE
8318418: hsdis build fails with system binutils on Ubuntu

### DIFF
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -236,7 +236,8 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
   if test "x$BINUTILS_DIR" = xsystem; then
     AC_CHECK_LIB(bfd, bfd_openr, [ HSDIS_LIBS="-lbfd" ], [ binutils_system_error="libbfd not found" ])
     AC_CHECK_LIB(opcodes, disassembler, [ HSDIS_LIBS="$HSDIS_LIBS -lopcodes" ], [ binutils_system_error="libopcodes not found" ])
-    AC_CHECK_LIB(iberty, xmalloc, [ HSDIS_LIBS="$HSDIS_LIBS -liberty" ], [ binutils_system_error="libiberty not found" ])
+    # libiberty is not required on Ubuntu
+    AC_CHECK_LIB(iberty, xmalloc, [ HSDIS_LIBS="$HSDIS_LIBS -liberty" ])
     AC_CHECK_LIB(z, deflate, [ HSDIS_LIBS="$HSDIS_LIBS -lz" ], [ binutils_system_error="libz not found" ])
     HSDIS_CFLAGS="-DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB"
   elif test "x$BINUTILS_DIR" != x; then

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -57,7 +57,6 @@
 #include <inttypes.h>
 #include <string.h>
 
-#include <libiberty.h>
 #include <bfd.h>
 #include <dis-asm.h>
 


### PR DESCRIPTION
hsdis-binutils.c doesn't use any functions from libiberty.h. This header is absent on Ubuntu (installed separately, and under a different path), so removing the include fixes the hsdis compilation on Ubuntu.

Additionally, the static link library for libiberty is not needed on Ubuntu; I changed the autoconf check to make libiberty optional.

Verification (Ubuntu):
- build with-binutils=system works
- build with-binutils-src=binutils-2.30 continues to work
- build with-binutils-src=binutils-2.38 continues to work

Source builds with versions newer than 2.38 fail, see #15138

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318418](https://bugs.openjdk.org/browse/JDK-8318418): hsdis build fails with system binutils on Ubuntu (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16238/head:pull/16238` \
`$ git checkout pull/16238`

Update a local copy of the PR: \
`$ git checkout pull/16238` \
`$ git pull https://git.openjdk.org/jdk.git pull/16238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16238`

View PR using the GUI difftool: \
`$ git pr show -t 16238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16238.diff">https://git.openjdk.org/jdk/pull/16238.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16238#issuecomment-1768084077)