### PR TITLE
8318959: C2: define MachNode::fill_new_machnode() statically

### DIFF
--- a/src/hotspot/share/adlc/formssel.hpp
+++ b/src/hotspot/share/adlc/formssel.hpp
@@ -257,7 +257,7 @@ public:
   void                set_cisc_reg_mask_name(const char *rm_name) { _cisc_reg_mask_name = rm_name; }
   // Output cisc-method prototypes and method bodies
   void                declare_cisc_version(ArchDesc &AD, FILE *fp_cpp);
-  bool                define_cisc_version (ArchDesc &AD, FILE *fp_cpp);
+  void                define_cisc_version(ArchDesc& AD, FILE* fp_cpp);
 
   bool                check_branch_variant(ArchDesc &AD, InstructForm *short_branch);
 
@@ -273,7 +273,7 @@ public:
   bool                has_short_branch_form() { return _short_branch_form != nullptr; }
   // Output short branch prototypes and method bodies
   void                declare_short_branch_methods(FILE *fp_cpp);
-  bool                define_short_branch_methods(ArchDesc &AD, FILE *fp_cpp);
+  void                define_short_branch_methods(ArchDesc& AD, FILE* fp_cpp);
 
   uint                alignment() { return _alignment; }
   void                set_alignment(uint val) { _alignment = val; }

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -4034,7 +4034,7 @@ void InstructForm::declare_cisc_version(ArchDesc &AD, FILE *fp_hpp) {
 
 //---------------------------define_cisc_version-------------------------------
 // Build CISC version of this instruction
-bool InstructForm::define_cisc_version(ArchDesc &AD, FILE *fp_cpp) {
+void InstructForm::define_cisc_version(ArchDesc& AD, FILE* fp_cpp) {
   InstructForm *inst_cisc = this->cisc_spill_alternate();
   if( AD.can_cisc_spill() && (inst_cisc != nullptr) ) {
     const char   *name      = inst_cisc->_ident;
@@ -4080,9 +4080,7 @@ bool InstructForm::define_cisc_version(ArchDesc &AD, FILE *fp_cpp) {
     fprintf(fp_cpp, "  return node;\n");
     fprintf(fp_cpp, "}\n");
     fprintf(fp_cpp, "\n");
-    return true;
   }
-  return false;
 }
 
 //---------------------------declare_short_branch_methods----------------------
@@ -4095,7 +4093,7 @@ void InstructForm::declare_short_branch_methods(FILE *fp_hpp) {
 
 //---------------------------define_short_branch_methods-----------------------
 // Build definitions for short branch methods
-bool InstructForm::define_short_branch_methods(ArchDesc &AD, FILE *fp_cpp) {
+void InstructForm::define_short_branch_methods(ArchDesc& AD, FILE* fp_cpp) {
   if (has_short_branch_form()) {
     InstructForm *short_branch = short_branch_form();
     const char   *name         = short_branch->_ident;
@@ -4124,9 +4122,7 @@ bool InstructForm::define_short_branch_methods(ArchDesc &AD, FILE *fp_cpp) {
     fprintf(fp_cpp, "  return node;\n");
     fprintf(fp_cpp, "}\n");
     fprintf(fp_cpp,"\n");
-    return true;
   }
-  return false;
 }
 
 

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -3099,42 +3099,6 @@ void ArchDesc::define_oper_interface(FILE *fp, OperandForm &oper, FormDict &glob
   }
 }
 
-//
-// Construct the method to copy _idx, inputs and operands to new node.
-static void define_fill_new_machnode(bool used, FILE *fp_cpp) {
-  fprintf(fp_cpp, "\n");
-  fprintf(fp_cpp, "// Copy _idx, inputs and operands to new node\n");
-  fprintf(fp_cpp, "void MachNode::fill_new_machnode(MachNode* node) const {\n");
-  if( !used ) {
-    fprintf(fp_cpp, "  // This architecture does not have cisc or short branch instructions\n");
-    fprintf(fp_cpp, "  ShouldNotCallThis();\n");
-    fprintf(fp_cpp, "}\n");
-  } else {
-    // New node must use same node index for access through allocator's tables
-    fprintf(fp_cpp, "  // New node must use same node index\n");
-    fprintf(fp_cpp, "  node->set_idx( _idx );\n");
-    // Copy machine-independent inputs
-    fprintf(fp_cpp, "  // Copy machine-independent inputs\n");
-    fprintf(fp_cpp, "  for( uint j = 0; j < req(); j++ ) {\n");
-    fprintf(fp_cpp, "    node->add_req(in(j));\n");
-    fprintf(fp_cpp, "  }\n");
-    // Copy machine operands to new MachNode
-    fprintf(fp_cpp, "  // Copy my operands, except for cisc position\n");
-    fprintf(fp_cpp, "  int nopnds = num_opnds();\n");
-    fprintf(fp_cpp, "  assert( node->num_opnds() == (uint)nopnds, \"Must have same number of operands\");\n");
-    fprintf(fp_cpp, "  MachOper **to = node->_opnds;\n");
-    fprintf(fp_cpp, "  for( int i = 0; i < nopnds; i++ ) {\n");
-    fprintf(fp_cpp, "    if( i != cisc_operand() ) \n");
-    fprintf(fp_cpp, "      to[i] = _opnds[i]->clone();\n");
-    fprintf(fp_cpp, "  }\n");
-    fprintf(fp_cpp, "  // Do not increment node index counter, since node reuses my index\n");
-    fprintf(fp_cpp, "  Compile* C = Compile::current();\n");
-    fprintf(fp_cpp, "  C->set_unique(C->unique() - 1);\n");
-    fprintf(fp_cpp, "}\n");
-  }
-  fprintf(fp_cpp, "\n");
-}
-
 //------------------------------defineClasses----------------------------------
 // Define members of MachNode and MachOper classes based on
 // operand and instruction lists
@@ -3230,7 +3194,6 @@ void ArchDesc::defineClasses(FILE *fp) {
     defineOut_RegMask(_CPP_MISC_file._fp, instr->_ident, reg_mask(*instr));
   }
 
-  bool used = false;
   // Output the definitions for expand rules & peephole rules
   _instructions.reset();
   for( ; (instr = (InstructForm*)_instructions.iter()) != nullptr; ) {
@@ -3249,14 +3212,11 @@ void ArchDesc::defineClasses(FILE *fp) {
       definePeephole(_CPP_PEEPHOLE_file._fp, instr);
 
     // Output code to convert to the cisc version, if applicable
-    used |= instr->define_cisc_version(*this, fp);
+    instr->define_cisc_version(*this, fp);
 
     // Output code to convert to the short branch version, if applicable
-    used |= instr->define_short_branch_methods(*this, fp);
+    instr->define_short_branch_methods(*this, fp);
   }
-
-  // Construct the method called by cisc_version() to copy inputs and operands.
-  define_fill_new_machnode(used, fp);
 
   // Output the definitions for labels
   _instructions.reset();

--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -183,6 +183,27 @@ bool MachNode::cmp( const Node &node ) const {
   return true;                  // match
 }
 
+void MachNode::fill_new_machnode(MachNode* node) const {
+  // New node must use same node index
+  node->set_idx(_idx);
+  // Copy machine-independent inputs
+  for (uint j = 0; j < req(); j++) {
+    node->add_req(in(j));
+  }
+  // Copy my operands, except for cisc position
+  int nopnds = num_opnds();
+  assert(node->num_opnds() == (uint)nopnds, "Must have same number of operands");
+  MachOper** to = node->_opnds;
+  for (int i = 0; i < nopnds; i++) {
+    if (i != cisc_operand()) {
+      to[i] = _opnds[i]->clone();
+    }
+  }
+  // Do not increment node index counter, since node reuses my index
+  Compile* C = Compile::current();
+  C->set_unique(C->unique() - 1);
+}
+
 // Return an equivalent instruction using memory for cisc_operand position
 MachNode *MachNode::cisc_version(int offset) {
   ShouldNotCallThis();

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -229,9 +229,8 @@ public:
   uint8_t barrier_data() const { return _barrier; }
   void set_barrier_data(uint8_t data) { _barrier = data; }
 
-  // Copy inputs and operands to new node of instruction.
+  // Copy index, inputs, and operands to a new version of the instruction.
   // Called from cisc_version() and short_branch_version().
-  // !!!! The method's body is defined in ad_<arch>.cpp file.
   void fill_new_machnode(MachNode *n) const;
 
   // Return an equivalent instruction using memory for cisc_operand position


### PR DESCRIPTION
This changeset makes the implementation of `MachNode::fill_new_machnode()` static instead of ADLC-generated, for better maintainability. The original motivation to generate this function was to replace its logic with a `ShouldNotCallThis()` call for targets that do not define CISC spill or short branch instruction versions. However, most targets (including x64 and aarch64) feature at least one of these and hence do not make use of the ADLC specialization. For those that do, the savings (approximately 140 bytes on a x64 build of `libjvm.so`) are marginal and (arguably) not worth the additional code complexity.

See motivating discussion in https://mail.openjdk.org/pipermail/hotspot-compiler-dev/2023-October/thread.html#69348.

#### Testing
- tier1-3 (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64; release and debug mode)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318959](https://bugs.openjdk.org/browse/JDK-8318959): C2: define MachNode::fill_new_machnode() statically (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16444/head:pull/16444` \
`$ git checkout pull/16444`

Update a local copy of the PR: \
`$ git checkout pull/16444` \
`$ git pull https://git.openjdk.org/jdk.git pull/16444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16444`

View PR using the GUI difftool: \
`$ git pr show -t 16444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16444.diff">https://git.openjdk.org/jdk/pull/16444.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16444#issuecomment-1788572588)