### PR TITLE
8318225: RISC-V: C2 UModI

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2408,7 +2408,12 @@ int MacroAssembler::corrected_idivl(Register result, Register rs1, Register rs2,
       divuw(result, rs1, rs2);
     }
   } else {
-    remw(result, rs1, rs2); // result = rs1 % rs2;
+    // result = rs1 % rs2;
+    if (is_signed) {
+      remw(result, rs1, rs2);
+    } else {
+      remuw(result, rs1, rs2);
+    }
   }
   return idivl_offset;
 }
@@ -2435,7 +2440,12 @@ int MacroAssembler::corrected_idivq(Register result, Register rs1, Register rs2,
       divu(result, rs1, rs2);
     }
   } else {
-    rem(result, rs1, rs2); // result = rs1 % rs2;
+    // result = rs1 % rs2;
+    if (is_signed) {
+      rem(result, rs1, rs2);
+    } else {
+      remu(result, rs1, rs2);
+    }
   }
   return idivq_offset;
 }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2478,12 +2478,28 @@ encode %{
     __ corrected_idivl(dst_reg, src1_reg, src2_reg, /* want_remainder */ true, /* is_signed */ true);
   %}
 
+  enc_class riscv_enc_moduw(iRegI dst, iRegI src1, iRegI src2) %{
+    C2_MacroAssembler _masm(&cbuf);
+    Register dst_reg = as_Register($dst$$reg);
+    Register src1_reg = as_Register($src1$$reg);
+    Register src2_reg = as_Register($src2$$reg);
+    __ corrected_idivl(dst_reg, src1_reg, src2_reg, /* want_remainder */ true, /* is_signed */ false);
+  %}
+
   enc_class riscv_enc_mod(iRegI dst, iRegI src1, iRegI src2) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
     Register src2_reg = as_Register($src2$$reg);
     __ corrected_idivq(dst_reg, src1_reg, src2_reg, /* want_remainder */ true, /* is_signed */ true);
+  %}
+
+  enc_class riscv_enc_modu(iRegI dst, iRegI src1, iRegI src2) %{
+    C2_MacroAssembler _masm(&cbuf);
+    Register dst_reg = as_Register($dst$$reg);
+    Register src1_reg = as_Register($src1$$reg);
+    Register src2_reg = as_Register($src2$$reg);
+    __ corrected_idivq(dst_reg, src1_reg, src2_reg, /* want_remainder */ true, /* is_signed */ false);
   %}
 
   enc_class riscv_enc_tail_call(iRegP jump_target) %{
@@ -6752,6 +6768,15 @@ instruct modI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   ins_pipe(ialu_reg_reg);
 %}
 
+instruct UmodI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+  match(Set dst (UModI src1 src2));
+  ins_cost(IDIVSI_COST);
+  format %{ "remuw  $dst, $src1, $src2\t#@UmodI" %}
+
+  ins_encode(riscv_enc_moduw(dst, src1, src2));
+  ins_pipe(ialu_reg_reg);
+%}
+
 // Long Remainder
 
 instruct modL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
@@ -6760,6 +6785,15 @@ instruct modL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   format %{ "rem  $dst, $src1, $src2\t#@modL" %}
 
   ins_encode(riscv_enc_mod(dst, src1, src2));
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct UmodL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
+  match(Set dst (UModL src1 src2));
+  ins_cost(IDIVDI_COST);
+  format %{ "remu  $dst, $src1, $src2\t#@UmodL" %}
+
+  ins_encode(riscv_enc_modu(dst, src1, src2));
   ins_pipe(ialu_reg_reg);
 %}
 


### PR DESCRIPTION
Hi,
Can you review the change to add intrinsic for UModI and UModL?
( This is a quite similar patch to https://github.com/openjdk/jdk/pull/16346, which addresses UDivI and UDivL, so for the performance consideration please also check the discussion in that pr. )
Thanks!


## Tests

### Functionality
Run tests successfully found via `grep -nr test/jdk/ -we remainderUnsigned` and `grep -nr test/hotspot/ -we remainderUnsigned` 

### Performance

#### Long
**NOTE: for positive divisor, it's the common case; for negative divisor, it's a rare case**

**Before**
```
LongDivMod.testRemainderUnsigned                 1024          mixed  avgt   10  21222.911 ± 57.735  ns/op
LongDivMod.testRemainderUnsigned                 1024       positive  avgt   10  28841.429 ±  6.294  ns/op
LongDivMod.testRemainderUnsigned                 1024       negative  avgt   10   7733.038 ±  3.856  ns/op
```

**After**
```
LongDivMod.testRemainderUnsigned                 1024          mixed  avgt   10  22666.448 ± 34.986  ns/op
LongDivMod.testRemainderUnsigned                 1024       positive  avgt   10  15967.846 ± 24.805  ns/op
LongDivMod.testRemainderUnsigned                 1024       negative  avgt   10  29507.865 ± 20.593  ns/op
```

#### Integer
**Before**
```
IntegerDivMod.testRemainderUnsigned                 1024          mixed  avgt   10  23396.475 ± 24.065  ns/op
IntegerDivMod.testRemainderUnsigned                 1024       positive  avgt   10  16796.796 ±  3.389  ns/op
IntegerDivMod.testRemainderUnsigned                 1024       negative  avgt   10  30159.407 ±  6.716  ns/op
```

**After**
```
IntegerDivMod.testRemainderUnsigned                 1024          mixed  avgt   10  23216.710 ± 14.351  ns/op
IntegerDivMod.testRemainderUnsigned                 1024       positive  avgt   10  16621.374 ±  3.203  ns/op
IntegerDivMod.testRemainderUnsigned                 1024       negative  avgt   10  30002.088 ± 41.212  ns/op

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8318225](https://bugs.openjdk.org/browse/JDK-8318225): RISC-V: C2 UModI (**Sub-task** - P4)
 * [JDK-8318226](https://bugs.openjdk.org/browse/JDK-8318226): RISC-V: C2 UModL (**Sub-task** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16394/head:pull/16394` \
`$ git checkout pull/16394`

Update a local copy of the PR: \
`$ git checkout pull/16394` \
`$ git pull https://git.openjdk.org/jdk.git pull/16394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16394`

View PR using the GUI difftool: \
`$ git pr show -t 16394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16394.diff">https://git.openjdk.org/jdk/pull/16394.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16394#issuecomment-1782585267)