### PR TITLE
8318788: java/net/Socks/SocksSocketProxySelectorTest.java fails on machines with no IPv6 link-local addresses

### DIFF
--- a/test/jdk/java/net/Socks/SocksSocketProxySelectorTest.java
+++ b/test/jdk/java/net/Socks/SocksSocketProxySelectorTest.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.Proxy;
@@ -76,6 +78,7 @@ public class SocksSocketProxySelectorTest {
         return NetworkInterface.networkInterfaces()
                         .flatMap(NetworkInterface::inetAddresses)
                         .filter(InetAddress::isLinkLocalAddress)
+                        .filter(Inet6Address.class::isInstance)
                         .map(InetAddress::getHostAddress);
     }
 
@@ -135,9 +138,12 @@ public class SocksSocketProxySelectorTest {
         }
     }
 
-    @ParameterizedTest
-    @MethodSource("linkLocalIpv6Literals")
-    public void testLinkLocalIpv6Literals(String host) throws Exception {
+    @Test
+    public void testLinkLocalIpv6Literals() throws Exception {
+        String host = linkLocalIpv6Literals()
+                .findFirst()
+                .orElseGet(() -> Assumptions.abort("No IPv6 link-local addresses found"));
+        System.err.println(host);
         try (Socket s1 = new Socket(host, 80)) {
             fail("IOException was expected to be thrown, but wasn't");
         } catch (IOException ioe) {


### PR DESCRIPTION
The test was failing on machines with no link-local addresses configured; JUnit's ParameterizedTest fails if the parameter source returns no parameters, and `linkLocalIpv6Literals` was used as a parameter source.

I changed the test to non-parameterized; the test now uses the first address from `linkLocalIpv6Literals`, and is aborted if the method returns no addresses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318788](https://bugs.openjdk.org/browse/JDK-8318788): java/net/Socks/SocksSocketProxySelectorTest.java fails on machines with no IPv6 link-local addresses (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16356/head:pull/16356` \
`$ git checkout pull/16356`

Update a local copy of the PR: \
`$ git checkout pull/16356` \
`$ git pull https://git.openjdk.org/jdk.git pull/16356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16356`

View PR using the GUI difftool: \
`$ git pr show -t 16356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16356.diff">https://git.openjdk.org/jdk/pull/16356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16356#issuecomment-1778794612)