### PR TITLE
JDK-8318643: +UseTransparentHugePages must enable +UseLargePages

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3775,6 +3775,8 @@ void os::large_page_init() {
     _large_page_size = HugePages::thp_pagesize();
     _page_sizes.add(_large_page_size);
     _page_sizes.add(os::vm_page_size());
+    // +UseTransparentHugePages implies +UseLargePages
+    UseLargePages = true;
 
   } else {
 


### PR DESCRIPTION
Per contract, +UseTransparentHugePages implies +UseLargePages. That automatism was lost with [JDK-8261894](https://bugs.openjdk.org/browse/JDK-8261894).

The fix is trivial.

Note that a regression test exists, (https://github.com/openjdk/jdk/pull/15159), that's how I found this issue. But this regression test has been drifting in Review Limbo since August. It just needs a second review, @kstefanj already reviewed it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318643](https://bugs.openjdk.org/browse/JDK-8318643): +UseTransparentHugePages must enable +UseLargePages (**Bug** - P3)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16302/head:pull/16302` \
`$ git checkout pull/16302`

Update a local copy of the PR: \
`$ git checkout pull/16302` \
`$ git pull https://git.openjdk.org/jdk.git pull/16302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16302`

View PR using the GUI difftool: \
`$ git pr show -t 16302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16302.diff">https://git.openjdk.org/jdk/pull/16302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16302#issuecomment-1774504842)