### PR TITLE
8318839: Update test thread factory to catch all exceptions

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -130,7 +130,8 @@ serviceability_ttf_virtual = \
   -serviceability/jvmti/vthread \
   -serviceability/jvmti/thread  \
   -serviceability/jvmti/events  \
-  -serviceability/jvmti/negative
+  -serviceability/jvmti/negative \
+  -serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorVMEventsTest.java
 
 tier1_common = \
   sanity/BasicVMTest.java \

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -64,6 +64,8 @@ java/lang/StackWalker/CallerFromMain.java 0000000 generic-all
 java/lang/Thread/MainThreadTest.java 0000000 generic-all
 java/lang/Thread/UncaughtExceptionsTest.java 0000000 generic-all
 java/lang/Thread/virtual/GetStackTraceWhenRunnable.java 0000000 generic-all
+java/lang/Thread/virtual/ThreadAPI.java#default 0000000 generic-all
+java/lang/Thread/virtual/ThreadAPI.java#no-vmcontinuations 0000000 generic-all
 java/lang/invoke/condy/CondyNestedResolutionTest.java 0000000 generic-all
 java/lang/ref/OOMEInReferenceHandler.java 0000000 generic-all
 java/util/concurrent/locks/Lock/OOMEInAQS.java 0000000 generic-all

--- a/test/jdk/java/util/concurrent/tck/ThreadTest.java
+++ b/test/jdk/java/util/concurrent/tck/ThreadTest.java
@@ -76,7 +76,6 @@ public class ThreadTest extends JSR166TestCase {
      * setDefaultUncaughtExceptionHandler.
      */
     public void testGetAndSetDefaultUncaughtExceptionHandler() {
-        assertNull(Thread.getDefaultUncaughtExceptionHandler());
         // failure due to SecurityException is OK.
         // Would be nice to explicitly test both ways, but cannot yet.
         Thread.UncaughtExceptionHandler defaultHandler

--- a/test/jtreg_test_thread_factory/src/share/classes/Virtual.java
+++ b/test/jtreg_test_thread_factory/src/share/classes/Virtual.java
@@ -23,12 +23,23 @@
 
 import java.util.concurrent.ThreadFactory;
 
+@SuppressWarnings("removal")
 public class Virtual implements ThreadFactory {
 
     static {
-        // This property is used by ProcessTools and some tests
         try {
+            // This property is used by ProcessTools and some tests
             System.setProperty("test.thread.factory", "Virtual");
+            // Temporary workaround until CODETOOLS-7903526 is fixed in jtreg
+            // The jtreg run main() in the ThreadGroup and catch only exceptions in this group.
+            // The virtual threads don't belong to any group and need global handler.
+            Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
+                    if (e instanceof ThreadDeath) {
+                        return;
+                    }
+                    e.printStackTrace(System.err);
+                    System.exit(1);
+                });
         } catch (Throwable t) {
             // might be thrown by security manager
         }


### PR DESCRIPTION
The jtreg starts the main thread in a separate ThreadGroup and checks unhandled exceptions for this group. However, it doesn't catch all unhandled exceptions. There is a jtreg issue for this https://bugs.openjdk.org/browse/CODETOOLS-7903526.
Catching such issues for virtual threads is important because they are not included in any groups. So this fix implements the handler for the test thread factory. 

A few tests start failing.

The test
serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorVMEventsTest.java
has testcases for platform and virtual threads. So, there is there's no need to run it with the thread factory.

The test
java/lang/Thread/virtual/ThreadAPI.java
tests UncaughtExceptionHandler and virtual threads. No need to run it with a thread factory.

Test 
test/jdk/java/util/concurrent/tck/ThreadTest.java is updated to not check the default empty handler.

Probably, we need some common approach about dealing with the UncaughtExceptionHandler in jtreg.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318839](https://bugs.openjdk.org/browse/JDK-8318839): Update test thread factory to catch all exceptions (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16369/head:pull/16369` \
`$ git checkout pull/16369`

Update a local copy of the PR: \
`$ git checkout pull/16369` \
`$ git pull https://git.openjdk.org/jdk.git pull/16369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16369`

View PR using the GUI difftool: \
`$ git pr show -t 16369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16369.diff">https://git.openjdk.org/jdk/pull/16369.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16369#issuecomment-1780066505)