### PR TITLE
8307982: Fix VerifyLoopOptimizations - step 3 - fix ctrl/loop

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4822,7 +4822,7 @@ bool PhaseIdealLoop::verify_loop_ctrl(Node* n, const PhaseIdealLoop* phase_verif
         n->dump();
         tty->print_cr("Loop for this:");
         loop_this->dump();
-        tty->print_cr("Loop for verif::");
+        tty->print_cr("Loop for verify::");
         loop_verify->dump();
         tty->cr();
         return false; // fail

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4792,42 +4792,32 @@ bool PhaseIdealLoop::verify_loop_ctrl(Node* n, const PhaseIdealLoop* phase_verif
     // n is a data node.
     // Verify that its ctrl is the same.
 
-    // Broken part of VerifyLoopOptimizations (A)
-    // Reason:
-    //   BUG, wrong control set for example in
-    //   PhaseIdealLoop::split_if_with_blocks
-    //   at "set_ctrl(x, new_ctrl);"
-    /*
-    if( _loop_or_ctrl[i] != loop_verify->_loop_or_ctrl[i] &&
-        get_ctrl_no_update(n) != loop_verify->get_ctrl_no_update(n) ) {
-      tty->print("Mismatched control setting for: ");
+    Node* ctrl_this = get_ctrl_no_update(n);
+    Node* ctrl_verify = phase_verify->get_ctrl_no_update(n);
+    if(_loop_or_ctrl[i] != phase_verify->_loop_or_ctrl[i] &&
+       ctrl_this != ctrl_verify) {
+      tty->print_cr("Mismatched ctrl for non-ctrl node: ");
       n->dump();
-      if( fail++ > 10 ) return;
-      Node *c = get_ctrl_no_update(n);
-      tty->print("We have it as: ");
-      if( c->in(0) ) c->dump();
-        else tty->print_cr("N%d",c->_idx);
-      tty->print("Verify thinks: ");
-      if( loop_verify->has_ctrl(n) )
-        loop_verify->get_ctrl_no_update(n)->dump();
-      else
-        loop_verify->get_loop_idx(n)->dump();
+      tty->print_cr("Ctrl for this:");
+      ctrl_this->dump();
+      tty->print_cr("Ctrl for verify:");
+      ctrl_verify->dump();
       tty->cr();
+      return false; // fail
     }
-    */
     return true; // pass
   } else {
     assert(!phase_verify->has_ctrl(n), "sanity");
     // n is a ctrl node.
     // Verify that not has_ctrl, and that get_loop_idx is the same.
 
-    if (!C->major_progress()) {
+    //if (!C->major_progress()) {
       // Loop selection can be messed up if we did a major progress
       // operation, like split-if.  Do not verify in that case.
       IdealLoopTree* loop_this = get_loop_idx(n);
       IdealLoopTree* loop_verify = phase_verify->get_loop_idx(n);
       if(loop_this->_head != loop_verify->_head ||
-	 loop_this->_tail != loop_verify->_tail ) {
+         loop_this->_tail != loop_verify->_tail ) {
         tty->print_cr("Mismatch get_loop_idx for ctrl node:");
         n->dump();
         tty->print_cr("Loop for this:");
@@ -4835,8 +4825,9 @@ bool PhaseIdealLoop::verify_loop_ctrl(Node* n, const PhaseIdealLoop* phase_verif
         tty->print_cr("Loop for verif::");
         loop_verify->dump();
         tty->cr();
+        return false; // fail
       }
-    }
+    //}
     return true; // pass
   }
 }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4821,28 +4821,22 @@ bool PhaseIdealLoop::verify_loop_ctrl(Node* n, const PhaseIdealLoop* phase_verif
     // n is a ctrl node.
     // Verify that not has_ctrl, and that get_loop_idx is the same.
 
-    // Broken part of VerifyLoopOptimizations (B)
-    // Reason:
-    //   NeverBranch node for example is added to loop outside its scope.
-    //   Once we run build_loop_tree again, it is added to the correct loop.
-    /*
     if (!C->major_progress()) {
       // Loop selection can be messed up if we did a major progress
       // operation, like split-if.  Do not verify in that case.
-      IdealLoopTree *us = get_loop_idx(n);
-      IdealLoopTree *them = loop_verify->get_loop_idx(n);
-      if( us->_head != them->_head ||  us->_tail != them->_tail ) {
-        tty->print("Unequals loops for: ");
+      IdealLoopTree* loop_this = get_loop_idx(n);
+      IdealLoopTree* loop_verify = phase_verify->get_loop_idx(n);
+      if(loop_this->_head != loop_verify->_head ||
+	 loop_this->_tail != loop_verify->_tail ) {
+        tty->print_cr("Mismatch get_loop_idx for ctrl node:");
         n->dump();
-        if( fail++ > 10 ) return;
-        tty->print("We have it as: ");
-        us->dump();
-        tty->print("Verify thinks: ");
-        them->dump();
+        tty->print_cr("Loop for this:");
+        loop_this->dump();
+        tty->print_cr("Loop for verif::");
+        loop_verify->dump();
         tty->cr();
       }
     }
-    */
     return true; // pass
   }
 }


### PR DESCRIPTION
TODO verify loop opts

Fails with
`./java -Xcomp -XX:+VerifyLoopOptimizations --version`

TODO
We can assert at the SuperWord bailout introduced in [JDK-8327172](https://bugs.openjdk.org/browse/JDK-8327172)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307982](https://bugs.openjdk.org/browse/JDK-8307982): Fix VerifyLoopOptimizations - step 3 - fix ctrl/loop (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16558/head:pull/16558` \
`$ git checkout pull/16558`

Update a local copy of the PR: \
`$ git checkout pull/16558` \
`$ git pull https://git.openjdk.org/jdk.git pull/16558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16558`

View PR using the GUI difftool: \
`$ git pr show -t 16558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16558.diff">https://git.openjdk.org/jdk/pull/16558.diff</a>

</details>
