### PR TITLE
8318837: javac generates wrong ldc instruction for dynamic constant loads

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -401,10 +401,11 @@ public class Code {
     */
     public void emitLdc(LoadableConstant constant) {
         int od = poolWriter.putConstant(constant);
-        if (od <= 255) {
+        if (LoadableConstant.isLongOrDouble(constant)) {
+            emitop2(ldc2w, od, constant);
+        } else if (od <= 255) {
             emitop1(ldc1, od, constant);
-        }
-        else {
+        } else {
             emitop2(ldc2, od, constant);
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Code.java
@@ -35,7 +35,9 @@ import java.util.function.ToIntBiFunction;
 import java.util.function.ToIntFunction;
 
 import static com.sun.tools.javac.code.TypeTag.BOT;
+import static com.sun.tools.javac.code.TypeTag.DOUBLE;
 import static com.sun.tools.javac.code.TypeTag.INT;
+import static com.sun.tools.javac.code.TypeTag.LONG;
 import static com.sun.tools.javac.jvm.ByteCodes.*;
 import static com.sun.tools.javac.jvm.ClassFile.CONSTANT_Class;
 import static com.sun.tools.javac.jvm.ClassFile.CONSTANT_Double;
@@ -401,7 +403,8 @@ public class Code {
     */
     public void emitLdc(LoadableConstant constant) {
         int od = poolWriter.putConstant(constant);
-        if (LoadableConstant.isLongOrDouble(constant)) {
+        Type constantType = types.constantType(constant);
+        if (constantType.hasTag(LONG) || constantType.hasTag(DOUBLE)) {
             emitop2(ldc2w, od, constant);
         } else if (od <= 255) {
             emitop1(ldc1, od, constant);
@@ -1063,15 +1066,13 @@ public class Code {
             Type t = types.erasure((Type)data);
             state.push(t);
             break; }
+        case ldc2:
         case ldc2w:
             state.push(types.constantType((LoadableConstant)data));
             break;
         case instanceof_:
             state.pop(1);
             state.push(syms.intType);
-            break;
-        case ldc2:
-            state.push(types.constantType((LoadableConstant)data));
             break;
         case jsr:
             break;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Items.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Items.java
@@ -590,15 +590,6 @@ public class Items {
                     throw new UnsupportedOperationException("unsupported tag: " + typecode);
             }
         }
-
-        private void ldc() {
-            if (typecode == LONGcode || typecode == DOUBLEcode) {
-                code.emitop2(ldc2w, value, PoolWriter::putConstant);
-            } else {
-                code.emitLdc(value);
-            }
-        }
-
         private Number numericValue() {
             return (Number)((BasicConstant)value).data;
         }
@@ -614,21 +605,21 @@ public class Items {
                 else if (Short.MIN_VALUE <= ival && ival <= Short.MAX_VALUE)
                     code.emitop2(sipush, ival);
                 else
-                    ldc();
+                    code.emitLdc(value);
                 break;
             case LONGcode:
                 long lval = numericValue().longValue();
                 if (lval == 0 || lval == 1)
                     code.emitop0(lconst_0 + (int)lval);
                 else
-                    ldc();
+                    code.emitLdc(value);
                 break;
             case FLOATcode:
                 float fval = numericValue().floatValue();
                 if (isPosZero(fval) || fval == 1.0 || fval == 2.0)
                     code.emitop0(fconst_0 + (int)fval);
                 else {
-                    ldc();
+                    code.emitLdc(value);
                 }
                 break;
             case DOUBLEcode:
@@ -636,10 +627,10 @@ public class Items {
                 if (isPosZero(dval) || dval == 1.0)
                     code.emitop0(dconst_0 + (int)dval);
                 else
-                    ldc();
+                    code.emitLdc(value);
                 break;
             case OBJECTcode:
-                ldc();
+                code.emitLdc(value);
                 break;
             default:
                 Assert.error();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolConstant.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolConstant.java
@@ -25,9 +25,12 @@
 
 package com.sun.tools.javac.jvm;
 
+import com.sun.tools.javac.code.Symbol.DynamicVarSymbol;
 import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.code.Types.UniqueType;
+import com.sun.tools.javac.jvm.PoolConstant.LoadableConstant.BasicConstant;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Pair;
@@ -116,6 +119,18 @@ public interface PoolConstant {
             public Object poolKey(Types types) {
                 return data;
             }
+        }
+
+        static boolean isLongOrDouble(LoadableConstant constant) {
+            return switch (constant) {
+                case DynamicVarSymbol dynamicVar ->
+                        dynamicVar.type.hasTag(TypeTag.LONG) ||
+                                dynamicVar.type.hasTag(TypeTag.DOUBLE);
+                case BasicConstant bc ->
+                        bc.tag == ClassFile.CONSTANT_Long ||
+                                bc.tag == ClassFile.CONSTANT_Double;
+                default -> false;
+            };
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolConstant.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolConstant.java
@@ -25,12 +25,9 @@
 
 package com.sun.tools.javac.jvm;
 
-import com.sun.tools.javac.code.Symbol.DynamicVarSymbol;
 import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.code.Types.UniqueType;
-import com.sun.tools.javac.jvm.PoolConstant.LoadableConstant.BasicConstant;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Pair;
@@ -119,18 +116,6 @@ public interface PoolConstant {
             public Object poolKey(Types types) {
                 return data;
             }
-        }
-
-        static boolean isLongOrDouble(LoadableConstant constant) {
-            return switch (constant) {
-                case DynamicVarSymbol dynamicVar ->
-                        dynamicVar.type.hasTag(TypeTag.LONG) ||
-                                dynamicVar.type.hasTag(TypeTag.DOUBLE);
-                case BasicConstant bc ->
-                        bc.tag == ClassFile.CONSTANT_Long ||
-                                bc.tag == ClassFile.CONSTANT_Double;
-                default -> false;
-            };
         }
     }
 

--- a/test/langtools/tools/javac/T8222949/TestConstantDynamic.java
+++ b/test/langtools/tools/javac/T8222949/TestConstantDynamic.java
@@ -81,21 +81,23 @@ import static java.lang.invoke.MethodHandleInfo.REF_invokeStatic;
 public class TestConstantDynamic extends ComboInstance<TestConstantDynamic> {
 
     enum ConstantType implements ComboParameter {
-        STRING("String", "Ljava/lang/String;"),
-        CLASS("Class<?>", "Ljava/lang/Class;"),
-        INTEGER("int", "I"),
-        LONG("long", "J"),
-        FLOAT("float", "F"),
-        DOUBLE("double", "D"),
-        METHOD_HANDLE("MethodHandle", "Ljava/lang/invoke/MethodHandle;"),
-        METHOD_TYPE("MethodType", "Ljava/lang/invoke/MethodType;");
+        STRING("String", "Ljava/lang/String;", Opcode.LDC),
+        CLASS("Class<?>", "Ljava/lang/Class;", Opcode.LDC),
+        INTEGER("int", "I", Opcode.LDC),
+        LONG("long", "J", Opcode.LDC2_W),
+        FLOAT("float", "F", Opcode.LDC),
+        DOUBLE("double", "D", Opcode.LDC2_W),
+        METHOD_HANDLE("MethodHandle", "Ljava/lang/invoke/MethodHandle;", Opcode.LDC),
+        METHOD_TYPE("MethodType", "Ljava/lang/invoke/MethodType;", Opcode.LDC);
 
         String sourceTypeStr;
         String bytecodeTypeStr;
+        Opcode opcode;
 
-        ConstantType(String sourceTypeStr, String bytecodeTypeStr) {
+        ConstantType(String sourceTypeStr, String bytecodeTypeStr, Opcode opcode) {
             this.sourceTypeStr = sourceTypeStr;
             this.bytecodeTypeStr = bytecodeTypeStr;
+            this.opcode = opcode;
         }
 
         @Override
@@ -203,6 +205,10 @@ public class TestConstantDynamic extends ComboInstance<TestConstantDynamic> {
                     System.out.println("condyInfo.getNameAndTypeInfo().getType() " + condyInfo.type().stringValue());
                     if (!condyInfo.type().equalsString(type.bytecodeTypeStr)) {
                         fail("type mismatch for ConstantDynamicEntry");
+                        return;
+                    }
+                    if (lci.opcode() != type.opcode) {
+                        fail("unexpected opcode for constant value: " + lci.opcode());
                         return;
                     }
                 }


### PR DESCRIPTION
This PR fixes how javac loads dynamic variable symbols in `Gen` - currently, either a `ldc` or `ldc_w` is emitted. This is problematic, as, depending on the type of the dynamic constant, in some cases `ldc2_w` might be required (e.g. if the type of the constant is either `long` or `double`).

I've updated the existing compiler condy test to check which `ldc` opcode is emitted for the various constants. I've also verified that the updated test fails w/o the changes in this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318837](https://bugs.openjdk.org/browse/JDK-8318837): javac generates wrong ldc instruction for dynamic constant loads (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to [23d4ef69](https://git.openjdk.org/jdk/pull/16367/files/23d4ef69d8f7a940731cbdcb3bda79252f7551a8)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [59c0bfe4](https://git.openjdk.org/jdk/pull/16367/files/59c0bfe44cef06c88c85887d635512262b72d21f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16367/head:pull/16367` \
`$ git checkout pull/16367`

Update a local copy of the PR: \
`$ git checkout pull/16367` \
`$ git pull https://git.openjdk.org/jdk.git pull/16367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16367`

View PR using the GUI difftool: \
`$ git pr show -t 16367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16367.diff">https://git.openjdk.org/jdk/pull/16367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16367#issuecomment-1779763398)