### PR TITLE
8318753: hsdis binutils may place libs in lib64

### DIFF
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -255,16 +255,25 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
     disasm_header="\"$BINUTILS_INSTALL_DIR/include/dis-asm.h\""
     if test -e $BINUTILS_INSTALL_DIR/lib/libbfd.a && \
        test -e $BINUTILS_INSTALL_DIR/lib/libopcodes.a && \
-       test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a; then
+       (test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a || test -e $BINUTILS_INSTALL_DIR/lib64/libiberty.a); then
       HSDIS_CFLAGS="-DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB -I$BINUTILS_INSTALL_DIR/include"
-      HSDIS_LIBS="$BINUTILS_INSTALL_DIR/lib/libbfd.a $BINUTILS_INSTALL_DIR/lib/libopcodes.a $BINUTILS_INSTALL_DIR/lib/libiberty.a"
+
+      # libiberty ignores --libdir and may be installed in $BINUTILS_INSTALL_DIR/lib or $BINUTILS_INSTALL_DIR/lib64
+      # depending on system setup
+      LIBIBERTY_LIB=""
+      if test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a; then
+        LIBIBERTY_LIB="$BINUTILS_INSTALL_DIR/lib/libiberty.a"
+      else
+        LIBIBERTY_LIB="$BINUTILS_INSTALL_DIR/lib64/libiberty.a"
+      fi
+      HSDIS_LIBS="$BINUTILS_INSTALL_DIR/lib/libbfd.a $BINUTILS_INSTALL_DIR/lib/libopcodes.a $LIBIBERTY_LIB"
       # If we have libsframe add it.
       if test -e $BINUTILS_INSTALL_DIR/lib/libsframe.a; then
         HSDIS_LIBS="$HSDIS_LIBS $BINUTILS_INSTALL_DIR/lib/libsframe.a"
       fi
       AC_CHECK_LIB(z, deflate, [ HSDIS_LIBS="$HSDIS_LIBS -lz" ], AC_MSG_ERROR([libz not found]))
     else
-      AC_MSG_ERROR(["$BINUTILS_INSTALL_DIR/libs/ must contain libbfd.a, libopcodes.a, libiberty.a"])
+      AC_MSG_ERROR(["$BINUTILS_INSTALL_DIR/lib[64] must contain libbfd.a, libopcodes.a and libiberty.a"])
     fi
   fi
 


### PR DESCRIPTION
The binutils build of libiberty is put in `$BINUTILS_INSTALL_DIR/lib64` on some Linux distributions (e.g. Fedora, Oracle Linux), `$BINUTILS_INSTALL_DIR/lib` on others (e.g. Ubuntu).

This PR suggest simply adding logic to look for `libiberty.a` in either place, favoring `.../lib` like now.  Alternative solutions like adding an explicit `--libdir=$BINUTILS_INSTALL_DIR/lib` in the binutils `configure` setup was tested, but this option was ignored by the libibrerty build on the binutils versions I've tried.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318753](https://bugs.openjdk.org/browse/JDK-8318753): hsdis binutils may place libs in lib64 (**Bug** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16387/head:pull/16387` \
`$ git checkout pull/16387`

Update a local copy of the PR: \
`$ git checkout pull/16387` \
`$ git pull https://git.openjdk.org/jdk.git pull/16387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16387`

View PR using the GUI difftool: \
`$ git pr show -t 16387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16387.diff">https://git.openjdk.org/jdk/pull/16387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16387#issuecomment-1781971899)