### PR TITLE
8318082: ConcurrentModificationException from IndexWriter

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractOverviewIndexWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractOverviewIndexWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,6 +111,11 @@ public abstract class AbstractOverviewIndexWriter extends HtmlDocletWriter {
         printHtmlDocument(
                 configuration.metakeywords.getOverviewMetaKeywords(titleKey, configuration.getOptions().docTitle()),
                 getDescription(), body);
+    }
+
+    @Override
+    public boolean isIndexable() {
+        return true;
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassWriter.java
@@ -769,4 +769,9 @@ public class ClassWriter extends SubWriterHolderWriter {
         }
         return section;
     }
+
+    @Override
+    public boolean isIndexable() {
+        return true;
+    }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandler.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/DocFilesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -300,6 +300,11 @@ public class DocFilesHandler {
                 }
             }
             return localTags;
+        }
+
+        @Override
+        public boolean isIndexable() {
+            return true;
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1369,7 +1369,9 @@ public abstract class HtmlDocletWriter {
                 @Override
                 public Boolean visitStartElement(StartElementTree node, Content content) {
                     Content attrs = new ContentBuilder();
-                    if (node.getName().toString().matches("(?i)h[1-6]")) {
+                    if (node.getName().toString().matches("(?i)h[1-6]")
+                            && !(HtmlDocletWriter.this instanceof IndexWriter)
+                            && !(HtmlDocletWriter.this instanceof SummaryListWriter<?>)) {
                         createSectionIdAndIndex(node, trees, attrs, element, context);
                     }
                     for (DocTree dt : node.getAttributes()) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -412,6 +412,20 @@ public abstract class HtmlDocletWriter {
     }
 
     /**
+     * {@return true if the page written by this writer should be indexed,
+     * false otherwise}
+     *
+     * Some pages merely aggregate filtered information available on other pages
+     * and, thus, have no indexing value. In fact, if indexed, they would
+     * clutter the index and mislead the reader.
+     *
+     * @implSpec The default implementation returns {@code false}.
+     */
+    public boolean isIndexable() {
+        return false;
+    }
+
+    /**
      * Generates the HTML document tree and prints it out.
      *
      * @param metakeywords Array of String keywords for META tag. Each element
@@ -1370,8 +1384,7 @@ public abstract class HtmlDocletWriter {
                 public Boolean visitStartElement(StartElementTree node, Content content) {
                     Content attrs = new ContentBuilder();
                     if (node.getName().toString().matches("(?i)h[1-6]")
-                            && !(HtmlDocletWriter.this instanceof IndexWriter)
-                            && !(HtmlDocletWriter.this instanceof SummaryListWriter<?>)) {
+                            && isIndexable()) {
                         createSectionIdAndIndex(node, trees, attrs, element, context);
                     }
                     for (DocTree dt : node.getAttributes()) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
@@ -923,4 +923,9 @@ public class ModuleWriter extends HtmlDocletWriter {
             li.add(deprDiv);
         }
     }
+
+    @Override
+    public boolean isIndexable() {
+        return true;
+    }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PackageWriter.java
@@ -455,4 +455,9 @@ public class PackageWriter extends HtmlDocletWriter {
                 .filter(p -> p != packageElement && filter.test(p))
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public boolean isIndexable() {
+        return true;
+    }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
@@ -49,6 +49,8 @@ import jdk.javadoc.internal.doclets.formats.html.HtmlConfiguration;
 import jdk.javadoc.internal.doclets.formats.html.HtmlDocletWriter;
 import jdk.javadoc.internal.doclets.formats.html.HtmlIds;
 import jdk.javadoc.internal.doclets.formats.html.HtmlOptions;
+import jdk.javadoc.internal.doclets.formats.html.IndexWriter;
+import jdk.javadoc.internal.doclets.formats.html.SummaryListWriter;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlId;
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle;
@@ -370,7 +372,10 @@ public class TagletWriter {
     @SuppressWarnings("preview")
     Content createAnchorAndSearchIndex(Element element, String tagText, Content tagContent, String desc, DocTree tree) {
         Content result;
-        if (context.isFirstSentence && context.inSummary || context.inTags.contains(DocTree.Kind.INDEX)) {
+        if (context.isFirstSentence && context.inSummary
+                || context.inTags.contains(DocTree.Kind.INDEX)
+                || htmlWriter instanceof IndexWriter
+                || htmlWriter instanceof SummaryListWriter<?>) {
             result = tagContent;
         } else {
             HtmlId id = HtmlIds.forText(tagText, htmlWriter.indexAnchorTable);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
@@ -372,10 +372,8 @@ public class TagletWriter {
     @SuppressWarnings("preview")
     Content createAnchorAndSearchIndex(Element element, String tagText, Content tagContent, String desc, DocTree tree) {
         Content result;
-        if (context.isFirstSentence && context.inSummary
-                || context.inTags.contains(DocTree.Kind.INDEX)
-                || htmlWriter instanceof IndexWriter
-                || htmlWriter instanceof SummaryListWriter<?>) {
+        if (context.isFirstSentence && context.inSummary || context.inTags.contains(DocTree.Kind.INDEX)
+                || !htmlWriter.isIndexable()) {
             result = tagContent;
         } else {
             HtmlId id = HtmlIds.forText(tagText, htmlWriter.indexAnchorTable);

--- a/test/langtools/jdk/javadoc/doclet/testIndex/TestSelfIndexing.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndex/TestSelfIndexing.java
@@ -146,19 +146,18 @@ public class TestSelfIndexing extends JavadocTester {
         return URL.matcher(content).results()
                 .filter(r -> {
                     String f = r.group("file");
-                    switch (f) {
-                        case "index-all.html", "deprecated-list.html", "overview-tree.html",
-                                "package-use.html", "package-tree.html", "preview-list.html",
-                                "new-list.html", "allclasses-index.html", "allpackages-index.html",
-                                "constant-values.html", "system-properties.html", "serialized-form.html"
-                                -> { /* nothing to do */}
+                    if (!f.contains("-"))
+                        return false;
+                    return switch (f) {
+                        case "package-summary.html",
+                                "module-summary.html",
+                                "overview-summary.html",
+                                "help-doc.html" -> false;
                         default -> {
-                            if (!f.matches("index-\\d+.html"))
-                                return false;
+                            String p = r.group("path");
+                            yield !p.contains("/doc-files/") && !p.startsWith("doc-files/");
                         }
-                    }
-                    String p = r.group("path");
-                    return !p.contains("/doc-files/") && !p.startsWith("doc-files/");
+                    };
                 })
                 .map(r -> r.group(0));
     }

--- a/test/langtools/jdk/javadoc/doclet/testIndex/TestSelfIndexing.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndex/TestSelfIndexing.java
@@ -71,7 +71,7 @@ public class TestSelfIndexing extends JavadocTester {
             for (var t : List.of("<h2>%s</h2>", "{@index %s}", "{@systemProperty %s}")) {
                 tb.writeJavaFiles(src, """
                         package pkg;
-                                        
+
                         /** @deprecated %s */
                         public class Hello { }
                         """.formatted(t.formatted(l)));

--- a/test/langtools/jdk/javadoc/doclet/testIndex/TestSelfIndexing.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndex/TestSelfIndexing.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+/*
+ * @test
+ * @bug 8318082
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestSelfIndexing
+ */
+public class TestSelfIndexing extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        new TestSelfIndexing().runTests();
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    /*
+     * Pages derived from other pages must not be indexed and may not
+     * cross-reference each other except for navigation ergonomics.
+     *
+     * For example, it's okay for all-index.html to reference deprecated-list.html;
+     * but it is not okay, for all-index.html to reference an anchor, such as
+     * deprecated-list.html#java.lang.Object.finalize()
+     */
+    @Test
+    public void test(Path base) throws Exception {
+        Path src = base.resolve("src");
+        int i = 0;
+        // try to start a search tag (i) with the same letter, H,
+        // as the class, Hello, and (ii) with some other letter, P
+        for (var l : List.of("H", "P")) {
+            // try all markup constructs that cause indexing
+            for (var t : List.of("<h2>%s</h2>", "{@index %s}", "{@systemProperty %s}")) {
+                tb.writeJavaFiles(src, """
+                        package pkg;
+                                        
+                        /** @deprecated %s */
+                        public class Hello { }
+                        """.formatted(t.formatted(l)));
+
+                Path out = base.resolve("out-" + i);
+                checking(t.formatted(l) + "; results in: " + out);
+                setAutomaticCheckNoStacktrace(true); // no exceptions
+                javadoc("-d", out.toString(),
+                        "--source-path", src.toString(),
+                        "pkg");
+                // check that index pages do not refer to derived pages
+                try (var s = findIndexFiles(out)) {
+                    record PathAndString(Path path, String str) { }
+                    Optional<PathAndString> r = s.map(p -> {
+                                try {
+                                    return new PathAndString(p, Files.readString(p));
+                                } catch (IOException e) {
+                                    throw new UncheckedIOException(e);
+                                }
+                            })
+                            .flatMap(pac -> findLinksToDerivedPages(pac.str)
+                                    .map(link -> new PathAndString(pac.path, link)))
+                            .findAny();
+                    r.ifPresentOrElse(p -> failed(p.toString()), () -> passed(t.formatted(l)));
+                }
+                i++;
+            }
+        }
+    }
+
+    // ----------- support and infrastructure -----------
+
+    private static Stream<Path> findIndexFiles(Path start) throws IOException {
+        return Files.find(start, Integer.MAX_VALUE, (path, attr) -> {
+            if (attr.isDirectory())
+                return false;
+            var fileName = path.getFileName().toString();
+            if (!fileName.endsWith(".html") && !fileName.endsWith(".js"))
+                return false;
+            if (!fileName.contains("-index") && !fileName.contains("index-"))
+                return false;
+            var underDocFiles = StreamSupport.stream(Spliterators.spliterator(path.iterator(),
+                            Integer.MAX_VALUE, Spliterator.ORDERED), false)
+                    .anyMatch(p -> p.equals(DOC_FILES));
+            return !underDocFiles;
+        });
+    }
+
+    private static final Path DOC_FILES = Path.of("doc-files");
+
+    // good enough to capture relevant parts of URLs that javadoc uses,
+    // from html and js files alike
+    private static final Pattern URL = Pattern.compile(
+            "(?<path>([a-zA-Z.%0-9-]+/)*+)(?<file>[a-zA-Z.%0-9-]+\\.html)#[a-zA-Z.%0-9-]+");
+
+    static {
+        assert findLinksToDerivedPages("module-summary.html#a").findAny().isEmpty();
+        assert findLinksToDerivedPages("package-summary.html#a").findAny().isEmpty();
+        assert findLinksToDerivedPages("Exception.html#a").findAny().isEmpty();
+        assert findLinksToDerivedPages("util/doc-files/coll-index.html#a").findAny().isEmpty();
+        assert findLinksToDerivedPages("util/doc-files/index-all.html#a").findAny().isEmpty(); // tricky
+
+
+        assert findLinksToDerivedPages("index-all.html#a").findAny().isPresent();
+        assert findLinksToDerivedPages("index-17.html#a").findAny().isPresent();
+    }
+
+    // NOTE: this will not find self-links that are allowed on some index pages.
+    // For example, the quick-jump first-character links, such as #I:A,
+    // #I:B, etc., on the top and at the bottom of index-all.html
+    private static Stream<String> findLinksToDerivedPages(String content) {
+        return URL.matcher(content).results()
+                .filter(r -> {
+                    String f = r.group("file");
+                    switch (f) {
+                        case "index-all.html", "deprecated-list.html", "overview-tree.html",
+                                "package-use.html", "package-tree.html", "preview-list.html",
+                                "new-list.html", "allclasses-index.html", "allpackages-index.html",
+                                "constant-values.html", "system-properties.html", "serialized-form.html"
+                                -> { /* nothing to do */}
+                        default -> {
+                            if (!f.matches("index-\\d+.html"))
+                                return false;
+                        }
+                    }
+                    String p = r.group("path");
+                    return !p.contains("/doc-files/") && !p.startsWith("doc-files/");
+                })
+                .map(r -> r.group(0));
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
+++ b/test/langtools/jdk/javadoc/doclet/testSearch/TestSearch.java
@@ -26,7 +26,7 @@
  * @bug 8141492 8071982 8141636 8147890 8166175 8168965 8176794 8175218 8147881
  *      8181622 8182263 8074407 8187521 8198522 8182765 8199278 8196201 8196202
  *      8184205 8214468 8222548 8223378 8234746 8241219 8254627 8247994 8263528
- *      8266808 8248863 8305710
+ *      8266808 8248863 8305710 8318082
  * @summary Test the search feature of javadoc.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -503,14 +503,6 @@ public class TestSearch extends JavadocTester {
                     <dt><a href="pkg2/TestEnum.html#TWO" class="member-name-link">TWO</a> - Enum con\
                     stant in enum class pkg2.<a href="pkg2/TestEnum.html" title="enum class in pkg2"\
                     >TestEnum</a></dt>""");
-        checkOutput("index-all.html", true,
-                """
-                    <div class="deprecation-comment">class_test1 passes. Search tag <span id="Search\
-                    TagDeprecatedClass" class="search-tag-result">SearchTagDeprecatedClass</span></d\
-                    iv>""",
-                """
-                    <div class="deprecation-comment">error_test3 passes. Search tag for
-                     method <span id="SearchTagDeprecatedMethod" class="search-tag-result">SearchTagDeprecatedMethod</span></div>""");
     }
 
     void checkSplitIndex() {
@@ -621,13 +613,7 @@ public class TestSearch extends JavadocTester {
                     k">SearchTagDeprecatedClass</a> - Search tag in class pkg2.TestClass</dt>""",
                 """
                     <dt><a href="pkg/package-summary.html#SingleWord" class="search-tag-link">Single\
-                    Word</a> - Search tag in package pkg</dt>""",
-                """
-                    <div class="deprecation-comment">class_test1 passes. Search tag <span id="Search\
-                    TagDeprecatedClass">SearchTagDeprecatedClass</div>""",
-                """
-                    <div class="deprecation-comment">error_test3 passes. Search tag for
-                     method <span id="SearchTagDeprecatedMethod">SearchTagDeprecatedMethod</span></div>""");
+                    Word</a> - Search tag in package pkg</dt>""");
         checkOutput("index-all.html", true,
                 """
                     <dt><a href="pkg2/TestEnum.html#searchphrasedeprecated" class="search-tag-link">\
@@ -665,13 +651,7 @@ public class TestSearch extends JavadocTester {
                     search phrase deprecated</a> - Search tag in pkg2.TestEnum.ONE</dt>""",
                 """
                     <dt><a href="pkg2/TestError.html#SearchTagDeprecatedMethod" class="search-tag-li\
-                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>""",
-                """
-                    <div class="deprecation-comment">class_test1 passes. Search tag <span id="Search\
-                    TagDeprecatedClass">SearchTagDeprecatedClass</span></div>""",
-                """
-                    <div class="deprecation-comment">error_test3 passes. Search tag for
-                     method <span id="SearchTagDeprecatedMethod">SearchTagDeprecatedMethod</span></div>""");
+                    nk">SearchTagDeprecatedMethod</a> - Search tag in pkg2.TestError.TestError()</dt>""");
     }
 
     void checkJavaFXOutput() {
@@ -840,19 +820,11 @@ public class TestSearch extends JavadocTester {
                 """
                     {"l":"search phrase","h":"class pkg1.RegClass","d":"with description","u":"pkg1/RegClass.html#searchphrase"}""",
                 """
-                    {"l":"search phrase deprecated","h":"pkg2.TestEnum.ONE","u":"deprecated-list.html#searchphrasedeprecated"}""",
-                """
                     {"l":"search phrase deprecated","h":"pkg2.TestEnum.ONE","u":"pkg2/TestEnum.html#searchphrasedeprecated"}""",
-                """
-                    {"l":"search phrase with desc deprecated","h":"annotation interface pkg2.TestAnnotationType","d":"description for phrase deprecated","u":"deprecated-list.html#searchphrasewithdescdeprecated"}""",
                 """
                     {"l":"search phrase with desc deprecated","h":"annotation interface pkg2.TestAnnotationType","d":"description for phrase deprecated","u":"pkg2/TestAnnotationType.html#searchphrasewithdescdeprecated"}""",
                 """
-                    {"l":"SearchTagDeprecatedClass","h":"class pkg2.TestClass","u":"deprecated-list.html#SearchTagDeprecatedClass"}""",
-                """
                     {"l":"SearchTagDeprecatedClass","h":"class pkg2.TestClass","u":"pkg2/TestClass.html#SearchTagDeprecatedClass"}""",
-                """
-                    {"l":"SearchTagDeprecatedMethod","h":"pkg2.TestError.TestError()","d":"with description","u":"deprecated-list.html#SearchTagDeprecatedMethod"}""",
                 """
                     {"l":"SearchTagDeprecatedMethod","h":"pkg2.TestError.TestError()","d":"with description","u":"pkg2/TestError.html#SearchTagDeprecatedMethod"}""",
                 """


### PR DESCRIPTION
Please review this fix to a bug in indexing.

The bug has been dormant for many releases and was noticed only because its likelihood was increased by [JDK-8286470](https://bugs.openjdk.org/browse/JDK-8286470) in JDK 21.

Here's the bug: every time an item is indexed, it is indexed relative to the context that triggers the indexing. For example, if an item is indexed in the context of a class page, then the index will refer to that class page. However, if that same item is indexed in the context of the "Deprecated" page, then the index will refer to the "Deprecated" page.

Since an item is indexed every time it is seen, the fix is to never index an item if seen in the context of a _derived_ page, such as hierarchy trees, indexes, and various lists (e.g. deprecated, new, preview). The fix includes a comprehensive test and updates an existing test to correct its bad assumptions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318082](https://bugs.openjdk.org/browse/JDK-8318082): ConcurrentModificationException from IndexWriter (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16271/head:pull/16271` \
`$ git checkout pull/16271`

Update a local copy of the PR: \
`$ git checkout pull/16271` \
`$ git pull https://git.openjdk.org/jdk.git pull/16271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16271`

View PR using the GUI difftool: \
`$ git pr show -t 16271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16271.diff">https://git.openjdk.org/jdk/pull/16271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16271#issuecomment-1771325628)