### PR TITLE
8319932: [JVMCI] class unloading related tests can fail on libgraal with Xcomp

### DIFF
--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -220,6 +220,13 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // or Truffle compilation threads.
   bool _for_compile_broker;
 
+  // Number of CompileBroker compilations performed by this runtime.
+  int _num_compile_broker_compilations;
+
+  // Max number of CompileBroker compilations performed by a runtime
+  // before it should destroy its JavaVM.
+  static int _max_compile_broker_compilations_per_javavm;
+
   JVMCIObject create_jvmci_primitive_type(BasicType type, JVMCI_TRAPS);
 
   // Implementation methods for loading and constant pool access.
@@ -267,6 +274,10 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // Releases all the non-null entries in _oop_handles and then clears
   // the list. Returns the number released handles.
   int release_and_clear_oop_handles();
+
+  // Increment the CompilerBroker compilations counter.
+  // Returns true iff the counter reached the max allowed and was reset.
+  bool inc_compile_broker_compilations();
 
  public:
   JVMCIRuntime(JVMCIRuntime* next, int id, bool for_compile_broker);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319932](https://bugs.openjdk.org/browse/JDK-8319932): [JVMCI] class unloading related tests can fail on libgraal with Xcomp (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16621/head:pull/16621` \
`$ git checkout pull/16621`

Update a local copy of the PR: \
`$ git checkout pull/16621` \
`$ git pull https://git.openjdk.org/jdk.git pull/16621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16621`

View PR using the GUI difftool: \
`$ git pr show -t 16621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16621.diff">https://git.openjdk.org/jdk/pull/16621.diff</a>

</details>
