### PR TITLE
JDK-8319516 - Native library suffix impact on the library loading in AIX- Java Class Loader

### DIFF
--- a/src/java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java
+++ b/src/java.base/aix/classes/jdk/internal/loader/ClassLoaderHelper.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+package jdk.internal.loader;
+
+import java.io.File;
+import java.util.ArrayList;
+
+class ClassLoaderHelper {
+
+    private ClassLoaderHelper() {}
+
+    /**
+     * Returns an alternate path name for the given file
+     * such that if the original pathname did not exist, then the
+     * file may be located at the alternate location.
+     * For AIX, this replaces the final .so suffix with .a
+     */
+    static File mapAlternativeName(File lib) {
+        String name = lib.toString();
+        int index = name.lastIndexOf('.');
+        if (index < 0) {
+            return null;
+        }
+        return new File(name.substring(0, index) + ".a");
+    }
+
+    /**
+     * Parse a PATH env variable.
+     *
+     * Empty elements will be replaced by dot.
+     */
+    static String[] parsePath(String ldPath) {
+        char ps = File.pathSeparatorChar;
+        ArrayList<String> paths = new ArrayList<>();
+        int pathStart = 0;
+        int pathEnd;
+        while ((pathEnd = ldPath.indexOf(ps, pathStart)) >= 0) {
+            paths.add((pathStart < pathEnd) ?
+                    ldPath.substring(pathStart, pathEnd) : ".");
+            pathStart = pathEnd + 1;
+        }
+        int ldLen = ldPath.length();
+        paths.add((pathStart < ldLen) ?
+                ldPath.substring(pathStart, ldLen) : ".");
+        return paths.toArray(new String[paths.size()]);
+    }
+}


### PR DESCRIPTION
Allow support for both .a and .so files in AIX.
If .so file is not found, allow fallback to .a extension.
JBS Issue: [JDK-8319516](https://bugs.openjdk.org/browse/JDK-8319516)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319516](https://bugs.openjdk.org/browse/JDK-8319516): Native library suffix impact on the library loading in AIX- Java Class Loader (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16490/head:pull/16490` \
`$ git checkout pull/16490`

Update a local copy of the PR: \
`$ git checkout pull/16490` \
`$ git pull https://git.openjdk.org/jdk.git pull/16490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16490`

View PR using the GUI difftool: \
`$ git pr show -t 16490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16490.diff">https://git.openjdk.org/jdk/pull/16490.diff</a>

</details>
