### PR TITLE
8318683: compiler/c2/irTests/TestPhiDuplicatedConversion.java "Failed IR Rules (2) of Methods (2)"

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPhiDuplicatedConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPhiDuplicatedConversion.java
@@ -114,13 +114,13 @@ public class TestPhiDuplicatedConversion {
     }
 
     @Test
-    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true", "asimd", "true"})
     public static short float2HalfFloat(boolean c, float a, float b) {
         return c ? Float.floatToFloat16(a) : Float.floatToFloat16(b);
     }
 
     @Test
-    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"avx", "true", "asimd", "true"})
+    @IR(counts = {IRNode.CONV, "1"}, applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true", "asimd", "true"})
     public static float halfFloat2Float(boolean c, short a, short b) {
         return c ? Float.float16ToFloat(a) : Float.float16ToFloat(b);
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -83,6 +83,7 @@ public class IREncodingPrinter {
     private static final List<String> verifiedCPUFeatures = new ArrayList<String>( Arrays.asList(
         // x86
         "fma",
+        "f16c",
         // Intel SSE
         "sse",
         "sse2",


### PR DESCRIPTION
This patch should fix the testbug where F16 conversions were expected but were not supported by the CPU. Instead of checking for AVX, I now check for `f16c` or `avx512vl`, mirroring the logic in vm_version_x86:
https://github.com/openjdk/jdk/blob/ec1bf23d012f007c126cb472fcff146cf7f41b1a/src/hotspot/cpu/x86/vm_version_x86.hpp#L770-L772

I went with the approach of changing the logic in the IR annotation itself instead of the test requirements, as the majority of the IR tests in this file should complete correctly on other platforms. Tier 1 testing passes on my (linux x64) machine. Reviews would be appreciated!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318683](https://bugs.openjdk.org/browse/JDK-8318683): compiler/c2/irTests/TestPhiDuplicatedConversion.java "Failed IR Rules (2) of Methods (2)" (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16378/head:pull/16378` \
`$ git checkout pull/16378`

Update a local copy of the PR: \
`$ git checkout pull/16378` \
`$ git pull https://git.openjdk.org/jdk.git pull/16378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16378`

View PR using the GUI difftool: \
`$ git pr show -t 16378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16378.diff">https://git.openjdk.org/jdk/pull/16378.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16378#issuecomment-1781036106)