### PR TITLE
8294432: Add provisions to calculate hash values from MemorySegments

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -45,7 +45,6 @@ import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.foreign.SegmentFactories;
 import jdk.internal.javac.Restricted;
-import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -2176,11 +2175,11 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * <p>
      * The general contract of this method is:
      * <ul>
-     * <li>Whenever invoked on the same segment with the same offset parameters (i.e. range)
+     * <li>Whenever invoked on the same segment with the same offset parameters (i.e. region)
      *     more than once during an execution of a Java application, the method
      *     consistently return the same long value, provided no information
-     *     in the segments range is modified.
-     * <li>Whenever invoked on different segments with ranges who's content are equal,
+     *     in the segment's region is modified.
+     * <li>Whenever invoked on different segments with regions who's sizes and contents are equal,
      *     during an execution of a Java application, the method will constantly return the same long value.
      * <li>The returned long value need not remain consistent from one execution of an
      *     application to another execution of the same application.

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -2202,7 +2202,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @see Object#hashCode()
      * @see Long#hashCode(long)
      */
-    static long hash(MemorySegment segment, long fromOffset, long toOffset) {
+    static long contentHash(MemorySegment segment, long fromOffset, long toOffset) {
         return AbstractMemorySegmentImpl.hash(segment, fromOffset, toOffset);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -731,6 +731,13 @@ public abstract sealed class AbstractMemorySegmentImpl
         };
     }
 
+    public static long hash(MemorySegment segment, long fromOffset, long toOffset) {
+        AbstractMemorySegmentImpl impl = (AbstractMemorySegmentImpl)Objects.requireNonNull(segment);
+        long bytes = toOffset - fromOffset;
+        impl.checkAccess(fromOffset, bytes, true);
+        return SCOPED_MEMORY_ACCESS.vectorizedHash((MemorySessionImpl) segment.scope(), segment, fromOffset, toOffset);
+    }
+
     // accessors
 
     @ForceInline

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,6 +233,27 @@ public class ScopedMemoryAccess {
         } finally {
             Reference.reachabilityFence(aSession);
             Reference.reachabilityFence(bSession);
+        }
+    }
+
+    @ForceInline
+    public long vectorizedHash(MemorySessionImpl session, MemorySegment segment, long from, long to) {
+        try {
+            return vectorizedHashInternal(session, segment, from, to);
+        } catch (ScopedAccessError ex) {
+            throw ex.newRuntimeException();
+        }
+    }
+
+    @ForceInline @Scoped
+    private long vectorizedHashInternal(MemorySessionImpl session, MemorySegment segment, long from, long to) {
+        try {
+            if (session != null) {
+                session.checkValidStateRaw();
+            }
+            return ArraysSupport.vectorizedHash(segment, from, to);
+        } finally {
+            Reference.reachabilityFence(session);
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -24,6 +24,8 @@
  */
 package jdk.internal.util;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.util.Arrays;
 import java.util.Collection;
 import jdk.internal.access.JavaLangAccess;
@@ -209,6 +211,29 @@ public class ArraysSupport {
             case T_INT -> hashCode(initialValue, (int[]) array, fromIndex, length);
                 default -> throw new IllegalArgumentException("unrecognized basic type: " + basicType);
         };
+    }
+
+    /**
+     * Calculate the hash code for a memory segment in a way that enables efficient
+     * vectorization.
+     *
+     * <p>This method does not perform bounds checks.  It is the
+     * responsibility of the caller to perform such checks before calling this
+     * method.
+     *
+     * @param segment for which to calculate hash code
+     * @param from start offset
+     * @param to stop offset (non-inclusive)
+     *
+     * @return the calculated hash value
+     */
+    // @IntrinsicCandidate
+    public static long vectorizedHash(MemorySegment segment, long from, long to) {
+        long result = 0;
+        for (long i = from; i < to; i++) {
+            result = 31 * result + (segment.get(ValueLayout.JAVA_BYTE, i) & 0xff);
+        }
+        return result;
     }
 
     private static int signedHashCode(int result, byte[] a, int fromIndex, int length) {

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -221,15 +221,15 @@ public class ArraysSupport {
      * responsibility of the caller to perform such checks before calling this
      * method.
      *
+     * @param result initial hash value (start value)
      * @param segment for which to calculate hash code
-     * @param from start offset
+     * @param from start offset (inclusive)
      * @param to stop offset (non-inclusive)
      *
      * @return the calculated hash value
      */
-    // @IntrinsicCandidate
-    public static long vectorizedHash(MemorySegment segment, long from, long to) {
-        long result = 0;
+    // Todo: Make this an @IntrinsicCandidate
+    public static long vectorizedHash(long result, MemorySegment segment, long from, long to) {
         for (long i = from; i < to; i++) {
             result = 31 * result + (segment.get(ValueLayout.JAVA_BYTE, i) & 0xff);
         }

--- a/test/jdk/java/foreign/TestSegmentHash.java
+++ b/test/jdk/java/foreign/TestSegmentHash.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+/*
+ * @test
+ * @run junit TestSegmentHash
+ */
+
+import org.junit.jupiter.api.*;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static org.junit.jupiter.api.Assertions.*;
+
+final class TestSegmentHash {
+
+    private static final MemorySegment SEGMENT = MemorySegment.ofArray(
+            new byte[]{8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23})
+            .asReadOnly();
+
+    @Test
+    void testZeroLengthHash() {
+        // This test assumes zero is returned for zero length hashes
+        for (int i = 0; i <SEGMENT.byteSize(); i++) {
+            assertEquals(0, MemorySegment.hash(SEGMENT, i, i));
+        }
+    }
+
+    @Test
+    void testHashDiffers() {
+        // This test is extremely likely to pass
+        Set<Long> seen = new HashSet<>();
+        for (int i = 0; i <SEGMENT.byteSize(); i++) {
+            assertTrue(seen.add(MemorySegment.hash(SEGMENT, 0, i)));
+        }
+    }
+
+    @Test
+    void testSlices() {
+        for (int i = 0; i <SEGMENT.byteSize(); i++) {
+            MemorySegment slice = SEGMENT.asSlice(i);
+            long expected = MemorySegment.hash(SEGMENT, i, SEGMENT.byteSize());
+            long actual = MemorySegment.hash(slice, 0, slice.byteSize());
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Test
+    void testInvariants() throws InterruptedException {
+        assertThrows(NullPointerException.class, () -> MemorySegment.hash(null, 0, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.hash(SEGMENT, -1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.hash(SEGMENT, 2, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.hash(SEGMENT, SEGMENT.byteSize(), SEGMENT.byteSize() + 1));
+
+        MemorySegment seg;
+        try (var arena = Arena.ofConfined()) {
+            seg = arena.allocate(JAVA_LONG);
+
+            AtomicReference<WrongThreadException> e = new AtomicReference<>();
+            Thread t = Thread.ofPlatform().start(() ->
+                    e.set(assertThrows(WrongThreadException.class, () -> {
+                        MemorySegment.hash(seg, 0, seg.byteSize());
+                    })));
+            t.join();
+            assertNotNull(e.get());
+        }
+
+        // Check a closed scope
+        assertThrows(IllegalStateException.class, () -> MemorySegment.hash(seg, 0, seg.byteSize()));
+    }
+
+}

--- a/test/jdk/java/foreign/TestSegmentHash.java
+++ b/test/jdk/java/foreign/TestSegmentHash.java
@@ -48,7 +48,7 @@ final class TestSegmentHash {
     void testZeroLengthHash() {
         // This test assumes zero is returned for zero length hashes
         for (int i = 0; i <SEGMENT.byteSize(); i++) {
-            assertEquals(0, MemorySegment.hash(SEGMENT, i, i));
+            assertEquals(0, MemorySegment.contentHash(SEGMENT, i, i));
         }
     }
 
@@ -57,7 +57,7 @@ final class TestSegmentHash {
         // This test is extremely likely to pass
         Set<Long> seen = new HashSet<>();
         for (int i = 0; i <SEGMENT.byteSize(); i++) {
-            assertTrue(seen.add(MemorySegment.hash(SEGMENT, 0, i)));
+            assertTrue(seen.add(MemorySegment.contentHash(SEGMENT, 0, i)));
         }
     }
 
@@ -65,18 +65,18 @@ final class TestSegmentHash {
     void testSlices() {
         for (int i = 0; i <SEGMENT.byteSize(); i++) {
             MemorySegment slice = SEGMENT.asSlice(i);
-            long expected = MemorySegment.hash(SEGMENT, i, SEGMENT.byteSize());
-            long actual = MemorySegment.hash(slice, 0, slice.byteSize());
+            long expected = MemorySegment.contentHash(SEGMENT, i, SEGMENT.byteSize());
+            long actual = MemorySegment.contentHash(slice, 0, slice.byteSize());
             assertEquals(expected, actual);
         }
     }
 
     @Test
     void testInvariants() throws InterruptedException {
-        assertThrows(NullPointerException.class, () -> MemorySegment.hash(null, 0, 0));
-        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.hash(SEGMENT, -1, 0));
-        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.hash(SEGMENT, 2, 1));
-        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.hash(SEGMENT, SEGMENT.byteSize(), SEGMENT.byteSize() + 1));
+        assertThrows(NullPointerException.class, () -> MemorySegment.contentHash(null, 0, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.contentHash(SEGMENT, -1, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.contentHash(SEGMENT, 2, 1));
+        assertThrows(IndexOutOfBoundsException.class, () -> MemorySegment.contentHash(SEGMENT, SEGMENT.byteSize(), SEGMENT.byteSize() + 1));
 
         MemorySegment seg;
         try (var arena = Arena.ofConfined()) {
@@ -85,14 +85,14 @@ final class TestSegmentHash {
             AtomicReference<WrongThreadException> e = new AtomicReference<>();
             Thread t = Thread.ofPlatform().start(() ->
                     e.set(assertThrows(WrongThreadException.class, () -> {
-                        MemorySegment.hash(seg, 0, seg.byteSize());
+                        MemorySegment.contentHash(seg, 0, seg.byteSize());
                     })));
             t.join();
             assertNotNull(e.get());
         }
 
         // Check a closed scope
-        assertThrows(IllegalStateException.class, () -> MemorySegment.hash(seg, 0, seg.byteSize()));
+        assertThrows(IllegalStateException.class, () -> MemorySegment.contentHash(seg, 0, seg.byteSize()));
     }
 
 }


### PR DESCRIPTION
This PR proposes to add a hash function for calculating hash values for regions in a `MemorySegment`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 22 to be approved (needs to be created)

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/SE1.gif)

### Issue
 * [JDK-8294432](https://bugs.openjdk.org/browse/JDK-8294432): Add provisions to calculate hash values from MemorySegments (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16473/head:pull/16473` \
`$ git checkout pull/16473`

Update a local copy of the PR: \
`$ git checkout pull/16473` \
`$ git pull https://git.openjdk.org/jdk.git pull/16473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16473`

View PR using the GUI difftool: \
`$ git pr show -t 16473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16473.diff">https://git.openjdk.org/jdk/pull/16473.diff</a>

</details>
