### PR TITLE
8319532: jshell - Non-sealed declarations sometimes break a snippet evaluation

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
@@ -306,7 +306,7 @@ class CompletenessAnalyzer {
         AMPAMP(TokenKind.AMPAMP, XEXPR, true),  //  &&
         BARBAR(TokenKind.BARBAR, XEXPR, true),  //  ||
         PLUS(TokenKind.PLUS, XEXPR1, true),  //  +
-        SUB(TokenKind.SUB, XEXPR1, true),  //  -
+        SUB(TokenKind.SUB, XEXPR1 | XDECL, true),  //  -
         SLASH(TokenKind.SLASH, XEXPR, true),  //  /
         BAR(TokenKind.BAR, XEXPR, true),  //  |
         CARET(TokenKind.CARET, XEXPR, true),  //  ^

--- a/src/jdk.jshell/share/classes/jdk/jshell/ReplParser.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/ReplParser.java
@@ -36,6 +36,7 @@ import static com.sun.tools.javac.parser.Tokens.TokenKind.CLASS;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.COLON;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.ENUM;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.EOF;
+import static com.sun.tools.javac.parser.Tokens.TokenKind.IDENTIFIER;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.IMPORT;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.INTERFACE;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.LPAREN;
@@ -182,11 +183,14 @@ class ReplParser extends JavacParser {
                 }
                 //fall-through
             default:
+                boolean nonSealed = token.kind == IDENTIFIER &&
+                                    isNonSealedIdentifier(token, 0);
                 JCModifiers mods = modifiersOpt(pmods);
                 if (token.kind == CLASS
                         || isRecordStart()
                         || token.kind == INTERFACE
-                        || token.kind == ENUM) {
+                        || token.kind == ENUM
+                        || nonSealed) {
                     return List.<JCTree>of(classOrRecordOrInterfaceOrEnumDeclaration(mods, dc));
                 } else {
                     int pos = token.pos;

--- a/src/jdk.jshell/share/classes/jdk/jshell/ReplParser.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/ReplParser.java
@@ -36,7 +36,6 @@ import static com.sun.tools.javac.parser.Tokens.TokenKind.CLASS;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.COLON;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.ENUM;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.EOF;
-import static com.sun.tools.javac.parser.Tokens.TokenKind.IDENTIFIER;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.IMPORT;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.INTERFACE;
 import static com.sun.tools.javac.parser.Tokens.TokenKind.LPAREN;
@@ -183,14 +182,11 @@ class ReplParser extends JavacParser {
                 }
                 //fall-through
             default:
-                boolean nonSealed = token.kind == IDENTIFIER &&
-                                    isNonSealedIdentifier(token, 0);
                 JCModifiers mods = modifiersOpt(pmods);
                 if (token.kind == CLASS
                         || isRecordStart()
                         || token.kind == INTERFACE
-                        || token.kind == ENUM
-                        || nonSealed) {
+                        || token.kind == ENUM) {
                     return List.<JCTree>of(classOrRecordOrInterfaceOrEnumDeclaration(mods, dc));
                 } else {
                     int pos = token.pos;

--- a/test/langtools/jdk/jshell/ClassesTest.java
+++ b/test/langtools/jdk/jshell/ClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8145239 8129559 8080354 8189248 8010319 8246353 8247456 8282160 8292755
+ * @bug 8145239 8129559 8080354 8189248 8010319 8246353 8247456 8282160 8292755 8319532
  * @summary Tests for EvaluationState.classes
  * @build KullaTesting TestingInputStream ExpectedDiagnostic
  * @run testng ClassesTest
@@ -372,6 +372,13 @@ public class ClassesTest extends KullaTesting {
                            }
                        }
                        """);
+    }
+
+    public void testNonSealed() {
+        assertAnalyze("non-sealed class C extends B {}int i;",
+                      "non-sealed class C extends B {}",
+                      "int i;",
+                      true);
     }
 
 }


### PR DESCRIPTION
JShell does not understand "non-sealed" modifier when splitting input into snippets. The reason is that `CompletenessAnalyzer.parseDeclaration` (https://github.com/openjdk/jdk/blob/cdf337357a62dd52c00e56e75912565e15b6adfd/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java#L687) is skipping through the declaration's initial tokens, but does not know it should ignore the `-` in the `non-sealed`. This patch fixes that by making `-` part of the declaration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319532](https://bugs.openjdk.org/browse/JDK-8319532): jshell - Non-sealed declarations sometimes break a snippet evaluation (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16523/head:pull/16523` \
`$ git checkout pull/16523`

Update a local copy of the PR: \
`$ git checkout pull/16523` \
`$ git pull https://git.openjdk.org/jdk.git pull/16523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16523`

View PR using the GUI difftool: \
`$ git pr show -t 16523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16523.diff">https://git.openjdk.org/jdk/pull/16523.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16523#issuecomment-1795469085)