### PR TITLE
8318109: Writing JFR records while a CHT has taken its lock asserts in rank checking

### DIFF
--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -295,7 +295,7 @@ void mutex_init() {
 #if INCLUDE_JFR
   MUTEX_DEFN(JfrBuffer_lock                  , PaddedMutex  , event);
   MUTEX_DEFN(JfrMsg_lock                     , PaddedMonitor, event);
-  MUTEX_DEFN(JfrStacktrace_lock              , PaddedMutex  , stackwatermark-1);
+  MUTEX_DEFN(JfrStacktrace_lock              , PaddedMutex  , event);
   MUTEX_DEFN(JfrThreadSampler_lock           , PaddedMonitor, nosafepoint);
 #endif
 


### PR DESCRIPTION
Hi all,

  please review this change to fix a lock rank issue after [JDK-8317440](https://bugs.openjdk.org/browse/JDK-8317440). The `JfrStacktrace_lock` rank needs to be adjusted because it may be used when gathering CHT statistics in generational ZGC (afaiu this operation may trigger a relocation which may trigger page allocation which may trigger a JFR event which may trigger JFR trace writing).

The `JfrStacktrace_lock` code seems to be a lock only guarding I/O too, so moving it to the lowest rank seems safe after code inspection, but also tier1-7 testing and around 100 runs of the failed application did not make it fail (reproduction is like 2/100 runs without this change).

Testing: tier1-7, ~100 runs of the failing application with no error

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318109](https://bugs.openjdk.org/browse/JDK-8318109): Writing JFR records while a CHT has taken its lock asserts in rank checking (**Bug** - P2)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16242/head:pull/16242` \
`$ git checkout pull/16242`

Update a local copy of the PR: \
`$ git checkout pull/16242` \
`$ git pull https://git.openjdk.org/jdk.git pull/16242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16242`

View PR using the GUI difftool: \
`$ git pr show -t 16242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16242.diff">https://git.openjdk.org/jdk/pull/16242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16242#issuecomment-1770269212)