### PR TITLE
8319158: Parallel: Make TestObjectTenuringFlags use createTestJavaProcessBuilder

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java
@@ -26,7 +26,7 @@ package gc.arguments;
 /*
  * @test TestObjectTenuringFlags
  * @bug 6521376
- * @requires vm.gc.Parallel
+ * @requires vm.gc.Parallel & vm.opt.NeverTenure == null & vm.opt.AlwaysTenure == null & vm.opt.MaxTenuringThreshold == null & vm.opt.InitialTenuringThreshold == null
  * @summary Tests argument processing for NeverTenure, AlwaysTenure,
  * and MaxTenuringThreshold
  * @library /test/lib
@@ -161,7 +161,7 @@ public class TestObjectTenuringFlags {
     }
     Collections.addAll(vmOpts, "-XX:+UseParallelGC", "-XX:+PrintFlagsFinal", "-version");
 
-    ProcessBuilder pb = GCArguments.createLimitedTestJavaProcessBuilder(vmOpts);
+    ProcessBuilder pb = GCArguments.createTestJavaProcessBuilder(vmOpts);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
 
     if (shouldFail) {


### PR DESCRIPTION
Tested with:
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java JTREG='VERBOSE=all;JAVA_OPTIONS='` -> pass 1
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:+UseSerialGC'` -> pass 0
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestObjectTenuringFlags.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:+NeverTenure'` -> pass 0 

I will later (before integrating) run this test together with more tests through high tier testing to see that we do not fail when rotating flags.