### PR TITLE
8319408: RISC-V: MaxVectorSize is not consistently checked in several situations

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -302,17 +302,17 @@ void VM_Version::c2_initialize() {
   if (UseRVV) {
     if (FLAG_IS_DEFAULT(MaxVectorSize)) {
       MaxVectorSize = _initial_vector_length;
-    } else if (MaxVectorSize < 16) {
+    } else if (!is_power_of_2(MaxVectorSize)) {
+      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
+    } else if (MaxVectorSize > _initial_vector_length) {
+      warning("Current system only supports max RVV vector length %d. Set MaxVectorSize to %d",
+              _initial_vector_length, _initial_vector_length);
+      MaxVectorSize = _initial_vector_length;
+    }
+    if (MaxVectorSize < 16) {
       warning("RVV does not support vector length less than 16 bytes. Disabling RVV.");
       UseRVV = false;
-    } else if (is_power_of_2(MaxVectorSize)) {
-      if (MaxVectorSize > _initial_vector_length) {
-        warning("Current system only supports max RVV vector length %d. Set MaxVectorSize to %d",
-                _initial_vector_length, _initial_vector_length);
-        MaxVectorSize = _initial_vector_length;
-      }
-    } else {
-      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
+      FLAG_SET_DEFAULT(MaxVectorSize, 0);
     }
   }
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -303,7 +303,7 @@ void VM_Version::c2_initialize() {
     if (FLAG_IS_DEFAULT(MaxVectorSize)) {
       MaxVectorSize = _initial_vector_length;
     } else if (!is_power_of_2(MaxVectorSize)) {
-      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d", (int)MaxVectorSize));
+      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d, must be a power of 2", (int)MaxVectorSize));
     } else if (MaxVectorSize > _initial_vector_length) {
       warning("Current system only supports max RVV vector length %d. Set MaxVectorSize to %d",
               _initial_vector_length, _initial_vector_length);


### PR DESCRIPTION
Hi,
Can you review the change to fix the MaxVectorSize checking in vm_version_riscv.cpp?
Thanks!

Current logic will not check whether (MaxVectorSize < 16), after the assignment `MaxVectorSize = _initial_vector_length;`, in following situation.
a) if FLAG_IS_DEFAULT(MaxVectorSize) == true
b) if FLAG_IS_DEFAULT(MaxVectorSize) == false and (MaxVectorSize >= 16) and is_power_of_2(MaxVectorSize) and (MaxVectorSize > _initial_vector_length)

And in original code, the logic is not consistent for the situations between MaxVectorSize < 16 and MaxVectorSize >= 16, when is_power_of_2(MaxVectorSize) == false; for the former (<16) it's to disable RVV, for the latter (>=16) it's vm_exit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319408](https://bugs.openjdk.org/browse/JDK-8319408): RISC-V: MaxVectorSize is not consistently checked in several situations (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [06945065](https://git.openjdk.org/jdk/pull/16498/files/06945065ac883dcd52a1ca81e3f9b4a78d900313)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16498/head:pull/16498` \
`$ git checkout pull/16498`

Update a local copy of the PR: \
`$ git checkout pull/16498` \
`$ git pull https://git.openjdk.org/jdk.git pull/16498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16498`

View PR using the GUI difftool: \
`$ git pr show -t 16498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16498.diff">https://git.openjdk.org/jdk/pull/16498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16498#issuecomment-1792738228)