### PR TITLE
8319670: Improve comments describing system properties for TLS server and client for max chain length

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLConfiguration.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLConfiguration.java
@@ -138,7 +138,10 @@ final class SSLConfiguration implements Cloneable {
     static {
         boolean globalPropSet = false;
 
-        // jdk.tls.maxCertificateChainLength property has no default
+        /*
+         * jdk.tls.maxCertificateChainLength system property works for both
+         * server and client modes.
+         */
         Integer maxCertificateChainLength = GetIntegerAction.privilegedGetProperty(
                 "jdk.tls.maxCertificateChainLength");
         if (maxCertificateChainLength != null && maxCertificateChainLength >= 0) {
@@ -146,20 +149,15 @@ final class SSLConfiguration implements Cloneable {
         }
 
         /*
-         * If either jdk.tls.server.maxInboundCertificateChainLength or
-         * jdk.tls.client.maxInboundCertificateChainLength is set, it will
-         * override jdk.tls.maxCertificateChainLength, regardless of whether
-         * jdk.tls.maxCertificateChainLength is set or not.
-         * If neither jdk.tls.server.maxInboundCertificateChainLength nor
-         * jdk.tls.client.maxInboundCertificateChainLength is set, the behavior
-         * depends on the setting of jdk.tls.maxCertificateChainLength. If
-         * jdk.tls.maxCertificateChainLength is set, it falls back to that
-         * value; otherwise, it defaults to 8 for
-         * jdk.tls.server.maxInboundCertificateChainLength
-         * and 10 for jdk.tls.client.maxInboundCertificateChainLength.
-         * Users can independently set either
-         * jdk.tls.server.maxInboundCertificateChainLength or
-         * jdk.tls.client.maxInboundCertificateChainLength.
+         * jdk.tls.server.maxInboundCertificateChainLength system property
+         * works in server mode.
+         * maxInboundClientCertChainLen is the maximum length of a client
+         * certificate chain accepted by a server. It is determined as follows:
+         *  - If the jdk.tls.server.maxInboundCertificateChainLength system
+         *    property is set and its value >= 0, it uses that value.
+         *  - Otherwise, if the jdk.tls.maxCertificateChainLength system
+         *    property is set and its value >= 0, it uses that value.
+         *  - Otherwise it is set to a default value of 8.
          */
         Integer inboundClientLen = GetIntegerAction.privilegedGetProperty(
                 "jdk.tls.server.maxInboundCertificateChainLength");
@@ -172,6 +170,17 @@ final class SSLConfiguration implements Cloneable {
             maxInboundClientCertChainLen = inboundClientLen;
         }
 
+        /*
+         * jdk.tls.client.maxInboundCertificateChainLength system property
+         * works in client mode.
+         * maxInboundServerCertChainLen is the maximum length of a server
+         * certificate chain accepted by a client. It is determined as follows:
+         *  - If the jdk.tls.client.maxInboundCertificateChainLength system
+         *    property is set and its value >= 0, it uses that value.
+         *  - Otherwise, if the jdk.tls.maxCertificateChainLength system
+         *    property is set and its value >= 0, it uses that value.
+         *  - Otherwise it is set to a default value of 10.
+         */
         Integer inboundServerLen = GetIntegerAction.privilegedGetProperty(
                 "jdk.tls.client.maxInboundCertificateChainLength");
 


### PR DESCRIPTION
Please review the comment change in SSLConfiguration class that describes TLS related system properties used to enforce certificate chain length. Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319670](https://bugs.openjdk.org/browse/JDK-8319670): Improve comments describing system properties for TLS server and client for max chain length (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16576/head:pull/16576` \
`$ git checkout pull/16576`

Update a local copy of the PR: \
`$ git checkout pull/16576` \
`$ git pull https://git.openjdk.org/jdk.git pull/16576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16576`

View PR using the GUI difftool: \
`$ git pr show -t 16576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16576.diff">https://git.openjdk.org/jdk/pull/16576.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16576#issuecomment-1803000716)