### PR TITLE
8319615: IGV incomplete gitignore

### DIFF
--- a/src/utils/IdealGraphVisualizer/.gitignore
+++ b/src/utils/IdealGraphVisualizer/.gitignore
@@ -4,4 +4,3 @@
 /lastModified/
 /localeVariants
 /package-attrs.dat
-

--- a/src/utils/IdealGraphVisualizer/.gitignore
+++ b/src/utils/IdealGraphVisualizer/.gitignore
@@ -1,2 +1,7 @@
 /*/target
 .igv.log
+/all-*.dat
+/lastModified/
+/localeVariants
+/package-attrs.dat
+


### PR DESCRIPTION
This changeset adds a number of IGV-generated files to the IGV `.gitignore`.

### Testing
No testing as there are no code changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319615](https://bugs.openjdk.org/browse/JDK-8319615): IGV incomplete gitignore (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16538/head:pull/16538` \
`$ git checkout pull/16538`

Update a local copy of the PR: \
`$ git checkout pull/16538` \
`$ git pull https://git.openjdk.org/jdk.git pull/16538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16538`

View PR using the GUI difftool: \
`$ git pr show -t 16538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16538.diff">https://git.openjdk.org/jdk/pull/16538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16538#issuecomment-1798269983)