### PR TITLE
8319944: Remove DynamicDumpSharedSpaces

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -26,6 +26,7 @@
 #include "cds/archiveBuilder.hpp"
 #include "cds/archiveHeapWriter.hpp"
 #include "cds/archiveUtils.hpp"
+#include "cds/cdsConfig.hpp"
 #include "cds/cppVtables.hpp"
 #include "cds/dumpAllocStats.hpp"
 #include "cds/dynamicArchive.hpp"
@@ -515,7 +516,7 @@ bool ArchiveBuilder::is_excluded(Klass* klass) {
     Klass* bottom = ObjArrayKlass::cast(klass)->bottom_klass();
     if (MetaspaceShared::is_shared_static(bottom)) {
       // The bottom class is in the static archive so it's clearly not excluded.
-      assert(DynamicDumpSharedSpaces, "sanity");
+      assert(CDSConfig::is_dumping_dynamic_archive(), "sanity");
       return false;
     } else if (bottom->is_instance_klass()) {
       return SystemDictionaryShared::is_excluded_class(InstanceKlass::cast(bottom));
@@ -743,7 +744,7 @@ void ArchiveBuilder::make_klasses_shareable() {
       assert(k->is_instance_klass(), " must be");
       num_instance_klasses ++;
       InstanceKlass* ik = InstanceKlass::cast(k);
-      if (DynamicDumpSharedSpaces) {
+      if (CDSConfig::is_dumping_dynamic_archive()) {
         // For static dump, class loader type are already set.
         ik->assign_class_loader_type();
       }
@@ -816,7 +817,7 @@ uintx ArchiveBuilder::buffer_to_offset(address p) const {
 
 uintx ArchiveBuilder::any_to_offset(address p) const {
   if (is_in_mapped_static_archive(p)) {
-    assert(DynamicDumpSharedSpaces, "must be");
+    assert(CDSConfig::is_dumping_dynamic_archive(), "must be");
     return p - _mapped_static_archive_bottom;
   }
   if (!is_in_buffer_space(p)) {
@@ -924,7 +925,7 @@ void ArchiveBuilder::relocate_to_requested() {
     RelocateBufferToRequested<true> patcher(this);
     patcher.doit();
   } else {
-    assert(DynamicDumpSharedSpaces, "must be");
+    assert(CDSConfig::is_dumping_dynamic_archive(), "must be");
     _requested_dynamic_archive_top = _requested_dynamic_archive_bottom + my_archive_size;
     RelocateBufferToRequested<false> patcher(this);
     patcher.doit();

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -26,7 +26,7 @@
 #include "cds/cdsConfig.hpp"
 #include "cds/heapShared.hpp"
 
-bool CDSConfig::_is_dumping_static_archive = false;
+bool CDSConfig::_is_dumping_dynamic_archive = false;
 
 bool CDSConfig::is_dumping_static_archive() {
   return DumpSharedSpaces;

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -26,16 +26,10 @@
 #include "cds/cdsConfig.hpp"
 #include "cds/heapShared.hpp"
 
-bool CDSConfig::is_dumping_archive() {
-  return is_dumping_static_archive() || is_dumping_dynamic_archive();
-}
+bool CDSConfig::_is_dumping_static_archive = false;
 
 bool CDSConfig::is_dumping_static_archive() {
   return DumpSharedSpaces;
-}
-
-bool CDSConfig::is_dumping_dynamic_archive() {
-  return DynamicDumpSharedSpaces;
 }
 
 #if INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -30,16 +30,16 @@
 
 class CDSConfig : public AllStatic {
 #if INCLUDE_CDS
-  static bool _is_dumping_static_archive;
+  static bool _is_dumping_dynamic_archive;
 #endif
 
 public:
   // Basic CDS features
   static bool      is_dumping_archive()                      { return is_dumping_static_archive() || is_dumping_dynamic_archive(); }
   static bool      is_dumping_static_archive()               NOT_CDS_RETURN_(false);
-  static bool      is_dumping_dynamic_archive()              { return CDS_ONLY(_is_dumping_static_archive) NOT_CDS(false); }
-  static void  enable_dumping_dynamic_archive()              { CDS_ONLY(_is_dumping_static_archive = true); }
-  static void disable_dumping_dynamic_archive()              { CDS_ONLY(_is_dumping_static_archive = false); }
+  static bool      is_dumping_dynamic_archive()              { return CDS_ONLY(_is_dumping_dynamic_archive) NOT_CDS(false); }
+  static void  enable_dumping_dynamic_archive()              { CDS_ONLY(_is_dumping_dynamic_archive = true); }
+  static void disable_dumping_dynamic_archive()              { CDS_ONLY(_is_dumping_dynamic_archive = false); }
 
   // CDS archived heap
   static bool      is_dumping_heap()                         NOT_CDS_JAVA_HEAP_RETURN_(false);

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -29,11 +29,17 @@
 #include "utilities/macros.hpp"
 
 class CDSConfig : public AllStatic {
+#if INCLUDE_CDS
+  static bool _is_dumping_static_archive;
+#endif
+
 public:
   // Basic CDS features
-  static bool      is_dumping_archive()                      NOT_CDS_RETURN_(false);
+  static bool      is_dumping_archive()                      { return is_dumping_static_archive() || is_dumping_dynamic_archive(); }
   static bool      is_dumping_static_archive()               NOT_CDS_RETURN_(false);
-  static bool      is_dumping_dynamic_archive()              NOT_CDS_RETURN_(false);
+  static bool      is_dumping_dynamic_archive()              { return CDS_ONLY(_is_dumping_static_archive) NOT_CDS(false); }
+  static void  enable_dumping_dynamic_archive()              { CDS_ONLY(_is_dumping_static_archive = true); }
+  static void disable_dumping_dynamic_archive()              { CDS_ONLY(_is_dumping_static_archive = false); }
 
   // CDS archived heap
   static bool      is_dumping_heap()                         NOT_CDS_JAVA_HEAP_RETURN_(false);

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -194,7 +194,7 @@ void FileMapHeader::populate(FileMapInfo *info, size_t core_region_alignment,
   set_base_archive_name_offset((unsigned int)base_archive_name_offset);
   set_base_archive_name_size((unsigned int)base_archive_name_size);
   set_common_app_classpath_prefix_size((unsigned int)common_app_classpath_prefix_size);
-  set_magic(DynamicDumpSharedSpaces ? CDS_DYNAMIC_ARCHIVE_MAGIC : CDS_ARCHIVE_MAGIC);
+  set_magic(CDSConfig::is_dumping_dynamic_archive() ? CDS_DYNAMIC_ARCHIVE_MAGIC : CDS_ARCHIVE_MAGIC);
   set_version(CURRENT_CDS_ARCHIVE_VERSION);
 
   if (!info->is_static() && base_archive_name_size != 0) {
@@ -235,7 +235,7 @@ void FileMapHeader::populate(FileMapInfo *info, size_t core_region_alignment,
   _mapped_base_address = (char*)SharedBaseAddress;
   _allow_archiving_with_java_agent = AllowArchivingWithJavaAgent;
 
-  if (!DynamicDumpSharedSpaces) {
+  if (!CDSConfig::is_dumping_dynamic_archive()) {
     set_shared_path_table(info->_shared_path_table);
   }
 }
@@ -932,7 +932,7 @@ bool FileMapInfo::validate_shared_path_table() {
 
   // Load the shared path table info from the archive header
   _shared_path_table = header()->shared_path_table();
-  if (DynamicDumpSharedSpaces) {
+  if (CDSConfig::is_dumping_dynamic_archive()) {
     // Only support dynamic dumping with the usage of the default CDS archive
     // or a simple base archive.
     // If the base layer archive contains additional path component besides
@@ -942,13 +942,13 @@ bool FileMapInfo::validate_shared_path_table() {
     // to include the application path and stored in the top layer archive.
     assert(shared_path(0)->is_modules_image(), "first shared_path must be the modules image");
     if (header()->app_class_paths_start_index() > 1) {
-      DynamicDumpSharedSpaces = false;
+      CDSConfig::disable_dumping_dynamic_archive();
       log_warning(cds)(
         "Dynamic archiving is disabled because base layer archive has appended boot classpath");
     }
     if (header()->num_module_paths() > 0) {
       if (!check_module_paths()) {
-        DynamicDumpSharedSpaces = false;
+        CDSConfig::disable_dumping_dynamic_archive();
         log_warning(cds)(
           "Dynamic archiving is disabled because base layer archive has a different module path");
       }
@@ -1523,7 +1523,7 @@ void FileMapInfo::write_region(int region, char* base, size_t size,
   } else if (HeapShared::is_heap_region(region)) {
     assert(HeapShared::can_write(), "sanity");
 #if INCLUDE_CDS_JAVA_HEAP
-    assert(!DynamicDumpSharedSpaces, "must be");
+    assert(!CDSConfig::is_dumping_dynamic_archive(), "must be");
     requested_base = (char*)ArchiveHeapWriter::requested_address();
     if (UseCompressedOops) {
       mapping_offset = (size_t)((address)requested_base - CompressedOops::base());
@@ -2272,7 +2272,7 @@ bool FileMapInfo::initialize() {
     } else {
       log_info(cds)("Initialize dynamic archive failed.");
       if (AutoCreateSharedArchive) {
-        DynamicDumpSharedSpaces = true;
+        CDSConfig::enable_dumping_dynamic_archive();
         ArchiveClassesAtExit = Arguments::GetSharedDynamicArchivePath();
       }
       return false;

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1126,9 +1126,9 @@ InstanceKlass* ClassLoader::load_class(Symbol* name, bool search_append_only, TR
     // check will determine if a shared class is visible based on the runtime
     // environment, including the runtime --patch-module setting.
     //
-    // DynamicDumpSharedSpaces requires UseSharedSpaces to be enabled. Since --patch-module
-    // is not supported with UseSharedSpaces, it is not supported with DynamicDumpSharedSpaces.
-    assert(!DynamicDumpSharedSpaces, "sanity");
+    // Dynamic dumping requires UseSharedSpaces to be enabled. Since --patch-module
+    // is not supported with UseSharedSpaces, we can never come here during dynamic dumping.
+    assert(!CDSConfig::is_dumping_dynamic_archive(), "sanity");
     if (!DumpSharedSpaces) {
       stream = search_module_entries(THREAD, _patch_mod_entries, class_name, file_name);
     }
@@ -1491,7 +1491,7 @@ void ClassLoader::classLoader_init2(JavaThread* current) {
   // entries will be added to the exploded build array.
   if (!has_jrt_entry()) {
     assert(!DumpSharedSpaces, "DumpSharedSpaces not supported with exploded module builds");
-    assert(!DynamicDumpSharedSpaces, "DynamicDumpSharedSpaces not supported with exploded module builds");
+    assert(!CDSConfig::is_dumping_dynamic_archive(), "not supported with exploded module builds");
     assert(!UseSharedSpaces, "UsedSharedSpaces not supported with exploded module builds");
     // Set up the boot loader's _exploded_entries list.  Note that this gets
     // done before loading any classes, by the same thread that will

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "cds/archiveBuilder.hpp"
+#include "cds/cdsConfig.hpp"
 #include "cds/dynamicArchive.hpp"
 #include "classfile/altHashing.hpp"
 #include "classfile/classLoaderData.hpp"
@@ -671,10 +672,11 @@ size_t SymbolTable::estimate_size_for_archive() {
 void SymbolTable::write_to_archive(GrowableArray<Symbol*>* symbols) {
   CompactHashtableWriter writer(int(_items_count), ArchiveBuilder::symbol_stats());
   copy_shared_symbol_table(symbols, &writer);
-  if (!DynamicDumpSharedSpaces) {
+  if (CDSConfig::is_dumping_static_archive()) {
     _shared_table.reset();
     writer.dump(&_shared_table, "symbol");
   } else {
+    assert(CDSConfig::is_dumping_dynamic_archive(), "must be");
     _dynamic_shared_table.reset();
     writer.dump(&_dynamic_shared_table, "symbol");
   }

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -986,7 +986,7 @@ void SystemDictionaryShared::record_linking_constraint(Symbol* name, InstanceKla
   assert(klass_loader != nullptr, "should not be called for boot loader");
   assert(loader1 != loader2, "must be");
 
-  if (DynamicDumpSharedSpaces && Thread::current()->is_VM_thread()) {
+  if (CDSConfig::is_dumping_dynamic_archive() && Thread::current()->is_VM_thread()) {
     // We are re-laying out the vtable/itables of the *copy* of
     // a class during the final stage of dynamic dumping. The
     // linking constraints for this class has already been recorded.

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -120,7 +120,7 @@ void Rewriter::make_constant_pool_cache(TRAPS) {
 #if INCLUDE_CDS
   if (!HAS_PENDING_EXCEPTION && CDSConfig::is_dumping_archive()) {
     if (_pool->pool_holder()->is_shared()) {
-      assert(DynamicDumpSharedSpaces, "must be");
+      assert(CDSConfig::is_dumping_dynamic_archive(), "must be");
       // We are linking a shared class from the base archive. This
       // class won't be written into the dynamic archive, so there's no
       // need to save its CpCaches.

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -1875,7 +1875,7 @@ NOINLINE int linear_search(const Array<Method*>* methods, const Symbol* name) {
 
 inline int InstanceKlass::quick_search(const Array<Method*>* methods, const Symbol* name) {
   if (_disable_method_binary_search) {
-    assert(DynamicDumpSharedSpaces, "must be");
+    assert(CDSConfig::is_dumping_dynamic_archive(), "must be");
     // At the final stage of dynamic dumping, the methods array may not be sorted
     // by ascending addresses of their names, so we can't use binary search anymore.
     // However, methods with the same name are still laid out consecutively inside the
@@ -2696,7 +2696,7 @@ void InstanceKlass::init_shared_package_entry() {
 #else
   if (!MetaspaceShared::use_full_module_graph()) {
     _package_entry = nullptr;
-  } else if (DynamicDumpSharedSpaces) {
+  } else if (CDSConfig::is_dumping_dynamic_archive()) {
     if (!MetaspaceShared::is_in_shared_metaspace(_package_entry)) {
       _package_entry = nullptr;
     }

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3726,7 +3726,7 @@ JVM_END
 
 JVM_LEAF(jboolean, JVM_IsDumpingClassList(JNIEnv *env))
 #if INCLUDE_CDS
-  return ClassListWriter::is_enabled() || DynamicDumpSharedSpaces;
+  return ClassListWriter::is_enabled() || CDSConfig::is_dumping_dynamic_archive();
 #else
   return false;
 #endif // INCLUDE_CDS
@@ -3734,12 +3734,12 @@ JVM_END
 
 JVM_ENTRY(void, JVM_LogLambdaFormInvoker(JNIEnv *env, jstring line))
 #if INCLUDE_CDS
-  assert(ClassListWriter::is_enabled() || DynamicDumpSharedSpaces,  "Should be set and open or do dynamic dump");
+  assert(ClassListWriter::is_enabled() || CDSConfig::is_dumping_dynamic_archive(),  "Should be set and open or do dynamic dump");
   if (line != nullptr) {
     ResourceMark rm(THREAD);
     Handle h_line (THREAD, JNIHandles::resolve_non_null(line));
     char* c_line = java_lang_String::as_utf8_string(h_line());
-    if (DynamicDumpSharedSpaces) {
+    if (CDSConfig::is_dumping_dynamic_archive()) {
       // Note: LambdaFormInvokers::append take same format which is not
       // same as below the print format. The line does not include LAMBDA_FORM_TAG.
       LambdaFormInvokers::append(os::strdup((const char*)c_line, mtInternal));

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3063,9 +3063,9 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
   }
 
   if (ArchiveClassesAtExit == nullptr && !RecordDynamicDumpInfo) {
-    DynamicDumpSharedSpaces = false;
+    CDSConfig::disable_dumping_dynamic_archive();
   } else {
-    DynamicDumpSharedSpaces = true;
+    CDSConfig::enable_dumping_dynamic_archive();
   }
 
   if (AutoCreateSharedArchive) {
@@ -3086,7 +3086,7 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
     UseSharedSpaces = false;
   }
 
-  if (DumpSharedSpaces || DynamicDumpSharedSpaces) {
+  if (CDSConfig::is_dumping_archive()) {
     // Always verify non-system classes during CDS dump
     if (!BytecodeVerificationRemote) {
       BytecodeVerificationRemote = true;
@@ -3493,7 +3493,7 @@ void Arguments::init_shared_archive_paths() {
           // If +AutoCreateSharedArchive and the specified shared archive does not exist,
           // regenerate the dynamic archive base on default archive.
           if (AutoCreateSharedArchive && !os::file_exists(SharedArchiveFile)) {
-            DynamicDumpSharedSpaces = true;
+            CDSConfig::enable_dumping_dynamic_archive();
             ArchiveClassesAtExit = const_cast<char *>(SharedArchiveFile);
             SharedArchivePath = get_default_shared_archive_path();
             SharedArchiveFile = nullptr;

--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -41,7 +41,6 @@ int BitsPerHeapOop     = 0;
 
 // Old CDS options
 bool DumpSharedSpaces;
-bool DynamicDumpSharedSpaces;
 bool RequireSharedSpaces;
 extern "C" {
 JNIEXPORT jboolean UseSharedSpaces = true;

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -554,7 +554,6 @@ const int max_method_code_size = 64*K - 1;  // JVM spec, 2nd ed. section 4.8.1 (
 //----------------------------------------------------------------------------------------------------
 // old CDS options
 extern bool DumpSharedSpaces;
-extern bool DynamicDumpSharedSpaces;
 extern bool RequireSharedSpaces;
 extern "C" {
 // Make sure UseSharedSpaces is accessible to the serviceability agent.


### PR DESCRIPTION
Please review this cleanup. Most of the changes are the following patterns:

- `if (DumpSharedSpaces)` => `if (CDSConfig::is_dumping_dynamic_archive())`
- `DumpSharedSpaces = true` => `CDSConfig::enable_dumping_dynamic_archive()`
- `DumpSharedSpaces = false` => `CDSConfig::disable_dumping_dynamic_archive()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319944](https://bugs.openjdk.org/browse/JDK-8319944): Remove DynamicDumpSharedSpaces (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16626/head:pull/16626` \
`$ git checkout pull/16626`

Update a local copy of the PR: \
`$ git checkout pull/16626` \
`$ git pull https://git.openjdk.org/jdk.git pull/16626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16626`

View PR using the GUI difftool: \
`$ git pr show -t 16626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16626.diff">https://git.openjdk.org/jdk/pull/16626.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16626#issuecomment-1807479141)