### PR TITLE
8318709: Improve System.nanoTime performance on Windows

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -801,7 +801,7 @@ void os::free_thread(OSThread* osthread) {
 static jlong first_filetime;
 static jlong initial_performance_count;
 static jlong performance_frequency;
-static double counts_per_nano; // NANOSECS_PER_SEC / performance_frequency
+static double nanos_per_count; // NANOSECS_PER_SEC / performance_frequency
 
 jlong os::elapsed_counter() {
   LARGE_INTEGER count;
@@ -971,7 +971,7 @@ void os::win32::initialize_performance_counter() {
   LARGE_INTEGER count;
   QueryPerformanceFrequency(&count);
   performance_frequency = count.QuadPart;
-  counts_per_nano = NANOSECS_PER_SEC / (double)performance_frequency;
+  nanos_per_count = NANOSECS_PER_SEC / (double)performance_frequency;
   QueryPerformanceCounter(&count);
   initial_performance_count = count.QuadPart;
 }
@@ -1076,7 +1076,7 @@ jlong os::javaTimeNanos() {
     LARGE_INTEGER current_count;
     QueryPerformanceCounter(&current_count);
     double current = current_count.QuadPart;
-    jlong time = (jlong)(current * counts_per_nano);
+    jlong time = (jlong)(current * nanos_per_count);
     return time;
 }
 

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -801,20 +801,12 @@ void os::free_thread(OSThread* osthread) {
 static jlong first_filetime;
 static jlong initial_performance_count;
 static jlong performance_frequency;
-
-
-jlong as_long(LARGE_INTEGER x) {
-  jlong result = 0; // initialization to avoid warning
-  set_high(&result, x.HighPart);
-  set_low(&result, x.LowPart);
-  return result;
-}
-
+static double counts_per_nano; // NANOSECS_PER_SEC / performance_frequency
 
 jlong os::elapsed_counter() {
   LARGE_INTEGER count;
   QueryPerformanceCounter(&count);
-  return as_long(count) - initial_performance_count;
+  return count.QuadPart - initial_performance_count;
 }
 
 
@@ -978,9 +970,10 @@ void os::set_native_thread_name(const char *name) {
 void os::win32::initialize_performance_counter() {
   LARGE_INTEGER count;
   QueryPerformanceFrequency(&count);
-  performance_frequency = as_long(count);
+  performance_frequency = count.QuadPart;
+  counts_per_nano = NANOSECS_PER_SEC / (double)performance_frequency;
   QueryPerformanceCounter(&count);
-  initial_performance_count = as_long(count);
+  initial_performance_count = count.QuadPart;
 }
 
 
@@ -1082,9 +1075,8 @@ void os::javaTimeSystemUTC(jlong &seconds, jlong &nanos) {
 jlong os::javaTimeNanos() {
     LARGE_INTEGER current_count;
     QueryPerformanceCounter(&current_count);
-    double current = as_long(current_count);
-    double freq = performance_frequency;
-    jlong time = (jlong)((current/freq) * NANOSECS_PER_SEC);
+    double current = current_count.QuadPart;
+    jlong time = (jlong)(current * counts_per_nano);
     return time;
 }
 


### PR DESCRIPTION
- use LARGE_INTEGER.QuadPart instead of assembling the jlong from high/low parts
- precalculate counts_per_nano to avoid costly floating-point division in counter to nanosecond conversion

Benchmark before:
SystemTime.nanoTime                avgt   15  19,366 � 0,383  ns/op

After:
SystemTime.nanoTime                avgt   15  15,812 � 0,385  ns/op

Tier1-2 clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318709](https://bugs.openjdk.org/browse/JDK-8318709): Improve System.nanoTime performance on Windows (**Enhancement** - P4)


### Reviewers
 * [Conor Cleary](https://openjdk.org/census#ccleary) (@c-cleary - Committer) ⚠️ Review applies to [50bf0dd3](https://git.openjdk.org/jdk/pull/16336/files/50bf0dd369b91c6451d4b328576196300c85da0a)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16336/head:pull/16336` \
`$ git checkout pull/16336`

Update a local copy of the PR: \
`$ git checkout pull/16336` \
`$ git pull https://git.openjdk.org/jdk.git pull/16336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16336`

View PR using the GUI difftool: \
`$ git pr show -t 16336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16336.diff">https://git.openjdk.org/jdk/pull/16336.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16336#issuecomment-1776916440)