### PR TITLE
8319306: Serial: Remove TenuredSpace::verify

### DIFF
--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -194,9 +194,6 @@ class Space: public CHeapObj<mtGC> {
   virtual void print_on(outputStream* st) const;
   void print_short() const;
   void print_short_on(outputStream* st) const;
-
-  // Debugging
-  virtual void verify() const = 0;
 };
 
 // A structure to represent a point at which objects are being copied
@@ -396,7 +393,7 @@ private:
   void print_on(outputStream* st) const override;
 
   // Debugging
-  void verify() const override;
+  void verify() const;
 };
 
 #if INCLUDE_SERIALGC
@@ -426,9 +423,6 @@ class TenuredSpace: public ContiguousSpace {
   void update_for_block(HeapWord* start, HeapWord* end) override;
 
   void print_on(outputStream* st) const override;
-
-  // Debugging
-  void verify() const override;
 };
 #endif //INCLUDE_SERIALGC
 


### PR DESCRIPTION
I didn't find the BOT verification logic much useful while working on JDK-8318647, so I propose removing it to simplify the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319306](https://bugs.openjdk.org/browse/JDK-8319306): Serial: Remove TenuredSpace::verify (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16471/head:pull/16471` \
`$ git checkout pull/16471`

Update a local copy of the PR: \
`$ git checkout pull/16471` \
`$ git pull https://git.openjdk.org/jdk.git pull/16471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16471`

View PR using the GUI difftool: \
`$ git pr show -t 16471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16471.diff">https://git.openjdk.org/jdk/pull/16471.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16471#issuecomment-1790442220)