### PR TITLE
8318454: TestLayoutPaths broken on Big Endian platforms after JDK-8317837

### DIFF
--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -37,13 +37,11 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.IntFunction;
 
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
 import static java.lang.foreign.MemoryLayout.PathElement.sequenceElement;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static java.lang.foreign.ValueLayout.JAVA_SHORT;
 import static org.testng.Assert.*;
 

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -37,6 +37,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.IntFunction;
 
 import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
@@ -139,8 +140,8 @@ public class TestLayoutPaths {
     @Test
     public void testBadAlignmentOfRoot() {
         MemoryLayout struct = MemoryLayout.structLayout(
-            JAVA_INT,
-            JAVA_SHORT.withName("x"));
+            JAVA_INT.withOrder(ByteOrder.LITTLE_ENDIAN),
+            JAVA_SHORT.withOrder(ByteOrder.LITTLE_ENDIAN).withName("x"));
         assertEquals(struct.byteAlignment(), 4);
 
         try (Arena arena = Arena.ofConfined()) {


### PR DESCRIPTION
This PR suggests a fix for a failing test on platforms with big endian.

The PR also contains a drive-by removal of an unused import.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318454](https://bugs.openjdk.org/browse/JDK-8318454): TestLayoutPaths broken on Big Endian platforms after JDK-8317837 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16259/head:pull/16259` \
`$ git checkout pull/16259`

Update a local copy of the PR: \
`$ git checkout pull/16259` \
`$ git pull https://git.openjdk.org/jdk.git pull/16259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16259`

View PR using the GUI difftool: \
`$ git pr show -t 16259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16259.diff">https://git.openjdk.org/jdk/pull/16259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16259#issuecomment-1770155817)