### PR TITLE
8308399: Recommend --release when -source and -target are misused

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Arguments.java
@@ -62,10 +62,12 @@ import com.sun.tools.javac.main.OptionHelper.GrumpyHelper;
 import com.sun.tools.javac.platform.PlatformDescription;
 import com.sun.tools.javac.platform.PlatformUtils;
 import com.sun.tools.javac.resources.CompilerProperties.Errors;
+import com.sun.tools.javac.resources.CompilerProperties.Fragments;
 import com.sun.tools.javac.resources.CompilerProperties.Warnings;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticInfo;
+import com.sun.tools.javac.util.JCDiagnostic.Fragment;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.ListBuffer;
 import com.sun.tools.javac.util.Log;
@@ -521,9 +523,9 @@ public class Arguments {
             if (target.compareTo(source.requiredTarget()) < 0) {
                 if (targetString != null) {
                     if (sourceString == null) {
-                        reportDiag(Warnings.TargetDefaultSourceConflict(targetString, source.requiredTarget()));
+                        reportDiag(Errors.TargetDefaultSourceConflict(source.name, targetString));
                     } else {
-                        reportDiag(Warnings.SourceTargetConflict(sourceString, source.requiredTarget()));
+                        reportDiag(Errors.SourceTargetConflict(sourceString, targetString));
                     }
                     return false;
                 } else {
@@ -569,10 +571,10 @@ public class Arguments {
             if (fm instanceof BaseFileManager baseFileManager) {
                 if (source.compareTo(Source.JDK8) <= 0) {
                     if (baseFileManager.isDefaultBootClassPath())
-                        log.warning(LintCategory.OPTIONS, Warnings.SourceNoBootclasspath(source.name));
+                        log.warning(LintCategory.OPTIONS, Warnings.SourceNoBootclasspath(source.name, releaseNote(source, targetString)));
                 } else {
                     if (baseFileManager.isDefaultSystemModulesPath())
-                        log.warning(LintCategory.OPTIONS, Warnings.SourceNoSystemModulesPath(source.name));
+                        log.warning(LintCategory.OPTIONS, Warnings.SourceNoSystemModulesPath(source.name, releaseNote(source, targetString)));
                 }
             }
         }
@@ -638,6 +640,22 @@ public class Arguments {
         }
 
         return !errors && (log.nerrors == 0);
+    }
+
+    private Fragment releaseNote(Source source, String targetString) {
+        if (source.compareTo(Source.JDK8) <= 0) {
+            if (targetString != null) {
+                return Fragments.SourceNoBootclasspathWithTarget(source.name, targetString);
+            } else {
+                return Fragments.SourceNoBootclasspath(source.name);
+            }
+        } else {
+            if (targetString != null) {
+                return Fragments.SourceNoSystemModulesPathWithTarget(source.name, targetString);
+            } else {
+                return Fragments.SourceNoSystemModulesPath(source.name);
+            }
+        }
     }
 
     private void validateAddExports(SourceVersion sv) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3995,11 +3995,6 @@ compiler.err.target.default.source.conflict=\
     specified target release {1} is too old for the default source release {0}\n\
     --release {1} is recommended when compiling code to run on JDK {1}
 
-# 0: string, 1: string
-compiler.warn.too.new.target.for.source=\
-    specified target release {1} is unnecessarily new for the specified source release {0}\n\
-    --release {0} is recommended when compiling code to run on JDK {0}
-
 # 0: profile, 1: target
 compiler.warn.profile.target.conflict=\
     profile {0} is not valid for target release {1}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2115,13 +2115,33 @@ compiler.warn.static.not.qualified.by.type=\
 compiler.warn.static.not.qualified.by.type2=\
     static {0} should not be used as a member of an anonymous class
 
-# 0: string
+# 0: string, 1: fragment
 compiler.warn.source.no.bootclasspath=\
-    bootstrap class path not set in conjunction with -source {0}
+    bootstrap class path is not set in conjunction with -source {0}\n{1}
+
+# 0: string, 1: fragment
+compiler.warn.source.no.system.modules.path=\
+    location of system modules is not set in conjunction with -source {0}\n{1}
 
 # 0: string
-compiler.warn.source.no.system.modules.path=\
-    system modules path not set in conjunction with -source {0}
+compiler.misc.source.no.bootclasspath=\
+  not setting the bootstrap class path may lead to class files that cannot run on JDK {0}\n\
+  --release {0} is recommended instead of -source {0} because it sets the bootstrap class path automatically
+
+# 0: string
+compiler.misc.source.no.system.modules.path=\
+  not setting the location of system modules may lead to class files that cannot run on JDK {0}\n\
+  --release {0} is recommended instead of -source {0} because it sets the location of system modules automatically
+
+# 0: string, 1: string
+compiler.misc.source.no.bootclasspath.with.target=\
+  not setting the bootstrap class path may lead to class files that cannot run on JDK 8\n\
+  --release {0} is recommended instead of -source {0} -target {1} because it sets the bootstrap class path automatically
+
+# 0: string, 1: string
+compiler.misc.source.no.system.modules.path.with.target=\
+  not setting the location of system modules may lead to class files that cannot run on JDK {0}\n\
+  --release {0} is recommended instead of -source {0} -target {1} because it sets the location of system modules automatically
 
 # 0: string
 compiler.warn.option.obsolete.source=\
@@ -3965,13 +3985,20 @@ compiler.err.error.writing.file=\
 compiler.err.sourcepath.modulesourcepath.conflict=\
     cannot specify both --source-path and --module-source-path
 
-# 0: string, 1: target
-compiler.warn.source.target.conflict=\
-    source release {0} requires target release {1}
+# 0: string, 1: string
+compiler.err.source.target.conflict=\
+    specified target release {1} is too old for the specified source release {0}\n\
+    --release {1} is recommended when compiling code to run on JDK {1}
 
-# 0: string, 1: target
-compiler.warn.target.default.source.conflict=\
-    target release {0} conflicts with default source release {1}
+# 0: string, 1: string
+compiler.err.target.default.source.conflict=\
+    specified target release {1} is too old for the default source release {0}\n\
+    --release {1} is recommended when compiling code to run on JDK {1}
+
+# 0: string, 1: string
+compiler.warn.too.new.target.for.source=\
+    specified target release {1} is unnecessarily new for the specified source release {0}\n\
+    --release {0} is recommended when compiling code to run on JDK {0}
 
 # 0: profile, 1: target
 compiler.warn.profile.target.conflict=\

--- a/test/langtools/tools/javac/T8222035/MinContextOpTest_A.out
+++ b/test/langtools/tools/javac/T8222035/MinContextOpTest_A.out
@@ -1,4 +1,4 @@
-- compiler.warn.source.no.system.modules.path: 15
+- compiler.warn.source.no.system.modules.path: 15, (compiler.misc.source.no.system.modules.path: 15)
 MinContextOpTest.java:16:25: compiler.err.mod.not.allowed.here: static
 MinContextOpTest.java:22:25: compiler.err.mod.not.allowed.here: static
 MinContextOpTest.java:28:34: compiler.err.prob.found.req: (compiler.misc.infer.no.conforming.assignment.exists: T,K,V,E, (compiler.misc.inconvertible.types: java.util.function.Function<MinContextOpTest.A.T,MinContextOpTest.A.T>, java.util.function.Function<? super MinContextOpTest.A.T,? extends MinContextOpTest.A.T<?>>))

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -207,8 +207,8 @@ compiler.err.two.class.loaders.2
 compiler.err.unmatched.quote
 compiler.err.unsupported.release.version
 compiler.warn.profile.target.conflict
-compiler.warn.source.target.conflict
-compiler.warn.target.default.source.conflict
+compiler.err.source.target.conflict
+compiler.err.target.default.source.conflict
 compiler.err.preview.not.latest
 compiler.err.preview.without.source.or.release
 compiler.misc.illegal.signature                               # the compiler can now detect more non-denotable types before class writing

--- a/test/langtools/tools/javac/diags/examples/EnumsMustBeStatic.java
+++ b/test/langtools/tools/javac/diags/examples/EnumsMustBeStatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,7 @@
  */
 
 // key: compiler.err.static.declaration.not.allowed.in.inner.classes
-// key: compiler.warn.source.no.system.modules.path
-// options: -source 15
+// options: --release 15
 
 class EnumsMustBeStatic {
     class Nested {

--- a/test/langtools/tools/javac/diags/examples/InnerClassCantHaveStatic.java
+++ b/test/langtools/tools/javac/diags/examples/InnerClassCantHaveStatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,7 @@
  */
 
 // key: compiler.err.icls.cant.have.static.decl
-// key: compiler.warn.source.no.system.modules.path
-// options: -source 15
+// options: --release 15
 
 class InnerClassCantHaveStatic {
     class Inner {

--- a/test/langtools/tools/javac/diags/examples/InterfaceNotAllowed.java
+++ b/test/langtools/tools/javac/diags/examples/InterfaceNotAllowed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,7 @@
  */
 
 // key: compiler.err.intf.not.allowed.here
-// key: compiler.warn.source.no.system.modules.path
-// options: -source 15
+// options: --release 15
 
 class InterfaceNotAllowed {
     void m() {

--- a/test/langtools/tools/javac/diags/examples/LocalEnum.java
+++ b/test/langtools/tools/javac/diags/examples/LocalEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,8 +22,7 @@
  */
 
 // key: compiler.err.local.enum
-// key: compiler.warn.source.no.system.modules.path
-// options: -source 15
+// options: --release 15
 
 class LocalEnum {
     void m() {

--- a/test/langtools/tools/javac/diags/examples/ObsoleteSourceAndTarget.java
+++ b/test/langtools/tools/javac/diags/examples/ObsoleteSourceAndTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 // key: compiler.warn.option.obsolete.target
 // key: compiler.warn.option.obsolete.suppression
 // key: compiler.warn.source.no.bootclasspath
+// key: compiler.misc.source.no.bootclasspath.with.target
 // options: -source 1.8 -target 1.8
 
 class ObsoleteSourceAndTarget {

--- a/test/langtools/tools/javac/diags/examples/OptionRemovedSource.java
+++ b/test/langtools/tools/javac/diags/examples/OptionRemovedSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 // key: compiler.err.option.removed.source
 // key: compiler.warn.source.no.bootclasspath
+// key: compiler.misc.source.no.bootclasspath
 // options: -source 1.5
 
 class RemovedSourceAndTarget {

--- a/test/langtools/tools/javac/diags/examples/OptionRemovedTarget.java
+++ b/test/langtools/tools/javac/diags/examples/OptionRemovedTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 // key: compiler.err.option.removed.source
 // key: compiler.err.option.removed.target
 // key: compiler.warn.source.no.bootclasspath
+// key: compiler.misc.source.no.bootclasspath.with.target
 // options: -source 1.5 -target 1.5
 
 class RemovedSourceAndTarget {

--- a/test/langtools/tools/javac/diags/examples/Records.java
+++ b/test/langtools/tools/javac/diags/examples/Records.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 
 // key: compiler.misc.feature.records
 // key: compiler.err.feature.not.supported.in.source.plural
-// key: compiler.warn.source.no.system.modules.path
-// options: -source 15
+// options: --release 15
 
 record R() {}

--- a/test/langtools/tools/javac/diags/examples/SealedTypes.java
+++ b/test/langtools/tools/javac/diags/examples/SealedTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,7 @@
 
 // key: compiler.misc.feature.sealed.classes
 // key: compiler.err.feature.not.supported.in.source.plural
-// key: compiler.warn.source.no.system.modules.path
-// options: -source 16
+// options: --release 16
 
 sealed class Sealed {}
 

--- a/test/langtools/tools/javac/diags/examples/SourceNoBootclasspath.java
+++ b/test/langtools/tools/javac/diags/examples/SourceNoBootclasspath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.warn.source.no.bootclasspath
+// key: compiler.misc.source.no.bootclasspath
 // key: compiler.warn.option.obsolete.source
 // key: compiler.warn.option.obsolete.suppression
 // options: -source 8

--- a/test/langtools/tools/javac/diags/examples/SourceNoSystemModulesPath.java
+++ b/test/langtools/tools/javac/diags/examples/SourceNoSystemModulesPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 // key: compiler.warn.source.no.system.modules.path
+// key: compiler.misc.source.no.system.modules.path
 // options: -source 9
 
 class SourceNoSystemModulesPath { }

--- a/test/langtools/tools/javac/diags/examples/SourceNoSystemModulesPathWithTarget.java
+++ b/test/langtools/tools/javac/diags/examples/SourceNoSystemModulesPathWithTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,8 @@
  * questions.
  */
 
-// key: compiler.err.expected3
-// options: --release 15
+// key: compiler.warn.source.no.system.modules.path
+// key: compiler.misc.source.no.system.modules.path.with.target
+// options: -source 9 -target 9
 
-int Expected3;
+class SourceNoSystemModulesPath { }

--- a/test/langtools/tools/javac/diags/examples/TextBlockSource.java
+++ b/test/langtools/tools/javac/diags/examples/TextBlockSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,7 @@
 
  // key: compiler.misc.feature.text.blocks
  // key: compiler.err.feature.not.supported.in.source.plural
- // key: compiler.warn.source.no.system.modules.path
- // options: -source 14
+ // options: --release 14
 
 class TextBlockSource {
     String m() {

--- a/test/langtools/tools/javac/diags/examples/UnderscoreInLambdaExpression.java
+++ b/test/langtools/tools/javac/diags/examples/UnderscoreInLambdaExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,7 @@
 
 // key: compiler.err.feature.not.supported.in.source.plural
 // key: compiler.misc.feature.unnamed.variables
-// key: compiler.warn.source.no.system.modules.path
-// options: -source 21
+// options: --release 21
 
 public class UnderscoreInLambdaExpression {
     java.util.function.Function<String,String> f = _ -> "x";

--- a/test/langtools/tools/javac/options/BCPOrSystemNotSpecified.java
+++ b/test/langtools/tools/javac/options/BCPOrSystemNotSpecified.java
@@ -78,7 +78,7 @@ public class BCPOrSystemNotSpecified extends TestRunner {
 
         List<String> log;
         List<String> expected = Arrays.asList(
-                "- compiler.warn.source.no.bootclasspath: 8",
+                "- compiler.warn.source.no.bootclasspath: 8, (compiler.misc.source.no.bootclasspath: 8)",
                 "- compiler.warn.option.obsolete.source: 8",
                 "- compiler.warn.option.obsolete.suppression",
                 "3 warnings"
@@ -125,7 +125,7 @@ public class BCPOrSystemNotSpecified extends TestRunner {
 
         List<String> log;
         List<String> expected = Arrays.asList(
-                "- compiler.warn.source.no.system.modules.path: 9",
+                "- compiler.warn.source.no.system.modules.path: 9, (compiler.misc.source.no.system.modules.path: 9)",
                 "1 warning"
         );
 

--- a/test/langtools/tools/javac/options/T6900037.out
+++ b/test/langtools/tools/javac/options/T6900037.out
@@ -1,4 +1,4 @@
-- compiler.warn.source.no.bootclasspath: 8
+- compiler.warn.source.no.bootclasspath: 8, (compiler.misc.source.no.bootclasspath: 8)
 - compiler.warn.option.obsolete.source: 8
 - compiler.warn.option.obsolete.suppression
 - compiler.err.warnings.and.werror

--- a/test/langtools/tools/javac/options/smokeTests/OptionSmokeTest.java
+++ b/test/langtools/tools/javac/options/smokeTests/OptionSmokeTest.java
@@ -139,13 +139,13 @@ public class OptionSmokeTest extends TestRunner {
 
     @Test
     public void sourceAndTargetMismatch(Path base) throws Exception {
-        doTest(base, String.format("warning: source release %s requires target release %s", Source.DEFAULT.name, Source.DEFAULT.name),
+        doTest(base, String.format("error: specified target release %s is too old for the specified source release %s", Source.DEFAULT.name, Source.DEFAULT.name),
                 String.format("-source %s -target %s", Source.DEFAULT.name, Source.MIN.name));
     }
 
     @Test
     public void targetConflictsWithDefaultSource(Path base) throws Exception {
-        doTest(base, String.format("warning: target release %s conflicts with default source release %s", Source.MIN.name, Source.DEFAULT.name),
+        doTest(base, String.format("error: specified target release %s is too old for the default source release %s", Source.MIN.name, Source.DEFAULT.name),
                 String.format("-target %s", Source.MIN.name));
     }
 

--- a/test/langtools/tools/javac/options/smokeTests/OptionSmokeTest.java
+++ b/test/langtools/tools/javac/options/smokeTests/OptionSmokeTest.java
@@ -139,7 +139,7 @@ public class OptionSmokeTest extends TestRunner {
 
     @Test
     public void sourceAndTargetMismatch(Path base) throws Exception {
-        doTest(base, String.format("error: specified target release %s is too old for the specified source release %s", Source.DEFAULT.name, Source.DEFAULT.name),
+        doTest(base, String.format("error: specified target release %s is too old for the specified source release %s", Source.MIN.name, Source.DEFAULT.name),
                 String.format("-source %s -target %s", Source.DEFAULT.name, Source.MIN.name));
     }
 

--- a/test/langtools/tools/javac/var_implicit_lambda/VarInImplicitLambdaNegTest01_source10.out
+++ b/test/langtools/tools/javac/var_implicit_lambda/VarInImplicitLambdaNegTest01_source10.out
@@ -1,4 +1,4 @@
-- compiler.warn.source.no.system.modules.path: 10
+- compiler.warn.source.no.system.modules.path: 10, (compiler.misc.source.no.system.modules.path: 10)
 VarInImplicitLambdaNegTest01.java:12:36: compiler.err.feature.not.supported.in.source.plural: (compiler.misc.feature.var.syntax.in.implicit.lambda), 10, 11
 VarInImplicitLambdaNegTest01.java:15:28: compiler.err.invalid.lambda.parameter.declaration: (compiler.misc.implicit.and.explicit.not.allowed)
 VarInImplicitLambdaNegTest01.java:17:52: compiler.err.restricted.type.not.allowed.here: var


### PR DESCRIPTION
This patch modifies some warning and error messages to recommend `--release` more loudly. Please see details below.

Note that while the patch changes `compiler.warn.source.target.conflict` to `compiler.err.source.target.conflict`, there is no change in the set of accepted options and their combinations. This used to behave as an error, and still behaves as an error. So this patch only changes the console text from `warning: ...` to `error: ...`.

```
+ javac -source 8 /tmp/Test.java
warning: [options] bootstrap class path is not set in conjunction with -source 8
  not setting the bootstrap class path may lead to class files that cannot run on JDK 8
    --release 8 is recommended instead of -source 8 because it sets the bootstrap class path automatically
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings
```

```
+ javac -source 8 -target 8 /tmp/Test.java
warning: [options] bootstrap class path is not set in conjunction with -source 8
  not setting the bootstrap class path may lead to class files that cannot run on JDK 8
    --release 8 is recommended instead of -source 8 -target 8 because it sets the bootstrap class path automatically
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
4 warnings
```

```
+ javac -source 11 /tmp/Test.java
warning: [options] location of system modules is not set in conjunction with -source 11
  not setting the location of system modules may lead to class files that cannot run on JDK 11
    --release 11 is recommended instead of -source 11 because it sets the location of system modules automatically
1 warning
```

```
+ javac -source 11 -target 11 /tmp/Test.java
warning: [options] location of system modules is not set in conjunction with -source 11
  not setting the location of system modules may lead to class files that cannot run on JDK 11
    --release 11 is recommended instead of -source 11 -target 11 because it sets the location of system modules automatically
1 warning
```

```
+ javac -target 17 -source 11 /tmp/Test.java
warning: [options] location of system modules is not set in conjunction with -source 11
  not setting the location of system modules may lead to class files that cannot run on JDK 11
    --release 11 is recommended instead of -source 11 -target 17 because it sets the location of system modules automatically
1 warning
```

```
+ javac -target 8 -source 11 /tmp/Test.java
error: specified target release 8 is too old for the specified source release 11
  --release 8 is recommended when compiling code to run on JDK 8
```

```
+ javac -target 8 /tmp/Test.java
error: specified target release 8 is too old for the default source release 22
  --release 8 is recommended when compiling code to run on JDK 8
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308399](https://bugs.openjdk.org/browse/JDK-8308399): Recommend --release when -source and -target are misused (**Enhancement** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16612/head:pull/16612` \
`$ git checkout pull/16612`

Update a local copy of the PR: \
`$ git checkout pull/16612` \
`$ git pull https://git.openjdk.org/jdk.git pull/16612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16612`

View PR using the GUI difftool: \
`$ git pr show -t 16612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16612.diff">https://git.openjdk.org/jdk/pull/16612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16612#issuecomment-1805736644)