### PR TITLE
8318834: s390x: Debug builds are missing debug helpers

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -522,7 +522,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     # do this on s390x also for libjvm (where serviceability agent is not supported)
     if test "x$ENABLE_LINKTIME_GC" = xtrue; then
       TOOLCHAIN_CFLAGS_JDK="$TOOLCHAIN_CFLAGS_JDK -ffunction-sections -fdata-sections"
-      if test "x$OPENJDK_TARGET_CPU" = xs390x; then
+      if test "x$OPENJDK_TARGET_CPU" = xs390x && test "x$DEBUG_LEVEL" == xrelease; then
         TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -ffunction-sections -fdata-sections"
       fi
     fi


### PR DESCRIPTION
On s390x only, HotSpot is built by GCC with -ffunction-sections.
This means that debug helpers such as ps() and pfl() are not available. These helpers are extremely useful in debugging, so it makes no sense to omit them from debug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318834](https://bugs.openjdk.org/browse/JDK-8318834): s390x: Debug builds are missing debug helpers (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16365/head:pull/16365` \
`$ git checkout pull/16365`

Update a local copy of the PR: \
`$ git checkout pull/16365` \
`$ git pull https://git.openjdk.org/jdk.git pull/16365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16365`

View PR using the GUI difftool: \
`$ git pr show -t 16365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16365.diff">https://git.openjdk.org/jdk/pull/16365.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16365#issuecomment-1779741440)