### PR TITLE
8317507: C2 compilation fails with "Exceeded _node_regs array"

### DIFF
--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -3127,6 +3127,9 @@ static void define_fill_new_machnode(bool used, FILE *fp_cpp) {
     fprintf(fp_cpp, "    if( i != cisc_operand() ) \n");
     fprintf(fp_cpp, "      to[i] = _opnds[i]->clone();\n");
     fprintf(fp_cpp, "  }\n");
+    fprintf(fp_cpp, "  // Do not increment node index counter, since node reuses my index\n");
+    fprintf(fp_cpp, "  Compile* C = Compile::current();\n");
+    fprintf(fp_cpp, "  C->set_unique(C->unique() - 1);\n");
     fprintf(fp_cpp, "}\n");
   }
   fprintf(fp_cpp, "\n");

--- a/test/hotspot/jtreg/compiler/regalloc/TestNodeRegArrayOverflow.java
+++ b/test/hotspot/jtreg/compiler/regalloc/TestNodeRegArrayOverflow.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.regalloc;
+
+/**
+ * @test
+ * @bug 8317507
+ * @summary Test that C2's PhaseRegAlloc::_node_regs (a post-register-allocation
+ *          mapping from machine nodes to assigned registers) does not overflow
+ *          in the face of a program with a high-density of CISC spilling
+ *          candidate nodes.
+ * @run main/othervm -Xcomp -XX:CompileOnly=compiler.regalloc.TestNodeRegArrayOverflow::test
+                     -XX:CompileCommand=dontinline,compiler.regalloc.TestNodeRegArrayOverflow::dontInline
+                     compiler.regalloc.TestNodeRegArrayOverflow
+ */
+
+public class TestNodeRegArrayOverflow {
+
+    static int dontInline() {
+        return 0;
+    }
+
+    static float test(float inc) {
+        int i = 0, j = 0;
+        // This non-inlined method call causes 'inc' to be spilled.
+        float f = dontInline();
+        // This two-level reduction loop is unrolled 512 times, which is
+        // requested by the SLP-specific unrolling analysis, but not vectorized.
+        // Because 'inc' is spilled, each of the unrolled AddF nodes is
+        // CISC-spill converted (PhaseChaitin::fixup_spills()). Before the fix,
+        // this causes the unique node index counter (Compile::_unique) to grow
+        // beyond the size of the node register array
+        // (PhaseRegAlloc::_node_regs), and leads to overflow when accessed for
+        // nodes that are created later (e.g. during the peephole phase).
+        while (i++ < 128) {
+            for (j = 0; j < 16; j++) {
+                f += inc;
+            }
+        }
+        return f;
+    }
+
+    public static void main(String[] args) {
+        test(0);
+    }
+}


### PR DESCRIPTION
This changeset avoids incrementing the global node index counter (`Compile::_unique`) when creating a CISC version node that replaces and reuses the index of the original node. This prevents out-of-bounds accesses to `PhaseRegAlloc::_node_regs` in programs with a high-density of CISC spill candidate nodes. Such programs can arise, for example, after extensive unrolling of reduction operations in x64 (see the [failure analysis](https://bugs.openjdk.org/browse/JDK-8317507) for further detail).

A more general fix would be to transform `PhaseRegAlloc::_node_regs` into a growable array. Besides eliminating potential out-of-bounds accesses by construction, this fix could also reduce memory overhead, as it would obviate the need for [over-allocating space for `PhaseRegAlloc::_node_regs`](https://github.com/openjdk/jdk/blob/fc29a2e152310ed81bd1bb23e6f17d02f055a454/src/hotspot/share/opto/regalloc.cpp#L113-L114). This is however a more intrusive, architecture-sensitive, and difficult-to-backport change that might be best addressed as a RFE in the early cycle of JDK 23. Note that the general fix would still benefit from the simpler one proposed in this changeset.

#### Testing

- tier1-5, stress test, fuzzing (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64; release and debug mode).