### PR TITLE
8319378: Spec for j.util.Timer::purge and j.util.Timer::cancel could be improved

### DIFF
--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ import jdk.internal.ref.CleanerFactory;
  * <p>This class does <i>not</i> offer real-time guarantees: it schedules
  * tasks using the {@code Object.wait(long)} method.
  *
- * <p>Java 5.0 introduced the {@code java.util.concurrent} package and
+ * @apiNote Java 5.0 introduced the {@code java.util.concurrent} package and
  * one of the concurrency utilities therein is the {@link
  * java.util.concurrent.ScheduledThreadPoolExecutor
  * ScheduledThreadPoolExecutor} which is a thread pool for repeatedly
@@ -74,13 +74,11 @@ import jdk.internal.ref.CleanerFactory;
  * implement {@code Runnable}).  Configuring {@code
  * ScheduledThreadPoolExecutor} with one thread makes it equivalent to
  * {@code Timer}.
- *
- * <p>Implementation note: This class scales to large numbers of concurrently
+ * @implNote This class scales to large numbers of concurrently
  * scheduled tasks (thousands should present no problem).  Internally,
  * it uses a binary heap to represent its task queue, so the cost to schedule
  * a task is O(log n), where n is the number of concurrently scheduled tasks.
- *
- * <p>Implementation note: All constructors start a timer thread.
+ * <p> All constructors start a timer thread.
  *
  * @author  Josh Bloch
  * @see     TimerTask
@@ -424,8 +422,12 @@ public class Timer {
     }
 
     /**
-     * Terminates this timer, discarding any currently scheduled tasks.
-     * Does not interfere with a currently executing task (if it exists).
+     * Terminates this timer, <i>discarding</i> any currently scheduled tasks.
+     * It should be noted that this method does not <i>cancel</i> the scheduled
+     * tasks. For a task to be considered cancelled, the task itself should
+     * invoke {@link TimerTask#cancel()}.
+     *
+     * <p>This method does not interfere with a currently executing task (if it exists).
      * Once a timer has been terminated, its execution thread terminates
      * gracefully, and no more tasks may be scheduled on it.
      *
@@ -436,6 +438,7 @@ public class Timer {
      *
      * <p>This method may be called repeatedly; the second and subsequent
      * calls have no effect.
+     * @see TimerTask#cancel()
      */
     public void cancel() {
         synchronized(queue) {
@@ -445,23 +448,25 @@ public class Timer {
     }
 
     /**
-     * Removes all cancelled tasks from this timer's task queue.  <i>Calling
-     * this method has no effect on the behavior of the timer</i>, but
-     * eliminates the references to the cancelled tasks from the queue.
+     * Removes all <i>cancelled</i> tasks from this timer's task queue.
+     * <i>Calling this method has no effect on the behavior of the timer</i>,
+     * but eliminates the references to the cancelled tasks from the queue.
      * If there are no external references to these tasks, they become
      * eligible for garbage collection.
      *
      * <p>Most programs will have no need to call this method.
      * It is designed for use by the rare application that cancels a large
      * number of tasks.  Calling this method trades time for space: the
-     * runtime of the method may be proportional to n + c log n, where n
-     * is the number of tasks in the queue and c is the number of cancelled
-     * tasks.
+     * runtime of the method may be proportional to {@code n + c log n}, where
+     * {@code n} is the number of tasks in the queue and {@code c} is the number
+     * of cancelled tasks.
      *
      * <p>Note that it is permissible to call this method from within
      * a task scheduled on this timer.
      *
      * @return the number of tasks removed from the queue.
+     * @see #cancel()
+     * @see TimerTask#cancel()
      * @since 1.5
      */
      public int purge() {


### PR DESCRIPTION
Please review this PR which clarifies the definition of a _cancelled_ task in _j.util.Timer::purge_ and _j.util.Timer::cancel_.

Timer::purge claims that its return value is the number of tasks in the queue that were cancelled. This can be misleading, as a user can call Timer::cancel, thinking the rest of the tasks in the queue will be canceled (which should be the return value of Timer::purge).

In actuality, Timer::cancel _discards_ all of the tasks in the queue. For a task to have been _cancelled_, the task itself must have called TimerTask::cancel. 

This change emphasizes the difference between _discarding_ and _cancelling_ a task.
Additionally, this change also includes a drive-by update to use an _apiNote_ and _implNote_ tag in the class description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8319415](https://bugs.openjdk.org/browse/JDK-8319415) to be approved

### Issues
 * [JDK-8319378](https://bugs.openjdk.org/browse/JDK-8319378): Spec for j.util.Timer::purge and j.util.Timer::cancel could be improved (**Bug** - P4)
 * [JDK-8319415](https://bugs.openjdk.org/browse/JDK-8319415): Spec for j.util.Timer::purge and j.util.Timer::cancel could be improved (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16503/head:pull/16503` \
`$ git checkout pull/16503`

Update a local copy of the PR: \
`$ git checkout pull/16503` \
`$ git pull https://git.openjdk.org/jdk.git pull/16503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16503`

View PR using the GUI difftool: \
`$ git pr show -t 16503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16503.diff">https://git.openjdk.org/jdk/pull/16503.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16503#issuecomment-1793078597)