### PR TITLE
8318805: RISC-V: Wrong comments instructions cost in riscv.ad

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -983,8 +983,8 @@ definitions %{
   int_def XFER_COST            (  300,  3 * DEFAULT_COST);          // mfc, mtc, fcvt, fmove, fcmp
   int_def BRANCH_COST          (  200,  2 * DEFAULT_COST);          // branch, jmp, call
   int_def IMUL_COST            ( 1000, 10 * DEFAULT_COST);          // imul
-  int_def IDIVSI_COST          ( 3400, 34 * DEFAULT_COST);          // idivdi
-  int_def IDIVDI_COST          ( 6600, 66 * DEFAULT_COST);          // idivsi
+  int_def IDIVSI_COST          ( 3400, 34 * DEFAULT_COST);          // idivsi
+  int_def IDIVDI_COST          ( 6600, 66 * DEFAULT_COST);          // idivdi
   int_def FMUL_SINGLE_COST     (  500,  5 * DEFAULT_COST);          // fmul, fmadd
   int_def FMUL_DOUBLE_COST     (  700,  7 * DEFAULT_COST);          // fmul, fmadd
   int_def FDIV_COST            ( 2000, 20 * DEFAULT_COST);          // fdiv


### PR DESCRIPTION
Hi,
Can you review this minor change in the comments of riscv.ad for the instruction cost?
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318805](https://bugs.openjdk.org/browse/JDK-8318805): RISC-V: Wrong comments instructions cost in riscv.ad (**Enhancement** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16357/head:pull/16357` \
`$ git checkout pull/16357`

Update a local copy of the PR: \
`$ git checkout pull/16357` \
`$ git pull https://git.openjdk.org/jdk.git pull/16357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16357`

View PR using the GUI difftool: \
`$ git pr show -t 16357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16357.diff">https://git.openjdk.org/jdk/pull/16357.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16357#issuecomment-1778919180)