### PR TITLE
8319456: jdk/jfr/event/gc/collection/TestGCCauseWith[Serial|Parallel].java : GC cause 'GCLocker Initiated GC' not in the valid causes

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithParallelOld.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithParallelOld.java
@@ -39,7 +39,7 @@ public class TestGCCauseWithParallelOld {
         String testID = "ParallelOld";
         String[] vmFlags = {"-XX:+UseParallelGC"};
         String[] gcNames = {GCHelper.gcParallelScavenge, GCHelper.gcParallelOld};
-        String[] gcCauses = {"Allocation Failure", "Ergonomics", "System.gc()"};
+        String[] gcCauses = {"Allocation Failure", "Ergonomics", "System.gc()", "GCLocker Initiated GC"};
         GCGarbageCollectionUtil.test(testID, vmFlags, gcNames, gcCauses);
     }
 }

--- a/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithSerial.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithSerial.java
@@ -39,7 +39,7 @@ public class TestGCCauseWithSerial {
         String testID = "Serial";
         String[] vmFlags = {"-XX:+UseSerialGC"};
         String[] gcNames = {GCHelper.gcDefNew, GCHelper.gcSerialOld};
-        String[] gcCauses = {"Allocation Failure", "System.gc()"};
+        String[] gcCauses = {"Allocation Failure", "System.gc()", "GCLocker Initiated GC"};
         GCGarbageCollectionUtil.test(testID, vmFlags, gcNames, gcCauses);
     }
 }


### PR DESCRIPTION
Hi all,

  please review these fixes to the `jdk/jfr/event/gc/collection/TestGCCauseWith[Serial|Parallel].java` tests that fail if the GC cause has been "GCLocker Initiated GC".

This is a valid gc cause, just extremely rare (interestingly the corresponding G1 tests added it).

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319456](https://bugs.openjdk.org/browse/JDK-8319456): jdk/jfr/event/gc/collection/TestGCCauseWith[Serial|Parallel].java : GC cause 'GCLocker Initiated GC' not in the valid causes (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16542/head:pull/16542` \
`$ git checkout pull/16542`

Update a local copy of the PR: \
`$ git checkout pull/16542` \
`$ git pull https://git.openjdk.org/jdk.git pull/16542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16542`

View PR using the GUI difftool: \
`$ git pr show -t 16542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16542.diff">https://git.openjdk.org/jdk/pull/16542.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16542#issuecomment-1798598418)