### PR TITLE
8317360: Missing null checks in JfrCheckpointManager and JfrStringPool initialization routines

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -109,6 +109,9 @@ bool JfrCheckpointManager::initialize() {
   // preallocate buffer count to each of the epoch live lists
   for (size_t i = 0; i < global_buffer_prealloc_count * 2; ++i) {
     Buffer* const buffer = mspace_allocate(global_buffer_size, _global_mspace);
+    if (buffer == nullptr) {
+      return false;
+    }
     _global_mspace->add_to_live_list(buffer, i % 2 == 0);
   }
   assert(_global_mspace->free_list_is_empty(), "invariant");

--- a/src/hotspot/share/jfr/recorder/stringpool/jfrStringPool.cpp
+++ b/src/hotspot/share/jfr/recorder/stringpool/jfrStringPool.cpp
@@ -131,6 +131,9 @@ bool JfrStringPool::initialize() {
   // preallocate buffer count to each of the epoch live lists
   for (size_t i = 0; i < string_pool_cache_count * 2; ++i) {
     Buffer* const buffer = mspace_allocate(string_pool_buffer_size, _mspace);
+    if (buffer == nullptr) {
+      return false;
+    }
     _mspace->add_to_live_list(buffer, i % 2 == 0);
   }
   assert(_mspace->free_list_is_empty(), "invariant");


### PR DESCRIPTION
Greetings,

Adding missing null checks for initialization routines.

Testing: jdk_jfr

Thanks
Markus