### PR TITLE
JDK-8318476: Add resource consumption note to BigInteger and BigDecimal

### DIFF
--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -306,7 +306,7 @@ import java.util.Objects;
  * {@link toPlainString} result with over one billion characters.
  *
  * <p>Operations may also allocate and compute on intermediate
- * results, potentially those allocations may be large as in
+ * results, potentially those allocations may be as large as in
  * proportion to the running time of the algorithm.
  *
  * <p>Users of {@code BigDecimal} concerned with bounding the running

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -293,6 +293,7 @@ import java.util.Objects;
  * {@code BigDecimal} arithmetic.
  *
  * <h2><a id=algorithmicComplexity>Algorithmic Complexity</a></h2>
+ *
  * Operations on {@code BigDecimal} values have a range of algorithmic
  * complexities; in general, those complexities are a function of both
  * the size of the unscaled value as well as the size of the
@@ -304,9 +305,13 @@ import java.util.Objects;
  * representation like {@code new BigDecimal(1E-1000000000)} has a
  * {@link toPlainString} result with over one billion characters.
  *
+ * <p>Operations may also allocate and compute on intermediate
+ * results, potentially those allocations may be large as in
+ * proportion to the running time of the algorithm.
+ *
  * <p>Users of {@code BigDecimal} concerned with bounding the running
- * time of operations can screen out {@code BigDecimal} values with
- * unscaled values or scales above a chosen magnitude.
+ * time or space of operations can screen out {@code BigDecimal}
+ * values with unscaled values or scales above a chosen magnitude.
  *
  * @see     BigInteger
  * @see     MathContext

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -292,6 +292,22 @@ import java.util.Objects;
  * such as dividing by zero, throw an {@code ArithmeticException} in
  * {@code BigDecimal} arithmetic.
  *
+ * <h2><a id=algorithmicComplexity>Algorithmic Complexity</a></h2>
+ * Operations on {@code BigDecimal} values have a range of algorithmic
+ * complexities; in general, those complexities are a function of both
+ * the size of the unscaled value as well as the size of the
+ * scale. For example, an {@linkplain BigDecimal#multiply(BigDecimal)
+ * exact multiply} of two {@code BigDecimal} values is subject to the
+ * same {@linkplain BigInteger##algorithmicComplexity complexity
+ * constraints} as {@code BigInteger} multiply of the unscaled
+ * values. In contrast, a {@code BigDecimal} value with a compact
+ * representation like {@code new BigDecimal(1E-1000000000)} has a
+ * {@link toPlainString} result with over one billion characters.
+ * 
+ * <p>Users of {@code BigDecimal} concerned with bounding the running
+ * time of operations can screen out {@code BigDecimal} values with
+ * unscaled values or scales above a chosen magnitude.
+ *
  * @see     BigInteger
  * @see     MathContext
  * @see     RoundingMode

--- a/src/java.base/share/classes/java/math/BigDecimal.java
+++ b/src/java.base/share/classes/java/math/BigDecimal.java
@@ -279,7 +279,7 @@ import java.util.Objects;
  * operations indicated by {@linkplain RoundingMode rounding modes}
  * are a proper superset of the IEEE 754 rounding-direction
  * attributes.
-
+ *
  * <p>{@code BigDecimal} arithmetic will most resemble IEEE 754
  * decimal arithmetic if a {@code MathContext} corresponding to an
  * IEEE 754 decimal format, such as {@linkplain MathContext#DECIMAL64
@@ -303,7 +303,7 @@ import java.util.Objects;
  * values. In contrast, a {@code BigDecimal} value with a compact
  * representation like {@code new BigDecimal(1E-1000000000)} has a
  * {@link toPlainString} result with over one billion characters.
- * 
+ *
  * <p>Users of {@code BigDecimal} concerned with bounding the running
  * time of operations can screen out {@code BigDecimal} values with
  * unscaled values or scales above a chosen magnitude.

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,6 +117,38 @@ import jdk.internal.vm.annotation.Stable;
  * The range of probable prime values is limited and may be less than
  * the full supported positive range of {@code BigInteger}.
  * The range must be at least 1 to 2<sup>500000000</sup>.
+ *
+ * @apiNote
+ * <a id=algorithmicComplexity>As {@code BigInteger} values are
+ * arbitrary precision integers, the algorithmic complexity of the
+ * methods of this class varies and may be superlinear in the size of
+ * the input. For example, a method like {@link intValue()} would be
+ * expected to run in <i>O</i>(1), that is constant time, since with
+ * the current internal presentation only a fixed-size component of
+ * the {@code BigInteger} needs to be accessed to perform the
+ * conversion to {@code int}. In contrast, a method like {@link not()}
+ * would be expected to run in <i>O</i>(<i>n</i>) time where <i>n</i>
+ * is size of the {@code BigInteger} in bits, that is, to run in time
+ * proportional to the size of the input. For multiplying two {@code
+ * BigInteger} values of size <i>n</i>, a naive multiply algorithm
+ * would run in time <i>O</i>(<i>n<sup>2</sup></i>) and theoretical
+ * results indicate a multiply algorithm for numbers using this
+ * category of representation must run in <em>at least</em>
+ * <i>O</i>(<i>n</i>&nbsp;log&nbsp;<i>n</i>). Common multiply
+ * algorithms between the bounds of the naive and theoretical cases
+ * include the Karatsuba multiplication
+ * (<i>O</i>(<i>n<sup>1.585</sup></i>)) and 3-way Toom-Cook
+ * multiplication (<i>O</i>(<i>n<sup>1.465</sup></i>)).</a>
+ *
+ * <p>A particular implementation of {@link multiply(BigInteger)
+ * multiply} is free to switch between different algorithms for
+ * different inputs, such as to improve actual running time to produce
+ * the product by using simpler algorithms for smaller inputs even if
+ * the simpler algorithm has a larger asymptotic complexity.
+ *
+ * <p>Users of {@code BigInteger} concerned with bounding the running
+ * time of operations can screen out {@code BigInteger} values above a
+ * chosen magnitude.
  *
  * @implNote
  * In the reference implementation, BigInteger constructors and

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -124,17 +124,17 @@ import jdk.internal.vm.annotation.Stable;
  * methods of this class varies and may be superlinear in the size of
  * the input. For example, a method like {@link intValue()} would be
  * expected to run in <i>O</i>(1), that is constant time, since with
- * the current internal reprentation only a fixed-size component of
+ * the current internal representation only a fixed-size component of
  * the {@code BigInteger} needs to be accessed to perform the
  * conversion to {@code int}. In contrast, a method like {@link not()}
  * would be expected to run in <i>O</i>(<i>n</i>) time where <i>n</i>
  * is size of the {@code BigInteger} in bits, that is, to run in time
  * proportional to the size of the input. For multiplying two {@code
- * BigInteger} values of size <i>n</i>, a naive multiply algorithm
+ * BigInteger} values of size <i>n</i>, a naive multiplication algorithm
  * would run in time <i>O</i>(<i>n<sup>2</sup></i>) and theoretical
- * results indicate a multiply algorithm for numbers using this
+ * results indicate a multiplication algorithm for numbers using this
  * category of representation must run in <em>at least</em>
- * <i>O</i>(<i>n</i>&nbsp;log&nbsp;<i>n</i>). Common multiply
+ * <i>O</i>(<i>n</i>&nbsp;log&nbsp;<i>n</i>). Common multiplication
  * algorithms between the bounds of the naive and theoretical cases
  * include the Karatsuba multiplication
  * (<i>O</i>(<i>n<sup>1.585</sup></i>)) and 3-way Toom-Cook
@@ -147,7 +147,7 @@ import jdk.internal.vm.annotation.Stable;
  * the simpler algorithm has a larger asymptotic complexity.
  *
  * <p>Operations may also allocate and compute on intermediate
- * results, potentially those allocations may be large as in
+ * results, potentially those allocations may be as large as in
  * proportion to the running time of the algorithm.
  *
  * <p>Users of {@code BigInteger} concerned with bounding the running

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -124,7 +124,7 @@ import jdk.internal.vm.annotation.Stable;
  * methods of this class varies and may be superlinear in the size of
  * the input. For example, a method like {@link intValue()} would be
  * expected to run in <i>O</i>(1), that is constant time, since with
- * the current internal presentation only a fixed-size component of
+ * the current internal reprentation only a fixed-size component of
  * the {@code BigInteger} needs to be accessed to perform the
  * conversion to {@code int}. In contrast, a method like {@link not()}
  * would be expected to run in <i>O</i>(<i>n</i>) time where <i>n</i>
@@ -146,9 +146,13 @@ import jdk.internal.vm.annotation.Stable;
  * the product by using simpler algorithms for smaller inputs even if
  * the simpler algorithm has a larger asymptotic complexity.
  *
+ * <p>Operations may also allocate and compute on intermediate
+ * results, potentially those allocations may be large as in
+ * proportion to the running time of the algorithm.
+ *
  * <p>Users of {@code BigInteger} concerned with bounding the running
- * time of operations can screen out {@code BigInteger} values above a
- * chosen magnitude.
+ * time or space of operations can screen out {@code BigInteger}
+ * values above a chosen magnitude.
  *
  * @implNote
  * In the reference implementation, BigInteger constructors and

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -128,12 +128,12 @@ import jdk.internal.vm.annotation.Stable;
  * the {@code BigInteger} needs to be accessed to perform the
  * conversion to {@code int}. In contrast, a method like {@link not()}
  * would be expected to run in <i>O</i>(<i>n</i>) time where <i>n</i>
- * is the size of the {@code BigInteger} in bits, that is, to run in time
- * proportional to the size of the input. For multiplying two {@code
- * BigInteger} values of size <i>n</i>, a naive multiplication algorithm
- * would run in time <i>O</i>(<i>n<sup>2</sup></i>) and theoretical
- * results indicate a multiplication algorithm for numbers using this
- * category of representation must run in <em>at least</em>
+ * is the size of the {@code BigInteger} in bits, that is, to run in
+ * time proportional to the size of the input. For multiplying two
+ * {@code BigInteger} values of size <i>n</i>, a naive multiplication
+ * algorithm would run in time <i>O</i>(<i>n<sup>2</sup></i>) and
+ * theoretical results indicate a multiplication algorithm for numbers
+ * using this category of representation must run in <em>at least</em>
  * <i>O</i>(<i>n</i>&nbsp;log&nbsp;<i>n</i>). Common multiplication
  * algorithms between the bounds of the naive and theoretical cases
  * include the Karatsuba multiplication

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -128,7 +128,7 @@ import jdk.internal.vm.annotation.Stable;
  * the {@code BigInteger} needs to be accessed to perform the
  * conversion to {@code int}. In contrast, a method like {@link not()}
  * would be expected to run in <i>O</i>(<i>n</i>) time where <i>n</i>
- * is size of the {@code BigInteger} in bits, that is, to run in time
+ * is the size of the {@code BigInteger} in bits, that is, to run in time
  * proportional to the size of the input. For multiplying two {@code
  * BigInteger} values of size <i>n</i>, a naive multiplication algorithm
  * would run in time <i>O</i>(<i>n<sup>2</sup></i>) and theoretical


### PR DESCRIPTION
Add informative notes to BigInteger and BigDecimal about possible running times, etc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318476](https://bugs.openjdk.org/browse/JDK-8318476): Add resource consumption note to BigInteger and BigDecimal (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [c959f3b5](https://git.openjdk.org/jdk/pull/16298/files/c959f3b5282495d90dec00df65aff5bef9fa2f77)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [0a48c48f](https://git.openjdk.org/jdk/pull/16298/files/0a48c48f5c07c6fee5e78337f0d66a4b000ccb1f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16298/head:pull/16298` \
`$ git checkout pull/16298`

Update a local copy of the PR: \
`$ git checkout pull/16298` \
`$ git pull https://git.openjdk.org/jdk.git pull/16298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16298`

View PR using the GUI difftool: \
`$ git pr show -t 16298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16298.diff">https://git.openjdk.org/jdk/pull/16298.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16298#issuecomment-1773577195)