### PR TITLE
8317965: TestLoadLibraryDeadlock.java fails with "Unable to load native library.: expected true, was false"

### DIFF
--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -32,11 +32,13 @@
  * called from Class1, then acquiring ZipFile during the search for a class
  * triggered from JNI.
  */
+
 import java.lang.*;
 
 public class LoadLibraryDeadlock {
 
     public static void main(String[] args) {
+        System.out.println("LoadLibraryDeadlock test started");
         Thread t1 = new Thread() {
             public void run() {
                 try {
@@ -68,7 +70,8 @@ public class LoadLibraryDeadlock {
         try {
             t1.join();
             t2.join();
-        } catch (InterruptedException ignore) {
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
         }
     }
 }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
@@ -32,7 +32,6 @@
  * called from Class1, then acquiring ZipFile during the search for a class
  * triggered from JNI.
  */
-
 import java.lang.*;
 
 public class LoadLibraryDeadlock {
@@ -45,6 +44,7 @@ public class LoadLibraryDeadlock {
                     // an instance of unsigned class that loads a native library
                     Class<?> c1 = Class.forName("Class1");
                     Object o = c1.newInstance();
+                    System.out.println("Class1 loaded from " + getLocation(c1));
                 } catch (ClassNotFoundException |
                          InstantiationException |
                          IllegalAccessException e) {
@@ -58,7 +58,7 @@ public class LoadLibraryDeadlock {
                 try {
                     // load a class from a signed jar, which locks the JarFile
                     Class<?> c2 = Class.forName("p.Class2");
-                    System.out.println("Signed jar loaded.");
+                    System.out.println("Class2 loaded from " + getLocation(c2));
                 } catch (ClassNotFoundException e) {
                     System.out.println("Class Class2 not found.");
                     throw new RuntimeException(e);
@@ -73,5 +73,11 @@ public class LoadLibraryDeadlock {
         } catch (InterruptedException ex) {
             throw new RuntimeException(ex);
         }
+    }
+
+    private static String getLocation(Class<?> c) {
+        var pd = c.getProtectionDomain();
+        var cs = pd != null ? pd.getCodeSource() : null;
+        return cs != null ? cs.getLocation().getPath() : null;
     }
 }


### PR DESCRIPTION
`TestLoadLibraryDeadlock.java` test runs `LoadLibraryDeadlock` and wait for 5 seconds and then grab the output. Then run `jcmd` to dump the thread stacks in case there is a deadlock. The test ignores and swallows any exception which makes it hard to diagnose test issues. 

This PR simplifies the test to use `jdk.test.lib.process.ProcessTools` to launch `LoadLibraryDeadlock` test so that the output and error will be captured in the same way as other tools are run by this test.   Also update the test to propagate exceptions where appropriate.   This hopes to collect more information to diagnose the issue if this test fails next time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317965](https://bugs.openjdk.org/browse/JDK-8317965): TestLoadLibraryDeadlock.java fails with "Unable to load native library.: expected true, was false" (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16459/head:pull/16459` \
`$ git checkout pull/16459`

Update a local copy of the PR: \
`$ git checkout pull/16459` \
`$ git pull https://git.openjdk.org/jdk.git pull/16459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16459`

View PR using the GUI difftool: \
`$ git pr show -t 16459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16459.diff">https://git.openjdk.org/jdk/pull/16459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16459#issuecomment-1789409102)