### PR TITLE
8319338: tools/jpackage/share/RuntimeImageTest.java fails with -XX:+UseZGC

### DIFF
--- a/test/jdk/tools/jpackage/share/RuntimeImageTest.java
+++ b/test/jdk/tools/jpackage/share/RuntimeImageTest.java
@@ -38,7 +38,7 @@ import jdk.jpackage.test.Executor;
  * @build jdk.jpackage.test.*
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @compile RuntimeImageTest.java
- * @run main/othervm/timeout=1400 -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=1400 jdk.jpackage.test.Main
  *  --jpt-run=RuntimeImageTest
  */
 


### PR DESCRIPTION
Remove `-Xmx512m` from the jtreg `@run` command as @AlanBateman suggested

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319338](https://bugs.openjdk.org/browse/JDK-8319338): tools/jpackage/share/RuntimeImageTest.java fails with -XX:+UseZGC (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16535/head:pull/16535` \
`$ git checkout pull/16535`

Update a local copy of the PR: \
`$ git checkout pull/16535` \
`$ git pull https://git.openjdk.org/jdk.git pull/16535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16535`

View PR using the GUI difftool: \
`$ git pr show -t 16535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16535.diff">https://git.openjdk.org/jdk/pull/16535.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16535#issuecomment-1797620806)