### PR TITLE
8319709: Make GrowableArrayCHeap copyable

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -827,7 +827,7 @@ public:
     this->_len = other._len;
   }
 
-  GrowableArrayCHeap<E,F>& operator=(GrowableArrayCHeap<E,F>& other) {
+  GrowableArrayCHeap<E,F>& operator=(const GrowableArrayCHeap<E,F>& other) {
     assert(&other != this, "must be different");
     this->clear_and_deallocate();
     this->grow(other._len);

--- a/test/hotspot/gtest/utilities/test_growableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_growableArray.cpp
@@ -589,33 +589,33 @@ TEST_VM_F(GrowableArrayTest, GrowableArrayCHeapShouldCopyTrivialElementsWhenCopy
   }
 }
 
-struct IncrementingCopying {
+struct IncrementIdOnCopy {
   static int current_id;
 public:
   int id;
-  IncrementingCopying() {
+  IncrementIdOnCopy() {
     this->id = 0;
   }
-  IncrementingCopying(const IncrementingCopying&) {
-    this->id = IncrementingCopying::current_id++;
+  IncrementIdOnCopy(const IncrementIdOnCopy&) {
+    this->id = IncrementIdOnCopy::current_id++;
   }
-  IncrementingCopying& operator=(const IncrementingCopying&) {
-    this->id = IncrementingCopying::current_id++;
+  IncrementIdOnCopy& operator=(const IncrementIdOnCopy&) {
+    this->id = IncrementIdOnCopy::current_id++;
     return *this;
   }
 };
-int IncrementingCopying::current_id = 0;
+int IncrementIdOnCopy::current_id = 0;
 TEST_VM_F(GrowableArrayTest, GrowableArrayCHeapShouldCallCopyConstructorWhenCopyConstructed) {
-  GrowableArrayCHeap<IncrementingCopying, mtTest> a(1);
-  a.push(IncrementingCopying{});
-  GrowableArrayCHeap<IncrementingCopying, mtTest> b(a);
+  GrowableArrayCHeap<IncrementIdOnCopy, mtTest> a(1);
+  a.push(IncrementIdOnCopy{});
+  GrowableArrayCHeap<IncrementIdOnCopy, mtTest> b(a);
   ASSERT_TRUE(a.at(0).id != b.at(0).id) << "The copy constructor should have been called but wasn't";
 }
 
 TEST_VM_F(GrowableArrayTest, GrowableArrayCHeapShouldCallCopyConstructorWhenCopyAssigned) {
-  GrowableArrayCHeap<IncrementingCopying, mtTest> a(1);
-  a.push(IncrementingCopying{});
-  GrowableArrayCHeap<IncrementingCopying, mtTest> b(0);
+  GrowableArrayCHeap<IncrementIdOnCopy, mtTest> a(1);
+  a.push(IncrementIdOnCopy{});
+  GrowableArrayCHeap<IncrementIdOnCopy, mtTest> b(0);
   b = a;
   ASSERT_TRUE(a.at(0).id != b.at(0).id) << "The copy constructor should have been called but wasn't";
 }


### PR DESCRIPTION
Hi,

Please consider this code change which makes `GrowableArrayCHeap` copyable. The resulting copy does not share its data array with the original.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319709](https://bugs.openjdk.org/browse/JDK-8319709): Make GrowableArrayCHeap copyable (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16559/head:pull/16559` \
`$ git checkout pull/16559`

Update a local copy of the PR: \
`$ git checkout pull/16559` \
`$ git pull https://git.openjdk.org/jdk.git pull/16559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16559`

View PR using the GUI difftool: \
`$ git pr show -t 16559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16559.diff">https://git.openjdk.org/jdk/pull/16559.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16559#issuecomment-1801902378)