### PR TITLE
JDK-8319195: Move most tier 1 vector API regression tests to tier 3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -41,7 +41,6 @@ tier1_part3 = \
     :jdk_math \
     :jdk_svc_sanity \
     :jdk_foreign \
-    :jdk_vector_sanity \
     java/nio/Buffer \
     com/sun/crypto/provider/Cipher \
     jdk/classfile \
@@ -70,6 +69,7 @@ tier2_part2 = \
     :jdk_time
 
 tier2_part3 = \
+    :jdk_vector_sanity \
     :jdk_net
 
 tier3 = \

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -41,6 +41,7 @@ tier1_part3 = \
     :jdk_math \
     :jdk_svc_sanity \
     :jdk_foreign \
+    :jdk_vector_sanity \
     java/nio/Buffer \
     com/sun/crypto/provider/Cipher \
     jdk/classfile \
@@ -69,7 +70,6 @@ tier2_part2 = \
     :jdk_time
 
 tier2_part3 = \
-    :jdk_vector_sanity \
     :jdk_net
 
 tier3 = \
@@ -366,28 +366,8 @@ jdk_vector = \
     jdk/incubator/vector
 
 jdk_vector_sanity = \
-    jdk/incubator/vector/AddTest.java \
-    jdk/incubator/vector/ByteMaxVectorLoadStoreTests.java \
-    jdk/incubator/vector/ByteMaxVectorTests.java \
-    jdk/incubator/vector/CovarOverrideTest.java \
-    jdk/incubator/vector/DoubleMaxVectorLoadStoreTests.java \
-    jdk/incubator/vector/DoubleMaxVectorTests.java \
-    jdk/incubator/vector/FloatMaxVectorLoadStoreTests.java \
-    jdk/incubator/vector/FloatMaxVectorTests.java \
-    jdk/incubator/vector/ImageTest.java \
-    jdk/incubator/vector/IntMaxVectorLoadStoreTests.java \
-    jdk/incubator/vector/IntMaxVectorTests.java \
-    jdk/incubator/vector/LoadJsvmlTest.java \
-    jdk/incubator/vector/LongMaxVectorLoadStoreTests.java \
-    jdk/incubator/vector/LongMaxVectorTests.java \
-    jdk/incubator/vector/MethodOverideTest.java \
-    jdk/incubator/vector/MismatchTest.java \
     jdk/incubator/vector/PreferredSpeciesTest.java \
-    jdk/incubator/vector/ShortMaxVectorLoadStoreTests.java \
-    jdk/incubator/vector/ShortMaxVectorTests.java \
     jdk/incubator/vector/VectorHash.java \
-    jdk/incubator/vector/VectorMaxConversionTests.java \
-    jdk/incubator/vector/VectorReshapeTests.java \
     jdk/incubator/vector/VectorRuns.java
 
 #############################


### PR DESCRIPTION
Due to their longer-than-typical running time and because the vector API is not (yet) in the base module, move the vector API tests in tier 1 to tier 2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319195](https://bugs.openjdk.org/browse/JDK-8319195): Move most tier 1 vector API regression tests to tier 3 (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16437/head:pull/16437` \
`$ git checkout pull/16437`

Update a local copy of the PR: \
`$ git checkout pull/16437` \
`$ git pull https://git.openjdk.org/jdk.git pull/16437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16437`

View PR using the GUI difftool: \
`$ git pr show -t 16437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16437.diff">https://git.openjdk.org/jdk/pull/16437.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16437#issuecomment-1787975203)