### PR TITLE
8317610: runtime/CompressedOops/CompressedClassPointers.java fails after JDK-8305765

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -110,7 +110,6 @@ applications/jcstress/copy.java 8229852 linux-all
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-all
 
-runtime/CompressedOops/CompressedClassPointers.java 8317610 linux-x64,windows-x64
 
 #############################################################################
 

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
@@ -227,6 +227,20 @@ public class CompressedClassPointers {
         output.shouldHaveExitValue(0);
     }
 
+    static final long unscaledClassSpaceMax = Long.decode("0x100000000");
+
+    private static void checkNarrowKlassShift(OutputAnalyzer output) throws Exception {
+        String s = output.firstMatch("Narrow klass base: .*");
+        int startIdx = s.indexOf("range:") + 7;
+        String longString = s.substring(startIdx);
+        long narrowKlassRange = Long.decode(longString);
+        if (narrowKlassRange < unscaledClassSpaceMax) {
+            output.shouldContain("Narrow klass shift: 0");
+        } else {
+            output.shouldContain("Narrow klass shift: 3");
+        }
+    }
+
     public static void smallHeapTestWith1GNoCoop() throws Exception {
         ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
             "-XX:-UseCompressedOops",
@@ -244,7 +258,7 @@ public class CompressedClassPointers {
         }
         if (!Platform.isAArch64() && !Platform.isPPC()) {
             // Currently relax this test for Aarch64 and ppc.
-            output.shouldContain("Narrow klass shift: 0");
+            checkNarrowKlassShift(output);
         }
         output.shouldHaveExitValue(0);
     }
@@ -266,7 +280,7 @@ public class CompressedClassPointers {
         }
         if (!Platform.isAArch64() && !Platform.isPPC()) {
             // Currently relax this test for Aarch64 and ppc.
-            output.shouldContain("Narrow klass shift: 0");
+            checkNarrowKlassShift(output);
         }
         output.shouldHaveExitValue(0);
     }


### PR DESCRIPTION
The `CompressedClassPointers.java` test is failing in the following two cases: `largeHeapTestNoCoop` and `smallHeapTestWith1GNoCoop`. The test is expecting the narrow klass shift to be 0 but the actual value is 3. It is due to the `Narrow klass range: 0x100000000`. See `CompressedKlassPointers::initialize` in `compressedKlass.cpp`  (https://github.com/openjdk/jdk/blob/master/src/hotspot/share/oops/compressedKlass.cpp#L81-#L87)

A possible fix in the test is to parse the output and obtain the value of the narrow klass range, and then check the narrow klass shift value based on the range.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317610](https://bugs.openjdk.org/browse/JDK-8317610): runtime/CompressedOops/CompressedClassPointers.java fails after JDK-8305765 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16254/head:pull/16254` \
`$ git checkout pull/16254`

Update a local copy of the PR: \
`$ git checkout pull/16254` \
`$ git pull https://git.openjdk.org/jdk.git pull/16254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16254`

View PR using the GUI difftool: \
`$ git pr show -t 16254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16254.diff">https://git.openjdk.org/jdk/pull/16254.diff</a>

</details>
