### PR TITLE
8318458: Update javac and java manpages with restricted method options

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -521,6 +521,20 @@ Allows classes to depend on \f[B]preview features\f[R]
 [https://docs.oracle.com/en/java/javase/12/language/index.html#JSLAN-GUID-5A82FE0E-0CA4-4F1F-B075-564874FE2823]
 of the release.
 .TP
+\f[V]--enable-native-access\f[R] \f[I]module\f[R][\f[V],\f[R]\f[I]module\f[R]...]
+Native access involves access to code or data outside the Java runtime.
+This is generally unsafe and, if done incorrectly, might crash the JVM
+or result in memory corruption.
+Methods that provide native access are restricted, and by default their
+use causes warnings.
+This option allows code in the specified modules to use restricted
+methods without warnings.
+\f[I]module\f[R] can be \f[V]ALL-UNNAMED\f[R] to indicate code on the
+class path.
+When this option is present, any use of restricted methods by code
+outside the specified modules causes an
+\f[V]IllegalCallerException\f[R].
+.TP
 \f[V]--finalization=\f[R]\f[I]value\f[R]
 Controls whether the JVM performs finalization of objects.
 Valid values are \[dq]enabled\[dq] and \[dq]disabled\[dq].
@@ -554,7 +568,7 @@ on other platforms it is a colon (\f[V]:\f[R]).
 .TP
 \f[V]--add-modules\f[R] \f[I]module\f[R][\f[V],\f[R]\f[I]module\f[R]...]
 Specifies the root modules to resolve in addition to the initial module.
-\f[I]module\f[R] also can be \f[V]ALL-DEFAULT\f[R],
+\f[I]module\f[R] can also be \f[V]ALL-DEFAULT\f[R],
 \f[V]ALL-SYSTEM\f[R], and \f[V]ALL-MODULE-PATH\f[R].
 .TP
 \f[V]--list-modules\f[R]
@@ -1116,13 +1130,14 @@ This option is similar to \f[V]-XX:ThreadStackSize\f[R].
 \f[V]--add-reads\f[R] \f[I]module\f[R]\f[V]=\f[R]\f[I]target-module\f[R](\f[V],\f[R]\f[I]target-module\f[R])*
 Updates \f[I]module\f[R] to read the \f[I]target-module\f[R], regardless
 of the module declaration.
-\f[I]target-module\f[R] can be all unnamed to read all unnamed modules.
+\f[I]target-module\f[R] can be \f[V]ALL-UNNAMED\f[R] to read all unnamed
+modules.
 .TP
 \f[V]--add-exports\f[R] \f[I]module\f[R]\f[V]/\f[R]\f[I]package\f[R]\f[V]=\f[R]\f[I]target-module\f[R](\f[V],\f[R]\f[I]target-module\f[R])*
 Updates \f[I]module\f[R] to export \f[I]package\f[R] to
 \f[I]target-module\f[R], regardless of module declaration.
-The \f[I]target-module\f[R] can be all unnamed to export to all unnamed
-modules.
+\f[I]target-module\f[R] can be \f[V]ALL-UNNAMED\f[R] to export to all
+unnamed modules.
 .TP
 \f[V]--add-opens\f[R] \f[I]module\f[R]\f[V]/\f[R]\f[I]package\f[R]\f[V]=\f[R]\f[I]target-module\f[R](\f[V],\f[R]\f[I]target-module\f[R])*
 Updates \f[I]module\f[R] to open \f[I]package\f[R] to

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -759,6 +759,8 @@ processing.
 \f[V]removal\f[R]: Warns about the use of an API that has been marked
 for removal.
 .IP \[bu] 2
+\f[V]restricted\f[R]: Warns about the use of restricted methods.
+.IP \[bu] 2
 \f[V]requires-automatic\f[R]: Warns developers about the use of
 automatic modules in requires clauses.
 .IP \[bu] 2


### PR DESCRIPTION
This PR updates the man pages for `javac` and `java` to document:
* the new `javac` warning for restricted methods (`-Xlint:restricted`)
* the `java` option to allow access to restricted methods without warnings (`--enable-native-access`)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318458](https://bugs.openjdk.org/browse/JDK-8318458): Update javac and java manpages with restricted method options (**Enhancement** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16249/head:pull/16249` \
`$ git checkout pull/16249`

Update a local copy of the PR: \
`$ git checkout pull/16249` \
`$ git pull https://git.openjdk.org/jdk.git pull/16249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16249`

View PR using the GUI difftool: \
`$ git pr show -t 16249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16249.diff">https://git.openjdk.org/jdk/pull/16249.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16249#issuecomment-1768754790)