### PR TITLE
JDK-8318955: Add ReleaseIntArrayElements in Java_sun_awt_X11_XlibWrapper_SetBitmapShape XlbWrapper.c to early return

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/xawt/XlibWrapper.c
+++ b/src/java.desktop/unix/native/libawt_xawt/xawt/XlibWrapper.c
@@ -2299,6 +2299,7 @@ Java_sun_awt_X11_XlibWrapper_SetBitmapShape
 
     pRect = (RECT_T *)SAFE_SIZE_ARRAY_ALLOC(malloc, worstBufferSize, sizeof(RECT_T));
     if (!pRect) {
+        (*env)->ReleaseIntArrayElements(env, bitmap, values, JNI_ABORT);
         return;
     }
 


### PR DESCRIPTION
There is an early return in Java_sun_awt_X11_XlibWrapper_SetBitmapShape XlbWrapper.c that seems to miss a ReleaseIntArrayElements call.