### PR TITLE
8318694: [JVMCI] disable can_call_java in most contexts for libjvmci compiler threads

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2721,6 +2721,10 @@ C2V_VMENTRY_PREFIX(jboolean, detachCurrentThread, (JNIEnv* env, jobject c2vm, jb
 C2V_END
 
 C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jboolean callPostTranslation))
+  // translate implies a mixed libjvmci/Java context in
+  // which the caller needs to be able to call Java
+  JVMCICanCallJava ccj(thread, true);
+
   requireJVMCINativeLibrary(JVMCI_CHECK_0);
   if (obj_handle == nullptr) {
     return 0L;
@@ -2808,6 +2812,10 @@ C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jbool
 C2V_END
 
 C2V_VMENTRY_NULL(jobject, unhand, (JNIEnv* env, jobject, jlong obj_handle))
+  // unhand implies a mixed libjvmci/Java context in
+  // which the caller needs to be able to call Java
+  JVMCICanCallJava ccj(thread, true);
+
   requireJVMCINativeLibrary(JVMCI_CHECK_NULL);
   if (obj_handle == 0L) {
     return nullptr;

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -29,6 +29,7 @@
 // No interfaceSupport.hpp
 
 #include "gc/shared/gc_globals.hpp"
+#include "compiler/compilerThread.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaThread.inline.hpp"
@@ -361,6 +362,7 @@ extern "C" {                                                         \
     MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
+    JVMCI_ONLY(JVMCICanCallJava ccj(thread, true);)                  \
     VM_ENTRY_BASE(result_type, header, thread)
 
 


### PR DESCRIPTION
Currently, a `CompilerThread` for libgraal is able to call into Java. It's well known this can cause dead-lock (e.g., [JDK-8317953](https://bugs.openjdk.org/browse/JDK-8317953)), especially when blocking compilation is enabled (e.g. `-Xcomp` or `-Xbatch`). 
This PR changes `CompilerThread` such that it can only make Java calls for jargraal (where there's no other option but to accept the dead-lock risk).
It also introduces a scoping mechanism for allowing a libgraal CompilerThread to make Java calls. This is required to handle Truffle-specific logic whereby libgraal calls Truffle code executing in the Java heap (see [JDK-8318694](https://bugs.openjdk.org/browse/JDK-8318694) for details).
Such calls are always made via a [JNI function](https://docs.oracle.com/en/java/javase/21/docs/specs/jni/functions.html) so in the scope of JNI function call, a CompilerThread for libgraal allows Java calls (see [here]).

There might be some concern about the overhead of adding extra code to `JNI_ENTRY_NO_PRESERVE`. To measure this, I modified `test/hotspot/jtreg/native_sanity/JniVersion.java` to [benchmark the cost of calling `GetVersion`](https://github.com/dougxc/jdk/commit/437c9f69890c991c069caa9da0d4b5c45b1722ea), the most lightweight JNI function.
The benchmark results imply that the overhead is negligible:
```
Timestamp                      iterations      duration (ns)   # label
2023-10-25 18:02:51.666        100,000,000     124,460,291     # master
2023-10-25 18:02:52.594        100,000,000     125,698,750     # master
2023-10-25 18:02:53.519        100,000,000     125,585,667     # master
2023-10-25 18:02:54.441        100,000,000     125,693,958     # master
2023-10-25 18:02:55.376        100,000,000     125,483,667     # master
2023-10-25 18:02:56.335        100,000,000     126,349,459     # master
2023-10-25 18:02:57.241        100,000,000     125,927,417     # master
2023-10-25 18:02:58.167        100,000,000     125,786,833     # master
2023-10-25 18:02:59.084        100,000,000     126,625,416     # master
2023-10-25 18:03:00.013        100,000,000     125,902,458     # master
2023-10-25 18:03:01.118        100,000,000     128,088,708     # master
2023-10-25 18:03:02.116        100,000,000     128,901,417     # master
2023-10-25 18:03:03.149        100,000,000     130,896,458     # master
2023-10-25 18:03:04.157        100,000,000     131,352,625     # master
2023-10-25 18:03:05.153        100,000,000     132,288,875     # master
2023-10-25 18:03:06.151        100,000,000     130,168,250     # master
2023-10-25 18:03:07.119        100,000,000     126,495,958     # master
2023-10-25 18:03:08.057        100,000,000     126,464,875     # master
2023-10-25 18:03:08.994        100,000,000     126,461,792     # master
2023-10-25 18:03:09.929        100,000,000     126,288,500     # master
2023-10-25 18:04:24.844        100,000,000     129,978,708     # JDK-8318694
2023-10-25 18:04:25.789        100,000,000     128,722,666     # JDK-8318694
2023-10-25 18:04:26.753        100,000,000     126,815,041     # JDK-8318694
2023-10-25 18:04:27.666        100,000,000     126,989,084     # JDK-8318694
2023-10-25 18:04:28.603        100,000,000     127,431,916     # JDK-8318694
2023-10-25 18:04:29.509        100,000,000     127,179,625     # JDK-8318694
2023-10-25 18:04:30.434        100,000,000     126,965,333     # JDK-8318694
2023-10-25 18:04:31.358        100,000,000     127,175,250     # JDK-8318694
2023-10-25 18:04:32.269        100,000,000     126,828,625     # JDK-8318694
2023-10-25 18:04:33.188        100,000,000     126,751,792     # JDK-8318694
2023-10-25 18:04:34.126        100,000,000     127,496,625     # JDK-8318694
2023-10-25 18:04:35.081        100,000,000     126,876,375     # JDK-8318694
2023-10-25 18:04:36.026        100,000,000     126,537,375     # JDK-8318694
2023-10-25 18:04:36.942        100,000,000     127,216,833     # JDK-8318694
2023-10-25 18:04:37.861        100,000,000     126,547,333     # JDK-8318694
2023-10-25 18:04:38.801        100,000,000     126,812,750     # JDK-8318694
```

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318694](https://bugs.openjdk.org/browse/JDK-8318694): [JVMCI] disable can_call_java in most contexts for libjvmci compiler threads (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16351/head:pull/16351` \
`$ git checkout pull/16351`

Update a local copy of the PR: \
`$ git checkout pull/16351` \
`$ git pull https://git.openjdk.org/jdk.git pull/16351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16351`

View PR using the GUI difftool: \
`$ git pr show -t 16351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16351.diff">https://git.openjdk.org/jdk/pull/16351.diff</a>

</details>
