### PR TITLE
8319213: Compatibility.java reads both stdout and stderr of JdkUtils

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
+++ b/test/jdk/sun/security/tools/jarsigner/compatibility/Compatibility.java
@@ -1026,7 +1026,7 @@ public class Compatibility {
         cmd[3] = JdkUtils.class.getName();
         cmd[4] = method;
         System.arraycopy(args, 0, cmd, 5, args.length);
-        return ProcessTools.executeCommand(cmd).getOutput();
+        return ProcessTools.executeCommand(cmd).getStdout();
     }
 
     // Executes the specified JDK tools, such as keytool and jarsigner, and


### PR DESCRIPTION
There might be more warnings from the java launcher. Better ignore them now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319213](https://bugs.openjdk.org/browse/JDK-8319213): Compatibility.java reads both stdout and stderr of JdkUtils (**Bug** - P4)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16450/head:pull/16450` \
`$ git checkout pull/16450`

Update a local copy of the PR: \
`$ git checkout pull/16450` \
`$ git pull https://git.openjdk.org/jdk.git pull/16450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16450`

View PR using the GUI difftool: \
`$ git pr show -t 16450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16450.diff">https://git.openjdk.org/jdk/pull/16450.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16450#issuecomment-1789027262)