### PR TITLE
8318573: The nsk.share.jpda.SocketConnection should fail if socket was closed.

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketConnection.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketConnection.java
@@ -517,7 +517,9 @@ public class SocketConnection extends BasicSocketConnection {
         try {
             return doReadObject();
         } catch (EOFException e) {
-            return null;
+            e.printStackTrace(logger.getOutStream());
+            throw new Failure("Caught EOFException while reading an object from " + name + " connection."
+                    + " Check if debugee process is exited (crashed, killed) before responded.\n\t");
         } catch (Exception e) {
             e.printStackTrace(logger.getOutStream());
             throw new Failure("Caught Exception while reading an object from " + name + " connection:\n\t" + e);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketConnection.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/SocketConnection.java
@@ -519,7 +519,7 @@ public class SocketConnection extends BasicSocketConnection {
         } catch (EOFException e) {
             e.printStackTrace(logger.getOutStream());
             throw new Failure("Caught EOFException while reading an object from " + name + " connection."
-                    + " Check if debugee process is exited (crashed, killed) before responded.\n\t");
+                    + " Check if debuggee process exited prematurely (crashed or killed).\n\t");
         } catch (Exception e) {
             e.printStackTrace(logger.getOutStream());
             throw new Failure("Caught Exception while reading an object from " + name + " connection:\n\t" + e);


### PR DESCRIPTION
There are several failure with reason
"Cannot invoke "String.equals(Object)" because "<local1>" is null"
which really caused by reading the command from debugee via socket.
Like:
```
        String command = pipe.readln();

        if (!command.equals(AbstractDebuggeeTest.COMMAND_READY)) {
            setSuccess(false);
            log.complain("TEST BUG: unknown debuggee's command: " + command);

            return false;
        }
```
The command is null when socket fails with EOFException which usually means that debugee has been crashed/exited or killed by timeout handler.

However, it is not clear from the error log. So
https://bugs.openjdk.org/browse/JDK-8310940 has different problems with the same NPE symptom.

The fix update error handling to improve logging.

So output loos like:
```
_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/tmp' \
        -Dtest.compiler.opts= \
        -Dtest.java.opts= \
        -Dtest.jdk=/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/images/jdk \
        -Dcompile.jdk=/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/images/jdk \
        -Dtest.timeout.factor=4.0 \
        -Dtest.nativepath=/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/images/test/hotspot/jtreg/native \
        -Dtest.root=/home/lmesnik/ws/jdk-vmTestbase/open/test/hotspot/jtreg \
        -Dtest.name=vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002/TestDescription.java \
        -Dtest.file=/home/lmesnik/ws/jdk-vmTestbase/open/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002/TestDescription.java \
        -Dtest.src=/home/lmesnik/ws/jdk-vmTestbase/open/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002 \
        -Dtest.src.path=/home/lmesnik/ws/jdk-vmTestbase/open/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002:/home/lmesnik/ws/jdk-vmTestbase/open/test/hotspot/jtreg/vmTestbase:/home/lmesnik/ws/jdk-vmTestbase/open/test/lib \
        -Dtest.classes=/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/classes/0/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002/TestDescription.d \
        -Dtest.class.path=/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/classes/0/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002/TestDescription.d:/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/classes/0/vmTestbase:/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/classes/0/test/lib \
        -Dtest.class.path.prefix=/home/lmesnik/ws/jdk-vmTestbase/open/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002:/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/classes/0/vmTestbase:/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/classes/0/test/lib \
        -XX:MaxRAMPercentage=1.5625 \
        -Dtest.boot.jdk=/var/tmp/jib-lmesnik/install/jdk/21/35/bundles/linux-x64/jdk-21_linux-x64_bin.tar.gz/jdk-21 \
        -Djava.io.tmpdir=/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/tmp \
        -Djava.library.path=/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/images/test/hotspot/jtreg/native \
        com.sun.javatest.regtest.agent.MainWrapper /home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002/TestDescription.d/main.0.jta -verbose -arch=linux-x64 -waittime=5 -debugee.vmkind=java -transport.address=dynamic '-debugee.vmkeys="-XX:MaxRAMPercentage=1.5625 -Dtest.boot.jdk=/var/tmp/jib-lmesnik/install/jdk/21/35/bundles/linux-x64/jdk-21_linux-x64_bin.tar.gz/jdk-21 -Djava.io.tmpdir=/home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/tmp' "

TEST RESULT: Failed. Execution failed: `main' threw exception: nsk.share.Failure: Caught EOFException while reading an object from PipeIO Listener Thread connection. Check if debugee process is exited (crashed, killed) before responded.
--------------------------------------------------
Test results: failed: 1
Report written to /home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-results/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java/html/report.html
Results written to /home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-support/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java
Error: Some tests failed or other problems occurred.
Finished running test 'jtreg:open/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/dispose/dispose002/TestDescription.java'
Test report is stored in /home/lmesnik/ws/jdk-vmTestbase/build/linux-x64/test-results/jtreg_open_test_hotspot_jtreg_vmTestbase_nsk_jdi_VirtualMachine_dispose_dispose002_TestDescription_java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318573](https://bugs.openjdk.org/browse/JDK-8318573): The nsk.share.jpda.SocketConnection should fail if socket was closed. (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [d305b0ea](https://git.openjdk.org/jdk/pull/16280/files/d305b0eade2506348cdae322657dafe53f2327d2)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16280/head:pull/16280` \
`$ git checkout pull/16280`

Update a local copy of the PR: \
`$ git checkout pull/16280` \
`$ git pull https://git.openjdk.org/jdk.git pull/16280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16280`

View PR using the GUI difftool: \
`$ git pr show -t 16280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16280.diff">https://git.openjdk.org/jdk/pull/16280.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16280#issuecomment-1772020171)