### PR TITLE
8318811: Compiler directives parser swallows a character after line comments

### DIFF
--- a/src/hotspot/share/utilities/json.cpp
+++ b/src/hotspot/share/utilities/json.cpp
@@ -580,7 +580,7 @@ u_char JSON::skip_line_comment() {
     return 0;
   }
   next();
-  return next();
+  return peek();
 }
 
 /*

--- a/test/hotspot/jtreg/compiler/compilercontrol/parser/DirectiveParserTest.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/parser/DirectiveParserTest.java
@@ -33,6 +33,9 @@
 
 package compiler.compilercontrol.parser;
 
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
+
 import compiler.compilercontrol.share.JSONFile;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -52,6 +55,7 @@ public class DirectiveParserTest {
         emptyFile();
         noFile();
         directory();
+        lineCommentTest();
     }
 
     private static void simpleTest() {
@@ -144,5 +148,21 @@ public class DirectiveParserTest {
         OutputAnalyzer output = HugeDirectiveUtil.execute(Utils.TEST_SRC);
         Asserts.assertNE(output.getExitValue(), 0, ERROR_MSG + "directory as "
                 + "a name");
+    }
+
+    private static void lineCommentTest() {
+        String fileName = "lineComment.json";
+        try {
+            PrintStream out = new PrintStream(fileName);
+            out.println("[{");
+            out.println("  match: \"*::*\",");
+            out.println("  c2: { Exclude: true } // c1 only for startup");
+            out.println("}]");
+            out.close();
+        } catch (FileNotFoundException e) {
+            throw new Error("TESTBUG: can't open/create file " + fileName, e);
+        }
+        OutputAnalyzer output = HugeDirectiveUtil.execute(fileName);
+        output.shouldHaveExitValue(0);
     }
 }


### PR DESCRIPTION
Currently, the following valid compiler directive file:
```
[{
  match: "*::*",
  c2: { Exclude: true } // c1 only for startup
}]
```
will be rejected by the parser:
```
Syntax error on line 4 byte 2: Expected value separator or object end (one of ',}').
  At ']'.
}]

Parsing of compiler directives failed
```

This is because `JSON::skip_line_comment()`, in contradiction to its specification, does **not** "*return the first token after the line comment without consuming it*" but does consumes it.

The fix is trivial:
```
--- a/src/hotspot/share/utilities/json.cpp
+++ b/src/hotspot/share/utilities/json.cpp
@@ -580,7 +580,7 @@ u_char JSON::skip_line_comment() {
     return 0;
   }
   next();
-  return next();
+  return peek();
 }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318811](https://bugs.openjdk.org/browse/JDK-8318811): Compiler directives parser swallows a character after line comments (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16359/head:pull/16359` \
`$ git checkout pull/16359`

Update a local copy of the PR: \
`$ git checkout pull/16359` \
`$ git pull https://git.openjdk.org/jdk.git pull/16359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16359`

View PR using the GUI difftool: \
`$ git pr show -t 16359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16359.diff">https://git.openjdk.org/jdk/pull/16359.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16359#issuecomment-1779101021)