### PR TITLE
8319465: Typos in javadoc of com.sun.management.OperatingSystemMXBean methods

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,7 @@ public interface OperatingSystemMXBean extends
      * double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs
      * were idle during the recent period of time observed, while a value
      * of 1.0 means that all CPUs were actively running 100% of the time
-     * during the recent period being observed. All values betweens 0.0 and
+     * during the recent period being observed. All values between 0.0 and
      * 1.0 are possible depending of the activities going on in the system.
      * If the system recent cpu usage is not available, the method returns a
      * negative value.
@@ -157,7 +157,7 @@ public interface OperatingSystemMXBean extends
      * is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs
      * were idle during the recent period of time observed, while a value
      * of 1.0 means that all CPUs were actively running 100% of the time
-     * during the recent period being observed. All values betweens 0.0 and
+     * during the recent period being observed. All values between 0.0 and
      * 1.0 are possible depending of the activities going on.
      * If the recent cpu usage is not available, the method returns a
      * negative value.
@@ -176,7 +176,7 @@ public interface OperatingSystemMXBean extends
      * CPUs were actively running threads from the JVM 100% of the time
      * during the recent period being observed. Threads from the JVM include
      * the application threads as well as the JVM internal threads. All values
-     * betweens 0.0 and 1.0 are possible depending of the activities going on
+     * between 0.0 and 1.0 are possible depending of the activities going on
      * in the JVM process and the whole system. If the Java Virtual Machine
      * recent CPU usage is not available, the method returns a negative value.
      *


### PR DESCRIPTION
Can I please get a review of this PR which fixes the typos in the method javadocs of com.sun.management.OperatingSystemMXBean? 

As noted in https://bugs.openjdk.org/browse/JDK-8319465, this PR replaces the word "betweens" by "between"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319465](https://bugs.openjdk.org/browse/JDK-8319465): Typos in javadoc of com.sun.management.OperatingSystemMXBean methods (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16516/head:pull/16516` \
`$ git checkout pull/16516`

Update a local copy of the PR: \
`$ git checkout pull/16516` \
`$ git pull https://git.openjdk.org/jdk.git pull/16516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16516`

View PR using the GUI difftool: \
`$ git pr show -t 16516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16516.diff">https://git.openjdk.org/jdk/pull/16516.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16516#issuecomment-1794194949)