### PR TITLE
JDK-8318485: Narrow klass shift should be zero if encoding range extends to 0x1_0000_0000

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -5298,7 +5298,6 @@ void os::print_memory_mappings(char* addr, size_t bytes, outputStream* st) {
     if (num_found == 0) {
       st->print_cr("nothing.");
     }
-    st->cr();
   }
 }
 

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -785,6 +785,11 @@ void Metaspace::global_initialize() {
       if (rs.is_reserved()) {
         log_info(metaspace)("Successfully forced class space address to " PTR_FORMAT, p2i(base));
       } else {
+        LogTarget(Debug, metaspace) lt;
+        if (lt.is_enabled()) {
+          LogStream ls(lt);
+          os::print_memory_mappings((char*)base, size, &ls);
+        }
         vm_exit_during_initialization(
             err_msg("CompressedClassSpaceBaseAddress=" PTR_FORMAT " given, but reserving class space failed.",
                 CompressedClassSpaceBaseAddress));

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -80,7 +80,7 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
 
   // We may not even need a shift if the range fits into 32bit:
   const uint64_t UnscaledClassSpaceMax = (uint64_t(max_juint) + 1);
-  if (range < UnscaledClassSpaceMax) {
+  if (range <= UnscaledClassSpaceMax) {
     shift = 0;
   } else {
     shift = LogKlassAlignmentInBytes;

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -377,7 +377,7 @@ static inline bool can_reserve_executable_memory(void) {
 #endif
 
 // Test that os::release_memory() can deal with areas containing multiple mappings.
-#define PRINT_MAPPINGS(s) { tty->print_cr("%s", s); os::print_memory_mappings((char*)p, total_range_len, tty); }
+#define PRINT_MAPPINGS(s) { tty->print_cr("%s", s); os::print_memory_mappings((char*)p, total_range_len, tty); tty->cr(); }
 //#define PRINT_MAPPINGS
 
 // Release a range allocated with reserve_multiple carefully, to not trip mapping

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Testing that, faced with a given (possibly odd) mapping address of class space, the encoding
+ *          scheme fits the address
+ * @requires vm.bits == 64 & !vm.graal.enabled
+ * @requires vm.flagless
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedClassPointersEncodingScheme
+ */
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+import java.io.IOException;
+
+public class CompressedClassPointersEncodingScheme {
+
+    private static void test(long forceAddress, long classSpaceSize, long expectedEncodingBase, int expectedEncodingShift) throws IOException {
+        String forceAddressString = String.format("0x%016X", forceAddress).toLowerCase();
+        String expectedEncodingBaseString = String.format("0x%016X", expectedEncodingBase).toLowerCase();
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-Xshare:off", // to make CompressedClassSpaceBaseAddress work
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:-UseCompressedOops", // keep VM from optimizing heap location
+                "-XX:CompressedClassSpaceBaseAddress=" + forceAddress,
+                "-XX:CompressedClassSpaceSize=" + classSpaceSize,
+                "-Xmx128m",
+                "-Xlog:metaspace*",
+                "-version");
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+
+        output.reportDiagnosticSummary();
+
+        output.shouldHaveExitValue(0);
+
+        // We ignore cases where we were not able to map at the force address
+        if (output.contains("reserving class space failed")) {
+            throw new SkippedException("Skipping because we cannot force ccs to " + forceAddressString);
+        }
+
+        output.shouldContain("Narrow klass base: " + expectedEncodingBaseString + ", Narrow klass shift: " + expectedEncodingShift);
+    }
+
+    final static long K = 1024;
+    final static long M = K * 1024;
+    final static long G = M * 1024;
+    public static void main(String[] args) throws Exception {
+        // Test ccs nestling right at the end of the 4G range
+        // Expecting base=0, shift=0
+        test(4 * G - 128 * M, 128 * M, 0, 0);
+
+        // add more...
+
+    }
+}

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
@@ -58,13 +58,12 @@ public class CompressedClassPointersEncodingScheme {
 
         output.reportDiagnosticSummary();
 
-        output.shouldHaveExitValue(0);
-
         // We ignore cases where we were not able to map at the force address
         if (output.contains("reserving class space failed")) {
             throw new SkippedException("Skipping because we cannot force ccs to " + forceAddressString);
         }
 
+        output.shouldHaveExitValue(0);
         output.shouldContain("Narrow klass base: " + expectedEncodingBaseString + ", Narrow klass shift: " + expectedEncodingShift);
     }
 

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -208,6 +208,27 @@ public final class OutputAnalyzer {
     }
 
     /**
+     * Returns true if stdout contains the given string
+     */
+    public boolean stdoutContains(String expectedString) {
+        return getStdout().contains(expectedString);
+    }
+
+    /**
+     * Returns true if stderr contains the given string
+     */
+    public boolean stderrContains(String expectedString) {
+        return getStderr().contains(expectedString);
+    }
+
+    /**
+     * Returns true if either stdout or stderr contains the given string
+     */
+    public boolean contains(String expectedString) {
+        return stdoutContains(expectedString) || stderrContains(expectedString);
+    }
+
+    /**
      * Verify that the stdout and stderr contents of output buffer contains the string
      *
      * @param expectedString String that buffer should contain


### PR DESCRIPTION
See JBS issue.

The real fix, trivial, is the comparison change in compressedKlass.cpp.

This patch then also adds a test that checks that for a given (forced) class space location the VM chose the correct encoding scheme. In this case, if class space nestles below and ends at 4G, we should use a shift of 0.

The test can be easily extended to test more narrow Klass encoding schemes. Note that the test is skipped if the VM could not map at the expected address to begin with.

Finally, to analyze test errors, I print out the mappings at the force address if metaspace logging is debug.

Tests: manual, GHA. x86 GHA errors unrelated.

/label remove core-libs
/label remove hotspot
/label add hotspot-runtime

Attention @iklam and @calvinccheung

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318485](https://bugs.openjdk.org/browse/JDK-8318485): Narrow klass shift should be zero if encoding range extends to 0x1_0000_0000 (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16261/head:pull/16261` \
`$ git checkout pull/16261`

Update a local copy of the PR: \
`$ git checkout pull/16261` \
`$ git pull https://git.openjdk.org/jdk.git pull/16261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16261`

View PR using the GUI difftool: \
`$ git pr show -t 16261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16261.diff">https://git.openjdk.org/jdk/pull/16261.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16261#issuecomment-1772121100)