### PR TITLE
8318895: Deoptimization results in incorrect lightweight locking stack

### DIFF
--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -1752,7 +1752,7 @@ class EARelockingSimpleTarget extends EATestCaseBaseTarget {
 
 /////////////////////////////////////////////////////////////////////////////
 
-// The debugger reads and publishes an object with eliminated locking to a static variable.
+// The debugger reads and publishes an object with eliminated locking to an instance field.
 // A 2nd thread in the debuggee finds it there and changes its state using a synchronized method.
 // Without eager relocking the accesses are unsynchronized which can be observed.
 class EARelockingSimpleWithAccessInOtherThread extends EATestCaseBaseDebugger {


### PR DESCRIPTION
See JBS issue for details.

I basically:
 - took the test-modification and turned it into its own test-case
 - added test runners for lightweight- and legacy-locking, so that we keep testing both, no matter what is the default
 - added Axels fix (mentioned in the JBS issue) with the modification to only inflate when exec_mode == Unpack_none, as explained by Richard.

Testing:
 - [x] EATests.java
 - [x] tier1
 - [x] tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318895](https://bugs.openjdk.org/browse/JDK-8318895): Deoptimization results in incorrect lightweight locking stack (**Bug** - P3)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [d9370df6](https://git.openjdk.org/jdk/pull/16568/files/d9370df6a51ef674a077be5b0196b554bf9e9e75)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**) ⚠️ Review applies to [966d0a3e](https://git.openjdk.org/jdk/pull/16568/files/966d0a3e7f6361df09c63d930c632fd96b09ddd4)


### Contributors
 * Axel Boldt-Christmas `<aboldtch@openjdk.org>`
 * Richard Reingruber `<rrich@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16568/head:pull/16568` \
`$ git checkout pull/16568`

Update a local copy of the PR: \
`$ git checkout pull/16568` \
`$ git pull https://git.openjdk.org/jdk.git pull/16568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16568`

View PR using the GUI difftool: \
`$ git pr show -t 16568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16568.diff">https://git.openjdk.org/jdk/pull/16568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16568#issuecomment-1802486928)