### PR TITLE
8224261: JProgressBar always with border painted around it

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthProgressBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthProgressBarUI.java
@@ -215,9 +215,12 @@ public class SynthProgressBarUI extends BasicProgressBarUI
         SynthContext context = getContext(c);
 
         SynthLookAndFeel.update(context, g);
-        context.getPainter().paintProgressBarBackground(context,
-                          g, 0, 0, c.getWidth(), c.getHeight(),
-                          progressBar.getOrientation());
+
+        if (((JProgressBar) c).isBorderPainted()) {
+            context.getPainter().paintProgressBarBackground(context,
+                    g, 0, 0, c.getWidth(), c.getHeight(),
+                    progressBar.getOrientation());
+        }
         paint(context, g);
     }
 

--- a/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
+++ b/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
@@ -73,8 +73,8 @@ public class TestProgressBarBorder {
                 ImageIO.write(withBorder, "png", new File("withBorder.png"));
                 ImageIO.write(withoutBorder, "png", new File("withoutBorder.png"));
             } catch (IOException e) {}
-            throw new RuntimeException("JProgressBar border is painted when border\n" +
-                    " painting is set to false");
+            throw new RuntimeException("JProgressBar border is painted when border " +
+                    "painting is set to false");
         }
     }
 

--- a/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
+++ b/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
@@ -46,7 +46,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_RGB;
 
 public class TestProgressBarBorder {
     private static JProgressBar progressBar;
-    private static volatile boolean isImgSame;
+    private static volatile boolean isImgEqual;
     private static BufferedImage borderPaintedImg;
     private static BufferedImage borderNotPaintedImg;
 
@@ -65,9 +65,9 @@ public class TestProgressBarBorder {
             borderPaintedImg = paintToImage(progressBar);
             progressBar.setBorderPainted(false);
             borderNotPaintedImg = paintToImage(progressBar);
-            isImgSame = Util.compareBufferedImages(borderPaintedImg, borderNotPaintedImg);
+            isImgEqual = Util.compareBufferedImages(borderPaintedImg, borderNotPaintedImg);
 
-            if (isImgSame) {
+            if (isImgEqual) {
                 ImageIO.write(borderPaintedImg, "png", new File("borderPaintedImg.png"));
                 ImageIO.write(borderNotPaintedImg, "png", new File("borderNotPaintedImg.png"));
                 throw new RuntimeException("JProgressBar border is painted when border\n" +
@@ -89,7 +89,7 @@ public class TestProgressBarBorder {
 
     private static void createAndShowUI() {
         progressBar = new JProgressBar();
-        progressBar.setSize(100,50);
+        progressBar.setSize(100, 50);
         // set initial value
         progressBar.setValue(0);
         progressBar.setBorderPainted(true);

--- a/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
+++ b/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
@@ -47,8 +47,7 @@ import static java.awt.image.BufferedImage.TYPE_INT_RGB;
  */
 
 public class TestProgressBarBorder {
-    public static void main(String[] args) throws InvocationTargetException,
-            InterruptedException {
+    public static void main(String[] args) throws Exception {
         for (UIManager.LookAndFeelInfo laf :
                 UIManager.getInstalledLookAndFeels()) {
             if (!laf.getName().contains("Nimbus") && !laf.getName().contains("GTK")) {
@@ -72,7 +71,8 @@ public class TestProgressBarBorder {
             try {
                 ImageIO.write(withBorder, "png", new File("withBorder.png"));
                 ImageIO.write(withoutBorder, "png", new File("withoutBorder.png"));
-            } catch (IOException e) {}
+            } catch (IOException ignored) {}
+
             throw new RuntimeException("JProgressBar border is painted when border " +
                     "painting is set to false");
         }

--- a/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
+++ b/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
@@ -21,17 +21,6 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 8224261
- * @key headful
- * @library ../regtesthelpers
- * @build Util
- * @summary Verifies JProgressBar border is not painted when border
- *          painting is set to false
- * @run main TestProgressBarBorder
- */
-
 import java.io.File;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
@@ -44,13 +33,24 @@ import javax.swing.UnsupportedLookAndFeelException;
 
 import static java.awt.image.BufferedImage.TYPE_INT_RGB;
 
+/*
+ * @test
+ * @bug 8224261
+ * @key headful
+ * @library ../regtesthelpers
+ * @build Util
+ * @summary Verifies JProgressBar border is not painted when border
+ *          painting is set to false
+ * @run main TestProgressBarBorder
+ */
+
 public class TestProgressBarBorder {
     private static JProgressBar progressBar;
-    private static volatile boolean isImgEqual;
-    private static BufferedImage borderPaintedImg;
-    private static BufferedImage borderNotPaintedImg;
+    private static volatile BufferedImage withBorder = null;
+    private static volatile BufferedImage withoutBorder = null;
 
     public static void main(String[] args) throws Exception {
+        boolean equal;
         for (UIManager.LookAndFeelInfo laf :
                 UIManager.getInstalledLookAndFeels()) {
             if (!laf.getName().contains("Nimbus") && !laf.getName().contains("GTK")) {
@@ -59,17 +59,16 @@ public class TestProgressBarBorder {
             System.out.println("Testing LAF: " + laf.getName());
             SwingUtilities.invokeAndWait(() -> {
                 setLookAndFeel(laf);
-                createAndShowUI();
+                initProgressBar();
+                progressBar.setBorderPainted(true);
+                withBorder = paintToImage(progressBar);
+                progressBar.setBorderPainted(false);
+                withoutBorder = paintToImage(progressBar);
             });
-
-            borderPaintedImg = paintToImage(progressBar);
-            progressBar.setBorderPainted(false);
-            borderNotPaintedImg = paintToImage(progressBar);
-            isImgEqual = Util.compareBufferedImages(borderPaintedImg, borderNotPaintedImg);
-
-            if (isImgEqual) {
-                ImageIO.write(borderPaintedImg, "png", new File("borderPaintedImg.png"));
-                ImageIO.write(borderNotPaintedImg, "png", new File("borderNotPaintedImg.png"));
+            equal = Util.compareBufferedImages(withBorder, withoutBorder);
+            if (equal) {
+                ImageIO.write(withBorder, "png", new File("withBorder.png"));
+                ImageIO.write(withoutBorder, "png", new File("withoutBorder.png"));
                 throw new RuntimeException("JProgressBar border is painted when border\n" +
                         " painting is set to false");
             }
@@ -87,12 +86,10 @@ public class TestProgressBarBorder {
         }
     }
 
-    private static void createAndShowUI() {
+    private static void initProgressBar() {
         progressBar = new JProgressBar();
         progressBar.setSize(100, 50);
-        // set initial value
         progressBar.setValue(0);
-        progressBar.setBorderPainted(true);
         progressBar.setStringPainted(true);
     }
 

--- a/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
+++ b/test/jdk/javax/swing/JProgressBar/TestProgressBarBorder.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8224261
+ * @key headful
+ * @summary Verifies if JProgressBar border is painted even though border
+ *          painting is set to false
+ * @run main TestProgressBarBorder
+ */
+
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class TestProgressBarBorder {
+
+    private static JFrame frame;
+    private static JProgressBar progressBar;
+    private static volatile Point pt;
+    private static volatile boolean passed;
+
+    public static void main(String[] args) throws Exception {
+        for (UIManager.LookAndFeelInfo laf :
+                UIManager.getInstalledLookAndFeels()) {
+            if (laf.getName().contains("Nimbus") || laf.getName().contains("GTK")) {
+                System.out.println("Testing LAF: " + laf.getName());
+                SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+            } else {
+                continue;
+            }
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            try {
+                SwingUtilities.invokeAndWait(() -> {
+                    createAndShowUI();
+                });
+
+                robot.waitForIdle();
+                robot.delay(1000);
+
+                SwingUtilities.invokeAndWait(() -> {
+                    pt = progressBar.getLocationOnScreen();
+                });
+
+                BufferedImage borderPaintedImg =
+                        robot.createScreenCapture(new Rectangle(pt.x, pt.y,
+                                progressBar.getWidth(), progressBar.getHeight()));
+
+                progressBar.setBorderPainted(false);
+                robot.waitForIdle();
+                robot.delay(500);
+
+                BufferedImage borderNotPaintedImg =
+                        robot.createScreenCapture(new Rectangle(pt.x, pt.y,
+                                progressBar.getWidth(), progressBar.getHeight()));
+
+                robot.delay(500);
+
+                SwingUtilities.invokeAndWait(() -> {
+                    passed = compareImage(borderPaintedImg, borderNotPaintedImg);
+                });
+
+                if (!passed) {
+                    ImageIO.write(borderPaintedImg, "png", new File("borderPaintedImg.png"));
+                    ImageIO.write(borderNotPaintedImg, "png", new File("borderNotPaintedImg.png"));
+                    throw new RuntimeException("JProgressBar border is painted although " +
+                            "border painting is set to false");
+                }
+            } finally {
+                SwingUtilities.invokeAndWait(() -> {
+                    if (frame != null) {
+                        frame.dispose();
+                    }
+                });
+            }
+        }
+    }
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported LAF: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                 | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new JFrame("Test JProgressBar Border");
+        JPanel p = new JPanel(new FlowLayout());
+        progressBar  = new JProgressBar();
+        // set initial value
+        progressBar.setValue(0);
+        progressBar.setBorderPainted(true);
+        progressBar.setStringPainted(true);
+        p.add(progressBar);
+        frame.add(p);
+        frame.setSize(200, 100);
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+    }
+
+    /*
+    * Compare JProgressBar border painted and border not painted image and
+    * if both images width and height are equal but pixel's RGB values are
+    * not equal, method returns true; false otherwise.
+    */
+
+    private static boolean compareImage(BufferedImage img1, BufferedImage img2) {
+        if (img1.getWidth() == img2.getWidth()
+                && img1.getHeight() == img2.getHeight()) {
+            for (int x = 0; x < img1.getWidth(); ++x) {
+                for (int y = 0; y < img1.getHeight(); ++y) {
+                    if (img1.getRGB(x, y) != img2.getRGB(x, y)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } else {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
JProgressBar is always painted with border irrespective of the value set via the API `setBorderPainted(boolean value)` in Synth (Nimbus and GTK) LAF. Proposed fix is to add a check before painting the component.

CI jobs are green after the fix. Links attached to JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8224261](https://bugs.openjdk.org/browse/JDK-8224261): JProgressBar always with border painted around it (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) ⚠️ Review applies to [a00f11fe](https://git.openjdk.org/jdk/pull/16467/files/a00f11fe40b3bbe33572c139e75d645666dc1344)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16467/head:pull/16467` \
`$ git checkout pull/16467`

Update a local copy of the PR: \
`$ git checkout pull/16467` \
`$ git pull https://git.openjdk.org/jdk.git pull/16467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16467`

View PR using the GUI difftool: \
`$ git pr show -t 16467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16467.diff">https://git.openjdk.org/jdk/pull/16467.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16467#issuecomment-1791021371)