### PR TITLE
JDK-8318591: avoid leaks in loadlib_aix.cpp reload_table()

### DIFF
--- a/src/hotspot/os/aix/loadlib_aix.cpp
+++ b/src/hotspot/os/aix/loadlib_aix.cpp
@@ -225,6 +225,7 @@ static bool reload_table() {
     lm->path = g_stringlist.add(ldi->ldinfo_filename);
     if (!lm->path) {
       trcVerbose("OOM.");
+      free(lm);
       goto cleanup;
     }
 
@@ -246,6 +247,7 @@ static bool reload_table() {
       lm->member = g_stringlist.add(p_mbr_name);
       if (!lm->member) {
         trcVerbose("OOM.");
+        free(lm);
         goto cleanup;
       }
     } else {


### PR DESCRIPTION
Seems loaded_module_t* lm is not freed in some special cases in loadlib_aix.cpp reload_table() .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318591](https://bugs.openjdk.org/browse/JDK-8318591): avoid leaks in loadlib_aix.cpp reload_table() (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16285/head:pull/16285` \
`$ git checkout pull/16285`

Update a local copy of the PR: \
`$ git checkout pull/16285` \
`$ git pull https://git.openjdk.org/jdk.git pull/16285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16285`

View PR using the GUI difftool: \
`$ git pr show -t 16285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16285.diff">https://git.openjdk.org/jdk/pull/16285.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16285#issuecomment-1772481407)