### PR TITLE
8319165: hsdis binutils: warns on empty string as option string

### DIFF
--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -336,8 +336,8 @@ static void setup_app_data(struct hsdis_app_data* app_data,
                                  app_data->printf_stream,
                                  app_data->printf_callback,
                                  native_bfd,
-                                 /* On PowerPC we get warnings, if we pass empty options */
-                                 (caller_options == NULL) ? NULL : app_data->insn_options);
+                                 /* On some archs we get warnings, if we pass empty options */
+                                 (app_data->insn_options[0] == '\0') ? NULL : app_data->insn_options);
 
   /* Finish linking together the various callback blocks. */
   app_data->dinfo.application_data = (void*) app_data;

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -337,7 +337,8 @@ static void setup_app_data(struct hsdis_app_data* app_data,
                                  app_data->printf_callback,
                                  native_bfd,
                                  /* On some archs we get warnings, if we pass empty options */
-                                 (app_data->insn_options[0] == '\0') ? NULL : app_data->insn_options);
+                                 ((caller_options == NULL) || (app_data->insn_options[0] == '\0'))
+                                 ? NULL : app_data->insn_options);
 
   /* Finish linking together the various callback blocks. */
   app_data->dinfo.application_data = (void*) app_data;

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -338,7 +338,7 @@ static void setup_app_data(struct hsdis_app_data* app_data,
                                  native_bfd,
                                  /* On some archs we get warnings, if we pass empty options */
                                  ((caller_options == NULL) || (app_data->insn_options[0] == '\0'))
-                                 ? NULL : app_data->insn_options);
+                                   ? NULL : app_data->insn_options);
 
   /* Finish linking together the various callback blocks. */
   app_data->dinfo.application_data = (void*) app_data;


### PR DESCRIPTION
Hi, please consider.

insn_options[0] is set to empty string if there is no options (NULL or empty strings).
Checking it for empty string should cover both cases, caller option is NULL or caller option is empty string.

Tested hsdis no longer gives me the warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319165](https://bugs.openjdk.org/browse/JDK-8319165): hsdis binutils: warns on empty string as option string (**Bug** - P5)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**) ⚠️ Review applies to [94ccd7f9](https://git.openjdk.org/jdk/pull/16433/files/94ccd7f9a348c7011427860240c144f023f3b58c)
 * [Jesper Wilhelmsson](https://openjdk.org/census#jwilhelm) (@JesperIRL - **Reviewer**) ⚠️ Review applies to [94ccd7f9](https://git.openjdk.org/jdk/pull/16433/files/94ccd7f9a348c7011427860240c144f023f3b58c)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [94ccd7f9](https://git.openjdk.org/jdk/pull/16433/files/94ccd7f9a348c7011427860240c144f023f3b58c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16433/head:pull/16433` \
`$ git checkout pull/16433`

Update a local copy of the PR: \
`$ git checkout pull/16433` \
`$ git pull https://git.openjdk.org/jdk.git pull/16433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16433`

View PR using the GUI difftool: \
`$ git pr show -t 16433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16433.diff">https://git.openjdk.org/jdk/pull/16433.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16433#issuecomment-1787199982)