### PR TITLE
JDK-8318189: ChoiceFormat::format throws undocumented AIOOBE

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -475,10 +475,18 @@ public class ChoiceFormat extends NumberFormat {
 
     /**
      * Specialization of format. This method really calls
-     * {@code format(double, StringBuffer, FieldPosition)}
-     * thus the range of longs that are supported is only equal to
+     * {@link #format(double, StringBuffer, FieldPosition)}.
+     * Thus, the range of longs that are supported is only equal to
      * the range that can be stored by double. This will never be
      * a practical limitation.
+     *
+     * @param number number to be formatted and substituted.
+     * @param toAppendTo where text is appended.
+     * @param status ignore no useful status is returned.
+     * @throws    ArrayIndexOutOfBoundsException if either the {@code limits}
+     *            or {@code formats} of this ChoiceFormat are empty
+     * @throws    NullPointerException if {@code toAppendTo}
+     *            is {@code null}
      */
     @Override
     public StringBuffer format(long number, StringBuffer toAppendTo,
@@ -488,9 +496,12 @@ public class ChoiceFormat extends NumberFormat {
 
     /**
      * Returns pattern with formatted double.
+     *
      * @param number number to be formatted and substituted.
      * @param toAppendTo where text is appended.
      * @param status ignore no useful status is returned.
+     * @throws    ArrayIndexOutOfBoundsException if either the {@code limits}
+     *            or {@code formats} of this ChoiceFormat are empty
      * @throws    NullPointerException if {@code toAppendTo}
      *            is {@code null}
      */


### PR DESCRIPTION
Please review this PR which makes an `ArrayIndexOutOfBoundsException` apparent in ChoiceFormat::format.

An _incomplete_ ChoiceFormat can be created, which is not revealed until format is invoked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8318191](https://bugs.openjdk.org/browse/JDK-8318191) to be approved

### Issues
 * [JDK-8318189](https://bugs.openjdk.org/browse/JDK-8318189): ChoiceFormat::format throws undocumented AIOOBE (**Bug** - P4)
 * [JDK-8318191](https://bugs.openjdk.org/browse/JDK-8318191): ChoiceFormat::format throws undocumented AIOOBE (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16587/head:pull/16587` \
`$ git checkout pull/16587`

Update a local copy of the PR: \
`$ git checkout pull/16587` \
`$ git pull https://git.openjdk.org/jdk.git pull/16587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16587`

View PR using the GUI difftool: \
`$ git pr show -t 16587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16587.diff">https://git.openjdk.org/jdk/pull/16587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16587#issuecomment-1804755359)