### PR TITLE
8319876: Reduce memory consumption of VM_ThreadDump::doit

### DIFF
--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -228,7 +228,6 @@ VM_ThreadDump::VM_ThreadDump(ThreadDumpResult* result,
   _result = result;
   _num_threads = 0; // 0 indicates all threads
   _threads = nullptr;
-  _result = result;
   _max_depth = max_depth;
   _with_locked_monitors = with_locked_monitors;
   _with_locked_synchronizers = with_locked_synchronizers;
@@ -243,7 +242,6 @@ VM_ThreadDump::VM_ThreadDump(ThreadDumpResult* result,
   _result = result;
   _num_threads = num_threads;
   _threads = threads;
-  _result = result;
   _max_depth = max_depth;
   _with_locked_monitors = with_locked_monitors;
   _with_locked_synchronizers = with_locked_synchronizers;

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -695,13 +695,12 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHasht
                         RegisterMap::UpdateMap::include,
                         RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
-
+    ResourceMark rm;
     // If full, we want to print both vthread and carrier frames
     vframe* start_vf = !full && _thread->is_vthread_mounted()
       ? _thread->carrier_last_java_vframe(&reg_map)
       : _thread->last_java_vframe(&reg_map);
     int count = 0;
-    ResourceMark rm;
     for (vframe* f = start_vf; f; f = f->sender() ) {
       if (maxDepth >= 0 && count == maxDepth) {
         // Skip frames if more than maxDepth

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -695,7 +695,7 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHasht
                         RegisterMap::UpdateMap::include,
                         RegisterMap::ProcessFrames::include,
                         RegisterMap::WalkContinuation::skip);
-    ResourceMark rm;
+    ResourceMark rm(VMThread::vm_thread());
     // If full, we want to print both vthread and carrier frames
     vframe* start_vf = !full && _thread->is_vthread_mounted()
       ? _thread->carrier_last_java_vframe(&reg_map)

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -701,6 +701,7 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHasht
       ? _thread->carrier_last_java_vframe(&reg_map)
       : _thread->last_java_vframe(&reg_map);
     int count = 0;
+    ResourceMark rm;
     for (vframe* f = start_vf; f; f = f->sender() ) {
       if (maxDepth >= 0 && count == maxDepth) {
         // Skip frames if more than maxDepth


### PR DESCRIPTION
I would like to fix this.

Create 4096 threads, and the stack depth of each thread is 256. 
After running jmx.dumpAllThreads(true, true), the RSS reaches 5.3GiB. 
After optimization, the RSS is 250MiB.

I would appreciate it if anyone could review this.

---------
update

If the number of `threads` and `stack depth` are relatively large, we need to apply for more space in `ResourceArea` during the execution of `jmx.dumpAllThreads(true, true)`.

The reason is that `VM_ThreadDump::doit` creates `vframe` for each `frame` of each `thread`.
https://github.com/openjdk/jdk/blob/fe0ccdf5f8a5559a608d2e2cd2b6aecbe245c5ec/src/hotspot/share/services/threadService.cpp#L704
sizeof `vframe` is 4808 (bytes), and sizeof `compiledVFrame` is 4824 (bytes), mainly because the `xmm registers` in `RegisterMap` are relatively large. Assuming there are 4096 `threads` and each `thread` has 256 `frames`, the memory required is 4096 * 256 * 4824 = 4.7GiB。

These memories of all threads are released once by the the initial `ResourceMark` of `VM_ThreadDump::doit`.
https://github.com/openjdk/jdk/blob/fe0ccdf5f8a5559a608d2e2cd2b6aecbe245c5ec/src/hotspot/share/runtime/vmOperations.cpp#L269
My solution is to add a `ResourceMark` for each thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319876](https://bugs.openjdk.org/browse/JDK-8319876): Reduce memory consumption of VM_ThreadDump::doit (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16598/head:pull/16598` \
`$ git checkout pull/16598`

Update a local copy of the PR: \
`$ git checkout pull/16598` \
`$ git pull https://git.openjdk.org/jdk.git pull/16598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16598`

View PR using the GUI difftool: \
`$ git pr show -t 16598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16598.diff">https://git.openjdk.org/jdk/pull/16598.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16598#issuecomment-1805362872)