### PR TITLE
8318940: [JVMCI] do not set HotSpotNmethod oop for a default HotSpotNmethod

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -2779,11 +2779,11 @@ C2V_VMENTRY_0(jlong, translate, (JNIEnv* env, jobject, jobject obj_handle, jbool
       } else {
         // Link the new HotSpotNmethod to the nmethod
         PEER_JVMCIENV->initialize_installed_code(result, nm, JVMCI_CHECK_0);
-        // Only HotSpotNmethod instances in the HotSpot heap are tracked directly by the runtime.
-        if (PEER_JVMCIENV->is_hotspot()) {
+        // Only non-default HotSpotNmethod instances in the HotSpot heap are tracked directly by the runtime.
+        if (!isDefault && PEER_JVMCIENV->is_hotspot()) {
           JVMCINMethodData* data = nm->jvmci_nmethod_data();
           if (data == nullptr) {
-            JVMCI_THROW_MSG_0(IllegalArgumentException, "Cannot set HotSpotNmethod mirror for default nmethod");
+            JVMCI_THROW_MSG_0(IllegalArgumentException, "Missing HotSpotNmethod data");
           }
           if (data->get_nmethod_mirror(nm, /* phantom_ref */ false) != nullptr) {
             JVMCI_THROW_MSG_0(IllegalArgumentException, "Cannot overwrite existing HotSpotNmethod mirror for nmethod");

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -824,10 +824,10 @@ oop JVMCINMethodData::get_nmethod_mirror(nmethod* nm, bool phantom_ref) {
 }
 
 void JVMCINMethodData::set_nmethod_mirror(nmethod* nm, oop new_mirror) {
-  assert(_nmethod_mirror_index != -1, "cannot set JVMCI mirror for nmethod");
+  guarantee(_nmethod_mirror_index != -1, "cannot set JVMCI mirror for nmethod");
   oop* addr = nm->oop_addr_at(_nmethod_mirror_index);
-  assert(new_mirror != nullptr, "use clear_nmethod_mirror to clear the mirror");
-  assert(*addr == nullptr, "cannot overwrite non-null mirror");
+  guarantee(new_mirror != nullptr, "use clear_nmethod_mirror to clear the mirror");
+  guarantee(*addr == nullptr, "cannot overwrite non-null mirror");
 
   *addr = new_mirror;
 


### PR DESCRIPTION
The code in `c2v_translate` for translating a `HotSpotNmethod` object from the libgraal heap to the HotSpot heap has a bug where it is setting the oop slot in an `nmethod` that ties the lifetime of the `HotSpotNmethod` object to the associated `nmethod`. Roughly speaking, when the `HotSpotNmethod` object becomes garbage, the `nmethod` is unloaded.

This relationship is only maintained for [non-default HotSpotNmethods](https://github.com/openjdk/jdk/blob/77fe0fd9e6f1e1f775a5191640411c37eb51b415/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotNmethod.java#L47-L54). For a default `HotSpotNmethod`, no such oop slot exists and so it must not be set. This PR makes that fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318940](https://bugs.openjdk.org/browse/JDK-8318940): [JVMCI] do not set HotSpotNmethod oop for a default HotSpotNmethod (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16386/head:pull/16386` \
`$ git checkout pull/16386`

Update a local copy of the PR: \
`$ git checkout pull/16386` \
`$ git pull https://git.openjdk.org/jdk.git pull/16386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16386`

View PR using the GUI difftool: \
`$ git pr show -t 16386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16386.diff">https://git.openjdk.org/jdk/pull/16386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16386#issuecomment-1781963038)