### PR TITLE
JDK-8318587: refresh libraries cache on AIX in print_vm_info

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -74,6 +74,10 @@
 #include "jvmci/jvmci.hpp"
 #endif
 
+#ifdef AIX
+#include "loadlib_aix.hpp"
+#endif
+
 #ifndef PRODUCT
 #include <signal.h>
 #endif // PRODUCT
@@ -1343,6 +1347,8 @@ void VMError::report(outputStream* st, bool _verbose) {
 void VMError::print_vm_info(outputStream* st) {
 
   char buf[O_BUFLEN];
+  AIX_ONLY(LoadedLibraries::reload());
+
   report_vm_version(st, buf, sizeof(buf));
 
   // STEP("printing summary")


### PR DESCRIPTION
print_vm_info outputs information about loaded shared libraries; but this info could be outdated on AIX because the libraries cache is currently not refreshed before printing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318587](https://bugs.openjdk.org/browse/JDK-8318587): refresh libraries cache on AIX in print_vm_info (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16284/head:pull/16284` \
`$ git checkout pull/16284`

Update a local copy of the PR: \
`$ git checkout pull/16284` \
`$ git pull https://git.openjdk.org/jdk.git pull/16284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16284`

View PR using the GUI difftool: \
`$ git pr show -t 16284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16284.diff">https://git.openjdk.org/jdk/pull/16284.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16284#issuecomment-1772284193)