### PR TITLE
8317937: @sealedGraph: Links to inner classes fails in links

### DIFF
--- a/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
+++ b/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
@@ -229,7 +229,7 @@ public final class SealedGraph implements Taglet {
                 var forwardNavigator = nodePackage.getQualifiedName().toString()
                         .replace(".", "/");
 
-                return backNavigator + forwardNavigator + "/" + node.getSimpleName() + ".html";
+                return backNavigator + forwardNavigator + "/" + packagelessCanonicalName(node) + ".html";
             }
 
             public void addEdge(TypeElement node, TypeElement subNode) {
@@ -314,6 +314,15 @@ public final class SealedGraph implements Taglet {
                 case ANONYMOUS, LOCAL -> Optional.empty();
                 case MEMBER -> packageName((TypeElement) element.getEnclosingElement());
             };
+        }
+
+        private static String packagelessCanonicalName(TypeElement element) {
+            String result = element.getSimpleName().toString();
+            while (element.getNestingKind() == NestingKind.MEMBER) {
+                element = (TypeElement) element.getEnclosingElement();
+                result = element.getSimpleName().toString() + '.' + result;
+            }
+            return result;
         }
     }
 }


### PR DESCRIPTION
This fixes the links to nested classes like `ValueLayout.OfLong` in the rendered sealed class hierarchy graph.

A similar problem with nested classes exist for `@sealedGraph` on them, where their graphs will be generated to a wrong directory and the graph link broken, as seen in `StringTemplate.Processor.Linkage`. That will be done in a separate RFE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317937](https://bugs.openjdk.org/browse/JDK-8317937): @<!---->sealedGraph: Links to inner classes fails in links (**Bug** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16292/head:pull/16292` \
`$ git checkout pull/16292`

Update a local copy of the PR: \
`$ git checkout pull/16292` \
`$ git pull https://git.openjdk.org/jdk.git pull/16292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16292`

View PR using the GUI difftool: \
`$ git pr show -t 16292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16292.diff">https://git.openjdk.org/jdk/pull/16292.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16292#issuecomment-1773124151)