### PR TITLE
8319444: Unhelpful failure output in TestLegalNotices

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testLegalNotices/TestLegalNotices.java
+++ b/test/langtools/jdk/javadoc/doclet/testLegalNotices/TestLegalNotices.java
@@ -111,6 +111,8 @@ public class TestLegalNotices extends JavadocTester {
         super.out.println("   Found: " + foundFiles);
         if (foundFiles.equals(expectFiles)) {
             passed("Found all expected files");
+        } else {
+            failed("Did not find all expected files");
         }
 
         // See JDK-8306980


### PR DESCRIPTION
Please consider this fix for [JDK-8319444: Unhelpful failure output in TestLegalNotices](https://bugs.openjdk.org/browse/JDK-8319444), which improves test output for failing subtests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319444](https://bugs.openjdk.org/browse/JDK-8319444): Unhelpful failure output in TestLegalNotices (**Bug** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16507/head:pull/16507` \
`$ git checkout pull/16507`

Update a local copy of the PR: \
`$ git checkout pull/16507` \
`$ git pull https://git.openjdk.org/jdk.git pull/16507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16507`

View PR using the GUI difftool: \
`$ git pr show -t 16507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16507.diff">https://git.openjdk.org/jdk/pull/16507.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16507#issuecomment-1793525878)