### PR TITLE
JDK-8319139: Improve diagnosability of `JavadocTester` output

### DIFF
--- a/test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTester.java
+++ b/test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTester.java
@@ -73,9 +73,9 @@ public class TestJavadocTester extends JavadocTester {
      * @param message a short description of the outcome
      */
     @Override
-    public void passed(String message) {
-        super.passed(message);
-        messages.add("Passed: " + message);
+    public void passed(String message, String... details) {
+        super.passed(message, details);
+        messages.add("Passed: " + join(message, details));
     }
 
     /**
@@ -85,9 +85,13 @@ public class TestJavadocTester extends JavadocTester {
      * @param message a short description of the outcome
      */
     @Override
-    public void failed(String message) {
-        super.failed(message);
-        messages.add("FAILED: " + message);
+    public void failed(String message, String... details) {
+        super.failed(message, details);
+        messages.add("FAILED: " + join(message, details));
+    }
+
+    private String join(String message, String... details) {
+        return details.length == 0 ? message : message + "\n" + String.join("\n", details);
     }
 
     /**
@@ -138,6 +142,8 @@ public class TestJavadocTester extends JavadocTester {
                 testErrors++;
             }
         }
+
+        messages.forEach(m -> out.println("MESSAGES: " + m));
     }
 
     /**
@@ -153,7 +159,7 @@ public class TestJavadocTester extends JavadocTester {
      * @param message the message to be reported.
      */
     private void report(String message) {
-        message.lines().forEachOrdered(l -> out.println(">>> " + l));
+        message.lines().forEachOrdered(l -> out.println(">>>> " + l));
     }
 
     //-------------------------------------------------
@@ -202,13 +208,13 @@ public class TestJavadocTester extends JavadocTester {
         messages.forEach(this::report);
         checkMessages(
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     Second sentence""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     abc123""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     def456""");
     }
 
@@ -220,7 +226,7 @@ public class TestJavadocTester extends JavadocTester {
                 .check("Third sentence.");
         checkMessages(
                 """
-                    Passed: out/p/C.html: following text not found:
+                    Passed: out/p/C.html: the following text was not found:
                     Third sentence""");
     }
 
@@ -231,7 +237,8 @@ public class TestJavadocTester extends JavadocTester {
                 .check("Third sentence.");
         checkMessages(
                 """
-                    FAILED: out/p/C.html: following text not found:
+                    FAILED: out/p/C.html: output not as expected
+                    >> the following text was not found:
                     Third sentence""");
     }
 
@@ -244,13 +251,13 @@ public class TestJavadocTester extends JavadocTester {
                         Pattern.compile("d.f4.6"));
         checkMessages(
                 """
-                    Passed: out/p/C.html: following pattern found:
+                    Passed: out/p/C.html: the following pattern was found:
                     S.cond s.nt.nc.""",
                 """
-                    Passed: out/p/C.html: following pattern found:
+                    Passed: out/p/C.html: the following pattern was found:
                     [abc]{3}[123]{3}""",
                 """
-                    Passed: out/p/C.html: following pattern found:
+                    Passed: out/p/C.html: the following pattern was found:
                     d.f4.6""");
     }
 
@@ -271,28 +278,28 @@ public class TestJavadocTester extends JavadocTester {
 
         checkMessages(
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     <h2>Method Summary</h2>""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     <a href="#m1()" class="member-name-link">m1</a>""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     <a href="#m2()" class="member-name-link">m2</a>""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     <a href="#m3()" class="member-name-link">m3</a>""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     <h2>Method Details</h2>""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     <section class="detail" id="m3()">""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     <section class="detail" id="m2()">""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     <section class="detail" id="m1()">"""
         );
     }
@@ -306,10 +313,10 @@ public class TestJavadocTester extends JavadocTester {
                         "First sentence");
         checkMessages(
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     Second sentence""",
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     First sentence""");
     }
 
@@ -321,10 +328,11 @@ public class TestJavadocTester extends JavadocTester {
                         "First sentence");
         checkMessages(
                 """
-                    Passed: out/p/C.html: following text found:
+                    Passed: out/p/C.html: the following text was found:
                     Second sentence""",
                 """
-                    FAILED: out/p/C.html: following text was found on line""");
+                    FAILED: out/p/C.html: output not as expected
+                    >> the following text was found on line""");
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTesterCrash.java
+++ b/test/langtools/jdk/javadoc/testJavadocTester/TestJavadocTesterCrash.java
@@ -86,7 +86,7 @@ public class TestJavadocTesterCrash extends TestJavadocTester {
             String s = tags.toString();
             if (s.contains("test")) {
                 throw new Error("demo error");
-            };
+            }
             return s;
         }
     }
@@ -118,6 +118,8 @@ public class TestJavadocTesterCrash extends TestJavadocTester {
                         "1 error");
 
         // verify that JavadocTester detected the crash
-        checkMessages("FAILED: STDERR: following text found:");
+        checkMessages("""
+            FAILED: STDERR: output not as expected
+            >> the following text was found:""");
     }
 }


### PR DESCRIPTION
Please review a small update to the output generated by `JavadocTester` when a test fails.

Although `JavadocTester` does report a stack trace, it appears after all the content of the failure message, which may be some distance away if the message is long.

The `String message` parameter for `passed` and `failed` is split in two: `String message, String... details` with the intent that the `message` should be a short one-line message, and any long additional info put in the effectively optional `details`.

The stack trace is now generated immediately after the initial `FAILED: `_message_ line and before the `details`.
Using a varargs `details` means that we do not have to concatenate strings with `\n`.

There are some other minor tweaks to the output to make it slightly less cryptic.

`JavadocTester` does have some specific tests of its own, and these are updated as appropriate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319139](https://bugs.openjdk.org/browse/JDK-8319139): Improve diagnosability of `JavadocTester` output (**Enhancement** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16436/head:pull/16436` \
`$ git checkout pull/16436`

Update a local copy of the PR: \
`$ git checkout pull/16436` \
`$ git pull https://git.openjdk.org/jdk.git pull/16436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16436`

View PR using the GUI difftool: \
`$ git pr show -t 16436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16436.diff">https://git.openjdk.org/jdk/pull/16436.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16436#issuecomment-1787972432)