### PR TITLE
8318486: Rename JavaLangAccess.xxNoRepl to xxReportError

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -706,7 +706,7 @@ public final class String
      *         {@code false} if the byte array can be exclusively used to construct
      *         the string and is not modified or used for any other purpose.
      */
-    static String newStringUTF8FailFast(byte[] bytes, int offset, int length, boolean noShare) {
+    static String newStringUTF8ReportError(byte[] bytes, int offset, int length, boolean noShare) {
         checkBoundsOffCount(offset, length, bytes.length);
         if (length == 0) {
             return "";
@@ -769,27 +769,23 @@ public final class String
         return new String(dst, UTF16);
     }
 
-    static String newStringNoRepl(byte[] src, Charset cs) throws CharacterCodingException {
+    static String newStringReportError(byte[] src, Charset cs) throws CharacterCodingException {
         try {
-            return newStringNoRepl1(src, cs);
+            return newStringReportErrorUnchecked(src, cs);
         } catch (IllegalArgumentException e) {
-            //newStringNoRepl1 throws IAE with MalformedInputException or CCE as the cause
-            Throwable cause = e.getCause();
-            if (cause instanceof MalformedInputException mie) {
-                throw mie;
-            }
-            throw (CharacterCodingException)cause;
+            //newStringReportErrorUnchecked throws IAE with MalformedInputException or CCE as the cause
+            throw (CharacterCodingException) e.getCause();
         }
     }
 
     @SuppressWarnings("removal")
-    private static String newStringNoRepl1(byte[] src, Charset cs) {
+    private static String newStringReportErrorUnchecked(byte[] src, Charset cs) {
         int len = src.length;
         if (len == 0) {
             return "";
         }
         if (cs == UTF_8.INSTANCE) {
-            return newStringUTF8FailFast(src, 0, src.length, false);
+            return newStringUTF8ReportError(src, 0, src.length, false);
         }
         if (cs == ISO_8859_1.INSTANCE) {
             if (COMPACT_STRINGS)
@@ -933,7 +929,7 @@ public final class String
     /*
      * Throws iae, instead of replacing, if unmappable.
      */
-    static byte[] getBytesUTF8FailFast(String s) {
+    static byte[] getBytesUTF8ReportError(String s) {
         return encodeUTF8(s.coder(), s.value(), false);
     }
 
@@ -944,20 +940,16 @@ public final class String
     /*
      * Throws CCE, instead of replacing, if unmappable.
      */
-    static byte[] getBytesNoRepl(String s, Charset cs) throws CharacterCodingException {
+    static byte[] getBytesReportError(String s, Charset cs) throws CharacterCodingException {
         try {
-            return getBytesNoRepl1(s, cs);
+            return getBytesReportErrorUnchecked(s, cs);
         } catch (IllegalArgumentException e) {
-            //getBytesNoRepl1 throws IAE with UnmappableCharacterException or CCE as the cause
-            Throwable cause = e.getCause();
-            if (cause instanceof UnmappableCharacterException) {
-                throw (UnmappableCharacterException)cause;
-            }
-            throw (CharacterCodingException)cause;
+            //getBytesReportErrorUnchecked throws IAE with UnmappableCharacterException or CCE as the cause
+            throw (CharacterCodingException) e.getCause();
         }
     }
 
-    private static byte[] getBytesNoRepl1(String s, Charset cs) {
+    private static byte[] getBytesReportErrorUnchecked(String s, Charset cs) {
         byte[] val = s.value();
         byte coder = s.coder();
         if (cs == UTF_8.INSTANCE) {

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -706,7 +706,7 @@ public final class String
      *         {@code false} if the byte array can be exclusively used to construct
      *         the string and is not modified or used for any other purpose.
      */
-    static String newStringUTF8NoRepl(byte[] bytes, int offset, int length, boolean noShare) {
+    static String newStringUTF8FailFast(byte[] bytes, int offset, int length, boolean noShare) {
         checkBoundsOffCount(offset, length, bytes.length);
         if (length == 0) {
             return "";
@@ -789,7 +789,7 @@ public final class String
             return "";
         }
         if (cs == UTF_8.INSTANCE) {
-            return newStringUTF8NoRepl(src, 0, src.length, false);
+            return newStringUTF8FailFast(src, 0, src.length, false);
         }
         if (cs == ISO_8859_1.INSTANCE) {
             if (COMPACT_STRINGS)
@@ -933,7 +933,7 @@ public final class String
     /*
      * Throws iae, instead of replacing, if unmappable.
      */
-    static byte[] getBytesUTF8NoRepl(String s) {
+    static byte[] getBytesUTF8FailFast(String s) {
         return encodeUTF8(s.coder(), s.value(), false);
     }
 

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2473,22 +2473,22 @@ public final class System {
             public int countPositives(byte[] bytes, int offset, int length) {
                 return StringCoding.countPositives(bytes, offset, length);
             }
-            public String newStringNoRepl(byte[] bytes, Charset cs) throws CharacterCodingException  {
-                return String.newStringNoRepl(bytes, cs);
+            public String newStringReportError(byte[] bytes, Charset cs) throws CharacterCodingException  {
+                return String.newStringReportError(bytes, cs);
             }
             public char getUTF16Char(byte[] bytes, int index) {
                 return StringUTF16.getChar(bytes, index);
             }
-            public byte[] getBytesNoRepl(String s, Charset cs) throws CharacterCodingException {
-                return String.getBytesNoRepl(s, cs);
+            public byte[] getBytesReportError(String s, Charset cs) throws CharacterCodingException {
+                return String.getBytesReportError(s, cs);
             }
 
-            public String newStringUTF8FailFast(byte[] bytes, int off, int len) {
-                return String.newStringUTF8FailFast(bytes, off, len, true);
+            public String newStringUTF8ReportError(byte[] bytes, int off, int len) {
+                return String.newStringUTF8ReportError(bytes, off, len, true);
             }
 
-            public byte[] getBytesUTF8FailFast(String s) {
-                return String.getBytesUTF8FailFast(s);
+            public byte[] getBytesUTF8ReportError(String s) {
+                return String.getBytesUTF8ReportError(s);
             }
 
             public void inflateBytesToChars(byte[] src, int srcOff, char[] dst, int dstOff, int len) {

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2483,12 +2483,12 @@ public final class System {
                 return String.getBytesNoRepl(s, cs);
             }
 
-            public String newStringUTF8NoRepl(byte[] bytes, int off, int len) {
-                return String.newStringUTF8NoRepl(bytes, off, len, true);
+            public String newStringUTF8FailFast(byte[] bytes, int off, int len) {
+                return String.newStringUTF8FailFast(bytes, off, len, true);
             }
 
-            public byte[] getBytesUTF8NoRepl(String s) {
-                return String.getBytesUTF8NoRepl(s);
+            public byte[] getBytesUTF8FailFast(String s) {
+                return String.getBytesUTF8FailFast(s);
             }
 
             public void inflateBytesToChars(byte[] src, int srcOff, char[] dst, int dstOff, int len) {

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -3351,7 +3351,7 @@ public final class Files {
         byte[] ba = readAllBytes(path);
         if (path.getClass().getModule() != Object.class.getModule())
             ba = ba.clone();
-        return JLA.newStringNoRepl(ba, cs);
+        return JLA.newStringReportError(ba, cs);
     }
 
     /**
@@ -3713,7 +3713,7 @@ public final class Files {
         Objects.requireNonNull(csq);
         Objects.requireNonNull(cs);
 
-        byte[] bytes = JLA.getBytesNoRepl(String.valueOf(csq), cs);
+        byte[] bytes = JLA.getBytesReportError(String.valueOf(csq), cs);
         if (path.getClass().getModule() != Object.class.getModule())
             bytes = bytes.clone();
         write(path, bytes, options);

--- a/src/java.base/share/classes/java/util/HexFormat.java
+++ b/src/java.base/share/classes/java/util/HexFormat.java
@@ -467,7 +467,7 @@ public final class HexFormat {
         }
         try {
             // Return a new string using the bytes without making a copy
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
+            return jla.newStringReportError(rep, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {
             throw new AssertionError(cce);
         }
@@ -701,7 +701,7 @@ public final class HexFormat {
         rep[0] = (byte)toHighHexDigit(value);
         rep[1] = (byte)toLowHexDigit(value);
         try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
+            return jla.newStringReportError(rep, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {
             throw new AssertionError(cce);
         }
@@ -737,7 +737,7 @@ public final class HexFormat {
         rep[3] = (byte)toLowHexDigit((byte)value);
 
         try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
+            return jla.newStringReportError(rep, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {
             throw new AssertionError(cce);
         }
@@ -765,7 +765,7 @@ public final class HexFormat {
         rep[7] = (byte)toLowHexDigit((byte)value);
 
         try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
+            return jla.newStringReportError(rep, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {
             throw new AssertionError(cce);
         }
@@ -801,7 +801,7 @@ public final class HexFormat {
         rep[15] = (byte)toLowHexDigit((byte)value);
 
         try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
+            return jla.newStringReportError(rep, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {
             throw new AssertionError(cce);
         }
@@ -829,7 +829,7 @@ public final class HexFormat {
             value = value >>> 4;
         }
         try {
-            return jla.newStringNoRepl(rep, StandardCharsets.ISO_8859_1);
+            return jla.newStringReportError(rep, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {
             throw new AssertionError(cce);
         }

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -500,7 +500,7 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
                 HexDigits.packDigits(((int) lsb) >> 8, (int) lsb));
 
         try {
-            return jla.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
+            return jla.newStringReportError(buf, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {
             throw new AssertionError(cce);
         }

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -267,12 +267,12 @@ class ZipCoder {
 
         @Override
         String toString(byte[] ba, int off, int length) {
-            return JLA.newStringUTF8FailFast(ba, off, length);
+            return JLA.newStringUTF8ReportError(ba, off, length);
         }
 
         @Override
         byte[] getBytes(String s) {
-            return JLA.getBytesUTF8FailFast(s);
+            return JLA.getBytesUTF8ReportError(s);
         }
 
         @Override
@@ -286,9 +286,9 @@ class ZipCoder {
                 // Non-ASCII, fall back to decoding a String
                 // We avoid using decoder() here since the UTF8ZipCoder is
                 // shared and that decoder is not thread safe.
-                // We use the JLA.newStringUTF8FailFast variant to throw
+                // We use the JLA.newStringUTF8ReportError variant to throw
                 // exceptions eagerly when opening ZipFiles
-                return hash(JLA.newStringUTF8FailFast(a, off, len));
+                return hash(JLA.newStringUTF8ReportError(a, off, len));
             }
             // T_BOOLEAN to treat the array as unsigned bytes, in line with StringLatin1.hashCode
             int h = ArraysSupport.vectorizedHashCode(a, off, len, 0, ArraysSupport.T_BOOLEAN);
@@ -306,7 +306,7 @@ class ZipCoder {
         @Override
         Comparison compare(String str, byte[] b, int off, int len, boolean matchDirectory) {
             try {
-                byte[] encoded = JLA.getBytesNoRepl(str, UTF_8.INSTANCE);
+                byte[] encoded = JLA.getBytesReportError(str, UTF_8.INSTANCE);
                 int mismatch = Arrays.mismatch(encoded, 0, encoded.length, b, off, off+len);
                 if (mismatch == -1) {
                     return Comparison.EXACT_MATCH;

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -267,12 +267,12 @@ class ZipCoder {
 
         @Override
         String toString(byte[] ba, int off, int length) {
-            return JLA.newStringUTF8NoRepl(ba, off, length);
+            return JLA.newStringUTF8FailFast(ba, off, length);
         }
 
         @Override
         byte[] getBytes(String s) {
-            return JLA.getBytesUTF8NoRepl(s);
+            return JLA.getBytesUTF8FailFast(s);
         }
 
         @Override
@@ -286,9 +286,9 @@ class ZipCoder {
                 // Non-ASCII, fall back to decoding a String
                 // We avoid using decoder() here since the UTF8ZipCoder is
                 // shared and that decoder is not thread safe.
-                // We use the JLA.newStringUTF8NoRepl variant to throw
+                // We use the JLA.newStringUTF8FailFast variant to throw
                 // exceptions eagerly when opening ZipFiles
-                return hash(JLA.newStringUTF8NoRepl(a, off, len));
+                return hash(JLA.newStringUTF8FailFast(a, off, len));
             }
             // T_BOOLEAN to treat the array as unsigned bytes, in line with StringLatin1.hashCode
             int h = ArraysSupport.vectorizedHashCode(a, off, len, 0, ArraysSupport.T_BOOLEAN);

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -305,44 +305,48 @@ public interface JavaLangAccess {
     int countPositives(byte[] ba, int off, int len);
 
     /**
-     * Constructs a new {@code String} by decoding the specified subarray of
-     * bytes using the specified {@linkplain java.nio.charset.Charset charset}.
-     *
-     * The caller of this method shall relinquish and transfer the ownership of
-     * the byte array to the callee since the later will not make a copy.
+     * Constructs a new String by decoding the specified sequence of
+     * bytes using the specified Charset.
+     * <p>
+     * This method throws CharacterCodingException instead of replacing when
+     * any malformed input or unmappable character is encountered.
+     * <p>
+     * The input byte array must not be accessible to user code or modified.
      *
      * @param bytes the byte array source
      * @param cs the Charset
      * @return the newly created string
      * @throws CharacterCodingException for malformed or unmappable bytes
      */
-    String newStringNoRepl(byte[] bytes, Charset cs) throws CharacterCodingException;
+    String newStringReportError(byte[] bytes, Charset cs) throws CharacterCodingException;
 
     /**
      * Encode the given string into a sequence of bytes using the specified Charset.
-     *
-     * This method avoids copying the String's internal representation if the input
-     * is ASCII.
-     *
+     * <p>
      * This method throws CharacterCodingException instead of replacing when
-     * malformed input or unmappable characters are encountered.
+     * any malformed input or unmappable character is encountered.
+     * <p>
+     * The returned byte array must not be accessible to user code or modified.
      *
      * @param s the string to encode
      * @param cs the charset
      * @return the encoded bytes
      * @throws CharacterCodingException for malformed input or unmappable characters
      */
-    byte[] getBytesNoRepl(String s, Charset cs) throws CharacterCodingException;
+    byte[] getBytesReportError(String s, Charset cs) throws CharacterCodingException;
 
     /**
-     * Returns a new string by decoding from the given utf8 bytes array.
+     * Returns a new string by decoding from the given utf8 range in the bytes array.
+     * <p>
+     * This method throws CharacterCodingException instead of replacing when
+     * any malformed input or unmappable character is encountered.
      *
      * @param off the index of the first byte to decode
      * @param len the number of bytes to decode
      * @return the newly created string
      * @throws IllegalArgumentException for malformed or unmappable bytes.
      */
-    String newStringUTF8FailFast(byte[] bytes, int off, int len);
+    String newStringUTF8ReportError(byte[] bytes, int off, int len);
 
     /**
      * Get the char at index in a byte[] in internal UTF-16 representation,
@@ -355,13 +359,16 @@ public interface JavaLangAccess {
     char getUTF16Char(byte[] bytes, int index);
 
     /**
-     * Encode the given string into a sequence of bytes using utf8.
+     * Encode the given string into a sequence of bytes in utf8.
+     * <p>
+     * This method throws CharacterCodingException instead of replacing when
+     * any malformed input or unmappable character is encountered.
      *
      * @param s the string to encode
      * @return the encoded bytes in utf8
      * @throws IllegalArgumentException for malformed surrogates
      */
-    byte[] getBytesUTF8FailFast(String s);
+    byte[] getBytesUTF8ReportError(String s);
 
     /**
      * Inflated copy from byte[] to char[], as defined by StringLatin1.inflate

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -342,7 +342,7 @@ public interface JavaLangAccess {
      * @return the newly created string
      * @throws IllegalArgumentException for malformed or unmappable bytes.
      */
-    String newStringUTF8NoRepl(byte[] bytes, int off, int len);
+    String newStringUTF8FailFast(byte[] bytes, int off, int len);
 
     /**
      * Get the char at index in a byte[] in internal UTF-16 representation,
@@ -361,7 +361,7 @@ public interface JavaLangAccess {
      * @return the encoded bytes in utf8
      * @throws IllegalArgumentException for malformed surrogates
      */
-    byte[] getBytesUTF8NoRepl(String s);
+    byte[] getBytesUTF8FailFast(String s);
 
     /**
      * Inflated copy from byte[] to char[], as defined by StringLatin1.inflate

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -126,7 +126,7 @@ class UnixPath implements Path {
     private static byte[] encode(UnixFileSystem fs, String input) {
         input = fs.normalizeNativePath(input);
         try {
-            return JLA.getBytesNoRepl(input, Util.jnuEncoding());
+            return JLA.getBytesReportError(input, Util.jnuEncoding());
         } catch (CharacterCodingException cce) {
             throw new InvalidPathException(input,
                 "Malformed input or input contains unmappable characters");

--- a/test/jdk/java/lang/String/ReportErrorTest.java
+++ b/test/jdk/java/lang/String/ReportErrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 
 /*
  * @test
- * @bug 8286287 8288589
- * @summary Tests for *NoRepl() shared secret methods.
- * @run testng NoReplTest
+ * @bug 8286287 8288589 8318486
+ * @summary Tests for *ReportError() shared secret methods.
+ * @run testng ReportErrorTest
  * @modules jdk.charsets
  */
 
@@ -39,17 +39,17 @@ import static java.nio.charset.StandardCharsets.UTF_16;
 import org.testng.annotations.Test;
 
 @Test
-public class NoReplTest {
+public class ReportErrorTest {
     private final static byte[] MALFORMED_UTF16 = {(byte)0x00, (byte)0x20, (byte)0x00};
     private final static String MALFORMED_WINDOWS_1252 = "\u0080\u041e";
     private final static Charset WINDOWS_1252 = Charset.forName("windows-1252");
 
     /**
-     * Verifies newStringNoRepl() throws a CharacterCodingException.
+     * Verifies newStringReportError() throws a CharacterCodingException.
      * The method is invoked by `Files.readString()` method.
      */
     @Test
-    public void newStringNoReplTest() throws IOException {
+    public void newStringReportErrorTest() throws IOException {
         var f = Files.createTempFile(null, null);
         try (var fos = Files.newOutputStream(f)) {
             fos.write(MALFORMED_UTF16);
@@ -67,11 +67,11 @@ public class NoReplTest {
     }
 
     /**
-     * Verifies getBytesNoRepl() throws a CharacterCodingException.
+     * Verifies getBytesReportError() throws a CharacterCodingException.
      * The method is invoked by `Files.writeString()` method.
      */
     @Test
-    public void getBytesNoReplTest() throws IOException {
+    public void getBytesReportErrorTest() throws IOException {
         var f = Files.createTempFile(null, null);
         try {
             Files.writeString(f, MALFORMED_WINDOWS_1252, WINDOWS_1252);


### PR DESCRIPTION
Please review a patch that renames `JavaLangAccess::xxNoRepl` to `xxReportError` to explicitly indicate these APIs report encoding errors.

The old "NoRepl" suffix presumably means "No Replacement", but it has been misunderstood as "No Replication" (#16209) and misused as an array sharing API in performance optimization patches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318486](https://bugs.openjdk.org/browse/JDK-8318486): Rename JavaLangAccess.xxNoRepl to xxReportError (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16260/head:pull/16260` \
`$ git checkout pull/16260`

Update a local copy of the PR: \
`$ git checkout pull/16260` \
`$ git pull https://git.openjdk.org/jdk.git pull/16260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16260`

View PR using the GUI difftool: \
`$ git pr show -t 16260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16260.diff">https://git.openjdk.org/jdk/pull/16260.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16260#issuecomment-1770197370)