### PR TITLE
8318144: Match on enum constants with body compiles but fails with MatchException

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -396,7 +396,8 @@ public class SwitchBootstraps {
             try {
                 Class<?> clazz = label.constantType().resolveConstantDesc(lookup);
 
-                if (value.getClass() != clazz) {
+                if (!(value instanceof Enum<?> enumValue) ||
+                    enumValue.getDeclaringClass() != clazz) {
                     return false;
                 }
 

--- a/test/jdk/java/lang/runtime/SwitchBootstrapsTest.java
+++ b/test/jdk/java/lang/runtime/SwitchBootstrapsTest.java
@@ -40,6 +40,7 @@ import static org.testng.Assert.fail;
 
 /**
  * @test
+ * @bug 8318144
  * @enablePreview
  * @compile SwitchBootstrapsTest.java
  * @run testng/othervm SwitchBootstrapsTest
@@ -70,7 +71,11 @@ public class SwitchBootstrapsTest {
     }
 
     private void testEnum(Enum<?> target, int start, int result, Object... labels) throws Throwable {
-        MethodType switchType = MethodType.methodType(int.class, target.getClass(), int.class);
+        testEnum(target.getClass(), target, start, result, labels);
+    }
+
+    private void testEnum(Class<?> targetClass, Enum<?> target, int start, int result, Object... labels) throws Throwable {
+        MethodType switchType = MethodType.methodType(int.class, targetClass, int.class);
         MethodHandle indy = ((CallSite) BSM_ENUM_SWITCH.invoke(MethodHandles.lookup(), "", switchType, labels)).dynamicInvoker();
         assertEquals((int) indy.invoke(target, start), result);
         assertEquals(-1, (int) indy.invoke(null, start));
@@ -136,6 +141,26 @@ public class SwitchBootstrapsTest {
         testEnum(E1.A, 1, 1, "A", "A", "B");
         testEnum(E1.A, 2, 3, "A", "A", "B");
         testEnum(E1.A, 0, 0);
+    }
+
+    public void testEnumsWithConstants() throws Throwable {
+        enum E {
+            A {},
+            B {},
+            C {}
+        }
+        ClassDesc eDesc = E.class.describeConstable().get();
+        Object[] typeParams = new Object[] {
+            EnumDesc.of(eDesc, "A"),
+            EnumDesc.of(eDesc, "B"),
+            EnumDesc.of(eDesc, "C"),
+        };
+        testType(E.A, 0, 0, typeParams);
+        testType(E.B, 0, 1, typeParams);
+        testType(E.C, 0, 2, typeParams);
+        testEnum(E.class, E.A, 0, 0, "A", "B", "C");
+        testEnum(E.class, E.B, 0, 1, "A", "B", "C");
+        testEnum(E.class, E.C, 0, 2, "A", "B", "C");
     }
 
     public void testWrongSwitchTypes() throws Throwable {

--- a/test/langtools/tools/javac/patterns/SwitchEnumConstants.java
+++ b/test/langtools/tools/javac/patterns/SwitchEnumConstants.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8318144
+ * @summary Verify switches work in presence of enum constants that have bodies
+ * @compile SwitchEnumConstants.java
+ * @run main SwitchEnumConstants
+ */
+
+import java.util.function.ToIntFunction;
+
+public class SwitchEnumConstants {
+
+    public static void main(String... args) throws Exception {
+        new SwitchEnumConstants().run();
+    }
+
+    void run() throws Exception {
+        doRun(this::typeSwitch);
+        doRun(this::enumSwitch);
+    }
+
+    void doRun(ToIntFunction<E> c) throws Exception {
+        assertEquals(0, c.applyAsInt(E.A));
+        assertEquals(1, c.applyAsInt(E.B));
+        assertEquals(2, c.applyAsInt(E.C));
+    }
+
+    int typeSwitch(Object o) {
+        return switch (o) {
+            case E.A -> 0;
+            case E.B -> 1;
+            case E.C -> 2;
+            default -> throw new IllegalStateException();
+        };
+    }
+
+    int enumSwitch(E e) {
+        return switch (e) {
+            case A -> 0;
+            case B -> 1;
+            case C -> 2;
+        };
+    }
+
+
+    private static void assertEquals(int expected, int actual) {
+        if (expected != actual) {
+            throw new AssertionError("expected: " + expected +
+                                     ", actual: " + actual);
+        }
+    }
+
+    enum E {
+        A {},
+        B {},
+        C {}
+    }
+}


### PR DESCRIPTION
For code like:
```
enum E {A {}, B {} }
Object o = E.A;
switch (o) {
     case E.A -> System.err.println(o);
     default -> System.err.println("default");
}
```

The result is `default`, not `A`, due to incorrect classes being compared. Thanks for @liach for noting the solution here:
https://github.com/openjdk/jdk/pull/16489#discussion_r1381411165
