### PR TITLE
8318705: [macos] ProblemList java/rmi/registry/multipleRegistries/MultipleRegistries.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -585,6 +585,7 @@ java/rmi/transport/rapidExportUnexport/RapidExportUnexport.java 7146541 linux-al
 java/rmi/transport/checkLeaseInfoLeak/CheckLeaseLeak.java       7191877 generic-all
 
 java/rmi/registry/readTest/CodebaseTest.java                    8173324 windows-all
+java/rmi/registry/multipleRegistries/MultipleRegistries.java    8268182 macosx-all
 
 java/rmi/Naming/DefaultRegistryPort.java                        8005619 windows-all
 java/rmi/Naming/legalRegistryNames/LegalRegistryNames.java      8005619 windows-all


### PR DESCRIPTION
…tipleRegistries.java

The test fails in our CI with the message listed here. We see both, aarch and x86_64. It happens rarely, but a long time back.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318705](https://bugs.openjdk.org/browse/JDK-8318705): [macos] ProblemList java/rmi/registry/multipleRegistries/MultipleRegistries.java (**Sub-task** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16341/head:pull/16341` \
`$ git checkout pull/16341`

Update a local copy of the PR: \
`$ git checkout pull/16341` \
`$ git pull https://git.openjdk.org/jdk.git pull/16341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16341`

View PR using the GUI difftool: \
`$ git pr show -t 16341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16341.diff">https://git.openjdk.org/jdk/pull/16341.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16341#issuecomment-1778604520)