### PR TITLE
8319668: Fixup of jar filename typo in BadFactoryTest.sh

### DIFF
--- a/test/jdk/javax/script/JDK_8196959/BadFactoryTest.sh
+++ b/test/jdk/javax/script/JDK_8196959/BadFactoryTest.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -56,5 +56,5 @@ fi
 
 echo "Running test without security manager ..."
 $JAVA ${TESTVMOPTS} -classpath \
-  "${TESTCLASSES}${PS}${TESTCLASSES}/badfactoty.jar" \
+  "${TESTCLASSES}${PS}${TESTCLASSES}/badfactory.jar" \
   BadFactoryTest


### PR DESCRIPTION
The file test/jdk/javax/script/JDK_8196959/BadFactoryTest.sh contains a typo. When running without security manager, the test references 'badfactoty.jar' instead of 'badfactory.jar'. This change addresses this by correcting the jar name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319668](https://bugs.openjdk.org/browse/JDK-8319668): Fixup of jar filename typo in BadFactoryTest.sh (**Bug** - P5)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [5cd537cb](https://git.openjdk.org/jdk/pull/16585/files/5cd537cb23795ef3d8264711137298a4028a51a2)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16585/head:pull/16585` \
`$ git checkout pull/16585`

Update a local copy of the PR: \
`$ git checkout pull/16585` \
`$ git pull https://git.openjdk.org/jdk.git pull/16585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16585`

View PR using the GUI difftool: \
`$ git pr show -t 16585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16585.diff">https://git.openjdk.org/jdk/pull/16585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16585#issuecomment-1804199315)