### PR TITLE
8318689: jtreg is confused when folder name is the same as the test name

### DIFF
--- a/test/jdk/javax/security/auth/Subject/DoAsTest.java
+++ b/test/jdk/javax/security/auth/Subject/DoAsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.security.auth.Subject;
 
-public class DoAs {
+public class DoAsTest {
 
     public static void main(String[] args) throws Exception {
         final Set<String> outer = new HashSet<>(Arrays.asList("Outer"));


### PR DESCRIPTION
Rename the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318689](https://bugs.openjdk.org/browse/JDK-8318689): jtreg is confused when folder name is the same as the test name (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16323/head:pull/16323` \
`$ git checkout pull/16323`

Update a local copy of the PR: \
`$ git checkout pull/16323` \
`$ git pull https://git.openjdk.org/jdk.git pull/16323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16323`

View PR using the GUI difftool: \
`$ git pr show -t 16323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16323.diff">https://git.openjdk.org/jdk/pull/16323.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16323#issuecomment-1776030448)