### PR TITLE
8319882: SequenceLayout::toString throws ArithmeticException

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/SequenceLayoutImpl.java
@@ -179,7 +179,7 @@ public final class SequenceLayoutImpl extends AbstractLayout<SequenceLayoutImpl>
 
     @Override
     public String toString() {
-        boolean max = (Long.MAX_VALUE / elementLayout.byteSize()) == elemCount;
+        boolean max = (Long.MAX_VALUE / Math.max(1, elementLayout.byteSize())) == elemCount;
         return decorateLayoutString(String.format("[%s:%s]",
                 max ? "*" : elemCount, elementLayout));
     }

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -217,6 +217,21 @@ public class TestLayouts {
     }
 
     @Test
+    public void testSequenceLayoutWithZeroLength() {
+        SequenceLayout layout = MemoryLayout.sequenceLayout(0, JAVA_INT);
+        assertEquals(layout.toString(), "[0:i4]");
+
+        SequenceLayout nested = MemoryLayout.sequenceLayout(0, layout);
+        assertEquals(nested.toString(), "[0:[0:i4]]");
+
+        SequenceLayout layout2 = MemoryLayout.sequenceLayout(0, JAVA_INT);
+        assertEquals(layout, layout2);
+
+        SequenceLayout nested2 = MemoryLayout.sequenceLayout(0, layout2);
+        assertEquals(nested, nested2);
+    }
+
+    @Test
     public void testStructOverflow() {
         assertThrows(IllegalArgumentException.class, // negative
                 () -> MemoryLayout.structLayout(MemoryLayout.sequenceLayout(Long.MAX_VALUE, JAVA_BYTE),


### PR DESCRIPTION
This PR proposes to fix a problem where a sequence layout contains an element of `byteSize()` zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319882](https://bugs.openjdk.org/browse/JDK-8319882): SequenceLayout::toString throws ArithmeticException (**Bug** - P2)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16599/head:pull/16599` \
`$ git checkout pull/16599`

Update a local copy of the PR: \
`$ git checkout pull/16599` \
`$ git pull https://git.openjdk.org/jdk.git pull/16599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16599`

View PR using the GUI difftool: \
`$ git pr show -t 16599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16599.diff">https://git.openjdk.org/jdk/pull/16599.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16599#issuecomment-1805388966)