### PR TITLE
8317289: javadoc fails with -sourcepath if module-info.java contains import statements

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1319,15 +1319,6 @@ public class TreeInfo {
     public static boolean isModuleInfo(JCCompilationUnit tree) {
         return tree.sourcefile.isNameCompatible("module-info", JavaFileObject.Kind.SOURCE)
                 && tree.getModuleDecl() != null;
-    }
-
-    public static JCModuleDecl getModule(JCCompilationUnit t) {
-        if (t.defs.nonEmpty()) {
-            JCTree def = t.defs.head;
-            if (def.hasTag(MODULEDEF))
-                return (JCModuleDecl) def;
-        }
-        return null;
     }
 
     public static boolean isPackageInfo(JCCompilationUnit tree) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,6 @@ import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCModuleDecl;
-import com.sun.tools.javac.tree.TreeInfo;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Name;
@@ -391,7 +390,7 @@ public class ElementsTable {
                     "module-info", JavaFileObject.Kind.SOURCE);
             if (jfo != null) {
                 JCCompilationUnit jcu = compiler.parse(jfo);
-                JCModuleDecl module = TreeInfo.getModule(jcu);
+                JCModuleDecl module = jcu.getModule();
                 if (module != null) {
                     return module.getName().toString();
                 }

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestSourcePathModule.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestSourcePathModule.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+/*
+ * @test
+ * @bug 8317289
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestSourcePathModule
+ */
+public class TestSourcePathModule extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        new TestSourcePathModule().runTests();
+    }
+
+    @Test
+    public void testSourcePath(Path base) throws Exception {
+        Path src = base.resolve("src");
+        new ToolBox().writeJavaFiles(src, """
+                import java.lang.Object;
+                /** documentation */
+                module m { }
+                """);
+        javadoc("-d", "out",
+                "-sourcepath", src.toString(),
+                "--module", "m");
+        checkExit(Exit.OK);
+    }
+}


### PR DESCRIPTION
Please review a fix to a bug in processing of the `sourcepath` javadoc option.

The bug is that when `-sourcepath`/`--source-path` is specified, retrieving a module name does not account for any import statements in `module-info.java`.

Originally, I was thinking to propose the following simple fix on the `javac` side:

```
diff --git a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
index b25c99d3b06..e046b3d310e 100644
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -1322,10 +1322,9 @@ public static boolean isModuleInfo(JCCompilationUnit tree) {
     }
 
     public static JCModuleDecl getModule(JCCompilationUnit t) {
-        if (t.defs.nonEmpty()) {
-            JCTree def = t.defs.head;
-            if (def.hasTag(MODULEDEF))
-                return (JCModuleDecl) def;
+        for (var d = t.defs; d.nonEmpty(); d = d.tail) {
+            if (d.head.hasTag(MODULEDEF))
+                return (JCModuleDecl) d.head;
         }
         return null;
     }
```

However, Jan Lahoda (@lahodaj) told me that `JCCompilationUnit` already provides this functionality in a like-named method:

```
        @DefinedBy(Api.COMPILER_TREE)
        public JCModuleDecl getModule() {
            return getModuleDecl();
        }
...
        public JCModuleDecl getModuleDecl() {
            for (JCTree tree : defs) {
                if (tree.hasTag(MODULEDEF)) {
                    return (JCModuleDecl) tree;
                }
            }

            return null;
        }
```

So the actual fix in this PR is even simpler than my original fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317289](https://bugs.openjdk.org/browse/JDK-8317289): javadoc fails with -sourcepath if module-info.java contains import statements (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16312/head:pull/16312` \
`$ git checkout pull/16312`

Update a local copy of the PR: \
`$ git checkout pull/16312` \
`$ git pull https://git.openjdk.org/jdk.git pull/16312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16312`

View PR using the GUI difftool: \
`$ git pr show -t 16312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16312.diff">https://git.openjdk.org/jdk/pull/16312.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16312#issuecomment-1775428397)