### PR TITLE
8318962: Update ProcessTools javadoc with suggestions in 8315097

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -612,7 +612,7 @@ public final class ProcessTools {
      * the process output.
      *
      * <p>The process is created using runtime flags set up by:
-     * {@link #createLimitedTestJavaProcessBuilder(String...)}. The
+     * {@link #createTestJavaProcessBuilder(String...)}. The
      * jvm process will have exited before this method returns.
      *
      * @param cmds User specified arguments.
@@ -627,7 +627,7 @@ public final class ProcessTools {
      * the process output.
      *
      * <p>The process is created using runtime flags set up by:
-     * {@link #createLimitedTestJavaProcessBuilder(String...)}. The
+     * {@link #createTestJavaProcessBuilder(String...)}. The
      * jvm process will have exited before this method returns.
      *
      * @param cmds User specified arguments.

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -492,12 +492,21 @@ public final class ProcessTools {
     }
 
     /**
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
-     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
-     * <p>
-     * The command line will be like:
-     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     * Create ProcessBuilder using the java launcher from the jdk to
+     * be tested. The default jvm options from jtreg, test.vm.opts and
+     * test.java.opts, are added.
+     *
+     * <p>Unless the "test.noclasspath" property is "true" the
+     * classpath property "java.class.path" is appended to the command
+     * line and the environment of the ProcessBuilder is modified to
+     * remove "CLASSPATH". If the property "test.thread.factory" is
+     * provided the command args are updated and appended to invoke
+     * ProcessTools main() and provide the name of the thread factory.
+     *
+     * <p>The "-Dtest.thread.factory" is appended to the arguments
+     * with the thread factory value. The remaining command args are
+     * scanned for unsupported options and are appended to the
+     * ProcessBuilder.
      *
      * @param command Arguments to pass to the java command.
      * @return The ProcessBuilder instance representing the java command.
@@ -507,12 +516,21 @@ public final class ProcessTools {
     }
 
     /**
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
-     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
-     * <p>
-     * The command line will be like:
-     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
-     * Create ProcessBuilder using the java launcher from the jdk to be tested.
+     * Create ProcessBuilder using the java launcher from the jdk to
+     * be tested. The default jvm options from jtreg, test.vm.opts and
+     * test.java.opts, are added.
+     *
+     * <p>Unless the "test.noclasspath" property is "true" the
+     * classpath property "java.class.path" is appended to the command
+     * line and the environment of the ProcessBuilder is modified to
+     * remove "CLASSPATH". If the property "test.thread.factory" is
+     * provided the command args are updated and appended to invoke
+     * ProcessTools main() and provide the name of the thread factory.
+     *
+     * <p>The "-Dtest.thread.factory" is appended to the arguments
+     * with the thread factory value. The remaining command args are
+     * scanned for unsupported options and are appended to the
+     * ProcessBuilder.
      *
      * @param command Arguments to pass to the java command.
      * @return The ProcessBuilder instance representing the java command.
@@ -536,6 +554,18 @@ public final class ProcessTools {
      * it in combination with <b>@requires vm.flagless</b> JTREG
      * anotation as to not waste energy and test resources.
      *
+     * <p>Unless the "test.noclasspath" property is "true" the
+     * classpath property "java.class.path" is appended to the command
+     * line and the environment of the ProcessBuilder is modified to
+     * remove "CLASSPATH". If the property "test.thread.factory" is
+     * provided the command args are updated and appended to invoke
+     * ProcessTools main() and provide the name of the thread factory.
+     *
+     * <p>The "-Dtest.thread.factory" is appended to the arguments
+     * with the thread factory value. The remaining command args are
+     * scanned for unsupported options and are appended to the
+     * ProcessBuilder.
+     *
      * @param command Arguments to pass to the java command.
      * @return The ProcessBuilder instance representing the java command.
      */
@@ -558,6 +588,18 @@ public final class ProcessTools {
      * it in combination with <b>@requires vm.flagless</b> JTREG
      * anotation as to not waste energy and test resources.
      *
+     * <p>Unless the "test.noclasspath" property is "true" the
+     * classpath property "java.class.path" is appended to the command
+     * line and the environment of the ProcessBuilder is modified to
+     * remove "CLASSPATH". If the property "test.thread.factory" is
+     * provided the command args are updated and appended to invoke
+     * ProcessTools main() and provide the name of the thread factory.
+     *
+     * <p>The "-Dtest.thread.factory" is appended to the arguments
+     * with the thread factory value. The remaining command args are
+     * scanned for unsupported options and are appended to the
+     * ProcessBuilder.
+     *
      * @param command Arguments to pass to the java command.
      * @return The ProcessBuilder instance representing the java command.
      */
@@ -566,14 +608,12 @@ public final class ProcessTools {
     }
 
     /**
-     * Executes a test jvm process, waits for it to finish and returns the process output.
-     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
-     * The java from the test.jdk is used to execute the command.
-     * <p>
-     * The command line will be like:
-     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
-     * <p>
-     * The jvm process will have exited before this method returns.
+     * Executes a test jvm process, waits for it to finish and returns
+     * the process output.
+     *
+     * <p>The process is created using runtime flags set up by:
+     * {@link #createLimitedTestJavaProcessBuilder(String...)}. The
+     * jvm process will have exited before this method returns.
      *
      * @param cmds User specified arguments.
      * @return The output from the process.
@@ -583,14 +623,12 @@ public final class ProcessTools {
     }
 
     /**
-     * Executes a test jvm process, waits for it to finish and returns the process output.
-     * The default jvm options from jtreg, test.vm.opts and test.java.opts, are added.
-     * The java from the test.jdk is used to execute the command.
-     * <p>
-     * The command line will be like:
-     * {test.jdk}/bin/java {test.vm.opts} {test.java.opts} cmds
-     * <p>
-     * The jvm process will have exited before this method returns.
+     * Executes a test jvm process, waits for it to finish and returns
+     * the process output.
+     *
+     * <p>The process is created using runtime flags set up by:
+     * {@link #createLimitedTestJavaProcessBuilder(String...)}. The
+     * jvm process will have exited before this method returns.
      *
      * @param cmds User specified arguments.
      * @return The output from the process.


### PR DESCRIPTION
Updates to javadoc after improvement ideas in the review of 8315097. I have also removed the incomplete invocation command line. I also removed incomplete information in `executeTestJvm` and added a link to `createLimitedTestJavaProcessBuilder`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318962](https://bugs.openjdk.org/browse/JDK-8318962): Update ProcessTools javadoc with suggestions in 8315097 (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16430/head:pull/16430` \
`$ git checkout pull/16430`

Update a local copy of the PR: \
`$ git checkout pull/16430` \
`$ git pull https://git.openjdk.org/jdk.git pull/16430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16430`

View PR using the GUI difftool: \
`$ git pr show -t 16430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16430.diff">https://git.openjdk.org/jdk/pull/16430.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16430#issuecomment-1786623892)