### PR TITLE
8319205: Parallel: Reenable work stealing after JDK-8310031

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -234,14 +234,9 @@ void PSPromotionManager::drain_stacks_depth(bool totally_drain) {
     // Drain overflow stack first, so other threads can steal from
     // claimed stack while we work.
     while (tq->pop_overflow(task)) {
-      // In PSCardTable::scavenge_contents_parallel(), when work is distributed
-      // among different workers, an object is never split between multiple workers.
-      // Therefore, if a worker gets owned a large objArray, it may accumulate
-      // many tasks (corresponding to every element in this array) in its
-      // task queue. When there are too many overflow tasks, publishing them
-      // (via try_push_to_taskqueue()) can incur noticeable overhead in Young GC
-      // pause, so it is better to process them locally until large-objArray-splitting is implemented.
-      process_popped_location_depth(task);
+      if (!tq->try_push_to_taskqueue(task)) {
+        process_popped_location_depth(task);
+      }
     }
 
     while (tq->pop_local(task, threshold)) {


### PR DESCRIPTION
No regression in young-gc for DelayInducer any more.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319205](https://bugs.openjdk.org/browse/JDK-8319205): Parallel: Reenable work stealing after JDK-8310031 (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16448/head:pull/16448` \
`$ git checkout pull/16448`

Update a local copy of the PR: \
`$ git checkout pull/16448` \
`$ git pull https://git.openjdk.org/jdk.git pull/16448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16448`

View PR using the GUI difftool: \
`$ git pr show -t 16448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16448.diff">https://git.openjdk.org/jdk/pull/16448.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16448#issuecomment-1788830857)