### PR TITLE
8319429: Resetting MXCSR flags degrades ecore

### DIFF
--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -214,6 +214,10 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
   product(bool, UseLibmIntrinsic, true, DIAGNOSTIC,                         \
           "Use Libm Intrinsics")                                            \
                                                                             \
+  /* Autodetected, see vm_version_x86.cpp */                                \
+  product(bool, DoEcoreOpt, false, DIAGNOSTIC,                              \
+          "Perform Ecore Optimization")                                     \
+                                                                            \
   /* Minimum array size in bytes to use AVX512 intrinsics */                \
   /* for copy, inflate and fill which don't bail out early based on any */  \
   /* condition. When this value is set to zero compare operations like */   \

--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -215,7 +215,7 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
           "Use Libm Intrinsics")                                            \
                                                                             \
   /* Autodetected, see vm_version_x86.cpp */                                \
-  product(bool, DoEcoreOpt, false, DIAGNOSTIC,                              \
+  product(bool, EnableX86ECoreOpts, false, DIAGNOSTIC,                      \
           "Perform Ecore Optimization")                                     \
                                                                             \
   /* Minimum array size in bytes to use AVX512 intrinsics */                \

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -3965,8 +3965,8 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::x86::_fpu_cntrl_wrd_trunc = 0x0D7F;
     // Round to nearest, 24-bit mode, exceptions masked
     StubRoutines::x86::_fpu_cntrl_wrd_24    = 0x007F;
-    // Round to nearest, 64-bit mode, exceptions masked
-    StubRoutines::x86::_mxcsr_std           = 0x1F80;
+    // Round to nearest, 64-bit mode, exceptions masked, flags specialized
+    StubRoutines::x86::_mxcsr_std           = DoEcoreOpt ? 0x1FBF : 0x1F80;
     // Note: the following two constants are 80-bit values
     //       layout is critical for correct loading by FPU.
     // Bias for strict fp multiply/divide

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -3966,7 +3966,7 @@ class StubGenerator: public StubCodeGenerator {
     // Round to nearest, 24-bit mode, exceptions masked
     StubRoutines::x86::_fpu_cntrl_wrd_24    = 0x007F;
     // Round to nearest, 64-bit mode, exceptions masked, flags specialized
-    StubRoutines::x86::_mxcsr_std           = DoEcoreOpt ? 0x1FBF : 0x1F80;
+    StubRoutines::x86::_mxcsr_std           = EnableX86ECoreOpts ? 0x1FBF : 0x1F80;
     // Note: the following two constants are 80-bit values
     //       layout is critical for correct loading by FPU.
     // Bias for strict fp multiply/divide

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3908,9 +3908,9 @@ address StubGenerator::generate_upcall_stub_exception_handler() {
 
 void StubGenerator::create_control_words() {
   // Round to nearest, 64-bit mode, exceptions masked, flags specialized
-  StubRoutines::x86::_mxcsr_std = DoEcoreOpt ? 0x1FBF : 0x1F80;
+  StubRoutines::x86::_mxcsr_std = EnableX86ECoreOpts ? 0x1FBF : 0x1F80;
   // Round to zero, 64-bit mode, exceptions masked, flags specialized
-  StubRoutines::x86::_mxcsr_rz = DoEcoreOpt ? 0x7FBF : 0x7F80;
+  StubRoutines::x86::_mxcsr_rz = EnableX86ECoreOpts ? 0x7FBF : 0x7F80;
 }
 
 // Initialization

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3907,10 +3907,10 @@ address StubGenerator::generate_upcall_stub_exception_handler() {
 }
 
 void StubGenerator::create_control_words() {
-  // Round to nearest, 64-bit mode, exceptions masked
-  StubRoutines::x86::_mxcsr_std = 0x1F80;
-  // Round to zero, 64-bit mode, exceptions masked
-  StubRoutines::x86::_mxcsr_rz = 0x7F80;
+  // Round to nearest, 64-bit mode, exceptions masked, flags specialized
+  StubRoutines::x86::_mxcsr_std = DoEcoreOpt ? 0x1FBF : 0x1F80;
+  // Round to zero, 64-bit mode, exceptions masked, flags specialized
+  StubRoutines::x86::_mxcsr_rz = DoEcoreOpt ? 0x7FBF : 0x7F80;
 }
 
 // Initialization

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -857,6 +857,12 @@ void VM_Version::get_processor_features() {
   }
 #endif
 
+  // Check if processor has Intel Ecore
+  if (FLAG_IS_DEFAULT(DoEcoreOpt) && is_intel() && cpu_family() == 6 &&
+    (_model == 0x97 || _model == 0xAC || _model == 0xAF)) {
+    FLAG_SET_DEFAULT(DoEcoreOpt, true);
+  }
+
   if (UseSSE < 4) {
     _features &= ~CPU_SSE4_1;
     _features &= ~CPU_SSE4_2;

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -858,9 +858,9 @@ void VM_Version::get_processor_features() {
 #endif
 
   // Check if processor has Intel Ecore
-  if (FLAG_IS_DEFAULT(DoEcoreOpt) && is_intel() && cpu_family() == 6 &&
+  if (FLAG_IS_DEFAULT(EnableX86ECoreOpts) && is_intel() && cpu_family() == 6 &&
     (_model == 0x97 || _model == 0xAC || _model == 0xAF)) {
-    FLAG_SET_DEFAULT(DoEcoreOpt, true);
+    FLAG_SET_DEFAULT(EnableX86ECoreOpts, true);
   }
 
   if (UseSSE < 4) {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -7423,7 +7423,7 @@ instruct vround_float_avx(vec dst, vec src, rRegP tmp, vec xtmp1, vec xtmp2, vec
   format %{ "vector_round_float $dst,$src\t! using $tmp, $xtmp1, $xtmp2, $xtmp3, $xtmp4 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    InternalAddress new_mxcsr = $constantaddress((jint)(DoEcoreOpt ? 0x3FBF : 0x3F80));
+    InternalAddress new_mxcsr = $constantaddress((jint)(EnableX86ECoreOpts ? 0x3FBF : 0x3F80));
     __ vector_round_float_avx($dst$$XMMRegister, $src$$XMMRegister,
                               ExternalAddress(StubRoutines::x86::vector_float_sign_flip()), new_mxcsr, vlen_enc,
                               $tmp$$Register, $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, $xtmp3$$XMMRegister, $xtmp4$$XMMRegister);
@@ -7440,7 +7440,7 @@ instruct vround_float_evex(vec dst, vec src, rRegP tmp, vec xtmp1, vec xtmp2, kR
   format %{ "vector_round_float $dst,$src\t! using $tmp, $xtmp1, $xtmp2, $ktmp1, $ktmp2 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    InternalAddress new_mxcsr = $constantaddress((jint)(DoEcoreOpt ? 0x3FBF : 0x3F80));
+    InternalAddress new_mxcsr = $constantaddress((jint)(EnableX86ECoreOpts ? 0x3FBF : 0x3F80));
     __ vector_round_float_evex($dst$$XMMRegister, $src$$XMMRegister,
                                ExternalAddress(StubRoutines::x86::vector_float_sign_flip()), new_mxcsr, vlen_enc,
                                $tmp$$Register, $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, $ktmp1$$KRegister, $ktmp2$$KRegister);
@@ -7455,7 +7455,7 @@ instruct vround_reg_evex(vec dst, vec src, rRegP tmp, vec xtmp1, vec xtmp2, kReg
   format %{ "vector_round_long $dst,$src\t! using $tmp, $xtmp1, $xtmp2, $ktmp1, $ktmp2 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    InternalAddress new_mxcsr = $constantaddress((jint)(DoEcoreOpt ? 0x3FBF : 0x3F80));
+    InternalAddress new_mxcsr = $constantaddress((jint)(EnableX86ECoreOpts ? 0x3FBF : 0x3F80));
     __ vector_round_double_evex($dst$$XMMRegister, $src$$XMMRegister,
                                 ExternalAddress(StubRoutines::x86::vector_double_sign_flip()), new_mxcsr, vlen_enc,
                                 $tmp$$Register, $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, $ktmp1$$KRegister, $ktmp2$$KRegister);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -7423,7 +7423,7 @@ instruct vround_float_avx(vec dst, vec src, rRegP tmp, vec xtmp1, vec xtmp2, vec
   format %{ "vector_round_float $dst,$src\t! using $tmp, $xtmp1, $xtmp2, $xtmp3, $xtmp4 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    InternalAddress new_mxcsr = $constantaddress((jint)0x3F80);
+    InternalAddress new_mxcsr = $constantaddress((jint)(DoEcoreOpt ? 0x3FBF : 0x3F80));
     __ vector_round_float_avx($dst$$XMMRegister, $src$$XMMRegister,
                               ExternalAddress(StubRoutines::x86::vector_float_sign_flip()), new_mxcsr, vlen_enc,
                               $tmp$$Register, $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, $xtmp3$$XMMRegister, $xtmp4$$XMMRegister);
@@ -7440,7 +7440,7 @@ instruct vround_float_evex(vec dst, vec src, rRegP tmp, vec xtmp1, vec xtmp2, kR
   format %{ "vector_round_float $dst,$src\t! using $tmp, $xtmp1, $xtmp2, $ktmp1, $ktmp2 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    InternalAddress new_mxcsr = $constantaddress((jint)0x3F80);
+    InternalAddress new_mxcsr = $constantaddress((jint)(DoEcoreOpt ? 0x3FBF : 0x3F80));
     __ vector_round_float_evex($dst$$XMMRegister, $src$$XMMRegister,
                                ExternalAddress(StubRoutines::x86::vector_float_sign_flip()), new_mxcsr, vlen_enc,
                                $tmp$$Register, $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, $ktmp1$$KRegister, $ktmp2$$KRegister);
@@ -7455,7 +7455,7 @@ instruct vround_reg_evex(vec dst, vec src, rRegP tmp, vec xtmp1, vec xtmp2, kReg
   format %{ "vector_round_long $dst,$src\t! using $tmp, $xtmp1, $xtmp2, $ktmp1, $ktmp2 as TEMP" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
-    InternalAddress new_mxcsr = $constantaddress((jint)0x3F80);
+    InternalAddress new_mxcsr = $constantaddress((jint)(DoEcoreOpt ? 0x3FBF : 0x3F80));
     __ vector_round_double_evex($dst$$XMMRegister, $src$$XMMRegister,
                                 ExternalAddress(StubRoutines::x86::vector_double_sign_flip()), new_mxcsr, vlen_enc,
                                 $tmp$$Register, $xtmp1$$XMMRegister, $xtmp2$$XMMRegister, $ktmp1$$KRegister, $ktmp2$$KRegister);

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -569,9 +569,6 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, PrintNMTStatistics, false, DIAGNOSTIC,                      \
           "Print native memory tracking summary data if it is on")          \
                                                                             \
-  product(bool, DoEcoreOpt, false, DIAGNOSTIC,                              \
-          "Perform Ecore Optimization")                                     \
-                                                                            \
   product(bool, LogCompilation, false, DIAGNOSTIC,                          \
           "Log compilation activity in detail to LogFile")                  \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -569,6 +569,9 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, PrintNMTStatistics, false, DIAGNOSTIC,                      \
           "Print native memory tracking summary data if it is on")          \
                                                                             \
+  product(bool, DoEcoreOpt, false, DIAGNOSTIC,                              \
+          "Perform Ecore Optimization")                                     \
+                                                                            \
   product(bool, LogCompilation, false, DIAGNOSTIC,                          \
           "Log compilation activity in detail to LogFile")                  \
                                                                             \


### PR DESCRIPTION
Improves vector rounding on ECore about 10x
```
(BEFORE) FpRoundingBenchmark.test_round_float        2048  thrpt    3  40.912 ± 0.044  ops/ms
(AFTER ) FpRoundingBenchmark.test_round_float        2048  thrpt    3  431.682 ± 0.727  ops/ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319429](https://bugs.openjdk.org/browse/JDK-8319429): Resetting MXCSR flags degrades ecore (**Enhancement** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16504/head:pull/16504` \
`$ git checkout pull/16504`

Update a local copy of the PR: \
`$ git checkout pull/16504` \
`$ git pull https://git.openjdk.org/jdk.git pull/16504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16504`

View PR using the GUI difftool: \
`$ git pr show -t 16504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16504.diff">https://git.openjdk.org/jdk/pull/16504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16504#issuecomment-1793207076)