### PR TITLE
8319462: Signature.ClassTypeSig::classDesc() incorrect for inner class types

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/Signature.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/Signature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,7 +118,9 @@ public sealed interface Signature {
 
         /** {@return the class name, as a symbolic descriptor} */
         default ClassDesc classDesc() {
-            return ClassDesc.ofInternalName(className());
+            var outer = outerType();
+            return outer.isEmpty() ? ClassDesc.ofInternalName(className())
+                    : outer.get().classDesc().nested(className());
         }
 
         /** {@return the type arguments of the class} */


### PR DESCRIPTION
Observed this erroneous implementation while browsing, and included a quick test against javac output class file to confirm the correct implementation. @asotona Please take a look.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319462](https://bugs.openjdk.org/browse/JDK-8319462): Signature.ClassTypeSig::classDesc() incorrect for inner class types (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16513/head:pull/16513` \
`$ git checkout pull/16513`

Update a local copy of the PR: \
`$ git checkout pull/16513` \
`$ git pull https://git.openjdk.org/jdk.git pull/16513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16513`

View PR using the GUI difftool: \
`$ git pr show -t 16513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16513.diff">https://git.openjdk.org/jdk/pull/16513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16513#issuecomment-1794143369)