### PR TITLE
8317538: RSA have scalability issue for high vCPU numbers

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1275,13 +1275,8 @@ public abstract class Provider extends Properties {
      */
     public Service getService(String type, String algorithm) {
         checkInitialized();
-        // avoid allocating a new ServiceKey object if possible
+        
         ServiceKey key = new ServiceKey(type, algorithm, false);
-        if (!key.matches(type, algorithm)) {
-            key = new ServiceKey(type, algorithm, false);
-            previousKey = key;
-        }
-
         Service s = serviceMap.get(key);
         if (s == null) {
             s = legacyMap.get(key);

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1276,7 +1276,7 @@ public abstract class Provider extends Properties {
     public Service getService(String type, String algorithm) {
         checkInitialized();
         // avoid allocating a new ServiceKey object if possible
-        ServiceKey key = previousKey;
+        ServiceKey key = new ServiceKey(type, algorithm, false);
         if (!key.matches(type, algorithm)) {
             key = new ServiceKey(type, algorithm, false);
             previousKey = key;


### PR DESCRIPTION
Modified `getService` method to prevent caching of `ServiceKey`, which was negatively impacting multithreaded performance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317538](https://bugs.openjdk.org/browse/JDK-8317538): RSA have scalability issue for high vCPU numbers (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16403/head:pull/16403` \
`$ git checkout pull/16403`

Update a local copy of the PR: \
`$ git checkout pull/16403` \
`$ git pull https://git.openjdk.org/jdk.git pull/16403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16403`

View PR using the GUI difftool: \
`$ git pr show -t 16403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16403.diff">https://git.openjdk.org/jdk/pull/16403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16403#issuecomment-1783051305)