### PR TITLE
8310933: Copying from runtime image to application image should not follow symlinks

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/StandardBundlerParam.java
@@ -30,6 +30,7 @@ import jdk.internal.util.OperatingSystem;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -596,8 +597,8 @@ class StandardBundlerParam<T> extends BundlerParamInfo<T> {
 
         // copy whole runtime, need to skip jmods and src.zip
         final List<String> excludes = Arrays.asList("jmods", "src.zip");
-        IOUtils.copyRecursive(topImage,
-                appLayout.runtimeHomeDirectory(), excludes);
+        IOUtils.copyRecursive(topImage, appLayout.runtimeHomeDirectory(),
+                        excludes, LinkOption.NOFOLLOW_LINKS);
 
         // if module-path given - copy modules to appDir/mods
         List<Path> modulePath = MODULE_PATH.fetchFrom(params);

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -693,6 +693,12 @@ final public class TKit {
         assertPathExists(path, true);
         assertTrue(path.toFile().isDirectory(), String.format(
                 "Check [%s] is a directory", path));
+    }
+
+    public static void assertSymbolicLinkExists(Path path) {
+        assertPathExists(path, true);
+        assertTrue(Files.isSymbolicLink(path), String.format
+                ("Check [%s] is a symbolic link", path));
     }
 
     public static void assertFileExists(Path path) {


### PR DESCRIPTION
- Added LinkOption.NOFOLLOW_LINKS when copying pre-define runtime image.
- Added test to cover this change.
- Cleanup RuntimeImageTest.java by removing unused imports and removed incubator from jpackage module name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310933](https://bugs.openjdk.org/browse/JDK-8310933): Copying from runtime image to application image should not follow symlinks (**Enhancement** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16426/head:pull/16426` \
`$ git checkout pull/16426`

Update a local copy of the PR: \
`$ git checkout pull/16426` \
`$ git pull https://git.openjdk.org/jdk.git pull/16426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16426`

View PR using the GUI difftool: \
`$ git pr show -t 16426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16426.diff">https://git.openjdk.org/jdk/pull/16426.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16426#issuecomment-1785929423)