### PR TITLE
8318982: Improve Exceptions::special_exception

### DIFF
--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -109,6 +109,7 @@ bool Exceptions::special_exception(JavaThread* thread, const char* file, int lin
 #endif // ASSERT
 
   if (!thread->can_call_java()) {
+    ResourceMark rm(thread);
     const char* exc_value = h_exception.not_null() ? h_exception->print_value_string() :
                       h_name != nullptr ? h_name->as_C_string() :
                       "null";

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -83,6 +83,9 @@ void ThreadShadow::clear_pending_nonasync_exception() {
 // Implementation of Exceptions
 
 bool Exceptions::special_exception(JavaThread* thread, const char* file, int line, Handle h_exception, Symbol* h_name, const char* message) {
+  assert(h_exception.is_null() != (h_name == nullptr), "either exception (" PTR_FORMAT ") or "
+         "symbol (" PTR_FORMAT ") must be non-null but not both", p2i(h_exception()), p2i(h_name));
+
   // bootstrapping check
   if (!Universe::is_fully_initialized()) {
     if (h_exception.not_null()) {

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -116,9 +116,9 @@ bool Exceptions::special_exception(JavaThread* thread, const char* file, int lin
     const char* exc_value = h_exception.not_null() ? h_exception->print_value_string() :
                       h_name != nullptr ? h_name->as_C_string() :
                       "null";
-    log_info(exceptions)("Exception <%s%s%s> (" PTR_FORMAT ") \n"
-                        "thrown [%s, line %d]\nfor thread " PTR_FORMAT "\n"
-                        "thread cannot call Java, throwing pre-allocated exception: %s",
+    log_info(exceptions)("Thread cannot call Java so instead of throwing exception <%s%s%s> (" PTR_FORMAT ") \n"
+                        "at [%s, line %d]\nfor thread " PTR_FORMAT ",\n"
+                        "throwing pre-allocated exception: %s",
                         exc_value, message ? ": " : "", message ? message : "",
                         p2i(h_exception()), file, line, p2i(thread),
                         Universe::vm_exception()->print_value_string());

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -82,10 +82,17 @@ void ThreadShadow::clear_pending_nonasync_exception() {
 
 // Implementation of Exceptions
 
-bool Exceptions::special_exception(JavaThread* thread, const char* file, int line, Handle h_exception) {
+bool Exceptions::special_exception(JavaThread* thread, const char* file, int line, Handle h_exception, Symbol* h_name, const char* message) {
   // bootstrapping check
   if (!Universe::is_fully_initialized()) {
-   vm_exit_during_initialization(h_exception);
+    if (h_exception.not_null()) {
+      vm_exit_during_initialization(h_exception);
+    } else if (h_name == nullptr) {
+      // at least an informative message.
+      vm_exit_during_initialization("Exception", message);
+    } else {
+      vm_exit_during_initialization(h_name, message);
+    }
    ShouldNotReachHere();
   }
 
@@ -94,7 +101,7 @@ bool Exceptions::special_exception(JavaThread* thread, const char* file, int lin
   // to prevent infinite recursion trying to initialize stack overflow without
   // adequate stack space.
   // This can happen with stress testing a large value of StackShadowPages
-  if (h_exception()->klass() == vmClasses::StackOverflowError_klass()) {
+  if (h_exception.not_null() && h_exception()->klass() == vmClasses::StackOverflowError_klass()) {
     InstanceKlass* ik = InstanceKlass::cast(h_exception->klass());
     assert(ik->is_initialized(),
            "need to increase java_thread_min_stack_allowed calculation");
@@ -102,33 +109,21 @@ bool Exceptions::special_exception(JavaThread* thread, const char* file, int lin
 #endif // ASSERT
 
   if (!thread->can_call_java()) {
+    const char* exc_value = h_exception.not_null() ? h_exception->print_value_string() :
+                      h_name != nullptr ? h_name->as_C_string() :
+                      "null";
+    log_info(exceptions)("Exception <%s%s%s> (" PTR_FORMAT ") \n"
+                        "thrown [%s, line %d]\nfor thread " PTR_FORMAT "\n"
+                        "thread cannot call Java, throwing pre-allocated exception: %s",
+                        exc_value, message ? ": " : "", message ? message : "",
+                        p2i(h_exception()), file, line, p2i(thread),
+                        Universe::vm_exception()->print_value_string());
     // We do not care what kind of exception we get for a thread which
     // is compiling.  We just install a dummy exception object
     thread->set_pending_exception(Universe::vm_exception(), file, line);
     return true;
   }
 
-  return false;
-}
-
-bool Exceptions::special_exception(JavaThread* thread, const char* file, int line, Symbol* h_name, const char* message) {
-  // bootstrapping check
-  if (!Universe::is_fully_initialized()) {
-    if (h_name == nullptr) {
-      // at least an informative message.
-      vm_exit_during_initialization("Exception", message);
-    } else {
-      vm_exit_during_initialization(h_name, message);
-    }
-    ShouldNotReachHere();
-  }
-
-  if (!thread->can_call_java()) {
-    // We do not care what kind of exception we get for a thread which
-    // is compiling.  We just install a dummy exception object
-    thread->set_pending_exception(Universe::vm_exception(), file, line);
-    return true;
-  }
   return false;
 }
 
@@ -187,7 +182,7 @@ void Exceptions::_throw(JavaThread* thread, const char* file, int line, Handle h
 void Exceptions::_throw_msg(JavaThread* thread, const char* file, int line, Symbol* name, const char* message,
                             Handle h_loader, Handle h_protection_domain) {
   // Check for special boot-strapping/compiler-thread handling
-  if (special_exception(thread, file, line, name, message)) return;
+  if (special_exception(thread, file, line, Handle(), name, message)) return;
   // Create and throw exception
   Handle h_cause(thread, nullptr);
   Handle h_exception = new_exception(thread, name, message, h_cause, h_loader, h_protection_domain);
@@ -197,7 +192,7 @@ void Exceptions::_throw_msg(JavaThread* thread, const char* file, int line, Symb
 void Exceptions::_throw_msg_cause(JavaThread* thread, const char* file, int line, Symbol* name, const char* message, Handle h_cause,
                                   Handle h_loader, Handle h_protection_domain) {
   // Check for special boot-strapping/compiler-thread handling
-  if (special_exception(thread, file, line, name, message)) return;
+  if (special_exception(thread, file, line, Handle(), name, message)) return;
   // Create and throw exception and init cause
   Handle h_exception = new_exception(thread, name, message, h_cause, h_loader, h_protection_domain);
   _throw(thread, file, line, h_exception, message);
@@ -214,7 +209,7 @@ void Exceptions::_throw_cause(JavaThread* thread, const char* file, int line, Sy
 
 void Exceptions::_throw_args(JavaThread* thread, const char* file, int line, Symbol* name, Symbol* signature, JavaCallArguments *args) {
   // Check for special boot-strapping/compiler-thread handling
-  if (special_exception(thread, file, line, name, nullptr)) return;
+  if (special_exception(thread, file, line, Handle(), name, nullptr)) return;
   // Create and throw exception
   Handle h_loader(thread, nullptr);
   Handle h_prot(thread, nullptr);

--- a/src/hotspot/share/utilities/exceptions.hpp
+++ b/src/hotspot/share/utilities/exceptions.hpp
@@ -105,6 +105,7 @@ class ThreadShadow: public CHeapObj<mtThread> {
 // used directly if the macros below are insufficient.
 
 class Exceptions {
+  // Either `exception` or `symbol` must be non-null but not both.
   static bool special_exception(JavaThread* thread, const char* file, int line, Handle exception, Symbol* name = nullptr, const char* message = nullptr);
 
   // Count out of memory errors that are interesting in error diagnosis

--- a/src/hotspot/share/utilities/exceptions.hpp
+++ b/src/hotspot/share/utilities/exceptions.hpp
@@ -105,8 +105,7 @@ class ThreadShadow: public CHeapObj<mtThread> {
 // used directly if the macros below are insufficient.
 
 class Exceptions {
-  static bool special_exception(JavaThread* thread, const char* file, int line, Handle exception);
-  static bool special_exception(JavaThread* thread, const char* file, int line, Symbol* name, const char* message);
+  static bool special_exception(JavaThread* thread, const char* file, int line, Handle exception, Symbol* name = nullptr, const char* message = nullptr);
 
   // Count out of memory errors that are interesting in error diagnosis
   static volatile int _out_of_memory_error_java_heap_errors;


### PR DESCRIPTION
This PR consolidates the 2 almost identical versions of `Exceptions::special_exception` into a single method.
If a special exception is thrown and `-Xlog:exceptions` is enabled, a log message is emitted and it indicates the special handling.

Here's an example in the output from running `compiler/linkage/LinkageErrors.java` with `-Xlog:exceptions -Xcomp`:
```
[0.194s][info][exceptions] Exception <java/lang/IllegalAccessError: class java.lang.module.ModuleDescriptor$1 tried to access private method 'void java.lang.module.ModuleDescriptor$Exports.<init>(java.util.Set, java.lang.String, java.util.Set, boolean)' (java.lang.module.ModuleDescriptor$1 and java.lang.module.ModuleDescriptor$Exports are in module java.base of loader 'bootstrap')> (0x0000000000000000)
thrown [src/hotspot/share/interpreter/linkResolver.cpp, line 591]
for thread 0x000000011e18c600
thread cannot call Java, throwing pre-allocated exception: a 'java/lang/VirtualMachineError'{0x0000000772e06f00}
```

The motivation for this change was work on [JDK-8318694](https://bugs.openjdk.org/browse/JDK-8318694) where it's useful to know when exceptions are thrown on a CompilerThread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318982](https://bugs.openjdk.org/browse/JDK-8318982): Improve Exceptions::special_exception (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [98da6cab](https://git.openjdk.org/jdk/pull/16401/files/98da6cab88397214e1045d2d2dad8407f2f86e67)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16401/head:pull/16401` \
`$ git checkout pull/16401`

Update a local copy of the PR: \
`$ git checkout pull/16401` \
`$ git pull https://git.openjdk.org/jdk.git pull/16401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16401`

View PR using the GUI difftool: \
`$ git pr show -t 16401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16401.diff">https://git.openjdk.org/jdk/pull/16401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16401#issuecomment-1784153159)