### PR TITLE
8319753: Duration javadoc has "period" instead of "duration" in several places

### DIFF
--- a/src/java.base/share/classes/java/time/Duration.java
+++ b/src/java.base/share/classes/java/time/Duration.java
@@ -305,7 +305,7 @@ public final class Duration
      * @param amount  the amount of the duration, measured in terms of the unit, positive or negative
      * @param unit  the unit that the duration is measured in, must have an exact duration, not null
      * @return a {@code Duration}, not null
-     * @throws DateTimeException if the period unit has an estimated duration
+     * @throws DateTimeException if the unit has an estimated duration
      * @throws ArithmeticException if a numeric overflow occurs
      */
     public static Duration of(long amount, TemporalUnit unit) {
@@ -352,7 +352,7 @@ public final class Duration
      * considered to be exactly 24 hours.
      * <p>
      * The string starts with an optional sign, denoted by the ASCII negative
-     * or positive symbol. If negative, the whole period is negated.
+     * or positive symbol. If negative, the whole duration is negated.
      * The ASCII letter "P" is next in upper or lower case.
      * There are then four sections, each consisting of a number and a suffix.
      * The sections have suffixes in ASCII of "D", "H", "M" and "S" for
@@ -476,7 +476,7 @@ public final class Duration
      * For full accuracy, either the {@link ChronoUnit#NANOS NANOS} unit or the
      * {@link ChronoField#NANO_OF_SECOND NANO_OF_SECOND} field should be supported.
      * <p>
-     * The result of this method can be a negative period if the end is before the start.
+     * The result of this method can be a negative duration if the end is before the start.
      * To guarantee to obtain a positive duration call {@link #abs()} on the result.
      *
      * @param startInclusive  the start instant, inclusive, not null
@@ -671,7 +671,7 @@ public final class Duration
      * This instance is immutable and unaffected by this method call.
      *
      * @param seconds  the seconds to represent, may be negative
-     * @return a {@code Duration} based on this period with the requested seconds, not null
+     * @return a {@code Duration} based on this duration with the requested seconds, not null
      */
     public Duration withSeconds(long seconds) {
         return create(seconds, nanos);
@@ -686,7 +686,7 @@ public final class Duration
      * This instance is immutable and unaffected by this method call.
      *
      * @param nanoOfSecond  the nano-of-second to represent, from 0 to 999,999,999
-     * @return a {@code Duration} based on this period with the requested nano-of-second, not null
+     * @return a {@code Duration} based on this duration with the requested nano-of-second, not null
      * @throws DateTimeException if the nano-of-second is invalid
      */
     public Duration withNanos(int nanoOfSecond) {


### PR DESCRIPTION
This change simply replaces "period" with "duration", or in one case replaces "period unit" with just "unit".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8319845](https://bugs.openjdk.org/browse/JDK-8319845) to be approved

### Issues
 * [JDK-8319753](https://bugs.openjdk.org/browse/JDK-8319753): Duration javadoc has "period" instead of "duration" in several places (**Bug** - P4)
 * [JDK-8319845](https://bugs.openjdk.org/browse/JDK-8319845): Duration javadoc has "period" instead of "duration" in several places (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16573/head:pull/16573` \
`$ git checkout pull/16573`

Update a local copy of the PR: \
`$ git checkout pull/16573` \
`$ git pull https://git.openjdk.org/jdk.git pull/16573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16573`

View PR using the GUI difftool: \
`$ git pr show -t 16573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16573.diff">https://git.openjdk.org/jdk/pull/16573.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16573#issuecomment-1802767727)