### PR TITLE
8316271: JfrJvmtiAgent::retransformClasses failed: JVMTI_ERROR_FAILS_VERIFICATION

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -451,7 +451,6 @@ final class EventInstrumentation {
                 // if (!settingsMethod(eventConfiguration.settingX)) goto fail;
                 codeBuilder.aload(0);
                 getEventConfiguration(codeBuilder);
-                codeBuilder.checkcast(TYPE_EVENT_CONFIGURATION);
                 codeBuilder.ldc(index);
                 invokevirtual(codeBuilder, TYPE_EVENT_CONFIGURATION, METHOD_EVENT_CONFIGURATION_GET_SETTING);
                 MethodTypeDesc mdesc = MethodTypeDesc.ofDescriptor("(" + sd.paramType().descriptorString() + ")Z");
@@ -712,6 +711,7 @@ final class EventInstrumentation {
     private void getEventConfiguration(CodeBuilder codeBuilder) {
         if (untypedEventConfiguration) {
             codeBuilder.getstatic(getEventClassDesc(), FIELD_EVENT_CONFIGURATION.name(), TYPE_OBJECT);
+            codeBuilder.checkcast(TYPE_EVENT_CONFIGURATION);
         } else {
             codeBuilder.getstatic(getEventClassDesc(), FIELD_EVENT_CONFIGURATION.name(), TYPE_EVENT_CONFIGURATION);
         }

--- a/test/jdk/jdk/jfr/jvm/TestVerifyInstrumentation.java
+++ b/test/jdk/jdk/jfr/jvm/TestVerifyInstrumentation.java
@@ -21,43 +21,41 @@
  * questions.
  */
 
- package jdk.jfr.jvm;
- 
- import jdk.jfr.Recording;
- import jdk.test.lib.jfr.EventNames;
- 
- /**
-  * @test
-  * @bug 8316271
-  * @key jfr
-  * @requires vm.hasJFR
-  * @library /test/lib
-  * @run main/othervm -Xverify:all jdk.jfr.jvm.TestVerifyInstrumentation
-  */
- public class TestVerifyInstrumentation {
- 
-     private final static String EVENT_NAME = EventNames.ThreadSleep;
- 
-     public static void main(String[] args) {
-         // This thread sleep wil load the jdk.internal.event.ThreadSleepEvent
-         // before JFR has started recording. This will set the type of the static
-         // field EventConfiguration to become untyped, i.e. java.lang.Object.
-         // Before issuing an invokevirtual instructions for this receiver, we must perform
-         // the proper type conversion, i.e. a downcast to type EventConfiguration using
-         // a conditional checkcast. -Xverify:all asserts this is ok.
-         //
-         // If not ok, the following exception is thrown as part of retransformation:
-         //
-         // java.lang.RuntimeException: JfrJvmtiAgent::retransformClasses failed: JVMTI_ERROR_FAILS_VERIFICATION.
-         //
-         try {
-             Thread.sleep(1);
-         } catch (InterruptedException ie) {}
-         try (Recording recording = new Recording()) {
-             recording.enable(EVENT_NAME).withoutThreshold().withStackTrace();
-             recording.start();
-             recording.stop();
-         }
-     }
- }
- 
+package jdk.jfr.jvm;
+
+import jdk.jfr.Recording;
+import jdk.test.lib.jfr.EventNames;
+
+/**
+ * @test
+ * @bug 8316271
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm -Xverify:all jdk.jfr.jvm.TestVerifyInstrumentation
+ */
+public class TestVerifyInstrumentation {
+    private final static String EVENT_NAME = EventNames.ThreadSleep;
+
+    public static void main(String[] args) {
+        // This thread sleep wil load the jdk.internal.event.ThreadSleepEvent
+        // before JFR has started recording. This will set the type of the static
+        // field EventConfiguration to become untyped, i.e. java.lang.Object.
+        // Before issuing an invokevirtual instructions for this receiver, we must perform
+        // the proper type conversion, i.e. a downcast to type EventConfiguration using
+        // a conditional checkcast. -Xverify:all asserts this is ok.
+        //
+        // If not ok, the following exception is thrown as part of retransformation:
+        //
+        // java.lang.RuntimeException: JfrJvmtiAgent::retransformClasses failed: JVMTI_ERROR_FAILS_VERIFICATION.
+        //
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException ie) {}
+        try (Recording recording = new Recording()) {
+            recording.enable(EVENT_NAME).withoutThreshold().withStackTrace();
+            recording.start();
+            recording.stop();
+        }
+    }
+}

--- a/test/jdk/jdk/jfr/jvm/TestVerifyInstrumentation.java
+++ b/test/jdk/jdk/jfr/jvm/TestVerifyInstrumentation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ package jdk.jfr.jvm;
+ 
+ import jdk.jfr.Recording;
+ import jdk.test.lib.jfr.EventNames;
+ 
+ /**
+  * @test
+  * @bug 8316271
+  * @key jfr
+  * @requires vm.hasJFR
+  * @library /test/lib
+  * @run main/othervm -Xverify:all jdk.jfr.jvm.TestVerifyInstrumentation
+  */
+ public class TestVerifyInstrumentation {
+ 
+     private final static String EVENT_NAME = EventNames.ThreadSleep;
+ 
+     public static void main(String[] args) {
+         // This thread sleep wil load the jdk.internal.event.ThreadSleepEvent
+         // before JFR has started recording. This will set the type of the static
+         // field EventConfiguration to become untyped, i.e. java.lang.Object.
+         // Before issuing an invokevirtual instructions for this receiver, we must perform
+         // the proper type conversion, i.e. a downcast to type EventConfiguration using
+         // a conditional checkcast. -Xverify:all asserts this is ok.
+         //
+         // If not ok, the following exception is thrown as part of retransformation:
+         //
+         // java.lang.RuntimeException: JfrJvmtiAgent::retransformClasses failed: JVMTI_ERROR_FAILS_VERIFICATION.
+         //
+         try {
+             Thread.sleep(1);
+         } catch (InterruptedException ie) {}
+         try (Recording recording = new Recording()) {
+             recording.enable(EVENT_NAME).withoutThreshold().withStackTrace();
+             recording.start();
+             recording.stop();
+         }
+     }
+ }
+ 


### PR DESCRIPTION
Greetings,

sometimes when running JFR with -Xverify:all, the bytecode retransform would fail with an JVMTI_ERROR_FAILS_VERIFICATION.

I say sometimes because it depends on whether event classes located in java.base are loaded before JFR is started.

If so, for those event classes, the type of the static field eventConfiguration is untyped, i.e. java.lang.Object, because the java.base module cannot use types in module jdk.jfr.

As part of the instrumentation of commit(), when issuing invokevirtual instructions for this receiver, a proper downcast must be performed using checkcast.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316271](https://bugs.openjdk.org/browse/JDK-8316271): JfrJvmtiAgent::retransformClasses failed: JVMTI_ERROR_FAILS_VERIFICATION (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16379/head:pull/16379` \
`$ git checkout pull/16379`

Update a local copy of the PR: \
`$ git checkout pull/16379` \
`$ git pull https://git.openjdk.org/jdk.git pull/16379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16379`

View PR using the GUI difftool: \
`$ git pr show -t 16379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16379.diff">https://git.openjdk.org/jdk/pull/16379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16379#issuecomment-1781327334)