### PR TITLE
JDK-8306980: Generated docs should contain correct Legal Documents

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1053,6 +1053,9 @@ else
   # All modules include the main license files from java.base.
   $(JMOD_TARGETS): java.base-copy
 
+  # jdk.javadoc uses an internal copy of the main license files from java.base.
+  jdk.javadoc-copy: java.base-copy
+
   zip-security: $(filter jdk.crypto%, $(JAVA_TARGETS))
 
   ifeq ($(ENABLE_GENERATE_CLASSLIST), true)

--- a/make/modules/jdk.javadoc/Copy.gmk
+++ b/make/modules/jdk.javadoc/Copy.gmk
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+include CopyCommon.gmk
+
+JDK_JAVADOC_DIR := $(JDK_OUTPUTDIR)/modules/jdk.javadoc
+JDK_JAVADOC_DOCLET_RESOURCE_DIR := $(JDK_JAVADOC_DIR)/jdk/javadoc/internal/doclets/formats/html/resources
+
+################################################################################
+
+$(eval $(call SetupCopyFiles, COPY_JAVADOC_MODULE_LEGAL_RESOURCES, \
+    DEST := $(JDK_JAVADOC_DOCLET_RESOURCE_DIR)/legal, \
+    FILES := $(wildcard $(TOPDIR)/src/jdk.javadoc/share/legal/*.md), \
+    FLATTEN := true, \
+))
+TARGETS += $(COPY_JAVADOC_MODULE_LEGAL_RESOURCES)
+
+################################################################################
+
+$(eval $(call SetupCopyFiles, COPY_JAVADOC_COMMON_LEGAL_RESOURCES, \
+    DEST := $(JDK_JAVADOC_DOCLET_RESOURCE_DIR)/legal, \
+    FILES := $(wildcard $(SUPPORT_OUTPUTDIR)/modules_legal/common/*), \
+    FLATTEN := true, \
+))
+TARGETS += $(COPY_JAVADOC_COMMON_LEGAL_RESOURCES)
+
+################################################################################

--- a/make/modules/jdk.javadoc/Copy.gmk
+++ b/make/modules/jdk.javadoc/Copy.gmk
@@ -32,8 +32,7 @@ JDK_JAVADOC_DOCLET_RESOURCE_DIR := $(JDK_JAVADOC_DIR)/jdk/javadoc/internal/docle
 
 $(eval $(call SetupCopyFiles, COPY_JAVADOC_MODULE_LEGAL_RESOURCES, \
     DEST := $(JDK_JAVADOC_DOCLET_RESOURCE_DIR)/legal, \
-    FILES := $(wildcard $(TOPDIR)/src/jdk.javadoc/share/legal/*.md), \
-    FLATTEN := true, \
+    FILES := $(wildcard $(MODULE_SRC)/share/legal/*.md), \
 ))
 TARGETS += $(COPY_JAVADOC_MODULE_LEGAL_RESOURCES)
 
@@ -41,8 +40,7 @@ TARGETS += $(COPY_JAVADOC_MODULE_LEGAL_RESOURCES)
 
 $(eval $(call SetupCopyFiles, COPY_JAVADOC_COMMON_LEGAL_RESOURCES, \
     DEST := $(JDK_JAVADOC_DOCLET_RESOURCE_DIR)/legal, \
-    FILES := $(wildcard $(SUPPORT_OUTPUTDIR)/modules_legal/common/*), \
-    FLATTEN := true, \
+    FILES := $(wildcard $(COMMON_LEGAL_DST_DIR)/*), \
 ))
 TARGETS += $(COPY_JAVADOC_COMMON_LEGAL_RESOURCES)
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -343,11 +343,12 @@ public class HtmlDoclet extends AbstractDoclet {
         String legalNotices = configuration.getOptions().legalNotices();
         switch (legalNotices) {
             case "", "default" -> {
-                // use a dummy resource as a stand-in, because we cannot get the URL for a resources directory
-                var url = HtmlDoclet.class.getResource(DocPaths.RESOURCES.resolve(DocPaths.STYLESHEET).getPath());
+                // use a known resource as a stand-in, because we cannot get the URL for a resources directory
+                var url = HtmlDoclet.class.getResource(
+                        DocPaths.RESOURCES.resolve(DocPaths.LEGAL).resolve(DocPaths.JQUERY_MD).getPath());
                 if (url != null) {
                     try {
-                        legalNoticesDir = Path.of(url.toURI()).getParent().resolve("legal");
+                        legalNoticesDir = Path.of(url.toURI()).getParent();
                     } catch (URISyntaxException e) {
                         // should not happen when running javadoc from a system image
                         return;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -27,6 +27,7 @@ package jdk.javadoc.internal.doclets.formats.html;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -342,8 +343,18 @@ public class HtmlDoclet extends AbstractDoclet {
         String legalNotices = configuration.getOptions().legalNotices();
         switch (legalNotices) {
             case "", "default" -> {
-                Path javaHome = Path.of(System.getProperty("java.home"));
-                legalNoticesDir = javaHome.resolve("legal").resolve(getClass().getModule().getName());
+                // use a dummy resource as a stand-in, because we cannot get the URL for a resources directory
+                var url = HtmlDoclet.class.getResource(DocPaths.RESOURCES.resolve(DocPaths.STYLESHEET).getPath());
+                if (url != null) {
+                    try {
+                        legalNoticesDir = Path.of(url.toURI()).getParent().resolve("legal");
+                    } catch (URISyntaxException e) {
+                        // should not happen when running javadoc from a system image
+                        return;
+                    }
+                } else {
+                    return;
+                }
             }
 
             case "none" -> {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/DocPaths.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/DocPaths.java
@@ -112,6 +112,9 @@ public class DocPaths {
     /** The name of the default jQuery UI javascript file. */
     public static final DocPath JQUERY_UI_JS = DocPath.create("jquery-ui.min.js");
 
+    /** The name of the default jQuery file for legal notices. */
+    public static final DocPath JQUERY_MD = DocPath.create("jquery.md");
+
     /** The name of the directory for legal files. */
     public static final DocPath LEGAL = DocPath.create("legal");
 

--- a/test/langtools/jdk/javadoc/doclet/testLegalNotices/TestLegalNotices.java
+++ b/test/langtools/jdk/javadoc/doclet/testLegalNotices/TestLegalNotices.java
@@ -112,6 +112,18 @@ public class TestLegalNotices extends JavadocTester {
         if (foundFiles.equals(expectFiles)) {
             passed("Found all expected files");
         }
+
+        // See JDK-8306980
+        for (Path p : foundFiles) {
+            // Somewhat unusually, the dominant test is that the string "Please see..."
+            // does _not_ appear in the generated legal-notice files.
+            // The string is used by jlink when creating the legal files for a module
+            // on platforms that do not support symbolic links.
+            // The test verifies that javadoc is not using any such files.
+            checkOutput("legal/" + p, false,
+                    "Please see");
+        }
+
     }
 
     Set<Path> getExpectFiles(OptionKind optionKind, IndexKind indexKind, Path legal) throws IOException {

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
@@ -840,6 +840,11 @@ First line // @highlight :
             }
 
             @Override
+            public Iterable<? extends JavaFileObject> getJavaFileObjects(Path... files) {
+                return delegate.getJavaFileObjects(files);
+            }
+
+            @Override
             public Iterable<? extends JavaFileObject> getJavaFileObjectsFromStrings(Iterable<String> names) {
                 return delegate.getJavaFileObjectsFromStrings(names);
             }

--- a/test/langtools/jdk/javadoc/tool/api/basic/GetTask_FileManagerTest.java
+++ b/test/langtools/jdk/javadoc/tool/api/basic/GetTask_FileManagerTest.java
@@ -133,6 +133,11 @@ public class GetTask_FileManagerTest extends APITest {
         }
 
         @Override
+        public Iterable<? extends JavaFileObject> getJavaFileObjects(Path... files) {
+            return fileManager.getJavaFileObjects(files);
+        }
+
+        @Override
         public Iterable<? extends JavaFileObject> getJavaFileObjectsFromStrings(Iterable<String> names) {
             return fileManager.getJavaFileObjectsFromStrings(names);
         }


### PR DESCRIPTION
Please review an update to the way that `javadoc` handles the default legal notices when generating docs.

Previously, the default notices were taken from the module's `legal` directory (`$JAVA_HOME/legal/jdk.javadoc`), but in some contexts, these files were either symbolic links, or "descriptive links" -- text files containing the words "Please see ..." -- on platforms that did not support symbolic links. This was set up when using `jlink` to create the image.  These "descriptive links" were insufficient and inappropriate when used in a generated docs bundle.

The solution is to put a copy of the necessary files into the `jdk.javadoc` module itself, at build time, as resource files, and to copy the files from there instead of the module's `legal` directory. 

The set of files may vary depending on the kind of build, so care is taken to not hardwire any specific list of names into the code. This means using direct access to the underlying `jrt:` file system in order to determine the set of legal notices that were set up at build time. 

The main test for legal notices is updated to verify that the words "Please see ..." do not appear in any of the legal notices in a generated docs bundle. There should be no other change to the set of legal notices.

Two other tests were affected, because they provided their own minimal file manager for use with `javadoc`, which relied on default methods in the file manager API. These default methods are not sufficiently for handling paths in non-default file systems, such as the `jrt:` file system used to access the resources for the legal notices. The fix is just to override the necessary methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306980](https://bugs.openjdk.org/browse/JDK-8306980): Generated docs should contain correct Legal Documents (**Bug** - P3)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [6a724bf6](https://git.openjdk.org/jdk/pull/16370/files/6a724bf66a8b3f6775a6c4dc97539e7e9ac44842)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16370/head:pull/16370` \
`$ git checkout pull/16370`

Update a local copy of the PR: \
`$ git checkout pull/16370` \
`$ git pull https://git.openjdk.org/jdk.git pull/16370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16370`

View PR using the GUI difftool: \
`$ git pr show -t 16370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16370.diff">https://git.openjdk.org/jdk/pull/16370.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16370#issuecomment-1780183728)