### PR TITLE
8318489: Remove unused alignment_unit and alignment_offset

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -702,14 +702,6 @@ void CodeCache::metadata_do(MetadataClosure* f) {
   }
 }
 
-int CodeCache::alignment_unit() {
-  return (int)_heaps->first()->alignment_unit();
-}
-
-int CodeCache::alignment_offset() {
-  return (int)_heaps->first()->alignment_offset();
-}
-
 // Calculate the number of GCs after which an nmethod is expected to have been
 // used in order to not be classed as cold.
 void CodeCache::update_cold_gc_count() {

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -151,8 +151,6 @@ class CodeCache : AllStatic {
   // Allocation/administration
   static CodeBlob* allocate(int size, CodeBlobType code_blob_type, bool handle_alloc_failure = true, CodeBlobType orig_code_blob_type = CodeBlobType::All); // allocates a new CodeBlob
   static void commit(CodeBlob* cb);                        // called when the allocated CodeBlob has been filled
-  static int  alignment_unit();                            // guaranteed alignment of all CodeBlobs
-  static int  alignment_offset();                          // guaranteed offset of first CodeBlob byte within alignment unit (i.e., allocation header)
   static void free(CodeBlob* cb);                          // frees a CodeBlob
   static void free_unused_tail(CodeBlob* cb, size_t used); // frees the unused tail of a CodeBlob (only used by TemplateInterpreter::initialize())
   static bool contains(void *p);                           // returns whether p is included

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -488,18 +488,6 @@ CodeBlob* CodeHeap::find_blob(void* start) const {
   return (result != nullptr && result->blob_contains((address)start)) ? result : nullptr;
 }
 
-size_t CodeHeap::alignment_unit() const {
-  // this will be a power of two
-  return _segment_size;
-}
-
-
-size_t CodeHeap::alignment_offset() const {
-  // The lowest address in any allocated block will be
-  // equal to alignment_offset (mod alignment_unit).
-  return sizeof(HeapBlock) & (_segment_size - 1);
-}
-
 // Returns the current block if available and used.
 // If not, it returns the subsequent block (if available), null otherwise.
 // Free blocks are merged, therefore there is at most one free block

--- a/src/hotspot/share/memory/heap.hpp
+++ b/src/hotspot/share/memory/heap.hpp
@@ -174,8 +174,6 @@ class CodeHeap : public CHeapObj<mtCode> {
 
   void* find_start(void* p)     const;   // returns the block containing p or null
   CodeBlob* find_blob(void* start) const;
-  size_t alignment_unit()       const;           // alignment of any block
-  size_t alignment_offset()     const;           // offset of first byte of any block, within the enclosing alignment unit
   static size_t header_size()         { return sizeof(HeapBlock); } // returns the header size for each heap block
 
   size_t segment_size()         const { return _segment_size; }  // for CodeHeapState


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318489](https://bugs.openjdk.org/browse/JDK-8318489): Remove unused alignment_unit and alignment_offset (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16263/head:pull/16263` \
`$ git checkout pull/16263`

Update a local copy of the PR: \
`$ git checkout pull/16263` \
`$ git pull https://git.openjdk.org/jdk.git pull/16263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16263`

View PR using the GUI difftool: \
`$ git pr show -t 16263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16263.diff">https://git.openjdk.org/jdk/pull/16263.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16263#issuecomment-1770370045)