### PR TITLE
8319820: Use unnamed variables in the FFM implementation

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -558,29 +558,23 @@ public abstract sealed class AbstractMemorySegmentImpl
         } else {
             bufferScope = MemorySessionImpl.createHeap(bufferRef(bb));
         }
+        long off = bbAddress + ((long)pos << scaleFactor);
+        long len = (long)size << scaleFactor;
         if (base != null) {
             return switch (base) {
-                case byte[] __ ->
-                        new HeapMemorySegmentImpl.OfByte(bbAddress + (pos << scaleFactor), base, size << scaleFactor, readOnly, bufferScope);
-                case short[] __ ->
-                        new HeapMemorySegmentImpl.OfShort(bbAddress + (pos << scaleFactor), base, size << scaleFactor, readOnly, bufferScope);
-                case char[] __ ->
-                        new HeapMemorySegmentImpl.OfChar(bbAddress + (pos << scaleFactor), base, size << scaleFactor, readOnly, bufferScope);
-                case int[] __ ->
-                        new HeapMemorySegmentImpl.OfInt(bbAddress + (pos << scaleFactor), base, size << scaleFactor, readOnly, bufferScope);
-                case float[] __ ->
-                        new HeapMemorySegmentImpl.OfFloat(bbAddress + (pos << scaleFactor), base, size << scaleFactor, readOnly, bufferScope);
-                case long[] __ ->
-                        new HeapMemorySegmentImpl.OfLong(bbAddress + (pos << scaleFactor), base, size << scaleFactor, readOnly, bufferScope);
-                case double[] __ ->
-                        new HeapMemorySegmentImpl.OfDouble(bbAddress + (pos << scaleFactor), base, size << scaleFactor, readOnly, bufferScope);
+                case byte[]   _ -> new HeapMemorySegmentImpl.OfByte(off, base, len, readOnly, bufferScope);
+                case short[]  _ -> new HeapMemorySegmentImpl.OfShort(off, base, len, readOnly, bufferScope);
+                case char[]   _ -> new HeapMemorySegmentImpl.OfChar(off, base, len, readOnly, bufferScope);
+                case int[]    _ -> new HeapMemorySegmentImpl.OfInt(off, base, len, readOnly, bufferScope);
+                case float[]  _ -> new HeapMemorySegmentImpl.OfFloat(off, base, len, readOnly, bufferScope);
+                case long[]   _ ->  new HeapMemorySegmentImpl.OfLong(off, base, len, readOnly, bufferScope);
+                case double[] _ -> new HeapMemorySegmentImpl.OfDouble(off, base, len, readOnly, bufferScope);
                 default -> throw new AssertionError("Cannot get here");
             };
         } else if (unmapper == null) {
-            return new NativeMemorySegmentImpl(bbAddress + (pos << scaleFactor), size << scaleFactor, readOnly, bufferScope);
+            return new NativeMemorySegmentImpl(off, len, readOnly, bufferScope);
         } else {
-            // we can ignore scale factor here, a mapped buffer is always a byte buffer, so scaleFactor == 0.
-            return new MappedMemorySegmentImpl(bbAddress + pos, unmapper, size, readOnly, bufferScope);
+            return new MappedMemorySegmentImpl(off, unmapper, len, readOnly, bufferScope);
         }
     }
 
@@ -721,13 +715,10 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     private static int getScaleFactor(Buffer buffer) {
         return switch (buffer) {
-            case ByteBuffer   __ -> 0;
-            case CharBuffer   __ -> 1;
-            case ShortBuffer  __ -> 1;
-            case IntBuffer    __ -> 2;
-            case FloatBuffer  __ -> 2;
-            case LongBuffer   __ -> 3;
-            case DoubleBuffer __ -> 3;
+            case ByteBuffer   _                 -> 0;
+            case CharBuffer   _, ShortBuffer  _ -> 1;
+            case IntBuffer    _, FloatBuffer  _ -> 2;
+            case LongBuffer   _, DoubleBuffer _ -> 3;
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -567,9 +567,9 @@ public abstract sealed class AbstractMemorySegmentImpl
                 case char[]   _ -> new HeapMemorySegmentImpl.OfChar(off, base, len, readOnly, bufferScope);
                 case int[]    _ -> new HeapMemorySegmentImpl.OfInt(off, base, len, readOnly, bufferScope);
                 case float[]  _ -> new HeapMemorySegmentImpl.OfFloat(off, base, len, readOnly, bufferScope);
-                case long[]   _ ->  new HeapMemorySegmentImpl.OfLong(off, base, len, readOnly, bufferScope);
+                case long[]   _ -> new HeapMemorySegmentImpl.OfLong(off, base, len, readOnly, bufferScope);
                 case double[] _ -> new HeapMemorySegmentImpl.OfDouble(off, base, len, readOnly, bufferScope);
-                default -> throw new AssertionError("Cannot get here");
+                default         -> throw new AssertionError("Cannot get here");
             };
         } else if (unmapper == null) {
             return new NativeMemorySegmentImpl(off, len, readOnly, bufferScope);

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -296,13 +296,13 @@ public final class Utils {
 
         public static BaseAndScale of(Object array) {
             return switch (array) {
-                case byte[]   __ -> BaseAndScale.BYTE;
-                case char[]   __ -> BaseAndScale.CHAR;
-                case short[]  __ -> BaseAndScale.SHORT;
-                case int[]    __ -> BaseAndScale.INT;
-                case float[]  __ -> BaseAndScale.FLOAT;
-                case long[]   __ -> BaseAndScale.LONG;
-                case double[] __ -> BaseAndScale.DOUBLE;
+                case byte[]   _ -> BaseAndScale.BYTE;
+                case char[]   _ -> BaseAndScale.CHAR;
+                case short[]  _ -> BaseAndScale.SHORT;
+                case int[]    _ -> BaseAndScale.INT;
+                case float[]  _ -> BaseAndScale.FLOAT;
+                case long[]   _ -> BaseAndScale.LONG;
+                case double[] _ -> BaseAndScale.DOUBLE;
                 default -> throw new IllegalArgumentException("Not a supported array class: " + array.getClass().getSimpleName());
             };
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -254,7 +254,7 @@ public final class FallbackLinker extends AbstractLinker {
                 acquireCallback.accept(addrArg);
                 argSeg.set(al, 0, addrArg);
             }
-            case GroupLayout           __ ->
+            case GroupLayout            _ ->
                     MemorySegment.copy((MemorySegment) arg, 0, argSeg, 0, argSeg.byteSize()); // by-value struct
             case null, default -> {
                 assert layout == null;

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/x64/sysv/TypeClass.java
@@ -220,7 +220,7 @@ class TypeClass {
                     }
                 }
             }
-            case PaddingLayout __ -> {
+            case PaddingLayout  _ -> {
             }
             case SequenceLayout seq -> {
                 MemoryLayout elem = seq.elementLayout();


### PR DESCRIPTION
This PR proposes to use unnamed variables now that they have become available in Java.

There is also a cosmetic cleanup making a switch rake smaller and where variables are pre-calculated rather than spreading expressions around.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319820](https://bugs.openjdk.org/browse/JDK-8319820): Use unnamed variables in the FFM implementation (**Enhancement** - P5)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [c2a94d36](https://git.openjdk.org/jdk/pull/16594/files/c2a94d36712d0461ad877e766d1bba6efd8e0b7f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16594/head:pull/16594` \
`$ git checkout pull/16594`

Update a local copy of the PR: \
`$ git checkout pull/16594` \
`$ git pull https://git.openjdk.org/jdk.git pull/16594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16594`

View PR using the GUI difftool: \
`$ git pr show -t 16594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16594.diff">https://git.openjdk.org/jdk/pull/16594.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16594#issuecomment-1805226670)