### PR TITLE
8169475 : WheelModifier.java fails by timeout

### DIFF
--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -170,7 +170,8 @@ public class WheelModifier {
             SwingUtilities.invokeAndWait(test::createGui);
             test.run();
         } finally {
-            SwingUtilities.invokeAndWait(test.f::dispose);
+            if (test.f != null)
+                SwingUtilities.invokeAndWait(test.f::dispose);
         }
 
         System.out.println("Done.");

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -164,17 +164,17 @@ public class WheelModifier {
             throw new RuntimeException("Mouse is not released");
         }
         System.out.println("# Released!");
-
-        if (f != null) {
-            f.dispose();
-        }
     }
 
     public static void main(String[] args) throws Exception {
         WheelModifier test = new WheelModifier();
 
-        SwingUtilities.invokeAndWait(test::createGui);
-        test.run();
+        try {
+            SwingUtilities.invokeAndWait(test::createGui);
+            test.run();
+        } finally {
+            SwingUtilities.invokeAndWait(test.f::dispose);
+        }
 
         System.out.println("Done.");
     }

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -138,14 +138,14 @@ public class WheelModifier {
 
         r.mouseMove(sLoc.x + bSize.width / 2, sLoc.y + bSize.height * 2);
         if (!exitSema.await(1, TimeUnit.SECONDS)) {
-            throw new RuntimeException("Mouse is not moved");
+            throw new RuntimeException("Mouse did not exit");
         }
         System.out.println("# Exited");
 
         wheelSema = new CountDownLatch(1);
         r.mouseWheel(1);
         if (!wheelSema.await(1, TimeUnit.SECONDS)) {
-            throw new RuntimeException("Mouse is not wheeled");
+            throw new RuntimeException("Mouse is not wheeled 1");
         }
         System.out.println("# Wheeled 1");
 
@@ -170,8 +170,9 @@ public class WheelModifier {
             SwingUtilities.invokeAndWait(test::createGui);
             test.run();
         } finally {
-            if (test.f != null)
+            if (test.f != null) {
                 SwingUtilities.invokeAndWait(test.f::dispose);
+            }
         }
 
         System.out.println("Done.");

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -125,7 +125,6 @@ public class WheelModifier {
 
         Robot r = new Robot();
         r.waitForIdle();
-        ((SunToolkit) Toolkit.getDefaultToolkit()).realSync();
 
         SwingUtilities.invokeAndWait(() -> {
             sLoc = fb.getLocationOnScreen();

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -39,8 +39,6 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
-import sun.awt.SunToolkit;
-
 /*
  * @test
  * @key headful
@@ -52,10 +50,10 @@ public class WheelModifier {
     JFrame f;
     JButton fb;
 
-    CountDownLatch focusSema = new CountDownLatch(1);
-    CountDownLatch pressSema = new CountDownLatch(1);
-    CountDownLatch exitSema = new CountDownLatch(1);
-    CountDownLatch releaseSema = new CountDownLatch(1);
+    final CountDownLatch focusSema = new CountDownLatch(1);
+    final CountDownLatch pressSema = new CountDownLatch(1);
+    final CountDownLatch exitSema = new CountDownLatch(1);
+    final CountDownLatch releaseSema = new CountDownLatch(1);
     volatile CountDownLatch wheelSema;
 
     private volatile Point sLoc;
@@ -133,7 +131,6 @@ public class WheelModifier {
 
         r.mouseMove(sLoc.x + bSize.width / 2, sLoc.y + bSize.height / 2);
         r.mousePress(MouseEvent.BUTTON1_DOWN_MASK);
-
         if (!pressSema.await(2, TimeUnit.SECONDS)) {
             throw new RuntimeException("Mouse is not pressed");
         }

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -165,12 +165,16 @@ public class WheelModifier {
             throw new RuntimeException("Mouse is not released");
         }
         System.out.println("# Released!");
+
+        if (f != null) {
+            f.dispose();
+        }
     }
 
     public static void main(String[] args) throws Exception {
         WheelModifier test = new WheelModifier();
 
-        SwingUtilities.invokeAndWait(() -> test.createGui());
+        SwingUtilities.invokeAndWait(test::createGui);
         test.run();
 
         System.out.println("Done.");

--- a/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
+++ b/test/jdk/java/awt/event/MouseWheelEvent/WheelModifier/WheelModifier.java
@@ -170,9 +170,11 @@ public class WheelModifier {
             SwingUtilities.invokeAndWait(test::createGui);
             test.run();
         } finally {
-            if (test.f != null) {
-                SwingUtilities.invokeAndWait(test.f::dispose);
-            }
+            SwingUtilities.invokeAndWait(() -> {
+                if (test.f != null) {
+                    test.f.dispose();
+                }
+            });
         }
 
         System.out.println("Done.");


### PR DESCRIPTION
Hi Reviewers,

I have added additional CountDownLatch for making sure button is visible before proceeding,(observe this was one of the key reason for failure) so this helps to improve test case stability. Modified _await()_ function by adding 1sec timeout with exception, this will help to reduce total execution time in case of failure. 
Please review and let me know your suggestions, if any.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8169475](https://bugs.openjdk.org/browse/JDK-8169475): WheelModifier.java fails by timeout (**Bug** - P4)


### Reviewers
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16281/head:pull/16281` \
`$ git checkout pull/16281`

Update a local copy of the PR: \
`$ git checkout pull/16281` \
`$ git pull https://git.openjdk.org/jdk.git pull/16281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16281`

View PR using the GUI difftool: \
`$ git pr show -t 16281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16281.diff">https://git.openjdk.org/jdk/pull/16281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16281#issuecomment-1772196694)