### PR TITLE
8319883: Zero: Use atomic built-ins for 64-bit accesses

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
@@ -288,17 +288,17 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
 // Atomically copy 64 bits of data
 inline void atomic_copy64(const volatile void *src, volatile void *dst) {
   int64_t tmp;
-  __atomic_load((int64_t*)src, &tmp, __ATOMIC_RELAXED);
-  __atomic_store((int64_t*)dst, &tmp, __ATOMIC_RELAXED);
+  __atomic_load(reinterpret_cast<const volatile int64_t*>(src), &tmp, __ATOMIC_RELAXED);
+  __atomic_store(reinterpret_cast<volatile int64_t*>(dst), &tmp, __ATOMIC_RELAXED);
 }
 
 template<>
 template<typename T>
 inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {
   STATIC_ASSERT(8 == sizeof(T));
-  int64_t dest;
-  __atomic_load((int64_t*)src, &dest, __ATOMIC_RELAXED);
-  return PrimitiveConversions::cast<T>(dest);
+  T dest;
+  __atomic_load(const_cast<T*>(src), &dest, __ATOMIC_RELAXED);
+  return dest;
 }
 
 template<>

--- a/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
@@ -286,30 +286,18 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
 }
 
 // Atomically copy 64 bits of data
-static void atomic_copy64(const volatile void *src, volatile void *dst) {
-#if defined(PPC32)
-  double tmp;
-  asm volatile ("lfd  %0, 0(%1)\n"
-                "stfd %0, 0(%2)\n"
-                : "=f"(tmp)
-                : "b"(src), "b"(dst));
-#elif defined(S390) && !defined(_LP64)
-  double tmp;
-  asm volatile ("ld  %0, 0(%1)\n"
-                "std %0, 0(%2)\n"
-                : "=r"(tmp)
-                : "a"(src), "a"(dst));
-#else
-  *(jlong *) dst = *(const jlong *) src;
-#endif
+inline void atomic_copy64(const volatile void *src, volatile void *dst) {
+  int64_t tmp;
+  __atomic_load((int64_t*)src, &tmp, __ATOMIC_RELAXED);
+  __atomic_store((int64_t*)dst, &tmp, __ATOMIC_RELAXED);
 }
 
 template<>
 template<typename T>
 inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {
   STATIC_ASSERT(8 == sizeof(T));
-  volatile int64_t dest;
-  atomic_copy64(reinterpret_cast<const volatile int64_t*>(src), reinterpret_cast<volatile int64_t*>(&dest));
+  int64_t dest;
+  __atomic_load((int64_t*)src, &dest, __ATOMIC_RELAXED);
   return PrimitiveConversions::cast<T>(dest);
 }
 
@@ -318,7 +306,7 @@ template<typename T>
 inline void Atomic::PlatformStore<8>::operator()(T volatile* dest,
                                                  T store_value) const {
   STATIC_ASSERT(8 == sizeof(T));
-  atomic_copy64(reinterpret_cast<const volatile int64_t*>(&store_value), reinterpret_cast<volatile int64_t*>(dest));
+  __atomic_store(dest, &store_value, __ATOMIC_RELAXED);
 }
 
 #endif // OS_CPU_BSD_ZERO_ATOMIC_BSD_ZERO_HPP

--- a/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
@@ -134,15 +134,17 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
 
 // Atomically copy 64 bits of data
 inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-  int64_t tmp = __atomic_load_n((int64_t*)src, __ATOMIC_RELAXED);
-  __atomic_store_n((int64_t*)dst, tmp, __ATOMIC_RELAXED);
+  int64_t tmp;
+  __atomic_load((int64_t*)src, &tmp, __ATOMIC_RELAXED);
+  __atomic_store((int64_t*)dst, &tmp, __ATOMIC_RELAXED);
 }
 
 template<>
 template<typename T>
 inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {
   STATIC_ASSERT(8 == sizeof(T));
-  int64_t dest = __atomic_load_n(src, __ATOMIC_RELAXED);
+  int64_t dest;
+  __atomic_load((int64_t*)src, &dest, __ATOMIC_RELAXED);
   return PrimitiveConversions::cast<T>(dest);
 }
 
@@ -151,7 +153,7 @@ template<typename T>
 inline void Atomic::PlatformStore<8>::operator()(T volatile* dest,
                                                  T store_value) const {
   STATIC_ASSERT(8 == sizeof(T));
-  __atomic_store_n(dest, store_value, __ATOMIC_RELAXED);
+  __atomic_store(dest, &store_value, __ATOMIC_RELAXED);
 }
 
 #endif // OS_CPU_LINUX_ZERO_ATOMIC_LINUX_ZERO_HPP

--- a/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
@@ -134,53 +134,15 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
 
 // Atomically copy 64 bits of data
 inline void atomic_copy64(const volatile void *src, volatile void *dst) {
-#if defined(PPC32) && !defined(__SPE__)
-  double tmp;
-  asm volatile ("lfd  %0, %2\n"
-                "stfd %0, %1\n"
-                : "=&f"(tmp), "=Q"(*(volatile double*)dst)
-                : "Q"(*(volatile double*)src));
-#elif defined(PPC32) && defined(__SPE__)
-  long tmp;
-  asm volatile ("evldd  %0, %2\n"
-                "evstdd %0, %1\n"
-                : "=&r"(tmp), "=Q"(*(volatile long*)dst)
-                : "Q"(*(volatile long*)src));
-#elif defined(S390) && !defined(_LP64)
-  double tmp;
-  asm volatile ("ld  %0, %2\n"
-                "std %0, %1\n"
-                : "=&f"(tmp), "=Q"(*(volatile double*)dst)
-                : "Q"(*(volatile double*)src));
-#elif defined(__ARM_ARCH_7A__)
-  // The only way to perform the atomic 64-bit load/store
-  // is to use ldrexd/strexd for both reads and writes.
-  // For store, we need to have the matching (fake) load first.
-  // Put clrex between exclusive ops on src and dst for clarity.
-  uint64_t tmp_r, tmp_w;
-  uint32_t flag_w;
-  asm volatile ("ldrexd %[tmp_r], [%[src]]\n"
-                "clrex\n"
-                "1:\n"
-                "ldrexd %[tmp_w], [%[dst]]\n"
-                "strexd %[flag_w], %[tmp_r], [%[dst]]\n"
-                "cmp    %[flag_w], 0\n"
-                "bne    1b\n"
-                : [tmp_r] "=&r" (tmp_r), [tmp_w] "=&r" (tmp_w),
-                  [flag_w] "=&r" (flag_w)
-                : [src] "r" (src), [dst] "r" (dst)
-                : "cc", "memory");
-#else
-  *(jlong *) dst = *(const jlong *) src;
-#endif
+  int64_t tmp = __atomic_load_n((int64_t*)src, __ATOMIC_RELAXED);
+  __atomic_store_n((int64_t*)dst, tmp, __ATOMIC_RELAXED);
 }
 
 template<>
 template<typename T>
 inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {
   STATIC_ASSERT(8 == sizeof(T));
-  volatile int64_t dest;
-  atomic_copy64(reinterpret_cast<const volatile int64_t*>(src), reinterpret_cast<volatile int64_t*>(&dest));
+  int64_t dest = __atomic_load_n(src, __ATOMIC_RELAXED);
   return PrimitiveConversions::cast<T>(dest);
 }
 
@@ -189,7 +151,7 @@ template<typename T>
 inline void Atomic::PlatformStore<8>::operator()(T volatile* dest,
                                                  T store_value) const {
   STATIC_ASSERT(8 == sizeof(T));
-  atomic_copy64(reinterpret_cast<const volatile int64_t*>(&store_value), reinterpret_cast<volatile int64_t*>(dest));
+  __atomic_store_n(dest, store_value, __ATOMIC_RELAXED);
 }
 
 #endif // OS_CPU_LINUX_ZERO_ATOMIC_LINUX_ZERO_HPP

--- a/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
@@ -135,17 +135,17 @@ inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
 // Atomically copy 64 bits of data
 inline void atomic_copy64(const volatile void *src, volatile void *dst) {
   int64_t tmp;
-  __atomic_load((int64_t*)src, &tmp, __ATOMIC_RELAXED);
-  __atomic_store((int64_t*)dst, &tmp, __ATOMIC_RELAXED);
+  __atomic_load(reinterpret_cast<const volatile int64_t*>(src), &tmp, __ATOMIC_RELAXED);
+  __atomic_store(reinterpret_cast<volatile int64_t*>(dst), &tmp, __ATOMIC_RELAXED);
 }
 
 template<>
 template<typename T>
 inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {
   STATIC_ASSERT(8 == sizeof(T));
-  int64_t dest;
-  __atomic_load((int64_t*)src, &dest, __ATOMIC_RELAXED);
-  return PrimitiveConversions::cast<T>(dest);
+  T dest;
+  __atomic_load(const_cast<T*>(src), &dest, __ATOMIC_RELAXED);
+  return dest;
 }
 
 template<>


### PR DESCRIPTION
See the bug for reproducer and discussion.

This reimplements related Zero parts using `__atomic_*`: we already use some of those both in Atomic and around Hotspot code. As far as I can see from both GCC and LLVM docs, these would be translated to proper accesses on all target platforms. Doing even the relaxed atomic access for 64-bit platforms is probably an overkill, but for Zero we want baseline correctness first and foremost.

Example current uses of `__atomic_load` on both BSD (I think it assumes clang) and Linux (assumes GCC):
https://github.com/openjdk/jdk/blob/a64fc48e2dbc650b31869dd79b1ba1012376fc51/src/hotspot/os_cpu/bsd_aarch64/atomic_bsd_aarch64.hpp#L115
https://github.com/openjdk/jdk/blob/a64fc48e2dbc650b31869dd79b1ba1012376fc51/src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.hpp#L203
https://github.com/openjdk/jdk/blob/a64fc48e2dbc650b31869dd79b1ba1012376fc51/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp#L172

Additional testing:
 - [x] MacOS AArch64 Zero fastdebug; light jcstress tests still pass
 - [x] Linux x86_32 Zero release; previously failing jcstress testing now passes
 - [x] Linux x86_32 Zero fastdebug, `compiler/unsafe java/lang/invoke/VarHandles`
 - [x] Linux x86_32 Zero fastdebug, bootcycle-images

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319883](https://bugs.openjdk.org/browse/JDK-8319883): Zero: Use atomic built-ins for 64-bit accesses (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16600/head:pull/16600` \
`$ git checkout pull/16600`

Update a local copy of the PR: \
`$ git checkout pull/16600` \
`$ git pull https://git.openjdk.org/jdk.git pull/16600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16600`

View PR using the GUI difftool: \
`$ git pr show -t 16600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16600.diff">https://git.openjdk.org/jdk/pull/16600.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16600#issuecomment-1805823268)