### PR TITLE
JDK-8318467 : [jmh] tests concurrent.Queues and concurrent.ProducerConsumer hang with 101+ threads

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/concurrent/ProducerConsumer.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ProducerConsumer.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.infra.ThreadParams;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -55,7 +56,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(3)
 public class ProducerConsumer {
 
-    @Param("100")
+    @Param("100") // Will be expanded to at least the number of threads used
     private int capacity;
 
     @Param
@@ -65,7 +66,10 @@ public class ProducerConsumer {
     private Producer prod;
 
     @Setup
-    public void prepare() {
+    public void prepare(ThreadParams params) {
+
+        capacity = Math.max(params.getThreadCount(), capacity);
+
         switch (type) {
             case ABQ_F:
                 q = new ArrayBlockingQueue<>(capacity, true);

--- a/test/micro/org/openjdk/bench/java/util/concurrent/ProducerConsumer.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/ProducerConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,6 @@ public class ProducerConsumer {
 
     @Setup
     public void prepare(ThreadParams params) {
-
         capacity = Math.max(params.getThreadCount(), capacity);
 
         switch (type) {

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Queues.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Queues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Queues.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Queues.java
@@ -34,6 +34,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.infra.ThreadParams;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -49,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(3)
 public class Queues {
 
-    @Param("100")
+    @Param("100") // Will be expanded to at least the number of threads used
     private int capacity;
 
     @Param
@@ -65,7 +66,9 @@ public class Queues {
     private BlockingQueue<Integer> q;
 
     @Setup
-    public void setup() {
+    public void setup(ThreadParams params) {
+        capacity = Math.max(params.getThreadCount(), capacity);
+
         switch (type) {
             case ABQ_F:
                 q = new ArrayBlockingQueue<>(capacity, true);


### PR DESCRIPTION
Discussed with @DougLea and adjusting the queue capacity to at least the number of participating threads seems like the most sensible fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318467](https://bugs.openjdk.org/browse/JDK-8318467): [jmh] tests concurrent.Queues and concurrent.ProducerConsumer hang with 101+ threads (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16419/head:pull/16419` \
`$ git checkout pull/16419`

Update a local copy of the PR: \
`$ git checkout pull/16419` \
`$ git pull https://git.openjdk.org/jdk.git pull/16419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16419`

View PR using the GUI difftool: \
`$ git pr show -t 16419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16419.diff">https://git.openjdk.org/jdk/pull/16419.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16419#issuecomment-1785407682)