### PR TITLE
8319067: ProblemList serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java on linux-aarch64 in Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -34,7 +34,7 @@ vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 82456
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64
 
-serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8303168 linux-x64
+serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8303168 linux-all
 
 serviceability/sa/ClhsdbInspect.java 8283578 windows-x64
 


### PR DESCRIPTION
A trivial fix to ProblemList serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java
on linux-aarch64 in Xcomp mode.

The test is already ProblemListed in -Xcomp mode for linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319067](https://bugs.openjdk.org/browse/JDK-8319067): ProblemList serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java on linux-aarch64 in Xcomp mode (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16410/head:pull/16410` \
`$ git checkout pull/16410`

Update a local copy of the PR: \
`$ git checkout pull/16410` \
`$ git pull https://git.openjdk.org/jdk.git pull/16410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16410`

View PR using the GUI difftool: \
`$ git pr show -t 16410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16410.diff">https://git.openjdk.org/jdk/pull/16410.diff</a>

</details>
