### PR TITLE
8318720: G1: Memory leak in G1CodeRootSet after JDK-8315503

### DIFF
--- a/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
@@ -176,7 +176,6 @@ public:
         blk->do_code_blob(*value);
         return true;
       };
-
     _table_scanner.do_safepoint_scan(do_value);
   }
 

--- a/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
@@ -143,25 +143,11 @@ public:
   }
 
   void clear() {
-    size_t num_entries = Atomic::load(&_num_entries);
-    if (num_entries != 0) {
-      auto always_true =
-        [] (nmethod** value) {
-          return true;
-      };
-
-      size_t num_deleted = 0;
-      auto do_delete =
-        [&] (nmethod** value) {
-          num_deleted++;
-      };
-
-      bool succeeded = _table.try_bulk_delete(Thread::current(), always_true, do_delete);
-      guarantee(succeeded, "unable to clean table");
-      assert(num_entries == num_deleted, "must empty the table");
-      Atomic::store(&_num_entries, (size_t)0);
-    }
-    _table.unsafe_reset();
+    // Remove all entries.
+    auto always_true = [] (nmethod** value) {
+                         return true;
+                       };
+    clean(always_true);
   }
 
   void iterate_at_safepoint(CodeBlobClosure* blk) {

--- a/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
@@ -145,7 +145,7 @@ public:
   void clear() {
     size_t num_entries = Atomic::load(&_num_entries);
     if (num_entries != 0) {
-      auto do_value =
+      auto always_true =
         [] (nmethod** value) {
           return true;
       };
@@ -156,7 +156,7 @@ public:
           num_deleted++;
       };
 
-      bool succeeded = _table.try_bulk_delete(Thread::current(), do_value, do_delete);
+      bool succeeded = _table.try_bulk_delete(Thread::current(), always_true, do_delete);
       guarantee(succeeded, "unable to clean table");
       assert(num_entries == num_deleted, "must empty the table");
       Atomic::store(&_num_entries, (size_t)0);


### PR DESCRIPTION
Calling `ConcurrentHashTable:table.unsafe_reset()` in `G1CodeRootSet::clear()` does not free the entries that still in the table. This patch empties the table before the `unsafe_reset()` call to avoid memory leak.

Test:
 tier1 and tier2 (fastdebug and release) on Linux x86_64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318720](https://bugs.openjdk.org/browse/JDK-8318720): G1: Memory leak in G1CodeRootSet after JDK-8315503 (**Bug** - P3)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16352/head:pull/16352` \
`$ git checkout pull/16352`

Update a local copy of the PR: \
`$ git checkout pull/16352` \
`$ git pull https://git.openjdk.org/jdk.git pull/16352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16352`

View PR using the GUI difftool: \
`$ git pr show -t 16352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16352.diff">https://git.openjdk.org/jdk/pull/16352.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16352#issuecomment-1778197667)