### PR TITLE
8319726: Parallel GC: Re-use object in object-iterator

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -247,7 +247,7 @@ void MutableSpace::object_iterate(ObjectClosure* cl) {
       assert(obj->forwardee() != obj, "must not be self-forwarded");
     }
 #endif
-    p += cast_to_oop(p)->size();
+    p += obj->size();
   }
 }
 


### PR DESCRIPTION
As a minor follow-up/clean-up to [JDK-8319376](https://bugs.openjdk.org/browse/JDK-8319376), we can use the local obj field that we casted a few lines up, instead of casting from p again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319726](https://bugs.openjdk.org/browse/JDK-8319726): Parallel GC: Re-use object in object-iterator (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16565/head:pull/16565` \
`$ git checkout pull/16565`

Update a local copy of the PR: \
`$ git checkout pull/16565` \
`$ git pull https://git.openjdk.org/jdk.git pull/16565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16565`

View PR using the GUI difftool: \
`$ git pr show -t 16565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16565.diff">https://git.openjdk.org/jdk/pull/16565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16565#issuecomment-1802256228)