### PR TITLE
8316132: CDSProtectionDomain::get_shared_protection_domain should check for exception

### DIFF
--- a/src/hotspot/share/cds/cdsProtectionDomain.cpp
+++ b/src/hotspot/share/cds/cdsProtectionDomain.cpp
@@ -241,7 +241,7 @@ Handle CDSProtectionDomain::get_shared_protection_domain(Handle class_loader,
                                                             TRAPS) {
   Handle protection_domain;
   if (shared_protection_domain(shared_path_index) == nullptr) {
-    Handle pd = get_protection_domain_from_classloader(class_loader, url, THREAD);
+    Handle pd = get_protection_domain_from_classloader(class_loader, url, CHECK_NH);
     atomic_set_shared_protection_domain(shared_path_index, pd());
   }
 


### PR DESCRIPTION
A simple fix to replace `THREAD` with `CHECK_NH` when calling `get_protection_domain_from_classloader()`.

Passed tier1 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316132](https://bugs.openjdk.org/browse/JDK-8316132): CDSProtectionDomain::get_shared_protection_domain should check for exception (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16428/head:pull/16428` \
`$ git checkout pull/16428`

Update a local copy of the PR: \
`$ git checkout pull/16428` \
`$ git pull https://git.openjdk.org/jdk.git pull/16428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16428`

View PR using the GUI difftool: \
`$ git pr show -t 16428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16428.diff">https://git.openjdk.org/jdk/pull/16428.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16428#issuecomment-1786174099)