### PR TITLE
8316719: C2 compilation still fails with "bad AD file"

### DIFF
--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -152,6 +152,16 @@ static bool ok_to_convert(Node* inc, Node* var) {
   return !(is_cloop_increment(inc) || var->is_cloop_ind_var());
 }
 
+static bool is_cloop_condition(Node* bol) {
+  for (DUIterator_Fast imax, i = bol->fast_outs(imax); i < imax; i++) {
+    Node* out = bol->fast_out(i);
+    if (out->is_CountedLoopEnd()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 //------------------------------Ideal------------------------------------------
 Node *SubINode::Ideal(PhaseGVN *phase, bool can_reshape){
   Node *in1 = in(1);
@@ -1556,15 +1566,15 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // and    "cmp (add X min_jint) c" into "cmpu X (c + min_jint)"
   if (cop == Op_CmpI &&
       cmp1_op == Op_AddI &&
-      !is_cloop_increment(cmp1) &&
-      phase->type(cmp1->in(2)) == TypeInt::MIN) {
+      phase->type(cmp1->in(2)) == TypeInt::MIN &&
+      !is_cloop_condition(this)) {
     if (cmp2_op == Op_ConI) {
       Node* ncmp2 = phase->intcon(java_add(cmp2->get_int(), min_jint));
       Node* ncmp = phase->transform(new CmpUNode(cmp1->in(1), ncmp2));
       return new BoolNode(ncmp, _test._test);
     } else if (cmp2_op == Op_AddI &&
-               !is_cloop_increment(cmp2) &&
-               phase->type(cmp2->in(2)) == TypeInt::MIN) {
+               phase->type(cmp2->in(2)) == TypeInt::MIN &&
+               !is_cloop_condition(this)) {
       Node* ncmp = phase->transform(new CmpUNode(cmp1->in(1), cmp2->in(1)));
       return new BoolNode(ncmp, _test._test);
     }
@@ -1574,15 +1584,15 @@ Node *BoolNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   // and    "cmp (add X min_jlong) c" into "cmpu X (c + min_jlong)"
   if (cop == Op_CmpL &&
       cmp1_op == Op_AddL &&
-      !is_cloop_increment(cmp1) &&
-      phase->type(cmp1->in(2)) == TypeLong::MIN) {
+      phase->type(cmp1->in(2)) == TypeLong::MIN &&
+      !is_cloop_condition(this)) {
     if (cmp2_op == Op_ConL) {
       Node* ncmp2 = phase->longcon(java_add(cmp2->get_long(), min_jlong));
       Node* ncmp = phase->transform(new CmpULNode(cmp1->in(1), ncmp2));
       return new BoolNode(ncmp, _test._test);
     } else if (cmp2_op == Op_AddL &&
-               !is_cloop_increment(cmp2) &&
-               phase->type(cmp2->in(2)) == TypeLong::MIN) {
+               phase->type(cmp2->in(2)) == TypeLong::MIN &&
+               !is_cloop_condition(this)) {
       Node* ncmp = phase->transform(new CmpULNode(cmp1->in(1), cmp2->in(1)));
       return new BoolNode(ncmp, _test._test);
     }

--- a/src/hotspot/share/opto/subnode.cpp
+++ b/src/hotspot/share/opto/subnode.cpp
@@ -152,7 +152,7 @@ static bool ok_to_convert(Node* inc, Node* var) {
   return !(is_cloop_increment(inc) || var->is_cloop_ind_var());
 }
 
-static bool is_cloop_condition(Node* bol) {
+static bool is_cloop_condition(BoolNode* bol) {
   for (DUIterator_Fast imax, i = bol->fast_outs(imax); i < imax; i++) {
     Node* out = bol->fast_out(i);
     if (out->is_CountedLoopEnd()) {

--- a/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
@@ -31,17 +31,41 @@ package compiler.c2;
  *                   -XX:CompileCommand=compileonly,*MinValueStrideCountedLoop::test*
  *                   compiler.c2.MinValueStrideCountedLoop
  */
+
+/*
+ * @test
+ * @bug 8316719
+ * @summary Loop increment should not be transformed into unsigned comparison
+ *
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:-UseLoopPredicate
+ *                   -XX:CompileCommand=compileonly,*MinValueStrideCountedLoop::test*
+ *                   compiler.c2.MinValueStrideCountedLoop
+ */
 public class MinValueStrideCountedLoop {
     static int limit = 0;
     static int res = 0;
+    static int[] array = new int[1];
+    static boolean b;
 
-    static void test() {
+    static void test1() {
         for (int i = 0; i >= limit + -2147483647; i += -2147483648) {
             res += 42;
         }
     }
 
+    static int test2(int init, int limit) {
+        int res = 0;
+        int i = init;
+        do {
+            if (b) { }
+            res += array[i];
+            i += -2147483648;
+        } while (i >= limit + -2147483647);
+        return res;
+    }
+
     public static void main(String[] args) {
-        test();
+        test1();
+        test2(0, 0);
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/MinValueStrideCountedLoop.java
@@ -36,7 +36,7 @@ package compiler.c2;
  * @test
  * @bug 8316719
  * @summary Loop increment should not be transformed into unsigned comparison
- *
+ * @requires vm.compiler2.enabled
  * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:-UseLoopPredicate
  *                   -XX:CompileCommand=compileonly,*MinValueStrideCountedLoop::test*
  *                   compiler.c2.MinValueStrideCountedLoop


### PR DESCRIPTION
Hi,

As noted by Christian in JBS, checking for loop increment is unreliable. Since we are operating on the `BoolNode`, we can check for the counted loop condition directly.

Please let me know if there is any issue with this approach. Thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316719](https://bugs.openjdk.org/browse/JDK-8316719): C2 compilation still fails with "bad AD file" (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16509/head:pull/16509` \
`$ git checkout pull/16509`

Update a local copy of the PR: \
`$ git checkout pull/16509` \
`$ git pull https://git.openjdk.org/jdk.git pull/16509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16509`

View PR using the GUI difftool: \
`$ git pr show -t 16509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16509.diff">https://git.openjdk.org/jdk/pull/16509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16509#issuecomment-1793811751)