### PR TITLE
8316538: runtime/handshake/MixedHandshakeWalkStackTest.java crashes with JFR

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrPostBox.cpp
@@ -112,7 +112,6 @@ void JfrPostBox::asynchronous_post(int msg) {
 void JfrPostBox::synchronous_post(int msg) {
   assert(is_synchronous(msg), "invariant");
   assert(!JfrMsg_lock->owned_by_self(), "should not hold JfrMsg_lock here!");
-  NoHandleMark nhm;
   ThreadBlockInVM transition(JavaThread::current());
   MonitorLocker msg_lock(JfrMsg_lock, Mutex::_no_safepoint_check_flag);
   deposit(msg);


### PR DESCRIPTION
Greetings,

Please help review this tiny adjustment to remove an unmotivated NoHandleMark.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316538](https://bugs.openjdk.org/browse/JDK-8316538): runtime/handshake/MixedHandshakeWalkStackTest.java crashes with JFR (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16452/head:pull/16452` \
`$ git checkout pull/16452`

Update a local copy of the PR: \
`$ git checkout pull/16452` \
`$ git pull https://git.openjdk.org/jdk.git pull/16452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16452`

View PR using the GUI difftool: \
`$ git pr show -t 16452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16452.diff">https://git.openjdk.org/jdk/pull/16452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16452#issuecomment-1789051254)