### PR TITLE
JDK-8319375: test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java runs into OutOfMemoryError: Metaspace on AIX

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -26,6 +26,7 @@
  * @bug 8308762
  * @library /test/lib
  * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
+ * @requires os.family == "aix"
  * @requires vm.jvmti
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
@@ -33,6 +34,21 @@
  *          java.compiler
  * @run main RedefineClassHelper
  * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=23m -XX:MaxMetaspaceSize=23m RedefineLeakThrowable
+ */
+
+/*
+ * @test
+ * @bug 8308762
+ * @library /test/lib
+ * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
+ * @requires os.family != "aix"
+ * @requires vm.jvmti
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.misc
+ * @modules java.instrument
+ *          java.compiler
+ * @run main RedefineClassHelper
+ * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=17m -XX:MaxMetaspaceSize=17m RedefineLeakThrowable
  */
 
 class Tester {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- # @bug 8308762
+ * @bug 8308762
  * @library /test/lib
  * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
  * @requires vm.jvmti
@@ -32,7 +32,7 @@
  * @modules java.instrument
  *          java.compiler
  * @run main RedefineClassHelper
- * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=23m  -XX:MaxMetaspaceSize=23m RedefineLeakThrowable
+ * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=23m -XX:MaxMetaspaceSize=23m RedefineLeakThrowable
  */
 
 class Tester {

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -32,7 +32,7 @@
  * @modules java.instrument
  *          java.compiler
  * @run main RedefineClassHelper
- * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=17m  -XX:MaxMetaspaceSize=17m RedefineLeakThrowable
+ * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=23m  -XX:MaxMetaspaceSize=23m RedefineLeakThrowable
  */
 
 class Tester {


### PR DESCRIPTION
On AIX the test test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java runs into this error:

java.lang.RuntimeException: java.lang.OutOfMemoryError: Metaspace
at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.invocationHelper(JavacTaskImpl.java:168)
at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.doCall(JavacTaskImpl.java:100)
at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:94)
at jdk.test.lib.compiler.InMemoryJavaCompiler.compile(InMemoryJavaCompiler.java:188)
at RedefineClassHelper.redefineClass(RedefineClassHelper.java:50)
at RedefineLeakThrowable.main(RedefineLeakThrowable.java:64)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1570)
Caused by: java.lang.OutOfMemoryError: Metaspace
at java.base/java.time.Duration.<clinit>(Duration.java:149)
at java.base/java.time.temporal.ChronoUnit.<clinit>(ChronoUnit.java:83)
at java.base/java.time.temporal.ChronoField.<clinit>(ChronoField.java:124)
at java.base/java.time.LocalDate.of(LocalDate.java:272)
at java.base/java.time.LocalDate.<clinit>(LocalDate.java:147)
at java.base/java.time.LocalDateTime.<clinit>(LocalDateTime.java:145)
at jdk.zipfs/jdk.nio.zipfs.ZipUtils.dosToJavaTime(ZipUtils.java:216)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem$Entry.readCEN(ZipFileSystem.java:2816)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem$Entry.<init>(ZipFileSystem.java:2778)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.getEntry(ZipFileSystem.java:1941)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.newInputStream(ZipFileSystem.java:859)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.isMultiReleaseJar(ZipFileSystem.java:1444)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.initializeReleaseVersion(ZipFileSystem.java:1416)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystem.<init>(ZipFileSystem.java:191)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.getZipFileSystem(ZipFileSystemProvider.java:125)
at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.newFileSystem(ZipFileSystemProvider.java:120)
at jdk.compiler/com.sun.tools.javac.file.JavacFileManager$ArchiveContainer.<init>(JavacFileManager.java:566)
at jdk.compiler/com.sun.tools.javac.file.JavacFileManager.getContainer(JavacFileManager.java:329)
at jdk.compiler/com.sun.tools.javac.file.JavacFileManager.pathsAndContainers(JavacFileManager.java:1078)
at jdk.compiler/com.sun.tools.javac.file.JavacFileManager.indexPathsAndContainersByRelativeDirectory(JavacFileManager.java:1033)
at jdk.compiler/com.sun.tools.javac.file.JavacFileManager$$Lambda/0x00000328001a3168.apply(Unknown Source)
at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1228)
at jdk.compiler/com.sun.tools.javac.file.JavacFileManager.pathsAndContainers(JavacFileManager.java:1021)
at jdk.compiler/com.sun.tools.javac.file.JavacFileManager.list(JavacFileManager.java:777)
at [java.compiler@22-internal](mailto:java.compiler@22-internal)/javax.tools.ForwardingJavaFileManager.list(ForwardingJavaFileManager.java:82)
at jdk.compiler/com.sun.tools.javac.api.ClientCodeWrapper$WrappedJavaFileManager.list(ClientCodeWrapper.java:223)
at jdk.compiler/com.sun.tools.javac.code.ClassFinder.list(ClassFinder.java:752)
at jdk.compiler/com.sun.tools.javac.code.ClassFinder.scanUserPaths(ClassFinder.java:689)
at jdk.compiler/com.sun.tools.javac.code.ClassFinder.fillIn(ClassFinder.java:570)
at jdk.compiler/com.sun.tools.javac.code.ClassFinder.complete(ClassFinder.java:311)
at jdk.compiler/com.sun.tools.javac.code.ClassFinder$$Lambda/0x00000328001287f0.complete(Unknown Source)
at jdk.compiler/com.sun.tools.javac.code.Symtab.lambda$addRootPackageFor$8(Symtab.java:855)

Seems the MetaSpace settings of the test need to be adjusted; 17m works on the other platforms but AIX needs 23m.

I tested with  higher iteration value in main of  RedefineLeakThrowable so see if it is not a leak and with 23m it passes too on AIX with higher iteration value.  For some reason, with product binaries  21m  was sufficient too  (but fastdebug needed a bit more).

Should we keep the old MetaSpace   value 17m  for  non - AIX  ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319375](https://bugs.openjdk.org/browse/JDK-8319375): test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java runs into OutOfMemoryError: Metaspace on AIX (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [5d61cda6](https://git.openjdk.org/jdk/pull/16553/files/5d61cda63cad215168763bb5017a67b47250adfb)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [5d61cda6](https://git.openjdk.org/jdk/pull/16553/files/5d61cda63cad215168763bb5017a67b47250adfb)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16553/head:pull/16553` \
`$ git checkout pull/16553`

Update a local copy of the PR: \
`$ git checkout pull/16553` \
`$ git pull https://git.openjdk.org/jdk.git pull/16553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16553`

View PR using the GUI difftool: \
`$ git pr show -t 16553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16553.diff">https://git.openjdk.org/jdk/pull/16553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16553#issuecomment-1801320686)