### PR TITLE
JDK-8319828: runtime/NMT/VirtualAllocCommitMerge.java may fail if mixing interpreted and compiled native invocations

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
+++ b/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
@@ -29,7 +29,7 @@
  *          java.management
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail VirtualAllocCommitMerge
+ * @run main/othervm -Xbootclasspath/a:. -Xint -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=detail VirtualAllocCommitMerge
  *
  */
 

--- a/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
+++ b/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
@@ -24,9 +24,9 @@
 /*
  * @test
  * @summary Test merging of committed virtual memory and that we track it correctly
- * @comment: needs to be executed with -Xint (or, alternatively, -Xcomp -Xbatch) since it relies on comparing
- *           NMT call stacks, and we must make sure that all functions on the stack that NMT sees are either compiled
- *           from the get-go or stay always interpreted.
+ * @comment needs to be executed with -Xint (or, alternatively, -Xcomp -Xbatch) since it relies on comparing
+ *          NMT call stacks, and we must make sure that all functions on the stack that NMT sees are either compiled
+ *          from the get-go or stay always interpreted.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
+++ b/test/hotspot/jtreg/runtime/NMT/VirtualAllocCommitMerge.java
@@ -24,6 +24,9 @@
 /*
  * @test
  * @summary Test merging of committed virtual memory and that we track it correctly
+ * @comment: needs to be executed with -Xint (or, alternatively, -Xcomp -Xbatch) since it relies on comparing
+ *           NMT call stacks, and we must make sure that all functions on the stack that NMT sees are either compiled
+ *           from the get-go or stay always interpreted.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
We saw this problem on s390x, but it was easy to reproduce on x64.

The test creates adjacent commit sections via NMTCommitMemory(), and then expects them to show up as merged sections in the NMT report. That sometimes fails.

The relevant snippet in the NMT report was:

```
[0x000003ff859fc000 - 0x000003ff85dfc000] reserved 4096KB for Test from
    [0x000003ffb4ad2a58] WB_NMTReserveMemory+0xc0
    [0x000003ff9bf43344]

    [0x000003ff859fc000 - 0x000003ff85a1c000] committed 128KB from
            [0x000003ffb4ad288c] WB_NMTCommitMemory+0xc4

    [0x000003ff85a1c000 - 0x000003ff85a5c000] committed 256KB from
            [0x000003ffb4ad288c] WB_NMTCommitMemory+0xc4
            [0x000003ff9bf43344]
```

Note how it shows two adjacent commit sections, one 128k, one 256k, that the test expected to show up as one merged section of 384k.

The reason for this is that the first invocation of NMTCommitMemory was done interpreted, the second one compiled. Therefore we run with different stacks, one with an interpreter codelet, one with an nmethod. Can be easily reproduced on x64, see annotated stack:

```
[0x00007fceb0147000 - 0x00007fceb0547000] reserved 4096KB for Test from
    [0x00007fcef3beccd5] WB_NMTReserveMemory+0xa5
    [0x00007fcedb92bbce]0x00007fcedb92bbce is at code_begin+1806 in an Interpreter codelet

[0x00007fceb0147000 - 0x00007fceb0167000] committed 128KB from
            [0x00007fcef3bed098] WB_NMTCommitMemory+0xa8
            [0x00007fcedc0901a1]0x00007fcedc0901a1 is at entry_point+225 in (nmethod*)0x00007fcedc08ff10

[0x00007fceb0167000 - 0x00007fceb01a7000] committed 256KB from
            [0x00007fcef3bed098] WB_NMTCommitMemory+0xa8
            [0x00007fcedb92bbce]0x00007fcedb92bbce is at code_begin+1806 in an Interpreter codelet

```

Since the stacks differ, NMT does not merge the sections. And that is fine; it shouldn't do that.

---

The fix is to just run everything interpreted. I don't want to just define compilation for NMTCommitMemory(), since the compiled vs interpreted question may affect other stack frames as well. Best to have stable stack frames for this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319828](https://bugs.openjdk.org/browse/JDK-8319828): runtime/NMT/VirtualAllocCommitMerge.java may fail if mixing interpreted and compiled native invocations (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16583/head:pull/16583` \
`$ git checkout pull/16583`

Update a local copy of the PR: \
`$ git checkout pull/16583` \
`$ git pull https://git.openjdk.org/jdk.git pull/16583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16583`

View PR using the GUI difftool: \
`$ git pr show -t 16583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16583.diff">https://git.openjdk.org/jdk/pull/16583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16583#issuecomment-1804126280)