### PR TITLE
8304446: javap --system flag doesn't override system APIs

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
@@ -25,6 +25,7 @@
 
 package com.sun.tools.javap;
 
+import com.sun.tools.javac.file.Locations;
 import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.FilterInputStream;
@@ -860,6 +861,17 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
             if (moduleLocation != null) {
                 fo = fileManager.getJavaFileForInput(moduleLocation, className, JavaFileObject.Kind.CLASS);
             } else {
+                try {
+                    //search over JDK modules specifed by --system option first
+                    for (Set<Location> locations: fileManager.listLocationsForModules(StandardLocation.SYSTEM_MODULES)) {
+                        for (Location systemModule: locations) {
+                            fo = fileManager.getJavaFileForInput(systemModule, className, JavaFileObject.Kind.CLASS);
+                            if (fo != null) return fo;
+                        }
+                    }
+                } catch (UnsupportedOperationException e) {
+                    //ignore when listLocationsForModules is not supported
+                }
                 fo = fileManager.getJavaFileForInput(StandardLocation.PLATFORM_CLASS_PATH, className, JavaFileObject.Kind.CLASS);
                 if (fo == null)
                     fo = fileManager.getJavaFileForInput(StandardLocation.CLASS_PATH, className, JavaFileObject.Kind.CLASS);


### PR DESCRIPTION
Javap ignores --system option when searching for JDK classes.
This patch prepends search over JDK system modules.

Please review.

Thanks,
Adam