### PR TITLE
8293713 : java/net/httpclient/BufferingSubscriberTest.java fails in timeout, blocked in submission publisher

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/SubmissionPublisher.java
+++ b/src/java.base/share/classes/java/util/concurrent/SubmissionPublisher.java
@@ -1059,7 +1059,7 @@ public class SubmissionPublisher<T> implements Publisher<T>,
         final Subscriber<? super T> subscriber;
         final BiConsumer<? super Subscriber<? super T>, ? super Throwable> onNextHandler;
         Executor executor;                 // null on error
-        Thread waiter;                     // blocked producer thread
+        volatile Thread waiter;            // blocked producer thread
         Throwable pendingError;            // holds until onError issued
         BufferedSubscription<T> next;      // used only by publisher
         BufferedSubscription<T> nextRetry; // used only by publisher


### PR DESCRIPTION
Resolves a visibility issue in SubmissionPublisher by making the `waiter` member of BufferedSubscription *volatile*.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293713](https://bugs.openjdk.org/browse/JDK-8293713): java/net/httpclient/BufferingSubscriberTest.java fails in timeout, blocked in submission publisher (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Contributors
 * Jaikiran Pai `<jpai@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16313/head:pull/16313` \
`$ git checkout pull/16313`

Update a local copy of the PR: \
`$ git checkout pull/16313` \
`$ git pull https://git.openjdk.org/jdk.git pull/16313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16313`

View PR using the GUI difftool: \
`$ git pr show -t 16313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16313.diff">https://git.openjdk.org/jdk/pull/16313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16313#issuecomment-1775478551)