### PR TITLE
8318540: make test cannot run .jasm tests directly

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -357,7 +357,7 @@ ExpandJtregPath = \
 # with test id: dir/Test.java#selection -> Test.java#selection -> .java#selection -> #selection
 #      without: dir/Test.java           -> Test.java           -> .java           -> <<empty string>>
 TestID = \
-    $(subst .sh,,$(subst .html,,$(subst .java,,$(suffix $(notdir $1)))))
+    $(subst .jasm,,$(subst .sh,,$(subst .html,,$(subst .java,,$(suffix $(notdir $1))))))
 
 # The test id starting with a hash (#testid) will be stripped by all
 # evals in ParseJtregTestSelectionInner and will be reinserted by calling


### PR DESCRIPTION
Simple fix to allow running `.jasm` tests directly, like we can do now with `.java` and `.sh` tests.

Before the fix:

```
% make images test TEST=runtime/clone/LocalClone.jasm
Test selection 'runtime/clone/LocalClone.jasm', will run:
* jtreg:test/hotspot/jtreg/runtime/clone/LocalClone.jasm.jasm

Running test 'jtreg:test/hotspot/jtreg/runtime/clone/LocalClone.jasm.jasm'
Error: Cannot find file: test/hotspot/jtreg/runtime/clone/LocalClone.jasm.jasm
```

After the fix:

```
$ make images test TEST=runtime/clone/LocalClone.jasm
Test selection 'runtime/clone/LocalClone.jasm', will run:
* jtreg:test/hotspot/jtreg/runtime/clone/LocalClone.jasm

Running test 'jtreg:test/hotspot/jtreg/runtime/clone/LocalClone.jasm'
Passed: runtime/clone/LocalClone.jasm
Test results: passed: 1
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318540](https://bugs.openjdk.org/browse/JDK-8318540): make test cannot run .jasm tests directly (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16274/head:pull/16274` \
`$ git checkout pull/16274`

Update a local copy of the PR: \
`$ git checkout pull/16274` \
`$ git pull https://git.openjdk.org/jdk.git pull/16274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16274`

View PR using the GUI difftool: \
`$ git pr show -t 16274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16274.diff">https://git.openjdk.org/jdk/pull/16274.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16274#issuecomment-1771501360)