### PR TITLE
JDK-8319104: GtestWrapper crashes with SIGILL in AsyncLogTest::test_asynclog_raw on AIX opt

### DIFF
--- a/test/hotspot/gtest/logging/test_logTagSet.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSet.cpp
@@ -45,7 +45,7 @@ TEST_VM(LogTagSet, defaults) {
   }
 }
 
-TEST(LogTagSet, has_output) {
+TEST_VM(LogTagSet, has_output) {
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   ts.set_output_level(LogConfiguration::StderrLog, LogLevel::Trace);
   EXPECT_TRUE(ts.has_output(LogConfiguration::StderrLog));
@@ -54,14 +54,14 @@ TEST(LogTagSet, has_output) {
   EXPECT_FALSE(ts.has_output(LogConfiguration::StderrLog));
 }
 
-TEST(LogTagSet, ntags) {
+TEST_VM(LogTagSet, ntags) {
   const LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   EXPECT_EQ(1u, ts.ntags());
   const LogTagSet& ts2 = LogTagSetMapping<LOG_TAGS(logging, gc, class, safepoint, heap)>::tagset();
   EXPECT_EQ(5u, ts2.ntags());
 }
 
-TEST(LogTagSet, is_level) {
+TEST_VM(LogTagSet, is_level) {
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   // Set info level on stdout and verify that is_level() reports correctly
   ts.set_output_level(LogConfiguration::StdoutLog, LogLevel::Info);
@@ -75,7 +75,7 @@ TEST(LogTagSet, is_level) {
   ts.set_output_level(LogConfiguration::StdoutLog, LogLevel::Off);
 }
 
-TEST(LogTagSet, level_for) {
+TEST_VM(LogTagSet, level_for) {
   LogOutput* output = LogConfiguration::StdoutLog;
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   for (uint i = 0; i < LogLevel::Count; i++) {
@@ -87,7 +87,7 @@ TEST(LogTagSet, level_for) {
   ts.set_output_level(output, LogLevel::Off);
 }
 
-TEST(LogTagSet, contains) {
+TEST_VM(LogTagSet, contains) {
   // Verify that contains works as intended for a few predetermined tagsets
   const LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   EXPECT_TRUE(ts.contains(PREFIX_LOG_TAG(logging)));
@@ -113,7 +113,7 @@ TEST(LogTagSet, contains) {
   EXPECT_TRUE(ts4.contains(PREFIX_LOG_TAG(heap)));
 }
 
-TEST(LogTagSet, label) {
+TEST_VM(LogTagSet, label) {
   char buf[256];
   const LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging, safepoint)>::tagset();
   ASSERT_NE(-1, ts.label(buf, sizeof(buf)));
@@ -139,7 +139,7 @@ TEST(LogTagSet, label) {
 
 }
 
-TEST(LogTagSet, duplicates) {
+TEST_VM(LogTagSet, duplicates) {
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
     char ts_name[512];
     ts->label(ts_name, sizeof(ts_name), ",");

--- a/test/hotspot/gtest/logging/test_logTagSet.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSet.cpp
@@ -32,7 +32,7 @@
 #include "unittest.hpp"
 
 // Test the default level for each tagset
-TEST(LogTagSet, defaults) {
+TEST_VM(LogTagSet, defaults) {
   for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
     char buf[256];
     ts->label(buf, sizeof(buf));
@@ -72,6 +72,7 @@ TEST(LogTagSet, is_level) {
   EXPECT_FALSE(ts.is_level(LogLevel::Trace));
   ts.set_output_level(LogConfiguration::StdoutLog, LogLevel::Default);
   EXPECT_TRUE(ts.is_level(LogLevel::Default));
+  ts.set_output_level(LogConfiguration::StdoutLog, LogLevel::Off);
 }
 
 TEST(LogTagSet, level_for) {
@@ -83,7 +84,7 @@ TEST(LogTagSet, level_for) {
     ts.set_output_level(output, level);
     EXPECT_EQ(level, ts.level_for(output));
   }
-  ts.set_output_level(output, LogLevel::Default);
+  ts.set_output_level(output, LogLevel::Off);
 }
 
 TEST(LogTagSet, contains) {


### PR DESCRIPTION
Currently gtest/GTestWrapper.java crashes on AIX in the opt build.

 SIGILL (0x4) at pc=0x0000000000000000, pid=15598006, tid=258

 JRE version: OpenJDK Runtime Environment (22.0) (build 22-internal-adhoc.openjdk.jdk-dev)
 Java VM: OpenJDK 64-Bit Server VM (22-internal-adhoc.openjdk.jdk-dev, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, aix-ppc64)
 Problematic frame:
 V [libjvm.so+0x42c9c] LogTagSet::vwrite(LogLevel::type, char const*, char*)+0x104

### The reason for the SIGILL is the following:
The _AsyncLogTest.asynclog_vm_ test iterates over the previously registered entries of _LogOutputList_. There it gets a Nullpointer, which it tries to use for a function call `(nullpointer)->write(...);` This results in an SIGILL.
The first reason for this is, that the LogTagSet tests (which seem to be called beforehand only on AIX) creates such an entry with
`ts.set_output_level(LogConfiguration::StdoutLog, LogLevel::Info);`
The first flaw is that this entry is not removed again at the end of the test. So the VM is modified and would behave differently depending on the sequence of the test execution.
The second flaw is that the registered _LogConfiguration::StdoutLog_ in the call above is still a nullpointer due to the fact that on AIX no VM was created before the LogTagSet tests and only a creation of a VM initializes the logConfiguration. So again the whole Gtestwrapper testsuite depends on the executable sequence of the tests. If no other test creates a vm beforehand the LogTagSet tests will fail. Again this has to be fixed by let the LogTagSet tests themself creating a VM.

### Solution to fix all errors:

1. Make the 1. LogTagSet test a TEST_VM test.
2. Clean up the _LogTagSet.is_level_ and _LogTagSet.level_for_ tests with a final `ts.set_output_level(LogConfiguration::StdoutLog, LogLevel::Off);` which will remove the entry from the LogOutputList again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319104](https://bugs.openjdk.org/browse/JDK-8319104): GtestWrapper crashes with SIGILL in AsyncLogTest::test_asynclog_raw on AIX opt (**Bug** - P3)


### Reviewers
 * @TOatGithub (no known openjdk.org user name / role) ⚠️ Review applies to [8c6fcbca](https://git.openjdk.org/jdk/pull/16479/files/8c6fcbcac710908f804c46ebe9203c5276d565a3)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [8c6fcbca](https://git.openjdk.org/jdk/pull/16479/files/8c6fcbcac710908f804c46ebe9203c5276d565a3)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16479/head:pull/16479` \
`$ git checkout pull/16479`

Update a local copy of the PR: \
`$ git checkout pull/16479` \
`$ git pull https://git.openjdk.org/jdk.git pull/16479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16479`

View PR using the GUI difftool: \
`$ git pr show -t 16479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16479.diff">https://git.openjdk.org/jdk/pull/16479.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16479#issuecomment-1791013639)