### PR TITLE
8315890: Attempts to load from nullptr in instanceKlass.cpp and unsafe.cpp

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1133,6 +1133,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
       // The address of _source_obj at runtime
       oop requested_obj = ArchiveHeapWriter::source_obj_to_requested_obj(_source_obj);
       // The address of this field in the requested space
+      assert(requested_obj != nullptr, "Attempting to load field from null oop");
       address requested_field_addr = cast_from_oop<address>(requested_obj) + fd->offset();
 
       fd->print_on(_st);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2502,10 +2502,10 @@ void InstanceKlass::clean_implementors_list() {
     assert (ClassUnloading, "only called for ClassUnloading");
     for (;;) {
       // Use load_acquire due to competing with inserts
-      InstanceKlass* impl = Atomic::load_acquire(adr_implementor());
+      InstanceKlass* volatile* iklass = adr_implementor();
+      InstanceKlass* impl = (iklass != nullptr) ? Atomic::load_acquire(iklass) : nullptr;
       if (impl != nullptr && !impl->is_loader_alive()) {
         // null this field, might be an unloaded instance klass or null
-        InstanceKlass* volatile* iklass = adr_implementor();
         if (Atomic::cmpxchg(iklass, impl, (InstanceKlass*)nullptr) == impl) {
           // Successfully unlinking implementor.
           if (log_is_enabled(Trace, class, unload)) {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2503,7 +2503,8 @@ void InstanceKlass::clean_implementors_list() {
     for (;;) {
       // Use load_acquire due to competing with inserts
       InstanceKlass* volatile* iklass = adr_implementor();
-      InstanceKlass* impl = (iklass != nullptr) ? Atomic::load_acquire(iklass) : nullptr;
+      assert(iklass != nullptr, "Klass must not be null");
+      InstanceKlass* impl = Atomic::load_acquire(iklass);
       if (impl != nullptr && !impl->is_loader_alive()) {
         // null this field, might be an unloaded instance klass or null
         if (Atomic::cmpxchg(iklass, impl, (InstanceKlass*)nullptr) == impl) {

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -231,7 +231,6 @@ public:
 
   T get_volatile() {
     GuardUnsafeAccess guard(_thread);
-    assert(addr() != nullptr, "Attempting to load from null pointer");
     volatile T ret = RawAccess<MO_SEQ_CST>::load(addr());
     return normalize_for_read(ret);
   }

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -231,6 +231,7 @@ public:
 
   T get_volatile() {
     GuardUnsafeAccess guard(_thread);
+    assert(addr() != nullptr, "Attempting to load from null pointer");
     volatile T ret = RawAccess<MO_SEQ_CST>::load(addr());
     return normalize_for_read(ret);
   }


### PR DESCRIPTION
Calls in instanceKlass.cpp and unsafe.cpp try to call an atomic load on method calls that could return nullptr. This patch ensures that nullptr is not passed into the load. 

In `print_as_native_pointer` in archiveBuilder, `source_obj_to_requested_obj` should not be able to return `nullptr` as the result is immediately cast to an oop which cascades down to the failure reported in  `get_volatile()` in `unsafe.cpp`. Placing an assert close to the top of this call stack should prevent this from happening and will better indicate the source of an unexpected `nullptr` should it occur.

Verified with tier1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315890](https://bugs.openjdk.org/browse/JDK-8315890): Attempts to load from nullptr in instanceKlass.cpp and unsafe.cpp (**Bug** - P3)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16405/head:pull/16405` \
`$ git checkout pull/16405`

Update a local copy of the PR: \
`$ git checkout pull/16405` \
`$ git pull https://git.openjdk.org/jdk.git pull/16405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16405`

View PR using the GUI difftool: \
`$ git pr show -t 16405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16405.diff">https://git.openjdk.org/jdk/pull/16405.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16405#issuecomment-1783213872)