### PR TITLE
8319136: Skip pkcs11 tests on linux-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -629,6 +629,7 @@ sun/security/pkcs11/rsa/TestKeyPairGenerator.java               8295343 generic-
 sun/security/pkcs11/rsa/TestKeyFactory.java                     8295343 generic-all
 sun/security/pkcs11/KeyStore/Basic.java                         8295343 generic-all
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183 linux-ppc64le
+sun/security/pkcs11/Provider/MultipleLogins.sh                  8319128 linux-aarch64
 
 ############################################################################
 

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -825,7 +825,7 @@ public abstract class PKCS11Test {
                 return fetchNssLib(LINUX_X64.class);
 
             case "Linux-aarch64-64":
-                throw new SkippedException("Skipping Linux aarch64 platforms.");
+                throw new SkippedException("Per JDK-8319128, skipping Linux aarch64 platforms.");
             default:
                 return null;
         }

--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -825,8 +825,7 @@ public abstract class PKCS11Test {
                 return fetchNssLib(LINUX_X64.class);
 
             case "Linux-aarch64-64":
-                return fetchNssLib(LINUX_AARCH64.class);
-
+                throw new SkippedException("Skipping Linux aarch64 platforms.");
             default:
                 return null;
         }


### PR DESCRIPTION
Due to test failures on OL 7.9 aarch64, this PR skips tests for LInux aarch64. The MultipleLogin.sh script had to be added to the ProblemList because it reported error when the Java component threw the skipped exception.

Tests will be fixed in JDK-8319128.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319136](https://bugs.openjdk.org/browse/JDK-8319136): Skip pkcs11 tests on linux-aarch64 (**Bug** - P3)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**) ⚠️ Review applies to [486d1010](https://git.openjdk.org/jdk/pull/16427/files/486d10106b30e184f4a5d6a18ee91beecd1bd609)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16427/head:pull/16427` \
`$ git checkout pull/16427`

Update a local copy of the PR: \
`$ git checkout pull/16427` \
`$ git pull https://git.openjdk.org/jdk.git pull/16427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16427`

View PR using the GUI difftool: \
`$ git pr show -t 16427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16427.diff">https://git.openjdk.org/jdk/pull/16427.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16427#issuecomment-1785948777)