### PR TITLE
8319818: Address GCC 13.2.0 warnings (stringop-overflow and dangling-pointer)

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -90,6 +90,7 @@ DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
 
 ifeq ($(DEBUG_LEVEL), fastdebug)
   ifeq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, aarch64)), true)
+    # False positive warnings for atomic_linux_aarch64.hpp on GCC >= 13
     DISABLED_WARNINGS_gcc += stringop-overflow
   endif
 endif

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -88,6 +88,12 @@ DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     maybe-uninitialized missing-field-initializers parentheses \
     shift-negative-value unknown-pragmas
 
+ifeq ($(DEBUG_LEVEL), fastdebug)
+  ifeq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, aarch64)), true)
+    DISABLED_WARNINGS_gcc += stringop-overflow
+  endif
+endif
+
 DISABLED_WARNINGS_clang := sometimes-uninitialized \
     missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas
 

--- a/src/hotspot/share/memory/resourceArea.cpp
+++ b/src/hotspot/share/memory/resourceArea.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,18 @@ void ResourceArea::bias_to(MEMFLAGS new_flags) {
 }
 
 #ifdef ASSERT
+
+ResourceMark::ResourceMark(ResourceArea* area, Thread* thread) :
+    _impl(area),
+    _thread(thread),
+    _previous_resource_mark(nullptr)
+{
+  if (_thread != nullptr) {
+    assert(_thread == Thread::current(), "not the current thread");
+    _previous_resource_mark = _thread->current_resource_mark();
+    _thread->set_current_resource_mark(this);
+  }
+}
 
 void ResourceArea::verify_has_resource_mark() {
   if (_nesting <= 0 && !VMError::is_error_reported()) {

--- a/src/hotspot/share/memory/resourceArea.hpp
+++ b/src/hotspot/share/memory/resourceArea.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -193,17 +193,7 @@ class ResourceMark: public StackObj {
 #ifndef ASSERT
   ResourceMark(ResourceArea* area, Thread* thread) : _impl(area) {}
 #else
-  ResourceMark(ResourceArea* area, Thread* thread) :
-    _impl(area),
-    _thread(thread),
-    _previous_resource_mark(nullptr)
-  {
-    if (_thread != nullptr) {
-      assert(_thread == Thread::current(), "not the current thread");
-      _previous_resource_mark = _thread->current_resource_mark();
-      _thread->set_current_resource_mark(this);
-    }
-  }
+  ResourceMark(ResourceArea* area, Thread* thread);
 #endif // ASSERT
 
 public:


### PR DESCRIPTION
This PR is splitting out the GCC 13.2.0 warning related changes from #16550, excluding the Oracle/devkit parts, for clarity and to make potential backports more straightforward.

GCC 13.2.0 generates two new warnings:

* linux-aarch64-debug

src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.hpp:203:66: error: 'long unsigned int __atomic_load_8(const volatile void*, int)' writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]

I did not find any way to adjust the code to avoid this warning, so I instead chose to disable it in `CompileJvm.gmk` for linux-aarch64-(fast)debug only.

* linux-zero

src/hotspot/share/runtime/thread.hpp:579:77: error: storing the address of local variable 'rm' in '*_thr_current.Thread::_current_resource_mark' [-Werror=dangling-pointer=]

Lots and lots of warnings related to ResourceMark. Thanks to @stefank for suggesting moving the ASSERT implementation of the ResourceMark constructor to the .cpp file. With that change there's no need to explicitly disable the warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319818](https://bugs.openjdk.org/browse/JDK-8319818): Address GCC 13.2.0 warnings (stringop-overflow and dangling-pointer) (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [47ace39f](https://git.openjdk.org/jdk/pull/16584/files/47ace39fdeb46ab80be3799808335e3da55c708a)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [47ace39f](https://git.openjdk.org/jdk/pull/16584/files/47ace39fdeb46ab80be3799808335e3da55c708a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16584/head:pull/16584` \
`$ git checkout pull/16584`

Update a local copy of the PR: \
`$ git checkout pull/16584` \
`$ git pull https://git.openjdk.org/jdk.git pull/16584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16584`

View PR using the GUI difftool: \
`$ git pr show -t 16584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16584.diff">https://git.openjdk.org/jdk/pull/16584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16584#issuecomment-1804132077)