### PR TITLE
8319161: GC: Make TestParallelGCThreads use createTestJavaProcessBuilder

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java
@@ -26,6 +26,7 @@ package gc.arguments;
 /*
  * @test TestParallelGCThreads
  * @bug 8059527 8081382
+ * @requires vm.gc == null & vm.opt.ParallelGCThreads == null
  * @summary Tests argument processing for ParallelGCThreads
  * @library /test/lib
  * @library /
@@ -56,7 +57,7 @@ public class TestParallelGCThreads {
   private static final String printFlagsFinalPattern = " *uint *" + flagName + " *:?= *(\\d+) *\\{product\\} *";
 
   public static void testDefaultValue()  throws Exception {
-    ProcessBuilder pb = GCArguments.createLimitedTestJavaProcessBuilder(
+    ProcessBuilder pb = GCArguments.createTestJavaProcessBuilder(
       "-XX:+UnlockExperimentalVMOptions", "-XX:+PrintFlagsFinal", "-version");
 
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
@@ -65,10 +66,10 @@ public class TestParallelGCThreads {
     try {
       Asserts.assertNotNull(value, "Couldn't find uint flag " + flagName);
 
-      Long longValue = new Long(value);
+      Long longValue = Long.valueOf(value);
 
       // Sanity check that we got a non-zero value.
-      Asserts.assertNotEquals(longValue, "0");
+      Asserts.assertNotEquals(longValue, 0L);
 
       output.shouldHaveExitValue(0);
     } catch (Exception e) {
@@ -87,6 +88,9 @@ public class TestParallelGCThreads {
     if (GC.Parallel.isSupported()) {
       supportedGC.add("Parallel");
     }
+    if (GC.Z.isSupported()) {
+      supportedGC.add("Z");
+    }
 
     if (supportedGC.isEmpty()) {
       throw new SkippedException("Skipping test because none of G1/Parallel is supported.");
@@ -94,7 +98,7 @@ public class TestParallelGCThreads {
 
     for (String gc : supportedGC) {
       // Make sure the VM does not allow ParallelGCThreads set to 0
-      ProcessBuilder pb = GCArguments.createLimitedTestJavaProcessBuilder(
+      ProcessBuilder pb = GCArguments.createTestJavaProcessBuilder(
           "-XX:+Use" + gc + "GC",
           "-XX:ParallelGCThreads=0",
           "-XX:+PrintFlagsFinal",
@@ -124,7 +128,7 @@ public class TestParallelGCThreads {
   }
 
   public static long getParallelGCThreadCount(String... flags) throws Exception {
-    ProcessBuilder pb = GCArguments.createLimitedTestJavaProcessBuilder(flags);
+    ProcessBuilder pb = GCArguments.createTestJavaProcessBuilder(flags);
     OutputAnalyzer output = new OutputAnalyzer(pb.start());
     output.shouldHaveExitValue(0);
     String stdout = output.getStdout();


### PR DESCRIPTION
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java JTREG='VERBOSE=all;JAVA_OPTIONS='` -> pass 1
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:ParallelGCThreads=42' ` --> total 0
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:+UseG1GC' ` --> total 0
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:+UseParallelGC' ` -> total 0
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:+UseSerialGC' ` -> total 0
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:+UseZGC' `-> total 0
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:+UseShenandoahGC' `-> total 0
`make run-test TEST=jtreg:test/hotspot/jtreg/gc/arguments/TestParallelGCThreads.java JTREG='VERBOSE=all;JAVA_OPTIONS=-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC' ` -> total 0 

I will later (before integrating) run this test together with more tests through high tier testing to see that we do not fail when rotating flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with updated jcheck configuration in pull request)

### Issue
 * [JDK-8319161](https://bugs.openjdk.org/browse/JDK-8319161): GC: Make TestParallelGCThreads use createTestJavaProcessBuilder (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16434/head:pull/16434` \
`$ git checkout pull/16434`

Update a local copy of the PR: \
`$ git checkout pull/16434` \
`$ git pull https://git.openjdk.org/jdk.git pull/16434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16434`

View PR using the GUI difftool: \
`$ git pr show -t 16434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16434.diff">https://git.openjdk.org/jdk/pull/16434.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16434#issuecomment-1787574379)