### PR TITLE
8319554: Select LogOutput* directly for stdout and stderr

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -505,10 +505,10 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
       errstream->print_cr("Invalid output index '%s'", outputstr);
       return false;
     }
-  } else if (0 == strcmp(outputstr, StdoutLog->name())) { // stdout
+  } else if (strcmp(outputstr, StdoutLog->name()) == 0) { // stdout
     idx = 0;
     assert(find_output(outputstr) == idx, "sanity check");
-  } else if (0 == strcmp(outputstr, StderrLog->name())) { // stderr
+  } else if (strcmp(outputstr, StderrLog->name()) == 0) { // stderr
     idx = 1;
     assert(find_output(outputstr) == idx, "sanity check");
   } else { // Output specified using name

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -505,6 +505,12 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
       errstream->print_cr("Invalid output index '%s'", outputstr);
       return false;
     }
+  } else if (0 == strcmp(outputstr, StdoutLog->name())) { // stdout
+    idx = 0;
+    assert(find_output(outputstr) == idx, "sanity check");
+  } else if (0 == strcmp(outputstr, StderrLog->name())) { // stderr
+    idx = 1;
+    assert(find_output(outputstr) == idx, "sanity check");
   } else { // Output specified using name
     // Normalize the name, stripping quotes and ensures it includes type prefix
     size_t len = strlen(outputstr) + strlen(implicit_output_prefix) + 1;

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -256,45 +256,55 @@ TEST_VM_F(AsyncLogTest, droppingMessage) {
 TEST_VM_F(AsyncLogTest, stdoutOutput) {
   testing::internal::CaptureStdout();
   fprintf(stdout, "header");
-  if (set_log_config("stdout", "logging=debug")) {
-    test_asynclog_ls();
-    test_asynclog_drop_messages();
 
-    AsyncLogWriter::flush();
-    fflush(nullptr);
+  if (!set_log_config("stdout", "logging=debug")) {
+    return;
+  }
 
-    if (write_to_file(testing::internal::GetCapturedStdout())) {
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+  test_asynclog_ls();
+  test_asynclog_drop_messages();
 
-      if (AsyncLogWriter::instance() != nullptr) {
-        EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
-      }
-    }
+  AsyncLogWriter::flush();
+  fflush(nullptr);
+
+  if (!write_to_file(testing::internal::GetCapturedStdout())) {
+    return;
+  }
+
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+
+  if (AsyncLogWriter::instance() != nullptr) {
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
   }
 }
 
 TEST_VM_F(AsyncLogTest, stderrOutput) {
   testing::internal::CaptureStderr();
   fprintf(stderr, "header");
-  if (set_log_config("stderr", "logging=debug")) {
-    test_asynclog_ls();
-    test_asynclog_drop_messages();
 
-    AsyncLogWriter::flush();
-    fflush(nullptr);
+  if (!set_log_config("stderr", "logging=debug")) {
+    return;
+  }
 
-    if (write_to_file(testing::internal::GetCapturedStderr())) {
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+  test_asynclog_ls();
+  test_asynclog_drop_messages();
 
-      if (AsyncLogWriter::instance() != nullptr) {
-        EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
-      }
-    }
+  AsyncLogWriter::flush();
+  fflush(nullptr);
+
+  if (!write_to_file(testing::internal::GetCapturedStderr())) {
+    return;
+  }
+
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
+
+  if (AsyncLogWriter::instance() != nullptr) {
+    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
   }
 }

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -256,22 +256,22 @@ TEST_VM_F(AsyncLogTest, droppingMessage) {
 TEST_VM_F(AsyncLogTest, stdoutOutput) {
   testing::internal::CaptureStdout();
   fprintf(stdout, "header");
-  set_log_config("stdout", "logging=debug");
+  if (set_log_config("stdout", "logging=debug")) {
+    test_asynclog_ls();
+    test_asynclog_drop_messages();
 
-  test_asynclog_ls();
-  test_asynclog_drop_messages();
+    AsyncLogWriter::flush();
+    fflush(nullptr);
 
-  AsyncLogWriter::flush();
-  fflush(nullptr);
+    if (write_to_file(testing::internal::GetCapturedStdout())) {
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
-  if (write_to_file(testing::internal::GetCapturedStdout())) {
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
-
-    if (AsyncLogWriter::instance() != nullptr) {
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+      if (AsyncLogWriter::instance() != nullptr) {
+        EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+      }
     }
   }
 }
@@ -279,22 +279,22 @@ TEST_VM_F(AsyncLogTest, stdoutOutput) {
 TEST_VM_F(AsyncLogTest, stderrOutput) {
   testing::internal::CaptureStderr();
   fprintf(stderr, "header");
-  set_log_config("stderr", "logging=debug");
+  if (set_log_config("stderr", "logging=debug")) {
+    test_asynclog_ls();
+    test_asynclog_drop_messages();
 
-  test_asynclog_ls();
-  test_asynclog_drop_messages();
+    AsyncLogWriter::flush();
+    fflush(nullptr);
 
-  AsyncLogWriter::flush();
-  fflush(nullptr);
+    if (write_to_file(testing::internal::GetCapturedStderr())) {
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
+      EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
-  if (write_to_file(testing::internal::GetCapturedStderr())) {
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
-
-    if (AsyncLogWriter::instance() != nullptr) {
-      EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+      if (AsyncLogWriter::instance() != nullptr) {
+        EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
+      }
     }
   }
 }


### PR DESCRIPTION
This patch skips allocation on C heap and invoking jio_snprintf for stdout and stderr. 
They are 2 predefined LogOuptuts and can't be deleted. 

We also check the return value of set_log_config in test_asynclog.cpp. if configuration fails,
the test will be skipped. We expect tot fix the flaky failures(JDK-8309067).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319554](https://bugs.openjdk.org/browse/JDK-8319554): Select LogOutput* directly for stdout and stderr (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16543/head:pull/16543` \
`$ git checkout pull/16543`

Update a local copy of the PR: \
`$ git checkout pull/16543` \
`$ git pull https://git.openjdk.org/jdk.git pull/16543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16543`

View PR using the GUI difftool: \
`$ git pr show -t 16543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16543.diff">https://git.openjdk.org/jdk/pull/16543.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16543#issuecomment-1799280639)