### PR TITLE
8318737: Fallback linker passes bad JNI handle

### DIFF
--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -199,13 +199,9 @@ jobjectRefType JNIHandles::handle_type(JavaThread* thread, jobject handle) {
     default:
       ShouldNotReachHere();
     }
-  } else {
+  } else if (is_local_handle(thread, handle) || is_frame_handle(thread, handle)) {
     // Not in global storage.  Might be a local handle.
-    if (is_local_handle(thread, handle) || is_frame_handle(thread, handle)) {
-      result = JNILocalRefType;
-    } else {
-      ShouldNotReachHere();
-    }
+    result = JNILocalRefType;
   }
   return result;
 }

--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -45,7 +45,7 @@ static const char* LibFallback_doUpcall_sig = "(JJLjava/lang/invoke/MethodHandle
 JNIEXPORT void JNICALL
 Java_jdk_internal_foreign_abi_fallback_LibFallback_init(JNIEnv* env, jclass cls) {
   (*env)->GetJavaVM(env, &VM);
-  LibFallback_class = (*env)->FindClass(env, "jdk/internal/foreign/abi/fallback/LibFallback");
+  LibFallback_class = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "jdk/internal/foreign/abi/fallback/LibFallback"));
   LibFallback_doUpcall_ID = (*env)->GetStaticMethodID(env,
     LibFallback_class, "doUpcall", LibFallback_doUpcall_sig);
 }

--- a/test/jdk/java/foreign/TestDowncallScope.java
+++ b/test/jdk/java/foreign/TestDowncallScope.java
@@ -26,7 +26,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
- * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ * @run testng/othervm -Xcheck:jni -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestDowncallScope
  *

--- a/test/jdk/java/foreign/TestDowncallStack.java
+++ b/test/jdk/java/foreign/TestDowncallStack.java
@@ -26,7 +26,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestDowncallBase
  *
- * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ * @run testng/othervm -Xcheck:jni -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestDowncallStack
  */

--- a/test/jdk/java/foreign/TestUpcallScope.java
+++ b/test/jdk/java/foreign/TestUpcallScope.java
@@ -26,7 +26,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
- * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ * @run testng/othervm -Xcheck:jni -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestUpcallScope
  */

--- a/test/jdk/java/foreign/TestUpcallStack.java
+++ b/test/jdk/java/foreign/TestUpcallStack.java
@@ -27,7 +27,7 @@
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
- * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
+ * @run testng/othervm -Xcheck:jni -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies
  *   --enable-native-access=ALL-UNNAMED -Dgenerator.sample.factor=17
  *   TestUpcallStack
  */


### PR DESCRIPTION
The result of `FindClass` is a local JNI handle (in `find_class_from_class_loader`, called from `jni_FindClass` [1]). As such, we need to wrap the return value of `FindClass` in a global reference when storing it inside fallbackLinker.c.

While investigating this, I also noticed an existing bug in `JNIHandles::handle_type`. This method is used from the implementation of `GetObjectRefType`, and from the implementation of `-Xcheck:jni` code. The former specifies that `JNIInvalidRefType` is a valid return value, and the latter compares the result against `JNIInvalidRefType`. However, if the handle is not any valid type, the implementation bottoms out in a `ShouldNotReachHere()`, meaning `JNIHandles::handle_type` can never return `JNIInvalidRefType`. I've fixed this by letting the enclosing if/else change fall through to just returning the default result, which is `JNIInvalidRefType`. In that case, I observe the expected stack trace when running with `-Xcheck:jni`. For example:

```
FATAL ERROR in native method: Bad global or local ref passed to JNI
        at jdk.internal.foreign.abi.fallback.LibFallback.doDowncall(java.base@22-internal/Native Method)
        at jdk.internal.foreign.abi.fallback.LibFallback.doDowncall(java.base@22-internal/LibFallback.java:94)
        at jdk.internal.foreign.abi.fallback.FallbackLinker.doDowncall(java.base@22-internal/FallbackLinker.java:197)
        at java.lang.invoke.LambdaForm$DMH/0x000001b585008000.invokeStaticInit(java.base@22-internal/LambdaForm$DMH)
        at java.lang.invoke.LambdaForm$MH/0x000001b585029400.invoke(java.base@22-internal/LambdaForm$MH)
        at java.lang.invoke.LambdaForm$MH/0x000001b58502d000.invokeExact_MT(java.base@22-internal/LambdaForm$MH)
        at TestUpcallDeopt.payload(TestUpcallDeopt.java:93)
        at TestUpcallDeopt.main(TestUpcallDeopt.java:84)
        at java.lang.invoke.LambdaForm$DMH/0x000001b585006800.invokeStatic(java.base@22-internal/LambdaForm$DMH)
        at java.lang.invoke.LambdaForm$MH/0x000001b58502a800.invoke(java.base@22-internal/LambdaForm$MH)
        at java.lang.invoke.Invokers$Holder.invokeExact_MT(java.base@22-internal/Invokers$Holder)
        at jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(java.base@22-internal/DirectMethodHandleAccessor.java:154)
        at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(java.base@22-internal/DirectMethodHandleAccessor.java:103)
        at java.lang.reflect.Method.invoke(java.base@22-internal/Method.java:580)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.lang.Thread.runWith(java.base@22-internal/Thread.java:1583)
        at java.lang.Thread.run(java.base@22-internal/Thread.java:1570)
```

(while with the current code, we crash and generate an hs_err file)

Testing: tier 1-5

[1]: https://github.com/openjdk/jdk/blob/6f352740cb5e7c47d226fd4039cfb977c0622488/src/hotspot/share/prims/jvm.cpp#L3548