### PR TITLE
8318492: Http2ClientImpl should attempt to close and remove connection in stop()

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2ClientImpl.java
@@ -228,11 +228,11 @@ class Http2ClientImpl {
             connectionPoolLock.unlock();
         }
         do {
-            connections.values().forEach(this::close);
+            connections.values().removeIf(this::close);
         } while (!connections.isEmpty());
     }
 
-    private void close(Http2Connection h2c) {
+    private boolean close(Http2Connection h2c) {
         // close all streams
         try { h2c.closeAllStreams(); } catch (Throwable t) {}
         // send GOAWAY
@@ -241,6 +241,8 @@ class Http2ClientImpl {
         try { h2c.shutdown(STOPPED); } catch (Throwable t) {}
         // double check and close any new streams
         try { h2c.closeAllStreams(); } catch (Throwable t) {}
+        // Allows for use of removeIf in stop()
+        return true;
     }
 
     HttpClientImpl client() {


### PR DESCRIPTION
If Http2ClientImpl::stop() is called, it will loop through the connections map and call the close() method on each connection. The changes in this PR make sure that the connection thread (where close is called from) removes the `Http2Connection` from the connection pool to prevent inactive connections from remaining in there rather than just closing it. 

Even though the connection can be and usually is removed from the pool in other places (reader or writer thread), this change ensures removal from the pool in cases where the connection is shutdown by an exception, reset, etc. The issue was first spotted when a RST_STREAM triggered repeated attempts to remove idle connections from the pool before a regular shutdown could occur.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318492](https://bugs.openjdk.org/browse/JDK-8318492): Http2ClientImpl should attempt to close and remove connection in stop() (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16340/head:pull/16340` \
`$ git checkout pull/16340`

Update a local copy of the PR: \
`$ git checkout pull/16340` \
`$ git pull https://git.openjdk.org/jdk.git pull/16340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16340`

View PR using the GUI difftool: \
`$ git pr show -t 16340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16340.diff">https://git.openjdk.org/jdk/pull/16340.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16340#issuecomment-1777146405)