### PR TITLE
JDK-8318445: More broken bailout chains in C2

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2301,6 +2301,7 @@ void Compile::Optimize() {
     }
     igvn.reset_from_gvn(initial_gvn());
     igvn.optimize();
+    if (failing()) return;
   }
 
   // Now that all inlining is over and no PhaseRemoveUseless will run, cut edge from root to loop
@@ -2330,7 +2331,7 @@ void Compile::Optimize() {
       igvn.optimize();
       print_method(PHASE_ITER_GVN_AFTER_EA, 2);
 
-      if (failing())  return;
+      if (failing()) return;
 
       if (congraph() != nullptr && macro_count() > 0) {
         TracePhase tp("macroEliminate", &timers[_t_macroEliminate]);
@@ -2340,6 +2341,8 @@ void Compile::Optimize() {
 
         igvn.set_delay_transform(false);
         igvn.optimize();
+        if (failing()) return;
+
         print_method(PHASE_ITER_GVN_AFTER_ELIMINATION, 2);
       }
 
@@ -2449,6 +2452,7 @@ void Compile::Optimize() {
   if (C->max_vector_size() > 0) {
     C->optimize_logic_cones(igvn);
     igvn.optimize();
+    if (failing()) return;
   }
 
   DEBUG_ONLY( _modified_nodes = nullptr; )
@@ -5083,6 +5087,7 @@ void Compile::sort_macro_nodes() {
 }
 
 void Compile::print_method(CompilerPhaseType cpt, int level, Node* n) {
+  if (failing()) { return; }
   EventCompilerPhase event;
   if (event.should_commit()) {
     CompilerEvent::PhaseEvent::post(event, C->_latest_stage_start_counter, cpt, C->_compile_id, level);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4370,6 +4370,7 @@ Compile::TracePhase::TracePhase(const char* name, elapsedTimer* accumulator)
 }
 
 Compile::TracePhase::~TracePhase() {
+  if (_compile->failing()) return;
 #ifdef ASSERT
   if (PrintIdealNodeCount) {
     tty->print_cr("phase name='%s' nodes='%d' live='%d' live_graph_walk='%d'",

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1854,6 +1854,7 @@ void Compile::process_for_post_loop_opts_igvn(PhaseIterGVN& igvn) {
       igvn._worklist.push(n);
     }
     igvn.optimize();
+    if (failing()) return;
     assert(_for_post_loop_igvn.length() == 0, "no more delayed nodes allowed");
     assert(C->parse_predicate_count() == 0, "all parse predicates should have been removed now");
 
@@ -2069,6 +2070,7 @@ void Compile::inline_incrementally_cleanup(PhaseIterGVN& igvn) {
     TracePhase tp("incrementalInline_igvn", &timers[_t_incrInline_igvn]);
     igvn.reset_from_gvn(initial_gvn());
     igvn.optimize();
+    if (failing()) return;
   }
   print_method(PHASE_INCREMENTAL_INLINE_CLEANUP, 3);
 }

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3605,9 +3605,13 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
   // Non-counted loops may be peeled; exactly 1 iteration is peeled.
   // This removes loop-invariant tests (usually null checks).
   if (!_head->is_CountedLoop()) { // Non-counted loop
-    if (PartialPeelLoop && phase->partial_peel(this, old_new)) {
-      // Partial peel succeeded so terminate this round of loop opts
-      return false;
+    if (PartialPeelLoop) {
+      bool rc = phase->partial_peel(this, old_new);
+      if (Compile::current()->failing()) { return false; }
+      if (rc) {
+        // Partial peel succeeded so terminate this round of loop opts
+        return false;
+      }
     }
     if (policy_peeling(phase)) {    // Should we peel?
       if (PrintOpto) { tty->print_cr("should_peel"); }

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -3685,6 +3685,7 @@ bool PhaseIdealLoop::partial_peel( IdealLoopTree *loop, Node_List &old_new ) {
           // and not a CMove (Matcher expects only bool->cmove).
           if (n->in(0) == nullptr && !n->is_Load() && !n->is_CMove()) {
             int new_clones = clone_for_use_outside_loop(loop, n, worklist);
+            if (C->failing()) return false;
             if (new_clones == -1) {
               too_many_clones = true;
               break;

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -361,6 +361,7 @@ void Matcher::match( ) {
   C->set_cached_top_node(n);
   if (!C->failing()) {
     Node* xroot =        xform( C->root(), 1 );
+    if (C->failing()) return;
     if (xroot == nullptr) {
       Matcher::soft_match_failure();  // recursive matching process failed
       assert(false, "instruction match failed");


### PR DESCRIPTION
More places where, after a node limit check, we did not bail out properly.

```
Crash:

Current CompileTask:
C2:2574 45 45 843 4 sun.nio.fs.UnixPath::resolve (17 bytes)

Stack: [0x00007fa608cb3000,0x00007fa608db4000], sp=0x00007fa608daf310, free space=1008k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V [libjvm.so+0x631bb4] Unique_Node_List::push(Node*)+0x20 (node.hpp:1650)
V [libjvm.so+0xb8ea65] ConnectionGraph::verify_ram_nodes(Compile*, Node*)+0x87 (escape.cpp:743)
V [libjvm.so+0x960dda] Compile::Optimize()+0x956 (compile.cpp:2361)
V [libjvm.so+0x959d6c] Compile::Compile(ciEnv*, ciMethod*, int, Options, DirectiveSet*)+0x165e (compile.cpp:860)
V [libjvm.so+0x81bcd9] C2Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*)+0x203 (c2compiler.cpp:134)
V [libjvm.so+0x97bf63] CompileBroker::invoke_compiler_on_method(CompileTask*)+0xac5 (compileBroker.cpp:2290)
V [libjvm.so+0x97a981] CompileBroker::compiler_thread_loop()+0x411 (compileBroker.cpp:1951)
V [libjvm.so+0x99ebc0] CompilerThread::thread_entry(JavaThread*, JavaThread*)+0x84 (compilerThread.cpp:61)
V [libjvm.so+0xde0050] JavaThread::thread_main_inner()+0x15c (javaThread.cpp:720)
V [libjvm.so+0xddfeea] JavaThread::run()+0x258 (javaThread.cpp:705)
V [libjvm.so+0x15f5a04] Thread::call_run()+0x1a8 (thread.cpp:220)
V [libjvm.so+0x12de0a2] thread_native_entry(Thread*)+0x1c3 (os_linux.cpp:785)

siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000000028

Pending compilation failure details for thread 0x00007fa5b8003140:
  Time: 2.545243 seconds (0d 0h 0m 2s) Compile id: 843
  Reason: 'hit memory limit while compiling'
  Callstack:[0x00007fa64262bd64] Compile::record_method_not_compilable(char const*)+0x4a
[0x00007fa6428be4d5] Compile::record_method_not_compilable_oom()+0x27
[0x00007fa6427c7130] Compile::check_node_count(unsigned int, char const*)+0x34
[0x00007fa64329bb06] PhaseIterGVN::optimize()+0xaa
[0x00007fa6428b2d75] Compile::Optimize()+0x8f1
[0x00007fa6428abd6c] Compile::Compile(ciEnv*, ciMethod*, int, Options, DirectiveSet*)+0x165e
[0x00007fa64276dcd9] C2Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*)+0x203
[0x00007fa6428cdf63] CompileBroker::invoke_compiler_on_method(CompileTask*)+0xac5
[0x00007fa6428cc981] CompileBroker::compiler_thread_loop()+0x411
[0x00007fa6428f0bc0] CompilerThread::thread_entry(JavaThread*, JavaThread*)+0x84
[0x00007fa642d32050] JavaThread::thread_main_inner()+0x15c
[0x00007fa642d31eea] JavaThread::run()+0x258
[0x00007fa643547a04] Thread::call_run()+0x1a8
[0x00007fa6432300a2] thread_native_entry(Thread*)+0x1c3
```

The patch adds the necessary bailouts to fix above crash. 

There should be a better way, though. E.g. a macro that wraps a function call and adds the bailout automatically. Maybe for a future RFE. For now, I solve this the same way the surrounding code solves this.

/label hotspot-compiler
/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8318445](https://bugs.openjdk.org/browse/JDK-8318445): More broken bailout chains in C2 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16248/head:pull/16248` \
`$ git checkout pull/16248`

Update a local copy of the PR: \
`$ git checkout pull/16248` \
`$ git pull https://git.openjdk.org/jdk.git pull/16248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16248`

View PR using the GUI difftool: \
`$ git pr show -t 16248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16248.diff">https://git.openjdk.org/jdk/pull/16248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16248#issuecomment-1768904784)