### PR TITLE
JDK-8319318: bufferedStream fixed case can be removed

### DIFF
--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -991,16 +991,6 @@ bufferedStream::bufferedStream(size_t initial_size, size_t bufmax) : outputStrea
   buffer_length = initial_size;
   buffer        = NEW_C_HEAP_ARRAY(char, buffer_length, mtInternal);
   buffer_pos    = 0;
-  buffer_fixed  = false;
-  buffer_max    = bufmax;
-  truncated     = false;
-}
-
-bufferedStream::bufferedStream(char* fixed_buffer, size_t fixed_buffer_size, size_t bufmax) : outputStream() {
-  buffer_length = fixed_buffer_size;
-  buffer        = fixed_buffer;
-  buffer_pos    = 0;
-  buffer_fixed  = true;
   buffer_max    = bufmax;
   truncated     = false;
 }
@@ -1017,38 +1007,32 @@ void bufferedStream::write(const char* s, size_t len) {
 
   size_t end = buffer_pos + len;
   if (end >= buffer_length) {
-    if (buffer_fixed) {
-      // if buffer cannot resize, silently truncate
-      len = buffer_length - buffer_pos - 1;
-      truncated = true;
-    } else {
-      // For small overruns, double the buffer.  For larger ones,
-      // increase to the requested size.
-      if (end < buffer_length * 2) {
-        end = buffer_length * 2;
+    // For small overruns, double the buffer.  For larger ones,
+    // increase to the requested size.
+    if (end < buffer_length * 2) {
+      end = buffer_length * 2;
+    }
+    // Impose a cap beyond which the buffer cannot grow - a size which
+    // in all probability indicates a real error, e.g. faulty printing
+    // code looping, while not affecting cases of just-very-large-but-its-normal
+    // output.
+    const size_t reasonable_cap = MAX2(100 * M, buffer_max * 2);
+    if (end > reasonable_cap) {
+      // In debug VM, assert right away.
+      assert(false, "Exceeded max buffer size for this string.");
+      // Release VM: silently truncate. We do this since these kind of errors
+      // are both difficult to predict with testing (depending on logging content)
+      // and usually not serious enough to kill a production VM for it.
+      end = reasonable_cap;
+      size_t remaining = end - buffer_pos;
+      if (len >= remaining) {
+        len = remaining - 1;
+        truncated = true;
       }
-      // Impose a cap beyond which the buffer cannot grow - a size which
-      // in all probability indicates a real error, e.g. faulty printing
-      // code looping, while not affecting cases of just-very-large-but-its-normal
-      // output.
-      const size_t reasonable_cap = MAX2(100 * M, buffer_max * 2);
-      if (end > reasonable_cap) {
-        // In debug VM, assert right away.
-        assert(false, "Exceeded max buffer size for this string.");
-        // Release VM: silently truncate. We do this since these kind of errors
-        // are both difficult to predict with testing (depending on logging content)
-        // and usually not serious enough to kill a production VM for it.
-        end = reasonable_cap;
-        size_t remaining = end - buffer_pos;
-        if (len >= remaining) {
-          len = remaining - 1;
-          truncated = true;
-        }
-      }
-      if (buffer_length < end) {
-        buffer = REALLOC_C_HEAP_ARRAY(char, buffer, end, mtInternal);
-        buffer_length = end;
-      }
+    }
+    if (buffer_length < end) {
+      buffer = REALLOC_C_HEAP_ARRAY(char, buffer, end, mtInternal);
+      buffer_length = end;
     }
   }
   if (len > 0) {
@@ -1066,9 +1050,7 @@ char* bufferedStream::as_string() {
 }
 
 bufferedStream::~bufferedStream() {
-  if (!buffer_fixed) {
-    FREE_C_HEAP_ARRAY(char, buffer);
-  }
+  FREE_C_HEAP_ARRAY(char, buffer);
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -293,11 +293,9 @@ class bufferedStream : public outputStream {
   size_t buffer_pos;
   size_t buffer_max;
   size_t buffer_length;
-  bool   buffer_fixed;
   bool   truncated;
  public:
   bufferedStream(size_t initial_bufsize = 256, size_t bufmax = 1024*1024*10);
-  bufferedStream(char* fixed_buffer, size_t fixed_buffer_size, size_t bufmax = 1024*1024*10);
   ~bufferedStream();
   virtual void write(const char* c, size_t len);
   size_t      size() { return buffer_pos; }

--- a/test/hotspot/gtest/utilities/test_ostream.cpp
+++ b/test/hotspot/gtest/utilities/test_ostream.cpp
@@ -93,24 +93,6 @@ TEST_VM(ostream, stringStream_static) {
   ASSERT_EQ(*canary_at, 'X'); // canary
 }
 
-TEST_VM(ostream, bufferedStream_static) {
-  char buf[100 + 1];
-  char* canary_at = buf + sizeof(buf) - 1;
-  *canary_at = 'X';
-  size_t stream_buf_size = sizeof(buf) - 1;
-  bufferedStream bs(buf, stream_buf_size);
-  size_t written = 0;
-  for (int i = 0; i < 100; i ++) {
-    written += print_lorem(&bs);
-    if (written < stream_buf_size) {
-      ASSERT_EQ(bs.size(), written);
-    } else {
-      ASSERT_EQ(bs.size(), stream_buf_size - 1);
-    }
-  }
-  ASSERT_EQ(*canary_at, 'X'); // canary
-}
-
 TEST_VM(ostream, bufferedStream_dynamic_small) {
   bufferedStream bs(1); // small to excercise realloc.
   size_t written = 0;


### PR DESCRIPTION
Trivial change to remove an unused constructor / use case for bufferedStream

Tests: GHAs (Windows error unrelated)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319318](https://bugs.openjdk.org/browse/JDK-8319318): bufferedStream fixed case can be removed (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16475/head:pull/16475` \
`$ git checkout pull/16475`

Update a local copy of the PR: \
`$ git checkout pull/16475` \
`$ git pull https://git.openjdk.org/jdk.git pull/16475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16475`

View PR using the GUI difftool: \
`$ git pr show -t 16475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16475.diff">https://git.openjdk.org/jdk/pull/16475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16475#issuecomment-1792345529)