### PR TITLE
8318843: ProblemList java/lang/management/MemoryMXBean/CollectionUsageThreshold.java in Xcomp

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -28,3 +28,4 @@
 #############################################################################
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
+java/lang/management/MemoryMXBean/CollectionUsageThreshold.java 8318668 generic-all


### PR DESCRIPTION
A trivia fix to ProblemList java/lang/management/MemoryMXBean/CollectionUsageThreshold.java in Xcomp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318843](https://bugs.openjdk.org/browse/JDK-8318843): ProblemList java/lang/management/MemoryMXBean/CollectionUsageThreshold.java in Xcomp (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16368/head:pull/16368` \
`$ git checkout pull/16368`

Update a local copy of the PR: \
`$ git checkout pull/16368` \
`$ git pull https://git.openjdk.org/jdk.git pull/16368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16368`

View PR using the GUI difftool: \
`$ git pr show -t 16368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16368.diff">https://git.openjdk.org/jdk/pull/16368.diff</a>

</details>
