### PR TITLE
8319379: G1: gc/logging/TestUnifiedLoggingSwitchStress.java crashes after JDK-8318894

### DIFF
--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.hpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.hpp
@@ -86,6 +86,9 @@ public:
   double surv_rate_pred(G1Predictions const& predictor, uint age) const {
     assert(is_valid_age(age), "must be");
 
+    // _stats_arrays_length might not be in sync with _num_added_regions in Cleanup pause.
+    age = MIN2(age, _stats_arrays_length - 1);
+
     return predictor.predict_in_unit_interval(_surv_rate_predictors[age]);
   }
 


### PR DESCRIPTION
Can reproduce the failure using `TEST=gc/logging/TestUnifiedLoggingSwitchStress.java JTREG="REPEAT_COUNT=10"`,  but not any more after the fix.

(The MIN2 was removed as part of JDK-8318894; added back now.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319379](https://bugs.openjdk.org/browse/JDK-8319379): G1: gc/logging/TestUnifiedLoggingSwitchStress.java crashes after JDK-8318894 (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16495/head:pull/16495` \
`$ git checkout pull/16495`

Update a local copy of the PR: \
`$ git checkout pull/16495` \
`$ git pull https://git.openjdk.org/jdk.git pull/16495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16495`

View PR using the GUI difftool: \
`$ git pr show -t 16495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16495.diff">https://git.openjdk.org/jdk/pull/16495.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16495#issuecomment-1792455671)