### PR TITLE
8318908: Parallel: Remove ExtendedCardValue

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -389,20 +389,7 @@ void PSCardTable::verify_all_young_refs_imprecise() {
 
 bool PSCardTable::addr_is_marked_imprecise(void *addr) {
   CardValue* p = byte_for(addr);
-  CardValue val = *p;
-
-  if (card_is_dirty(val))
-    return true;
-
-  if (card_is_newgen(val))
-    return true;
-
-  if (card_is_clean(val))
-    return false;
-
-  assert(false, "Found unhandled card mark type");
-
-  return false;
+  return is_dirty(p);
 }
 
 bool PSCardTable::is_in_young(const void* p) const {

--- a/src/hotspot/share/gc/parallel/psCardTable.hpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.hpp
@@ -63,11 +63,6 @@ class PSCardTable: public CardTable {
                      HeapWord* const start,
                      HeapWord* const end);
 
-  enum ExtendedCardValue {
-    youngergen_card   = CT_MR_BS_last_reserved + 1,
-    verify_card       = CT_MR_BS_last_reserved + 5
-  };
-
   void scan_obj_with_limit(PSPromotionManager* pm,
                            oop obj,
                            HeapWord* start,
@@ -76,9 +71,6 @@ class PSCardTable: public CardTable {
  public:
   PSCardTable(MemRegion whole_heap) : CardTable(whole_heap),
                                       _preprocessing_active_workers(0) {}
-
-  static CardValue youngergen_card_val() { return youngergen_card; }
-  static CardValue verify_card_val()     { return verify_card; }
 
   // Scavenge support
   void pre_scavenge(HeapWord* old_gen_bottom, uint active_workers);
@@ -92,28 +84,14 @@ class PSCardTable: public CardTable {
 
   bool addr_is_marked_imprecise(void *addr);
 
-  void set_card_newgen(void* addr)   { CardValue* p = byte_for(addr); *p = verify_card; }
-
-  // Testers for entries
-  static bool card_is_dirty(int value)      { return value == dirty_card; }
-  static bool card_is_newgen(int value)     { return value == youngergen_card; }
-  static bool card_is_clean(int value)      { return value == clean_card; }
-  static bool card_is_verify(int value)     { return value == verify_card; }
-
   // Card marking
   void inline_write_ref_field_gc(void* field) {
     CardValue* byte = byte_for(field);
-    *byte = youngergen_card;
+    *byte = dirty_card_val();
   }
 
   // ReduceInitialCardMarks support
   bool is_in_young(const void* p) const override;
-
-#ifdef ASSERT
-  bool is_valid_card_address(CardValue* addr) {
-    return (addr >= _byte_map) && (addr < _byte_map + _byte_map_size);
-  }
-#endif // ASSERT
 
   // Verification
   void verify_all_young_refs_imprecise();


### PR DESCRIPTION
Simple removing some dead code; after this, a card is either clean or dirty.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318908](https://bugs.openjdk.org/browse/JDK-8318908): Parallel: Remove ExtendedCardValue (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16380/head:pull/16380` \
`$ git checkout pull/16380`

Update a local copy of the PR: \
`$ git checkout pull/16380` \
`$ git pull https://git.openjdk.org/jdk.git pull/16380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16380`

View PR using the GUI difftool: \
`$ git pr show -t 16380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16380.diff">https://git.openjdk.org/jdk/pull/16380.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16380#issuecomment-1781323127)