### PR TITLE
8317287: [macos14] InterJVMGetDropSuccessTest.java: Child VM: abnormal termination

### DIFF
--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -218,9 +218,9 @@ class Child {
         }
 
         public void dragDropEnd(DragSourceDropEvent dsde) {
-            finished = true;
-            dropSuccess = dsde.getDropSuccess();
             synchronized (Util.SYNC_LOCK) {
+                finished = true;
+                dropSuccess = dsde.getDropSuccess();
                 Util.SYNC_LOCK.notifyAll();
             }
         }
@@ -267,6 +267,7 @@ class Child {
             Robot robot = new Robot();
             robot.setAutoWaitForIdle(true);
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
+            Thread.sleep(50);
             robot.mousePress(InputEvent.BUTTON1_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);
                  p.translate(Util.sign(targetPoint.x - p.x),
@@ -275,19 +276,20 @@ class Child {
                 Thread.sleep(50);
             }
 
+            boolean success1 = false;
             synchronized (Util.SYNC_LOCK) {
                 robot.mouseRelease(InputEvent.BUTTON1_MASK);
                 Util.SYNC_LOCK.wait(Util.FRAME_ACTIVATION_TIMEOUT);
+                if (!dragSourceListener.isDropFinished()) {
+                    throw new RuntimeException("Drop not finished");
+                }
+                success1 = dragSourceListener.getDropSuccess();
+                dragSourceListener.reset();
             }
 
-            if (!dragSourceListener.isDropFinished()) {
-                throw new RuntimeException("Drop not finished");
-            }
 
-            boolean success1 = dragSourceListener.getDropSuccess();
-
-            dragSourceListener.reset();
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
+            Thread.sleep(50);
             robot.mousePress(InputEvent.BUTTON1_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);
                  p.translate(Util.sign(targetPoint.x - p.x),
@@ -296,16 +298,16 @@ class Child {
                 Thread.sleep(50);
             }
 
+            boolean success2 = false;
             synchronized (Util.SYNC_LOCK) {
                 robot.mouseRelease(InputEvent.BUTTON1_MASK);
                 Util.SYNC_LOCK.wait(Util.FRAME_ACTIVATION_TIMEOUT);
+                if (!dragSourceListener.isDropFinished()) {
+                    throw new RuntimeException("Drop not finished");
+                }
+                success2 = dragSourceListener.getDropSuccess();
             }
 
-            if (!dragSourceListener.isDropFinished()) {
-                throw new RuntimeException("Drop not finished");
-            }
-
-            boolean success2 = dragSourceListener.getDropSuccess();
             int retCode = 0;
 
             if (success1) {

--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -226,8 +226,8 @@ class Child {
         }
     }
 
-    private boolean success1 = false;
-    private boolean success2 = false;
+    private volatile boolean success1 = false;
+    private volatile boolean success2 = false;
 
     final Frame frame = new Frame("Source Frame");
     final DragSource dragSource = DragSource.getDefaultDragSource();

--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,6 +265,7 @@ class Child {
             Point targetPoint = new Point(x + w / 2, y + h / 2);
 
             Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
             robot.mousePress(InputEvent.BUTTON1_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);

--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -183,9 +183,9 @@ final class Util implements AWTEventListener {
         robot.waitForIdle();
         reset();
         robot.mouseMove(p.x, p.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         synchronized (SYNC_LOCK) {
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             SYNC_LOCK.wait(MOUSE_RELEASE_TIMEOUT);
         }
 
@@ -268,7 +268,7 @@ class Child {
             robot.setAutoWaitForIdle(true);
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
             Thread.sleep(50);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);
                  p.translate(Util.sign(targetPoint.x - p.x),
                              Util.sign(targetPoint.y - p.y))) {
@@ -278,7 +278,7 @@ class Child {
 
             boolean success1 = false;
             synchronized (Util.SYNC_LOCK) {
-                robot.mouseRelease(InputEvent.BUTTON1_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
                 Util.SYNC_LOCK.wait(Util.FRAME_ACTIVATION_TIMEOUT);
                 if (!dragSourceListener.isDropFinished()) {
                     throw new RuntimeException("Drop not finished");
@@ -290,7 +290,7 @@ class Child {
 
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
             Thread.sleep(50);
-            robot.mousePress(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);
                  p.translate(Util.sign(targetPoint.x - p.x),
                              Util.sign(targetPoint.y - p.y))) {
@@ -300,7 +300,7 @@ class Child {
 
             boolean success2 = false;
             synchronized (Util.SYNC_LOCK) {
-                robot.mouseRelease(InputEvent.BUTTON1_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
                 Util.SYNC_LOCK.wait(Util.FRAME_ACTIVATION_TIMEOUT);
                 if (!dragSourceListener.isDropFinished()) {
                     throw new RuntimeException("Drop not finished");

--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -270,13 +270,13 @@ class Child {
             Robot robot = new Robot();
             robot.setAutoWaitForIdle(true);
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
-            Thread.sleep(50);
+            robot.delay(50);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);
-                 p.translate(Util.sign(targetPoint.x - p.x),
+                p.translate(Util.sign(targetPoint.x - p.x),
                              Util.sign(targetPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);
-                Thread.sleep(50);
+                robot.delay(50);
             }
 
             synchronized (Util.SYNC_LOCK) {
@@ -284,8 +284,8 @@ class Child {
                 Util.SYNC_LOCK.wait(Util.FRAME_ACTIVATION_TIMEOUT);
             }
 
-            EventQueue.invokeAndWait(()-> {
-                 if (!dragSourceListener.isDropFinished()) {
+            EventQueue.invokeAndWait(() -> {
+                if (!dragSourceListener.isDropFinished()) {
                     throw new RuntimeException("Drop not finished");
                 }
                 success1 = dragSourceListener.getDropSuccess();
@@ -294,13 +294,13 @@ class Child {
 
 
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
-            Thread.sleep(50);
+            robot.delay(50);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             for (Point p = new Point(sourcePoint); !p.equals(targetPoint);
-                 p.translate(Util.sign(targetPoint.x - p.x),
+                p.translate(Util.sign(targetPoint.x - p.x),
                              Util.sign(targetPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);
-                Thread.sleep(50);
+                robot.delay(50);
             }
 
             synchronized (Util.SYNC_LOCK) {
@@ -308,7 +308,7 @@ class Child {
                 Util.SYNC_LOCK.wait(Util.FRAME_ACTIVATION_TIMEOUT);
             }
 
-            EventQueue.invokeAndWait(()-> {
+            EventQueue.invokeAndWait(() -> {
                 if (!dragSourceListener.isDropFinished()) {
                     throw new RuntimeException("Drop not finished");
                 }

--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -159,6 +159,7 @@ final class Util implements AWTEventListener {
     public static final int CODE_SECOND_SUCCESS = 0x2;
     public static final int CODE_FAILURE = 0x1;
     public static final int FRAME_ACTIVATION_TIMEOUT = 1000;
+    
     static final Object SYNC_LOCK = new Object();
     static final Util theInstance = new Util();
 

--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -158,9 +158,11 @@ final class Util implements AWTEventListener {
     public static final int CODE_FIRST_SUCCESS = 0x2;
     public static final int CODE_SECOND_SUCCESS = 0x2;
     public static final int CODE_FAILURE = 0x1;
+
     public static final int FRAME_ACTIVATION_TIMEOUT = 1000;
 
     static final Object SYNC_LOCK = new Object();
+
     static final Util theInstance = new Util();
 
     static {

--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -29,37 +29,37 @@
   @run main InterJVMGetDropSuccessTest
 */
 
-import java.awt.Frame;
+import java.awt.AWTEvent;
 import java.awt.Component;
-import java.awt.Point;
 import java.awt.Dimension;
 import java.awt.EventQueue;
-import java.awt.Toolkit;
-import java.awt.AWTEvent;
+import java.awt.Frame;
+import java.awt.Point;
 import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DragGestureEvent;
+import java.awt.dnd.DragGestureListener;
+import java.awt.dnd.DragGestureRecognizer;
+import java.awt.dnd.DragSource;
+import java.awt.dnd.DragSourceAdapter;
+import java.awt.dnd.DragSourceDropEvent;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetAdapter;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetListener;
 import java.awt.event.AWTEventListener;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.Transferable;
-import java.awt.dnd.DropTarget;
-import java.awt.dnd.DragGestureListener;
-import java.awt.dnd.DragSourceAdapter;
-import java.awt.dnd.DragSourceDropEvent;
-import java.awt.dnd.DnDConstants;
-import java.awt.dnd.DropTargetDropEvent;
-import java.awt.dnd.DropTargetAdapter;
-import java.awt.dnd.DragGestureRecognizer;
-import java.awt.dnd.DragSource;
-import java.awt.dnd.DropTargetListener;
-import java.awt.dnd.DragGestureEvent;
 import java.io.File;
 import java.io.InputStream;
 
 public class InterJVMGetDropSuccessTest {
 
     private int returnCode = Util.CODE_NOT_RETURNED;
-    private final boolean successCodes[] = new boolean[]{ true, false };
+    private final boolean[] successCodes = { true, false };
     private int dropCount = 0;
 
     final Frame frame = new Frame("Target Frame");
@@ -89,7 +89,9 @@ public class InterJVMGetDropSuccessTest {
         frame.setVisible(true);
 
         try {
-            Thread.sleep(Util.FRAME_ACTIVATION_TIMEOUT);
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(Util.FRAME_ACTIVATION_TIMEOUT);
 
             Point p = frame.getLocationOnScreen();
             Dimension d = frame.getSize();
@@ -156,12 +158,8 @@ final class Util implements AWTEventListener {
     public static final int CODE_FIRST_SUCCESS = 0x2;
     public static final int CODE_SECOND_SUCCESS = 0x2;
     public static final int CODE_FAILURE = 0x1;
-
     public static final int FRAME_ACTIVATION_TIMEOUT = 1000;
-
     static final Object SYNC_LOCK = new Object();
-    static final int MOUSE_RELEASE_TIMEOUT = 1000;
-
     static final Util theInstance = new Util();
 
     static {
@@ -250,13 +248,13 @@ class Child {
             frame.setBounds(300, 200, 150, 150);
             frame.setVisible(true);
 
-            Thread.sleep(Util.FRAME_ACTIVATION_TIMEOUT);
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(Util.FRAME_ACTIVATION_TIMEOUT);
 
             Point sourcePoint = Util.getCenterLocationOnScreen(frame);
-
             Point targetPoint = new Point(x + w / 2, y + h / 2);
 
-            Robot robot = new Robot();
             robot.mouseMove(sourcePoint.x, sourcePoint.y);
             robot.waitForIdle();
             robot.delay(50);
@@ -265,7 +263,7 @@ class Child {
                 p.translate(Util.sign(targetPoint.x - p.x),
                             Util.sign(targetPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);
-                robot.delay(50);
+                robot.delay(5);
             }
 
             synchronized (Util.SYNC_LOCK) {
@@ -290,7 +288,7 @@ class Child {
                 p.translate(Util.sign(targetPoint.x - p.x),
                             Util.sign(targetPoint.y - p.y))) {
                 robot.mouseMove(p.x, p.y);
-                robot.delay(50);
+                robot.delay(5);
             }
 
             synchronized (Util.SYNC_LOCK) {

--- a/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
+++ b/test/jdk/java/awt/dnd/InterJVMGetDropSuccessTest/InterJVMGetDropSuccessTest.java
@@ -159,7 +159,7 @@ final class Util implements AWTEventListener {
     public static final int CODE_SECOND_SUCCESS = 0x2;
     public static final int CODE_FAILURE = 0x1;
     public static final int FRAME_ACTIVATION_TIMEOUT = 1000;
-    
+
     static final Object SYNC_LOCK = new Object();
     static final Util theInstance = new Util();
 


### PR DESCRIPTION
The root cause of the bug is because mousePress() method is invoked before mouseMove() event is completely processed causing the drag & drop behavior not being able to be recognized properly. This in turn makes the method dragSourceListener.isDropFinished() returns false and fail the test. To fix this, setAutoWaitForIdle(true) and Thread.Sleep is called to make sure the mouseMove() event is processed completely before moving to execute the mousePress() method.

JBS issue: [JDK-8317287](https://bugs.openjdk.org/browse/JDK-8317287)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317287](https://bugs.openjdk.org/browse/JDK-8317287): [macos14] InterJVMGetDropSuccessTest.java: Child VM: abnormal termination (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [51c97fb1](https://git.openjdk.org/jdk/pull/16396/files/51c97fb14ed07eaab6b953c4865685a310101651)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexandre Iline](https://openjdk.org/census#shurailine) - Committer ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16396/head:pull/16396` \
`$ git checkout pull/16396`

Update a local copy of the PR: \
`$ git checkout pull/16396` \
`$ git pull https://git.openjdk.org/jdk.git pull/16396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16396`

View PR using the GUI difftool: \
`$ git pr show -t 16396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16396.diff">https://git.openjdk.org/jdk/pull/16396.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16396#issuecomment-1782695774)