### PR TITLE
8319573: Change to Visual Studio 17.6.5 for building on Windows at Oracle

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -548,7 +548,7 @@ to compile successfully without issues.</p>
 </tr>
 <tr class="odd">
 <td>Windows</td>
-<td>Microsoft Visual Studio 2022 update 17.1.0</td>
+<td>Microsoft Visual Studio 2022 version 17.6.5</td>
 </tr>
 </tbody>
 </table>

--- a/doc/building.md
+++ b/doc/building.md
@@ -334,11 +334,11 @@ possible to compile the JDK with both older and newer versions, but the closer
 you stay to this list, the more likely you are to compile successfully without
 issues.
 
-| Operating system   | Toolchain version                          |
-| ------------------ | ------------------------------------------ |
-| Linux              | gcc 11.2.0                                 |
-| macOS              | Apple Xcode 14.3.1 (using clang 14.0.3)    |
-| Windows            | Microsoft Visual Studio 2022 update 17.1.0 |
+| Operating system   | Toolchain version                           |
+| ------------------ | ------------------------------------------- |
+| Linux              | gcc 11.2.0                                  |
+| macOS              | Apple Xcode 14.3.1 (using clang 14.0.3)     |
+| Windows            | Microsoft Visual Studio 2022 version 17.6.5 |
 
 All compilers are expected to be able to compile to the C99 language standard,
 as some C99 features are used in the source code. Microsoft Visual Studio

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1087,7 +1087,7 @@ var getJibProfilesDependencies = function (input, common) {
     var devkit_platform_revisions = {
         linux_x64: "gcc11.2.0-OL6.4+1.0",
         macosx: "Xcode14.3.1+1.0",
-        windows_x64: "VS2022-17.1.0+1.1",
+        windows_x64: "VS2022-17.6.5+1.0",
         linux_aarch64: input.build_cpu == "x64" ? "gcc11.2.0-OL7.6+1.1" : "gcc11.2.0-OL7.6+1.0",
         linux_arm: "gcc8.2.0-Fedora27+1.0",
         linux_ppc64le: "gcc8.2.0-Fedora27+1.0",


### PR DESCRIPTION
Oracle is updating the version of Visual Studio for building the JDK on Windows to Visual Studio 2022 17.6.5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319573](https://bugs.openjdk.org/browse/JDK-8319573): Change to Visual Studio 17.6.5 for building on Windows at Oracle (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16533/head:pull/16533` \
`$ git checkout pull/16533`

Update a local copy of the PR: \
`$ git checkout pull/16533` \
`$ git pull https://git.openjdk.org/jdk.git pull/16533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16533`

View PR using the GUI difftool: \
`$ git pr show -t 16533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16533.diff">https://git.openjdk.org/jdk/pull/16533.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16533#issuecomment-1797031673)