### PR TITLE
8318953: RISC-V: Small refactoring for MacroAssembler::test_bit

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -63,7 +63,7 @@ void C2_MacroAssembler::fast_lock(Register objectReg, Register boxReg, Register 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(flag, oop);
     lwu(flag, Address(flag, Klass::access_flags_offset()));
-    test_bit(flag, flag, exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS), tmp /* tmp */);
+    test_bit(flag, flag, exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
     bnez(flag, cont, true /* is_far */);
   }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4667,13 +4667,19 @@ void MacroAssembler::rt_call(address dest, Register tmp) {
   }
 }
 
-void MacroAssembler::test_bit(Register Rd, Register Rs, uint32_t bit_pos, Register tmp) {
+void MacroAssembler::test_bit(Register Rd, Register Rs, uint32_t bit_pos) {
   assert(bit_pos < 64, "invalid bit range");
   if (UseZbs) {
     bexti(Rd, Rs, bit_pos);
     return;
   }
-  andi(Rd, Rs, 1UL << bit_pos, tmp);
+  int64_t imm = (int64_t)(1UL << bit_pos);
+  if (is_simm12(imm)) {
+    andi(Rd, Rs, imm);
+  } else {
+    srli(Rd, Rs, bit_pos);
+    andi(Rd, Rd, 1);
+  }
 }
 
 // Implements lightweight-locking.

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4675,10 +4675,10 @@ void MacroAssembler::test_bit(Register Rd, Register Rs, uint32_t bit_pos) {
   }
   int64_t imm = (int64_t)(1UL << bit_pos);
   if (is_simm12(imm)) {
-    andi(Rd, Rs, imm);
+    and_imm12(Rd, Rs, imm);
   } else {
     srli(Rd, Rs, bit_pos);
-    andi(Rd, Rd, 1);
+    and_imm12(Rd, Rd, 1);
   }
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1240,7 +1240,7 @@ public:
   void shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
 
   // test single bit in Rs, result is set to Rd
-  void test_bit(Register Rd, Register Rs, uint32_t bit_pos, Register tmp = t0);
+  void test_bit(Register Rd, Register Rs, uint32_t bit_pos);
 
   // Here the float instructions with safe deal with some exceptions.
   // e.g. convert from NaN, +Inf, -Inf to int, float, double


### PR DESCRIPTION
Hi, The current test_bit assembly function needs to accept a temporary register because it needs one if it goes to the andi else branch. However, in this case we can actually avoid calling andi and accomplish the same thing by logically shifting to the right and testing the lowest bit. The advantage is that it makes the test_bit function much simpler. Also, to reduce the number of instructions in a given case (consider the mv function), mv actually calls the li function, which generates more than one instruction when the parameter imm exceeds the 32-bit range.
https://github.com/openjdk/jdk/blob/9123961aaa47aa58ec436640590d2cceedb8cbb1/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L2009-L2017
https://github.com/openjdk/jdk/blob/9123961aaa47aa58ec436640590d2cceedb8cbb1/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp#L730
https://github.com/openjdk/jdk/blob/9123961aaa47aa58ec436640590d2cceedb8cbb1/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L804-L840

### Testing:
qemu 8.1.50:
- [x] Tier1 tests (fastdebug)
- [x] Tier2 tests (release)
- [x] Tier3 tests (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318953](https://bugs.openjdk.org/browse/JDK-8318953): RISC-V: Small refactoring for MacroAssembler::test_bit (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16391/head:pull/16391` \
`$ git checkout pull/16391`

Update a local copy of the PR: \
`$ git checkout pull/16391` \
`$ git pull https://git.openjdk.org/jdk.git pull/16391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16391`

View PR using the GUI difftool: \
`$ git pr show -t 16391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16391.diff">https://git.openjdk.org/jdk/pull/16391.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16391#issuecomment-1782399217)