### PR TITLE
8318701: Fix copyright year

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/jfr/jvm/TestEventWriterLog.java
+++ b/test/jdk/jdk/jfr/jvm/TestEventWriterLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Fix copyright year to 2023

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318701](https://bugs.openjdk.org/browse/JDK-8318701): Fix copyright year (**Enhancement** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16338/head:pull/16338` \
`$ git checkout pull/16338`

Update a local copy of the PR: \
`$ git checkout pull/16338` \
`$ git pull https://git.openjdk.org/jdk.git pull/16338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16338`

View PR using the GUI difftool: \
`$ git pr show -t 16338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16338.diff">https://git.openjdk.org/jdk/pull/16338.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16338#issuecomment-1776826053)