### PR TITLE
JDK-8319704: LogTagSet::set_output_level() should not accept NULL as LogOutput

### DIFF
--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -52,7 +52,7 @@ void LogOutputList::wait_until_no_readers() const {
 }
 
 void LogOutputList::set_output_level(LogOutput* output, LogLevelType level) {
-  assert(output != nullptr, "LogOutput is NULL");
+  assert(output != nullptr, "LogOutput is null");
   LogOutputNode* node = find(output);
   if (level == LogLevel::Off && node != nullptr) {
     remove_output(node);

--- a/src/hotspot/share/logging/logOutputList.cpp
+++ b/src/hotspot/share/logging/logOutputList.cpp
@@ -52,6 +52,7 @@ void LogOutputList::wait_until_no_readers() const {
 }
 
 void LogOutputList::set_output_level(LogOutput* output, LogLevelType level) {
+  assert(output != nullptr, "LogOutput is NULL");
   LogOutputNode* node = find(output);
   if (level == LogLevel::Off && node != nullptr) {
     remove_output(node);


### PR DESCRIPTION
Trivial change to add an assert.

See [JDK-8319104](https://bugs.openjdk.org/browse/JDK-8319104)

`LogTagSet::set_output_level()` and `LogOutputList::set_output_level` should not accept NULL as LogOutput* argument.

They do, currently, which leads to delayed crashes later since the NULL output is registered in the output list.

That triggered [JDK-8319104](https://bugs.openjdk.org/browse/JDK-8319104), where - due to a fluke in C++ initialization order and a mislabeling of LogTagSet tests as "TEST", without "_VM" - `LogTagSet::set_output_level()` was called with `LogConfiguration::StdoutLog` which was still uninitialized (null). 

An assert would have saved investigation time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319704](https://bugs.openjdk.org/browse/JDK-8319704): LogTagSet::set_output_level() should not accept NULL as LogOutput (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [f942134a](https://git.openjdk.org/jdk/pull/16555/files/f942134a4cb99b884d22a01e530137ac372cee29)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16555/head:pull/16555` \
`$ git checkout pull/16555`

Update a local copy of the PR: \
`$ git checkout pull/16555` \
`$ git pull https://git.openjdk.org/jdk.git pull/16555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16555`

View PR using the GUI difftool: \
`$ git pr show -t 16555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16555.diff">https://git.openjdk.org/jdk/pull/16555.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16555#issuecomment-1805591479)