### PR TITLE
JDK-8319053: Segment dump files remain after parallel heap dump on Windows

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1956,7 +1956,7 @@ void DumpMerger::do_merge() {
     }
     // Delete selected segmented heap file nevertheless
     if (remove(path) != 0) {
-      log_info(heapdump)("Remove segment file (%d) failed (%d)", i, errno);
+      log_info(heapdump)("Removal of segment file (%d) failed (%d)", i, errno);
     }
   }
 

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1955,7 +1955,9 @@ void DumpMerger::do_merge() {
       merge_file(path);
     }
     // Delete selected segmented heap file nevertheless
-    remove(path);
+    if (remove(path) != 0) {
+      log_info(heapdump)("Remove segment file (%d) failed (%d)", i, errno);
+    }
   }
 
   // restore compressor for further use
@@ -2358,6 +2360,7 @@ void VM_HeapDumper::work(uint worker_id) {
       _dumper_controller->wait_all_dumpers_complete();
     } else {
       _dumper_controller->dumper_complete(local_writer, writer());
+      delete local_writer;
       return;
     }
   }

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -389,7 +389,7 @@ enum {
 
 // Supports I/O operations for a dump
 // Base class for dump and parallel dump
-class AbstractDumpWriter : public ResourceObj {
+class AbstractDumpWriter : public CHeapObj<mtInternal> {
  protected:
   enum {
     io_buffer_max_size = 1*M,

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jdk.test.lib.Asserts;
 import jdk.test.lib.JDKToolLauncher;
@@ -39,13 +41,15 @@ import jdk.test.lib.hprof.HprofParser;
 
 /**
  * @test
- * @bug 8306441
+ * @bug 8306441 8319053
  * @summary Verify the integrity of generated heap dump and capability of parallel dump
  * @library /test/lib
  * @run main HeapDumpParallelTest
  */
 
 public class HeapDumpParallelTest {
+
+    private static final String heapDumpFileName = "parallelHeapDump.bin";
 
     private static void checkAndVerify(OutputAnalyzer dcmdOut, LingeredApp app, File heapDumpFile, boolean expectSerial) throws Exception {
         dcmdOut.shouldHaveExitValue(0);
@@ -65,9 +69,20 @@ public class HeapDumpParallelTest {
             appOut.shouldNotContain("Merge heap files complete");
         }
         HprofParser.parseAndVerify(heapDumpFile);
+
+        List<String> files
+            = Stream.of(heapDumpFile.getAbsoluteFile().getParentFile().listFiles())
+                .filter(file -> !file.isDirectory())
+                .map(File::getName)
+                .filter(name -> name.startsWith(heapDumpFileName) && !name.equals(heapDumpFileName))
+                .collect(Collectors.toList());
+        if (!files.isEmpty()) {
+            throw new RuntimeException("Unexpected files left: " + files);
+        }
         if (heapDumpFile.exists()) {
             heapDumpFile.delete();
         }
+        
     }
 
     private static LingeredApp launchApp() throws IOException {
@@ -79,8 +94,6 @@ public class HeapDumpParallelTest {
     }
 
     public static void main(String[] args) throws Exception {
-        String heapDumpFileName = "parallelHeapDump.bin";
-
         File heapDumpFile = new File(heapDumpFileName);
         if (heapDumpFile.exists()) {
             heapDumpFile.delete();

--- a/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/gc/HeapDumpParallelTest.java
@@ -82,7 +82,6 @@ public class HeapDumpParallelTest {
         if (heapDumpFile.exists()) {
             heapDumpFile.delete();
         }
-        
     }
 
     private static LingeredApp launchApp() throws IOException {


### PR DESCRIPTION
Segment file is closed from DumpWriter dtor.
On Unix systems `remove` can delete an opened file, on Windows it fails with "access denied".
The fix destroys DumpWriter objects for segment files after all data are dumped

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319053](https://bugs.openjdk.org/browse/JDK-8319053): Segment dump files remain after parallel heap dump on Windows (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Yi Yang](https://openjdk.org/census#yyang) (@y1yang0 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16462/head:pull/16462` \
`$ git checkout pull/16462`

Update a local copy of the PR: \
`$ git checkout pull/16462` \
`$ git pull https://git.openjdk.org/jdk.git pull/16462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16462`

View PR using the GUI difftool: \
`$ git pr show -t 16462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16462.diff">https://git.openjdk.org/jdk/pull/16462.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16462#issuecomment-1789547267)