### PR TITLE
JDK-8318957: enhance agentlib:jdwp help output by info about allow option

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -836,6 +836,7 @@ printUsage(void)
  "address=<listen/attach address>  transport spec                    \"\"\n"
  "server=y|n                       listen for debugger?              n\n"
  "allow=<IP|IP-list>               If server=y, allows connections only from the IP addresses/subnets specified.\n"
+ "                                 A list of multiple IP address/subnet entries must be separated by \'+\'.\n"
  "                                                                   * (allows connection from any address)\n"
  "launch=<command line>            run debugger on event             none\n"
  "onthrow=<exception name>         debug on throw                    none\n"

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -835,6 +835,8 @@ printUsage(void)
  "transport=<name>                 transport spec                    none\n"
  "address=<listen/attach address>  transport spec                    \"\"\n"
  "server=y|n                       listen for debugger?              n\n"
+ "allow=<IP|IP-list>               If server=y, allows connections only from the IP addresses/subnets specified.\n"
+ "                                                                   * (allows connection from any address)\n"
  "launch=<command line>            run debugger on event             none\n"
  "onthrow=<exception name>         debug on throw                    none\n"
  "onuncaught=y|n                   debug on any uncaught?            n\n"


### PR DESCRIPTION
The allow option of agentlib:jdwp has been introduced a long time ago (see JDK-8061228) and is documented here :
https://docs.oracle.com/en/java/javase/17/docs/specs/jpda/conninv.html#oracle-vm-invocation-options
However it is still missing in the agentlib:jdwp help output and should be added there too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318957](https://bugs.openjdk.org/browse/JDK-8318957): enhance agentlib:jdwp help output by info about allow option (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16393/head:pull/16393` \
`$ git checkout pull/16393`

Update a local copy of the PR: \
`$ git checkout pull/16393` \
`$ git pull https://git.openjdk.org/jdk.git pull/16393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16393`

View PR using the GUI difftool: \
`$ git pr show -t 16393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16393.diff">https://git.openjdk.org/jdk/pull/16393.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16393#issuecomment-1782507949)