### PR TITLE
8319450: New methods java.net.InetXAddress.ofLiteral() miss @since tag

### DIFF
--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -173,6 +173,7 @@ class Inet4Address extends InetAddress {
      * @throws IllegalArgumentException if the {@code ipv4AddressLiteral} cannot be
      *         parsed as an IPv4 address literal.
      * @throws NullPointerException if the {@code ipv4AddressLiteral} is {@code null}.
+     * @since 22
      */
     public static Inet4Address ofLiteral(String ipv4AddressLiteral) {
         Objects.requireNonNull(ipv4AddressLiteral);

--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -518,6 +518,7 @@ class Inet6Address extends InetAddress {
      * @throws IllegalArgumentException if the {@code ipv6AddressLiteral} cannot be
      *         parsed as an IPv6 address literal.
      * @throws NullPointerException if the {@code ipv6AddressLiteral} is {@code null}.
+     * @since 22
      */
     public static InetAddress ofLiteral(String ipv6AddressLiteral) {
         Objects.requireNonNull(ipv6AddressLiteral);

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -1722,6 +1722,7 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * @throws NullPointerException if the {@code ipAddressLiteral} is {@code null}.
      * @see Inet4Address#ofLiteral(String)
      * @see Inet6Address#ofLiteral(String)
+     * @since 22
      */
     public static InetAddress ofLiteral(String ipAddressLiteral) {
         Objects.requireNonNull(ipAddressLiteral);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319450](https://bugs.openjdk.org/browse/JDK-8319450): New methods java.net.InetXAddress.ofLiteral() miss @<!---->since tag (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16511/head:pull/16511` \
`$ git checkout pull/16511`

Update a local copy of the PR: \
`$ git checkout pull/16511` \
`$ git pull https://git.openjdk.org/jdk.git pull/16511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16511`

View PR using the GUI difftool: \
`$ git pr show -t 16511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16511.diff">https://git.openjdk.org/jdk/pull/16511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16511#issuecomment-1793820652)