### PR TITLE
8319253: [BACKOUT] Change LockingMode default from LM_LEGACY to LM_LIGHTWEIGHT

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1978,11 +1978,11 @@ const int ObjectAlignmentInBytes = 8;
              "Mark all threads after a safepoint, and clear on a modify "   \
              "fence. Add cleanliness checks.")                              \
                                                                             \
-  product(int, LockingMode, LM_LIGHTWEIGHT,                                 \
+  product(int, LockingMode, LM_LEGACY,                                      \
           "Select locking mode: "                                           \
           "0: monitors only (LM_MONITOR), "                                 \
-          "1: monitors & legacy stack-locking (LM_LEGACY), "                \
-          "2: monitors & new lightweight locking (LM_LIGHTWEIGHT, default)") \
+          "1: monitors & legacy stack-locking (LM_LEGACY, default), "       \
+          "2: monitors & new lightweight locking (LM_LIGHTWEIGHT)")         \
           range(0, 2)                                                       \
                                                                             \
   product(uint, TrimNativeHeapInterval, 0, EXPERIMENTAL,                    \


### PR DESCRIPTION
The change of default locking mode for JDK 22 is being restored to LM_LEGACY due to remaining stability and performance issues that have been uncovered with lightweight locking, for which solutions have not yet been found, but are being actively investigated. We will make the change in JDK 23 instead.

This reverts commit 455cfae1e137ff3055b3cc858e8954f60bdf3147.

Testing: tiers 1-3 (our internal tier 3 testing includes a set of tests using mode LM_LIGHTWEIGHT so that it will continue to experience some testing until we flip things back in December)

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319253](https://bugs.openjdk.org/browse/JDK-8319253): [BACKOUT] Change LockingMode default from LM_LEGACY to LM_LIGHTWEIGHT (**Sub-task** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16551/head:pull/16551` \
`$ git checkout pull/16551`

Update a local copy of the PR: \
`$ git checkout pull/16551` \
`$ git pull https://git.openjdk.org/jdk.git pull/16551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16551`

View PR using the GUI difftool: \
`$ git pr show -t 16551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16551.diff">https://git.openjdk.org/jdk/pull/16551.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16551#issuecomment-1800703060)