### PR TITLE
8319713: Parallel: Remove PSAdaptiveSizePolicy::should_full_GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -169,22 +169,6 @@ void PSAdaptiveSizePolicy::major_collection_end(size_t amount_live,
   _major_timer.start();
 }
 
-// If the remaining free space in the old generation is less that
-// that expected to be needed by the next collection, do a full
-// collection now.
-bool PSAdaptiveSizePolicy::should_full_GC(size_t old_free_in_bytes) {
-
-  // A similar test is done in the scavenge's should_attempt_scavenge().  If
-  // this is changed, decide if that test should also be changed.
-  bool result = padded_average_promoted_in_bytes() > (float) old_free_in_bytes;
-  log_trace(gc, ergo)("%s after scavenge average_promoted " SIZE_FORMAT " padded_average_promoted " SIZE_FORMAT " free in old gen " SIZE_FORMAT,
-                      result ? "Full" : "No full",
-                      (size_t) average_promoted_in_bytes(),
-                      (size_t) padded_average_promoted_in_bytes(),
-                      old_free_in_bytes);
-  return result;
-}
-
 void PSAdaptiveSizePolicy::clear_generation_free_space_flags() {
 
   AdaptiveSizePolicy::clear_generation_free_space_flags();

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -306,10 +306,6 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
   }
   double major_collection_slope() { return _major_collection_estimator->slope();}
 
-  // Given the amount of live data in the heap, should we
-  // perform a Full GC?
-  bool should_full_GC(size_t live_in_old_gen);
-
   // Calculates optimal (free) space sizes for both the young and old
   // generations.  Stores results in _eden_size and _promo_size.
   // Takes current used space in all generations as input, as well

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -239,8 +239,7 @@ bool PSScavenge::invoke() {
   IsGCActiveMark mark;
 
   const bool scavenge_done = PSScavenge::invoke_no_policy();
-  const bool need_full_gc = !scavenge_done ||
-    policy->should_full_GC(heap->old_gen()->free_in_bytes());
+  const bool need_full_gc = !scavenge_done;
   bool full_gc_done = false;
 
   if (UsePerfData) {
@@ -703,8 +702,6 @@ bool PSScavenge::should_attempt_scavenge() {
   // Test to see if the scavenge will likely fail.
   PSAdaptiveSizePolicy* policy = heap->size_policy();
 
-  // A similar test is done in the policy's should_full_GC().  If this is
-  // changed, decide if that test should also be changed.
   size_t avg_promoted = (size_t) policy->padded_average_promoted_in_bytes();
   size_t promotion_estimate = MIN2(avg_promoted, young_gen->used_in_bytes());
   bool result = promotion_estimate < old_gen->free_in_bytes();


### PR DESCRIPTION
Simple removing too-conservative full-gc heuristic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319713](https://bugs.openjdk.org/browse/JDK-8319713): Parallel: Remove PSAdaptiveSizePolicy::should_full_GC (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16560/head:pull/16560` \
`$ git checkout pull/16560`

Update a local copy of the PR: \
`$ git checkout pull/16560` \
`$ git pull https://git.openjdk.org/jdk.git pull/16560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16560`

View PR using the GUI difftool: \
`$ git pr show -t 16560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16560.diff">https://git.openjdk.org/jdk/pull/16560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16560#issuecomment-1801940962)