### PR TITLE
8318029: Minor improvement to logging output in container at-requires

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -610,7 +610,7 @@ public class VMProps implements Callable<Map<String, String>> {
         log("checkDockerSupport(): entering");
         ProcessBuilder pb = new ProcessBuilder("which", Container.ENGINE_COMMAND);
         Map<String, String> logFileNames =
-            redirectOutputToLogFile("checkDockerSupport(): which <container-engine>",
+            redirectOutputToLogFile("checkDockerSupport(): which " + Container.ENGINE_COMMAND,
                                                       pb, "which-container");
         Process p = pb.start();
         p.waitFor(10, TimeUnit.SECONDS);


### PR DESCRIPTION
Please review this trivial change

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318029](https://bugs.openjdk.org/browse/JDK-8318029): Minor improvement to logging output in container at-requires (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16250/head:pull/16250` \
`$ git checkout pull/16250`

Update a local copy of the PR: \
`$ git checkout pull/16250` \
`$ git pull https://git.openjdk.org/jdk.git pull/16250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16250`

View PR using the GUI difftool: \
`$ git pr show -t 16250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16250.diff">https://git.openjdk.org/jdk/pull/16250.diff</a>

</details>
