### PR TITLE
8318735: RISC-V: Enable related hotspot tests run on riscv

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/CmpUWithZero.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/CmpUWithZero.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2022, 2023, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/CmpUWithZero.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/CmpUWithZero.java
@@ -29,7 +29,7 @@ import compiler.lib.ir_framework.*;
  * @test
  * bug 8290529
  * @summary verify that x <u 1 is transformed to x == 0
- * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="riscv64"
  * @library /test/lib /
  * @requires vm.compiler2.enabled
  * @run driver compiler.c2.irTests.CmpUWithZero

--- a/test/hotspot/jtreg/compiler/intrinsics/TestCompareUnsigned.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestCompareUnsigned.java
@@ -30,7 +30,7 @@ import jdk.test.lib.Utils;
  * @test
  * @key randomness
  * @bug 8283726 8287925
- * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64"
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch=="riscv64"
  * @summary Test the intrinsics implementation of Integer/Long::compareUnsigned
  * @library /test/lib /
  * @run driver compiler.intrinsics.TestCompareUnsigned


### PR DESCRIPTION
Hi,
Can you review the simple change? It enables related hotspot tests to run on riscv for intrinsic of CmpU3 and CmpUL3?
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318735](https://bugs.openjdk.org/browse/JDK-8318735): RISC-V: Enable related hotspot tests run on riscv (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16348/head:pull/16348` \
`$ git checkout pull/16348`

Update a local copy of the PR: \
`$ git checkout pull/16348` \
`$ git pull https://git.openjdk.org/jdk.git pull/16348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16348`

View PR using the GUI difftool: \
`$ git pr show -t 16348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16348.diff">https://git.openjdk.org/jdk/pull/16348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16348#issuecomment-1777540767)