### PR TITLE
8318894: G1: Use uint for age in G1SurvRateGroup

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -257,7 +257,7 @@ public:
                   HR_FORMAT_PARAMS(r),
                   p2i(r->top_at_mark_start()),
                   p2i(r->parsable_bottom()),
-                  r->has_surv_rate_group() ? r->age_in_surv_rate_group() : -1);
+                  r->has_surv_rate_group() ? checked_cast<int>(r->age_in_surv_rate_group()) : -1);
     return false;
   }
 };

--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -32,10 +32,10 @@
 
 G1SurvRateGroup::G1SurvRateGroup() :
   _stats_arrays_length(0),
+  _num_added_regions(0),
   _accum_surv_rate_pred(nullptr),
   _last_pred(0.0),
-  _surv_rate_predictors(nullptr),
-  _num_added_regions(0) {
+  _surv_rate_predictors(nullptr) {
   reset();
   start_adding_regions();
 }
@@ -82,12 +82,11 @@ void G1SurvRateGroup::stop_adding_regions() {
   }
 }
 
-void G1SurvRateGroup::record_surviving_words(int age_in_group, size_t surv_words) {
-  guarantee(0 <= age_in_group && (size_t)age_in_group < _num_added_regions,
-            "age_in_group is %d not between 0 and " SIZE_FORMAT, age_in_group, _num_added_regions);
+void G1SurvRateGroup::record_surviving_words(uint age, size_t surv_words) {
+  assert(is_valid_age(age), "age is %u not between 0 and %u", age, _num_added_regions);
 
   double surv_rate = (double)surv_words / HeapRegion::GrainWords;
-  _surv_rate_predictors[age_in_group]->add(surv_rate);
+  _surv_rate_predictors[age]->add(surv_rate);
 }
 
 void G1SurvRateGroup::all_surviving_words_recorded(const G1Predictions& predictor, bool update_predictors) {

--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.hpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.hpp
@@ -49,31 +49,33 @@
 // predictors in reverse chronological order as returned by age_in_group(). I.e.
 // index 0 contains the rate information for the region retired most recently.
 class G1SurvRateGroup : public CHeapObj<mtGC> {
-  size_t  _stats_arrays_length;
+  uint _stats_arrays_length;
+  uint _num_added_regions;   // The number of regions in this survivor rate group.
+
   double* _accum_surv_rate_pred;
   double  _last_pred;
   TruncatedSeq** _surv_rate_predictors;
-
-  size_t _num_added_regions;   // The number of regions in this survivor rate group.
 
   void fill_in_last_surv_rates();
   void finalize_predictions(const G1Predictions& predictor);
 
 public:
-  static const int InvalidAgeIndex = -1;
-  static bool is_valid_age_index(int age) { return age >= 0; }
+  static const uint InvalidAgeIndex = UINT_MAX;
+  bool is_valid_age_index(uint age_index) const {
+    return age_index >= 1 && age_index <= _num_added_regions;
+  }
+  bool is_valid_age(uint age) const { return age < _num_added_regions; }
 
   G1SurvRateGroup();
   void reset();
   void start_adding_regions();
   void stop_adding_regions();
-  void record_surviving_words(int age_in_group, size_t surv_words);
+  void record_surviving_words(uint age, size_t surv_words);
   void all_surviving_words_recorded(const G1Predictions& predictor, bool update_predictors);
 
-  double accum_surv_rate_pred(int age) const {
+  double accum_surv_rate_pred(uint age) const {
     assert(_stats_arrays_length > 0, "invariant" );
-    assert(is_valid_age_index(age), "must be");
-    if ((size_t)age < _stats_arrays_length)
+    if (age < _stats_arrays_length)
       return _accum_surv_rate_pred[age];
     else {
       double diff = (double)(age - _stats_arrays_length + 1);
@@ -81,22 +83,19 @@ public:
     }
   }
 
-  double surv_rate_pred(G1Predictions const& predictor, int age) const {
-    assert(is_valid_age_index(age), "must be");
-
-    age = MIN2(age, (int)_stats_arrays_length - 1);
+  double surv_rate_pred(G1Predictions const& predictor, uint age) const {
+    assert(is_valid_age(age), "must be");
 
     return predictor.predict_in_unit_interval(_surv_rate_predictors[age]);
   }
 
-  int next_age_index() {
-    return (int)++_num_added_regions;
+  uint next_age_index() {
+    return ++_num_added_regions;
   }
 
-  int age_in_group(int age_index) const {
-    int result = (int)(_num_added_regions - age_index);
-    assert(is_valid_age_index(result), "invariant" );
-    return result;
+  uint age_in_group(uint age_index) const {
+    assert(is_valid_age_index(age_index), "invariant" );
+    return _num_added_regions - age_index;
   }
 };
 

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -244,7 +244,7 @@ private:
   // Data for young region survivor prediction.
   uint  _young_index_in_cset;
   G1SurvRateGroup* _surv_rate_group;
-  int  _age_index;
+  uint  _age_index;
 
   // NUMA node.
   uint _node_index;
@@ -507,7 +507,7 @@ public:
     _young_index_in_cset = index;
   }
 
-  int age_in_surv_rate_group() const;
+  uint age_in_surv_rate_group() const;
   bool has_valid_age_in_surv_rate() const;
 
   bool has_surv_rate_group() const;

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -501,14 +501,14 @@ HeapWord* HeapRegion::oops_on_memregion_seq_iterate_careful(MemRegion mr,
   return oops_on_memregion_iterate<Closure, in_gc_pause>(mr, cl);
 }
 
-inline int HeapRegion::age_in_surv_rate_group() const {
+inline uint HeapRegion::age_in_surv_rate_group() const {
   assert(has_surv_rate_group(), "pre-condition");
   assert(has_valid_age_in_surv_rate(), "pre-condition");
   return _surv_rate_group->age_in_group(_age_index);
 }
 
 inline bool HeapRegion::has_valid_age_in_surv_rate() const {
-  return G1SurvRateGroup::is_valid_age_index(_age_index);
+  return _surv_rate_group->is_valid_age_index(_age_index);
 }
 
 inline bool HeapRegion::has_surv_rate_group() const {
@@ -537,15 +537,13 @@ inline void HeapRegion::uninstall_surv_rate_group() {
     _surv_rate_group = nullptr;
     _age_index = G1SurvRateGroup::InvalidAgeIndex;
   } else {
-    assert(!has_valid_age_in_surv_rate(), "pre-condition");
+    assert(_age_index == G1SurvRateGroup::InvalidAgeIndex, "inv");
   }
 }
 
 inline void HeapRegion::record_surv_words_in_group(size_t words_survived) {
-  assert(has_surv_rate_group(), "pre-condition");
-  assert(has_valid_age_in_surv_rate(), "pre-condition");
-  int age_in_group = age_in_surv_rate_group();
-  _surv_rate_group->record_surviving_words(age_in_group, words_survived);
+  uint age = age_in_surv_rate_group();
+  _surv_rate_group->record_surviving_words(age, words_survived);
 }
 
 #endif // SHARE_GC_G1_HEAPREGION_INLINE_HPP


### PR DESCRIPTION
Simple refactoring to use unsigned type for region-age.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318894](https://bugs.openjdk.org/browse/JDK-8318894): G1: Use uint for age in G1SurvRateGroup (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16376/head:pull/16376` \
`$ git checkout pull/16376`

Update a local copy of the PR: \
`$ git checkout pull/16376` \
`$ git pull https://git.openjdk.org/jdk.git pull/16376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16376`

View PR using the GUI difftool: \
`$ git pr show -t 16376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16376.diff">https://git.openjdk.org/jdk/pull/16376.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16376#issuecomment-1780936027)