### PR TITLE
8267532: Try/catch block not optimized as expected

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -136,7 +136,7 @@ void ciMethodData::load_remaining_extra_data() {
   // Copy the extra data once it is prepared (i.e. cache populated, no release of extra data lock anymore)
   Copy::disjoint_words_atomic((HeapWord*) mdo->extra_data_base(),
                               (HeapWord*)((address) _data + _data_size),
-                              (_extra_data_size - mdo->parameters_size_in_bytes()) / HeapWordSize);
+                              (_extra_data_size - mdo->parameters_size_in_bytes() - _ex_handlers_size) / HeapWordSize);
 
   // speculative trap entries also hold a pointer to a Method so need to be translated
   DataLayout* dp_src  = mdo->extra_data_base();

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -438,12 +438,9 @@ ciProfileData* ciMethodData::bci_to_data(int bci, ciMethod* m) {
   return nullptr;
 }
 
-ciBitData* ciMethodData::ex_handler_bci_to_data(int bci) {
-  BitData* data = get_MethodData()->ex_handler_bci_to_data(bci);
-  if (data == nullptr) {
-    return nullptr;
-  }
-  return new ciBitData((DataLayout*) data->dp());
+ciBitData ciMethodData::ex_handler_bci_to_data(int bci) {
+  BitData data = get_MethodData()->ex_handler_bci_to_data(bci);
+  return ciBitData((DataLayout*) data.dp());
 }
 
 // Conservatively decode the trap_state of a ciProfileData.

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -438,6 +438,14 @@ ciProfileData* ciMethodData::bci_to_data(int bci, ciMethod* m) {
   return nullptr;
 }
 
+ciBitData* ciMethodData::ex_handler_bci_to_data(int bci) {
+  BitData* data = get_MethodData()->ex_handler_bci_to_data(bci);
+  if (data == nullptr) {
+    return nullptr;
+  }
+  return new ciBitData((DataLayout*) data->dp());
+}
+
 // Conservatively decode the trap_state of a ciProfileData.
 int ciMethodData::has_trap_at(ciProfileData* data, int reason) {
   typedef Deoptimization::DeoptReason DR_t;

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -51,7 +51,6 @@ ciMethodData::ciMethodData(MethodData* md)
   _eflags(0), _arg_local(0), _arg_stack(0), _arg_returned(0),
   _invocation_counter(0),
   _orig(),
-  _parameters(nullptr),
   _parameters_data_offset(0),
   _ex_handlers_data_offset(0) {}
 
@@ -251,8 +250,8 @@ bool ciMethodData::load_data() {
     data = mdo->next_data(data);
   }
   if (mdo->parameters_type_data() != nullptr) {
-    _parameters = data_layout_at(mdo->parameters_type_data_di());
-    ciParametersTypeData* parameters = new ciParametersTypeData(_parameters);
+    DataLayout* parameters_data = data_layout_at(_parameters_data_offset);
+    ciParametersTypeData* parameters = new ciParametersTypeData(parameters_data);
     parameters->translate_from(mdo->parameters_type_data());
   }
 
@@ -631,7 +630,7 @@ uint ciMethodData::arg_modified(int arg) const {
 }
 
 ciParametersTypeData* ciMethodData::parameters_type_data() const {
-  return _parameters != nullptr ? new ciParametersTypeData(_parameters) : nullptr;
+  return parameter_data_size() != 0 ? new ciParametersTypeData(data_layout_at(_parameters_data_offset)) : nullptr;
 }
 
 ByteSize ciMethodData::offset_of_slot(ciProfileData* data, ByteSize slot_offset_in_data) {

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -409,6 +409,8 @@ private:
     return _parameters == nullptr ? 0 : parameters_type_data()->size_in_bytes();
   }
 
+  int _ex_handlers_size; // size of ex handlers data
+
   ciMethodData(MethodData* md = nullptr);
 
   // Accessors
@@ -516,7 +518,7 @@ public:
 
   DataLayout* extra_data_base() const  { return data_layout_at(data_size()); }
   DataLayout* args_data_limit() const  { return data_layout_at(data_size() + extra_data_size() -
-                                                               parameters_size()); }
+                                                               parameters_size() - _ex_handlers_size); }
 
   // Get the data at an arbitrary bci, or null if there is none. If m
   // is not null look for a SpeculativeTrapData if any first.

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -522,7 +522,7 @@ public:
   // is not null look for a SpeculativeTrapData if any first.
   ciProfileData* bci_to_data(int bci, ciMethod* m = nullptr);
 
-  ciBitData* ex_handler_bci_to_data(int bci);
+  ciBitData ex_handler_bci_to_data(int bci);
 
   uint overflow_trap_count() const {
     return _orig.overflow_trap_count();

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -522,6 +522,8 @@ public:
   // is not null look for a SpeculativeTrapData if any first.
   ciProfileData* bci_to_data(int bci, ciMethod* m = nullptr);
 
+  ciBitData* ex_handler_bci_to_data(int bci);
+
   uint overflow_trap_count() const {
     return _orig.overflow_trap_count();
   }

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -407,12 +407,6 @@ private:
   // Coherent snapshot of original header.
   MethodData::CompilerCounters _orig;
 
-  // Area dedicated to parameters. null if no parameter profiling for this method.
-  DataLayout* _parameters;
-  int parameters_size() const {
-    return _parameters == nullptr ? 0 : parameters_type_data()->size_in_bytes();
-  }
-
   ciMethodData(MethodData* md = nullptr);
 
   // Accessors

--- a/src/hotspot/share/ci/ciMethodData.hpp
+++ b/src/hotspot/share/ci/ciMethodData.hpp
@@ -433,6 +433,12 @@ private:
     return data_index >= data_size();
   }
 
+  bool out_of_bounds_extra(int data_index) {
+    return data_index < data_size() || data_index >= data_size() + extra_data_size();
+  }
+
+  DataLayout* next_data_layout_helper(DataLayout* current, bool extra);
+
   // hint accessors
   int      hint_di() const  { return _hint_di; }
   void set_hint_di(int di)  {
@@ -511,6 +517,7 @@ public:
   ciProfileData* first_data() { return data_at(first_di()); }
   ciProfileData* next_data(ciProfileData* current);
   DataLayout* next_data_layout(DataLayout* current);
+  DataLayout* next_extra_data_layout(DataLayout* current);
   bool is_valid(ciProfileData* current) { return current != nullptr; }
   bool is_valid(DataLayout* current)    { return current != nullptr; }
 

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -465,6 +465,7 @@ JRT_END
 // bci where the exception happened. If the exception was propagated back
 // from a call, the expression stack contains the values for the bci at the
 // invoke w/o arguments (i.e., as if one were inside the call).
+// Note that the implementation of this method assumes it's only called when an exception has actually occured
 JRT_ENTRY(address, InterpreterRuntime::exception_handler_for_exception(JavaThread* current, oopDesc* exception))
   // We get here after we have unwound from a callee throwing an exception
   // into the interpreter. Any deferred stack processing is notified of
@@ -579,13 +580,7 @@ JRT_ENTRY(address, InterpreterRuntime::exception_handler_for_exception(JavaThrea
   } else {
     // handler in this method => change bci/bcp to handler bci/bcp and continue there
     handler_pc = h_method->code_base() + handler_bci;
-    if (PruneDeadCatchBlocks) {
-        MethodData* mdo = h_method()->method_data();
-        if (mdo != nullptr) {
-          BitData* bit_data = mdo->ex_handler_bci_to_data(handler_bci);
-          bit_data->set_ex_handler_entered();
-        }
-    }
+    h_method->set_ex_handler_entered(handler_bci); // profiling
 #ifndef ZERO
     set_bcp_and_mdp(handler_pc, current);
     continuation = Interpreter::dispatch_table(vtos)[*handler_pc];

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -579,6 +579,13 @@ JRT_ENTRY(address, InterpreterRuntime::exception_handler_for_exception(JavaThrea
   } else {
     // handler in this method => change bci/bcp to handler bci/bcp and continue there
     handler_pc = h_method->code_base() + handler_bci;
+    if (PruneDeadCatchBlocks) {
+        MethodData* mdo = h_method()->method_data();
+        if (mdo != nullptr) {
+          BitData* bit_data = mdo->ex_handler_bci_to_data(handler_bci);
+          bit_data->set_ex_handler_entered();
+        }
+    }
 #ifndef ZERO
     set_bcp_and_mdp(handler_pc, current);
     continuation = Interpreter::dispatch_table(vtos)[*handler_pc];

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -648,6 +648,16 @@ bool Method::init_method_counters(MethodCounters* counters) {
   return Atomic::replace_if_null(&_method_counters, counters);
 }
 
+void Method::set_ex_handler_entered(int handler_bci) {
+  if (PruneDeadCatchBlocks) {
+    MethodData* mdo = method_data();
+    if (mdo != nullptr) {
+      BitData handler_data = mdo->ex_handler_bci_to_data(handler_bci);
+      handler_data.set_ex_handler_entered();
+    }
+  }
+}
+
 int Method::extra_stack_words() {
   // not an inline function, to avoid a header dependency on Interpreter
   return extra_stack_entries() * Interpreter::stackElementSize;

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -308,6 +308,9 @@ class Method : public Metadata {
     return _method_data;
   }
 
+  // mark an exception handler as entered (used to prune dead catch blocks in C2)
+  void set_ex_handler_entered(int handler_bci);
+
   MethodCounters* method_counters() const {
     return _method_counters;
   }

--- a/src/hotspot/share/oops/methodData.cpp
+++ b/src/hotspot/share/oops/methodData.cpp
@@ -1400,14 +1400,15 @@ ProfileData* MethodData::bci_to_data(int bci) {
   return bci_to_extra_data(bci, nullptr, false);
 }
 
-BitData* MethodData::ex_handler_bci_to_data(int bci) {
+BitData MethodData::ex_handler_bci_to_data(int bci) {
   for (int i = 0; i < _num_ex_handler_data; i++) {
-    BitData* ex_handler_data = ex_handler_data_at(i)->data_in()->as_BitData();
+    DataLayout* ex_handler_data = ex_handler_data_at(i);
     if (ex_handler_data->bci() == bci) {
-      return ex_handler_data;
+      return BitData(ex_handler_data);
     }
   }
-  return nullptr;
+  // called with invalid bci or wrong Method/MethodData
+  ShouldNotReachHere();
 }
 
 DataLayout* MethodData::next_extra(DataLayout* dp) {

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -2296,6 +2296,10 @@ public:
     return param == nullptr ? 0 : param->size_in_bytes();
   }
 
+  int ex_handlers_size_in_bytes() const {
+    return _num_ex_handler_data * DataLayout::compute_size_in_bytes(BitData::static_cell_count());
+  }
+
   // Accessors
   Method* method() const { return _method; }
 
@@ -2352,7 +2356,7 @@ public:
   DataLayout* extra_data_base() const  { return limit_data_position(); }
   DataLayout* extra_data_limit() const { return (DataLayout*)((address)this + size_in_bytes()); }
   DataLayout* args_data_limit() const  { return (DataLayout*)((address)this + size_in_bytes() -
-                                                              parameters_size_in_bytes()); }
+                                                              parameters_size_in_bytes() - ex_handlers_size_in_bytes()); }
   int extra_data_size() const          { return (int)((address)extra_data_limit() - (address)extra_data_base()); }
   static DataLayout* next_extra(DataLayout* dp);
 

--- a/src/hotspot/share/oops/methodData.hpp
+++ b/src/hotspot/share/oops/methodData.hpp
@@ -2087,6 +2087,7 @@ private:
   }
 
   DataLayout* ex_handler_data_at(int ex_handler_index) const {
+    assert(ex_handler_index >= 0 && ex_handler_index < _num_ex_handler_data, "OOB");
     return data_layout_at(_ex_handler_data_di + (ex_handler_index * DataLayout::compute_size_in_bytes(BitData::static_cell_count())));
   }
 
@@ -2345,7 +2346,7 @@ public:
     return bci_to_extra_data(bci, nullptr, true);
   }
 
-  BitData* ex_handler_bci_to_data(int bci);
+  BitData ex_handler_bci_to_data(int bci);
 
   // Add a handful of extra data records, for trap tracking.
   DataLayout* extra_data_base() const  { return limit_data_position(); }

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -777,6 +777,8 @@
           "more than this threshold")                                       \
           range(0, 100)                                                     \
                                                                             \
+  product(bool, PruneDeadCatchBlocks, true,                                 \
+          "Prune catch blocks that are never entered")                      \
 
 // end of C2_FLAGS
 

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1535,9 +1535,8 @@ void Parse::do_one_block() {
   if (PruneDeadCatchBlocks && block()->is_handler()) {
     ciMethodData* methodData = method()->method_data();
     if (methodData->is_mature()) {
-      ciBitData* data = methodData->ex_handler_bci_to_data(block()->start());
-      assert(data != nullptr, "need data for catch block");
-      if (!data->ex_handler_entered()) {
+      ciBitData data = methodData->ex_handler_bci_to_data(block()->start());
+      if (!data.ex_handler_entered()) {
         // dead catch block
         // Emit an uncommon trap instead of processing the block.
         set_parse_bci(block()->start());

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -690,7 +690,6 @@ address SharedRuntime::compute_compiled_exc_handler(CompiledMethod* cm, address 
     ExceptionHandlerTable table(cm);
     HandlerTableEntry *t = table.entry_for(catch_pco, -1, 0);
     if (t != nullptr) {
-      //cm->method()->set_ex_handler_entered(t->bci()); // profiling
       return cm->code_begin() + t->pco();
     } else {
       return Deoptimization::deoptimize_for_missing_exception_handler(cm);
@@ -781,7 +780,7 @@ address SharedRuntime::compute_compiled_exc_handler(CompiledMethod* cm, address 
     return nullptr;
   }
 
-  //sd->method()->set_ex_handler_entered(t->bci()); // profiling
+  sd->method()->set_ex_handler_entered(handler_bci); // profiling
   return nm->code_begin() + t->pco();
 }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -780,7 +780,9 @@ address SharedRuntime::compute_compiled_exc_handler(CompiledMethod* cm, address 
     return nullptr;
   }
 
-  sd->method()->set_ex_handler_entered(handler_bci); // profiling
+  if (handler_bci != -1) { // did we find a handler in this method?
+    sd->method()->set_ex_handler_entered(handler_bci); // profile
+  }
   return nm->code_begin() + t->pco();
 }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -677,6 +677,7 @@ JRT_END
 
 // ret_pc points into caller; we are returning caller's exception handler
 // for given exception
+// Note that the implementation of this method assumes it's only called when an exception has actually occured
 address SharedRuntime::compute_compiled_exc_handler(CompiledMethod* cm, address ret_pc, Handle& exception,
                                                     bool force_unwind, bool top_frame_only, bool& recursive_exception_occurred) {
   assert(cm != nullptr, "must exist");
@@ -689,6 +690,7 @@ address SharedRuntime::compute_compiled_exc_handler(CompiledMethod* cm, address 
     ExceptionHandlerTable table(cm);
     HandlerTableEntry *t = table.entry_for(catch_pco, -1, 0);
     if (t != nullptr) {
+      //cm->method()->set_ex_handler_entered(t->bci()); // profiling
       return cm->code_begin() + t->pco();
     } else {
       return Deoptimization::deoptimize_for_missing_exception_handler(cm);
@@ -779,6 +781,7 @@ address SharedRuntime::compute_compiled_exc_handler(CompiledMethod* cm, address 
     return nullptr;
   }
 
+  //sd->method()->set_ex_handler_entered(t->bci()); // profiling
   return nm->code_begin() + t->pco();
 }
 

--- a/test/hotspot/jtreg/compiler/c2/TestExHandlerTrap.java
+++ b/test/hotspot/jtreg/compiler/c2/TestExHandlerTrap.java
@@ -46,8 +46,14 @@ public class TestExHandlerTrap {
             payload(false);
         }
 
-        // trigger uncommon trap in pruned catch block
-        payload(true);
+        try {
+            // trigger uncommon trap in pruned catch block
+            payload(true);
+        } catch (IllegalStateException e) {
+            if (!e.getMessage().equals("Testing trap")) {
+                throw e;
+            }
+        }
     }
 
     public static void payload(boolean shouldThrow) {
@@ -63,7 +69,7 @@ public class TestExHandlerTrap {
 
     private static void maybeThrow(boolean shouldThrow) {
         if (shouldThrow) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("Testing trap");
         }
     }
 

--- a/test/hotspot/jtreg/compiler/c2/TestExHandlerTrap.java
+++ b/test/hotspot/jtreg/compiler/c2/TestExHandlerTrap.java
@@ -54,6 +54,11 @@ public class TestExHandlerTrap {
                 throw e;
             }
         }
+
+        // continue for a bit, to see if anything breaks
+        for (int i = 0; i < 1_000; i++) {
+            payload(false);
+        }
     }
 
     public static void payload(boolean shouldThrow) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8267532
+ * @summary check that uncommon trap is generated for unhandled catch block
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestPrunedExHandler
+ */
+
+public class TestPrunedExHandler {
+    public static void main(String[] args) {
+        TestFramework.runWithFlags(
+            "-XX:CompileCommand=dontinline,compiler.c2.irTests.TestPrunedExHandler::outOfLine");
+    }
+
+    @Test
+    @IR(counts = {IRNode.UNREACHED_TRAP, "1"})
+    public static void testTrap() {
+        try {
+            outOfLine(false);
+        } catch (IllegalStateException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void outOfLine(boolean shouldThrow) {
+        if (shouldThrow) {
+            throw new IllegalStateException();
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.UNREACHED_TRAP, "0"})
+    public static void testNoTrap(boolean shouldThrow) {
+        try {
+            outOfLine(shouldThrow);
+        } catch (IllegalStateException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Run(test = "testNoTrap", mode = RunMode.STANDALONE)
+    public static void runNoTrap() {
+        for (int i = 0; i < 2_000; i++) { // tier 3
+            testNoTrap(false);
+        }
+
+        testNoTrap(true); // mark ex handler as entered
+
+        for (int i = 0; i < 20_000; i++) { // tier 4
+            testNoTrap(false); // should have no trap
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1531,6 +1531,11 @@ public class IRNode {
         trapNodes(UNSTABLE_IF_TRAP,"unstable_if");
     }
 
+    public static final String UNREACHED_TRAP = PREFIX + "UNREACHED_TRAP" + POSTFIX;
+    static {
+        trapNodes(UNREACHED_TRAP,"unreached");
+    }
+
     public static final String URSHIFT = PREFIX + "URSHIFT" + POSTFIX;
     static {
         beforeMatchingNameRegex(URSHIFT, "URShift(B|S|I|L)");

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ResourceScopeCloseMin.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ResourceScopeCloseMin.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3)
+public class ResourceScopeCloseMin {
+
+    Runnable dummy = () -> {};
+
+    static class ConfinedScope {
+        final Thread owner;
+        boolean closed;
+        final List<Runnable> resources = new ArrayList<>();
+
+        private void checkState() {
+            if (closed) {
+                throw new AssertionError("Closed");
+            } else if (owner != Thread.currentThread()) {
+                throw new AssertionError("Wrong thread");
+            }
+        }
+
+        ConfinedScope() {
+            this.owner = Thread.currentThread();
+        }
+
+        void addCloseAction(Runnable runnable) {
+            checkState();
+            resources.add(runnable);
+        }
+
+        public void close() {
+            checkState();
+            closed = true;
+            for (Runnable r : resources) {
+                r.run();
+            }
+        }
+    }
+
+    @Benchmark
+    public void confined_close() {
+        ConfinedScope scope = new ConfinedScope();
+        try { // simulate TWR
+            scope.addCloseAction(dummy);
+            scope.close();
+        } catch (RuntimeException ex) {
+            scope.close();
+            throw ex;
+        }
+    }
+
+    @Benchmark
+    public void confined_close_notry() {
+        ConfinedScope scope = new ConfinedScope();
+        scope.addCloseAction(dummy);
+        scope.close();
+    }
+}


### PR DESCRIPTION
The issue is essentially that for the Java try-with-resource construct, javac generates multiple calls to `close(`) the resource. One of those calls is inside the hidden exception handler of the try block. The issue for us is that typically the exception handler is never entered (since no exception is thrown), however we don't profile exception handlers at the moment, so the block is not pruned. C2 doesn't inline the `close()` call in the handler due to low call site frequency. As a result, the receiver of that call escapes and can not be scalar replaced, which then leads to a loss in performance.

There has been some discussion on the JBS issue that this could be fixed by profiling catch blocks. And another suggestion that partial escape analysis could help here to prevent the object from escaping. But, I think there are other benefits to being able to prune dead catch blocks, such as general reduction in code size, and other optimizations being possible by dead code being eliminated. So, I've implemented catch block profiling + pruning in this patch.

The implementation is essentially very straightforward: we allocate an extra bit of profiling data for each
exception handler of a method in the `MethodData` for that method (which holds all the profiling
data). Then when looking up the exception handler after an exception is thrown, we mark the
exception handler as entered. When C2 parses the exception handler block, and it sees that it has
never been entered, we emit an uncommon trap instead.

I've also cleaned up the handling of profiling data sections a bit. After adding the extra section of data to MethodData, I was seeing several crashes when ciMethodData was used. The underlying issue seemed to be that the offset of the parameter data was computed based on the total data size - parameter data size (which doesn't work if we add an additional section for exception handler data). I've re-written the code around this a bit to try and prevent issues in the future. Both MethodData and ciMethodData now track offsets of parameter data and exception handler data, and the size of the each data section is derived from the offsets.

Benchmark with `-XX:-PruneDeadCatchBlocks`:

```
Benchmark                                                      Mode  Cnt      Score     Error   Units
ResourceScopeCloseMin.confined_close                           avgt   30     10.458 ±   0.070   ns/op
ResourceScopeCloseMin.confined_close:gc.alloc.rate             avgt   30   9480.988 ±  63.335  MB/sec
ResourceScopeCloseMin.confined_close:gc.alloc.rate.norm        avgt   30    104.000 ±   0.001    B/op
ResourceScopeCloseMin.confined_close:gc.count                  avgt   30    119.000            counts
ResourceScopeCloseMin.confined_close:gc.time                   avgt   30     94.000                ms
ResourceScopeCloseMin.confined_close_notry                     avgt   30      4.691 ±   0.063   ns/op
ResourceScopeCloseMin.confined_close_notry:gc.alloc.rate       avgt   30  11383.693 ± 151.145  MB/sec
ResourceScopeCloseMin.confined_close_notry:gc.alloc.rate.norm  avgt   30     56.000 ±   0.001    B/op
ResourceScopeCloseMin.confined_close_notry:gc.count            avgt   30    120.000            counts
ResourceScopeCloseMin.confined_close_notry:gc.time             avgt   30    104.000                ms
```

with `-XX:+PruneDeadCatchBlocks`:

```
Benchmark                                                      Mode  Cnt      Score     Error   Units
ResourceScopeCloseMin.confined_close                           avgt   30      4.563 ±   0.043   ns/op
ResourceScopeCloseMin.confined_close:gc.alloc.rate             avgt   30  11702.868 ± 108.816  MB/sec
ResourceScopeCloseMin.confined_close:gc.alloc.rate.norm        avgt   30     56.000 ±   0.001    B/op
ResourceScopeCloseMin.confined_close:gc.count                  avgt   30    121.000            counts
ResourceScopeCloseMin.confined_close:gc.time                   avgt   30     93.000                ms
ResourceScopeCloseMin.confined_close_notry                     avgt   30      4.601 ±   0.054   ns/op
ResourceScopeCloseMin.confined_close_notry:gc.alloc.rate       avgt   30  11605.391 ± 134.000  MB/sec
ResourceScopeCloseMin.confined_close_notry:gc.alloc.rate.norm  avgt   30     56.000 ±   0.001    B/op
ResourceScopeCloseMin.confined_close_notry:gc.count            avgt   30    121.000            counts
ResourceScopeCloseMin.confined_close_notry:gc.time             avgt   30    101.000                ms
```

(note that with the optimization turned on, timing and `gc.alloc.rate.norm` is ~equal)

Testing : tier 1-6