### PR TITLE
8318669: Target OS detection in 'test-prebuilt' makefile target is incorrect when running on MSYS2

### DIFF
--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -158,22 +158,20 @@ ifeq ($(UNAME_OS), CYGWIN)
   OPENJDK_TARGET_OS := windows
   OPENJDK_TARGET_OS_TYPE := windows
   OPENJDK_TARGET_OS_ENV := windows.cygwin
+else ifeq ($(UNAME_OS), MINGW64)
+  OPENJDK_TARGET_OS := windows
+  OPENJDK_TARGET_OS_TYPE := windows
+  OPENJDK_TARGET_OS_ENV := windows.msys2
 else
-  ifeq ($(UNAME_OS), MINGW64)
-    OPENJDK_TARGET_OS := windows
-    OPENJDK_TARGET_OS_TYPE := windows
-    OPENJDK_TARGET_OS_ENV := windows.msys2
+  OPENJDK_TARGET_OS_TYPE:=unix
+  ifeq ($(UNAME_OS), Linux)
+    OPENJDK_TARGET_OS := linux
+  else ifeq ($(UNAME_OS), Darwin)
+    OPENJDK_TARGET_OS := macosx
   else
-    OPENJDK_TARGET_OS_TYPE:=unix
-    ifeq ($(UNAME_OS), Linux)
-      OPENJDK_TARGET_OS := linux
-    else ifeq ($(UNAME_OS), Darwin)
-      OPENJDK_TARGET_OS := macosx
-    else
-      OPENJDK_TARGET_OS := $(UNAME_OS)
-    endif
-    OPENJDK_TARGET_OS_ENV := $(OPENJDK_TARGET_OS)
+    OPENJDK_TARGET_OS := $(UNAME_OS)
   endif
+  OPENJDK_TARGET_OS_ENV := $(OPENJDK_TARGET_OS)
 endif
 
 # Sanity check env detection

--- a/make/RunTestsPrebuilt.gmk
+++ b/make/RunTestsPrebuilt.gmk
@@ -159,16 +159,25 @@ ifeq ($(UNAME_OS), CYGWIN)
   OPENJDK_TARGET_OS_TYPE := windows
   OPENJDK_TARGET_OS_ENV := windows.cygwin
 else
-  OPENJDK_TARGET_OS_TYPE:=unix
-  ifeq ($(UNAME_OS), Linux)
-    OPENJDK_TARGET_OS := linux
-  else ifeq ($(UNAME_OS), Darwin)
-    OPENJDK_TARGET_OS := macosx
+  ifeq ($(UNAME_OS), MINGW64)
+    OPENJDK_TARGET_OS := windows
+    OPENJDK_TARGET_OS_TYPE := windows
+    OPENJDK_TARGET_OS_ENV := windows.msys2
   else
-    OPENJDK_TARGET_OS := $(UNAME_OS)
+    OPENJDK_TARGET_OS_TYPE:=unix
+    ifeq ($(UNAME_OS), Linux)
+      OPENJDK_TARGET_OS := linux
+    else ifeq ($(UNAME_OS), Darwin)
+      OPENJDK_TARGET_OS := macosx
+    else
+      OPENJDK_TARGET_OS := $(UNAME_OS)
+    endif
+    OPENJDK_TARGET_OS_ENV := $(OPENJDK_TARGET_OS)
   endif
-  OPENJDK_TARGET_OS_ENV := $(OPENJDK_TARGET_OS)
 endif
+
+# Sanity check env detection
+$(info Detected target OS, type and env: [$(OPENJDK_TARGET_OS)] [$(OPENJDK_TARGET_OS_TYPE)] [$(OPENJDK_TARGET_OS_ENV)])
 
 # Assume little endian unless otherwise specified
 OPENJDK_TARGET_CPU_ENDIAN := little


### PR DESCRIPTION
This PR addresses OS detection not working properly when running test-prebuilt on MSYS2, which causes some Windows specific tests to misbehave or fail in Github Actions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318669](https://bugs.openjdk.org/browse/JDK-8318669): Target OS detection in 'test-prebuilt' makefile target is incorrect when running on MSYS2 (**Bug** - P3)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16343/head:pull/16343` \
`$ git checkout pull/16343`

Update a local copy of the PR: \
`$ git checkout pull/16343` \
`$ git pull https://git.openjdk.org/jdk.git pull/16343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16343`

View PR using the GUI difftool: \
`$ git pr show -t 16343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16343.diff">https://git.openjdk.org/jdk/pull/16343.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16343#issuecomment-1777793893)