### PR TITLE
8318594: NMT: VM.native_memory crashes on assert if functionality isn't supported by OS

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3381,6 +3381,11 @@ bool os::committed_in_range(address start, size_t size, address& committed_start
       return false;
     }
 
+    // If mincore is not supported.
+    if (mincore_return_value == -1 && errno == ENOSYS) {
+      return false;
+    }
+
     assert(vec[stripe] == 'X', "overflow guard");
     assert(mincore_return_value == 0, "Range must be valid");
     // Process this stripe


### PR DESCRIPTION
The case of unsupported call (`mincore`) is caught and returned `false`.
Tier1 tested.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318594](https://bugs.openjdk.org/browse/JDK-8318594): NMT: VM.native_memory crashes on assert if functionality isn't supported by OS (**Bug** - P3)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16540/head:pull/16540` \
`$ git checkout pull/16540`

Update a local copy of the PR: \
`$ git checkout pull/16540` \
`$ git pull https://git.openjdk.org/jdk.git pull/16540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16540`

View PR using the GUI difftool: \
`$ git pr show -t 16540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16540.diff">https://git.openjdk.org/jdk/pull/16540.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16540#issuecomment-1798545659)