### PR TITLE
8318569: Add getter methods for Locale and Patterns in ListFormat

### DIFF
--- a/src/java.base/share/classes/java/text/ListFormat.java
+++ b/src/java.base/share/classes/java/text/ListFormat.java
@@ -323,6 +323,28 @@ public final class ListFormat extends Format {
     }
 
     /**
+     * {@return the {@code Locale} of this instance}
+     *
+     * {@code locale} is either the one specified in the {@link #getInstance(Locale, Type, Style)},
+     * or the invariant locale, i.e., {@link java.util.Locale#ROOT} if the instance is
+     * created with {@link #getInstance(String[])}.
+     */
+    public Locale getLocale() {
+        return locale;
+    }
+
+    /**
+     * {@return the patterns array used in this instance}
+     *
+     * {@code patterns} is either the one specified in the {@link #getInstance(String[])},
+     * or derived from {@code Locale}, {@code #Type}, and {@code #Style} specified in
+     * {@link #getInstance(Locale, Type, Style)}.
+     */
+    public String[] getPatterns() {
+        return Arrays.copyOf(patterns, patterns.length);
+    }
+
+    /**
      * {@return the string that consists of the input strings, concatenated with the
      * patterns of this {@code ListFormat}}
      * @apiNote Formatting the string from an excessively long list may exceed memory

--- a/src/java.base/share/classes/java/text/ListFormat.java
+++ b/src/java.base/share/classes/java/text/ListFormat.java
@@ -323,22 +323,20 @@ public final class ListFormat extends Format {
     }
 
     /**
-     * {@return the {@code Locale} of this instance}
+     * {@return the {@code Locale} of this ListFormat}
      *
-     * {@code locale} is either the one specified in the {@link #getInstance(Locale, Type, Style)},
-     * or the invariant locale, i.e., {@link java.util.Locale#ROOT} if the instance is
-     * created with {@link #getInstance(String[])}.
+     * The {@code locale} is defined by {@link #getInstance(Locale, Type, Style)} or
+     * {@link #getInstance(String[])}.
      */
     public Locale getLocale() {
         return locale;
     }
 
     /**
-     * {@return the patterns array used in this instance}
+     * {@return the patterns used in this ListFormat}
      *
-     * {@code patterns} is either the one specified in the {@link #getInstance(String[])},
-     * or derived from {@code Locale}, {@code #Type}, and {@code #Style} specified in
-     * {@link #getInstance(Locale, Type, Style)}.
+     * The {@code patterns} are defined by {@link #getInstance(Locale, Type, Style)} or
+     * {@link #getInstance(String[])}.
      */
     public String[] getPatterns() {
         return Arrays.copyOf(patterns, patterns.length);

--- a/test/jdk/java/text/Format/ListFormat/TestListFormat.java
+++ b/test/jdk/java/text/Format/ListFormat/TestListFormat.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8041488 8316974
+ * @bug 8041488 8316974 8318569
  * @summary Tests for ListFormat class
  * @run junit TestListFormat
  */
@@ -200,6 +200,7 @@ public class TestListFormat {
                 arguments(CUSTOM_PATTERNS_MINIMAL, SAMPLE4),
         };
     }
+
     static Arguments[] getInstance_3Arg_InheritPatterns() {
         return new Arguments[] {
                 arguments(ListFormat.Type.STANDARD, ListFormat.Style.FULL),
@@ -213,6 +214,17 @@ public class TestListFormat {
                 arguments(ListFormat.Type.UNIT, ListFormat.Style.NARROW),
         };
     }
+
+    static Arguments[] getLocale_localeDependent() {
+        return new Arguments[] {
+                arguments(Locale.ROOT),
+                arguments(Locale.US),
+                arguments(Locale.GERMANY),
+                arguments(Locale.JAPAN),
+                arguments(Locale.SIMPLIFIED_CHINESE),
+        };
+    }
+
     @ParameterizedTest
     @MethodSource
     void getInstance_1Arg(String[] patterns, List<String> input, String expected) throws ParseException {
@@ -233,6 +245,33 @@ public class TestListFormat {
     void getInstance_3Arg(Locale l, ListFormat.Type type, ListFormat.Style style, String expected, boolean roundTrip) throws ParseException {
         var f = ListFormat.getInstance(l, type, style);
         compareResult(f, SAMPLE3, expected, roundTrip);
+    }
+
+    @Test
+    void getLocale_invariant() {
+        var f = ListFormat.getInstance(CUSTOM_PATTERNS_FULL);
+        assertEquals(Locale.ROOT, f.getLocale());
+    }
+
+    @Test
+    void getLocale_default() {
+        var f = ListFormat.getInstance();
+        assertEquals(Locale.getDefault(Locale.Category.FORMAT), f.getLocale());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getLocale_localeDependent(Locale l) {
+        var f = ListFormat.getInstance(l, ListFormat.Type.STANDARD, ListFormat.Style.FULL);
+        assertEquals(l, f.getLocale());
+    }
+
+    @Test
+    void getPatterns_immutability() {
+        var f = ListFormat.getInstance(CUSTOM_PATTERNS_FULL);
+        var p = f.getPatterns();
+        p[0] = null;
+        assertArrayEquals(CUSTOM_PATTERNS_FULL, f.getPatterns());
     }
 
     @Test


### PR DESCRIPTION
Proposing adding getter methods for `locale` and `patterns` fields in the `ListFormat` instances. Those fields are used for `equals()`, but without the public getter methods, users cannot tell the reasoning of the equality of two instances. A corresponding CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8318571](https://bugs.openjdk.org/browse/JDK-8318571) to be approved

### Issues
 * [JDK-8318569](https://bugs.openjdk.org/browse/JDK-8318569): Add getter methods for Locale and Patterns in ListFormat (**Enhancement** - P4)
 * [JDK-8318571](https://bugs.openjdk.org/browse/JDK-8318571): Add getter methods for Locale and Patterns in ListFormat (**CSR**)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16293/head:pull/16293` \
`$ git checkout pull/16293`

Update a local copy of the PR: \
`$ git checkout pull/16293` \
`$ git pull https://git.openjdk.org/jdk.git pull/16293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16293`

View PR using the GUI difftool: \
`$ git pr show -t 16293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16293.diff">https://git.openjdk.org/jdk/pull/16293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16293#issuecomment-1773173732)