### PR TITLE
8318622: ProblemList gc/cslocker/TestCSLocker.java on linux-x64 in Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -46,3 +46,5 @@ vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 829
 
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 compiler/interpreter/TestVerifyStackAfterDeopt.java 8316392 macosx-aarch64
+
+gc/cslocker/TestCSLocker.java 8310480 linux-x64


### PR DESCRIPTION
A trivial fix to ProblemList gc/cslocker/TestCSLocker.java on linux-x64 in Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318622](https://bugs.openjdk.org/browse/JDK-8318622): ProblemList gc/cslocker/TestCSLocker.java on linux-x64 in Xcomp mode (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16296/head:pull/16296` \
`$ git checkout pull/16296`

Update a local copy of the PR: \
`$ git checkout pull/16296` \
`$ git pull https://git.openjdk.org/jdk.git pull/16296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16296`

View PR using the GUI difftool: \
`$ git pr show -t 16296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16296.diff">https://git.openjdk.org/jdk/pull/16296.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16296#issuecomment-1773416536)