### PR TITLE
8319153: Fix: Class is a raw type in ProcessTools

### DIFF
--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -921,7 +921,7 @@ public final class ProcessTools {
         String className = args[1];
         String[] classArgs = new String[args.length - 2];
         System.arraycopy(args, 2, classArgs, 0, args.length - 2);
-        Class c = Class.forName(className);
+        Class<?> c = Class.forName(className);
         Method mainMethod = c.getMethod("main", new Class[] { String[].class });
         mainMethod.setAccessible(true);
 


### PR DESCRIPTION
Changing from `Class c` to `Class<?> c` removes two warnings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319153](https://bugs.openjdk.org/browse/JDK-8319153): Fix: Class is a raw type in ProcessTools (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16431/head:pull/16431` \
`$ git checkout pull/16431`

Update a local copy of the PR: \
`$ git checkout pull/16431` \
`$ git pull https://git.openjdk.org/jdk.git pull/16431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16431`

View PR using the GUI difftool: \
`$ git pr show -t 16431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16431.diff">https://git.openjdk.org/jdk/pull/16431.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16431#issuecomment-1786679042)