### PR TITLE
JDK-8318981: compiler/compilercontrol/TestConflictInlineCommands.java fails intermittent with 'disallowed by CompileCommand' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/TestConflictInlineCommands.java
@@ -40,6 +40,7 @@ import jdk.test.lib.process.ProcessTools;
 public class TestConflictInlineCommands {
     public static void main(String[] args) throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+                "-Xbatch",
                 "-XX:CompileCommand=inline,*TestConflictInlineCommands::caller",
                 "-XX:CompileCommand=dontinline,*TestConflictInlineCommands::caller",
                 "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*Launcher::main",


### PR DESCRIPTION
We run sometimes into this error (especially on some virtualized windows machines) :

java.lang.RuntimeException: 'disallowed by CompileCommand' missing from stdout/stderr
at jdk.test.lib.process.OutputAnalyzer.shouldContain(OutputAnalyzer.java:221)
at compiler.compilercontrol.TestConflictInlineCommands.main(TestConflictInlineCommands.java:51)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
at java.base/java.lang.Thread.run(Thread.java:1570)

might be similar to [JDK-8316411](https://bugs.openjdk.org/browse/JDK-8316411) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318981](https://bugs.openjdk.org/browse/JDK-8318981): compiler/compilercontrol/TestConflictInlineCommands.java fails intermittent with 'disallowed by CompileCommand' missing from stdout/stderr (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16402/head:pull/16402` \
`$ git checkout pull/16402`

Update a local copy of the PR: \
`$ git checkout pull/16402` \
`$ git pull https://git.openjdk.org/jdk.git pull/16402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16402`

View PR using the GUI difftool: \
`$ git pr show -t 16402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16402.diff">https://git.openjdk.org/jdk/pull/16402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16402#issuecomment-1782998167)