### PR TITLE
8318723: RISC-V: C2 UDivL

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_arith_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_arith_riscv.cpp
@@ -86,7 +86,7 @@ void LIR_Assembler::arithmetic_idiv(LIR_Code code, LIR_Opr left, LIR_Opr right, 
     }
   } else {
     Register rreg = right->as_register();
-    __ corrected_idivl(dreg, lreg, rreg, is_irem);
+    __ corrected_idivl(dreg, lreg, rreg, is_irem, /* is_signed */ true);
   }
 }
 
@@ -172,8 +172,12 @@ void LIR_Assembler::arith_op_double_cpu(LIR_Code code, LIR_Opr left, LIR_Opr rig
       case lir_add: __ add(dest->as_register_lo(), lreg_lo, rreg_lo); break;
       case lir_sub: __ sub(dest->as_register_lo(), lreg_lo, rreg_lo); break;
       case lir_mul: __ mul(dest->as_register_lo(), lreg_lo, rreg_lo); break;
-      case lir_div: __ corrected_idivq(dest->as_register_lo(), lreg_lo, rreg_lo, false); break;
-      case lir_rem: __ corrected_idivq(dest->as_register_lo(), lreg_lo, rreg_lo, true); break;
+      case lir_div: __ corrected_idivq(dest->as_register_lo(), lreg_lo, rreg_lo,
+                                       /* want_remainder */ false, /* is_signed */ true);
+                    break;
+      case lir_rem: __ corrected_idivq(dest->as_register_lo(), lreg_lo, rreg_lo,
+                                       /* want_remainder */ true, /* is_signed */ true);
+                    break;
       default:
         ShouldNotReachHere();
     }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2386,7 +2386,7 @@ void MacroAssembler::store_heap_oop_null(Address dst) {
 }
 
 int MacroAssembler::corrected_idivl(Register result, Register rs1, Register rs2,
-                                    bool want_remainder)
+                                    bool want_remainder, bool is_signed)
 {
   // Full implementation of Java idiv and irem.  The function
   // returns the (pc) offset of the div instruction - may be needed
@@ -2402,7 +2402,11 @@ int MacroAssembler::corrected_idivl(Register result, Register rs1, Register rs2,
 
   int idivl_offset = offset();
   if (!want_remainder) {
-    divw(result, rs1, rs2);
+    if (is_signed) {
+      divw(result, rs1, rs2);
+    } else {
+      divuw(result, rs1, rs2);
+    }
   } else {
     remw(result, rs1, rs2); // result = rs1 % rs2;
   }
@@ -2410,7 +2414,7 @@ int MacroAssembler::corrected_idivl(Register result, Register rs1, Register rs2,
 }
 
 int MacroAssembler::corrected_idivq(Register result, Register rs1, Register rs2,
-                                    bool want_remainder)
+                                    bool want_remainder, bool is_signed)
 {
   // Full implementation of Java ldiv and lrem.  The function
   // returns the (pc) offset of the div instruction - may be needed
@@ -2425,7 +2429,20 @@ int MacroAssembler::corrected_idivq(Register result, Register rs1, Register rs2,
 
   int idivq_offset = offset();
   if (!want_remainder) {
-    div(result, rs1, rs2);
+    if (is_signed) {
+      div(result, rs1, rs2);
+    } else {
+      Label Lltz, Ldone;
+      bltz(rs2, Lltz);
+      divu(result, rs1, rs2);
+      j(Ldone);
+      bind(Lltz); // For the algorithm details, check j.l.Long::divideUnsigned
+      sub(result, rs1, rs2);
+      notr(result, result);
+      andr(result, result, rs1);
+      srli(result, result, 63);
+      bind(Ldone);
+    }
   } else {
     rem(result, rs1, rs2); // result = rs1 % rs2;
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2432,16 +2432,7 @@ int MacroAssembler::corrected_idivq(Register result, Register rs1, Register rs2,
     if (is_signed) {
       div(result, rs1, rs2);
     } else {
-      Label Lltz, Ldone;
-      bltz(rs2, Lltz);
       divu(result, rs1, rs2);
-      j(Ldone);
-      bind(Lltz); // For the algorithm details, check j.l.Long::divideUnsigned
-      sub(result, rs1, rs2);
-      notr(result, result);
-      andr(result, result, rs1);
-      srli(result, result, 63);
-      bind(Ldone);
     }
   } else {
     rem(result, rs1, rs2); // result = rs1 % rs2;

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -241,9 +241,9 @@ class MacroAssembler: public Assembler {
 
   // idiv variant which deals with MINLONG as dividend and -1 as divisor
   int corrected_idivl(Register result, Register rs1, Register rs2,
-                      bool want_remainder, bool is_signed = true);
+                      bool want_remainder, bool is_signed);
   int corrected_idivq(Register result, Register rs1, Register rs2,
-                      bool want_remainder, bool is_signed = true);
+                      bool want_remainder, bool is_signed);
 
   // interface method calling
   void lookup_interface_method(Register recv_klass,

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -241,9 +241,9 @@ class MacroAssembler: public Assembler {
 
   // idiv variant which deals with MINLONG as dividend and -1 as divisor
   int corrected_idivl(Register result, Register rs1, Register rs2,
-                      bool want_remainder);
+                      bool want_remainder, bool is_signed = true);
   int corrected_idivq(Register result, Register rs1, Register rs2,
-                      bool want_remainder);
+                      bool want_remainder, bool is_signed = true);
 
   // interface method calling
   void lookup_interface_method(Register recv_klass,

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6673,6 +6673,17 @@ instruct divI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   ins_pipe(idiv_reg_reg);
 %}
 
+instruct UdivI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (UDivI src1 src2));
+  ins_cost(IDIVSI_COST);
+  format %{ "divuw  $dst, $src1, $src2\t#@UdivI"%}
+
+  ins_encode %{
+    __ divuw(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
+  %}
+  ins_pipe(idiv_reg_reg);
+%}
+
 instruct signExtract(iRegINoSp dst, iRegIorL2I src1, immI_31 div1, immI_31 div2) %{
   match(Set dst (URShiftI (RShiftI src1 div1) div2));
   ins_cost(ALU_COST);
@@ -6692,6 +6703,38 @@ instruct divL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   format %{ "div  $dst, $src1, $src2\t#@divL" %}
 
   ins_encode(riscv_enc_div(dst, src1, src2));
+  ins_pipe(ldiv_reg_reg);
+%}
+
+instruct UdivL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
+  match(Set dst (UDivL src1 src2));
+  ins_cost(IDIVDI_COST);
+
+  format %{
+    "bltz $src2, Lltz\t#@UdivL\n\t"
+    "divu  $dst, $src1, $src2\n\t"
+    "j Ldone\n\t"
+    "Lltz:"
+    "sub $dst, $src1, $src2\n\t"
+    "not $dst, $dst\n\t"
+    "and $dst, $dst, $src1\n\t"
+    "srli $dst, $dst, 63\n\t"
+    "Ldone:\t#@UdivL"
+  %}
+
+  ins_encode %{
+    Label Lltz, Ldone;
+    __ bltz(as_Register($src2$$reg), Lltz);
+    __ divu(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
+    __ j(Ldone);
+    __ bind(Lltz); // check j.l.Long::divideUnsigned
+    __ sub(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
+    __ notr(as_Register($dst$$reg), as_Register($dst$$reg));
+    __ andr(as_Register($dst$$reg), as_Register($dst$$reg), as_Register($src1$$reg));
+    __ srli(as_Register($dst$$reg), as_Register($dst$$reg), 63);
+    __ bind(Ldone);
+  %}
+
   ins_pipe(ldiv_reg_reg);
 %}
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2443,7 +2443,7 @@ encode %{
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivl(dst_reg, src1_reg, src2_reg, false);
+    __ corrected_idivl(dst_reg, src1_reg, src2_reg, /* want_remainder */ false, /* is_signed */ true);
   %}
 
   enc_class riscv_enc_divuw(iRegI dst, iRegI src1, iRegI src2) %{
@@ -2451,7 +2451,7 @@ encode %{
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivl(dst_reg, src1_reg, src2_reg, false, false);
+    __ corrected_idivl(dst_reg, src1_reg, src2_reg, /* want_remainder */ false, /* is_signed */ false);
   %}
 
   enc_class riscv_enc_div(iRegI dst, iRegI src1, iRegI src2) %{
@@ -2459,7 +2459,7 @@ encode %{
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivq(dst_reg, src1_reg, src2_reg, false);
+    __ corrected_idivq(dst_reg, src1_reg, src2_reg, /* want_remainder */ false, /* is_signed */ true);
   %}
 
   enc_class riscv_enc_divu(iRegI dst, iRegI src1, iRegI src2) %{
@@ -2467,7 +2467,7 @@ encode %{
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivq(dst_reg, src1_reg, src2_reg, false, false);
+    __ corrected_idivq(dst_reg, src1_reg, src2_reg, /* want_remainder */ false, /* is_signed */ false);
   %}
 
   enc_class riscv_enc_modw(iRegI dst, iRegI src1, iRegI src2) %{
@@ -2475,7 +2475,7 @@ encode %{
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivl(dst_reg, src1_reg, src2_reg, true);
+    __ corrected_idivl(dst_reg, src1_reg, src2_reg, /* want_remainder */ true, /* is_signed */ true);
   %}
 
   enc_class riscv_enc_mod(iRegI dst, iRegI src1, iRegI src2) %{
@@ -2483,7 +2483,7 @@ encode %{
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
-    __ corrected_idivq(dst_reg, src1_reg, src2_reg, true);
+    __ corrected_idivq(dst_reg, src1_reg, src2_reg, /* want_remainder */ true, /* is_signed */ true);
   %}
 
   enc_class riscv_enc_tail_call(iRegP jump_target) %{

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2446,12 +2446,28 @@ encode %{
     __ corrected_idivl(dst_reg, src1_reg, src2_reg, false);
   %}
 
+  enc_class riscv_enc_divuw(iRegI dst, iRegI src1, iRegI src2) %{
+    C2_MacroAssembler _masm(&cbuf);
+    Register dst_reg = as_Register($dst$$reg);
+    Register src1_reg = as_Register($src1$$reg);
+    Register src2_reg = as_Register($src2$$reg);
+    __ corrected_idivl(dst_reg, src1_reg, src2_reg, false, false);
+  %}
+
   enc_class riscv_enc_div(iRegI dst, iRegI src1, iRegI src2) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
     __ corrected_idivq(dst_reg, src1_reg, src2_reg, false);
+  %}
+
+  enc_class riscv_enc_divu(iRegI dst, iRegI src1, iRegI src2) %{
+    C2_MacroAssembler _masm(&cbuf);
+    Register dst_reg = as_Register($dst$$reg);
+    Register src1_reg = as_Register($src1$$reg);
+    Register src2_reg = as_Register($src2$$reg);
+    __ corrected_idivq(dst_reg, src1_reg, src2_reg, false, false);
   %}
 
   enc_class riscv_enc_modw(iRegI dst, iRegI src1, iRegI src2) %{
@@ -6678,9 +6694,7 @@ instruct UdivI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   ins_cost(IDIVSI_COST);
   format %{ "divuw  $dst, $src1, $src2\t#@UdivI"%}
 
-  ins_encode %{
-    __ divuw(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
-  %}
+  ins_encode(riscv_enc_divuw(dst, src1, src2));
   ins_pipe(idiv_reg_reg);
 %}
 
@@ -6722,19 +6736,7 @@ instruct UdivL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
     "Ldone:\t#@UdivL"
   %}
 
-  ins_encode %{
-    Label Lltz, Ldone;
-    __ bltz(as_Register($src2$$reg), Lltz);
-    __ divu(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
-    __ j(Ldone);
-    __ bind(Lltz); // For the algorithm, check j.l.Long::divideUnsigned
-    __ sub(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
-    __ notr(as_Register($dst$$reg), as_Register($dst$$reg));
-    __ andr(as_Register($dst$$reg), as_Register($dst$$reg), as_Register($src1$$reg));
-    __ srli(as_Register($dst$$reg), as_Register($dst$$reg), 63);
-    __ bind(Ldone);
-  %}
-
+  ins_encode(riscv_enc_divu(dst, src1, src2));
   ins_pipe(ldiv_reg_reg);
 %}
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6712,12 +6712,12 @@ instruct UdivL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 
   format %{
     "bltz $src2, Lltz\t#@UdivL\n\t"
-    "divu  $dst, $src1, $src2\n\t"
-    "j Ldone\n\t"
+    "divu $dst, $src1, $src2\n\t"
+    "j    Ldone\n\t"
     "Lltz:"
-    "sub $dst, $src1, $src2\n\t"
-    "not $dst, $dst\n\t"
-    "and $dst, $dst, $src1\n\t"
+    "sub  $dst, $src1, $src2\n\t"
+    "not  $dst, $dst\n\t"
+    "and  $dst, $dst, $src1\n\t"
     "srli $dst, $dst, 63\n\t"
     "Ldone:\t#@UdivL"
   %}
@@ -6727,7 +6727,7 @@ instruct UdivL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
     __ bltz(as_Register($src2$$reg), Lltz);
     __ divu(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
     __ j(Ldone);
-    __ bind(Lltz); // check j.l.Long::divideUnsigned
+    __ bind(Lltz); // For the algorithm, check j.l.Long::divideUnsigned
     __ sub(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
     __ notr(as_Register($dst$$reg), as_Register($dst$$reg));
     __ andr(as_Register($dst$$reg), as_Register($dst$$reg), as_Register($src1$$reg));

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6724,17 +6724,7 @@ instruct UdivL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   match(Set dst (UDivL src1 src2));
   ins_cost(IDIVDI_COST);
 
-  format %{
-    "bltz $src2, Lltz\t#@UdivL\n\t"
-    "divu $dst, $src1, $src2\n\t"
-    "j    Ldone\n\t"
-    "Lltz:"
-    "sub  $dst, $src1, $src2\n\t"
-    "not  $dst, $dst\n\t"
-    "and  $dst, $dst, $src1\n\t"
-    "srli $dst, $dst, 63\n\t"
-    "Ldone:\t#@UdivL"
-  %}
+  format %{ "divu $dst, $src1, $src2\t#@UdivL" %}
 
   ins_encode(riscv_enc_divu(dst, src1, src2));
   ins_pipe(ldiv_reg_reg);

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -1318,7 +1318,7 @@ void TemplateTable::idiv() {
   __ bind(no_div0);
   __ pop_i(x11);
   // x10 <== x11 idiv x10
-  __ corrected_idivl(x10, x11, x10, /* want_remainder */ false);
+  __ corrected_idivl(x10, x11, x10, /* want_remainder */ false, /* is_signed */ true);
 }
 
 void TemplateTable::irem() {
@@ -1331,7 +1331,7 @@ void TemplateTable::irem() {
   __ bind(no_div0);
   __ pop_i(x11);
   // x10 <== x11 irem x10
-  __ corrected_idivl(x10, x11, x10, /* want_remainder */ true);
+  __ corrected_idivl(x10, x11, x10, /* want_remainder */ true, /* is_signed */ true);
 }
 
 void TemplateTable::lmul() {
@@ -1350,7 +1350,7 @@ void TemplateTable::ldiv() {
   __ bind(no_div0);
   __ pop_l(x11);
   // x10 <== x11 ldiv x10
-  __ corrected_idivq(x10, x11, x10, /* want_remainder */ false);
+  __ corrected_idivq(x10, x11, x10, /* want_remainder */ false, /* is_signed */ true);
 }
 
 void TemplateTable::lrem() {
@@ -1363,7 +1363,7 @@ void TemplateTable::lrem() {
   __ bind(no_div0);
   __ pop_l(x11);
   // x10 <== x11 lrem x10
-  __ corrected_idivq(x10, x11, x10, /* want_remainder */ true);
+  __ corrected_idivq(x10, x11, x10, /* want_remainder */ true, /* is_signed */ true);
 }
 
 void TemplateTable::lshl() {

--- a/test/hotspot/jtreg/compiler/intrinsics/TestIntegerUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestIntegerUnsignedDivMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 /**
 * @test
-* @summary Test x86_64 intrinsic for divideUnsigned() and remainderUnsigned() methods for Integer
-* @requires os.arch=="amd64" | os.arch=="x86_64"
+* @summary Test intrinsic for divideUnsigned() and remainderUnsigned() methods for Integer
+* @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="riscv64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestIntegerUnsignedDivMod
 */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,8 @@
 
 /**
 * @test
-* @summary Test x86_64 intrinsic for divideUnsigned() and remainderUnsigned() methods for Long
-* @requires os.arch=="amd64" | os.arch=="x86_64"
+* @summary Test intrinsic for divideUnsigned() and remainderUnsigned() methods for Long
+* @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="riscv64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestLongUnsignedDivMod
 */


### PR DESCRIPTION
Hi,
Can you review the change to add intrinsic for UDivI and UDivL?
Thanks!


## Tests

### Functionality
Run tests successfully found via `grep -nr test/jdk/ -we divideUnsigned` and `grep -nr test/hotspot/ -we divideUnsigned` 

### Performance
( NOTE: there are another 2 related issues: https://bugs.openjdk.org/browse/JDK-8318225, https://bugs.openjdk.org/browse/JDK-8318226, the pr of which will be subseqently sent out after this one finished. )

#### Long
**NOTE: for positive divisor, it's the common case; for negative divisor, it's a rare case**

**Before**
```
LongDivMod.testDivideUnsigned                    1024          mixed  avgt   10  19684.873 ± 21.882  ns/op
LongDivMod.testDivideUnsigned                    1024       positive  avgt   10  28853.041 ±  6.425  ns/op
LongDivMod.testDivideUnsigned                    1024       negative  avgt   10   6367.239 ± 16.011  ns/op
```

**After**
```
LongDivMod.testDivideUnsigned                    1024          mixed  avgt   10  22622.133 ±  7.158  ns/op
LongDivMod.testDivideUnsigned                    1024       positive  avgt   10  15957.272 ±  3.174  ns/op
LongDivMod.testDivideUnsigned                    1024       negative  avgt   10  29499.721 ± 10.404  ns/op
```

#### Integer
**Before**
```
IntegerDivMod.testDivideUnsigned                    1024          mixed  avgt   10  23397.267 ± 36.980  ns/op
IntegerDivMod.testDivideUnsigned                    1024       positive  avgt   10  16792.414 ±  5.869  ns/op
IntegerDivMod.testDivideUnsigned                    1024       negative  avgt   10  30184.357 ± 55.464  ns/op
```

**After**
```
IntegerDivMod.testDivideUnsigned                    1024          mixed  avgt   10  23210.437 ±  4.463  ns/op
IntegerDivMod.testDivideUnsigned                    1024       positive  avgt   10  16622.342 ±  4.047  ns/op
IntegerDivMod.testDivideUnsigned                    1024       negative  avgt   10  30013.414 ± 48.695  ns/op
```


/************ following is just backup: quick path for negative divisor *************/
#### Long
**Before**
```
LongDivMod.testDivideUnsigned                    1024          mixed  avgt   10  19704.317 ± 64.078  ns/op
LongDivMod.testDivideUnsigned                    1024       positive  avgt   10  28856.859 ± 14.901  ns/op
LongDivMod.testDivideUnsigned                    1024       negative  avgt   10   6364.974 ±  2.465  ns/op
```

**After v1**
(This is a simpler version, please check the diff from `After v2` below)
```
LongDivMod.testDivideUnsigned                    1024          mixed  avgt   10  22668.228 ± 74.161  ns/op
LongDivMod.testDivideUnsigned                    1024       positive  avgt   10  15966.320 ± 14.985  ns/op
LongDivMod.testDivideUnsigned                    1024       negative  avgt   10  29518.033 ± 49.056  ns/op
```

**After v2**
(This is the current patch, **This version has a huge regression for negative values!!!**)
```
LongDivMod.testDivideUnsigned                    1024          mixed  avgt   10  11432.738 ±  95.785  ns/op
LongDivMod.testDivideUnsigned                    1024       positive  avgt   10  15969.044 ±  19.492  ns/op
LongDivMod.testDivideUnsigned                    1024       negative  avgt   10   6376.674 ±  16.869  ns/op
```

##### Diff of v1 from v2
```
diff --git a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
index b96f7611133..dfb40e171e7 100644
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2432,16 +2432,7 @@ int MacroAssembler::corrected_idivq(Register result, Register rs1, Register rs2,
     if (is_signed) {
       div(result, rs1, rs2);
     } else {
-      Label Lltz, Ldone;
-      bltz(rs2, Lltz);
       divu(result, rs1, rs2);
-      j(Ldone);
-      bind(Lltz); // For the algorithm details, check j.l.Long::divideUnsigned
-      sub(result, rs1, rs2);
-      notr(result, result);
-      andr(result, result, rs1);
-      srli(result, result, 63);
-      bind(Ldone);
     }
   } else {
     rem(result, rs1, rs2); // result = rs1 % rs2;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8318723](https://bugs.openjdk.org/browse/JDK-8318723): RISC-V: C2 UDivL (**Sub-task** - P4)
 * [JDK-8318224](https://bugs.openjdk.org/browse/JDK-8318224): RISC-V: C2 UDivI (**Sub-task** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16346/head:pull/16346` \
`$ git checkout pull/16346`

Update a local copy of the PR: \
`$ git checkout pull/16346` \
`$ git pull https://git.openjdk.org/jdk.git pull/16346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16346`

View PR using the GUI difftool: \
`$ git pr show -t 16346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16346.diff">https://git.openjdk.org/jdk/pull/16346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16346#issuecomment-1777488427)