### PR TITLE
JDK-8319927: Add some logging after 8295159

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -978,6 +978,12 @@ bool os::dll_address_to_library_name(address addr, char* buf,
 
 void *os::Bsd::dlopen_helper(const char *filename, int mode) {
 #ifndef IA32
+  bool ieee_handling = IEEE_subnormal_handling_OK();
+  if (!ieee_handling) {
+    Events::log_dll_message(nullptr, "IEEE subnormal handling check failed before loading %s", filename);
+    log_info(os)("IEEE subnormal handling check failed before loading %s", filename);
+  }
+
   // Save and restore the floating-point environment around dlopen().
   // There are known cases where global library initialization sets
   // FPU flags that affect computation accuracy, for example, enabling
@@ -1004,7 +1010,17 @@ void *os::Bsd::dlopen_helper(const char *filename, int mode) {
     // flags. Silently fix things now.
     int rtn = fesetenv(&default_fenv);
     assert(rtn == 0, "fesetenv must succeed");
-    assert(IEEE_subnormal_handling_OK(), "fsetenv didn't work");
+    bool ieee_handling_after_issue = IEEE_subnormal_handling_OK();
+
+    if (ieee_handling_after_issue) {
+      Events::log_dll_message(nullptr, "IEEE subnormal handling had to be corrected after loading %s", filename);
+      log_info(os)("IEEE subnormal handling had to be corrected after loading %s", filename);
+    } else {
+      Events::log_dll_message(nullptr, "IEEE subnormal handling could not be corrected after loading %s", filename);
+      log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
+    }
+
+    assert(ieee_handling_after_issue, "fesetenv didn't work");
   }
 #endif // IA32
 

--- a/test/hotspot/jtreg/compiler/floatingpoint/TestSubnormalDouble.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/TestSubnormalDouble.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8295159
  * @summary DSO created with -ffast-math breaks Java floating-point arithmetic
- * @run main/othervm/native compiler.floatingpoint.TestSubnormalDouble
+ * @run main/othervm/native -Xlog:os=info compiler.floatingpoint.TestSubnormalDouble
  */
 
 package compiler.floatingpoint;

--- a/test/hotspot/jtreg/compiler/floatingpoint/TestSubnormalFloat.java
+++ b/test/hotspot/jtreg/compiler/floatingpoint/TestSubnormalFloat.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8295159
  * @summary DSO created with -ffast-math breaks Java floating-point arithmetic
- * @run main/othervm/native compiler.floatingpoint.TestSubnormalFloat
+ * @run main/othervm/native -Xlog:os=info compiler.floatingpoint.TestSubnormalFloat
  */
 
 package compiler.floatingpoint;


### PR DESCRIPTION
[JDK-8295159](https://bugs.openjdk.org/browse/JDK-8295159) added some IEEE conformance checks and corrections on Linux and macOS/BSD , however in case of issues no logging is done, this should be improved.