### PR TITLE
8319725: G1: Subtracting virtual time from wall time after JDK-8319204

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2760,7 +2760,7 @@ void G1CMTask::do_marking_step(double time_target_ms,
     // Separated the asserts so that we know which one fires.
     assert(_cm->out_of_regions(), "only way to reach here");
     assert(_task_queue->size() == 0, "only way to reach here");
-    double termination_start_time_ms = os::elapsedVTime() * 1000.0;
+    double termination_start_time_ms = os::elapsedTime() * 1000.0;
 
     // The G1CMTask class also extends the TerminatorTerminator class,
     // hence its should_exit_termination() method will also decide


### PR DESCRIPTION
Noticed this when looking at the [JDK-8319204](https://bugs.openjdk.org/browse/JDK-8319204) changeset: we end subtracting `elapsedVTime()` vs `elapsedTime()`, which looks incorrect, as it does math on two unrelated quantities.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319725](https://bugs.openjdk.org/browse/JDK-8319725): G1: Subtracting virtual time from wall time after JDK-8319204 (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16564/head:pull/16564` \
`$ git checkout pull/16564`

Update a local copy of the PR: \
`$ git checkout pull/16564` \
`$ git pull https://git.openjdk.org/jdk.git pull/16564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16564`

View PR using the GUI difftool: \
`$ git pr show -t 16564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16564.diff">https://git.openjdk.org/jdk/pull/16564.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16564#issuecomment-1802190436)