### PR TITLE
JDK-8296240: Augment discussion of test tiers in doc/testing.md

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -210,18 +210,19 @@ tier1.</p>
 <li><p><code>tier1</code>: This is the most fundamental test tier.
 Roughly speaking, a failure of a test in this tier has the potential to
 indicate a problem that would affect many Java programs. Tests in
-<code>tier1</code> include tests of HotSpot, core libraries in the
+<code>tier1</code> include tests of HotSpot, core APIs in the
 <code>java.base</code> module, and the <code>javac</code> compiler.
 Multiple developers run these tests every day. Because of the widespread
 use, the tests in <code>tier1</code> are carefully selected and
 optimized to run fast, and to run in the most stable manner. As a
-guideline, nearly all individual tests in <code>tier1</code> should
-complete in less than ten seconds when run on common configurations used
-for development. Long-running tests, even of core functionality, should
-occur in higher tiers or be covered in other kinds of testing. The test
-failures in <code>tier1</code> are usually followed up on quickly,
-either with fixes, or adding relevant tests to problem list. GitHub
-Actions workflows, if enabled, run <code>tier1</code> tests.</p></li>
+guideline, nearly all individual tests in <code>tier1</code> are
+expected to run to completion in ten seconds or less when run on common
+configurations used for development. Long-running tests, even of core
+functionality, should occur in higher tiers or be covered in other kinds
+of testing. The test failures in <code>tier1</code> are usually followed
+up on quickly, either with fixes, or adding relevant tests to problem
+list. GitHub Actions workflows, if enabled, run <code>tier1</code>
+tests.</p></li>
 <li><p><code>tier2</code>: This test group covers even more ground.
 These contain, among other things, tests that either run for too long to
 be at <code>tier1</code>, or may require special configuration, or tests

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -207,13 +207,21 @@ changed, and the first N tiers they can afford to run, but at least
 tier1.</p>
 <p>A brief description of the tiered test groups:</p>
 <ul>
-<li><p><code>tier1</code>: This is the lowest test tier. Multiple
-developers run these tests every day. Because of the widespread use, the
-tests in <code>tier1</code> are carefully selected and optimized to run
-fast, and to run in the most stable manner. The test failures in
-<code>tier1</code> are usually followed up on quickly, either with
-fixes, or adding relevant tests to problem list. GitHub Actions
-workflows, if enabled, run <code>tier1</code> tests.</p></li>
+<li><p><code>tier1</code>: This is the most fundamental test tier.
+Roughly speaking, a failure of a test in this tier has the potential to
+indicate a problem that would affect many Java programs. Tests in
+<code>tier1</code> include tests of HotSpot, core libraries in the
+<code>java.base</code> module, and the <code>javac</code> compiler.
+Multiple developers run these tests every day. Because of the widespread
+use, the tests in <code>tier1</code> are carefully selected and
+optimized to run fast, and to run in the most stable manner. As a
+guideline, nearly all individual tests in <code>tier1</code> should
+complete in less than ten seconds when run on common configurations used
+for development. Long-running tests, even of core functionality, should
+occur in higher tiers or be covered in other kinds of testing. The test
+failures in <code>tier1</code> are usually followed up on quickly,
+either with fixes, or adding relevant tests to problem list. GitHub
+Actions workflows, if enabled, run <code>tier1</code> tests.</p></li>
 <li><p><code>tier2</code>: This test group covers even more ground.
 These contain, among other things, tests that either run for too long to
 be at <code>tier1</code>, or may require special configuration, or tests

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -136,20 +136,20 @@ the first N tiers they can afford to run, but at least tier1.
 A brief description of the tiered test groups:
 
 - `tier1`: This is the most fundamental test tier.
-  Roughly speaking, a failure of a test in this tier has the potential to
-  indicate a problem that would affect many Java programs. Tests in `tier1` include
-  tests of HotSpot, core APIs in the `java.base` module, and the `javac` compiler.
-  Multiple developers run these tests
-  every day. Because of the widespread use, the tests in `tier1` are
-  carefully selected and optimized to run fast, and to run in the most stable
-  manner.
-  As a guideline, nearly all individual tests in `tier1` are expected to run to completion in ten seconds or less
-  when run on common configurations used for development. Long-running tests,
-  even of core functionality, should occur in higher tiers or be covered in
-  other kinds of testing.
-  The test failures in `tier1` are usually followed up on quickly,
-  either with fixes, or adding relevant tests to problem list. GitHub Actions
-  workflows, if enabled, run `tier1` tests.
+  Roughly speaking, a failure of a test in this tier has the potential
+  to indicate a problem that would affect many Java programs. Tests in
+  `tier1` include tests of HotSpot, core APIs in the `java.base`
+  module, and the `javac` compiler. Multiple developers run these
+  tests every day. Because of the widespread use, the tests in `tier1`
+  are carefully selected and optimized to run fast, and to run in the
+  most stable manner. As a guideline, nearly all individual tests in
+  `tier1` are expected to run to completion in ten seconds or less
+  when run on common configurations used for development. Long-running
+  tests, even of core functionality, should occur in higher tiers or
+  be covered in other kinds of testing. The test failures in `tier1`
+  are usually followed up on quickly, either with fixes, or adding
+  relevant tests to problem list. GitHub Actions workflows, if
+  enabled, run `tier1` tests.
 
 - `tier2`: This test group covers even more ground. These contain, among other
   things, tests that either run for too long to be at `tier1`, or may require

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -135,10 +135,19 @@ the first N tiers they can afford to run, but at least tier1.
 
 A brief description of the tiered test groups:
 
-- `tier1`: This is the lowest test tier. Multiple developers run these tests
+- `tier1`: This is the lowest test tier.
+  Roughly speaking, a failure of a test in this tier has the potential to
+  indicate a problem that would affect many Java programs. Tests in `tier1` include
+  tests of HotSpot, libraries in the `java.base` module, and the `javac` compiler.
+  Multiple developers run these tests
   every day. Because of the widespread use, the tests in `tier1` are
   carefully selected and optimized to run fast, and to run in the most stable
-  manner. The test failures in `tier1` are usually followed up on quickly,
+  manner.
+  As a guideline, individual tests in `tier1` should complete in less than ten seconds
+  when run on common configurations used for development. Long-running tests,
+  even of core functionality, should occur in higher tiers or be covered in
+  other kinds of testing.
+  The test failures in `tier1` are usually followed up on quickly,
   either with fixes, or adding relevant tests to problem list. GitHub Actions
   workflows, if enabled, run `tier1` tests.
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -138,12 +138,12 @@ A brief description of the tiered test groups:
 - `tier1`: This is the most fundamental test tier.
   Roughly speaking, a failure of a test in this tier has the potential to
   indicate a problem that would affect many Java programs. Tests in `tier1` include
-  tests of HotSpot, core libraries in the `java.base` module, and the `javac` compiler.
+  tests of HotSpot, core APIs in the `java.base` module, and the `javac` compiler.
   Multiple developers run these tests
   every day. Because of the widespread use, the tests in `tier1` are
   carefully selected and optimized to run fast, and to run in the most stable
   manner.
-  As a guideline, nearly all individual tests in `tier1` should complete in less than ten seconds
+  As a guideline, nearly all individual tests in `tier1` are expected to run to completion in ten seconds or less
   when run on common configurations used for development. Long-running tests,
   even of core functionality, should occur in higher tiers or be covered in
   other kinds of testing.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -143,7 +143,7 @@ A brief description of the tiered test groups:
   every day. Because of the widespread use, the tests in `tier1` are
   carefully selected and optimized to run fast, and to run in the most stable
   manner.
-  As a guideline, individual tests in `tier1` should complete in less than ten seconds
+  As a guideline, nearly all individual tests in `tier1` should complete in less than ten seconds
   when run on common configurations used for development. Long-running tests,
   even of core functionality, should occur in higher tiers or be covered in
   other kinds of testing.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -135,7 +135,7 @@ the first N tiers they can afford to run, but at least tier1.
 
 A brief description of the tiered test groups:
 
-- `tier1`: This is the lowest test tier.
+- `tier1`: This is the most fundamental test tier.
   Roughly speaking, a failure of a test in this tier has the potential to
   indicate a problem that would affect many Java programs. Tests in `tier1` include
   tests of HotSpot, libraries in the `java.base` module, and the `javac` compiler.

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -138,7 +138,7 @@ A brief description of the tiered test groups:
 - `tier1`: This is the most fundamental test tier.
   Roughly speaking, a failure of a test in this tier has the potential to
   indicate a problem that would affect many Java programs. Tests in `tier1` include
-  tests of HotSpot, libraries in the `java.base` module, and the `javac` compiler.
+  tests of HotSpot, selected libraries in the `java.base` module, and the `javac` compiler.
   Multiple developers run these tests
   every day. Because of the widespread use, the tests in `tier1` are
   carefully selected and optimized to run fast, and to run in the most stable

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -138,7 +138,7 @@ A brief description of the tiered test groups:
 - `tier1`: This is the most fundamental test tier.
   Roughly speaking, a failure of a test in this tier has the potential to
   indicate a problem that would affect many Java programs. Tests in `tier1` include
-  tests of HotSpot, selected libraries in the `java.base` module, and the `javac` compiler.
+  tests of HotSpot, core libraries in the `java.base` module, and the `javac` compiler.
   Multiple developers run these tests
   every day. Because of the widespread use, the tests in `tier1` are
   carefully selected and optimized to run fast, and to run in the most stable


### PR DESCRIPTION
Clarify the intention of tier 1 tests. I'll reflow the paragraph and regenerate the HTML file once the wording is agreed upon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296240](https://bugs.openjdk.org/browse/JDK-8296240): Augment discussion of test tiers in doc/testing.md (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [75c64b60](https://git.openjdk.org/jdk/pull/16384/files/75c64b601ed8bf5097a5377287814658c2f5dbbd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16384/head:pull/16384` \
`$ git checkout pull/16384`

Update a local copy of the PR: \
`$ git checkout pull/16384` \
`$ git pull https://git.openjdk.org/jdk.git pull/16384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16384`

View PR using the GUI difftool: \
`$ git pr show -t 16384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16384.diff">https://git.openjdk.org/jdk/pull/16384.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16384#issuecomment-1781748430)