### PR TITLE
8318474: Fix memory reporter for thread_count

### DIFF
--- a/src/hotspot/share/services/memReporter.cpp
+++ b/src/hotspot/share/services/memReporter.cpp
@@ -236,7 +236,6 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
         MallocMemory* thread_stack_memory = _malloc_snapshot->by_type(mtThreadStack);
         const char* scale = current_scale();
         // report thread count
-        assert(ThreadStackTracker::thread_count() == 0, "Not used");
         out->print_cr("%27s (threads #" SIZE_FORMAT ")", " ", thread_stack_memory->malloc_count());
         out->print("%27s (Stack: " SIZE_FORMAT "%s", " ",
           amount_in_current_scale(thread_stack_memory->malloc_size()), scale);


### PR DESCRIPTION
Hi,

[JDK-8315362](https://bugs.openjdk.org/browse/JDK-8315362) did the right thing and always updated the `_thread_count` regardless of the 'mode' that we are in, but we forgot about this assert. So, let's get rid of the assert.

@tstuefe, @gerard-ziemski, I was wondering if we can't actually just use the `_thread_count` on AIX now when printing the thread count, shouldn't that be correct now? Regardless, let's not have this assert, as it breaks NMT tests on AIX.

@MBaesken, would you mind trying this patch out? It's on top of current master, so you can check it out directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318474](https://bugs.openjdk.org/browse/JDK-8318474): Fix memory reporter for thread_count (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Afshin Zafari](https://openjdk.org/census#azafari) (@afshin-zafari - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16255/head:pull/16255` \
`$ git checkout pull/16255`

Update a local copy of the PR: \
`$ git checkout pull/16255` \
`$ git pull https://git.openjdk.org/jdk.git pull/16255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16255`

View PR using the GUI difftool: \
`$ git pr show -t 16255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16255.diff">https://git.openjdk.org/jdk/pull/16255.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16255#issuecomment-1769354466)