### PR TITLE
8318481: linux-arm32 attribute warning for offset_of

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -88,6 +88,10 @@ DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     maybe-uninitialized missing-field-initializers parentheses \
     shift-negative-value unknown-pragmas
 
+ifeq ($(call isTargetCpu, arm), true)
+    DISABLED_WARNINGS_gcc += attributes
+endif
+
 DISABLED_WARNINGS_clang := sometimes-uninitialized \
     missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas
 


### PR DESCRIPTION
The linux-arm32 build generates a somewhat spectacular number of warnings, all for the same code - the offset_of macro in hotspot:

```
src/hotspot/share/utilities/globalDefinitions_gcc.hpp:144:40: warning: requested alignment 16 is larger than 8 [-Wattributes]
    alignas(16) char space[sizeof (klass)];
```

I was hoping to find a simple fix for the code in question but I'm not sure what that would look like. Until proven otherwise I propose that we disable the warning for arm32.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318481](https://bugs.openjdk.org/browse/JDK-8318481): linux-arm32 attribute warning for offset_of (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16256/head:pull/16256` \
`$ git checkout pull/16256`

Update a local copy of the PR: \
`$ git checkout pull/16256` \
`$ git pull https://git.openjdk.org/jdk.git pull/16256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16256`

View PR using the GUI difftool: \
`$ git pr show -t 16256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16256.diff">https://git.openjdk.org/jdk/pull/16256.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16256#issuecomment-1769545880)