### PR TITLE
8319197: Exclude hb-subset and hb-style from compilation

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -493,6 +493,7 @@ else
    endif
 
    # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
+   # hb-subset and hb-style APIs are not needed, excluded to cut on compilation time.
    LIBFONTMANAGER_EXCLUDE_FILES += hb-ft.cc hb-subset-cff-common.cc \
        hb-subset-cff1.cc hb-subset-cff2.cc hb-subset-input.cc hb-subset-plan.cc \
        hb-subset.cc hb-subset-instancer-solver.cc gsubgpos-context.cc hb-style.cc

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -493,7 +493,9 @@ else
    endif
 
    # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
-   LIBFONTMANAGER_EXCLUDE_FILES += libharfbuzz/hb-ft.cc
+   LIBFONTMANAGER_EXCLUDE_FILES += hb-ft.cc hb-subset-cff-common.cc \
+       hb-subset-cff1.cc hb-subset-cff2.cc hb-subset-input.cc hb-subset-plan.cc \
+       hb-subset.cc hb-subset-instancer-solver.cc gsubgpos-context.cc hb-style.cc
 
    # list of disabled warnings and the compilers for which it was specifically added.
    # array-bounds         -> GCC 12 on Alpine Linux


### PR DESCRIPTION
hb-subset and hb-style APIs are not used and not exported by libfontmanger. We can cut the compilation time by not compiling the unused files.

The added exclusions reduce the build time by ~1 minute (~8%) on my machine. This is with harfbuzz 8, with harfbuzz 7 the improvement was ~30 seconds.

Client libs tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8319197](https://bugs.openjdk.org/browse/JDK-8319197): Exclude hb-subset and hb-style from compilation (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16440/head:pull/16440` \
`$ git checkout pull/16440`

Update a local copy of the PR: \
`$ git checkout pull/16440` \
`$ git pull https://git.openjdk.org/jdk.git pull/16440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16440`

View PR using the GUI difftool: \
`$ git pr show -t 16440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16440.diff">https://git.openjdk.org/jdk/pull/16440.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16440#issuecomment-1788642843)