### PR TITLE
8318691: runtime/CompressedOops/CompressedClassPointersEncodingScheme.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointersEncodingScheme.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Testing that, faced with a given (possibly odd) mapping address of class space, the encoding
  *          scheme fits the address
- * @requires vm.bits == 64 & !vm.graal.enabled
+ * @requires vm.bits == 64 & !vm.graal.enabled & vm.debug == true
  * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
The test fails due to VM option 'CompressedClassSpaceBaseAddress' is develop and is available only in debug version of VM.
So the fix just disables the test for release VMs.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318691](https://bugs.openjdk.org/browse/JDK-8318691): runtime/CompressedOops/CompressedClassPointersEncodingScheme.java fails with release VMs (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16330/head:pull/16330` \
`$ git checkout pull/16330`

Update a local copy of the PR: \
`$ git checkout pull/16330` \
`$ git pull https://git.openjdk.org/jdk.git pull/16330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16330`

View PR using the GUI difftool: \
`$ git pr show -t 16330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16330.diff">https://git.openjdk.org/jdk/pull/16330.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16330#issuecomment-1776370740)