### PR TITLE
8317807: JAVA_FLAGS removed from jtreg running in JDK-8317039

### DIFF
--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -122,7 +122,7 @@ $(eval $(call SetupVariable,JT_HOME))
 $(eval $(call SetupVariable,JDK_IMAGE_DIR,$(OUTPUTDIR)/images/jdk))
 $(eval $(call SetupVariable,TEST_IMAGE_DIR,$(OUTPUTDIR)/images/test))
 $(eval $(call SetupVariable,SYMBOLS_IMAGE_DIR,$(OUTPUTDIR)/images/symbols,NO_CHECK))
-$(eval $(call SetupVariable,JTREG_JAVA,$(BOOT_JDK)/bin/java))
+$(eval $(call SetupVariable,JTREG_JDK,$(BOOT_JDK)))
 
 # Provide default values for tools that we need
 $(eval $(call SetupVariable,MAKE,make,NO_CHECK))
@@ -249,7 +249,7 @@ $(call CreateNewSpec, $(NEW_SPEC), \
     TOPDIR := $(TOPDIR), \
     OUTPUTDIR := $(OUTPUTDIR), \
     BOOT_JDK := $(BOOT_JDK), \
-    JTREG_JAVA := $(FIXPATH) $(JTREG_JAVA), \
+    JTREG_JDK := $(JTREG_JDK), \
     JT_HOME := $(JT_HOME), \
     JDK_IMAGE_DIR := $(JDK_IMAGE_DIR), \
     JCOV_IMAGE_DIR := $(JCOV_IMAGE_DIR), \

--- a/make/RunTestsPrebuiltSpec.gmk
+++ b/make/RunTestsPrebuiltSpec.gmk
@@ -124,6 +124,8 @@ JAR := $(FIXPATH) $(JAR_CMD)
 JLINK := $(FIXPATH) $(JLINK_CMD)
 JMOD := $(FIXPATH) $(JMOD_CMD)
 
+JTREG_JAVA := $(FIXPATH) $(JTREG_JDK)/bin/java $(JAVA_FLAGS_BIG) $(JAVA_FLAGS)
+
 BUILD_JAVA := $(JDK_IMAGE_DIR)/bin/JAVA
 ################################################################################
 # Some common tools. Assume most common name and no path.

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -251,11 +251,10 @@ AC_DEFUN_ONCE([LIB_TESTS_SETUP_JTREG],
     AC_MSG_RESULT([no, using BOOT_JDK])
   fi
 
-  JTREG_JAVA="$JTREG_JDK/bin/java"
-  UTIL_FIXUP_PATH(JTREG_JAVA)
-  JTREG_JAVA="$FIXPATH $JTREG_JAVA"
-  AC_SUBST([JTREG_JAVA])
-
+  UTIL_FIXUP_PATH(JTREG_JDK)
+  AC_SUBST([JTREG_JDK])
+  # For use in the configure script
+  JTREG_JAVA="$FIXPATH $JTREG_JDK/bin/java"
 
   # Verify jtreg version
   if test "x$JT_HOME" != x; then

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -666,8 +666,6 @@ JAVA_FLAGS_SMALL:=@JAVA_FLAGS_SMALL@
 BUILDJDK_JAVA_FLAGS_SMALL:=@BUILDJDK_JAVA_FLAGS_SMALL@
 JAVA_TOOL_FLAGS_SMALL:=@JAVA_TOOL_FLAGS_SMALL@
 
-JTREG_JAVA:=@JTREG_JAVA@
-
 # The *_CMD variables are defined separately to be easily overridden in bootcycle-spec.gmk
 # for bootcycle-images build. Make sure to keep them in sync. Do not use the *_CMD
 # versions of the variables directly.
@@ -686,6 +684,9 @@ JAVADOC = $(JAVADOC_CMD)
 JAR = $(JAR_CMD)
 JLINK = $(JLINK_CMD)
 JMOD = $(JMOD_CMD)
+
+JTREG_JDK := @JTREG_JDK@
+JTREG_JAVA = @FIXPATH@ $(JTREG_JDK)/bin/java $(JAVA_FLAGS_BIG) $(JAVA_FLAGS)
 
 BUILD_JAVA_FLAGS := @BOOTCYCLE_JVM_ARGS_BIG@
 BUILD_JAVA=@FIXPATH@ $(BUILD_JDK)/bin/java $(BUILD_JAVA_FLAGS)


### PR DESCRIPTION
Unfortunately, [JDK-8317039](https://bugs.openjdk.org/browse/JDK-8317039) caused a regression. The `$(JAVA)` variable did not just contain a path, which was assumed by the patch, but also the necessary flags in `$(JAVA_FLAGS)`.

Furthermore, the original implementation deviated from how we typically treat JDKs in the build system, that is, we store the root to the JDK as the primary setting, and then we use that as base to get a fixpath'ed executable command line. I've changed the code to more closely align to our existing uses of external JDKs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317807](https://bugs.openjdk.org/browse/JDK-8317807): JAVA_FLAGS removed from jtreg running in JDK-8317039 (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16288/head:pull/16288` \
`$ git checkout pull/16288`

Update a local copy of the PR: \
`$ git checkout pull/16288` \
`$ git pull https://git.openjdk.org/jdk.git pull/16288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16288`

View PR using the GUI difftool: \
`$ git pr show -t 16288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16288.diff">https://git.openjdk.org/jdk/pull/16288.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16288#issuecomment-1772854720)