### PR TITLE
8319316: Clarify text around which layouts a linker supports

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -246,7 +246,7 @@ import java.util.stream.Stream;
  *
  * Linker implementations may optionally support additional layouts, such as <em>packed</em> struct layouts.
  * A packed struct is a struct in which there is at least one member layout {@code L} that has an alignment
- * constraint less than its natural alignment. This allows avoiding padding between member layouts,
+ * constraint less strict than its natural alignment. This allows avoiding padding between member layouts,
  * as well as avoiding padding at the end of the struct layout. For example:
  * {@snippet lang = java:
  * // No padding between the 2 element layouts:

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -244,7 +244,21 @@ import java.util.stream.Stream;
  * </li>
  * </ul>
  *
- * Linker implementations may optionally support additional layouts, such as 'packed' struct layouts.
+ * Linker implementations may optionally support additional layouts, such as <em>packed</em> struct layouts.
+ * A packed struct is a struct in which there is at least one member layout {@code L} that has an alignment
+ * constraint less than its natural alignment. This allows avoiding padding between member layouts,
+ * as well as avoiding padding at the end of the struct layout. For example:
+ * {@snippet lang = java:
+ * // No padding between the 2 element layouts:
+ * MemoryLayout noFieldPadding = MemoryLayout.structLayout(
+ *         ValueLayout.JAVA_INT,
+ *         ValueLayout.JAVA_DOUBLE.withByteAlignment(4));
+ *
+ * // No padding at the end of the struct:
+ * MemoryLayout noTrailingPadding = MemoryLayout.structLayout(
+ *         ValueLayout.JAVA_DOUBLE.withByteAlignment(4),
+ *         ValueLayout.JAVA_INT);
+ * }
  * <p>
  * A native linker only supports function descriptors whose argument/return layouts are layouts supported by that linker
  * and are not sequence layouts.

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -224,7 +224,7 @@ import java.util.stream.Stream;
  * </tbody>
  * </table></blockquote>
  * <p>
- * All native linker implementations support at least so called <em>naturally aligned layouts</em>. More formally,
+ * All native linker implementations support a well-defined subset of layouts. More formally,
  * a layout {@code L} is supported by a native linker {@code NL} if:
  * <ul>
  * <li>{@code L} is a value layout {@code V} and {@code V.withoutName()} is a canonical layout</li>

--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -224,8 +224,8 @@ import java.util.stream.Stream;
  * </tbody>
  * </table></blockquote>
  * <p>
- * All native linker implementations operate on a subset of memory layouts. More formally, a layout {@code L}
- * is supported by a native linker {@code NL} if:
+ * All native linker implementations support at least so called <em>naturally aligned layouts</em>. More formally,
+ * a layout {@code L} is supported by a native linker {@code NL} if:
  * <ul>
  * <li>{@code L} is a value layout {@code V} and {@code V.withoutName()} is a canonical layout</li>
  * <li>{@code L} is a sequence layout {@code S} and all the following conditions hold:
@@ -244,6 +244,8 @@ import java.util.stream.Stream;
  * </li>
  * </ul>
  *
+ * Linker implementations may optionally support additional layouts, such as 'packed' struct layouts.
+ * <p>
  * A native linker only supports function descriptors whose argument/return layouts are layouts supported by that linker
  * and are not sequence layouts.
  *


### PR DESCRIPTION
- Add linker note about packed structs.
- Relax language a bit to avoid implying that only listed layouts are supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8319381](https://bugs.openjdk.org/browse/JDK-8319381) to be approved

### Issues
 * [JDK-8319316](https://bugs.openjdk.org/browse/JDK-8319316): Clarify text around which layouts a linker supports (**Enhancement** - P3)
 * [JDK-8319381](https://bugs.openjdk.org/browse/JDK-8319381): Clarify text around which layouts a linker supports (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16485/head:pull/16485` \
`$ git checkout pull/16485`

Update a local copy of the PR: \
`$ git checkout pull/16485` \
`$ git pull https://git.openjdk.org/jdk.git pull/16485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16485`

View PR using the GUI difftool: \
`$ git pr show -t 16485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16485.diff">https://git.openjdk.org/jdk/pull/16485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16485#issuecomment-1792423011)