### PR TITLE
JDK-8319382: com/sun/jdi/JdwpAllowTest.java shows failures on AIX if prefixLen of mask is larger than 32 in IPv6 case

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -460,6 +460,12 @@ parseAllowedMask(const char *buffer, int isIPv4, struct in6_addr *result) {
     int maxValue = isIPv4 ? 32 : 128;
     int i;
 
+    // on AIX we might get IPv6 detected (by getaddrinfo) as IPv4,
+    // so the default maxValue does not always work
+#if defined(_AIX)
+    maxValue = 128;
+#endif
+
     do {
         if (*buffer < '0' || *buffer > '9') {
             return JDWPTRANSPORT_ERROR_ILLEGAL_ARGUMENT;


### PR DESCRIPTION
In parseAllowedMask (file socketTransport.c) , prefixLen of mask is compared with a maxValue (32 for IPv4, 128 otherwise). This fails on AIX if it is larger than 32, because getaddrinfo seems to often (always ?) detect IPv4 family, even for IPv6 addresses, so we take the wrong maxValue.
Probably we have to adjust the allowed maxValue on AIX, or adjust the IPv6 check.

Example:
images/jdk/bin/java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:0,allow=0:0:0:0:0:0:10:0/106
Error in allow option: '106'
ERROR: transport error 103: invalid netmask in allow option
ERROR: JDWP Transport dt_socket failed to initialize, TRANSPORT_INIT(510)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319382](https://bugs.openjdk.org/browse/JDK-8319382): com/sun/jdi/JdwpAllowTest.java shows failures on AIX if prefixLen of mask is larger than 32 in IPv6 case (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16561/head:pull/16561` \
`$ git checkout pull/16561`

Update a local copy of the PR: \
`$ git checkout pull/16561` \
`$ git pull https://git.openjdk.org/jdk.git pull/16561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16561`

View PR using the GUI difftool: \
`$ git pr show -t 16561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16561.diff">https://git.openjdk.org/jdk/pull/16561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16561#issuecomment-1802028158)