### PR TITLE
JDK-8318736: com/sun/jdi/JdwpOnThrowTest.java failed with "transport error 202: bind failed: Address already in use"

### DIFF
--- a/test/jdk/com/sun/jdi/JdwpOnThrowTest.java
+++ b/test/jdk/com/sun/jdi/JdwpOnThrowTest.java
@@ -57,12 +57,11 @@ public class JdwpOnThrowTest {
     private static AttachingConnector attachingConnector;
 
     public static void main(String[] args) throws Exception {
-        int port = findFreePort();
-        try (Debuggee debuggee = Debuggee.launcher("ThrowCaughtException").setAddress("localhost:" + port)
+        try (Debuggee debuggee = Debuggee.launcher("ThrowCaughtException")
                                          .enableOnThrow("Ex", "Start").setSuspended(true).launch()) {
             VirtualMachine vm = null;
             try {
-                vm = attach("localhost", "" + port);
+                vm = attach("localhost", debuggee.getAddress());
                 EventQueue queue = vm.eventQueue();
                 log("Waiting for exception event");
                 long start = System.currentTimeMillis();
@@ -107,14 +106,6 @@ public class JdwpOnThrowTest {
         }
         if (!ex.exception().type().name().equals("Ex")) {
             throw new RuntimeException("Exception has wrong type: " + ex.exception().type().name());
-        }
-    }
-
-    private static int findFreePort() {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/test/jdk/com/sun/jdi/JdwpOnThrowTest.java
+++ b/test/jdk/com/sun/jdi/JdwpOnThrowTest.java
@@ -58,7 +58,7 @@ public class JdwpOnThrowTest {
 
     public static void main(String[] args) throws Exception {
         try (Debuggee debuggee = Debuggee.launcher("ThrowCaughtException")
-                                         .enableOnThrow("Ex", "Start").setSuspended(true).launch()) {
+                                         .enableOnThrow("Ex").setSuspended(true).launch()) {
             VirtualMachine vm = null;
             try {
                 vm = attach("localhost", debuggee.getAddress());

--- a/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
@@ -128,8 +128,8 @@ public class Debuggee implements Closeable {
         public Debuggee launch(String name) {
             return new Debuggee(prepare(), name,
                 onthrow.isEmpty() ?
-                JDWP::parseListenAddress :
-                Launcher::parseLaunchEchoListenAddress
+                    JDWP::parseListenAddress :
+                    Launcher::parseLaunchEchoListenAddress
             );
         }
         public Debuggee launch() {

--- a/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
@@ -138,7 +138,7 @@ public class Debuggee implements Closeable {
         }
     }
 
-    // starts the process, waits for "Listening for transport" output and detects transport/address
+    // starts the process, waits until the provided addressDetector detects transport/address from the process output
     private Debuggee(ProcessBuilder pb, String name, Function<String, JDWP.ListenAddress> addressDetector) {
         JDWP.ListenAddress[] listenAddress = new JDWP.ListenAddress[1];
         try {

--- a/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
@@ -103,7 +103,7 @@ public class Debuggee implements Closeable {
         }
 
         // required to pass non null port with address and emit string before the throw
-        public Launcher enableOnThrow(String value, String expectedOutputBeforeThrow) {
+        public Launcher enableOnThrow(String exceptionClassName) {
             this.onthrow = value;
             this.expectedOutputBeforeThrow = expectedOutputBeforeThrow;
             return this;

--- a/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
+++ b/test/jdk/com/sun/jdi/lib/jdb/Debuggee.java
@@ -133,7 +133,7 @@ public class Debuggee implements Closeable {
     }
 
     // starts the process, waits for "Listening for transport" output and detects transport/address
-    private Debuggee(ProcessBuilder pb, String name, boolean hasOnThrow, String expectedOutputBeforeThrow) {
+    private Debuggee(ProcessBuilder pb, String name, Function<String, JDWP.ListenAddress> addressDetector) {
         JDWP.ListenAddress[] listenAddress = new JDWP.ListenAddress[1];
         try {
             p = ProcessTools.startProcess(name, pb,

--- a/test/lib/jdk/test/lib/JDWP.java
+++ b/test/lib/jdk/test/lib/JDWP.java
@@ -49,17 +49,4 @@ public class JDWP {
         return null;
     }
 
-    /**
-     * Parses debuggee output to get listening transport and address, printed by `launch=echo`.
-     * Returns null if the string specified does not contain required info.
-     */
-    public static ListenAddress parseLaunchEchoListenAddress(String debuggeeOutput) {
-        String[] parts = debuggeeOutput.split(" ");
-        if (parts.length != 2) {
-            return null;
-        }
-        return new ListenAddress(parts[0], parts[1]);
-    }
-
-
 }

--- a/test/lib/jdk/test/lib/JDWP.java
+++ b/test/lib/jdk/test/lib/JDWP.java
@@ -49,4 +49,17 @@ public class JDWP {
         return null;
     }
 
+    /**
+     * Parses debuggee output to get listening transport and address, printed by `launch=echo`.
+     * Returns null if the string specified does not contain required info.
+     */
+    public static ListenAddress parseLaunchEchoListenAddress(String debuggeeOutput) {
+        String[] parts = debuggeeOutput.split(" ");
+        if (parts.length != 2) {
+            return null;
+        }
+        return new ListenAddress(parts[0], parts[1]);
+    }
+
+
 }


### PR DESCRIPTION
Fix race condition in debugger port selection, introduced with [JDK-8317920](https://bugs.openjdk.org/browse/JDK-8317920).

Tested on my Mac M1, but it doesn't contain platform-dependent code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318736](https://bugs.openjdk.org/browse/JDK-8318736): com/sun/jdi/JdwpOnThrowTest.java failed with "transport error 202: bind failed: Address already in use" (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [8a9b7133](https://git.openjdk.org/jdk/pull/16358/files/8a9b713364fcbc9f2b6c0c295e82abce96c421df)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16358/head:pull/16358` \
`$ git checkout pull/16358`

Update a local copy of the PR: \
`$ git checkout pull/16358` \
`$ git pull https://git.openjdk.org/jdk.git pull/16358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16358`

View PR using the GUI difftool: \
`$ git pr show -t 16358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16358.diff">https://git.openjdk.org/jdk/pull/16358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16358#issuecomment-1779067929)