### PR TITLE
8315361: C2: Create a superclass of SuperWord

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -816,7 +816,7 @@ public:
 // into a loop tree. Drives the loop-based transformations on the ideal graph.
 class PhaseIdealLoop : public PhaseTransform {
   friend class IdealLoopTree;
-  friend class SuperWord;
+  friend class Vectorizer;
   friend class ShenandoahBarrierC2Support;
   friend class AutoNodeBudget;
 

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1029,7 +1029,7 @@ void SuperWord::dependence_graph() {
 
   // First, assign a dependence node to each memory node
   for (int i = 0; i < _body_nodes.length(); i++ ) {
-    Node *n = _body_nodes.at(i);
+    Node* n = _body_nodes.at(i);
     if (n->is_Mem() || n->is_memory_phi()) {
       _dg.make_node(n);
     }
@@ -3537,9 +3537,9 @@ void SuperWord::align_initial_loop_index(MemNode* align_to_ref) {
   int v_align  = vw / elt_size;
   assert(v_align > 1, "sanity");
   int offset   = align_to_ref_p.offset_in_bytes() / elt_size;
-  Node *offsn  = igvn()->intcon(offset);
+  Node* offsn  = igvn()->intcon(offset);
 
-  Node *e = offsn;
+  Node* e = offsn;
   if (align_to_ref_p.invar() != nullptr) {
     // incorporate any extra invariant piece producing (offset +/- invar) >>> log2(elt)
     Node* log2_elt = igvn()->intcon(exact_log2(elt_size));

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -31,7 +31,10 @@
 #include "opto/rootnode.hpp"
 #include "opto/vectorization.hpp"
 
+#ifndef PRODUCT
 uintx Vectorizer::_vector_loop_debug = 0;
+int VPointer::Tracer::_depth = 0;
+#endif
 
 Vectorizer::Vectorizer(PhaseIdealLoop* phase) :
   _phase(phase),
@@ -176,10 +179,6 @@ void Vectorizer::print_body_nodes() {
   }
 #endif
 }
-
-#ifndef PRODUCT
-int VPointer::Tracer::_depth = 0;
-#endif
 
 VPointer::VPointer(MemNode* mem, PhaseIdealLoop* phase, IdealLoopTree* lpt,
                    Node_Stack* nstack, bool analyze_only) :


### PR DESCRIPTION
As discussed in [JDK-8308994](https://bugs.openjdk.org/browse/JDK-8308994), we should first do some refactoring work before proceeding with the new post loop vectorization. In this patch, we have done the following refactoring. (Most of changes are just moving the code around without real change on logic.)

1) We have created a superclass for shared data structures and utilities for C2's auto-vectorization.

2) We have moved data structures for basic loop info and the field _vector_loop_debug to the superclass. We also drop the class member "_visited" and "_post_visited", and instead use local variables, namely allocating them when using them.

3) Both two vectorizers traverse and store loop body nodes in RPO (Reverse Post-Order) separately. So we withdraw the logic into a new function `collect_nodes_in_reverse_postorder()`, and move the function and related data structures to the superclass. Before, the code for counting the number of reduction uses is mixed in the RPO logic. Now, we have decoupled the code and put it into SuperWord separately.

Tested tier1~3 on x86 and AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8320668](https://bugs.openjdk.org/browse/JDK-8320668) to be approved

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8315361](https://bugs.openjdk.org/browse/JDK-8315361)

### Issues
 * [JDK-8315361](https://bugs.openjdk.org/browse/JDK-8315361): C2 SuperWord: refactor out loop analysis into shared auto-vectorization facility VLoopAnalyzer (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.
 * [JDK-8320668](https://bugs.openjdk.org/browse/JDK-8320668): Remove CompileCommand option VectorizeDebug (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16353/head:pull/16353` \
`$ git checkout pull/16353`

Update a local copy of the PR: \
`$ git checkout pull/16353` \
`$ git pull https://git.openjdk.org/jdk.git pull/16353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16353`

View PR using the GUI difftool: \
`$ git pr show -t 16353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16353.diff">https://git.openjdk.org/jdk/pull/16353.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16353#issuecomment-1778361219)