### PR TITLE
8318510: Serial: Remove TenuredGeneration::block_size

### DIFF
--- a/src/hotspot/share/gc/serial/cardTableRS.cpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.cpp
@@ -106,8 +106,6 @@ HeapWord* DirtyCardToOopClosure::get_actual_top(HeapWord* top,
       // Otherwise, it is possible that the object starting on the dirty
       // card spans the entire card, and that the store happened on a
       // later card.  Figure out where the object ends.
-      assert(_sp->block_size(top_obj) == cast_to_oop(top_obj)->size(),
-             "Block size and object size mismatch");
       top = top_obj + cast_to_oop(top_obj)->size();
     }
   } else {

--- a/src/hotspot/share/gc/serial/generation.cpp
+++ b/src/hotspot/share/gc/serial/generation.cpp
@@ -194,14 +194,6 @@ class GenerationBlockSizeClosure : public SpaceClosure {
   GenerationBlockSizeClosure(const HeapWord* p) { _p = p; size = 0; }
 };
 
-size_t Generation::block_size(const HeapWord* p) const {
-  GenerationBlockSizeClosure blk(p);
-  // Cast away const
-  ((Generation*)this)->space_iterate(&blk);
-  assert(blk.size > 0, "seems reasonable");
-  return blk.size;
-}
-
 class GenerationBlockIsObjClosure : public SpaceClosure {
  public:
   const HeapWord* _p;

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -331,11 +331,6 @@ class Generation: public CHeapObj<mtGC> {
   // non-object.
   virtual HeapWord* block_start(const void* addr) const;
 
-  // Requires "addr" to be the start of a chunk, and returns its size.
-  // "addr + size" is required to be the start of a new chunk, or the end
-  // of the active area of the heap.
-  virtual size_t block_size(const HeapWord* addr) const ;
-
   // Requires "addr" to be the start of a block, and returns "TRUE" iff
   // the block is an object.
   virtual bool block_is_obj(const HeapWord* addr) const;

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -477,7 +477,7 @@ void TenuredGeneration::complete_loaded_archive_space(MemRegion archive_space) {
   space->initialize_threshold();
   HeapWord* start = archive_space.start();
   while (start < archive_space.end()) {
-    size_t word_size = _the_space->block_size(start);
+    size_t word_size = cast_to_oop(start)->size();;
     space->alloc_block(start, start + word_size);
     start += word_size;
   }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -133,8 +133,6 @@ class TenuredGeneration: public Generation {
 
   bool no_allocs_since_save_marks();
 
-  inline size_t block_size(const HeapWord* addr) const;
-
   inline bool block_is_obj(const HeapWord* addr) const;
 
   virtual void collect(bool full,

--- a/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
@@ -65,15 +65,6 @@ HeapWord* TenuredGeneration::par_allocate(size_t word_size,
   return _the_space->par_allocate(word_size);
 }
 
-size_t TenuredGeneration::block_size(const HeapWord* addr) const {
-  if (addr < _the_space->top()) {
-    return cast_to_oop(addr)->size();
-  } else {
-    assert(addr == _the_space->top(), "non-block head arg to block_size");
-    return _the_space->end() - _the_space->top();
-  }
-}
-
 bool TenuredGeneration::block_is_obj(const HeapWord* addr) const {
   return addr < _the_space  ->top();
 }


### PR DESCRIPTION
Simple one-line change inside `complete_loaded_archive_space`, then `block_size` becomes unused.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318510](https://bugs.openjdk.org/browse/JDK-8318510): Serial: Remove TenuredGeneration::block_size (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16266/head:pull/16266` \
`$ git checkout pull/16266`

Update a local copy of the PR: \
`$ git checkout pull/16266` \
`$ git pull https://git.openjdk.org/jdk.git pull/16266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16266`

View PR using the GUI difftool: \
`$ git pr show -t 16266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16266.diff">https://git.openjdk.org/jdk/pull/16266.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16266#issuecomment-1770921013)