### PR TITLE
8318801: Parallel: Remove unused verify_all_young_refs_precise

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -95,29 +95,6 @@ class CheckForUnmarkedObjects : public ObjectClosure {
   }
 };
 
-// Checks for precise marking of oops as newgen.
-class CheckForPreciseMarks : public BasicOopIterateClosure {
- private:
-  PSYoungGen*  _young_gen;
-  PSCardTable* _card_table;
-
- protected:
-  template <class T> void do_oop_work(T* p) {
-    oop obj = RawAccess<IS_NOT_NULL>::oop_load(p);
-    if (_young_gen->is_in_reserved(obj)) {
-      assert(_card_table->addr_is_marked_precise(p), "Found unmarked precise oop");
-      _card_table->set_card_newgen(p);
-    }
-  }
-
- public:
-  CheckForPreciseMarks(PSYoungGen* young_gen, PSCardTable* card_table) :
-    _young_gen(young_gen), _card_table(card_table) { }
-
-  virtual void do_oop(oop* p)       { CheckForPreciseMarks::do_oop_work(p); }
-  virtual void do_oop(narrowOop* p) { CheckForPreciseMarks::do_oop_work(p); }
-};
-
 static void prefetch_write(void *p) {
   if (PrefetchScanIntervalInBytes >= 0) {
     Prefetch::write(p, PrefetchScanIntervalInBytes);
@@ -410,29 +387,6 @@ void PSCardTable::verify_all_young_refs_imprecise() {
   old_gen->object_iterate(&check);
 }
 
-// This should be called immediately after a scavenge, before mutators resume.
-void PSCardTable::verify_all_young_refs_precise() {
-  ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
-  PSOldGen* old_gen = heap->old_gen();
-
-  CheckForPreciseMarks check(heap->young_gen(), this);
-
-  old_gen->oop_iterate(&check);
-
-  verify_all_young_refs_precise_helper(old_gen->object_space()->used_region());
-}
-
-void PSCardTable::verify_all_young_refs_precise_helper(MemRegion mr) {
-  CardValue* bot = byte_for(mr.start());
-  CardValue* top = byte_for(mr.end());
-  while (bot <= top) {
-    assert(*bot == clean_card || *bot == verify_card, "Found unwanted or unknown card mark");
-    if (*bot == verify_card)
-      *bot = youngergen_card;
-    bot++;
-  }
-}
-
 bool PSCardTable::addr_is_marked_imprecise(void *addr) {
   CardValue* p = byte_for(addr);
   CardValue val = *p;
@@ -444,28 +398,6 @@ bool PSCardTable::addr_is_marked_imprecise(void *addr) {
     return true;
 
   if (card_is_clean(val))
-    return false;
-
-  assert(false, "Found unhandled card mark type");
-
-  return false;
-}
-
-// Also includes verify_card
-bool PSCardTable::addr_is_marked_precise(void *addr) {
-  CardValue* p = byte_for(addr);
-  CardValue val = *p;
-
-  if (card_is_newgen(val))
-    return true;
-
-  if (card_is_verify(val))
-    return true;
-
-  if (card_is_clean(val))
-    return false;
-
-  if (card_is_dirty(val))
     return false;
 
   assert(false, "Found unhandled card mark type");

--- a/src/hotspot/share/gc/parallel/psCardTable.hpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.hpp
@@ -63,8 +63,6 @@ class PSCardTable: public CardTable {
                      HeapWord* const start,
                      HeapWord* const end);
 
-  void verify_all_young_refs_precise_helper(MemRegion mr);
-
   enum ExtendedCardValue {
     youngergen_card   = CT_MR_BS_last_reserved + 1,
     verify_card       = CT_MR_BS_last_reserved + 5
@@ -93,7 +91,6 @@ class PSCardTable: public CardTable {
                                   uint n_stripes);
 
   bool addr_is_marked_imprecise(void *addr);
-  bool addr_is_marked_precise(void *addr);
 
   void set_card_newgen(void* addr)   { CardValue* p = byte_for(addr); *p = verify_card; }
 
@@ -120,7 +117,6 @@ class PSCardTable: public CardTable {
 
   // Verification
   void verify_all_young_refs_imprecise();
-  void verify_all_young_refs_precise();
 };
 
 #endif // SHARE_GC_PARALLEL_PSCARDTABLE_HPP

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -643,11 +643,7 @@ bool PSScavenge::invoke_no_policy() {
       old_gen->verify_object_start_array();
     }
 
-    // Verify all old -> young cards are now precise
     if (VerifyRememberedSets) {
-      // Precise verification will give false positives. Until this is fixed,
-      // use imprecise verification.
-      // heap->card_table()->verify_all_young_refs_precise();
       heap->card_table()->verify_all_young_refs_imprecise();
     }
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318801](https://bugs.openjdk.org/browse/JDK-8318801): Parallel: Remove unused verify_all_young_refs_precise (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16355/head:pull/16355` \
`$ git checkout pull/16355`

Update a local copy of the PR: \
`$ git checkout pull/16355` \
`$ git pull https://git.openjdk.org/jdk.git pull/16355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16355`

View PR using the GUI difftool: \
`$ git pr show -t 16355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16355.diff">https://git.openjdk.org/jdk/pull/16355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16355#issuecomment-1778778071)