### PR TITLE
8319649: inline_boxing_calls unused gvn variable

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2001,7 +2001,6 @@ void Compile::inline_boxing_calls(PhaseIterGVN& igvn) {
   if (_boxing_late_inlines.length() > 0) {
     assert(has_boxed_value(), "inconsistent");
 
-    PhaseGVN* gvn = initial_gvn();
     set_inlining_incrementally(true);
 
     igvn_worklist()->ensure_empty(); // should be done with igvn


### PR DESCRIPTION
Passes tier1 tests locally

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319649](https://bugs.openjdk.org/browse/JDK-8319649): inline_boxing_calls unused gvn variable (**Enhancement** - P5)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16544/head:pull/16544` \
`$ git checkout pull/16544`

Update a local copy of the PR: \
`$ git checkout pull/16544` \
`$ git pull https://git.openjdk.org/jdk.git pull/16544/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16544`

View PR using the GUI difftool: \
`$ git pr show -t 16544`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16544.diff">https://git.openjdk.org/jdk/pull/16544.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16544#issuecomment-1799344916)