### PR TITLE
8319268: Build failure with GCC8.3.1 after 8313643

### DIFF
--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -504,7 +504,7 @@ else
        unused-result array-bounds parentheses
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
-   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type expansion-to-defined dangling-reference
+   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type expansion-to-defined dangling-reference maybe-uninitialized
    HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers range-loop-analysis
    HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
 

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -505,7 +505,8 @@ else
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
    # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.
-   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type expansion-to-defined dangling-reference maybe-uninitialized
+   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type \
+       expansion-to-defined dangling-reference maybe-uninitialized
    HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers range-loop-analysis
    HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
 

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -504,6 +504,7 @@ else
        unused-result array-bounds parentheses
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
+   # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.
    HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type expansion-to-defined dangling-reference maybe-uninitialized
    HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers range-loop-analysis
    HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244


### PR DESCRIPTION
Build failure with GCC8.3.1
```
=== Output from failing command(s) repeated here ===
* For target support_native_java.desktop_libfontmanager_hb-ot-layout.o:
/data/codes/bobjdk/src/java.desktop/share/native/libharfbuzz/hb-ot-layout.cc: In function 'hb_bool_t hb_ot_layout_get_font_extents(hb_font_t*, hb_direction_t, hb_tag_t, hb_tag_t, hb_font_extents_t*)':
/data/codes/bobjdk/src/java.desktop/share/native/libharfbuzz/hb-ot-layout.cc:2136:26: error: 'max' may be used uninitialized in this function [-Werror=maybe-uninitialized]
       extents->ascender = max;
       ~~~~~~~~~~~~~~~~~~~^~~~~
/data/codes/bobjdk/src/java.desktop/share/native/libharfbuzz/hb-ot-layout.cc:2137:26: error: 'min' may be used uninitialized in this function [-Werror=maybe-uninitialized]
       extents->descender = min;
       ~~~~~~~~~~~~~~~~~~~^~~~~
At global scope:
cc1plus: error: unrecognized command line option '-Wno-dangling-reference' [-Werror]
cc1plus: all warnings being treated as errors

* All command lines available in /data/codes/bobjdk/build/linux-x86_64-server-release/make-support/failure-logs.
=== End of repeated output ===

No indication of failed target found.
HELP: Try searching the build log for '] Error'.
HELP: Run 'make doctor' to diagnose build problems.

make[1]: *** [main] Error 1
make: *** [images] Error 2
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319268](https://bugs.openjdk.org/browse/JDK-8319268): Build failure with GCC8.3.1 after 8313643 (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**) ⚠️ Review applies to [c4f20e30](https://git.openjdk.org/jdk/pull/16468/files/c4f20e30334e92fff184d801b31ea7bb8acf9e67)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16468/head:pull/16468` \
`$ git checkout pull/16468`

Update a local copy of the PR: \
`$ git checkout pull/16468` \
`$ git pull https://git.openjdk.org/jdk.git pull/16468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16468`

View PR using the GUI difftool: \
`$ git pr show -t 16468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16468.diff">https://git.openjdk.org/jdk/pull/16468.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16468#issuecomment-1790050398)