### PR TITLE
8318113: CSS.BackgroundImage doesn't implement equals

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2028,7 +2028,7 @@ public class CSS implements Serializable {
 
         @Override
         public int hashCode() {
-            return (this.svalue != null) ? this.svalue.hashCode() : 0;
+            return (this.svalue != null) ? Objects.hashCode(this.svalue) : 0;
         }
 
         @Override

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2028,7 +2028,7 @@ public class CSS implements Serializable {
 
         @Override
         public int hashCode() {
-            return (this.svalue != null) ? Objects.hashCode(this.svalue) : 0;
+            return (this.svalue != null) ? this.svalue.hashCode() : 0;
         }
 
         @Override
@@ -2968,7 +2968,7 @@ public class CSS implements Serializable {
 
         @Override
         public int hashCode() {
-            return (this.svalue != null) ? this.svalue.hashCode() : 0;
+            return (this.svalue != null) ? Objects.hashCode(this.svalue) : 0;
         }
 
         @Override

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2968,13 +2968,13 @@ public class CSS implements Serializable {
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(this.svalue);
+            return Objects.hashCode(svalue);
         }
 
         @Override
         public boolean equals(Object val) {
             return val instanceof CSS.BackgroundImage img
-                   && Objects.equals(this.svalue, img.svalue);
+                   && Objects.equals(svalue, img.svalue);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2965,6 +2965,17 @@ public class CSS implements Serializable {
             }
             return image;
         }
+
+        @Override
+        public int hashCode() {
+            return (this.svalue != null) ? this.svalue.hashCode() : 0;
+        }
+
+        @Override
+        public boolean equals(Object val) {
+            return val instanceof CSS.BackgroundImage img
+                   && Objects.equals(this.svalue, img.svalue);
+        }
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2968,7 +2968,7 @@ public class CSS implements Serializable {
 
         @Override
         public int hashCode() {
-            return (this.svalue != null) ? Objects.hashCode(this.svalue) : 0;
+            return Objects.hashCode(this.svalue);
         }
 
         @Override

--- a/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
+++ b/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
@@ -73,7 +73,7 @@ public class CSSAttributeEqualityBug {
 
             "border-width: medium",
 
-	    "background-image: none",
+            "background-image: none",
             "background-image: url(image.png)",
     };
 

--- a/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
+++ b/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
@@ -31,7 +31,7 @@ import javax.swing.text.html.StyleSheet;
 
 /*
  * @test
- * @bug 7083187
+ * @bug 7083187 8318113
  * @summary  Verifies if CSS.CSSValue attribute is same
  * @run main CSSAttributeEqualityBug
  */
@@ -89,6 +89,7 @@ public class CSSAttributeEqualityBug {
             {"margin-top: 42px", "margin-top: 22px"},
             {"margin-top: 42px", "margin-top: 42pt"},
             {"margin-top: 100%", "margin-top: 50%"},
+
             {"background-image: none", "background-image: url(image.png)"},
     };
 

--- a/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
+++ b/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
@@ -72,6 +72,9 @@ public class CSSAttributeEqualityBug {
             "background-position: 1em 2em",
 
             "border-width: medium",
+
+	    "background-image: none",
+            "background-image: url(image.png)",
     };
 
     /**
@@ -86,6 +89,7 @@ public class CSSAttributeEqualityBug {
             {"margin-top: 42px", "margin-top: 22px"},
             {"margin-top: 42px", "margin-top: 42pt"},
             {"margin-top: 100%", "margin-top: 50%"},
+            {"background-image: none", "background-image: url(image.png)"},
     };
 
     private static final String[][] EQUALS_WITH_SPACE = {


### PR DESCRIPTION
CSSBackgroundImage.equals() is implemented

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318113](https://bugs.openjdk.org/browse/JDK-8318113): CSS.BackgroundImage doesn't implement equals (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [d0d90aeb](https://git.openjdk.org/jdk/pull/16613/files/d0d90aebe9ab619d5de6d343a30f1c3cbb1f2206)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [d0d90aeb](https://git.openjdk.org/jdk/pull/16613/files/d0d90aebe9ab619d5de6d343a30f1c3cbb1f2206)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16613/head:pull/16613` \
`$ git checkout pull/16613`

Update a local copy of the PR: \
`$ git checkout pull/16613` \
`$ git pull https://git.openjdk.org/jdk.git pull/16613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16613`

View PR using the GUI difftool: \
`$ git pr show -t 16613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16613.diff">https://git.openjdk.org/jdk/pull/16613.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16613#issuecomment-1805827717)