### PR TITLE
8318649: G1: Remove unimplemented HeapRegionRemSet::add_code_root_locked

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -149,7 +149,6 @@ public:
   // Routines for managing the list of code roots that point into
   // the heap region that owns this RSet.
   void add_code_root(nmethod* nm);
-  void add_code_root_locked(nmethod* nm);
   void remove_code_root(nmethod* nm);
 
   // Applies blk->do_code_blob() to each of the entries in _code_roots


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318649](https://bugs.openjdk.org/browse/JDK-8318649): G1: Remove unimplemented HeapRegionRemSet::add_code_root_locked (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16305/head:pull/16305` \
`$ git checkout pull/16305`

Update a local copy of the PR: \
`$ git checkout pull/16305` \
`$ git pull https://git.openjdk.org/jdk.git pull/16305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16305`

View PR using the GUI difftool: \
`$ git pr show -t 16305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16305.diff">https://git.openjdk.org/jdk/pull/16305.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16305#issuecomment-1774799583)