### PR TITLE
8318479: [jmh] the test security.CacheBench  failed for multiple threads run

### DIFF
--- a/test/micro/org/openjdk/bench/java/security/CacheBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CacheBench.java
@@ -44,7 +44,7 @@ import sun.security.util.Cache;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED", "-Xmx1g"})
+@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 public class CacheBench {


### PR DESCRIPTION
Remove the hardcoded maximum heap size.

Verified that the benchmark now passes with 100 threads given sufficient heap:
```
make test TEST=micro:CacheBench MICRO="OPTIONS=-t 100;JAVA_OPTIONS=-Xmx16g"
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318479](https://bugs.openjdk.org/browse/JDK-8318479): [jmh] the test security.CacheBench  failed for multiple threads run (**Bug** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16315/head:pull/16315` \
`$ git checkout pull/16315`

Update a local copy of the PR: \
`$ git checkout pull/16315` \
`$ git pull https://git.openjdk.org/jdk.git pull/16315/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16315`

View PR using the GUI difftool: \
`$ git pr show -t 16315`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16315.diff">https://git.openjdk.org/jdk/pull/16315.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16315#issuecomment-1775594613)