### PR TITLE
JDK-8319628: DateFormat does not mention IllegalArgumentException for invalid style args

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -61,10 +61,12 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * normalization.  The date is represented as a {@code Date} object or
  * as the milliseconds since January 1, 1970, 00:00:00 GMT.
  *
- * <p>{@code DateFormat} provides many class methods for obtaining default date/time
+ * <p>{@code DateFormat} provides static factory methods for obtaining default date/time
  * formatters based on the default or a given locale and a number of formatting
- * styles. The formatting styles include {@link #FULL}, {@link #LONG}, {@link #MEDIUM}, and {@link #SHORT}. More
- * detail and examples of using these styles are provided in the method
+ * styles. The formatting styles include {@link #FULL}, {@link #LONG}, {@link #MEDIUM}, and {@link #SHORT}.
+ * For any of the factory methods with the parameter <i>style</i>, an {@code
+ * IllegalArgumentException} will be thrown if <i>style</i> is not equal to one
+ * of the defined formatting styles. More detail and examples of using these styles are provided in the method
  * descriptions.
  *
  * <p>{@code DateFormat} helps you to format and parse dates for any locale.
@@ -162,7 +164,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * {@code null}, but any subsequent operations on the same instance may throw
  * {@code NullPointerException}.</li>
  * <li>The {@link #getCalendar()}, {@link #getNumberFormat()} and
- * {@link getTimeZone()} methods may return {@code null}, if the respective
+ * {@link #getTimeZone()} methods may return {@code null}, if the respective
  * values of this instance is set to {@code null} through the corresponding
  * setter methods. For Example: {@link #getTimeZone()} may return {@code null},
  * if the {@code TimeZone} value of this instance is set as

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -65,7 +65,7 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
  * formatters based on the default or a given locale and a number of formatting
  * styles. The formatting styles include {@link #FULL}, {@link #LONG}, {@link #MEDIUM}, and {@link #SHORT}.
  * For any of the factory methods with the parameter <i>style</i>, an {@code
- * IllegalArgumentException} will be thrown if <i>style</i> is not equal to one
+ * IllegalArgumentException} will be thrown if <i>style</i> is not equal to any
  * of the defined formatting styles. More detail and examples of using these styles are provided in the method
  * descriptions.
  *


### PR DESCRIPTION
Please review this PR and [CSR](https://bugs.openjdk.org/browse/JDK-8319868) which makes IllegalArgumentExceptions apparent for the _j.text.DateFormat_ static factory methods that have the _style_ parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8319868](https://bugs.openjdk.org/browse/JDK-8319868) to be approved

### Issues
 * [JDK-8319628](https://bugs.openjdk.org/browse/JDK-8319628): DateFormat does not mention IllegalArgumentException for invalid style args (**Enhancement** - P4)
 * [JDK-8319868](https://bugs.openjdk.org/browse/JDK-8319868): DateFormat does not mention IllegalArgumentException for invalid style args (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16624/head:pull/16624` \
`$ git checkout pull/16624`

Update a local copy of the PR: \
`$ git checkout pull/16624` \
`$ git pull https://git.openjdk.org/jdk.git pull/16624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16624`

View PR using the GUI difftool: \
`$ git pr show -t 16624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16624.diff">https://git.openjdk.org/jdk/pull/16624.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16624#issuecomment-1807249243)