### PR TITLE
8318694: [JVMCI] disable can_call_java in most contexts for libjvmci compiler threads

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2453,7 +2453,7 @@ void java_lang_Throwable::print_stack_trace(Handle throwable, outputStream* st) 
       BacktraceElement bte = iter.next(THREAD);
       print_stack_element_to_stream(st, bte._mirror, bte._method_id, bte._version, bte._bci, bte._name);
     }
-    {
+    if (THREAD->can_call_java()) {
       // Call getCause() which doesn't necessarily return the _cause field.
       ExceptionMark em(THREAD);
       JavaValue cause(T_OBJECT);
@@ -2475,6 +2475,9 @@ void java_lang_Throwable::print_stack_trace(Handle throwable, outputStream* st) 
           st->cr();
         }
       }
+    } else {
+      st->print_raw_cr("<<cannot call Java to get cause>>");
+      return;
     }
   }
 }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -611,7 +611,7 @@ InstanceKlass* SystemDictionary::resolve_instance_class_or_null(Symbol* name,
   InstanceKlass* loaded_class = nullptr;
   SymbolHandle superclassname; // Keep alive while loading in parallel thread.
 
-  assert(THREAD->can_call_java(),
+  guarantee(THREAD->can_call_java(),
          "can not load classes with compiler thread: class=%s, classloader=%s",
          name->as_C_string(),
          class_loader.is_null() ? "null" : class_loader->klass()->name()->as_C_string());
@@ -2056,7 +2056,7 @@ Method* SystemDictionary::find_method_handle_invoker(Klass* klass,
                                                      Klass* accessing_klass,
                                                      Handle* appendix_result,
                                                      TRAPS) {
-  assert(THREAD->can_call_java() ,"");
+  guarantee(THREAD->can_call_java(), "");
   Handle method_type =
     SystemDictionary::find_method_handle_type(signature, accessing_klass, CHECK_NULL);
 

--- a/src/hotspot/share/compiler/compilerThread.cpp
+++ b/src/hotspot/share/compiler/compilerThread.cpp
@@ -39,6 +39,7 @@ CompilerThread::CompilerThread(CompileQueue* queue,
   _queue = queue;
   _counters = counters;
   _buffer_blob = nullptr;
+  _can_call_java = false;
   _compiler = nullptr;
   _arena_stat = CompilationMemoryStatistic::enabled() ? new ArenaStatCounter : nullptr;
 
@@ -56,13 +57,15 @@ CompilerThread::~CompilerThread() {
   delete _arena_stat;
 }
 
+void CompilerThread::set_compiler(AbstractCompiler* c) {
+  // Only jvmci compiler threads can call Java
+  _can_call_java = c != nullptr && c->is_jvmci();
+  _compiler = c;
+}
+
 void CompilerThread::thread_entry(JavaThread* thread, TRAPS) {
   assert(thread->is_Compiler_thread(), "must be compiler thread");
   CompileBroker::compiler_thread_loop();
-}
-
-bool CompilerThread::can_call_java() const {
-  return _compiler != nullptr && _compiler->is_jvmci();
 }
 
 // Hide native compiler threads from external view.

--- a/src/hotspot/share/compiler/compilerThread.hpp
+++ b/src/hotspot/share/compiler/compilerThread.hpp
@@ -31,18 +31,17 @@ class AbstractCompiler;
 class ArenaStatCounter;
 class BufferBlob;
 class ciEnv;
-class CompileThread;
+class CompilerThread;
 class CompileLog;
 class CompileTask;
 class CompileQueue;
 class CompilerCounters;
 class IdealGraphPrinter;
-class JVMCIEnv;
-class JVMCIPrimitiveArray;
 
 // A thread used for Compilation.
 class CompilerThread : public JavaThread {
   friend class VMStructs;
+  JVMCI_ONLY(friend class CompilerThreadCanCallJava;)
  private:
   CompilerCounters* _counters;
 
@@ -51,6 +50,7 @@ class CompilerThread : public JavaThread {
   CompileTask* volatile _task;  // print_threads_compiling can read this concurrently.
   CompileQueue*         _queue;
   BufferBlob*           _buffer_blob;
+  bool                  _can_call_java;
 
   AbstractCompiler*     _compiler;
   TimeStamp             _idle_time;
@@ -73,13 +73,13 @@ class CompilerThread : public JavaThread {
 
   bool is_Compiler_thread() const                { return true; }
 
-  virtual bool can_call_java() const;
+  virtual bool can_call_java() const             { return _can_call_java; }
 
   // Returns true if this CompilerThread is hidden from JVMTI and FlightRecorder.  C1 and C2 are
   // always hidden but JVMCI compiler threads might be hidden.
   virtual bool is_hidden_from_external_view() const;
 
-  void set_compiler(AbstractCompiler* c)         { _compiler = c; }
+  void set_compiler(AbstractCompiler* c);
   AbstractCompiler* compiler() const             { return _compiler; }
 
   CompileQueue* queue()        const             { return _queue; }

--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -23,6 +23,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "compiler/abstractCompiler.hpp"
 #include "compiler/compileTask.hpp"
 #include "compiler/compilerThread.hpp"
 #include "gc/shared/collectedHeap.hpp"
@@ -52,6 +53,29 @@ StringEventLog* JVMCI::_verbose_events = nullptr;
 volatile intx JVMCI::_fatal_log_init_thread = -1;
 volatile int JVMCI::_fatal_log_fd = -1;
 const char* JVMCI::_fatal_log_filename = nullptr;
+
+CompilerThreadCanCallJava::CompilerThreadCanCallJava(JavaThread* current, bool new_state) {
+  _current = nullptr;
+  if (current->is_Compiler_thread()) {
+    CompilerThread* ct = CompilerThread::cast(current);
+    if (ct->_can_call_java != new_state &&
+        ct->_compiler != nullptr &&
+        ct->_compiler->is_jvmci())
+    {
+      // Only enter a new context if the ability of the
+      // current thread to call Java actually changes
+      _reset_state = ct->_can_call_java;
+      ct->_can_call_java = new_state;
+      _current = ct;
+    }
+  }
+}
+
+CompilerThreadCanCallJava::~CompilerThreadCanCallJava() {
+  if (_current != nullptr) {
+    _current->_can_call_java = _reset_state;
+  }
+}
 
 void jvmci_vmStructs_init() NOT_DEBUG_RETURN;
 
@@ -175,6 +199,10 @@ void JVMCI::ensure_box_caches_initialized(TRAPS) {
     java_lang_Integer_IntegerCache::symbol(),
     java_lang_Long_LongCache::symbol()
   };
+
+  // Class resolution and initialization below
+  // requires calling into Java
+  CompilerThreadCanCallJava ccj(THREAD, true);
 
   for (unsigned i = 0; i < sizeof(box_classes) / sizeof(Symbol*); i++) {
     Klass* k = SystemDictionary::resolve_or_fail(box_classes[i], true, CHECK);

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -29,6 +29,7 @@
 #include "utilities/exceptions.hpp"
 
 class BoolObjectClosure;
+class CompilerThread;
 class constantPoolHandle;
 class JavaThread;
 class JVMCIEnv;
@@ -45,6 +46,34 @@ typedef FormatStringEventLog<256> StringEventLog;
 
 struct _jmetadata;
 typedef struct _jmetadata *jmetadata;
+
+// A stack object that manages a scope in which the current thread, if
+// it's a CompilerThread, can have its CompilerThread::_can_call_java
+// field changed. This allows restricting libjvmci better in terms
+// of when it can make Java calls. If a Java call on a CompilerThread
+// reaches a clinit, there's a risk of dead-lock when async compilation
+// is disabled (e.g. -Xbatch or -Xcomp) as the non-CompilerThread thread
+// waiting for the blocking compilation may hold the clinit lock.
+//
+// This scope is primarily used to disable Java calls when libjvmci enters
+// the VM via a C2V (i.e. CompilerToVM) native method.
+class CompilerThreadCanCallJava : StackObj {
+ private:
+  CompilerThread* _current; // Only non-null if state of thread changed
+  bool _reset_state;        // Value prior to state change, undefined
+                            // if no state change.
+public:
+  // Enters a scope in which the ability of the current CompilerThread
+  // to call Java is specified by `new_state`. This call only makes a
+  // change if the current thread is a CompilerThread associated with
+  // a JVMCI compiler whose CompilerThread::_can_call_java is not
+  // currently `new_state`.
+  CompilerThreadCanCallJava(JavaThread* current, bool new_state);
+
+  // Resets CompilerThread::_can_call_java of the current thread if the
+  // constructor changed it.
+  ~CompilerThreadCanCallJava();
+};
 
 class JVMCI : public AllStatic {
   friend class JVMCIRuntime;

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3034,6 +3034,7 @@ C2V_VMENTRY_0(jboolean, addFailedSpeculation, (JNIEnv* env, jobject, jlong faile
 C2V_END
 
 C2V_VMENTRY(void, callSystemExit, (JNIEnv* env, jobject, jint status))
+  CompilerThreadCanCallJava canCallJava(thread, true);
   JavaValue result(T_VOID);
   JavaCallArguments jargs(1);
   jargs.push_int(status);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -448,6 +448,15 @@ class HotSpotToSharedLibraryExceptionTranslation : public ExceptionTranslation {
  private:
   const Handle& _throwable;
 
+  char* print_throwable_to_buffer(Handle throwable, jlong buffer, int buffer_size) {
+    char* char_buffer = (char*) buffer + 4;
+    stringStream st(char_buffer, (size_t) buffer_size - 4);
+    java_lang_Throwable::print_stack_trace(throwable, &st);
+    u4 len = (u4) st.size();
+    *((u4*) buffer) = len;
+    return char_buffer;
+  }
+
   bool handle_pending_exception(JavaThread* THREAD, jlong buffer, int buffer_size) {
     if (HAS_PENDING_EXCEPTION) {
       Handle throwable = Handle(THREAD, PENDING_EXCEPTION);
@@ -457,11 +466,7 @@ class HotSpotToSharedLibraryExceptionTranslation : public ExceptionTranslation {
         JVMCI_event_1("error translating exception: OutOfMemoryError");
         decode(THREAD, _encode_oome_fail, 0L);
       } else {
-        char* char_buffer = (char*) buffer + 4;
-        stringStream st(char_buffer, (size_t) buffer_size - 4);
-        java_lang_Throwable::print_stack_trace(throwable, &st);
-        u4 len = (u4) st.size();
-        *((u4*) buffer) = len;
+        char* char_buffer = print_throwable_to_buffer(throwable, buffer, buffer_size);
         JVMCI_event_1("error translating exception: %s", char_buffer);
         decode(THREAD, _encode_fail, buffer);
       }
@@ -471,6 +476,12 @@ class HotSpotToSharedLibraryExceptionTranslation : public ExceptionTranslation {
   }
 
   int encode(JavaThread* THREAD, jlong buffer, int buffer_size) {
+    if (!THREAD->can_call_java()) {
+      char* char_buffer = print_throwable_to_buffer(_throwable, buffer, buffer_size);
+      JVMCI_event_1("cannot call Java to translate exception: %s", char_buffer);
+      decode(THREAD, _encode_fail, buffer);
+      return 0;
+    }
     Klass* vmSupport = SystemDictionary::resolve_or_fail(vmSymbols::jdk_internal_vm_VMSupport(), true, THREAD);
     if (handle_pending_exception(THREAD, buffer, buffer_size)) {
       return 0;
@@ -1311,6 +1322,7 @@ JVMCIObject JVMCIEnv::get_jvmci_type(const JVMCIKlassHandle& klass, JVMCI_TRAPS)
   JavaThread* THREAD = JVMCI::compilation_tick(JavaThread::current()); // For exception macros.
   jboolean exception = false;
   if (is_hotspot()) {
+    CompilerThreadCanCallJava ccj(THREAD, true);
     JavaValue result(T_OBJECT);
     JavaCallArguments args;
     args.push_long(pointer);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -478,7 +478,8 @@ class HotSpotToSharedLibraryExceptionTranslation : public ExceptionTranslation {
   int encode(JavaThread* THREAD, jlong buffer, int buffer_size) {
     if (!THREAD->can_call_java()) {
       char* char_buffer = print_throwable_to_buffer(_throwable, buffer, buffer_size);
-      JVMCI_event_1("cannot call Java to translate exception: %s", char_buffer);
+      const char* detail = log_is_enabled(Info, exceptions) ? "" : " (-Xlog:exceptions may give more detail)";
+      JVMCI_event_1("cannot call Java to translate exception%s: %s", detail, char_buffer);
       decode(THREAD, _encode_fail, buffer);
       return 0;
     }

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1820,57 +1820,6 @@ Klass* JVMCIRuntime::get_klass_by_index(const constantPoolHandle& cpool,
 }
 
 // ------------------------------------------------------------------
-// Implementation of get_field_by_index.
-//
-// Implementation note: the results of field lookups are cached
-// in the accessor klass.
-void JVMCIRuntime::get_field_by_index_impl(InstanceKlass* klass, fieldDescriptor& field_desc,
-                                        int index, Bytecodes::Code bc) {
-  JVMCI_EXCEPTION_CONTEXT;
-
-  assert(klass->is_linked(), "must be linked before using its constant-pool");
-
-  constantPoolHandle cpool(thread, klass->constants());
-
-  // Get the field's name, signature, and type.
-  Symbol* name  = cpool->name_ref_at(index, bc);
-
-  int nt_index = cpool->name_and_type_ref_index_at(index, bc);
-  int sig_index = cpool->signature_ref_index_at(nt_index);
-  Symbol* signature = cpool->symbol_at(sig_index);
-
-  // Get the field's declared holder.
-  int holder_index = cpool->klass_ref_index_at(index, bc);
-  bool holder_is_accessible;
-  Klass* declared_holder = get_klass_by_index(cpool, holder_index,
-                                               holder_is_accessible,
-                                               klass);
-
-  // The declared holder of this field may not have been loaded.
-  // Bail out with partial field information.
-  if (!holder_is_accessible) {
-    return;
-  }
-
-
-  // Perform the field lookup.
-  Klass*  canonical_holder =
-    InstanceKlass::cast(declared_holder)->find_field(name, signature, &field_desc);
-  if (canonical_holder == nullptr) {
-    return;
-  }
-
-  assert(canonical_holder == field_desc.field_holder(), "just checking");
-}
-
-// ------------------------------------------------------------------
-// Get a field by index from a klass's constant pool.
-void JVMCIRuntime::get_field_by_index(InstanceKlass* accessor, fieldDescriptor& fd, int index, Bytecodes::Code bc) {
-  ResourceMark rm;
-  return get_field_by_index_impl(accessor, fd, index, bc);
-}
-
-// ------------------------------------------------------------------
 // Perform an appropriate method lookup based on accessor, holder,
 // name, signature, and bytecode.
 Method* JVMCIRuntime::lookup_method(InstanceKlass* accessor,

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -231,8 +231,6 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
                                           int klass_index,
                                           bool& is_accessible,
                                           Klass* loading_klass);
-  static void   get_field_by_index_impl(InstanceKlass* loading_klass, fieldDescriptor& fd,
-                                        int field_index, Bytecodes::Code bc);
   static Method*  get_method_by_index_impl(const constantPoolHandle& cpool,
                                            int method_index, Bytecodes::Code bc,
                                            InstanceKlass* loading_klass);
@@ -417,8 +415,6 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
                                      int klass_index,
                                      bool& is_accessible,
                                      Klass* loading_klass);
-  static void   get_field_by_index(InstanceKlass* loading_klass, fieldDescriptor& fd,
-                                   int field_index, Bytecodes::Code bc);
   static Method*  get_method_by_index(const constantPoolHandle& cpool,
                                       int method_index, Bytecodes::Code bc,
                                       InstanceKlass* loading_klass);

--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -79,7 +79,7 @@ JavaThread* UpcallLinker::on_entry(UpcallStub::FrameData* context, jobject recei
   guarantee(thread->thread_state() == _thread_in_native, "wrong thread state for upcall");
   context->thread = thread;
 
-  assert(thread->can_call_java(), "must be able to call Java");
+  guarantee(thread->can_call_java(), "must be able to call Java");
 
   // Allocate handle block for Java code. This must be done before we change thread_state to _thread_in_Java,
   // since it can potentially block.

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -565,7 +565,8 @@ final class CompilerToVM {
      * The behavior of this method is undefined if {@code rawIndex} is invalid.
      *
      * @param info an array in which the details of the field are returned
-     * @return the type defining the field if resolution is successful, null otherwise
+     * @return the type defining the field if resolution is successful, null if the type cannot be resolved
+     * @throws LinkageError if there were other problems resolving the field
      */
     HotSpotResolvedObjectTypeImpl resolveFieldInPool(HotSpotConstantPool constantPool, int rawIndex, HotSpotResolvedJavaMethodImpl method, byte opcode, int[] info) {
         long methodPointer = method != null ? method.getMethodPointer() : 0L;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -841,16 +841,16 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
         final int holderIndex = getKlassRefIndexAt(rawIndex, opcode);
         JavaType fieldHolder = lookupType(holderIndex, opcode);
 
-        if (fieldHolder instanceof HotSpotResolvedObjectTypeImpl) {
+        if (fieldHolder instanceof HotSpotResolvedObjectTypeImpl)  {
             int[] info = new int[4];
             HotSpotResolvedObjectTypeImpl resolvedHolder;
             try {
                 resolvedHolder = compilerToVM().resolveFieldInPool(this, rawIndex, (HotSpotResolvedJavaMethodImpl) method, (byte) opcode, info);
             } catch (Throwable t) {
-                /*
-                 * If there was an exception resolving the field we give up and return an unresolved
-                 * field.
-                 */
+                resolvedHolder = null;
+            }
+            if (resolvedHolder == null) {
+                // There was an exception resolving the field or it returned null so return an unresolved field.
                 return new UnresolvedJavaField(fieldHolder, lookupUtf8(getNameRefIndexAt(nameAndTypeIndex)), type);
             }
             final int flags = info[0];

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -841,7 +841,7 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
         final int holderIndex = getKlassRefIndexAt(rawIndex, opcode);
         JavaType fieldHolder = lookupType(holderIndex, opcode);
 
-        if (fieldHolder instanceof HotSpotResolvedObjectTypeImpl)  {
+        if (fieldHolder instanceof HotSpotResolvedObjectTypeImpl) {
             int[] info = new int[4];
             HotSpotResolvedObjectTypeImpl resolvedHolder;
             try {


### PR DESCRIPTION
This PR reduces the context in which a libjvmci CompilerThread can make a Java call. By default, a CompileThread for a JVMCI compiler can make Java calls (as jarjvmci only works that way). When libjvmci calls into the VM via a CompilerToVM native method, it enters a scope where Java calls are disabled until either the call returns or a nested scope is entered that re-enables Java calls. The latter is required for the Truffle use case described in [JDK-8318694](https://bugs.openjdk.org/browse/JDK-8318694) as well as for a few other VM entry points where libgraal currently still requires the ability to make Java calls (e.g. to load the Java classes used for boxing primitives). We may be able to eventually eliminate all need for libgraal to make Java calls but this PR is a first step in the right direction.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318694](https://bugs.openjdk.org/browse/JDK-8318694): [JVMCI] disable can_call_java in most contexts for libjvmci compiler threads (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [b7181d70](https://git.openjdk.org/jdk/pull/16383/files/b7181d70c154fa1b7ef509701968d944edcc6f51)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [b7181d70](https://git.openjdk.org/jdk/pull/16383/files/b7181d70c154fa1b7ef509701968d944edcc6f51)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16383/head:pull/16383` \
`$ git checkout pull/16383`

Update a local copy of the PR: \
`$ git checkout pull/16383` \
`$ git pull https://git.openjdk.org/jdk.git pull/16383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16383`

View PR using the GUI difftool: \
`$ git pr show -t 16383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16383.diff">https://git.openjdk.org/jdk/pull/16383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16383#issuecomment-1782743022)