### PR TITLE
8318507: G1: Improve remset clearing for humongous candidates

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1196,11 +1196,6 @@ class G1MergeHeapRootsTask : public WorkerTask {
       // We want to continue collecting remembered set entries for humongous regions
       // that were not reclaimed.
       r->rem_set()->clear(true /* only_cardset */, true /* keep_tracked */);
-#ifdef ASSERT
-      G1HeapRegionAttr region_attr = g1h->region_attr(region_index);
-      assert(region_attr.remset_is_tracked(), "must be");
-#endif
-      assert(r->rem_set()->is_empty(), "At this point any humongous candidate remembered set must be empty.");
 
       return false;
     }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1186,7 +1186,6 @@ class G1MergeHeapRootsTask : public WorkerTask {
       guarantee(r->rem_set()->occupancy_less_or_equal_than(G1EagerReclaimRemSetThreshold),
                 "Found a not-small remembered set here. This is inconsistent with previous assumptions.");
 
-
       _cl.merge_card_set_for_region(r);
 
       // We should only clear the card based remembered set here as we will not
@@ -1196,6 +1195,8 @@ class G1MergeHeapRootsTask : public WorkerTask {
       // We want to continue collecting remembered set entries for humongous regions
       // that were not reclaimed.
       r->rem_set()->clear(true /* only_cardset */, true /* keep_tracked */);
+
+      assert(r->rem_set()->is_empty() && r->rem_set()->is_complete(), "must be for eager reclaim candidates");
 
       return false;
     }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1193,11 +1193,9 @@ class G1MergeHeapRootsTask : public WorkerTask {
       // implicitly rebuild anything else during eager reclaim. Note that at the moment
       // (and probably never) we do not enter this path if there are other kind of
       // remembered sets for this region.
-      r->rem_set()->clear(true /* only_cardset */);
-      // Clear_locked() above sets the state to Empty. However we want to continue
-      // collecting remembered set entries for humongous regions that were not
-      // reclaimed.
-      r->rem_set()->set_state_complete();
+      // We want to continue collecting remembered set entries for humongous regions
+      // that were not reclaimed.
+      r->rem_set()->clear(true /* only_cardset */, true /* keep_tracked */);
 #ifdef ASSERT
       G1HeapRegionAttr region_attr = g1h->region_attr(region_index);
       assert(region_attr.remset_is_tracked(), "must be");


### PR DESCRIPTION
Hi all,

  please review this small cleanup that merges two calls to `HeapRegionRemSet::clear()/HeapRegionRemSet::set_state_complete()` to a single call to `clear()` with appropriate parameters.

Also remove now obsolete asserts that are done in `clear()` already; actually the second one is wrong, there may be code roots attached to the region.

Testing: gha, tier1-5 almost done

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318507](https://bugs.openjdk.org/browse/JDK-8318507): G1: Improve remset clearing for humongous candidates (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [6af1e899](https://git.openjdk.org/jdk/pull/16270/files/6af1e8994a79f21701d01e6b475335126f35770b)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16270/head:pull/16270` \
`$ git checkout pull/16270`

Update a local copy of the PR: \
`$ git checkout pull/16270` \
`$ git pull https://git.openjdk.org/jdk.git pull/16270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16270`

View PR using the GUI difftool: \
`$ git pr show -t 16270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16270.diff">https://git.openjdk.org/jdk/pull/16270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16270#issuecomment-1771242025)