### PR TITLE
8316592: RISC-V: implement poly1305 intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2050,11 +2050,16 @@ void MacroAssembler::cmp_klass(Register oop, Register trial_klass, Register tmp1
 
 // Multiply and multiply-accumulate unsigned 64-bit registers.
 void MacroAssembler::wide_mul(Register prod_lo, Register prod_hi, Register n, Register m) {
+  assert_different_registers(prod_lo, prod_hi);
+
   mul(prod_lo, n, m);
   mulhu(prod_hi, n, m);
 }
 void MacroAssembler::wide_madd(Register sum_lo, Register sum_hi, Register n,
                 Register m, Register tmp1, Register tmp2) {
+  assert_different_registers(sum_lo, sum_hi);
+  assert_different_registers(sum_hi, tmp2);
+
   wide_mul(tmp1, tmp2, n, m);
   cad(sum_lo, sum_lo, tmp1, tmp1);  // Add tmp1 to sum_lo with carry output to tmp1
   adc(sum_hi, sum_hi, tmp2, tmp1);  // Add tmp2 with carry to sum_hi

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2048,6 +2048,18 @@ void MacroAssembler::cmp_klass(Register oop, Register trial_klass, Register tmp1
   beq(trial_klass, tmp1, L);
 }
 
+// Multiply and multiply-accumulate unsigned 64-bit registers.
+void MacroAssembler::wide_mul(Register prod_lo, Register prod_hi, Register n, Register m) {
+  mul(prod_lo, n, m);
+  mulhu(prod_hi, n, m);
+}
+void MacroAssembler::wide_madd(Register sum_lo, Register sum_hi, Register n,
+                Register m, Register tmp1, Register tmp2) {
+  wide_mul(tmp1, tmp2, n, m);
+  cad(sum_lo, sum_lo, tmp1, tmp1);  // Add tmp1 to sum_lo with carry output to tmp1
+  adc(sum_hi, sum_hi, tmp2, tmp1);  // Add tmp2 with carry to sum_hi
+}
+
 // Move an oop into a register.
 void MacroAssembler::movoop(Register dst, jobject obj) {
   int oop_index;

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -198,6 +198,10 @@ class MacroAssembler: public Assembler {
   void store_klass(Register dst, Register src, Register tmp = t0);
   void cmp_klass(Register oop, Register trial_klass, Register tmp1, Register tmp2, Label &L);
 
+  void wide_mul(Register prod_lo, Register prod_hi, Register n, Register m);
+  void wide_madd(Register sum_lo, Register sum_hi, Register n,
+                Register m, Register tmp1, Register tmp2);
+
   void encode_klass_not_null(Register r, Register tmp = t0);
   void decode_klass_not_null(Register r, Register tmp = t0);
   void encode_klass_not_null(Register dst, Register src, Register tmp);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2709,7 +2709,7 @@ class StubGenerator: public StubCodeGenerator {
     __ ctzc_bit(trailing_zeros, match_mask, haystack_isL, tmp, ch2);
     __ addi(trailing_zeros, trailing_zeros, haystack_isL ? 7 : 15);
     __ slli(needle_len, needle_len, BitsPerByte * wordSize / 2);
-    __ orr(haystack_len, haystack_len, needle_len); // restore needle_len(3right_2_bits)
+    __ orr(haystack_len, haystack_len, needle_len); // restore needle_len(32bits)
     __ sub(result, result, 1); // array index from 0, so result -= 1
 
     __ bind(L_HAS_ZERO_LOOP);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4474,7 +4474,7 @@ static const int64_t bits3 = right_n_bits(3);
     // First, U_2:U_1:U_0 += (U_2 >> 2)
     __ srli(tmp1, U_2, 2);
     __ cad(U_0, U_0, tmp1, tmp2); // Add tmp1 to U_0 with carry output to tmp2
-    __ andi(U_2, U_2, bits2); // Clear U_2 except for the first two bits
+    __ andi(U_2, U_2, bits2); // Clear U_2 except for the lowest two bits
     __ cad(U_1, U_1, tmp2, tmp2); // Add carry to U_1 with carry output to tmp2
     __ add(U_2, U_2, tmp2);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4464,18 +4464,6 @@ class StubGenerator: public StubCodeGenerator {
     pack_26(dest0, dest1, noreg, src, tmp1, tmp2);
   }
 
-  // Multiply and multiply-accumulate unsigned 64-bit registers.
-  void wide_mul(Register prod_lo, Register prod_hi, Register n, Register m) {
-    __ mul(prod_lo, n, m);
-    __ mulhu(prod_hi, n, m);
-  }
-  void wide_madd(Register sum_lo, Register sum_hi, Register n,
-                 Register m, Register tmp1, Register tmp2) {
-    wide_mul(tmp1, tmp2, n, m);
-    __ cad(sum_lo, sum_lo, tmp1, tmp1);  // Add tmp1 to sum_lo with carry output to tmp1
-    __ adc(sum_hi, sum_hi, tmp2, tmp1);  // Add tmp2 with carry to sum_hi
-  }
-
   // Poly1305, RFC 7539
   // Intrinsified version of com.sun.crypto.provider.Poly1305.processMultipleBlocks
 
@@ -4546,13 +4534,13 @@ class StubGenerator: public StubCodeGenerator {
       // four bits of R_0 and R_1 are zero, we can add together
       // partial products without any risk of needing to propagate a
       // carry out.
-      wide_mul(U_0, U_0HI, S_0, R_0);
-      wide_madd(U_0, U_0HI, S_1, RR_1, t1, t2);
-      wide_madd(U_0, U_0HI, S_2, RR_0, t1, t2);
+      __ wide_mul(U_0, U_0HI, S_0, R_0);
+      __ wide_madd(U_0, U_0HI, S_1, RR_1, t1, t2);
+      __ wide_madd(U_0, U_0HI, S_2, RR_0, t1, t2);
 
-      wide_mul(U_1, U_1HI, S_0, R_1);
-      wide_madd(U_1, U_1HI, S_1, R_0, t1, t2);
-      wide_madd(U_1, U_1HI, S_2, RR_1, t1, t2);
+      __ wide_mul(U_1, U_1HI, S_0, R_1);
+      __ wide_madd(U_1, U_1HI, S_1, R_0, t1, t2);
+      __ wide_madd(U_1, U_1HI, S_2, RR_1, t1, t2);
 
       __ andi(U_2, R_0, bits2);
       __ mul(U_2, S_2, U_2);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4567,9 +4567,9 @@ static const int64_t bits3 = right_n_bits(3);
       // U_2:U_1:U_0: += (U_2 >> 2) * 5
       poly1305_reduce(U_2, U_1, U_0, t1, t2);
 
-      __ sub(length, length, checked_cast<u1>(BLOCK_LENGTH));
-      __ addi(input_start, input_start, 2 * wordSize);
-      __ mv(t1, checked_cast<u1>(BLOCK_LENGTH));
+      __ sub(length, length, BLOCK_LENGTH);
+      __ addi(input_start, input_start, BLOCK_LENGTH);
+      __ mv(t1, BLOCK_LENGTH);
       __ bge(length, t1, LOOP);
     }
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4471,11 +4471,17 @@ static const int64_t bits3 = right_n_bits(3);
   void poly1305_reduce(Register U_2, Register U_1, Register U_0, Register tmp1, Register tmp2) {
     assert_different_registers(U_2, U_1, U_0, tmp1, tmp2);
 
+    // First, U_2:U_1:U_0 += (U_2 >> 2)
     __ srli(tmp1, U_2, 2);
-    __ shadd(tmp1, tmp1, tmp1, tmp2, 2);
-    __ cad(U_0, U_0, tmp1, tmp2); // Add tmp1 (= (U_2 >> 2) * 5) to U_0 with carry output to tmp2
-    __ cad(U_1, U_1, tmp2, tmp2); // Add carry to U_1 with carry output to tmp2
+    __ cad(U_0, U_0, tmp1, tmp2); // Add tmp1 to U_0 with carry output to tmp2
     __ andi(U_2, U_2, bits2); // Clear U_2 except for the first two bits
+    __ cad(U_1, U_1, tmp2, tmp2); // Add carry to U_1 with carry output to tmp2
+    __ add(U_2, U_2, tmp2);
+
+    // Second, U_2:U_1:U_0 += (U_2 >> 2) << 2
+    __ slli(tmp1, tmp1, 2);
+    __ cad(U_0, U_0, tmp1, tmp2); // Add tmp1 to U_0 with carry output to tmp2
+    __ cad(U_1, U_1, tmp2, tmp2); // Add carry to U_1 with carry output to tmp2
     __ add(U_2, U_2, tmp2);
   }
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4471,7 +4471,7 @@ static const int64_t bits2 = right_n_bits(2);
     assert_different_registers(U_2, U_1, U_0, tmp1, tmp2);
 
     __ srli(tmp1, U_2, 2);
-    __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 is impossible to overflow since two leftmost bits are zero'ed in 'srli(tmp1, U_2, 2)'
+    __ shadd(tmp1, tmp1, tmp1, tmp2, 2);
     __ cad(U_0, U_0, tmp1, tmp2); // Add tmp1 (= (U_2 >> 2) * 5) to U_0 with carry output to tmp2
     __ cad(U_1, U_1, tmp2, tmp2); // Add carry to U_1 with carry output to tmp2
     __ andi(U_2, U_2, bits2); // Clear U_2 except for the first two bits
@@ -4574,6 +4574,12 @@ static const int64_t bits2 = right_n_bits(2);
 
     // Further reduce modulo 2^130 - 5
     reduce(U_2, U_1, U_0, t1, t2);
+
+    Label no_final_reduce;
+    __ srli(t1, U_2, 2);
+    __ beqz(t1, no_final_reduce);
+    reduce(U_2, U_1, U_0, t1, t2);
+    __ bind(no_final_reduce);
 
     // Unpack the sum into five 26-bit limbs and write to memory.
     // First 26 bits is the first limb

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4545,15 +4545,10 @@ class StubGenerator: public StubCodeGenerator {
       __ andi(U_2, R_0, bits2);
       __ mul(U_2, S_2, U_2);
 
-      // Recycle registers S_0, S_1, S_2
-      regs = (regs.remaining() + S_0 + S_1 + S_2).begin();
-
       // Partial reduction mod 2**130 - 5
       __ cad(U_1, U_1, U_0HI, t1); // Add U_0HI to U_1 with carry output to t1
       __ adc(U_2, U_2, U_1HI, t1);
-      // Sum now in U_2:U_1:U_0.
-      // Dead: U_0HI, U_1HI.
-      regs = (regs.remaining() + U_0HI + U_1HI).begin();
+      // Sum is now in U_2:U_1:U_0.
 
       // U_2:U_1:U_0: += (U_2 >> 2) * 5
       __ srli(t1, U_2, 2);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4526,7 +4526,7 @@ static const int64_t bits3 = right_n_bits(3);
     static constexpr int BLOCK_LENGTH = 16;
     Label DONE, LOOP;
 
-    __ mv(t1, checked_cast<u1>(BLOCK_LENGTH));
+    __ mv(t1, BLOCK_LENGTH);
     __ blt(length, t1, DONE); {
       __ bind(LOOP);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4417,6 +4417,7 @@ class StubGenerator: public StubCodeGenerator {
 #ifdef COMPILER2
 
 static const int64_t bits2 = right_n_bits(2);
+static const int64_t bits3 = right_n_bits(3);
 
   // In sun.security.util.math.intpoly.IntegerPolynomial1305, integers
   // are represented as long[5], with BITS_PER_LIMB = 26.
@@ -4575,12 +4576,6 @@ static const int64_t bits2 = right_n_bits(2);
     // Further reduce modulo 2^130 - 5
     poly1305_reduce(U_2, U_1, U_0, t1, t2);
 
-    Label no_final_reduce;
-    __ srli(t1, U_2, 2);
-    __ beqz(t1, no_final_reduce);
-    poly1305_reduce(U_2, U_1, U_0, t1, t2);
-    __ bind(no_final_reduce);
-
     // Unpack the sum into five 26-bit limbs and write to memory.
     // First 26 bits is the first limb
     __ slli(t1, U_0, 38); // Take lowest 26 bits
@@ -4604,9 +4599,9 @@ static const int64_t bits2 = right_n_bits(2);
     __ srli(t1, t1, 38); // Clear all other bits from t1
     __ sd(t1, Address(acc_start, 3 * sizeof (jlong))); // Fourth 26-bit limb
 
-    // Storing 41-64 bits of U_1 and first two bits from U_2 in one register
+    // Storing 41-64 bits of U_1 and first three bits from U_2 in one register
     __ srli(t1, U_1, 40);
-    __ andi(t2, U_2, bits2); // Clear all bits in U_2 except for first 2
+    __ andi(t2, U_2, bits3);
     __ slli(t2, t2, 24);
     __ add(t1, t1, t2);
     __ sd(t1, Address(acc_start, 4 * sizeof (jlong))); // Fifth 26-bit limb

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4480,7 +4480,7 @@ static const int64_t bits3 = right_n_bits(3);
   }
 
   // Poly1305, RFC 7539
-  // Intrinsified version of com.sun.crypto.provider.Poly1305.processMultipleBlocks
+  // void com.sun.crypto.provider.Poly1305.processMultipleBlocks(byte[] input, int offset, int length, long[] aLimbs, long[] rLimbs)
 
   // Arguments:
   //    c_rarg0:   input_start -- where the input is stored

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4550,7 +4550,7 @@ class StubGenerator: public StubCodeGenerator {
       wide_madd(U_1, U_1HI, S_1, R_0, tmp1, tmp2);
       wide_madd(U_1, U_1HI, S_2, RR_1, tmp1, tmp2);
 
-      __ andi(U_2, R_0, 3);
+      __ andi(U_2, R_0, bits2);
       __ mul(U_2, S_2, U_2);
 
       // Recycle registers S_0, S_1, S_2
@@ -4582,7 +4582,7 @@ class StubGenerator: public StubCodeGenerator {
     __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 = U_2 * 5
     __ cad(U_0, U_0, tmp1, tmp3); // U_0 += U_2 * 5 with carry output to tmp3
     __ cadc(U_1, U_1, zr, tmp3); // Add carry to U_1 with carry output to tmp3
-    __ andi(U_2, U_2, 3);
+    __ andi(U_2, U_2, bits2);
     __ add(U_2, U_2, tmp3); // Add carry to U_2
 
     // Unpack the sum into five 26-bit limbs and write to memory.

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4510,11 +4510,9 @@ class StubGenerator: public StubCodeGenerator {
     // RR_n is (R_n >> 2) * 5
     const Register RR_0 = *++regs, RR_1 = *++regs;
     __ srli(tmp1, R_0, 2);
-    __ slli(tmp2, tmp1, 2);
-    __ add(RR_0, tmp1, tmp2);
+    __ shadd(RR_0, tmp1, tmp1, tmp2, 2);
     __ srli(tmp1, R_1, 2);
-    __ slli(tmp2, tmp1, 2);
-    __ add(RR_1, tmp1, tmp2);
+    __ shadd(RR_1, tmp1, tmp1, tmp2, 2);
 
     // U_n is the current checksum
     const Register U_0 = *++regs, U_1 = *++regs, U_2 = *++regs;
@@ -4564,8 +4562,7 @@ class StubGenerator: public StubCodeGenerator {
       __ srli(tmp1, U_2, 2);
       const int64_t bits2 = right_n_bits(2);
       __ andi(U_2, U_2, bits2); // Clear U_2 except for the first two bits
-      __ slli(tmp2, tmp1, 2);
-      __ add(tmp1, tmp1, tmp2); // Impossible to overflow since two leftmost bits are zero'ed in 'srli(tmp1, U_2, 2)'
+      __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 is impossible to overflow since two leftmost bits are zero'ed in 'srli(tmp1, U_2, 2)'
       __ cad(U_0, U_0, tmp1, tmp3); // Add tmp1 (= (U_2 >> 2) * 5) to U_0 with carry output to tmp3
       __ cadc(U_1, U_1, zr, tmp3); // Add carry to U_1 with carry output to tmp3
       __ add(U_2, U_2, tmp3);
@@ -4578,8 +4575,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // Further reduce modulo 2^130 - 5
     __ srli(tmp1, U_2, 2);
-    __ slli(tmp2, tmp1, 2);
-    __ add(tmp1, tmp1, tmp2); // tmp1 = U_2 * 5
+    __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 = U_2 * 5
     __ cad(U_0, U_0, tmp1, tmp3); // U_0 += U_2 * 5 with carry output to tmp3
     __ cadc(U_1, U_1, zr, tmp3); // Add carry to U_1 with carry output to tmp3
     __ andi(U_2, U_2, 3);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4531,7 +4531,7 @@ class StubGenerator: public StubCodeGenerator {
 
       __ cad(S_0, S_0, U_0, tmp1); // Add U_0 to S_0 with carry output to tmp1
       __ cadc(S_1, S_1, U_1, tmp1); // Add U_1 with carry to S_1 with carry output to tmp1
-      __ adc(S_2, zr, U_2, tmp1);
+      __ add(S_2, U_2, tmp1);
 
       __ addi(S_2, S_2, 1);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4419,7 +4419,7 @@ class StubGenerator: public StubCodeGenerator {
   // In sun.security.util.math.intpoly.IntegerPolynomial1305, integers
   // are represented as long[5], with BITS_PER_LIMB = 26.
   // Pack five 26-bit limbs into three 64-bit registers.
-  void pack_26(Register dest0, Register dest1, Register dest2, Register src, Regster tmp1, Register tmp2) {
+  void pack_26(Register dest0, Register dest1, Register dest2, Register src, Register tmp1, Register tmp2) {
     assert_different_registers(dest0, dest1, dest2, src, tmp1, tmp2);
 
     // The goal is to have 128-bit value in dest2:dest1:dest0

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4477,6 +4477,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   // Poly1305, RFC 7539
+  // Intrinsified version of com.sun.crypto.provider.Poly1305.processMultipleBlocks
 
   // See https://loup-vaillant.fr/tutorials/poly1305-design for a
   // description of the tricks used to simplify and accelerate this

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4479,6 +4479,12 @@ class StubGenerator: public StubCodeGenerator {
   // Poly1305, RFC 7539
   // Intrinsified version of com.sun.crypto.provider.Poly1305.processMultipleBlocks
 
+  // Arguments:
+  //    c_rarg0:   input_start -- where the input is stored
+  //    c_rarg1:   length
+  //    c_rarg2:   acc_start -- where the output will be stored
+  //    c_rarg3:   r_start -- where the randomly generated 128-bit key is stored
+
   // See https://loup-vaillant.fr/tutorials/poly1305-design for a
   // description of the tricks used to simplify and accelerate this
   // computation.

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4445,12 +4445,13 @@ class StubGenerator: public StubCodeGenerator {
     __ slli(t4, t3, 40);
     __ add(dest1, dest1, t4);       // dest1 is full
 
-    __ srli(t3, t3, 24);
     if (dest2->is_valid()) {
+      __ srli(t3, t3, 24);
       __ add(dest2, zr, t3);        // 2 bits in dest2
     } else {
 #ifdef ASSERT
       Label OK;
+      __ srli(t3, t3, 24);
       __ beq(zr, t3, OK);           // 2 bits
       __ stop("high bits of Poly1305 integer should be zero");
       __ should_not_reach_here();

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4493,7 +4493,7 @@ class StubGenerator: public StubCodeGenerator {
     RegSet saved_regs = RegSet::range(x18, x25);
     __ push_reg(saved_regs, sp);
 
-    RegSetIterator<Register> regs = RegSet::range(x14, x31).begin();
+    RegSetIterator<Register> regs = RegSet::range(x13, x31).begin();
 
     // Arguments
     const Register input_start = c_rarg0, length = c_rarg1, acc_start = c_rarg2, r_start = c_rarg3;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4487,6 +4487,7 @@ class StubGenerator: public StubCodeGenerator {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", "poly1305_processBlocks");
     address start = __ pc();
+    __ enter();
     Label here;
 
     RegSet saved_regs = RegSet::range(x18, x25);
@@ -4613,6 +4614,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ bind(DONE);
     __ pop_reg(saved_regs, sp);
+    __ leave(); // Required for proper stackwalking
     __ ret();
 
     return start;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4542,8 +4542,14 @@ class StubGenerator: public StubCodeGenerator {
       // four bits of R_0 and R_1 are zero, we can add together
       // partial products without any risk of needing to propagate a
       // carry out.
-      wide_mul(U_0, U_0HI, S_0, R_0);  wide_madd(U_0, U_0HI, S_1, RR_1, tmp1, tmp2); wide_madd(U_0, U_0HI, S_2, RR_0, tmp1, tmp2);
-      wide_mul(U_1, U_1HI, S_0, R_1);  wide_madd(U_1, U_1HI, S_1, R_0, tmp1, tmp2);  wide_madd(U_1, U_1HI, S_2, RR_1, tmp1, tmp2);
+      wide_mul(U_0, U_0HI, S_0, R_0);
+      wide_madd(U_0, U_0HI, S_1, RR_1, tmp1, tmp2);
+      wide_madd(U_0, U_0HI, S_2, RR_0, tmp1, tmp2);
+
+      wide_mul(U_1, U_1HI, S_0, R_1);
+      wide_madd(U_1, U_1HI, S_1, R_0, tmp1, tmp2);
+      wide_madd(U_1, U_1HI, S_2, RR_1, tmp1, tmp2);
+
       __ andi(U_2, R_0, 3);
       __ mul(U_2, S_2, U_2);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4490,10 +4490,9 @@ class StubGenerator: public StubCodeGenerator {
     Label here;
     const int64_t bits2 = right_n_bits(2);
 
-    RegSet saved_regs = RegSet::range(x18, x25);
+    RegSet saved_regs = RegSet::range(x18, x21);
+    RegSetIterator<Register> regs = (RegSet::range(x13, x31) - RegSet::range(x22, x27)).begin();
     __ push_reg(saved_regs, sp);
-
-    RegSetIterator<Register> regs = RegSet::range(x13, x31).begin();
 
     // Arguments
     const Register input_start = c_rarg0, length = c_rarg1, acc_start = c_rarg2, r_start = c_rarg3;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4610,7 +4610,7 @@ class StubGenerator: public StubCodeGenerator {
     __ srli(tmp1, U_1, 40);
     __ andi(tmp2, U_2, bits2); // Clear all bits in U_2 except for first 2
     __ slli(tmp2, tmp2, 24);
-    __ addw(tmp1, tmp1, tmp2);
+    __ add(tmp1, tmp1, tmp2);
     __ sd(tmp1, Address(acc_start, 4 * sizeof (jlong))); // Fifth 26-bit limb
 
     __ bind(DONE);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4568,7 +4568,7 @@ class StubGenerator: public StubCodeGenerator {
       __ andi(U_2, U_2, bits2); // Clear U_2 except for the first two bits
       __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 is impossible to overflow since two leftmost bits are zero'ed in 'srli(tmp1, U_2, 2)'
       __ cad(U_0, U_0, tmp1, tmp3); // Add tmp1 (= (U_2 >> 2) * 5) to U_0 with carry output to tmp3
-      __ cadc(U_1, U_1, zr, tmp3); // Add carry to U_1 with carry output to tmp3
+      __ cad(U_1, U_1, tmp3, tmp3); // Add carry to U_1 with carry output to tmp3
       __ add(U_2, U_2, tmp3);
 
       __ sub(length, length, checked_cast<u1>(BLOCK_LENGTH));
@@ -4581,7 +4581,7 @@ class StubGenerator: public StubCodeGenerator {
     __ srli(tmp1, U_2, 2);
     __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 = U_2 * 5
     __ cad(U_0, U_0, tmp1, tmp3); // U_0 += U_2 * 5 with carry output to tmp3
-    __ cadc(U_1, U_1, zr, tmp3); // Add carry to U_1 with carry output to tmp3
+    __ cad(U_1, U_1, tmp3, tmp3); // Add carry to U_1 with carry output to tmp3
     __ andi(U_2, U_2, bits2);
     __ add(U_2, U_2, tmp3); // Add carry to U_2
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4489,6 +4489,7 @@ class StubGenerator: public StubCodeGenerator {
     address start = __ pc();
     __ enter();
     Label here;
+    const int64_t bits2 = right_n_bits(2);
 
     RegSet saved_regs = RegSet::range(x18, x25);
     __ push_reg(saved_regs, sp);
@@ -4561,7 +4562,6 @@ class StubGenerator: public StubCodeGenerator {
 
       // U_2:U_1:U_0: += (U_2 >> 2) * 5
       __ srli(tmp1, U_2, 2);
-      const int64_t bits2 = right_n_bits(2);
       __ andi(U_2, U_2, bits2); // Clear U_2 except for the first two bits
       __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 is impossible to overflow since two leftmost bits are zero'ed in 'srli(tmp1, U_2, 2)'
       __ cad(U_0, U_0, tmp1, tmp3); // Add tmp1 (= (U_2 >> 2) * 5) to U_0 with carry output to tmp3
@@ -4607,7 +4607,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // Storing 41-64 bits of U_1 and first two bits from U_2 in one register
     __ srli(tmp1, U_1, 40);
-    __ andi(tmp2, U_2, 3); // Clear all bits in U_2 except for first 2
+    __ andi(tmp2, U_2, bits2); // Clear all bits in U_2 except for first 2
     __ slli(tmp2, tmp2, 24);
     __ addw(tmp1, tmp1, tmp2);
     __ sd(tmp1, Address(acc_start, 4 * sizeof (jlong))); // Fifth 26-bit limb

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4498,7 +4498,7 @@ class StubGenerator: public StubCodeGenerator {
     // Arguments
     const Register input_start = c_rarg0, length = c_rarg1, acc_start = c_rarg2, r_start = c_rarg3;
     // Temporal registers
-    const Register tmp1 = t0, tmp2 = t1, tmp3 = t2;
+    const Register tmp1 = t1, tmp2 = t2;
 
     // R_n is the 128-bit randomly-generated key, packed into two
     // registers. The caller passes this key to us as long[5], with
@@ -4567,9 +4567,9 @@ class StubGenerator: public StubCodeGenerator {
       __ srli(tmp1, U_2, 2);
       __ andi(U_2, U_2, bits2); // Clear U_2 except for the first two bits
       __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 is impossible to overflow since two leftmost bits are zero'ed in 'srli(tmp1, U_2, 2)'
-      __ cad(U_0, U_0, tmp1, tmp3); // Add tmp1 (= (U_2 >> 2) * 5) to U_0 with carry output to tmp3
-      __ cad(U_1, U_1, tmp3, tmp3); // Add carry to U_1 with carry output to tmp3
-      __ add(U_2, U_2, tmp3);
+      __ cad(U_0, U_0, tmp1, tmp2); // Add tmp1 (= (U_2 >> 2) * 5) to U_0 with carry output to tmp2
+      __ cad(U_1, U_1, tmp2, tmp2); // Add carry to U_1 with carry output to tmp2
+      __ add(U_2, U_2, tmp2);
 
       __ sub(length, length, checked_cast<u1>(BLOCK_LENGTH));
       __ addi(input_start, input_start, 2 * wordSize);
@@ -4580,10 +4580,10 @@ class StubGenerator: public StubCodeGenerator {
     // Further reduce modulo 2^130 - 5
     __ srli(tmp1, U_2, 2);
     __ shadd(tmp1, tmp1, tmp1, tmp2, 2); // tmp1 = U_2 * 5
-    __ cad(U_0, U_0, tmp1, tmp3); // U_0 += U_2 * 5 with carry output to tmp3
-    __ cad(U_1, U_1, tmp3, tmp3); // Add carry to U_1 with carry output to tmp3
+    __ cad(U_0, U_0, tmp1, tmp2); // U_0 += U_2 * 5 with carry output to tmp2
+    __ cad(U_1, U_1, tmp2, tmp2); // Add carry to U_1 with carry output to tmp2
     __ andi(U_2, U_2, bits2);
-    __ add(U_2, U_2, tmp3); // Add carry to U_2
+    __ add(U_2, U_2, tmp2); // Add carry to U_2
 
     // Unpack the sum into five 26-bit limbs and write to memory.
     // First 26 bits is the first limb
@@ -4605,7 +4605,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // Storing 15-40 bits of U_1
     __ slli(tmp1, U_1, 24); // Already used up 14 bits
-    __ srli(tmp1, tmp1, 38); // Clear all other bits from tmp3
+    __ srli(tmp1, tmp1, 38); // Clear all other bits from tmp1
     __ sd(tmp1, Address(acc_start, 3 * sizeof (jlong))); // Fourth 26-bit limb
 
     // Storing 41-64 bits of U_1 and first two bits from U_2 in one register

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4493,10 +4493,10 @@ class StubGenerator: public StubCodeGenerator {
     RegSet saved_regs = RegSet::range(x18, x25);
     __ push_reg(saved_regs, sp);
 
-    RegSetIterator<Register> regs = RegSet::range(x10, x31).begin();
+    RegSetIterator<Register> regs = RegSet::range(x14, x31).begin();
 
     // Arguments
-    const Register input_start = *regs, length = *++regs, acc_start = *++regs, r_start = *++regs;
+    const Register input_start = c_rarg0, length = c_rarg1, acc_start = c_rarg2, r_start = c_rarg3;
     // Temporal registers
     const Register tmp1 = t0, tmp2 = t1, tmp3 = t2;
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4445,7 +4445,7 @@ class StubGenerator: public StubCodeGenerator {
 
     if (dest2->is_valid()) {
       __ srli(tmp1, tmp1, 24);
-      __ add(dest2, zr, tmp1);        // 2 bits in dest2
+      __ mv(dest2, tmp1);               // 2 bits in dest2
     } else {
 #ifdef ASSERT
       Label OK;
@@ -4520,7 +4520,7 @@ class StubGenerator: public StubCodeGenerator {
     static constexpr int BLOCK_LENGTH = 16;
     Label DONE, LOOP;
 
-    __ addi(tmp1, zr, checked_cast<u1>(BLOCK_LENGTH));
+    __ mv(tmp1, checked_cast<u1>(BLOCK_LENGTH));
     __ blt(length, tmp1, DONE); {
       __ bind(LOOP);
 
@@ -4573,7 +4573,7 @@ class StubGenerator: public StubCodeGenerator {
 
       __ sub(length, length, checked_cast<u1>(BLOCK_LENGTH));
       __ addi(input_start, input_start, 2 * wordSize);
-      __ addi(tmp1, zr, checked_cast<u1>(BLOCK_LENGTH));
+      __ mv(tmp1, checked_cast<u1>(BLOCK_LENGTH))
       __ bge(length, tmp1, LOOP);
     }
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4571,7 +4571,7 @@ class StubGenerator: public StubCodeGenerator {
 
       __ sub(length, length, checked_cast<u1>(BLOCK_LENGTH));
       __ addi(input_start, input_start, 2 * wordSize);
-      __ mv(t1, checked_cast<u1>(BLOCK_LENGTH))
+      __ mv(t1, checked_cast<u1>(BLOCK_LENGTH));
       __ bge(length, t1, LOOP);
     }
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4584,26 +4584,26 @@ class StubGenerator: public StubCodeGenerator {
     __ add(U_2, U_2, tmp3); // Add carry to U_2
 
     // Unpack the sum into five 26-bit limbs and write to memory.
-    const int64_t bits26 = right_n_bits(26);
     // First 26 bits is the first limb
-    __ andi(tmp1, U_0, bits26); // Take lowest 26 bits
+    __ slli(tmp1, U_0, 38); // Take lowest 26 bits
+    __ srli(tmp1, tmp1, 38);
     __ sd(tmp1, Address(acc_start)); // First 26-bit limb
 
     // 27-52 bits of U_0 is the second limb
-    __ srli(tmp2, U_0, 26);
-    __ andi(tmp2, tmp2, bits26); // Take next 27-52 bits
-    __ sd(tmp2, Address(acc_start, sizeof (jlong))); // Second 26-bit limb
+    __ slli(tmp1, U_0, 12); // Take next 27-52 bits
+    __ srli(tmp1, tmp1, 38);
+    __ sd(tmp1, Address(acc_start, sizeof (jlong))); // Second 26-bit limb
 
     // Getting 53-64 bits of U_0 and 1-14 bits of U_1 in one register
     __ srli(tmp1, U_0, 52);
-    __ slli(tmp2, U_1, 12);
-    __ addw(tmp1, tmp1, tmp2);
-    __ andi(tmp3, tmp1, bits26, tmp2); // Take remaining bits of tmp1
-    __ sd(tmp3, Address(acc_start, 2 * sizeof (jlong))); // Third 26-bit limb
+    __ slli(tmp2, U_1, 50);
+    __ srli(tmp2, tmp2, 38);
+    __ add(tmp1, tmp1, tmp2);
+    __ sd(tmp1, Address(acc_start, 2 * sizeof (jlong))); // Third 26-bit limb
 
     // Storing 15-40 bits of U_1
-    __ srli(tmp3, U_1, 14); // Already used up 14 bits
-    __ andi(tmp1, tmp3, bits26); // Clear all other bits from tmp3
+    __ slli(tmp1, U_1, 24); // Already used up 14 bits
+    __ srli(tmp1, tmp1, 38); // Clear all other bits from tmp3
     __ sd(tmp1, Address(acc_start, 3 * sizeof (jlong))); // Fourth 26-bit limb
 
     // Storing 41-64 bits of U_1 and first two bits from U_2 in one register

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -191,6 +191,10 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, true);
   }
 
+  if (FLAG_IS_DEFAULT(UsePoly1305Intrinsics)) {
+    FLAG_SET_DEFAULT(UsePoly1305Intrinsics, true);
+  }
+
   if (FLAG_IS_DEFAULT(UseCopySignIntrinsic)) {
       FLAG_SET_DEFAULT(UseCopySignIntrinsic, true);
   }


### PR DESCRIPTION
Hi everyone, please review this port of [AArch64](https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp#L7124) `_poly1305_processBlocks` intrinsic to RISC-V platform. 

### Correctness checks

Tier 1 tests are passed. Also I explicitly ran the `test/jdk/com/sun/crypto/provider/Cipher/ChaCha20/unittest/Poly1305UnitTestDriver.java` test for multiple times and it passes.

### Performance results on T-Head board

#### Results for enabled intrinsic:

Benchmark | (dataSize) | Mode | Cnt | Score | Error | Units
-- | -- | -- | -- | -- | -- | --
Poly1305DigestBench.digestBuffer | 64| thrpt | 3 | 247207.525 | 2853.920 | ops/s
Poly1305DigestBench.digestBuffer | 256 | thrpt | 3 | 221994.065 | 6891.601 | ops/s
Poly1305DigestBench.digestBuffer | 1024 | thrpt | 3 | 164485.375 | 4979.286 | ops/s
Poly1305DigestBench.digestBuffer | 16384 | thrpt | 3 | 27261.181 | 448.178 | ops/s
Poly1305DigestBench.digestBuffer | 1048576 | thrpt | 3 | 270.784 | 3445.077 | ops/s
Poly1305DigestBench.digestBytes | 64 | thrpt | 3 | 266049.018 | 9909.155 | ops/s
Poly1305DigestBench.digestBytes | 256 | thrpt | 3 | 231891.890 | 715.000 | ops/s
Poly1305DigestBench.digestBytes | 1024 | thrpt | 3 | 172746.932 | 1202.374 | ops/s
Poly1305DigestBench.digestBytes | 16384 | thrpt | 3 | 27626.478 | 341.915 | ops/s
Poly1305DigestBench.digestBytes | 1048576 | thrpt | 3 | 265.235 | 3522.458 | ops/s
Poly1305DigestBench.updateBytes | 64 | thrpt | 3 | 3394516.156 | 14656.687 | ops/s
Poly1305DigestBench.updateBytes | 256 | thrpt | 3 | 1463745.045 | 19608.937 | ops/s
Poly1305DigestBench.updateBytes | 1024 | thrpt | 3 | 459312.198 | 1720.655 | ops/s
Poly1305DigestBench.updateBytes | 16384 | thrpt | 3 | 30969.117 | 813.712 | ops/s
Poly1305DigestBench.updateBytes | 1048576 | thrpt | 3 | 300.773 | 3345.716 | ops/s

#### Results for disabled intrinsic:

Benchmark | (dataSize) | Mode | Cnt | Score | Error | Units
-- | -- | -- | -- | -- | -- | -- 
Poly1305DigestBench.digestBuffer | 64 | thrpt | 3 | 225424.813 | 1083.844 | ops/s
Poly1305DigestBench.digestBuffer | 256 | thrpt | 3 | 167848.372 | 3488.837 | ops/s
Poly1305DigestBench.digestBuffer | 1024 | thrpt | 3 | 81802.600 | 1839.218 | ops/s
Poly1305DigestBench.digestBuffer | 16384 | thrpt | 3 | 7781.049 | 1101.150 | ops/s
Poly1305DigestBench.digestBuffer | 1048576 | thrpt | 3 | 118.778 | 74.388 | ops/s
Poly1305DigestBench.digestBytes | 64 | thrpt | 3 | 235107.377 | 16410.542 | ops/s
Poly1305DigestBench.digestBytes | 256 | thrpt | 3 | 149680.589 | 4748.996 | ops/s
Poly1305DigestBench.digestBytes | 1024 | thrpt | 3 | 73649.642 | 2436.135 | ops/s
Poly1305DigestBench.digestBytes | 16384 | thrpt | 3 | 7845.284 | 15.763 | ops/s
Poly1305DigestBench.digestBytes | 1048576 | thrpt | 3 | 120.673 | 50.138 | ops/s
Poly1305DigestBench.updateBytes | 64 | thrpt | 3 | 1382356.741 | 12203.309 | ops/s
Poly1305DigestBench.updateBytes | 256 | thrpt | 3 | 412198.616 | 1926.171 | ops/s
Poly1305DigestBench.updateBytes | 1024 | thrpt | 3 | 109357.414 | 275.333 | ops/s
Poly1305DigestBench.updateBytes | 16384 | thrpt | 3 | 8214.049 | 258.471 | ops/s
Poly1305DigestBench.updateBytes | 1048576 | thrpt | 3 | 121.006 | 51.510 | ops/s

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316592](https://bugs.openjdk.org/browse/JDK-8316592): RISC-V: implement poly1305 intrinsic (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer) ⚠️ Review applies to [82e51f88](https://git.openjdk.org/jdk/pull/16417/files/82e51f8878175bf3352f15ed25795fbf618b3242)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to [4bdc39bd](https://git.openjdk.org/jdk/pull/16417/files/4bdc39bd6ee790bfd4cecca9af02f2082c09fd2a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16417/head:pull/16417` \
`$ git checkout pull/16417`

Update a local copy of the PR: \
`$ git checkout pull/16417` \
`$ git pull https://git.openjdk.org/jdk.git pull/16417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16417`

View PR using the GUI difftool: \
`$ git pr show -t 16417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16417.diff">https://git.openjdk.org/jdk/pull/16417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16417#issuecomment-1785392022)