### PR TITLE
8319665: [macOS] Obsolete imports of <Carbon/Carbon.h> in java.desktop

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuItem.m
@@ -23,7 +23,6 @@
  * questions.
  */
 
-#include <Carbon/Carbon.h>
 #import "CMenuItem.h"
 #import "CMenu.h"
 #import "AWTEvent.h"

--- a/src/java.desktop/macosx/native/libosxui/ScreenMenu.h
+++ b/src/java.desktop/macosx/native/libosxui/ScreenMenu.h
@@ -24,4 +24,3 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import <Carbon/Carbon.h>


### PR DESCRIPTION
Remove unused imports

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319665](https://bugs.openjdk.org/browse/JDK-8319665): [macOS] Obsolete imports of &lt;Carbon/Carbon.h&gt; in java.desktop (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16548/head:pull/16548` \
`$ git checkout pull/16548`

Update a local copy of the PR: \
`$ git checkout pull/16548` \
`$ git pull https://git.openjdk.org/jdk.git pull/16548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16548`

View PR using the GUI difftool: \
`$ git pr show -t 16548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16548.diff">https://git.openjdk.org/jdk/pull/16548.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16548#issuecomment-1800285033)