### PR TITLE
8318613: ChoiceFormat patterns are not well tested

### DIFF
--- a/test/jdk/java/text/Format/ChoiceFormat/PatternsTest.java
+++ b/test/jdk/java/text/Format/ChoiceFormat/PatternsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6801704
+ * @summary Test the expected behavior for a wide range of patterns (both
+ *          correct and incorrect). This test documents the behavior of incorrect
+ *          ChoiceFormat patterns either throwing an exception, or discarding
+ *          the incorrect portion of a pattern.
+ * @run junit PatternsTest
+ */
+
+import java.text.ChoiceFormat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class PatternsTest {
+
+    private static final String err1 =
+            "Each interval must contain a number before a format";
+    private static final String err2 =
+            "Incorrect order of intervals, must be in ascending order";
+
+    // Check that some valid patterns do not throw an exception
+    @ParameterizedTest
+    @MethodSource("validPatterns")
+    public void validPatternsTest(String pattern) {
+        assertDoesNotThrow( ()-> new ChoiceFormat(pattern),
+                "Valid pattern threw an exception");
+    }
+
+    // Valid patterns ranging from normal appearing to odd
+    private static String[] validPatterns() {
+        return new String[] {
+                "1#foo|2#foo|", // Trailing '|'
+                "1#foo|1<baz", // Same numerical value Limits, different Relations
+                "1#foo|2#bar>", // Using a '>' (not a Relation) within a Format
+                "1#|2<|3#", // Format can be an empty string
+                "1#foo", // normal pattern
+                "1#foo|2#bar", // normal multi pattern
+                "1#" // normal pattern with empty string Format
+        };
+    }
+
+    // Check that the incorrect pattern throws an IAE with the desired error msg
+    // This also tests applyPattern, as the ChoiceFormat constructor calls applyPattern
+    @ParameterizedTest
+    @MethodSource
+    public void invalidPatternsThrows(String pattern, String errMsg) {
+        var ex = assertThrows(IllegalArgumentException.class,
+                () -> new ChoiceFormat(pattern));
+        assertEquals(errMsg, ex.getMessage());
+    }
+
+    // Variety of patterns that break the ChoiceFormat pattern syntax and throw
+    // an exception.
+    private static Arguments[] invalidPatternsThrows() {
+        return new Arguments[] {
+                arguments("#foo", err1), // No Limit
+                arguments("0#foo|#|1#bar", err1), // Missing Relation in SubPattern
+                arguments("#|", err1), // Missing Limit
+                arguments("##|", err1), // Double Relations
+                arguments("0#foo1#", err1), // SubPattern not separated by '|'
+                arguments("0#foo#", err1), // Using a Relation in a format
+                arguments("0#test|#", err1), // SubPattern missing Limit
+                arguments("0#foo|3#bar|1#baz", err2), // Non-ascending Limits
+        };
+    }
+
+    // Check that the incorrect pattern discards the trailing incorrect portion
+    // These incorrect patterns should ideally throw an exception, but for
+    // behavioral compatibility reasons do not.
+    @ParameterizedTest
+    @MethodSource
+    public void invalidPatternsDiscarded(String brokenPattern, String actualPattern) {
+        var cf1 = new ChoiceFormat(brokenPattern);
+        var cf2 = new ChoiceFormat(actualPattern);
+        assertEquals(cf2, cf1,
+                String.format("Expected %s, but got %s", cf2.toPattern(), cf1.toPattern()));
+        if (actualPattern.isEmpty()) {
+            assertThrows(ArrayIndexOutOfBoundsException.class, () -> cf1.format(1));
+        }
+    }
+
+    // Variety of incorrect patterns with the actual expected pattern
+    private static Arguments[] invalidPatternsDiscarded() {
+        return new Arguments[] {
+                // Incomplete SubPattern at the end of the Pattern
+                arguments("0#foo|1#bar|baz", "0#foo|1#bar"),
+
+                // --- These throw an ArrayIndexOutOfBoundsException
+                // when attempting to format with them ---
+                // SubPattern with only a Limit (which is interpreted as a Format)
+                arguments("0", ""),
+                // SubPattern with only a Format
+                arguments("foo", ""),
+                // empty string
+                arguments("", "")
+        };
+    }
+}

--- a/test/jdk/java/text/Format/ChoiceFormat/PatternsTest.java
+++ b/test/jdk/java/text/Format/ChoiceFormat/PatternsTest.java
@@ -45,30 +45,41 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class PatternsTest {
 
-    private static final String err1 =
+    private static final String ERR1 =
             "Each interval must contain a number before a format";
-    private static final String err2 =
+    private static final String ERR2 =
             "Incorrect order of intervals, must be in ascending order";
 
-    // Check that some valid patterns do not throw an exception
+    // Check that some valid patterns do not throw an exception. Check
+    // them against the expected values they should be formatted as.
     @ParameterizedTest
     @MethodSource
-    public void validPatternsTest(String pattern) {
-        assertDoesNotThrow( ()-> new ChoiceFormat(pattern),
-                "Valid pattern should not have thrown an exception");
+    public void validPatternsTest(String pattern, String[] expectedValues) {
+        var fmt = new ChoiceFormat(pattern);
+        for (int i=1; i<=expectedValues.length; i++) {
+            assertEquals(expectedValues[i-1], fmt.format(i),
+                    String.format("ChoiceFormat formatted %s incorrectly:", i));
+        }
     }
 
     // Valid patterns ranging from normal appearing to odd. These should not
     // throw an exception or discard any portions of the pattern.
-    private static String[] validPatternsTest() {
-        return new String[] {
-                "1#foo|2#bar|3#", // Multi pattern with trailing empty string Format
-                "1#foo|2#foo|", // Multi patten with trailing '|'
-                "1#foo|2#bar>", // Using a '>' (not a Relation) within a Format
-                "1#foo|2#bar", // Standard Multi Pattern
-                "1#foo|1<baz", // Same numerical value Limits, different Relations
-                "1#foo", // Standard Single Pattern
-                "1#", // Single pattern with empty string Format
+    private static Arguments[] validPatternsTest() {
+        return new Arguments[] {
+                // Multi pattern with trailing empty string Format
+                arguments("1#foo|2#bar|3#", new String[]{"foo", "bar", ""}),
+                // Multi patten with trailing '|'
+                arguments("1#foo|2#bar|", new String[]{"foo", "bar"}),
+                // Using a '>' (not a Relation) within a Format
+                arguments("1#foo|2#bar>", new String[]{"foo", "bar>"}),
+                // Standard Multi Pattern
+                arguments("1#foo|2#bar", new String[]{"foo", "bar"}),
+                // Same numerical value Limits, different Relations
+                arguments("1#foo|1<baz", new String[]{"foo", "baz"}),
+                // Standard Single Pattern
+                arguments("1#foo", new String[]{"foo"}),
+                // Single pattern with empty string Format
+                arguments("1#", new String[]{""})
         };
     }
 
@@ -86,14 +97,14 @@ public class PatternsTest {
     // an exception.
     private static Arguments[] invalidPatternsThrowsTest() {
         return new Arguments[] {
-                arguments("#foo", err1), // No Limit
-                arguments("0#foo|#|1#bar", err1), // Missing Relation in SubPattern
-                arguments("#|", err1), // Missing Limit
-                arguments("##|", err1), // Double Relations
-                arguments("0#foo1#", err1), // SubPattern not separated by '|'
-                arguments("0#foo#", err1), // Using a Relation in a format
-                arguments("0#test|#", err1), // SubPattern missing Limit
-                arguments("0#foo|3#bar|1#baz", err2), // Non-ascending Limits
+                arguments("#foo", ERR1), // No Limit
+                arguments("0#foo|#|1#bar", ERR1), // Missing Relation in SubPattern
+                arguments("#|", ERR1), // Missing Limit
+                arguments("##|", ERR1), // Double Relations
+                arguments("0#foo1#", ERR1), // SubPattern not separated by '|'
+                arguments("0#foo#", ERR1), // Using a Relation in a format
+                arguments("0#test|#", ERR1), // SubPattern missing Limit
+                arguments("0#foo|3#bar|1#baz", ERR2), // Non-ascending Limits
         };
     }
 

--- a/test/jdk/java/text/Format/ChoiceFormat/PatternsTest.java
+++ b/test/jdk/java/text/Format/ChoiceFormat/PatternsTest.java
@@ -33,6 +33,7 @@
 
 import java.text.ChoiceFormat;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -106,9 +107,6 @@ public class PatternsTest {
         var cf2 = new ChoiceFormat(actualPattern);
         assertEquals(cf2, cf1,
                 String.format("Expected %s, but got %s", cf2.toPattern(), cf1.toPattern()));
-        if (actualPattern.isEmpty()) {
-            assertThrows(ArrayIndexOutOfBoundsException.class, () -> cf1.format(1));
-        }
     }
 
     // Variety of incorrect patterns with the actual expected pattern
@@ -127,5 +125,18 @@ public class PatternsTest {
                 // empty string
                 arguments("", "")
         };
+    }
+
+    // Calling format() with empty limits and formats
+    // throws an ArrayIndexOutOfBoundsException
+    @Test
+    public void emptyLimitsAndFormatsTest() {
+        var cf1 = new ChoiceFormat("");
+        assertThrows(ArrayIndexOutOfBoundsException.class,
+                () -> cf1.format(1));
+
+        var cf2 = new ChoiceFormat(new double[]{}, new String[]{});
+        assertThrows(ArrayIndexOutOfBoundsException.class,
+                () -> cf2.format(2));
     }
 }

--- a/test/jdk/java/text/Format/ChoiceFormat/PatternsTest.java
+++ b/test/jdk/java/text/Format/ChoiceFormat/PatternsTest.java
@@ -51,22 +51,23 @@ public class PatternsTest {
 
     // Check that some valid patterns do not throw an exception
     @ParameterizedTest
-    @MethodSource("validPatterns")
+    @MethodSource
     public void validPatternsTest(String pattern) {
         assertDoesNotThrow( ()-> new ChoiceFormat(pattern),
-                "Valid pattern threw an exception");
+                "Valid pattern should not have thrown an exception");
     }
 
-    // Valid patterns ranging from normal appearing to odd
-    private static String[] validPatterns() {
+    // Valid patterns ranging from normal appearing to odd. These should not
+    // throw an exception or discard any portions of the pattern.
+    private static String[] validPatternsTest() {
         return new String[] {
-                "1#foo|2#foo|", // Trailing '|'
-                "1#foo|1<baz", // Same numerical value Limits, different Relations
+                "1#foo|2#bar|3#", // Multi pattern with trailing empty string Format
+                "1#foo|2#foo|", // Multi patten with trailing '|'
                 "1#foo|2#bar>", // Using a '>' (not a Relation) within a Format
-                "1#|2<|3#", // Format can be an empty string
-                "1#foo", // normal pattern
-                "1#foo|2#bar", // normal multi pattern
-                "1#" // normal pattern with empty string Format
+                "1#foo|2#bar", // Standard Multi Pattern
+                "1#foo|1<baz", // Same numerical value Limits, different Relations
+                "1#foo", // Standard Single Pattern
+                "1#", // Single pattern with empty string Format
         };
     }
 
@@ -74,7 +75,7 @@ public class PatternsTest {
     // This also tests applyPattern, as the ChoiceFormat constructor calls applyPattern
     @ParameterizedTest
     @MethodSource
-    public void invalidPatternsThrows(String pattern, String errMsg) {
+    public void invalidPatternsThrowsTest(String pattern, String errMsg) {
         var ex = assertThrows(IllegalArgumentException.class,
                 () -> new ChoiceFormat(pattern));
         assertEquals(errMsg, ex.getMessage());
@@ -82,7 +83,7 @@ public class PatternsTest {
 
     // Variety of patterns that break the ChoiceFormat pattern syntax and throw
     // an exception.
-    private static Arguments[] invalidPatternsThrows() {
+    private static Arguments[] invalidPatternsThrowsTest() {
         return new Arguments[] {
                 arguments("#foo", err1), // No Limit
                 arguments("0#foo|#|1#bar", err1), // Missing Relation in SubPattern
@@ -95,12 +96,12 @@ public class PatternsTest {
         };
     }
 
-    // Check that the incorrect pattern discards the trailing incorrect portion
+    // Check that the incorrect pattern discards the trailing incorrect portion.
     // These incorrect patterns should ideally throw an exception, but for
     // behavioral compatibility reasons do not.
     @ParameterizedTest
     @MethodSource
-    public void invalidPatternsDiscarded(String brokenPattern, String actualPattern) {
+    public void invalidPatternsDiscardedTest(String brokenPattern, String actualPattern) {
         var cf1 = new ChoiceFormat(brokenPattern);
         var cf2 = new ChoiceFormat(actualPattern);
         assertEquals(cf2, cf1,
@@ -111,7 +112,8 @@ public class PatternsTest {
     }
 
     // Variety of incorrect patterns with the actual expected pattern
-    private static Arguments[] invalidPatternsDiscarded() {
+    // after discarding occurs.
+    private static Arguments[] invalidPatternsDiscardedTest() {
         return new Arguments[] {
                 // Incomplete SubPattern at the end of the Pattern
                 arguments("0#foo|1#bar|baz", "0#foo|1#bar"),


### PR DESCRIPTION
Please review this PR which adds a test for ChoiceFormat intended to test a wide range of ChoiceFormat patterns.

The existing test _Bug4387255_ only tests a singular basic pattern and does not test for incorrect patterns either.

The new test checks 

- both correct and incorrect patterns
- the behavior of incorrect patterns that either throw an IllegalArgumentException or discard the incorrect portion
- the case of formatting with an empty pattern (that leads to empty limits and formats)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318613](https://bugs.openjdk.org/browse/JDK-8318613): ChoiceFormat patterns are not well tested (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16324/head:pull/16324` \
`$ git checkout pull/16324`

Update a local copy of the PR: \
`$ git checkout pull/16324` \
`$ git pull https://git.openjdk.org/jdk.git pull/16324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16324`

View PR using the GUI difftool: \
`$ git pr show -t 16324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16324.diff">https://git.openjdk.org/jdk/pull/16324.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16324#issuecomment-1776043267)