### PR TITLE
8318100: Remove redundant check for Metal support

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
@@ -125,16 +125,7 @@ public class MacOSFlags {
                                 System.out.println("Could not enable OpenGL pipeline (CGL not available)");
                             }
                             oglEnabled = false;
-                            metalEnabled = MTLGraphicsConfig.isMetalAvailable();
-                        }
-                    } else if (metalEnabled && !oglEnabled) {
-                        // Check whether Metal framework is available
-                        if (!MTLGraphicsConfig.isMetalAvailable()) {
-                            if (metalVerbose) {
-                                System.out.println("Could not enable Metal pipeline (Metal framework not available)");
-                            }
-                            metalEnabled = false;
-                            oglEnabled = CGLGraphicsConfig.isCGLAvailable();
+                            metalEnabled = true;
                         }
                     }
 

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLGraphicsConfig.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLGraphicsConfig.java
@@ -72,7 +72,6 @@ import static sun.java2d.metal.MTLContext.MTLContextCaps.CAPS_EXT_BIOP_SHADER;
 public final class MTLGraphicsConfig extends CGraphicsConfig
         implements AccelGraphicsConfig, SurfaceManager.ProxiedGraphicsConfig
 {
-    private static boolean mtlAvailable;
     private static ImageCapabilities imageCaps = new MTLImageCaps();
 
     @SuppressWarnings("removal")
@@ -89,7 +88,6 @@ public final class MTLGraphicsConfig extends CGraphicsConfig
     private final Object disposerReferent = new Object();
     private final int maxTextureSize;
 
-    private static native boolean isMetalFrameworkAvailable();
     private static native boolean tryLoadMetalLibrary(int displayID, String shaderLib);
     private static native long getMTLConfigInfo(int displayID, String mtlShadersLib);
 
@@ -98,10 +96,6 @@ public final class MTLGraphicsConfig extends CGraphicsConfig
      * called under MTLRQ lock.
      */
     private static native int nativeGetMaxTextureSize();
-
-    static {
-        mtlAvailable = isMetalFrameworkAvailable();
-    }
 
     private MTLGraphicsConfig(CGraphicsDevice device,
                               long configInfo, int maxTextureSize,
@@ -133,10 +127,6 @@ public final class MTLGraphicsConfig extends CGraphicsConfig
     public static MTLGraphicsConfig getConfig(CGraphicsDevice device,
                                               int displayID)
     {
-        if (!mtlAvailable) {
-            return null;
-        }
-
         if (!tryLoadMetalLibrary(displayID, mtlShadersLib)) {
             return null;
         }
@@ -169,10 +159,6 @@ public final class MTLGraphicsConfig extends CGraphicsConfig
                         CAPS_EXT_BIOP_SHADER | CAPS_EXT_GRAD_SHADER,
                 null);
         return new MTLGraphicsConfig(device, cfginfo, textureSize, caps);
-    }
-
-    public static boolean isMetalAvailable() {
-        return mtlAvailable;
     }
 
     /**

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
@@ -55,22 +55,6 @@ MTLGC_DestroyMTLGraphicsConfig(jlong pConfigInfo)
 }
 
 JNIEXPORT jboolean JNICALL
-Java_sun_java2d_metal_MTLGraphicsConfig_isMetalFrameworkAvailable
-    (JNIEnv *env, jclass mtlgc)
-{
-    jboolean metalSupported = JNI_FALSE;
-
-    // It is guaranteed that metal supported GPU is available since macOS 10.14
-    if (@available(macOS 10.14, *)) {
-        metalSupported = JNI_TRUE;
-    }
-
-    J2dRlsTraceLn1(J2D_TRACE_INFO, "MTLGraphicsConfig_isMetalFrameworkAvailable : %d", metalSupported);
-
-    return metalSupported;
-}
-
-JNIEXPORT jboolean JNICALL
 Java_sun_java2d_metal_MTLGraphicsConfig_tryLoadMetalLibrary
     (JNIEnv *env, jclass mtlgc, jint displayID, jstring shadersLibName)
 {


### PR DESCRIPTION
We have updated minimum macOS version on which JDK can be used to macOS 11 and we have check to enable metal pipeline only when macOS version is >=10.14.

Since minimum macOS version is updated we don't need this check now.
Removed redundant check and ran all clientlibs tests on CI for verification.
Also ran a sample program with different combination of sun.java2d.metal and sun.java2d.opengl flags and i see that appropriate pipeline is getting selected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318100](https://bugs.openjdk.org/browse/JDK-8318100): Remove redundant check for Metal support (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16316/head:pull/16316` \
`$ git checkout pull/16316`

Update a local copy of the PR: \
`$ git checkout pull/16316` \
`$ git pull https://git.openjdk.org/jdk.git pull/16316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16316`

View PR using the GUI difftool: \
`$ git pr show -t 16316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16316.diff">https://git.openjdk.org/jdk/pull/16316.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16316#issuecomment-1775611834)