### PR TITLE
JDK-8319300: Remove unused methods in WorkArounds and Utils

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/WorkArounds.java
@@ -128,68 +128,6 @@ public class WorkArounds {
         return ((PackageSymbol)packageElement).sourcefile;
     }
 
-    // TODO: needs to ported to jx.l.m.
-    public TypeElement searchClass(TypeElement klass, String className) {
-        TypeElement te;
-
-        // search by qualified name in current module first
-        ModuleElement me = utils.containingModule(klass);
-        if (me != null) {
-            te = elementUtils.getTypeElement(me, className);
-            if (te != null) {
-                return te;
-            }
-        }
-
-        // search inner classes
-        for (TypeElement ite : utils.getClasses(klass)) {
-            TypeElement innerClass = searchClass(ite, className);
-            if (innerClass != null) {
-                return innerClass;
-            }
-        }
-
-        // check in this package
-        te = utils.findClassInPackageElement(utils.containingPackage(klass), className);
-        if (te != null) {
-            return te;
-        }
-
-        ClassSymbol tsym = (ClassSymbol)klass;
-        // make sure that this symbol has been completed
-        // TODO: do we need this anymore ?
-        if (tsym.completer != null) {
-            tsym.complete();
-        }
-
-        // search imports
-        if (tsym.sourcefile != null) {
-
-            //### This information is available only for source classes.
-            Env<AttrContext> compenv = toolEnv.getEnv(tsym);
-            if (compenv == null) {
-                return null;
-            }
-            Names names = tsym.name.table.names;
-            Scope s = compenv.toplevel.namedImportScope;
-            for (Symbol sym : s.getSymbolsByName(names.fromString(className))) {
-                if (sym.kind == TYP) {
-                    return (TypeElement)sym;
-                }
-            }
-
-            s = compenv.toplevel.starImportScope;
-            for (Symbol sym : s.getSymbolsByName(names.fromString(className))) {
-                if (sym.kind == TYP) {
-                    return (TypeElement)sym;
-                }
-            }
-        }
-
-        // finally, search by qualified name in all modules
-        return elementUtils.getTypeElement(className);
-    }
-
     // TODO: jx.l.m ?
     public Location getLocationForModule(ModuleElement mdle) {
         ModuleSymbol msym = (ModuleSymbol)mdle;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Utils.java
@@ -806,20 +806,6 @@ public class Utils {
     }
 
     /**
-     * Lookup for a class within this package.
-     *
-     * @return TypeElement of found class, or null if not found.
-     */
-    public TypeElement findClassInPackageElement(PackageElement pkg, String className) {
-        for (TypeElement c : getAllClasses(pkg)) {
-            if (getSimpleName(c).equals(className)) {
-                return c;
-            }
-        }
-        return null;
-    }
-
-    /**
      * Returns true if {@code type} or any of its enclosing types has non-empty type arguments.
      * @param type the type
      * @return {@code true} if type arguments were found
@@ -832,30 +818,6 @@ public class Utils {
             type = dt.getEnclosingType();
         }
         return false;
-    }
-
-    /**
-     * TODO: FIXME: port to javax.lang.model
-     * Find a class within the context of this class. Search order: qualified name, in this class
-     * (inner), in this package, in the class imports, in the package imports. Return the
-     * TypeElement if found, null if not found.
-     */
-    //### The specified search order is not the normal rule the
-    //### compiler would use.  Leave as specified or change it?
-    public TypeElement findClass(Element element, String className) {
-        TypeElement encl = getEnclosingTypeElement(element);
-        TypeElement searchResult = configuration.workArounds.searchClass(encl, className);
-        if (searchResult == null) {
-            encl = getEnclosingTypeElement(encl);
-            //Expand search space to include enclosing class.
-            while (encl != null && getEnclosingTypeElement(encl) != null) {
-                encl = getEnclosingTypeElement(encl);
-            }
-            searchResult = encl == null
-                    ? null
-                    : configuration.workArounds.searchClass(encl, className);
-        }
-        return searchResult;
     }
 
     /**
@@ -1561,17 +1523,6 @@ public class Utils {
      */
     public List<VariableElement> getFieldsUnfiltered(TypeElement te) {
         return getAllItems(te, FIELD, VariableElement.class);
-    }
-
-    /**
-     * Returns the documented classes in an element,
-     * such as a package element or type element.
-     *
-     * @param e the element
-     * @return the classes
-     */
-    public List<TypeElement> getClasses(Element e) {
-        return getDocumentedItems(e, CLASS, TypeElement.class);
     }
 
     /**


### PR DESCRIPTION
Please review a simple removal of unused methods in `WorkArounds` and `Utils`. 

`Utils.findClass(Element,String)` was the principal entry point of this cluster of methods. It was last used by the `ThrowsTaglet` `inherit` method, but that code was removed in JDK-8295277.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319300](https://bugs.openjdk.org/browse/JDK-8319300): Remove unused methods in WorkArounds and Utils (**Task** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to [812785a7](https://git.openjdk.org/jdk/pull/16472/files/812785a7c301cd0740bb1b3e0c6819db40b62cdd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16472/head:pull/16472` \
`$ git checkout pull/16472`

Update a local copy of the PR: \
`$ git checkout pull/16472` \
`$ git pull https://git.openjdk.org/jdk.git pull/16472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16472`

View PR using the GUI difftool: \
`$ git pr show -t 16472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16472.diff">https://git.openjdk.org/jdk/pull/16472.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16472#issuecomment-1790454508)