### PR TITLE
8317723: C2: CountedLoopEndNodes and Zero Trip Guards are wrongly treated as Runtime Predicate

### DIFF
--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -431,6 +431,7 @@ public:
   Node* fold_compares(PhaseIterGVN* phase);
   static Node* up_one_dom(Node* curr, bool linear_only = false);
   Node* dominated_by(Node* prev_dom, PhaseIterGVN* igvn);
+  bool is_zero_trip_guard() const;
 
   // Takes the type of val and filters it through the test represented
   // by if_proj and returns a more refined type if one is produced.

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1774,6 +1774,13 @@ Node* IfProjNode::Identity(PhaseGVN* phase) {
   return this;
 }
 
+bool IfNode::is_zero_trip_guard() const {
+  if (in(1)->is_Bool() && in(1)->in(1)->is_Cmp()) {
+    return in(1)->in(1)->in(1)->Opcode() == Op_OpaqueZeroTripGuard;
+  }
+  return false;
+}
+
 #ifndef PRODUCT
 //------------------------------dump_spec--------------------------------------
 void IfNode::dump_spec(outputStream *st) const {

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -87,17 +87,14 @@ bool RuntimePredicate::is_success_proj(Node* node, Deoptimization::DeoptReason d
 // A Runtime Predicate must have an If or a RangeCheck node, while the If should not be a zero trip guard check.
 bool RuntimePredicate::may_be_runtime_predicate_if(Node* node) {
   if (node->is_IfProj()) {
-    const int opcode_if = node->in(0)->Opcode();
-    if ((opcode_if == Op_If && is_not_zero_trip_guard(node->as_IfProj()))
+    const IfNode* if_node = node->in(0)->as_If();
+    const int opcode_if = if_node->Opcode();
+    if ((opcode_if == Op_If && !if_node->is_zero_trip_guard())
         || opcode_if == Op_RangeCheck) {
       return true;
     }
   }
   return false;
-}
-
-bool RuntimePredicate::is_not_zero_trip_guard(const IfProjNode* if_proj) {
-  return !if_proj->in(0)->as_If()->is_zero_trip_guard();
 }
 
 ParsePredicateIterator::ParsePredicateIterator(const Predicates& predicates) : _current_index(0) {

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -77,11 +77,27 @@ Deoptimization::DeoptReason RuntimePredicate::uncommon_trap_reason(IfProjNode* i
 }
 
 bool RuntimePredicate::is_success_proj(Node* node, Deoptimization::DeoptReason deopt_reason) {
-  if (node->is_IfProj() && !node->in(0)->is_ParsePredicate()) {
+  if (may_be_runtime_predicate_if(node)) {
     return deopt_reason == uncommon_trap_reason(node->as_IfProj());
   } else {
     return false;
   }
+}
+
+// A Runtime Predicate must have an If or a RangeCheck node, while the If should not be a zero trip guard check.
+bool RuntimePredicate::may_be_runtime_predicate_if(Node* node) {
+  if (node->is_IfProj()) {
+    const int opcode_if = node->in(0)->Opcode();
+    if ((opcode_if == Op_If && is_not_zero_trip_guard(node->as_IfProj()))
+        || opcode_if == Op_RangeCheck) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool RuntimePredicate::is_not_zero_trip_guard(const IfProjNode* if_proj) {
+  return !if_proj->in(0)->as_If()->is_zero_trip_guard();
 }
 
 ParsePredicateIterator::ParsePredicateIterator(const Predicates& predicates) : _current_index(0) {
@@ -118,6 +134,7 @@ void PredicateBlock::verify_block() {
     const int opcode = next->Opcode();
     assert(next->is_IfProj() || opcode == Op_If || opcode == Op_RangeCheck,
            "Regular Predicates consist of an IfProj and an If or RangeCheck node");
+    assert(opcode != Op_If || !next->as_If()->is_zero_trip_guard(), "should not be zero trip guard");
     next = next->in(0);
   }
 }

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -258,6 +258,9 @@ class ParsePredicate : public StackObj {
 class RuntimePredicate : public StackObj {
   static Deoptimization::DeoptReason uncommon_trap_reason(IfProjNode* if_proj);
 
+  static bool may_be_runtime_predicate_if(Node* node);
+  static bool is_not_zero_trip_guard(const IfProjNode* if_proj);
+
  public:
   static bool is_success_proj(Node* node, Deoptimization::DeoptReason deopt_reason);
 };

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -257,9 +257,7 @@ class ParsePredicate : public StackObj {
 // Utility class for queries on Runtime Predicates.
 class RuntimePredicate : public StackObj {
   static Deoptimization::DeoptReason uncommon_trap_reason(IfProjNode* if_proj);
-
   static bool may_be_runtime_predicate_if(Node* node);
-  static bool is_not_zero_trip_guard(const IfProjNode* if_proj);
 
  public:
   static bool is_success_proj(Node* node, Deoptimization::DeoptReason deopt_reason);

--- a/test/hotspot/jtreg/compiler/predicates/TestWrongRuntimePredicateDetection.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestWrongRuntimePredicateDetection.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8317723
+ * @library /test/lib
+ * @summary Test that CountedLoopEndNodes and zero trip guard check If nodes are not treated as Runtime Predicates.
+ * @run main/othervm -XX:-TieredCompilation -Xbatch
+ *                   -XX:CompileCommand=compileonly,compiler.predicates.TestWrongRuntimePredicateDetection::test*
+ *                   compiler.predicates.TestWrongRuntimePredicateDetection
+ */
+
+package compiler.predicates;
+
+public class TestWrongRuntimePredicateDetection {
+    static int[] iArr = new int[50];
+    static long instanceCount;
+    static boolean bFld = true;
+    static volatile byte byFld;
+    static long[][] lArrFld;
+
+
+    public static void main(String[] x) {
+        for (int i = 0; i < 1000; i++) {
+            testCountedLoopEndAsRuntimePredicate();
+        }
+        for (int i = 0; i < 10; i++) {
+            testZeroTripGuardAsRuntimePredicate();
+        }
+    }
+
+    static void testCountedLoopEndAsRuntimePredicate() {
+        int i22 = 7, i26, i28, i29 = 8, i31 = 1;
+        float f4;
+        do {
+            for (int i = 0; i < 10000; i++) {
+                if (bFld) {
+                    break;
+                }
+                instanceCount = byFld;
+            }
+            for (i26 = 4; 80 > i26; i26 += 2) ;
+        } while (++i22 < 315);
+        i28 = 6;
+        while ((i28 -= 3) > 0) {
+            for (f4 = i28; f4 < 53; f4++) {
+                bFld = false;
+            }
+            instanceCount = i26;
+            do {
+                switch ((i26 >>> 1) % 2 * 5 + 6) {
+                    case 12:
+                    case 10:
+                        lArrFld[i31][1] = i29;
+                }
+            } while (++i31 < 53);
+        }
+    }
+
+    static void testZeroTripGuardAsRuntimePredicate() {
+        int m;
+        int a[] = new int[50];
+        for (int j = 0; j < a.length; j++) {
+            a[j] = j;
+        }
+
+        for (int j = 4; j < 42; j++) {
+            for (int k = 1; k < 5; k++) {
+                iArr[1] = 34;
+                switch (j % 4) {
+                    case 0:
+                        iArr = iArr;
+                    case 1:
+                    case 3:
+                        m = 3;
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
In `testCountedLoopEndAsRuntimePredicate()`, a `CountedLoopEndNode` is wrongly treated as Runtime Predicate and added to a Predicate Block. This happens because a predicate trap ends up at one of the projections of the `CountedLoopEndNode` due to folding some other nodes:

![image](https://github.com/openjdk/jdk/assets/17833009/d00af4aa-e962-454f-b7cd-5984dfda293f)

The verification code then reports this failure when trying to find all predicates above `530 CountedLoop`. I've fixed `RuntimePredicate::is_success_proj()` to only treat an `IfNode` or a `RangeCheckNode` as Runtime Predicate.

We could also end up treating a zero trip guard If node with an `OpaqueZeroTripGuardNode` as Runtime Predicate (see `testZeroTripGuardAsRuntimePredicate()`):

![image](https://github.com/openjdk/jdk/assets/17833009/a515bdfb-b599-4a81-902c-e85b980f5899)

This could also potentially lead to problems. I've improved `RuntimePredicate::is_success_proj()` to additionally exclude zero trip guard checks. I've strengthened the verification code accordingly such that it would have failed with  `testZeroTripGuardAsRuntimePredicate()`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317723](https://bugs.openjdk.org/browse/JDK-8317723): C2: CountedLoopEndNodes and Zero Trip Guards are wrongly treated as Runtime Predicate (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16596/head:pull/16596` \
`$ git checkout pull/16596`

Update a local copy of the PR: \
`$ git checkout pull/16596` \
`$ git pull https://git.openjdk.org/jdk.git pull/16596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16596`

View PR using the GUI difftool: \
`$ git pr show -t 16596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16596.diff">https://git.openjdk.org/jdk/pull/16596.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16596#issuecomment-1805338492)