### PR TITLE
8318702: G1: Fix nonstandard indentation in g1HeapTransition.cpp

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -143,11 +143,11 @@ void G1HeapTransition::print() {
     usage = blk._usage;
     assert(usage._eden_region_count == 0, "Expected no eden regions, but got " SIZE_FORMAT, usage._eden_region_count);
     assert(usage._survivor_region_count == after._survivor_length, "Expected survivors to be " SIZE_FORMAT " but was " SIZE_FORMAT,
-        after._survivor_length, usage._survivor_region_count);
+           after._survivor_length, usage._survivor_region_count);
     assert(usage._old_region_count == after._old_length, "Expected old to be " SIZE_FORMAT " but was " SIZE_FORMAT,
-        after._old_length, usage._old_region_count);
+           after._old_length, usage._old_region_count);
     assert(usage._humongous_region_count == after._humongous_length, "Expected humongous to be " SIZE_FORMAT " but was " SIZE_FORMAT,
-        after._humongous_length, usage._humongous_region_count);
+           after._humongous_length, usage._humongous_region_count);
   }
 
   log_regions("Eden", _before._eden_length, after._eden_length, eden_capacity_length_after_gc,
@@ -157,17 +157,17 @@ void G1HeapTransition::print() {
   log_regions("Survivor", _before._survivor_length, after._survivor_length, survivor_capacity_length_before_gc,
               _before._survivor_length_per_node, after._survivor_length_per_node);
   log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
-      usage._survivor_used / K, ((after._survivor_length * HeapRegion::GrainBytes) - usage._survivor_used) / K);
+                      usage._survivor_used / K, ((after._survivor_length * HeapRegion::GrainBytes) - usage._survivor_used) / K);
 
   log_info(gc, heap)("Old regions: " SIZE_FORMAT "->" SIZE_FORMAT,
                      _before._old_length, after._old_length);
   log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
-      usage._old_used / K, ((after._old_length * HeapRegion::GrainBytes) - usage._old_used) / K);
+                      usage._old_used / K, ((after._old_length * HeapRegion::GrainBytes) - usage._old_used) / K);
 
   log_info(gc, heap)("Humongous regions: " SIZE_FORMAT "->" SIZE_FORMAT,
                      _before._humongous_length, after._humongous_length);
   log_trace(gc, heap)(" Used: " SIZE_FORMAT "K, Waste: " SIZE_FORMAT "K",
-      usage._humongous_used / K, ((after._humongous_length * HeapRegion::GrainBytes) - usage._humongous_used) / K);
+                      usage._humongous_used / K, ((after._humongous_length * HeapRegion::GrainBytes) - usage._humongous_used) / K);
 
   MetaspaceUtils::print_metaspace_change(_before._meta_sizes);
 }


### PR DESCRIPTION
Hi all,

  please review this trivial change to indentation in [g1HeapTransition.cpp](https://github.com/openjdk/jdk/compare/master...tschatzl:jdk:submit/8318702-indentation-g1heaptransition#diff-8b92b84617e96611627362128515c65c52cadc1cfec3ec6c986c780a6d744e5f).

Test: local compilation.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318702](https://bugs.openjdk.org/browse/JDK-8318702): G1: Fix nonstandard indentation in g1HeapTransition.cpp (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16339/head:pull/16339` \
`$ git checkout pull/16339`

Update a local copy of the PR: \
`$ git checkout pull/16339` \
`$ git pull https://git.openjdk.org/jdk.git pull/16339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16339`

View PR using the GUI difftool: \
`$ git pr show -t 16339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16339.diff">https://git.openjdk.org/jdk/pull/16339.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16339#issuecomment-1776836079)