### PR TITLE
8316746: Top of lock-stack does not match the unlocked object

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -2241,7 +2241,7 @@ void PhaseMacroExpand::expand_unlock_node(UnlockNode *unlock) {
   Node* obj = unlock->obj_node();
   Node* box = unlock->box_node();
 
-  assert(!box->as_BoxLock()->is_eliminated(), "sanity");
+  assert(box->is_Con() || !box->as_BoxLock()->is_eliminated(), "sanity");
 
   // No need for a null check on unlock
 


### PR DESCRIPTION
In case of OSR compilations, `map()->peek_monitor_obj()` may return the objects in wrong order. We should use the popped object. I'm not changing the code for `LM_LEGACY`. That may be done separately.
Note that C1 uses the popped object, too: `case Bytecodes::_monitorexit    : monitorexit (apop(), s.cur_bci());`

This PR is not complete: A lot of C2 code uses the BoxLock. Ideas to solve that are welcome! I think we should get rid of these nodes in the long term because they are only really needed by `LM_LEGACY`.
The vmTestbase/nsk/jdi/StepEvent tests are passing stable on x64 and ppc64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316746](https://bugs.openjdk.org/browse/JDK-8316746): Top of lock-stack does not match the unlocked object (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16345/head:pull/16345` \
`$ git checkout pull/16345`

Update a local copy of the PR: \
`$ git checkout pull/16345` \
`$ git pull https://git.openjdk.org/jdk.git pull/16345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16345`

View PR using the GUI difftool: \
`$ git pr show -t 16345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16345.diff">https://git.openjdk.org/jdk/pull/16345.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16345#issuecomment-1777106878)