### PR TITLE
8319960: RISC-V: compiler/intrinsics/TestInteger/LongUnsignedDivMod.java failed with "counts: Graph contains wrong number of nodes"

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/TestIntegerUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestIntegerUnsignedDivMod.java
@@ -73,7 +73,7 @@ public class TestIntegerUnsignedDivMod {
 
     @Test // needs to be run in (fast) debug mode
     @Warmup(10000)
-    @IR(counts = {IRNode.UDIV_I, ">= 1"}) // Atleast one UDivI node is generated if intrinsic is used
+    @IR(counts = {IRNode.UDIV_I, ">= 1"}) // At least one UDivI node is generated if intrinsic is used
     public void testDivideUnsigned() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
             try {
@@ -87,7 +87,7 @@ public class TestIntegerUnsignedDivMod {
 
     @Test // needs to be run in (fast) debug mode
     @Warmup(10000)
-    @IR(counts = {IRNode.UMOD_I, ">= 1"}) // Atleast one UModI node is generated if intrinsic is used
+    @IR(counts = {IRNode.UMOD_I, ">= 1"}) // At least one UModI node is generated if intrinsic is used
     public void testRemainderUnsigned() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
             try {
@@ -102,7 +102,8 @@ public class TestIntegerUnsignedDivMod {
 
     @Test // needs to be run in (fast) debug mode
     @Warmup(10000)
-    @IR(counts = {IRNode.UDIV_MOD_I, ">= 1"}) // Atleast one UDivModI node is generated if intrinsic is used
+    @IR(applyIfPlatform = {"x64", "true"},
+        counts = {IRNode.UDIV_MOD_I, ">= 1"}) // At least one UDivModI node is generated if intrinsic is used
     public void testDivModUnsigned() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
             try {

--- a/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
@@ -140,7 +140,8 @@ public class TestLongUnsignedDivMod {
 
     @Test // needs to be run in (fast) debug mode
     @Warmup(10000)
-    @IR(counts = {IRNode.UDIV_MOD_L, ">= 1"}) // Atleast one UDivModL node is generated if intrinsic is used
+    @IR(applyIfPlatform = {"x64", "true"},
+        counts = {IRNode.UDIV_MOD_L, ">= 1"}) // At least one UDivModL node is generated if intrinsic is used
     public void testDivModUnsigned() {
         for (int i = 0; i < BUFFER_SIZE; i++) {
             try {


### PR DESCRIPTION
Hi,
Can you review this patch to fix the test failure in compiler/intrinsics/TestInteger/LongUnsignedDivMod.java?
The reason of failure is that, `UDivModI` is only supplied on x86_64.ad, so it can not find this node on riscv.
Fix is to apply the check only on x64.
Thanks!


## Test
To reproduce the issue, 
```
jtreg -timeout:10 -retain -v1 -conc:32 -nr -javaoptions:"" -testjdk:build/linux-riscv64-server-fastdebug/images/jdk/ ./test/hotspot/jtreg/compiler/intrinsics/TestIntegerUnsignedDivMod.java ./test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319960](https://bugs.openjdk.org/browse/JDK-8319960): RISC-V: compiler/intrinsics/TestInteger/LongUnsignedDivMod.java failed with "counts: Graph contains wrong number of nodes" (**Bug** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16630/head:pull/16630` \
`$ git checkout pull/16630`

Update a local copy of the PR: \
`$ git checkout pull/16630` \
`$ git pull https://git.openjdk.org/jdk.git pull/16630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16630`

View PR using the GUI difftool: \
`$ git pr show -t 16630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16630.diff">https://git.openjdk.org/jdk/pull/16630.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16630#issuecomment-1808157600)