### PR TITLE
8319339: Internal error on spurious markup in a hybrid snippet

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -376,9 +376,10 @@ public class SnippetTaglet extends BaseTaglet {
         StyledText externalSnippet = null;
 
         try {
-            Diags d = (text, pos) -> {
+            Diags d = (key, pos) -> {
                 var path = utils.getCommentHelper(holder)
                         .getDocTreePath(snippetTag.getBody());
+                var text = resources.getText(key);
                 config.getReporter().print(Diagnostic.Kind.WARNING,
                         path, pos, pos, pos, text);
             };
@@ -397,7 +398,7 @@ public class SnippetTaglet extends BaseTaglet {
 
         try {
             var finalFileObject = fileObject;
-            Diags d = (text, pos) -> messages.warning(finalFileObject, pos, pos, pos, text);
+            Diags d = (key, pos) -> messages.warning(finalFileObject, pos, pos, pos, key);
             if (externalContent != null) {
                 externalSnippet = parse(resources, d, language, externalContent);
             }
@@ -484,7 +485,7 @@ public class SnippetTaglet extends BaseTaglet {
     }
 
     public interface Diags {
-        void warn(String text, int pos);
+        void warn(String key, int pos);
     }
 
     private static String stringValueOf(AttributeTree at) throws BadSnippetException {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/snippet/Parser.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/snippet/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,7 +161,7 @@ public final class Parser {
                     }
                 }
                 if (parsedTags.isEmpty()) { // (2)
-                    diags.warn(resources.getText("doclet.snippet.markup.spurious"), next.offset() + markedUpLine.start("markup"));
+                    diags.warn("doclet.snippet.markup.spurious", next.offset() + markedUpLine.start("markup"));
                     line = rawLine + (addLineTerminator ? "\n" : "");
                 } else { // (3)
                     hasMarkup = true;

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8266666 8281969
+ * @bug 8266666 8281969 8319339
  * @summary Implementation for snippets
  * @library /tools/lib ../../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -629,7 +629,7 @@ First line // @highlight :
     }
 
     @Test
-    public void testPositiveInlineTagMarkup_FalseMarkup(Path base) throws Exception {
+    public void testPositiveInlineTagMarkup_SpuriousMarkup(Path base) throws Exception {
         var testCases = List.of(
                 new TestCase(
                         """
@@ -665,6 +665,19 @@ First line // @highlight :
                         """)
         );
         testPositive(base, testCases);
+        checkOutput(Output.OUT, true, """
+                A.java:6: warning: spurious markup
+                // @formatter:off
+                  ^""","""
+                A.java:9: warning: spurious markup
+                    // @formatter:on
+                      ^""","""
+                A.java:17: warning: spurious markup
+                // @formatter:off
+                  ^""","""
+                A.java:22: warning: spurious markup
+                    // @formatter:on
+                      ^""");
     }
 
     @Test

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,8 +259,12 @@ public class TestSnippetMarkup extends SnippetTester {
         Path srcDir = base.resolve("src");
         Path outDir = base.resolve("out");
         var goodFile = "good.txt";
+        // use two files that differ in name but not content, to work around
+        // error deduplication, whereby an error related to coordinates
+        // (file, pos) reported before is suppressed; see:
+        // com.sun.tools.javac.util.Log.shouldReport(JavaFileObject, int)
         var badFile = "bad.txt";
-        var badFile2 = "bad2.txt"; // to workaround error deduplication
+        var badFile2 = "bad2.txt";
         new ClassBuilder(tb, "pkg.A")
                 .setModifiers("public", "class")
                 .addMembers(


### PR DESCRIPTION
Please review this PR to fix an internal error caused by (malfunctioning diagnostics for) spurious markup in hybrid and external snippets.

Spurious markup resembles snippet markup, but isn't one. In particular, spurious markup has no effect on snippet processing and, if appears in the displayed region, is shown as is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319339](https://bugs.openjdk.org/browse/JDK-8319339): Internal error on spurious markup in a hybrid snippet (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16501/head:pull/16501` \
`$ git checkout pull/16501`

Update a local copy of the PR: \
`$ git checkout pull/16501` \
`$ git pull https://git.openjdk.org/jdk.git pull/16501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16501`

View PR using the GUI difftool: \
`$ git pr show -t 16501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16501.diff">https://git.openjdk.org/jdk/pull/16501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16501#issuecomment-1792864159)