### PR TITLE
8321620: Optimize JImage decompressors

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -341,7 +341,7 @@ public class ImageStringsReader implements ImageStrings {
         return length;
     }
 
-    static void mutf8FromString(byte[] bytes, int offset, String s) {
+    public static int mutf8FromString(byte[] bytes, int offset, String s) {
         int j = offset;
         byte[] buffer = null;
         int slen = s.length();
@@ -375,6 +375,8 @@ public class ImageStringsReader implements ImageStrings {
                 bytes[j++] = (byte)uch;
             }
         }
+
+        return j - offset;
     }
 
     public static byte[] mutf8FromString(String string) {

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageStringsReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -341,7 +341,7 @@ public class ImageStringsReader implements ImageStrings {
         return length;
     }
 
-    public static int mutf8FromString(byte[] bytes, int offset, String s) {
+    static void mutf8FromString(byte[] bytes, int offset, String s) {
         int j = offset;
         byte[] buffer = null;
         int slen = s.length();
@@ -375,8 +375,6 @@ public class ImageStringsReader implements ImageStrings {
                 bytes[j++] = (byte)uch;
             }
         }
-
-        return j - offset;
     }
 
     public static byte[] mutf8FromString(String string) {

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressIndexes.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressIndexes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package jdk.internal.jimage.decompressor;
 
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -55,24 +54,6 @@ public class CompressIndexes {
         }
 
         return lst;
-    }
-
-    public static int readInt(DataInputStream cr) throws IOException {
-        // Get header byte.
-        byte header = cr.readByte();
-        // Determine size.
-        int size = getHeaderLength(header);
-        // Prepare result.
-        int result = getHeaderValue(header);
-
-        // For each value byte
-        for (int i = 1; i < size; i++) {
-            // Merge byte value.
-            result <<= Byte.SIZE;
-            result |= cr.readByte() & 0xFF;
-        }
-
-        return result;
     }
 
     public static int readInt(ByteBuffer cr) throws IOException {

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressIndexes.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressIndexes.java
@@ -26,8 +26,7 @@ package jdk.internal.jimage.decompressor;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 /**
  *
@@ -45,15 +44,16 @@ public class CompressIndexes {
     private static final int HEADER_WIDTH = 3;
     private static final int HEADER_SHIFT = Byte.SIZE - HEADER_WIDTH;
 
-    public static List<Integer> decompressFlow(byte[] values) {
-        List<Integer> lst = new ArrayList<>();
+    public static int[] decompressFlow(byte[] values) {
+        int[] ints = new int[values.length];
 
+        int count = 0;
         for (int i = 0; i < values.length; i += getHeaderLength(values[i])) {
             int decompressed = decompress(values, i);
-            lst.add(decompressed);
+            ints[count++] = decompressed;
         }
 
-        return lst;
+        return count == ints.length ? ints : Arrays.copyOf(ints, count);
     }
 
     public static int readInt(ByteBuffer cr) throws IOException {

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressIndexes.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressIndexes.java
@@ -75,6 +75,24 @@ public class CompressIndexes {
         return result;
     }
 
+    public static int readInt(ByteBuffer cr) throws IOException {
+        // Get header byte.
+        byte header = cr.get();
+        // Determine size.
+        int size = getHeaderLength(header);
+        // Prepare result.
+        int result = getHeaderValue(header);
+
+        // For each value byte
+        for (int i = 1; i < size; i++) {
+            // Merge byte value.
+            result <<= Byte.SIZE;
+            result |= cr.get() & 0xFF;
+        }
+
+        return result;
+    }
+
     private static boolean isCompressed(byte b) {
         return (b & COMPRESSED_FLAG) != 0;
     }

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 package jdk.internal.jimage.decompressor;
 
+import jdk.internal.jimage.ImageStringsReader;
+
 /**
  *
  * JLink Image Decompressor.
@@ -36,14 +38,20 @@ package jdk.internal.jimage.decompressor;
  */
 public interface ResourceDecompressor {
 
-    public interface StringsProvider {
-        public String getString(int offset);
+    interface StringsProvider {
+        String getString(int offset);
+
+        default int getStringMUTF8(int offset, byte[] bytesOut, int bytesOutOffset) {
+            byte[] bytes = ImageStringsReader.mutf8FromString(getString(offset));
+            System.arraycopy(bytes, 0, bytesOut, bytesOutOffset, bytes.length);
+            return bytes.length;
+        }
     }
     /**
      * Decompressor unique name.
      * @return The decompressor name.
      */
-    public String getName();
+    String getName();
 
     /**
      * Decompress a resource.
@@ -54,6 +62,6 @@ public interface ResourceDecompressor {
      * @return Uncompressed resource
      * @throws Exception
      */
-    public byte[] decompress(StringsProvider strings, byte[] content, int offset,
+    byte[] decompress(StringsProvider strings, byte[] content, int offset,
             long originalSize) throws Exception;
 }

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
@@ -28,7 +28,6 @@ import jdk.internal.jimage.ImageStringsReader;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
 import java.util.Properties;
 
 /**
@@ -168,20 +167,20 @@ public class StringSharingDecompressor implements ResourceDecompressor {
         int indexes_length = CompressIndexes.readInt(bytesIn);
         byte[] bytes = new byte[indexes_length];
         bytesIn.get(bytes);
-        List<Integer> indices = CompressIndexes.decompressFlow(bytes);
+        int[] indices = CompressIndexes.decompressFlow(bytes);
         int argIndex = 0;
         int current = bytesOutOffset + 2;
         for (byte c : encodedDesc) {
             if (c == 'L') {
                 bytesOut[current++] = c;
-                int index = indices.get(argIndex);
+                int index = indices[argIndex];
                 argIndex += 1;
                 String pkg = reader.getString(index);
                 if (!pkg.isEmpty()) {
                     pkg = pkg + "/";
                     current += ImageStringsReader.mutf8FromString(bytesOut, current, pkg);
                 }
-                int classIndex = indices.get(argIndex);
+                int classIndex = indices[argIndex];
                 argIndex += 1;
                 String clazz = reader.getString(classIndex);
                 current += ImageStringsReader.mutf8FromString(bytesOut, current, clazz);

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
@@ -177,8 +177,8 @@ public class StringSharingDecompressor implements ResourceDecompressor {
                 argIndex += 1;
                 String pkg = reader.getString(index);
                 if (!pkg.isEmpty()) {
-                    pkg = pkg + "/";
                     current += ImageStringsReader.mutf8FromString(bytesOut, current, pkg);
+                    bytesOut[current++] = '/';
                 }
                 int classIndex = indices[argIndex];
                 argIndex += 1;

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
@@ -109,7 +109,7 @@ public class StringSharingDecompressor implements ResourceDecompressor {
         bytesOut[bytesOutOffset++] = (byte) ((count >> 8) & 0xff);
         bytesOut[bytesOutOffset++] = (byte) (count & 0xff);
         for (int i = 1; i < count; i++) {
-            int tag = bytesIn.get() & 0xff;
+            int tag = Byte.toUnsignedInt(bytesIn.get());
             switch (tag) {
                 case CONSTANT_Utf8: {
                     int stringLength = Short.toUnsignedInt(bytesIn.getShort());

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package jdk.internal.jimage.decompressor;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.zip.Inflater;
 
 /**
@@ -44,21 +45,25 @@ final class ZipDecompressor implements ResourceDecompressor {
         return ZipDecompressorFactory.NAME;
     }
 
-    static byte[] decompress(byte[] bytesIn, int offset) throws Exception {
+    static byte[] decompress(byte[] bytesIn, int offset, long originalSize) throws Exception {
+        if (originalSize > Integer.MAX_VALUE) {
+            throw new OutOfMemoryError("Required array size too large");
+        }
+        byte[] bytesOut = new byte[(int) originalSize];
+
         Inflater inflater = new Inflater();
         inflater.setInput(bytesIn, offset, bytesIn.length - offset);
-        ByteArrayOutputStream stream = new ByteArrayOutputStream(bytesIn.length - offset);
-        byte[] buffer = new byte[1024];
 
-        while (!inflater.finished()) {
-            int count = inflater.inflate(buffer);
-            stream.write(buffer, 0, count);
+        int count = 0;
+        while (!inflater.finished() && count < originalSize) {
+            count += inflater.inflate(bytesOut, count, bytesOut.length - count);
         }
 
-        stream.close();
-
-        byte[] bytesOut = stream.toByteArray();
         inflater.end();
+
+        if (count != originalSize) {
+            throw new IOException("Resource content size mismatch");
+        }
 
         return bytesOut;
     }
@@ -66,7 +71,7 @@ final class ZipDecompressor implements ResourceDecompressor {
     @Override
     public byte[] decompress(StringsProvider reader, byte[] content, int offset,
             long originalSize) throws Exception {
-        byte[] decompressed = decompress(content, offset);
+        byte[] decompressed = decompress(content, offset, originalSize);
         return decompressed;
     }
 }

--- a/test/jdk/tools/jlink/plugins/CompressIndexesTest.java
+++ b/test/jdk/tools/jlink/plugins/CompressIndexesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,15 +83,15 @@ public class CompressIndexesTest {
         check(flow, arrays);
         System.err.println(arrays.size() * 4 + " compressed in " + flow.length
                 + " gain of " + (100 - ((flow.length * 100) / (arrays.size() * 4))) + "%");
-        try (DataInputStream is = new DataInputStream(new ByteArrayInputStream(flow))) {
-            int index = 0;
-            while (is.available() > 0) {
-                int d = CompressIndexes.readInt(is);
-                if (data[index] != d) {
-                    throw new AssertionError("Expected: " + data[index] + ", got: " + d);
-                }
-                ++index;
+
+        ByteBuffer bf = ByteBuffer.wrap(flow);
+        int index = 0;
+        while (bf.hasRemaining()) {
+            int d = CompressIndexes.readInt(bf);
+            if (data[index] != d) {
+                throw new AssertionError("Expected: " + data[index] + ", got: " + d);
             }
+            ++index;
         }
     }
 

--- a/test/jdk/tools/jlink/plugins/CompressIndexesTest.java
+++ b/test/jdk/tools/jlink/plugins/CompressIndexesTest.java
@@ -34,6 +34,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import jdk.internal.jimage.decompressor.CompressIndexes;
@@ -96,7 +97,7 @@ public class CompressIndexesTest {
     }
 
     private void check(byte[] flow, List<byte[]> arrays) {
-        List<Integer> d = CompressIndexes.decompressFlow(flow);
+        List<Integer> d = Arrays.stream(CompressIndexes.decompressFlow(flow)).boxed().toList();
         List<Integer> dd = new ArrayList<>();
         for (byte[] b : arrays) {
             int i = CompressIndexes.decompress(b, 0);

--- a/test/jdk/tools/jlink/plugins/StringSharingPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/StringSharingPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/tools/jlink/plugins/StringSharingPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/StringSharingPluginTest.java
@@ -136,7 +136,8 @@ public class StringSharingPluginTest {
             if (res.path().endsWith(".class")) {
                 try {
                     byte[] uncompacted = StringSharingDecompressor.normalize(reversedMap::get, res.contentBytes(),
-                        CompressedResourceHeader.getSize());
+                        CompressedResourceHeader.getSize(),
+                        ((ResourcePoolManager.CompressedModuleData) res).getUncompressedSize());
                     JImageValidator.readClass(uncompacted);
                 } catch (IOException exp) {
                     throw new UncheckedIOException(exp);


### PR DESCRIPTION
This PR significantly speeds up decompressing resources in Jimage while significantly reducing temporary memory allocations in the process.

This will improve startup speed for runtime images generated using `jlink --compress 1` and `jlink --compress 2` .

I generated a runtime image containing javac using `jlink --compress 1 --add-modules jdk.compiler` and tested the time it took to compile a simple HelloWorld program 20 times using `perf stat -r20 javac /dev/shm/HelloWorld.java`, this PR reduces the total time taken from 17830ms to 13598ms (31.12% faster).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321620](https://bugs.openjdk.org/browse/JDK-8321620): Optimize JImage decompressors (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16556/head:pull/16556` \
`$ git checkout pull/16556`

Update a local copy of the PR: \
`$ git checkout pull/16556` \
`$ git pull https://git.openjdk.org/jdk.git pull/16556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16556`

View PR using the GUI difftool: \
`$ git pr show -t 16556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16556.diff">https://git.openjdk.org/jdk/pull/16556.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16556#issuecomment-1847932819)