### PR TITLE
8320577: Improve MessageHeader's toString() function to make HttpURLConnection's debug log readable

### DIFF
--- a/src/java.base/share/classes/sun/net/www/MessageHeader.java
+++ b/src/java.base/share/classes/sun/net/www/MessageHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/net/www/MessageHeader.java
+++ b/src/java.base/share/classes/sun/net/www/MessageHeader.java
@@ -554,7 +554,7 @@ class MessageHeader {
     }
 
     public synchronized String toString() {
-        String result = super.toString() + nkeys + " pairs: ";
+        String result = super.toString() + " " + nkeys + " pairs: ";
         for (int i = 0; i < keys.length && i < nkeys; i++) {
             result += "{"+keys[i]+": "+values[i]+"}";
         }


### PR DESCRIPTION
At the moment, if you have debug logging turned on for the `HttpURLConnection` class, then from [line 746](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java#L746) a log message like this is generated:
> sun.net.www.MessageHeader@49c4f2906 pairs: {null: HTTP/1.1 200}{Content-Type: application/json}{Transfer-Encoding: chunked}{Date: Thu, 09 Nov 2023 11:50:00 GMT}{Keep-Alive: timeout=60}{Connection: keep-alive}

The lack of separation after the `Object.toString()` output makes it hard to realise from the above that it's trying to say "6 pairs". 
The change proposed by this PR would make the same log operation output this, instead:
> sun.net.www.MessageHeader@49c4f290 6 pairs: {null: HTTP/1.1 200}{Content-Type: application/json}{Transfer-Encoding: chunked}{Date: Thu, 09 Nov 2023 11:50:00 GMT}{Keep-Alive: timeout=60}{Connection: keep-alive}

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320577](https://bugs.openjdk.org/browse/JDK-8320577): Improve MessageHeader's toString() function to make HttpURLConnection's debug log readable (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [5cb93c0f](https://git.openjdk.org/jdk/pull/16615/files/5cb93c0f53afdee7d8f3de12a9a712ae4ac724f5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16615/head:pull/16615` \
`$ git checkout pull/16615`

Update a local copy of the PR: \
`$ git checkout pull/16615` \
`$ git pull https://git.openjdk.org/jdk.git pull/16615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16615`

View PR using the GUI difftool: \
`$ git pr show -t 16615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16615.diff">https://git.openjdk.org/jdk/pull/16615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16615#issuecomment-1822393126)