### PR TITLE
8318107: Un-ProblemList LocaleProvidersRun and CalendarDataRegression

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -724,8 +724,6 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 # jdk_util
 
-java/util/Locale/LocaleProvidersRun.java                        8268379 macosx-x64
-sun/util/locale/provider/CalendarDataRegression.java            8268379 macosx-x64
 java/util/concurrent/forkjoin/AsyncShutdownNow.java             8286352 linux-all,windows-x64
 java/util/concurrent/ExecutorService/CloseTest.java             8288899 macosx-aarch64
 


### PR DESCRIPTION
LocaleProvidersRun and CalendarDataRegression intermittently timeout together on MAC using the HOST LocaleProviderAdapter. The initial thought is that there may be some race condition at the native level.

It has been difficult to reproduce locally, and the goal is to allow it to trigger through the CI again. Once reproduced, additional diagnostic code can be added to get more information on the timeout.

These tests can remain off the problem list as long as the JDK22 CI is not too noisy, which Dan has approved of.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318107](https://bugs.openjdk.org/browse/JDK-8318107): Un-ProblemList LocaleProvidersRun and CalendarDataRegression (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16278/head:pull/16278` \
`$ git checkout pull/16278`

Update a local copy of the PR: \
`$ git checkout pull/16278` \
`$ git pull https://git.openjdk.org/jdk.git pull/16278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16278`

View PR using the GUI difftool: \
`$ git pr show -t 16278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16278.diff">https://git.openjdk.org/jdk/pull/16278.diff</a>

</details>
