### PR TITLE
JDK-7061097: [Doc] Inconsistenency between the spec and the implementation for DateFormat.Field

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -944,9 +944,12 @@ public abstract class DateFormat extends Format {
         /**
          * Returns the {@code Calendar} field associated with this
          * attribute. For example, if this represents the hours field of
-         * a {@code Calendar}, this would return
-         * {@code Calendar.HOUR}. If there is no corresponding
-         * {@code Calendar} constant, this will return -1.
+         * a {@code Calendar}, this method would return {@code Calendar.HOUR}.
+         * The return value of {@code -1} guarantees that this field does not
+         * represent any corresponding constant in {@code Calendar}.
+         *
+         * @implSpec This implementation always returns {@code -1} if it does
+         * not represent any corresponding constant in {@code Calendar}.
          *
          * @return Calendar constant for this field
          * @see java.util.Calendar

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -948,7 +948,7 @@ public abstract class DateFormat extends Format {
          * The return value of {@code -1} guarantees that this field does not
          * represent any corresponding constant in {@code Calendar}.
          *
-         * @implSpec This implementation always returns {@code -1} if it does
+         * @implSpec The default implementation always returns {@code -1} if it does
          * not represent any corresponding constant in {@code Calendar}.
          *
          * @return Calendar constant for this field


### PR DESCRIPTION
Please review this PR which adjusts the specification of `DateFormat.Field::getCalendarField` to conform to the implementation.

`getCalendarField()` claims that it will return -1 if there is no corresponding `Calendar` constant.

Although the built-in DateFormat.Fields with no associated `Calendar` constant are created with a `calendarField` equal to -1, a subclass can create a DateFormat.Field with no associated `Calendar` constant with `calendarField` equal to anything.

The specification of `getCalendarField()` should be adjusted to reflect this. That is, a separate implementation may or may not return -1 if there is no associated `Calendar` constant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8318035](https://bugs.openjdk.org/browse/JDK-8318035) to be approved

### Issues
 * [JDK-7061097](https://bugs.openjdk.org/browse/JDK-7061097): [Doc] Inconsistenency between the spec and the implementation for DateFormat.Field (**Bug** - P4)
 * [JDK-8318035](https://bugs.openjdk.org/browse/JDK-8318035): [Doc] Inconsistenency between the spec and the implementation for DateFormat.Field (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16279/head:pull/16279` \
`$ git checkout pull/16279`

Update a local copy of the PR: \
`$ git checkout pull/16279` \
`$ git pull https://git.openjdk.org/jdk.git pull/16279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16279`

View PR using the GUI difftool: \
`$ git pr show -t 16279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16279.diff">https://git.openjdk.org/jdk/pull/16279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16279#issuecomment-1771748448)