### PR TITLE
8288989: Make tests not depend on the source code

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testDocletExample/TestDocletExample.java
+++ b/test/langtools/jdk/javadoc/doclet/testDocletExample/TestDocletExample.java
@@ -50,8 +50,12 @@ import javax.tools.JavaFileObject;
 
 public class TestDocletExample extends TestRunner {
     public static void main(String... args) throws Exception {
-        var t = new TestDocletExample();
-        t.runTests(m -> new Object[] { Path.of(m.getName()) });
+        try {
+            var t = new TestDocletExample();
+            t.runTests(m -> new Object[] { Path.of(m.getName()) });
+        } catch (SnippetUtils.ConfigurationException e) {
+            System.err.println("NOTE: " + e.getMessage() + "; test skipped");
+        }
     }
 
     SnippetUtils snippets;

--- a/test/langtools/tools/javac/api/snippets/TestJavaxToolsSnippets.java
+++ b/test/langtools/tools/javac/api/snippets/TestJavaxToolsSnippets.java
@@ -58,7 +58,11 @@ import toolbox.ToolBox;
  */
 public class TestJavaxToolsSnippets extends TestRunner {
     public static void main(String... args) throws Exception {
-        new TestJavaxToolsSnippets().runTests(m -> new Object[] { Path.of(m.getName()) });
+        try {
+            new TestJavaxToolsSnippets().runTests(m -> new Object[] { Path.of(m.getName()) });
+        } catch (SnippetUtils.ConfigurationException e) {
+            System.err.println("NOTE: " + e.getMessage() + "; test skipped");
+        }
     }
 
     SnippetUtils snippets = new SnippetUtils("java.compiler");


### PR DESCRIPTION
Two langtool tests depend on the JDK source tree presence. 
This patch skips the tests execution in a source-less test environment.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288989](https://bugs.openjdk.org/browse/JDK-8288989): Make tests not depend on the source code (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16470/head:pull/16470` \
`$ git checkout pull/16470`

Update a local copy of the PR: \
`$ git checkout pull/16470` \
`$ git pull https://git.openjdk.org/jdk.git pull/16470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16470`

View PR using the GUI difftool: \
`$ git pr show -t 16470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16470.diff">https://git.openjdk.org/jdk/pull/16470.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16470#issuecomment-1790334795)