### PR TITLE
8319115: GrowableArray: Do not initialize up to capacity

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -505,7 +505,7 @@ void GrowableArrayWithAllocator<E, Derived>::expand_to(int new_capacity) {
   int i = 0;
   for (     ; i < this->_len; i++) ::new ((void*)&newData[i]) E(this->_data[i]);
   for (     ; i < this->_capacity; i++) ::new ((void*)&newData[i]) E();
-  for (i = 0; i < old_capacity; i++) this->_data[i].~E();
+  for (i = 0; i < this->_len; i++) this->_data[i].~E();
   if (this->_data != nullptr) {
     static_cast<Derived*>(this)->deallocate(this->_data);
   }

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -502,10 +502,10 @@ void GrowableArrayWithAllocator<E, Derived>::expand_to(int new_capacity) {
          "expected growth but %d <= %d", new_capacity, old_capacity);
   this->_capacity = new_capacity;
   E* newData = static_cast<Derived*>(this)->allocate();
-  int i = 0;
-  for (     ; i < this->_len; i++) ::new ((void*)&newData[i]) E(this->_data[i]);
-  for (     ; i < this->_capacity; i++) ::new ((void*)&newData[i]) E();
-  for (i = 0; i < this->_len; i++) this->_data[i].~E();
+  for (int i = 0; i < this->_len; i++) {
+    ::new ((void*)&newData[i]) E(this->_data[i]);
+    this->_data[i].~E();
+  }
   if (this->_data != nullptr) {
     static_cast<Derived*>(this)->deallocate(this->_data);
   }

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -366,20 +366,13 @@ class GrowableArrayWithAllocator : public GrowableArrayView<E> {
 
 protected:
   GrowableArrayWithAllocator(E* data, int capacity) :
-      GrowableArrayView<E>(data, capacity, 0) {
-    for (int i = 0; i < capacity; i++) {
-      ::new ((void*)&data[i]) E();
-    }
-  }
+      GrowableArrayView<E>(data, capacity, 0) {}
 
   GrowableArrayWithAllocator(E* data, int capacity, int initial_len, const E& filler) :
       GrowableArrayView<E>(data, capacity, initial_len) {
     int i = 0;
     for (; i < initial_len; i++) {
       ::new ((void*)&data[i]) E(filler);
-    }
-    for (; i < capacity; i++) {
-      ::new ((void*)&data[i]) E();
     }
   }
 
@@ -545,7 +538,7 @@ void GrowableArrayWithAllocator<E, Derived>::shrink_to_fit() {
     for (int i = 0; i < len; ++i) ::new (&new_data[i]) E(old_data[i]);
   }
   // Destroy contents of old data, and deallocate it.
-  for (int i = 0; i < old_capacity; ++i) old_data[i].~E();
+  for (int i = 0; i < len; ++i) old_data[i].~E();
   if (old_data != nullptr) {
     static_cast<Derived*>(this)->deallocate(old_data);
   }


### PR DESCRIPTION
Hi,

There's no reason to initialize the memory for the elements in the range `[_len, _capacity)` on resize, so let's not do it.

Currently running testing tier1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319115](https://bugs.openjdk.org/browse/JDK-8319115): GrowableArray: Do not initialize up to capacity (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16418/head:pull/16418` \
`$ git checkout pull/16418`

Update a local copy of the PR: \
`$ git checkout pull/16418` \
`$ git pull https://git.openjdk.org/jdk.git pull/16418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16418`

View PR using the GUI difftool: \
`$ git pr show -t 16418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16418.diff">https://git.openjdk.org/jdk/pull/16418.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16418#issuecomment-1785411747)