### PR TITLE
8319559: [JVMCI] ensureLinked must be able to call Java

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -1978,6 +1978,7 @@ C2V_VMENTRY(void, ensureInitialized, (JNIEnv* env, jobject, ARGUMENT_PAIR(klass)
 C2V_END
 
 C2V_VMENTRY(void, ensureLinked, (JNIEnv* env, jobject, ARGUMENT_PAIR(klass)))
+  CompilerThreadCanCallJava canCallJava(thread, true); // Linking requires Java calls
   Klass* klass = UNPACK_PAIR(Klass, klass);
   if (klass == nullptr) {
     JVMCI_THROW(NullPointerException);


### PR DESCRIPTION
As of [JDK-8318694](https://bugs.openjdk.org/browse/JDK-8318694), only a few select C2V entry points in `jvmciCompilerToVM.cpp` can make Java calls. The `ensureLinked` method was not included but needs to be as it is called from a Truffle context executing on a Compiler thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319559](https://bugs.openjdk.org/browse/JDK-8319559): [JVMCI] ensureLinked must be able to call Java (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16530/head:pull/16530` \
`$ git checkout pull/16530`

Update a local copy of the PR: \
`$ git checkout pull/16530` \
`$ git pull https://git.openjdk.org/jdk.git pull/16530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16530`

View PR using the GUI difftool: \
`$ git pr show -t 16530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16530.diff">https://git.openjdk.org/jdk/pull/16530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16530#issuecomment-1796545114)