### PR TITLE
8316437: JFR: assert(!tl->has_java_buffer()) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
+++ b/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
@@ -260,7 +260,6 @@ jobject JfrJavaEventWriter::new_event_writer(TRAPS) {
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(THREAD));
   assert(event_writer(THREAD) == nullptr, "invariant");
   JfrThreadLocal* const tl = THREAD->jfr_thread_local();
-  assert(!tl->has_java_buffer(), "invariant");
   JfrBuffer* const buffer = tl->java_buffer();
   if (buffer == nullptr) {
     JfrJavaSupport::throw_out_of_memory_error("OOME for thread local buffer", THREAD);


### PR DESCRIPTION
Greetings,

Please help review this tiny adjustment that removes an overly restrictive assert—reasoning in the JIRA issue.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316437](https://bugs.openjdk.org/browse/JDK-8316437): JFR: assert(!tl-&gt;has_java_buffer()) failed: invariant (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16364/head:pull/16364` \
`$ git checkout pull/16364`

Update a local copy of the PR: \
`$ git checkout pull/16364` \
`$ git pull https://git.openjdk.org/jdk.git pull/16364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16364`

View PR using the GUI difftool: \
`$ git pr show -t 16364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16364.diff">https://git.openjdk.org/jdk/pull/16364.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16364#issuecomment-1779715751)