### PR TITLE
JDK-8318175 : AIX PPC64: Handle alignment of double in structs

### DIFF
--- a/test/jdk/java/foreign/nested/libNested.c
+++ b/test/jdk/java/foreign/nested/libNested.c
@@ -26,8 +26,8 @@
 #else
 #define EXPORT
 #endif
-#ifdef _AIX 
-#pragma align (natural) 
+#ifdef _AIX
+#pragma align (natural)
 #endif
 
 struct S1{ double f0; long long f1; double f2; int f3; };

--- a/test/jdk/java/foreign/nested/libNested.c
+++ b/test/jdk/java/foreign/nested/libNested.c
@@ -26,6 +26,9 @@
 #else
 #define EXPORT
 #endif
+#ifdef _AIX 
+#pragma align (natural) 
+#endif
 
 struct S1{ double f0; long long f1; double f2; int f3; };
 union U1{ short f0; long long f1; short f2; char f3[4][3]; };
@@ -92,3 +95,7 @@ EXPORT struct S13 test_S13(struct S13 arg, struct S13(*cb)(struct S13)) { return
 EXPORT struct S14 test_S14(struct S14 arg, struct S14(*cb)(struct S14)) { return cb(arg); }
 EXPORT union U16 test_U16(union U16 arg, union U16(*cb)(union U16)) { return cb(arg); }
 EXPORT struct S15 test_S15(struct S15 arg, struct S15(*cb)(struct S15)) { return cb(arg); }
+
+#ifdef _AIX
+#pragma align (reset)
+#endif

--- a/test/jdk/java/foreign/shared.h
+++ b/test/jdk/java/foreign/shared.h
@@ -34,6 +34,9 @@
 #else
 #define EXPORT
 #endif
+#ifdef _AIX
+#pragma align (natural)
+#endif
 
 struct S_I { int p0; };
 struct S_F { float p0; };
@@ -120,3 +123,7 @@ struct S_PPF { void* p0; void* p1; float p2; };
 struct S_PPD { void* p0; void* p1; double p2; };
 struct S_PPP { void* p0; void* p1; void* p2; };
 struct S_FFFF { float p0; float p1; float p2; float p3; };
+
+#ifdef _AIX
+#pragma align (reset)
+#endif


### PR DESCRIPTION
1. use pragma directive to handle alignment.

JBS Issue: [JDK-8318175](https://bugs.openjdk.org/browse/JDK-8318175)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318175](https://bugs.openjdk.org/browse/JDK-8318175): AIX PPC64: Handle alignment of double in structs (**Sub-task** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16579/head:pull/16579` \
`$ git checkout pull/16579`

Update a local copy of the PR: \
`$ git checkout pull/16579` \
`$ git pull https://git.openjdk.org/jdk.git pull/16579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16579`

View PR using the GUI difftool: \
`$ git pr show -t 16579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16579.diff">https://git.openjdk.org/jdk/pull/16579.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16579#issuecomment-1810503510)