### PR TITLE
8316046: x64 platforms unecessarily save xmm16-31 when UseAVX >= 3

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -76,7 +76,9 @@ public class CallArranger {
         new VMStorage[] { xmm0, xmm1 },
         2,
         new VMStorage[] { r10, r11 },
-        new VMStorage[] { xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14, xmm15 },
+        new VMStorage[] { xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14, xmm15,
+                          xmm16, xmm17, xmm18, xmm19, xmm20, xmm21, xmm22, xmm23,
+                          xmm24, xmm25, xmm26, xmm27, xmm28, xmm29, xmm30, xmm31 },
         16,
         0, //no shadow space
         r10, r11 // scratch 1 & 2

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -66,7 +66,9 @@ public class CallArranger {
         new VMStorage[] { xmm0 },
         0,
         new VMStorage[] { rax, r10, r11 },
-        new VMStorage[] { xmm4, xmm5 },
+        new VMStorage[] { xmm4, xmm5,
+                          xmm16, xmm17, xmm18, xmm19, xmm20, xmm21, xmm22, xmm23,
+                          xmm24, xmm25, xmm26, xmm27, xmm28, xmm29, xmm30, xmm31 },
         16,
         32,
         r10, r11 // scratch 1 & 2


### PR DESCRIPTION
See JBS issue. We don't need to save xmm16+ on x64 platforms (which are currently saved in FFM upcall stubs). This is achieved simply by adding these registers to the volatile register lists of both ABIs.

Related: https://github.com/openjdk/jdk/pull/15688

Testing: `jdk_foreign`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316046](https://bugs.openjdk.org/browse/JDK-8316046): x64 platforms unecessarily save xmm16-31 when UseAVX &gt;= 3 (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16307/head:pull/16307` \
`$ git checkout pull/16307`

Update a local copy of the PR: \
`$ git checkout pull/16307` \
`$ git pull https://git.openjdk.org/jdk.git pull/16307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16307`

View PR using the GUI difftool: \
`$ git pr show -t 16307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16307.diff">https://git.openjdk.org/jdk/pull/16307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16307#issuecomment-1775104045)