### PR TITLE
JDK-8319784: VM crash during heap dump after JDK-8287061

### DIFF
--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -265,6 +265,14 @@ ObjectValue* ObjectMergeValue::select(frame& fr, RegisterMap& reg_map) {
   }
 }
 
+Handle ObjectMergeValue::value() const {
+  if (_selected != nullptr) {
+    return _selected->value();
+  } else {
+    return Handle();
+  }
+}
+
 void ObjectMergeValue::read_object(DebugInfoReadStream* stream) {
   _selector = read_from(stream);
   _merge_pointer = read_from(stream);

--- a/src/hotspot/share/code/debugInfo.hpp
+++ b/src/hotspot/share/code/debugInfo.hpp
@@ -232,7 +232,7 @@ public:
   ScopeValue*                 field_at(int i) const           { ShouldNotReachHere(); return nullptr; }
   int                         field_size()                    { ShouldNotReachHere(); return -1; }
 
-  Handle                      value() const ;
+  Handle                      value() const;
   void                        set_value(oop value)            { assert(_selected != nullptr, "Should call select() first."); _selected->set_value(value); }
 
   // Serialization of debugging information

--- a/src/hotspot/share/code/debugInfo.hpp
+++ b/src/hotspot/share/code/debugInfo.hpp
@@ -232,7 +232,7 @@ public:
   ScopeValue*                 field_at(int i) const           { ShouldNotReachHere(); return nullptr; }
   int                         field_size()                    { ShouldNotReachHere(); return -1; }
 
-  Handle                      value() const                   { assert(_selected != nullptr, "Should call select() first."); return _selected->value(); }
+  Handle                      value() const ;
   void                        set_value(oop value)            { assert(_selected != nullptr, "Should call select() first."); _selected->set_value(value); }
 
   // Serialization of debugging information

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -44,7 +44,7 @@ public class TestReduceAllocationAndHeapDump {
                 dumpDirectory.mkdir();
             }
 
-            String[] dumper_args = {
+            String[] dumperArgs = {
                 "-server",
                 "-XX:CompileThresholdScaling=0.01",
                 "-XX:+HeapDumpAfterFullGC",
@@ -54,7 +54,7 @@ public class TestReduceAllocationAndHeapDump {
                 HeapDumper.class.getName()
             };
 
-            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(dumper_args);
+            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(dumperArgs);
             Process p = pb.start();
             OutputAnalyzer out = new OutputAnalyzer(p);
 

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8319784
+ * @summary Check that the JVM is able to dump the heap even when there are ReduceAllocationMerge in the scope.
+ * @requires vm.compiler2.enabled & vm.flagless
+ * @library /test/lib /
+ * @run main/othervm -server
+ *                   -XX:CompileThresholdScaling=0.01
+ *                   -XX:+HeapDumpAfterFullGC
+ *                   -XX:CompileCommand=compileonly,compiler.c2.TestReduceAllocationAndHeapDump::testIt
+ *                   -XX:CompileCommand=exclude,compiler.c2.TestReduceAllocationAndHeapDump::dummy
+ *                   compiler.c2.TestReduceAllocationAndHeapDump
+ */
+
+package compiler.c2;
+
+public class TestReduceAllocationAndHeapDump {
+    public static Point p = new Point(0);
+
+    public static void main(String[] args) throws Exception {
+        for (int i=0; i<5000; i++) {
+            testIt(i);
+        }
+    }
+
+    public static void testIt(int i) throws Exception {
+        Point p = (i % 2 == 0) ? new Point(i) : new Point(i);
+
+        dummy(i);
+
+        if (i < 5000) {
+            dummy(i);
+        } else {
+            dummy(p.x + i);
+        }
+    }
+
+    public static void dummy(int x) {
+        if (x > 4900)
+            System.gc();
+    }
+}
+
+// Helper class
+class Point {
+    public int x;
+
+    public Point(int xx) {
+        this.x = xx;
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java
@@ -76,7 +76,7 @@ class HeapDumper {
     public static Point p = new Point(0);
 
     public static void main(String[] args) throws Exception {
-        for (int i=0; i<5000; i++) {
+        for (int i = 0; i < 5000; i++) {
             testIt(i);
         }
     }


### PR DESCRIPTION
This fixes an incorrect assert in `debugInfo.hpp`. The assert is incorrect because this method may be called before rematerialization of the ObjectValue takes place, and therefore, `_selected` will be nullptr. This pull request patches the method to just return `Handle() => nullptr` if the rematerialization of the object hasn't taken place yet. This is the same behavior used by scalar-replaced objects not participating in merges.

I added a test to reproduce a scenario where the assert was causing a problem.

Tested on Ubuntu/MacOS/Windows x86_64 tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319784](https://bugs.openjdk.org/browse/JDK-8319784): VM crash during heap dump after JDK-8287061 (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [aa723f50](https://git.openjdk.org/jdk/pull/16622/files/aa723f50fca4f46e3d28aaccae4635ede0c8cf9e)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [26f7c936](https://git.openjdk.org/jdk/pull/16622/files/26f7c9365565396999caa83e571b682816096d55)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [26f7c936](https://git.openjdk.org/jdk/pull/16622/files/26f7c9365565396999caa83e571b682816096d55)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16622/head:pull/16622` \
`$ git checkout pull/16622`

Update a local copy of the PR: \
`$ git checkout pull/16622` \
`$ git pull https://git.openjdk.org/jdk.git pull/16622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16622`

View PR using the GUI difftool: \
`$ git pr show -t 16622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16622.diff">https://git.openjdk.org/jdk/pull/16622.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16622#issuecomment-1809347536)