### PR TITLE
JDK-8318854: [macos14] Running any AWT app prints Secure coding warning

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -841,7 +841,7 @@ AWT_ASSERT_APPKIT_THREAD;
         isDisabled = !awtWindow.isEnabled;
     }
 
-    if (menuBar == nil) {
+    if (menuBar == nil && [ApplicationDelegate sharedDelegate] != nil) {
         menuBar = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
         isDisabled = NO;
     }
@@ -1230,7 +1230,7 @@ JNI_COCOA_ENTER(env);
         window.javaMenuBar = menuBar;
 
         CMenuBar* actualMenuBar = menuBar;
-        if (actualMenuBar == nil) {
+        if (actualMenuBar == nil && [ApplicationDelegate sharedDelegate] != nil) {
             actualMenuBar = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
         }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -116,7 +116,7 @@ AWT_ASSERT_APPKIT_THREAD;
 
     // don't install the EAWT delegate if another kind of NSApplication is installed, like say, Safari
     BOOL shouldInstall = NO;
-    BOOL overrideDelegate = (getenv("AWT_INSTALL_NSDELEGATE") != NULL);
+    BOOL overrideDelegate = (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL);
     if (NSApp != nil) {
         if ([NSApp isMemberOfClass:[NSApplication class]] && overrideDelegate) shouldInstall = YES;
         if ([NSApp isKindOfClass:[NSApplicationAWT class]]) shouldInstall = YES;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -116,8 +116,9 @@ AWT_ASSERT_APPKIT_THREAD;
 
     // don't install the EAWT delegate if another kind of NSApplication is installed, like say, Safari
     BOOL shouldInstall = NO;
+    BOOL overrideDelegate = (int)(getenv("AWT_OVERRIDE_DELEGATE") != NULL);
     if (NSApp != nil) {
-        if ([NSApp isMemberOfClass:[NSApplication class]]) shouldInstall = YES;
+        if ([NSApp isMemberOfClass:[NSApplication class]] && overrideDelegate) shouldInstall = YES;
         if ([NSApp isKindOfClass:[NSApplicationAWT class]]) shouldInstall = YES;
     }
     checked = YES;
@@ -510,8 +511,10 @@ AWT_ASSERT_APPKIT_THREAD;
     [dockImageView setImageScaling:NSImageScaleProportionallyUpOrDown];
     [dockImageView setImage:image];
 
-    [[ApplicationDelegate sharedDelegate].fProgressIndicator removeFromSuperview];
-    [dockImageView addSubview:[ApplicationDelegate sharedDelegate].fProgressIndicator];
+    if ([ApplicationDelegate sharedDelegate] != nil) {
+        [[ApplicationDelegate sharedDelegate].fProgressIndicator removeFromSuperview];
+        [dockImageView addSubview:[ApplicationDelegate sharedDelegate].fProgressIndicator];
+    }
 
     // add it to the NSDockTile
     [dockTile setContentView: dockImageView];
@@ -524,14 +527,15 @@ AWT_ASSERT_APPKIT_THREAD;
 AWT_ASSERT_APPKIT_THREAD;
 
     ApplicationDelegate *delegate = [ApplicationDelegate sharedDelegate];
-    if ([value doubleValue] >= 0 && [value doubleValue] <=100) {
-        [delegate.fProgressIndicator setDoubleValue:[value doubleValue]];
-        [delegate.fProgressIndicator setHidden:NO];
-    } else {
-        [delegate.fProgressIndicator setHidden:YES];
+    if ([ApplicationDelegate sharedDelegate] != nil) {
+        if ([value doubleValue] >= 0 && [value doubleValue] <=100) {
+            [delegate.fProgressIndicator setDoubleValue:[value doubleValue]];
+            [delegate.fProgressIndicator setHidden:NO];
+        } else {
+            [delegate.fProgressIndicator setHidden:YES];
+        }
+        [[NSApp dockTile] display];
     }
-
-    [[NSApp dockTile] display];
 }
 
 // Obtains the image of the Dock icon, either manually set, a drawn copy, or the default NSApplicationIcon

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -116,7 +116,7 @@ AWT_ASSERT_APPKIT_THREAD;
 
     // don't install the EAWT delegate if another kind of NSApplication is installed, like say, Safari
     BOOL shouldInstall = NO;
-    BOOL overrideDelegate = (int)(getenv("AWT_OVERRIDE_DELEGATE") != NULL);
+    BOOL overrideDelegate = (getenv("AWT_INSTALL_NSDELEGATE") != NULL);
     if (NSApp != nil) {
         if ([NSApp isMemberOfClass:[NSApplication class]] && overrideDelegate) shouldInstall = YES;
         if ([NSApp isKindOfClass:[NSApplicationAWT class]]) shouldInstall = YES;
@@ -411,7 +411,11 @@ AWT_ASSERT_APPKIT_THREAD;
 }
 
 - (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
-    return YES;
+    BOOL supportsSecureState = YES;
+       if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
+           supportsSecureState = NO;
+       }
+    return supportsSecureState;
 }
 
 + (void)_systemWillPowerOff {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -531,7 +531,7 @@ AWT_ASSERT_APPKIT_THREAD;
 AWT_ASSERT_APPKIT_THREAD;
 
     ApplicationDelegate *delegate = [ApplicationDelegate sharedDelegate];
-    if ([ApplicationDelegate sharedDelegate] != nil) {
+    if (delegate != nil) {
         if ([value doubleValue] >= 0 && [value doubleValue] <=100) {
             [delegate.fProgressIndicator setDoubleValue:[value doubleValue]];
             [delegate.fProgressIndicator setHidden:NO];

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -411,9 +411,14 @@ AWT_ASSERT_APPKIT_THREAD;
 }
 
 - (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
-    BOOL supportsSecureState = YES;
-    if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
-       supportsSecureState = NO;
+    static BOOL checked = NO;
+    static BOOL supportsSecureState = YES;
+
+    if (checked == NO) {
+        checked = YES;
+        if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
+            supportsSecureState = NO;
+        }
     }
     return supportsSecureState;
 }
@@ -650,7 +655,9 @@ JNI_COCOA_ENTER(env);
 
     NSMenu *menu = (NSMenu *)jlong_to_ptr(nsMenuPtr);
     [ThreadUtilities performOnMainThreadWaiting:YES block:^(){
-        [ApplicationDelegate sharedDelegate].fDockMenu = menu;
+        if ([ApplicationDelegate sharedDelegate] != nil) {
+            [ApplicationDelegate sharedDelegate].fDockMenu = menu;
+        }
     }];
 
 JNI_COCOA_EXIT(env);
@@ -830,13 +837,15 @@ JNI_COCOA_ENTER(env);
 
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
         ApplicationDelegate *delegate = [ApplicationDelegate sharedDelegate];
-        switch (menuID) {
-            case com_apple_eawt__AppMenuBarHandler_MENU_ABOUT:
-                [delegate _updateAboutMenu:visible enabled:enabled];
-                break;
-            case com_apple_eawt__AppMenuBarHandler_MENU_PREFS:
-                [delegate _updatePreferencesMenu:visible enabled:enabled];
-                break;
+        if (delegate != nil) {
+            switch (menuID) {
+                case com_apple_eawt__AppMenuBarHandler_MENU_ABOUT:
+                    [delegate _updateAboutMenu:visible enabled:enabled];
+                    break;
+                case com_apple_eawt__AppMenuBarHandler_MENU_PREFS:
+                    [delegate _updatePreferencesMenu:visible enabled:enabled];
+                    break;
+            }
         }
     }];
 
@@ -855,7 +864,9 @@ JNI_COCOA_ENTER(env);
 
     CMenuBar *menu = (CMenuBar *)jlong_to_ptr(cMenuBarPtr);
     [ThreadUtilities performOnMainThreadWaiting:NO block:^(){
-        [ApplicationDelegate sharedDelegate].fDefaultMenuBar = menu;
+        if ([ApplicationDelegate sharedDelegate] != nil) {
+            [ApplicationDelegate sharedDelegate].fDefaultMenuBar = menu;
+        }
     }];
 
 JNI_COCOA_EXIT(env);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -116,7 +116,7 @@ AWT_ASSERT_APPKIT_THREAD;
 
     // don't install the EAWT delegate if another kind of NSApplication is installed, like say, Safari
     BOOL shouldInstall = NO;
-    BOOL overrideDelegate = (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL);
+    BOOL overrideDelegate = (getenv("AWT_OVERRIDE_NSDELEGATE") != NULL);
     if (NSApp != nil) {
         if ([NSApp isMemberOfClass:[NSApplication class]] && overrideDelegate) shouldInstall = YES;
         if ([NSApp isKindOfClass:[NSApplicationAWT class]]) shouldInstall = YES;
@@ -412,9 +412,9 @@ AWT_ASSERT_APPKIT_THREAD;
 
 - (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
     BOOL supportsSecureState = YES;
-       if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
-           supportsSecureState = NO;
-       }
+    if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
+       supportsSecureState = NO;
+    }
     return supportsSecureState;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -409,6 +409,10 @@ AWT_ASSERT_APPKIT_THREAD;
     return NSTerminateLater;
 }
 
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
+    return YES;
+}
+
 + (void)_systemWillPowerOff {
     [self _notifyJava:com_apple_eawt__AppEventHandler_NOTIFY_SHUTDOWN];
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CMenuBar.m
@@ -210,9 +210,11 @@ static BOOL sSetupHelpMenu = NO;
         // In theory, this might cause flickering if the window gaining focus
         // has its own menu. However, I couldn't reproduce it on practice, so
         // perhaps this is a non issue.
-        CMenuBar* defaultMenu = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
-        if (defaultMenu != nil) {
-            [CMenuBar activate:defaultMenu modallyDisabled:NO];
+        if ([ApplicationDelegate sharedDelegate] != nil) {
+            CMenuBar* defaultMenu = [[ApplicationDelegate sharedDelegate] defaultMenuBar];
+            if (defaultMenu != nil) {
+                [CMenuBar activate:defaultMenu modallyDisabled:NO];
+            }
         }
     }
 }

--- a/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
@@ -203,7 +203,11 @@
 
 - (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
 {
-    return YES;
+    BOOL supportsSecureState = YES;
+    if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
+        supportsSecureState = NO;
+    }
+    return supportsSecureState;
 }
 
 - (void)processQueuedEventsWithTargetDelegate:(id <NSApplicationDelegate>)delegate

--- a/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
@@ -121,10 +121,6 @@
     } copy]];
 }
 
-- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
-    return YES;
-}
-
 - (void)application:(NSApplication *)theApplication openFiles:(NSArray *)fileNames
 {
     [self.queue addObject:[^(){
@@ -202,6 +198,12 @@
     [self.queue addObject:[^(){
         [[self.realDelegate class] _appDidUnhide];
     } copy]];
+}
+
+
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
+{
+    return YES;
 }
 
 - (void)processQueuedEventsWithTargetDelegate:(id <NSApplicationDelegate>)delegate

--- a/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
@@ -203,9 +203,14 @@
 
 - (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
 {
-    BOOL supportsSecureState = YES;
-    if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
-        supportsSecureState = NO;
+    static BOOL checked = NO;
+    static BOOL supportsSecureState = YES;
+
+    if (checked == NO) {
+        checked = YES;
+        if (getenv("AWT_DISABLE_NSDELEGATE_SECURE_SAVE") != NULL) {
+            supportsSecureState = NO;
+        }
     }
     return supportsSecureState;
 }

--- a/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libosxapp/QueuingApplicationDelegate.m
@@ -121,6 +121,10 @@
     } copy]];
 }
 
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
+    return YES;
+}
+
 - (void)application:(NSApplication *)theApplication openFiles:(NSArray *)fileNames
 {
     [self.queue addObject:[^(){


### PR DESCRIPTION
With Xcode upgraded to 14.3.1 for macOS builds secure coding warning message was seen in the logs as below:

"WARNING: Secure coding is not enabled for restorable state! Enable secure coding by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState: and returning YES."

which requires AppDelegate to explicitly implement applicationSupportsSecureRestorableState() to return true as mentioned here in [Apple Release notes](https://developer.apple.com/documentation/macos-release-notes/appkit-release-notes-for-macos-14#Restorable-State).

While investigating JFX embedded scenario (Swing components in FX window) another issue observed was that the AWT was overriding the FX delegate causing the app to crash in certain scenarios. This issue is also being fixed in this PR and also as part of [JDK-8319669](https://bugs.openjdk.org/browse/JDK-8319669) , https://github.com/openjdk/jfx/pull/1280.

The fix for JDK-8318854 involves:

- implementing applicationSupportsSecureRestorableState() in ApplicationDelegate.m & QueuingApplicationDelegate.m to return YES  by default, unless the env var - **AWT_DISABLE_NSDELEGATE_SECURE_SAVE**  is defined.

- Fix added to stop AWT toolkit from overriding a delegate set by another NSApplication by default. There is an option to restore the old behavior by defining the env var - **AWT_OVERRIDE_NSDELEGATE**.

- Null checks are added for shared delegate in cases where it can be null and cause issues in AWTWindow.m, CMenuBar.m, ApplicationDelegate.m

Test scenarios involving JDK and JFX fixes is documented here 
[Updated_Test_Scenarios.xlsx](https://github.com/openjdk/jdk/files/13491545/Updated_Test_Scenarios.xlsx)

 
**PLEASE NOTE !!**  The environment variables being added as part of this fix are for debugging only and should NOT be used for application purpose. As such they will NOT be documented.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8318854](https://bugs.openjdk.org/browse/JDK-8318854): [macos14] Running any AWT app prints Secure coding warning (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16569/head:pull/16569` \
`$ git checkout pull/16569`

Update a local copy of the PR: \
`$ git checkout pull/16569` \
`$ git pull https://git.openjdk.org/jdk.git pull/16569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16569`

View PR using the GUI difftool: \
`$ git pr show -t 16569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16569.diff">https://git.openjdk.org/jdk/pull/16569.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16569#issuecomment-1804492690)