### PR TITLE
8319121: hsdis binutils: speedup building from source

### DIFF
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -200,13 +200,13 @@ AC_DEFUN([LIB_BUILD_BINUTILS],
       AC_MSG_ERROR([Cannot continue])
     fi
     AC_MSG_NOTICE([Running binutils make])
-    $MAKE all-opcodes all-libiberty
+    $MAKE -j$JOBS all-opcodes all-libiberty
     if test $? -ne 0; then
       AC_MSG_NOTICE([Automatic building of binutils failed on make. Try building it manually])
       AC_MSG_ERROR([Cannot continue])
     fi
     AC_MSG_NOTICE([Running binutils make install])
-    $MAKE install-opcodes install-libiberty
+    $MAKE -j$JOBS install-opcodes install-libiberty
     if test $? -ne 0; then
       AC_MSG_NOTICE([Automatic building, install step, of binutils failed on make. Try building it manually])
       AC_MSG_ERROR([Cannot continue])


### PR DESCRIPTION
Hi all, please consider.

Tested configure with binutils-src.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319121](https://bugs.openjdk.org/browse/JDK-8319121): hsdis binutils: speedup building from source (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16421/head:pull/16421` \
`$ git checkout pull/16421`

Update a local copy of the PR: \
`$ git checkout pull/16421` \
`$ git pull https://git.openjdk.org/jdk.git pull/16421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16421`

View PR using the GUI difftool: \
`$ git pr show -t 16421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16421.diff">https://git.openjdk.org/jdk/pull/16421.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16421#issuecomment-1785506119)