### PR TITLE
8187591: -Werror turns incubator module warning to an error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -333,7 +333,7 @@ public class Lint
         VARARGS("varargs"),
 
         /**
-         * Warn about use of preview features.
+         * Warn about use of preview features and incubating modules.
          */
         PREVIEW("preview"),
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -117,6 +117,7 @@ import com.sun.tools.javac.code.Kinds;
 import static com.sun.tools.javac.code.Kinds.Kind.ERR;
 import static com.sun.tools.javac.code.Kinds.Kind.MDL;
 import static com.sun.tools.javac.code.Kinds.Kind.MTH;
+import com.sun.tools.javac.code.Lint;
 
 import com.sun.tools.javac.code.Symbol.ModuleResolutionFlags;
 
@@ -134,6 +135,7 @@ public class Modules extends JCTree.Visitor {
     private static final String ALL_SYSTEM = "ALL-SYSTEM";
     private static final String ALL_MODULE_PATH = "ALL-MODULE-PATH";
 
+    private final Lint lint;
     private final Log log;
     private final Names names;
     private final Symtab syms;
@@ -185,6 +187,7 @@ public class Modules extends JCTree.Visitor {
     protected Modules(Context context) {
         context.put(Modules.class, this);
         log = Log.instance(context);
+        lint = Lint.instance(context);
         names = Names.instance(context);
         syms = Symtab.instance(context);
         attr = Attr.instance(context);
@@ -1351,13 +1354,15 @@ public class Modules extends JCTree.Visitor {
                 .forEach(result::add);
         }
 
-        String incubatingModules = filterAlreadyWarnedIncubatorModules(result.stream()
-                .filter(msym -> msym.resolutionFlags.contains(ModuleResolutionFlags.WARN_INCUBATING))
-                .map(msym -> msym.name.toString()))
-                .collect(Collectors.joining(","));
+        if (lint.isEnabled(LintCategory.PREVIEW)) {
+            String incubatingModules = filterAlreadyWarnedIncubatorModules(result.stream()
+                    .filter(msym -> msym.resolutionFlags.contains(ModuleResolutionFlags.WARN_INCUBATING))
+                    .map(msym -> msym.name.toString()))
+                    .collect(Collectors.joining(","));
 
-        if (!incubatingModules.isEmpty()) {
-            log.warning(Warnings.IncubatingModules(incubatingModules));
+            if (!incubatingModules.isEmpty()) {
+                log.warning(Warnings.IncubatingModules(incubatingModules));
+            }
         }
 
         allModules = result;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -280,7 +280,7 @@ javac.opt.Xlint.desc.varargs=\
     Warn about potentially unsafe vararg methods.
 
 javac.opt.Xlint.desc.preview=\
-    Warn about use of preview language features.
+    Warn about use of preview language features and incubating modules.
 
 javac.opt.Xlint.desc.restricted=\
     Warn about use of restricted methods.

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -749,7 +749,8 @@ This can occur, for example, on case-insensitive filesystems.
 \f[V]path\f[R]: Warns about the invalid path elements on the command
 line.
 .IP \[bu] 2
-\f[V]preview\f[R]: Warns about the use of preview language features.
+\f[V]preview\f[R]: Warns about the use of preview language features and
+incubating modules.
 .IP \[bu] 2
 \f[V]processing\f[R]: Warns about the issues related to annotation
 processing.

--- a/test/langtools/tools/javac/modules/IncubatingTest.java
+++ b/test/langtools/tools/javac/modules/IncubatingTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8171177
+ * @bug 8171177 8187591
  * @summary Verify that ModuleResolution attribute flags are honored.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -238,6 +238,16 @@ public class IncubatingTest extends ModuleTestBase {
         if (!expected.equals(log)) {
             throw new AssertionError("Unexpected output: " + log);
         }
+
+        //test disable lint preview
+        new JavacTask(tb)
+                .options("--module-path", classes.toString(),
+                         "-XDrawDiagnostics",
+                         "-Xlint:-preview",
+                         "-Werror")
+                .outdir(testModuleClasses)
+                .files(findJavaFiles(testModuleSrc))
+                .run(Expect.SUCCESS);
     }
 
     private void copyJavaBase(Path targetDir) throws IOException {


### PR DESCRIPTION
-Werror turns incubator module warning to an error
This patch disables incubating module warning at compile time when "preview" lint category is disabled.
It also adds a test, adjusts "preview" lint category description  and updates javac man pages.

Please review.

Thanks,
Adam