### PR TITLE
8319620: Parallel: Remove unused PSPromotionManager::*_is_full getters and setters

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.hpp
@@ -133,11 +133,6 @@ class PSPromotionManager {
     return &_claimed_stack_depth;
   }
 
-  bool young_gen_is_full()             { return _young_gen_is_full; }
-
-  bool old_gen_is_full()               { return _old_gen_is_full; }
-  void set_old_gen_is_full(bool state) { _old_gen_is_full = state; }
-
   // Promotion methods
   template<bool promote_immediately> oop copy_to_survivor_space(oop o);
   oop oop_promotion_failed(oop obj, markWord obj_mark);


### PR DESCRIPTION
Hello,

  please review this trivial removal of some unused member functions in `PSPromotionManager`.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319620](https://bugs.openjdk.org/browse/JDK-8319620): Parallel: Remove unused PSPromotionManager::*_is_full getters and setters (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16539/head:pull/16539` \
`$ git checkout pull/16539`

Update a local copy of the PR: \
`$ git checkout pull/16539` \
`$ git pull https://git.openjdk.org/jdk.git pull/16539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16539`

View PR using the GUI difftool: \
`$ git pr show -t 16539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16539.diff">https://git.openjdk.org/jdk/pull/16539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16539#issuecomment-1798288842)