### PR TITLE
8318525: Atomic gtest should run as TEST_VM to access VM capabilities

### DIFF
--- a/test/hotspot/gtest/runtime/test_atomic.cpp
+++ b/test/hotspot/gtest/runtime/test_atomic.cpp
@@ -53,7 +53,7 @@ struct AtomicAddTestSupport {
   }
 };
 
-TEST(AtomicAddTest, int32) {
+TEST_VM(AtomicAddTest, int32) {
   using Support = AtomicAddTestSupport<int32_t>;
   Support().test_add();
   Support().test_fetch_add();
@@ -61,14 +61,14 @@ TEST(AtomicAddTest, int32) {
 
 // 64bit Atomic::add is only supported on 64bit platforms.
 #ifdef _LP64
-TEST(AtomicAddTest, int64) {
+TEST_VM(AtomicAddTest, int64) {
   using Support = AtomicAddTestSupport<int64_t>;
   Support().test_add();
   Support().test_fetch_add();
 }
 #endif // _LP64
 
-TEST(AtomicAddTest, ptr) {
+TEST_VM(AtomicAddTest, ptr) {
   uint _test_values[10] = {};
   uint* volatile _test_value{};
 
@@ -103,14 +103,14 @@ struct AtomicXchgTestSupport {
   }
 };
 
-TEST(AtomicXchgTest, int32) {
+TEST_VM(AtomicXchgTest, int32) {
   using Support = AtomicXchgTestSupport<int32_t>;
   Support().test();
 }
 
 // 64bit Atomic::xchg is only supported on 64bit platforms.
 #ifdef _LP64
-TEST(AtomicXchgTest, int64) {
+TEST_VM(AtomicXchgTest, int64) {
   using Support = AtomicXchgTestSupport<int64_t>;
   Support().test();
 }
@@ -136,12 +136,12 @@ struct AtomicCmpxchgTestSupport {
   }
 };
 
-TEST(AtomicCmpxchgTest, int32) {
+TEST_VM(AtomicCmpxchgTest, int32) {
   using Support = AtomicCmpxchgTestSupport<int32_t>;
   Support().test();
 }
 
-TEST(AtomicCmpxchgTest, int64) {
+TEST_VM(AtomicCmpxchgTest, int64) {
   using Support = AtomicCmpxchgTestSupport<int64_t>;
   Support().test();
 }
@@ -186,7 +186,7 @@ struct AtomicCmpxchg1ByteStressSupport {
   }
 };
 
-TEST(AtomicCmpxchg1Byte, stress) {
+TEST_VM(AtomicCmpxchg1Byte, stress) {
   AtomicCmpxchg1ByteStressSupport support;
   support.test();
 }
@@ -224,7 +224,7 @@ namespace AtomicEnumTestUnscoped {       // Scope the enumerators.
   enum TestEnum { A, B, C };
 }
 
-TEST(AtomicEnumTest, unscoped_enum) {
+TEST_VM(AtomicEnumTest, unscoped_enum) {
   using namespace AtomicEnumTestUnscoped;
   using Support = AtomicEnumTestSupport<TestEnum>;
 
@@ -235,7 +235,7 @@ TEST(AtomicEnumTest, unscoped_enum) {
 
 enum class AtomicEnumTestScoped { A, B, C };
 
-TEST(AtomicEnumTest, scoped_enum) {
+TEST_VM(AtomicEnumTest, scoped_enum) {
   const AtomicEnumTestScoped B = AtomicEnumTestScoped::B;
   const AtomicEnumTestScoped C = AtomicEnumTestScoped::C;
   using Support = AtomicEnumTestSupport<AtomicEnumTestScoped>;
@@ -329,28 +329,28 @@ const T AtomicBitopsTestSupport<T>::_old_value;
 template<typename T>
 const T AtomicBitopsTestSupport<T>::_change_value;
 
-TEST(AtomicBitopsTest, int8) {
+TEST_VM(AtomicBitopsTest, int8) {
   AtomicBitopsTestSupport<int8_t>()();
 }
 
-TEST(AtomicBitopsTest, uint8) {
+TEST_VM(AtomicBitopsTest, uint8) {
   AtomicBitopsTestSupport<uint8_t>()();
 }
 
-TEST(AtomicBitopsTest, int32) {
+TEST_VM(AtomicBitopsTest, int32) {
   AtomicBitopsTestSupport<int32_t>()();
 }
 
-TEST(AtomicBitopsTest, uint32) {
+TEST_VM(AtomicBitopsTest, uint32) {
   AtomicBitopsTestSupport<uint32_t>()();
 }
 
 #ifdef _LP64
-TEST(AtomicBitopsTest, int64) {
+TEST_VM(AtomicBitopsTest, int64) {
   AtomicBitopsTestSupport<int64_t>()();
 }
 
-TEST(AtomicBitopsTest, uint64) {
+TEST_VM(AtomicBitopsTest, uint64) {
   AtomicBitopsTestSupport<uint64_t>()();
 }
 #endif // _LP64


### PR DESCRIPTION
While doing JDK-8316961, I noticed that atomic tests behave weirdly when executed from gtest. I believe the reason is that tests are running as TEST, not as TEST_VM. So the VM is not initialized, which fails the tests on asserts and/or takes weird paths in the atomic code.

Some Atomic implementations reach to VM_Version for asserts:
https://github.com/openjdk/jdk/blob/9cf334fb6488188ea4236e5d156b11245bace88f/src/hotspot/os_cpu/linux_arm/atomic_linux_arm.hpp#L149

Some Atomic implementations reach to StubRoutines for fallbacks:
https://github.com/openjdk/jdk/blob/9cf334fb6488188ea4236e5d156b11245bace88f/src/hotspot/os_cpu/linux_arm/os_linux_arm.cpp#L520

Additional testing:
 - [x] linux-aarch64-server-fastdebug, affected test passes
 - [x] linux-arm-server-fastdebug, affected test passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318525](https://bugs.openjdk.org/browse/JDK-8318525): Atomic gtest should run as TEST_VM to access VM capabilities (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16269/head:pull/16269` \
`$ git checkout pull/16269`

Update a local copy of the PR: \
`$ git checkout pull/16269` \
`$ git pull https://git.openjdk.org/jdk.git pull/16269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16269`

View PR using the GUI difftool: \
`$ git pr show -t 16269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16269.diff">https://git.openjdk.org/jdk/pull/16269.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16269#issuecomment-1771264355)