### PR TITLE
8319265: TestLoadLibraryDeadlock.java fails on windows-x64 "Unable to load b.jar"

### DIFF
--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/LoadLibraryDeadlock.java
@@ -33,6 +33,7 @@
  * triggered from JNI.
  */
 import java.lang.*;
+import java.net.URISyntaxException;
 
 public class LoadLibraryDeadlock {
 
@@ -78,6 +79,11 @@ public class LoadLibraryDeadlock {
     private static String getLocation(Class<?> c) {
         var pd = c.getProtectionDomain();
         var cs = pd != null ? pd.getCodeSource() : null;
-        return cs != null ? cs.getLocation().getPath() : null;
+        try {
+            // same format as returned by TestLoadLibraryDeadlock::getLocation
+            return cs != null ? cs.getLocation().toURI().getPath() : null;
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/TestLoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/TestLoadLibraryDeadlock.java
@@ -182,6 +182,7 @@ public class TestLoadLibraryDeadlock {
     }
 
     private static String toLocationString(Path path) {
+        // same format as returned by LoadLibraryDeadlock::getLocation
         return path.toUri().getPath();
     }
 }

--- a/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/TestLoadLibraryDeadlock.java
+++ b/test/jdk/java/lang/ClassLoader/loadLibraryDeadlock/TestLoadLibraryDeadlock.java
@@ -169,15 +169,19 @@ public class TestLoadLibraryDeadlock {
                 "Unable to load native library.");
 
         Asserts.assertTrue(
-                countLines(outputAnalyzer, "Class1 loaded from " + bJar) > 0,
-                "Unable to load b.jar.");
+                countLines(outputAnalyzer, "Class1 loaded from " + toLocationString(bJar)) > 0,
+                "Unable to load " + toLocationString(bJar));
 
         Asserts.assertTrue(
-                countLines(outputAnalyzer, "Class2 loaded from " + cJar) > 0,
-                "Unable to load signed c.jar.");
+                countLines(outputAnalyzer, "Class2 loaded from " + toLocationString(cJar)) > 0,
+                "Unable to load signed " + toLocationString(cJar));
 
         Asserts.assertTrue(
                 countLines(outputAnalyzer, "Signed jar loaded from native library.") > 0,
                 "Unable to load signed jar from native library.");
+    }
+
+    private static String toLocationString(Path path) {
+        return path.toUri().getPath();
     }
 }


### PR DESCRIPTION
The test fails on windows because unmatched comparison of `Path.toString()` vs `URL.getPath().toString()` after JDK-8317965.   A simple fix is to evaluate the JAR file path in the same way as `LoadLibraryDeadlock` does.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319265](https://bugs.openjdk.org/browse/JDK-8319265): TestLoadLibraryDeadlock.java fails on windows-x64 "Unable to load b.jar" (**Bug** - P2)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16466/head:pull/16466` \
`$ git checkout pull/16466`

Update a local copy of the PR: \
`$ git checkout pull/16466` \
`$ git pull https://git.openjdk.org/jdk.git pull/16466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16466`

View PR using the GUI difftool: \
`$ git pr show -t 16466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16466.diff">https://git.openjdk.org/jdk/pull/16466.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16466#issuecomment-1789904920)