### PR TITLE
8319106: Remove unimplemented TaskTerminator::do_delay_step

### DIFF
--- a/src/hotspot/share/gc/shared/taskTerminator.hpp
+++ b/src/hotspot/share/gc/shared/taskTerminator.hpp
@@ -91,9 +91,6 @@ class TaskTerminator : public CHeapObj<mtGC> {
 
   size_t tasks_in_queue_set() const;
 
-  // Perform one iteration of spin-master work.
-  void do_delay_step(DelayContext& delay_context);
-
   NONCOPYABLE(TaskTerminator);
 
 public:


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319106](https://bugs.openjdk.org/browse/JDK-8319106): Remove unimplemented TaskTerminator::do_delay_step (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16415/head:pull/16415` \
`$ git checkout pull/16415`

Update a local copy of the PR: \
`$ git checkout pull/16415` \
`$ git pull https://git.openjdk.org/jdk.git pull/16415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16415`

View PR using the GUI difftool: \
`$ git pr show -t 16415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16415.diff">https://git.openjdk.org/jdk/pull/16415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16415#issuecomment-1785017280)