### PR TITLE
8319531: FileServerHandler::discardRequestBody could be improved

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/LeftOverInputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/LeftOverInputStream.java
@@ -112,6 +112,9 @@ abstract class LeftOverInputStream extends FilterInputStream {
         int size = (int)Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
         byte[] skipBuffer = new byte[size];
         while (remaining > 0) {
+            if (server.isFinishing()) {
+                break;
+            }
             nr = readImpl(skipBuffer, 0, (int)Math.min(size, remaining));
             if (nr < 0) {
                 eof = true;

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/LeftOverInputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/LeftOverInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ abstract class LeftOverInputStream extends FilterInputStream {
     protected boolean closed = false;
     protected boolean eof = false;
     byte[] one = new byte [1];
+    private static final int MAX_SKIP_BUFFER_SIZE = 2048;
 
     public LeftOverInputStream (ExchangeImpl t, InputStream src) {
         super (src);
@@ -99,6 +100,29 @@ abstract class LeftOverInputStream extends FilterInputStream {
         return readImpl (b, off, len);
     }
 
+    @Override
+    public synchronized long skip(long n) throws IOException {
+        long remaining = n;
+        int nr;
+
+        if (n <= 0) {
+            return 0;
+        }
+
+        int size = (int)Math.min(MAX_SKIP_BUFFER_SIZE, remaining);
+        byte[] skipBuffer = new byte[size];
+        while (remaining > 0) {
+            nr = readImpl(skipBuffer, 0, (int)Math.min(size, remaining));
+            if (nr < 0) {
+                eof = true;
+                break;
+            }
+            remaining -= nr;
+        }
+
+        return n - remaining;
+    }
+
     /**
      * read and discard up to l bytes or "eof" occurs,
      * (whichever is first). Then return true if the stream
@@ -106,12 +130,12 @@ abstract class LeftOverInputStream extends FilterInputStream {
      * (still bytes to be read)
      */
     public boolean drain (long l) throws IOException {
-        int bufSize = 2048;
-        byte[] db = new byte [bufSize];
+        byte[] db = new byte [MAX_SKIP_BUFFER_SIZE];
         while (l > 0) {
             if (server.isFinishing()) {
                 break;
             }
+            int bufSize = Math.clamp(l, 0, MAX_SKIP_BUFFER_SIZE);
             long len = readImpl (db, 0, bufSize);
             if (len == -1) {
                 eof = true;

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/LeftOverInputStream.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/LeftOverInputStream.java
@@ -133,20 +133,11 @@ abstract class LeftOverInputStream extends FilterInputStream {
      * (still bytes to be read)
      */
     public boolean drain (long l) throws IOException {
-        byte[] db = new byte [MAX_SKIP_BUFFER_SIZE];
         while (l > 0) {
-            if (server.isFinishing()) {
-                break;
-            }
-            int bufSize = Math.clamp(l, 0, MAX_SKIP_BUFFER_SIZE);
-            long len = readImpl (db, 0, bufSize);
-            if (len == -1) {
-                eof = true;
-                return true;
-            } else {
-                l = l - len;
-            }
+            long skip = skip(l);
+            if (skip <= 0) break; // might return 0 if isFinishing or EOF
+            l -= skip;
         }
-        return false;
+        return eof;
     }
 }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/FileServerHandler.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/FileServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,7 +159,7 @@ public final class FileServerHandler implements HttpHandler {
 
     private static void discardRequestBody(HttpExchange exchange) throws IOException {
         try (InputStream is = exchange.getRequestBody()) {
-            is.readAllBytes();
+            is.skip(Integer.MAX_VALUE);
         }
     }
 


### PR DESCRIPTION
**Problem**
`discardRequestBody` calls `InputStream::readAllBytes` to read and discard all the request body bytes. This is somewhat wasteful as they can instead be skipped.

**Changes**
- Updated `FileServerHandler::discardRequestBody` to use `InputStream::skip`.
- Created skip in `LeftOverInputStream` based on [InputStream](https://github.com/openjdk/jdk/blob/c9657cad124d2be10b8d6006d0ca9a038b1c5945/src/java.base/share/classes/java/io/InputStream.java#L540). This gets used by `FixedLengthInputStream` and `ChunkedInputStream` which previously had been using the skip implementation from `FilteredInputStream` which would have caused blocking.

- Also made a minor change to `LeftOverInputStream::Drain` to change bufSize.


I ran test tiers 1-3 and all tests are passing with these changes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319531](https://bugs.openjdk.org/browse/JDK-8319531): FileServerHandler::discardRequestBody could be improved (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16616/head:pull/16616` \
`$ git checkout pull/16616`

Update a local copy of the PR: \
`$ git checkout pull/16616` \
`$ git pull https://git.openjdk.org/jdk.git pull/16616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16616`

View PR using the GUI difftool: \
`$ git pr show -t 16616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16616.diff">https://git.openjdk.org/jdk/pull/16616.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16616#issuecomment-1805946738)