### PR TITLE
8295343: sun/security/pkcs11 tests fail on Linux RHEL 8.6 and newer

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -579,9 +579,9 @@ sun/security/pkcs11/Secmod/AddTrustedCert.java may fail on Ubuntu 18.04
 with the default NSS version in the system. To run these tests
 correctly, the system property
 <code>jdk.test.lib.artifacts.&lt;NAME&gt;</code> is required on Ubuntu
-18.04 to specify the alternative NSS lib directories. The
+18.04 to specify the alternative NSS lib directory. The
 <code>&lt;NAME&gt;</code> component should be replaced with the name
-element of the appropriate<code>@Artfact</code> class. (See
+element of the appropriate<code>@Artifact</code> class. (See
 <code>test/jdk/sun/security/pkcs11/PKCS11Test.java</code>)</p>
 <p>For example:</p>
 <pre><code>$ make test TEST=&quot;jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java&quot; \

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -581,11 +581,11 @@ correctly, the system property
 <code>jdk.test.lib.artifacts.&lt;NAME&gt;</code> is required on Ubuntu
 18.04 to specify the alternative NSS lib directory. The
 <code>&lt;NAME&gt;</code> component should be replaced with the name
-element of the appropriate<code>@Artifact</code> class. (See
+element of the appropriate <code>@Artifact</code> class. (See
 <code>test/jdk/sun/security/pkcs11/PKCS11Test.java</code>)</p>
 <p>For example:</p>
 <pre><code>$ make test TEST=&quot;jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java&quot; \
-    JTREG=&quot;JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/your/latest/NSS-libs&quot;</code></pre>
+    JTREG=&quot;JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/NSS-libs&quot;</code></pre>
 <p>For more notes about the PKCS11 tests, please refer to
 test/jdk/sun/security/pkcs11/README.</p>
 <h3 id="client-ui-tests">Client UI Tests</h3>

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -580,8 +580,8 @@ with the default NSS version in the system. To run these tests
 correctly, the system property
 <code>jdk.test.lib.artifacts.&lt;NAME&gt;</code> is required on Ubuntu
 18.04 to specify the alternative NSS lib directories. The
-<code>&lt;NAME&gt;</code> component should be replaced with the name of
-the appropriate <code>@Artfact</code> class. (See
+<code>&lt;NAME&gt;</code> component should be replaced with the name
+element of the appropriate<code>@Artfact</code> class. (See
 <code>test/jdk/sun/security/pkcs11/PKCS11Test.java</code>)</p>
 <p>For example:</p>
 <pre><code>$ make test TEST=&quot;jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java&quot; \

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -577,12 +577,15 @@ PKCS11 tests. Improper NSS version may lead to unexpected failures which
 are hard to diagnose. For example,
 sun/security/pkcs11/Secmod/AddTrustedCert.java may fail on Ubuntu 18.04
 with the default NSS version in the system. To run these tests
-correctly, the system property <code>test.nss.lib.paths</code> is
-required on Ubuntu 18.04 to specify the alternative NSS lib
-directories.</p>
+correctly, the system property
+<code>jdk.test.lib.artifacts.&lt;NAME&gt;</code> is required on Ubuntu
+18.04 to specify the alternative NSS lib directories. The
+<code>&lt;NAME&gt;</code> component should be replaced with the name of
+the appropriate <code>@Artfact</code> class. (See
+<code>test/jdk/sun/security/pkcs11/PKCS11Test.java</code>)</p>
 <p>For example:</p>
 <pre><code>$ make test TEST=&quot;jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java&quot; \
-    JTREG=&quot;JAVA_OPTIONS=-Dtest.nss.lib.paths=/path/to/your/latest/NSS-libs&quot;</code></pre>
+    JTREG=&quot;JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/your/latest/NSS-libs&quot;</code></pre>
 <p>For more notes about the PKCS11 tests, please refer to
 test/jdk/sun/security/pkcs11/README.</p>
 <h3 id="client-ui-tests">Client UI Tests</h3>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -602,7 +602,7 @@ diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail
 on Ubuntu 18.04 with the default NSS version in the system. To run these tests
 correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on
 Ubuntu 18.04 to specify the alternative NSS lib directory. The `<NAME>`
-component should be replaced with the name element of the appropriate 
+component should be replaced with the name element of the appropriate
 `@Artifact` class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 For example:

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -602,14 +602,14 @@ diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail
 on Ubuntu 18.04 with the default NSS version in the system. To run these tests
 correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on
 Ubuntu 18.04 to specify the alternative NSS lib directory. The `<NAME>`
-component should be replaced with the name element of the appropriate`@Artifact`
-class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
+component should be replaced with the name element of the appropriate 
+`@Artifact` class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 For example:
 
 ```
 $ make test TEST="jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java" \
-    JTREG="JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/your/latest/NSS-libs"
+    JTREG="JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/NSS-libs"
 ```
 
 For more notes about the PKCS11 tests, please refer to

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -601,8 +601,8 @@ tests. Improper NSS version may lead to unexpected failures which are hard to
 diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail
 on Ubuntu 18.04 with the default NSS version in the system. To run these tests
 correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on
-Ubuntu 18.04 to specify the alternative NSS lib directories. The `<NAME>`
-component should be replaced with the name element of the appropriate`@Artfact`
+Ubuntu 18.04 to specify the alternative NSS lib directory. The `<NAME>`
+component should be replaced with the name element of the appropriate`@Artifact`
 class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 For example:

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -600,9 +600,11 @@ It is highly recommended to use the latest NSS version when running PKCS11
 tests. Improper NSS version may lead to unexpected failures which are hard to
 diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail
 on Ubuntu 18.04 with the default NSS version in the system. To run these tests
-correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on Ubuntu 18.04
-to specify the alternative NSS lib directories. The `<NAME>` component should be replaced
-with the name of the appropriate `@Artfact` class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
+correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on 
+Ubuntu 18.04 to specify the alternative NSS lib directories. The `<NAME>` 
+component should be replaced with the name of the appropriate `@Artfact` class. 
+(See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
+
 
 For example:
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -602,9 +602,8 @@ diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail
 on Ubuntu 18.04 with the default NSS version in the system. To run these tests
 correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on 
 Ubuntu 18.04 to specify the alternative NSS lib directories. The `<NAME>` 
-component should be replaced with the name of the appropriate `@Artfact` class. 
-(See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
-
+component should be replaced with the name element of the appropriate`@Artfact`
+class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 For example:
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -600,14 +600,15 @@ It is highly recommended to use the latest NSS version when running PKCS11
 tests. Improper NSS version may lead to unexpected failures which are hard to
 diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail
 on Ubuntu 18.04 with the default NSS version in the system. To run these tests
-correctly, the system property `test.nss.lib.paths` is required on Ubuntu 18.04
-to specify the alternative NSS lib directories.
+correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on Ubuntu 18.04
+to specify the alternative NSS lib directories. The `<NAME>` component should be replaced
+with the name of the appropriate `@Artfact` class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 For example:
 
 ```
 $ make test TEST="jtreg:sun/security/pkcs11/Secmod/AddTrustedCert.java" \
-    JTREG="JAVA_OPTIONS=-Dtest.nss.lib.paths=/path/to/your/latest/NSS-libs"
+    JTREG="JAVA_OPTIONS=-Djdk.test.lib.artifacts.nsslib-linux_aarch64=/path/to/your/latest/NSS-libs"
 ```
 
 For more notes about the PKCS11 tests, please refer to

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -600,8 +600,8 @@ It is highly recommended to use the latest NSS version when running PKCS11
 tests. Improper NSS version may lead to unexpected failures which are hard to
 diagnose. For example, sun/security/pkcs11/Secmod/AddTrustedCert.java may fail
 on Ubuntu 18.04 with the default NSS version in the system. To run these tests
-correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on 
-Ubuntu 18.04 to specify the alternative NSS lib directories. The `<NAME>` 
+correctly, the system property `jdk.test.lib.artifacts.<NAME>` is required on
+Ubuntu 18.04 to specify the alternative NSS lib directories. The `<NAME>`
 component should be replaced with the name element of the appropriate`@Artfact`
 class. (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -622,12 +622,6 @@ com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
 
-sun/security/tools/keytool/NssTest.java                         8295343 generic-all
-sun/security/pkcs11/Signature/TestRSAKeyLength.java             8295343 generic-all
-sun/security/pkcs11/rsa/TestSignatures.java                     8295343 generic-all
-sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 generic-all
-sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 generic-all
-sun/security/pkcs11/KeyStore/Basic.java                         8295343 generic-all
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183 linux-ppc64le
 
 ############################################################################

--- a/test/jdk/sun/security/pkcs11/README
+++ b/test/jdk/sun/security/pkcs11/README
@@ -7,13 +7,12 @@ The libraries come from the following sources.
 1. Specified by system property jdk.test.lib.artifacts.<NAME>
 The system property, jdk.test.lib.artifacts.<NAME>, can specify an absolute path
 to the local NSS library directory. The <NAME> component should be replaced with
-the name element of the appropriate @Artfact class.
+the name element of the appropriate @Artifact class.
 (See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 2. Pre-built NSS libraries from artifactory server
-If the value of system property test.nss.lib.paths is not set, the tests will try
-to download pre-built NSS libraries from artifactory server. Currently, the
-tests only looks for libraries for Windows and MacOSX platforms on artifactory.
+If the value of system property jdk.test.lib.artifacts.<NAME> is not set, the
+tests will try to download pre-built NSS libraries from artifactory server.
 Please note that JIB jar MUST be present in classpath when downloading the
 libraries.
 

--- a/test/jdk/sun/security/pkcs11/README
+++ b/test/jdk/sun/security/pkcs11/README
@@ -4,9 +4,11 @@ perform as a result of bugs or features in NSS or other pkcs11 libraries.
 - How to get NSS libraries?
 The libraries come from the following sources.
 
-1. Specified by system property test.nss.lib.paths
-System property test.nss.lib.paths can specify a set of absolute paths to
-the local NSS library directories. The paths are separated by comma.
+1. Specified by system property jdk.test.lib.artifacts.<NAME>
+The system property, jdk.test.lib.artifacts.<NAME>, can specify an absolute path
+to the local NSS library directory. The <NAME> component should be replaced with
+the name element of the appropriate @Artfact class.
+(See `test/jdk/sun/security/pkcs11/PKCS11Test.java`)
 
 2. Pre-built NSS libraries from artifactory server
 If the value of system property test.nss.lib.paths is not set, the tests will try

--- a/test/jdk/sun/security/tools/keytool/NssTest.java
+++ b/test/jdk/sun/security/tools/keytool/NssTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,9 @@ public class NssTest {
 
         Path dbPath = srcPath.getParent().getParent()
                 .resolve("pkcs11").resolve("nss").resolve("db");
-        Files.copy(dbPath.resolve("cert8.db"), Paths.get("cert8.db"));
-        Files.copy(dbPath.resolve("key3.db"), Paths.get("key3.db"));
-        Files.copy(dbPath.resolve("secmod.db"), Paths.get("secmod.db"));
+        Path destDir = Path.of( "tmpdb");
+        Files.createDirectory(destDir);
+        Files.copy(dbPath.resolve("cert9.db"), destDir.resolve("cert9.db"));
+        Files.copy(dbPath.resolve("key4.db"), destDir.resolve("key4.db"));
     }
 }

--- a/test/jdk/sun/security/tools/keytool/p11-nss.txt
+++ b/test/jdk/sun/security/tools/keytool/p11-nss.txt
@@ -6,7 +6,7 @@ slot = 2
 
 library = ${nss.lib}
 
-nssArgs = "configdir='.' certPrefix='' keyPrefix='' secmod='secmod.db'"
+nssArgs = "configdir='sql:./tmpdb' certPrefix='' keyPrefix='' secmod='secmod.db'"
 
 #forceLogin = true
 


### PR DESCRIPTION
Hello,

In this PR I removed NSS tests from the ProblemList and updated NssTest to use Sqlite databases. I also removed code in PKCS11Test.java that falls back to NSS libraries installed on the test system. The tests can still be run with different NSS libraries but they have to be specified by a system property. I updated `doc/testing.md` to reflect that change.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295343](https://bugs.openjdk.org/browse/JDK-8295343): sun/security/pkcs11 tests fail on Linux RHEL 8.6 and newer (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [8df921f6](https://git.openjdk.org/jdk/pull/16294/files/8df921f69691029c901fc0665dc574873d348f3c)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16294/head:pull/16294` \
`$ git checkout pull/16294`

Update a local copy of the PR: \
`$ git checkout pull/16294` \
`$ git pull https://git.openjdk.org/jdk.git pull/16294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16294`

View PR using the GUI difftool: \
`$ git pr show -t 16294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16294.diff">https://git.openjdk.org/jdk/pull/16294.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16294#issuecomment-1773284403)