### PR TITLE
8319598: SMFParser misinterprets interrupted running status

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/StandardMidiFileReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/StandardMidiFileReader.java
@@ -313,10 +313,10 @@ final class SMFParser {
             // reset current tick to 0
             long tick = 0;
 
-            // reset current status byte to 0 (invalid value).
+            // reset current running status byte to 0 (invalid value).
             // this should cause us to throw an InvalidMidiDataException if we don't
             // get a valid status byte from the beginning of the track.
-            int status = 0;
+            int runningStatus = 0;
             boolean endOfTrackFound = false;
 
             while (!trackFinished() && !endOfTrackFound) {
@@ -333,10 +333,17 @@ final class SMFParser {
                 // check for new status
                 int byteValue = readUnsigned();
 
+                int status;
                 if (byteValue >= 0x80) {
                     status = byteValue;
+
+                    // update running status (only for channel messages)
+                    if ((status & 0xF0) != 0xF0) {
+                        runningStatus = status;
+                    }
                 } else {
-                    data1 = byteValue;
+                    status = runningStatus;
+                    data1  = byteValue;
                 }
 
                 switch (status & 0xF0) {

--- a/test/jdk/javax/sound/midi/File/SMFInterruptedRunningStatus.java
+++ b/test/jdk/javax/sound/midi/File/SMFInterruptedRunningStatus.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayInputStream;
+
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.Sequence;
+import javax.sound.midi.Track;
+
+/**
+ * @test
+ * @bug 8319598
+ * @summary SMFParser bug with running status, interrupted by Meta or SysEx messages
+ */
+public class SMFInterruptedRunningStatus {
+
+    public static void main(String[] args) throws Exception {
+
+        byte[][] files = new byte[][] {SMF_1, SMF_2, SMF_3};
+        for (int i = 0; i < files.length; i++) {
+            Sequence seq = MidiSystem.getSequence(new ByteArrayInputStream(files[i]));
+            testSequence(seq, i + 1);
+        }
+
+        // no exception thrown, all files have been parsed correctly
+        System.out.println("Test passed");
+    }
+
+    private static void testSequence(Sequence seq, int fileNumber) {
+
+        // check number of tracks and number of events
+        Track[] tracks = seq.getTracks();
+        if (1 != tracks.length) {
+            throw new RuntimeException("file number " + fileNumber + " fails (incorrect number of tracks: " + tracks.length + ")");
+        }
+        Track track = tracks[0];
+        if (7 != track.size()) {
+            throw new RuntimeException("file number " + fileNumber + " fails (incorrect number of events: " + track.size() + ")");
+        }
+
+        // check status byte of each message
+        int[] expectedStatusBytes = new int[] {0x90, 0xFF, 0x90, 0x90, 0x90, 0xFF, 0xFF};
+        for (int i = 0; i < expectedStatusBytes.length; i++) {
+            int expected = expectedStatusBytes[i];
+            if (expected != track.get(i).getMessage().getStatus()) {
+                throw new RuntimeException("file number " + fileNumber + " fails (wrong status byte in event " + i + ")");
+            }
+        }
+    }
+
+    // MIDI file without running status - should work equally before and after the bugfix
+    private static final byte[] SMF_1 = {
+        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80, // file header
+        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x24,                                            // track header
+        0x00, (byte) 0x90, 0x3C, 0x7F,                         // delta time + Note-ON (C)
+        0x40, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (text)
+        0x20, (byte) 0x90, 0x3C, 0x00,                         // delta time + Note-OFF (C)
+        0x20, (byte) 0x90, 0x3E, 0x7F,                         // delta time + Note-ON (D)
+        0x60, (byte) 0x90, 0x3E, 0x00,                         // delta time + Note-OFF (D)
+        0x20, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (text)
+        0x00, (byte) 0xFF, 0x2F, 0x00                          // delta time + META message (end of track)
+    };
+
+    // MIDI file with running status, interrupted by a META message - failed before the bugfix
+    private static final byte[] SMF_2 = {
+        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80, // file header
+        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x21,                                            // track header
+        0x00, (byte) 0x90, 0x3C, 0x7F,                         // delta time + Note-ON (C)
+        0x40, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (interruptor)
+        0x20,              0x3C, 0x00,                         // delta time + Note-OFF (C) - running status
+        0x20,              0x3E, 0x7F,                         // delta time + Note-ON (D) - running status
+        0x60,              0x3E, 0x00,                         // delta time + Note-OFF (D) - running status
+        0x20, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (text)
+        0x00, (byte) 0xFF, 0x2F, 0x00                          // delta time + META message (end of track)
+    };
+
+    // MIDI file with running status, interrupted by a META message - succeeded before the bugfix
+    // but with wrong interpretation of the data
+    private static final byte[] SMF_3 = {
+        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80, // file header
+        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x21,                                            // track header
+        0x00, (byte) 0x90, 0x3C, 0x7F,                         // delta time + Note-ON (C)
+        0x40, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (interruptor)
+        0x20,              0x3C, 0x00,                         // delta time + Note-OFF (C) - running status
+        0x0D,              0x3E, 0x7F,                         // delta time + Note-ON (D) - running status
+        0x60,              0x3E, 0x00,                         // delta time + Note-OFF (D) - running status
+        0x20, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (text)
+        0x00, (byte) 0xFF, 0x2F, 0x00                          // delta time + META message (end of track)
+    };
+}
+

--- a/test/jdk/javax/sound/midi/File/SMFInterruptedRunningStatus.java
+++ b/test/jdk/javax/sound/midi/File/SMFInterruptedRunningStatus.java
@@ -38,7 +38,8 @@ public class SMFInterruptedRunningStatus {
 
         byte[][] files = new byte[][] {SMF_1, SMF_2, SMF_3};
         for (int i = 0; i < files.length; i++) {
-            Sequence seq = MidiSystem.getSequence(new ByteArrayInputStream(files[i]));
+            Sequence seq = MidiSystem.getSequence(
+                    new ByteArrayInputStream(files[i]));
             testSequence(seq, i + 1);
         }
 
@@ -51,61 +52,93 @@ public class SMFInterruptedRunningStatus {
         // check number of tracks and number of events
         Track[] tracks = seq.getTracks();
         if (1 != tracks.length) {
-            throw new RuntimeException("file number " + fileNumber + " fails (incorrect number of tracks: " + tracks.length + ")");
+            throw new RuntimeException("file number "
+                    + fileNumber + " fails (incorrect number of tracks: "
+                    + tracks.length + ")");
         }
         Track track = tracks[0];
         if (7 != track.size()) {
-            throw new RuntimeException("file number " + fileNumber + " fails (incorrect number of events: " + track.size() + ")");
+            throw new RuntimeException("file number " + fileNumber
+                    + " fails (incorrect number of events: "
+                    + track.size() + ")");
         }
 
         // check status byte of each message
-        int[] expectedStatusBytes = new int[] {0x90, 0xFF, 0x90, 0x90, 0x90, 0xFF, 0xFF};
+        int[] expectedStatusBytes = new int[] {
+                0x90, 0xFF, 0x90, 0x90, 0x90, 0xFF, 0xFF};
         for (int i = 0; i < expectedStatusBytes.length; i++) {
             int expected = expectedStatusBytes[i];
             if (expected != track.get(i).getMessage().getStatus()) {
-                throw new RuntimeException("file number " + fileNumber + " fails (wrong status byte in event " + i + ")");
+                throw new RuntimeException("file number " + fileNumber
+                        + " fails (wrong status byte in event " + i + ")");
             }
         }
     }
 
-    // MIDI file without running status - should work equally before and after the bugfix
+    // MIDI file without running status - should work equally before
+    // and after the bugfix
     private static final byte[] SMF_1 = {
-        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80, // file header
-        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x24,                                            // track header
-        0x00, (byte) 0x90, 0x3C, 0x7F,                         // delta time + Note-ON (C)
-        0x40, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (text)
-        0x20, (byte) 0x90, 0x3C, 0x00,                         // delta time + Note-OFF (C)
-        0x20, (byte) 0x90, 0x3E, 0x7F,                         // delta time + Note-ON (D)
-        0x60, (byte) 0x90, 0x3E, 0x00,                         // delta time + Note-OFF (D)
-        0x20, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (text)
-        0x00, (byte) 0xFF, 0x2F, 0x00                          // delta time + META message (end of track)
+        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06,  // file header (start)
+        0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80,       // file header (end)
+        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x24,  // track header
+        0x00,                                            // delta time
+        (byte) 0x90, 0x3C, 0x7F,                         // Note-ON (C)
+        0x40,                                            // delta time
+        (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // META (text)
+        0x20,                                            // delta time
+        (byte) 0x90, 0x3C, 0x00,                         // Note-OFF (C)
+        0x20,                                            // delta time
+        (byte) 0x90, 0x3E, 0x7F,                         // Note-ON (D)
+        0x60,                                            // delta time
+        (byte) 0x90, 0x3E, 0x00,                         // Note-OFF (D)
+        0x20,                                            // delta time
+        (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // META (text)
+        0x00,                                            // delta time
+        (byte) 0xFF, 0x2F, 0x00                          // META (end of track)
     };
 
-    // MIDI file with running status, interrupted by a META message - failed before the bugfix
+    // MIDI file with running status, interrupted by a META message
+    // - failed before the bugfix
     private static final byte[] SMF_2 = {
-        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80, // file header
-        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x21,                                            // track header
-        0x00, (byte) 0x90, 0x3C, 0x7F,                         // delta time + Note-ON (C)
-        0x40, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (interruptor)
-        0x20,              0x3C, 0x00,                         // delta time + Note-OFF (C) - running status
-        0x20,              0x3E, 0x7F,                         // delta time + Note-ON (D) - running status
-        0x60,              0x3E, 0x00,                         // delta time + Note-OFF (D) - running status
-        0x20, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (text)
-        0x00, (byte) 0xFF, 0x2F, 0x00                          // delta time + META message (end of track)
+        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06,  // file header (start)
+        0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80,       // file header (end)
+        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x21,  // track header
+        0x00,                                            // delta time
+        (byte) 0x90, 0x3C, 0x7F,                         // Note-ON (C)
+        0x40,                                            // delta time
+        (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // META (interruptor)
+        0x20,                                            // delta time
+        0x3C, 0x00,                                      // Note-OFF (C) - running status
+        0x20,                                            // delta time
+        0x3E, 0x7F,                                      // Note-ON (D) - running status
+        0x60,                                            // delta time
+        0x3E, 0x00,                                      // Note-OFF (D) - running status
+        0x20,                                            // delta time
+        (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // META (text)
+        0x00,                                            // delta time
+        (byte) 0xFF, 0x2F, 0x00                          // META (end of track)
     };
 
-    // MIDI file with running status, interrupted by a META message - succeeded before the bugfix
-    // but with wrong interpretation of the data
+    // MIDI file with running status, interrupted by a META message
+    // - succeeded before the bugfix but with wrong interpretation of the data
     private static final byte[] SMF_3 = {
-        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06, 0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80, // file header
-        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x21,                                            // track header
-        0x00, (byte) 0x90, 0x3C, 0x7F,                         // delta time + Note-ON (C)
-        0x40, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (interruptor)
-        0x20,              0x3C, 0x00,                         // delta time + Note-OFF (C) - running status
-        0x0D,              0x3E, 0x7F,                         // delta time + Note-ON (D) - running status
-        0x60,              0x3E, 0x00,                         // delta time + Note-OFF (D) - running status
-        0x20, (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // delta time + META message (text)
-        0x00, (byte) 0xFF, 0x2F, 0x00                          // delta time + META message (end of track)
+        0x4D, 0x54, 0x68, 0x64, 0x00, 0x00, 0x00, 0x06,  // file header (start)
+        0x00, 0x01, 0x00, 0x01, 0x00, (byte) 0x80,       // file header (end)
+        0x4D, 0x54, 0x72, 0x6B, 0x00, 0x00, 0x00, 0x21,  // track header
+        0x00,                                            // delta time
+        (byte) 0x90, 0x3C, 0x7F,                         // Note-ON (C)
+        0x40,                                            // delta time
+        (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // META (interruptor)
+        0x20,                                            // delta time
+        0x3C, 0x00,                                      // Note-OFF (C) - running status
+        0x0D,                                            // delta time
+        0x3E, 0x7F,                                      // Note-ON (D) - running status
+        0x60,                                            // delta time
+        0x3E, 0x00,                                      // Note-OFF (D) - running status
+        0x20,                                            // delta time
+        (byte) 0xFF, 0x01, 0x04, 0x54, 0x65, 0x73, 0x74, // META (text)
+        0x00,                                            // delta time
+        (byte) 0xFF, 0x2F, 0x00                          // META (end of track)
     };
 }
 


### PR DESCRIPTION
The MIDI file parser misinterprets events without status byte when they appear directly after a Meta of SysEx event.

For my bugfix I had to decide between two possible solutions:
- Strict solution: Throw an InvalidMidiDataException
- Tolerant solution: Use the status of the last channel event as running status

I used the tolerant solution.
I will send an email to the list client-libs-dev with my reasons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319598](https://bugs.openjdk.org/browse/JDK-8319598): SMFParser misinterprets interrupted running status (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16546/head:pull/16546` \
`$ git checkout pull/16546`

Update a local copy of the PR: \
`$ git checkout pull/16546` \
`$ git pull https://git.openjdk.org/jdk.git pull/16546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16546`

View PR using the GUI difftool: \
`$ git pr show -t 16546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16546.diff">https://git.openjdk.org/jdk/pull/16546.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16546#issuecomment-1799773019)