### PR TITLE
8318580 : "javax/swing/MultiMonitor/MultimonVImage.java failing with Error. Can't find library: /open/test/jdk/java/awt/regtesthelpers" after JDK-8316053

### DIFF
--- a/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
+++ b/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
@@ -28,7 +28,8 @@
  * @summary displays an animating fps (frames per second)
  *  counter.  When the window is dragged from monitor to monitor,
  *  the speed of the animation should not change too greatly.
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual MultimonVImage
  */
 
@@ -181,3 +182,4 @@ class AnimatingFrame extends JFrame implements Runnable {
         }
     }
 }
+


### PR DESCRIPTION
1) Fixed the @library regtesthelpers file path 
2) Added @build PassFailJFrame
3) Added a empty line at the end of the file that was missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318580](https://bugs.openjdk.org/browse/JDK-8318580): "javax/swing/MultiMonitor/MultimonVImage.java failing with Error. Can't find library: /open/test/jdk/java/awt/regtesthelpers" after JDK-8316053 (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16408/head:pull/16408` \
`$ git checkout pull/16408`

Update a local copy of the PR: \
`$ git checkout pull/16408` \
`$ git pull https://git.openjdk.org/jdk.git pull/16408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16408`

View PR using the GUI difftool: \
`$ git pr show -t 16408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16408.diff">https://git.openjdk.org/jdk/pull/16408.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16408#issuecomment-1783613304)