### PR TITLE
8210807: Printing a JTable with a JScrollPane prints table without rows populated

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -605,14 +605,14 @@ public class JViewport extends JComponent implements Accessible
 
 
     private Graphics getBackingStoreGraphics(Graphics g) {
-        if (g instanceof PrinterGraphics || g instanceof PrintGraphics) {
-            return g;
-        } else {
+        if (!SwingUtilities2.isPrinting(g)) {
             Graphics bsg = backingStoreImage.getGraphics();
             bsg.setColor(g.getColor());
             bsg.setFont(g.getFont());
             bsg.setClip(g.getClipBounds());
             return bsg;
+        } else {
+            return g;
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -48,7 +48,8 @@ import java.util.Collections;
 
 import sun.awt.AWTAccessor;
 import sun.swing.SwingUtilities2;
-import sun.java2d.SunGraphics2D;
+import java.awt.PrintGraphics;
+import java.awt.print.PrinterGraphics;
 
 /**
  * The "viewport" or "porthole" through which you see the underlying
@@ -604,14 +605,14 @@ public class JViewport extends JComponent implements Accessible
 
 
     private Graphics getBackingStoreGraphics(Graphics g) {
-        if (g instanceof SunGraphics2D) {
+        if (g instanceof PrinterGraphics || g instanceof PrintGraphics) {
+            return g;
+        } else {
             Graphics bsg = backingStoreImage.getGraphics();
             bsg.setColor(g.getColor());
             bsg.setFont(g.getFont());
             bsg.setClip(g.getClipBounds());
             return bsg;
-        } else {
-            return g;
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -604,22 +604,22 @@ public class JViewport extends JComponent implements Accessible
 
 
     private Graphics getBackingStoreGraphics(Graphics g) {
-        Graphics bsg = backingStoreImage.getGraphics();
-        bsg.setColor(g.getColor());
-        bsg.setFont(g.getFont());
-        bsg.setClip(g.getClipBounds());
-        return bsg;
+        if (g instanceof SunGraphics2D) {
+            Graphics bsg = backingStoreImage.getGraphics();
+            bsg.setColor(g.getColor());
+            bsg.setFont(g.getFont());
+            bsg.setClip(g.getClipBounds());
+            return bsg;
+        } else {
+            return g;
+        }
     }
 
 
     private void paintViaBackingStore(Graphics g) {
         Graphics bsg = getBackingStoreGraphics(g);
         try {
-            if (g instanceof SunGraphics2D) {
-                super.paint(bsg);
-            } else {
-                super.paint(g);
-            }
+            super.paint(bsg);
             g.drawImage(backingStoreImage, 0, 0, this);
         } finally {
             bsg.dispose();
@@ -629,11 +629,7 @@ public class JViewport extends JComponent implements Accessible
     private void paintViaBackingStore(Graphics g, Rectangle oClip) {
         Graphics bsg = getBackingStoreGraphics(g);
         try {
-            if (g instanceof SunGraphics2D) {
-                super.paint(bsg);
-            } else {
-                super.paint(g);
-            }
+            super.paint(bsg);
             g.setClip(oClip);
             g.drawImage(backingStoreImage, 0, 0, this);
         } finally {

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 
 import sun.awt.AWTAccessor;
 import sun.swing.SwingUtilities2;
+import sun.java2d.SunGraphics2D;
 
 /**
  * The "viewport" or "porthole" through which you see the underlying
@@ -614,7 +615,11 @@ public class JViewport extends JComponent implements Accessible
     private void paintViaBackingStore(Graphics g) {
         Graphics bsg = getBackingStoreGraphics(g);
         try {
-            super.paint(bsg);
+            if (g instanceof SunGraphics2D) {
+                super.paint(bsg);
+            } else {
+                super.paint(g);
+            }
             g.drawImage(backingStoreImage, 0, 0, this);
         } finally {
             bsg.dispose();
@@ -624,7 +629,11 @@ public class JViewport extends JComponent implements Accessible
     private void paintViaBackingStore(Graphics g, Rectangle oClip) {
         Graphics bsg = getBackingStoreGraphics(g);
         try {
-            super.paint(bsg);
+            if (g instanceof SunGraphics2D) {
+                super.paint(bsg);
+            } else {
+                super.paint(g);
+            }
             g.setClip(oClip);
             g.drawImage(backingStoreImage, 0, 0, this);
         } finally {

--- a/src/java.desktop/share/classes/javax/swing/JViewport.java
+++ b/src/java.desktop/share/classes/javax/swing/JViewport.java
@@ -48,8 +48,6 @@ import java.util.Collections;
 
 import sun.awt.AWTAccessor;
 import sun.swing.SwingUtilities2;
-import java.awt.PrintGraphics;
-import java.awt.print.PrinterGraphics;
 
 /**
  * The "viewport" or "porthole" through which you see the underlying

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -1317,7 +1317,7 @@ public class SwingUtilities2 {
      * returns true if the Graphics is print Graphics
      * false otherwise
      */
-    static boolean isPrinting(Graphics g) {
+    public static boolean isPrinting(Graphics g) {
         return (g instanceof PrinterGraphics || g instanceof PrintGraphics);
     }
 

--- a/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
+++ b/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
@@ -45,8 +45,14 @@ import javax.swing.table.DefaultTableModel;
  * @bug 8210807
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
- * @summary Test to check if JTable can be printed when it is
- * added JScrollPane.
+ * @summary Test to check if JTable can be printed when JScrollPane added to it.
+ *
+ *
+ *
+ *
+ *
+ *
+ *   
  * @run main/manual JTableScrollPrintTest
  */
 
@@ -65,7 +71,7 @@ public class JTableScrollPrintTest {
         passFailJFrame.awaitAndCheck();
     }
 
-    public static void initialize() throws Exception{
+    public static void initialize() throws Exception {
         final String INSTRUCTIONS = """
                 Instructions to Test:
                 1. Print table onto Paper/PDF, using the Print Dialog.
@@ -119,6 +125,7 @@ public class JTableScrollPrintTest {
 
     static class PrintUtilities implements Printable {
         private Component componentToBePrinted;
+
         public void printComponent(Component c, String jobname) {
             new PrintUtilities(c).print(jobname);
         }
@@ -160,8 +167,8 @@ public class JTableScrollPrintTest {
 
                 double panelX= c.getWidth();
                 double panelY= c.getHeight();
-                float imageableX = (float) pageFormat.getImageableWidth()-1;
-                float imageableY = (float) pageFormat.getImageableHeight()-1;
+                float imageableX = (float) pageFormat.getImageableWidth() - 1;
+                float imageableY = (float) pageFormat.getImageableHeight() - 1;
 
                 double xscale = imageableX/panelX;
                 double yscale = imageableY/panelY;

--- a/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
+++ b/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
@@ -97,9 +97,10 @@ public class JTableScrollPrintTest {
             model.addColumn("Column 3");
             model.addColumn("Column 4");
 
-            for (int row = 1; row <= 5; row++)
-                model.addRow(new Object[] {
-                        "R"+row+" C1", "R"+row+" C2", "R"+row+" C3", "R"+row+" C4" });
+            for (int row = 1; row <= 5; row++) {
+                model.addRow(new Object[]{
+                        "R" + row + " C1", "R" + row + " C2", "R" + row + " C3", "R" + row + " C4"});
+            }
 
             JTable table = new JTable(model);
 

--- a/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
+++ b/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
@@ -143,7 +143,7 @@ public class JTableScrollPrintTest {
             if (printJob.printDialog()) {
                 try {
                     printJob.print();
-                } catch(PrinterException pe) {
+                } catch (PrinterException pe) {
                     System.out.println("Error printing: " + pe);
                 }
             }
@@ -151,7 +151,7 @@ public class JTableScrollPrintTest {
 
         public int print(Graphics g, PageFormat pageFormat, int pageIndex) {
             if (pageIndex > 0) {
-                return(NO_SUCH_PAGE);
+                return NO_SUCH_PAGE;
             } else {
                 Graphics2D g2d = (Graphics2D)g;
                 g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
@@ -178,7 +178,7 @@ public class JTableScrollPrintTest {
 
                 g2d.scale(optimalScale, optimalScale);
                 c.paint(g2d);
-                return(PAGE_EXISTS);
+                return PAGE_EXISTS;
             }
         }
     }

--- a/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
+++ b/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
@@ -194,10 +194,4 @@ public class JTableScrollPrintTest {
             currentManager.setDoubleBufferingEnabled(true);
         }
     }
-
-    protected void processWindowEvent(WindowEvent e) {
-        if (e.getID() == WindowEvent.WINDOW_CLOSING) {
-            System.exit(0);
-        }
-    }
 }

--- a/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
+++ b/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
@@ -46,13 +46,6 @@ import javax.swing.table.DefaultTableModel;
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Test to check if JTable can be printed when JScrollPane added to it.
- *
- *
- *
- *
- *
- *
- *   
  * @run main/manual JTableScrollPrintTest
  */
 
@@ -141,7 +134,7 @@ public class JTableScrollPrintTest {
 
             // set margins to 1/2"
             Paper p = new Paper();
-            p.setImageableArea(36, 36, p.getWidth()-72, p.getHeight()-72);
+            p.setImageableArea(36, 36, p.getWidth() - 72, p.getHeight() - 72);
             pf.setPaper(p);
 
             printJob.setPrintable(this, pf);
@@ -162,11 +155,11 @@ public class JTableScrollPrintTest {
             } else {
                 Graphics2D g2d = (Graphics2D)g;
                 g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
-                Component c= componentToBePrinted;
+                Component c = componentToBePrinted;
                 c.setSize(c.getPreferredSize());
 
-                double panelX= c.getWidth();
-                double panelY= c.getHeight();
+                double panelX = c.getWidth();
+                double panelY = c.getHeight();
                 float imageableX = (float) pageFormat.getImageableWidth() - 1;
                 float imageableY = (float) pageFormat.getImageableHeight() - 1;
 

--- a/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
+++ b/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Paper;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import javax.swing.BoxLayout;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JViewport;
+import javax.swing.RepaintManager;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+
+import java.awt.event.WindowEvent;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8210807
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Test to check if JTable can be printed when it is
+ * added JScrollPane.
+ * @run main/manual JTableScrollPrintTest
+ */
+
+public class JTableScrollPrintTest {
+    public static JFrame frame;
+    public static PassFailJFrame passFailJFrame;
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            try {
+                initialize();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        passFailJFrame.awaitAndCheck();
+    }
+
+    public static void initialize() throws Exception{
+        final String INSTRUCTIONS = """
+                Instructions to Test:
+                1. Print table onto Paper/PDF, using the Print Dialog.
+                2. If entire table is printed, then the Test is PASS.
+                3. If table is partially printed without table cells,
+                then the Test is FAIL.
+                """;
+        TestTable testTable = new TestTable(true);
+        frame = new JFrame("JTable Print Test");
+        passFailJFrame = new PassFailJFrame("Test Instructions", INSTRUCTIONS, 5L, 6, 35);
+
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.VERTICAL);
+        frame.add(testTable);
+        frame.pack();
+        frame.setVisible(true);
+        PrintUtilities printerJob = new PrintUtilities(testTable);
+        printerJob.print("Test BackingStore Image Print");
+    }
+
+    public static class TestTable extends JPanel {
+        public TestTable(Boolean useScrollPane) {
+
+            setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+
+            DefaultTableModel model = new DefaultTableModel();
+            model.addColumn("Column 1");
+            model.addColumn("Column 2");
+            model.addColumn("Column 3");
+            model.addColumn("Column 4");
+
+            for (int row=1;row<=5;row++)
+                model.addRow(new Object[] {
+                        "R"+row+" C1", "R"+row+" C2", "R"+row+" C3", "R"+row+" C4" });
+
+            JTable table = new JTable(model);
+
+            if (useScrollPane == true) {
+                JScrollPane sp = new JScrollPane(table,
+                        JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
+                        JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+                sp.getViewport().setScrollMode(JViewport.BACKINGSTORE_SCROLL_MODE);
+                add(sp);
+            } else {
+                add(table.getTableHeader());
+                add(table);
+            }
+        }
+    }
+
+    static class PrintUtilities implements Printable {
+        private Component componentToBePrinted;
+        public void printComponent(Component c, String jobname) {
+            new PrintUtilities(c).print(jobname);
+        }
+
+        public PrintUtilities(Component componentToBePrinted) {
+            this.componentToBePrinted = componentToBePrinted;
+        }
+
+        public void print(String jobname) {
+            PrinterJob printJob = PrinterJob.getPrinterJob();
+            PageFormat pf = printJob.defaultPage();
+            pf.setOrientation(PageFormat.PORTRAIT);
+
+            // set margins to 1/2"
+            Paper p = new Paper();
+            p.setImageableArea(36, 36, p.getWidth()-72, p.getHeight()-72);
+            pf.setPaper(p);
+
+            printJob.setPrintable(this, pf);
+            printJob.setJobName(jobname);
+
+            if (printJob.printDialog()) {
+                try {
+                    printJob.print();
+                } catch(PrinterException pe) {
+                    System.out.println("Error printing: " + pe);
+                }
+            }
+        }
+
+        public int print(Graphics g, PageFormat pageFormat, int pageIndex) {
+            if (pageIndex > 0) {
+                return(NO_SUCH_PAGE);
+            } else {
+                Graphics2D g2d = (Graphics2D)g;
+                g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+                Component c= componentToBePrinted;
+                c.setSize(c.getPreferredSize());
+
+                double panelX= c.getWidth();
+                double panelY= c.getHeight();
+                float imageableX = (float) pageFormat.getImageableWidth()-1;
+                float imageableY = (float) pageFormat.getImageableHeight()-1;
+
+                double xscale = imageableX/panelX;
+                double yscale = imageableY/panelY;
+                double optimalScale;
+                if (xscale < yscale)
+                    optimalScale = xscale;
+                else
+                    optimalScale = yscale;
+
+                if (optimalScale > 1)
+                    optimalScale = 1;
+
+                g2d.scale(optimalScale, optimalScale);
+                disableDoubleBuffering(c);
+                c.paint(g2d);
+                enableDoubleBuffering(c);
+                return(PAGE_EXISTS);
+            }
+        }
+
+        public void disableDoubleBuffering(Component c) {
+            RepaintManager currentManager = RepaintManager.currentManager(c);
+            currentManager.setDoubleBufferingEnabled(false);
+        }
+
+        public void enableDoubleBuffering(Component c) {
+            RepaintManager currentManager = RepaintManager.currentManager(c);
+            currentManager.setDoubleBufferingEnabled(true);
+        }
+    }
+
+    protected void processWindowEvent(WindowEvent e) {
+        if (e.getID() == WindowEvent.WINDOW_CLOSING) {
+            System.exit(0);
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
+++ b/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
@@ -36,11 +36,8 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JViewport;
-import javax.swing.RepaintManager;
 import javax.swing.SwingUtilities;
 import javax.swing.table.DefaultTableModel;
-
-import java.awt.event.WindowEvent;
 
 /*
  * @test
@@ -177,21 +174,9 @@ public class JTableScrollPrintTest {
                     optimalScale = 1;
 
                 g2d.scale(optimalScale, optimalScale);
-                disableDoubleBuffering(c);
                 c.paint(g2d);
-                enableDoubleBuffering(c);
                 return(PAGE_EXISTS);
             }
-        }
-
-        public void disableDoubleBuffering(Component c) {
-            RepaintManager currentManager = RepaintManager.currentManager(c);
-            currentManager.setDoubleBufferingEnabled(false);
-        }
-
-        public void enableDoubleBuffering(Component c) {
-            RepaintManager currentManager = RepaintManager.currentManager(c);
-            currentManager.setDoubleBufferingEnabled(true);
         }
     }
 }

--- a/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
+++ b/test/jdk/javax/swing/JTable/JTableScrollPrintTest.java
@@ -97,7 +97,7 @@ public class JTableScrollPrintTest {
             model.addColumn("Column 3");
             model.addColumn("Column 4");
 
-            for (int row=1;row<=5;row++)
+            for (int row = 1; row <= 5; row++)
                 model.addRow(new Object[] {
                         "R"+row+" C1", "R"+row+" C2", "R"+row+" C3", "R"+row+" C4" });
 
@@ -165,13 +165,15 @@ public class JTableScrollPrintTest {
                 double xscale = imageableX/panelX;
                 double yscale = imageableY/panelY;
                 double optimalScale;
-                if (xscale < yscale)
+                if (xscale < yscale) {
                     optimalScale = xscale;
-                else
+                } else {
                     optimalScale = yscale;
+                }
 
-                if (optimalScale > 1)
+                if (optimalScale > 1) {
                     optimalScale = 1;
+                }
 
                 g2d.scale(optimalScale, optimalScale);
                 c.paint(g2d);


### PR DESCRIPTION
`BackingStore` uses its own Graphics to Paint the Image. This is fine when we want to paint it on a Window/Frame, but fails to print. Since `WPathGraphics` is used for Printing, backing store fails to print it and backing store uses newly created `SunGraphics2D` always. The proposed fix is to ignore `backingstore` graphics if passed on Graphics is different from `SunGraphics2D` which ensures the Image is painted on Window and also printed when required. 
The fix is tested in CI and doesn't cause any regression. The test is verified manually.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210807](https://bugs.openjdk.org/browse/JDK-8210807): Printing a JTable with a JScrollPane prints table without rows populated (**Bug** - P3)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [8111eaa8](https://git.openjdk.org/jdk/pull/16552/files/8111eaa80c8f94c70004eaa6e5adc95bd6117375)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [dbcc134b](https://git.openjdk.org/jdk/pull/16552/files/dbcc134b083c9c3ed9b4692de5d3750b8bff4a41)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16552/head:pull/16552` \
`$ git checkout pull/16552`

Update a local copy of the PR: \
`$ git checkout pull/16552` \
`$ git pull https://git.openjdk.org/jdk.git pull/16552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16552`

View PR using the GUI difftool: \
`$ git pr show -t 16552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16552.diff">https://git.openjdk.org/jdk/pull/16552.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16552#issuecomment-1801244791)