### PR TITLE
8318421 : AbstractPipeline.sourceStageSpliterator() chases pointers needlessly

### DIFF
--- a/src/java.base/share/classes/java/util/stream/AbstractPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/AbstractPipeline.java
@@ -270,8 +270,9 @@ abstract class AbstractPipeline<E_IN, E_OUT, S extends BaseStream<E_OUT, S>>
      * @throws IllegalStateException if this pipeline stage is not the source
      *         stage.
      */
-    @SuppressWarnings("unchecked")
+
     final Spliterator<E_OUT> sourceStageSpliterator() {
+        // Ensures that this method is only ever called on the sourceStage
         if (this != sourceStage)
             throw new IllegalStateException();
 
@@ -279,16 +280,16 @@ abstract class AbstractPipeline<E_IN, E_OUT, S extends BaseStream<E_OUT, S>>
             throw new IllegalStateException(MSG_STREAM_LINKED);
         linkedOrConsumed = true;
 
-        if (sourceStage.sourceSpliterator != null) {
+        if (sourceSpliterator != null) {
             @SuppressWarnings("unchecked")
-            Spliterator<E_OUT> s = sourceStage.sourceSpliterator;
-            sourceStage.sourceSpliterator = null;
+            Spliterator<E_OUT> s = (Spliterator<E_OUT>)sourceSpliterator;
+            sourceSpliterator = null;
             return s;
         }
-        else if (sourceStage.sourceSupplier != null) {
+        else if (sourceSupplier != null) {
             @SuppressWarnings("unchecked")
-            Spliterator<E_OUT> s = (Spliterator<E_OUT>) sourceStage.sourceSupplier.get();
-            sourceStage.sourceSupplier = null;
+            Spliterator<E_OUT> s = (Spliterator<E_OUT>)sourceSupplier.get();
+            sourceSupplier = null;
             return s;
         }
         else {
@@ -317,8 +318,8 @@ abstract class AbstractPipeline<E_IN, E_OUT, S extends BaseStream<E_OUT, S>>
         linkedOrConsumed = true;
         sourceSupplier = null;
         sourceSpliterator = null;
-        if (sourceStage.sourceCloseAction != null) {
-            Runnable closeAction = sourceStage.sourceCloseAction;
+        Runnable closeAction = sourceStage.sourceCloseAction;
+        if (closeAction != null) {
             sourceStage.sourceCloseAction = null;
             closeAction.run();
         }


### PR DESCRIPTION
Removes a few unnecessary dereferences of `sourceStage`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318421](https://bugs.openjdk.org/browse/JDK-8318421): AbstractPipeline.sourceStageSpliterator() chases pointers needlessly (**Enhancement** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16241/head:pull/16241` \
`$ git checkout pull/16241`

Update a local copy of the PR: \
`$ git checkout pull/16241` \
`$ git pull https://git.openjdk.org/jdk.git pull/16241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16241`

View PR using the GUI difftool: \
`$ git pr show -t 16241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16241.diff">https://git.openjdk.org/jdk/pull/16241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16241#issuecomment-1770425140)