### PR TITLE
8314614: jdk/jshell/ImportTest.java failed with "InternalError: Failed remote listen"

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/JShell.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/JShell.java
@@ -134,7 +134,7 @@ public class JShell implements AutoCloseable {
                 String loopback = InetAddress.getLoopbackAddress().getHostAddress();
                 String spec = b.executionControlSpec == null
                         ? "failover:0(jdi:hostname(" + loopback + ")),"
-                          + "1(jdi:launch(true)), 2(jdi), 3(local)"
+                          + "1(jdi:launch(true)), 2(jdi)"
                         : b.executionControlSpec;
                 executionControl = ExecutionControl.generate(new ExecutionEnvImpl(), spec);
             }

--- a/src/jdk.jshell/share/classes/jdk/jshell/JShell.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/JShell.java
@@ -134,7 +134,7 @@ public class JShell implements AutoCloseable {
                 String loopback = InetAddress.getLoopbackAddress().getHostAddress();
                 String spec = b.executionControlSpec == null
                         ? "failover:0(jdi:hostname(" + loopback + ")),"
-                          + "1(jdi:launch(true)), 2(jdi)"
+                          + "1(jdi:launch(true)), 2(jdi), 3(local)"
                         : b.executionControlSpec;
                 executionControl = ExecutionControl.generate(new ExecutionEnvImpl(), spec);
             }

--- a/test/langtools/jdk/jshell/AnalyzeSnippetTest.java
+++ b/test/langtools/jdk/jshell/AnalyzeSnippetTest.java
@@ -64,6 +64,7 @@ public class AnalyzeSnippetTest {
         state = JShell.builder()
                 .out(new PrintStream(new ByteArrayOutputStream()))
                 .err(new PrintStream(new ByteArrayOutputStream()))
+                .executionEngine(Presets.TEST_DEFAULT_EXECUTION)
                 .build();
         sca = state.sourceCodeAnalysis();
     }

--- a/test/langtools/jdk/jshell/CustomInputToolBuilder.java
+++ b/test/langtools/jdk/jshell/CustomInputToolBuilder.java
@@ -90,7 +90,8 @@ public class CustomInputToolBuilder extends KullaTesting {
                     .interactiveTerminal(interactiveTerminal)
                     .promptCapture(true)
                     .persistence(new HashMap<>())
-                    .start("--no-startup");
+                    .start("--no-startup",
+                           "--execution", Presets.TEST_DEFAULT_EXECUTION);
 
             String actual = new String(out.toByteArray());
             List<String> actualLines = Arrays.asList(actual.split("\\R"));

--- a/test/langtools/jdk/jshell/IdGeneratorTest.java
+++ b/test/langtools/jdk/jshell/IdGeneratorTest.java
@@ -53,7 +53,8 @@ public class IdGeneratorTest {
         return JShell.builder()
                 .in(inStream)
                 .out(new PrintStream(outStream))
-                .err(new PrintStream(errStream));
+                .err(new PrintStream(errStream))
+                .executionEngine(Presets.TEST_DEFAULT_EXECUTION);
     }
 
     public void testTempNameGenerator() {

--- a/test/langtools/jdk/jshell/KullaTesting.java
+++ b/test/langtools/jdk/jshell/KullaTesting.java
@@ -100,7 +100,9 @@ public class KullaTesting {
     private Set<Snippet> allSnippets = new LinkedHashSet<>();
 
     static {
-        JShell js = JShell.create();
+        JShell js = JShell.builder()
+                          .executionEngine(Presets.TEST_DEFAULT_EXECUTION)
+                          .build();
         MAIN_SNIPPET = js.eval("MAIN_SNIPPET").get(0).snippet();
         js.close();
         assertTrue(MAIN_SNIPPET != null, "Bad MAIN_SNIPPET set-up -- must not be null");
@@ -192,7 +194,8 @@ public class KullaTesting {
         JShell.Builder builder = JShell.builder()
                 .in(in)
                 .out(new PrintStream(outStream))
-                .err(new PrintStream(errStream));
+                .err(new PrintStream(errStream))
+                .executionEngine(Presets.TEST_DEFAULT_EXECUTION);
         bc.accept(builder);
         state = builder.build();
         allSnippets = new LinkedHashSet<>();

--- a/test/langtools/jdk/jshell/Presets.java
+++ b/test/langtools/jdk/jshell/Presets.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.net.InetAddress;
+import java.util.*;
+
+public class Presets {
+    public static final String TEST_DEFAULT_EXECUTION;
+
+    static {
+        String loopback = InetAddress.getLoopbackAddress().getHostAddress();
+
+        TEST_DEFAULT_EXECUTION = "failover:0(jdi:hostname(" + loopback + "))," +
+                                 "1(jdi:launch(true)), 2(jdi), 3(local)";
+    }
+
+    public static String[] addExecutionIfMissing(String[] args) {
+        if (Arrays.stream(args).noneMatch(a -> "--execution".equals(a))) {
+            List<String> augmentedArgs = new ArrayList<>();
+
+            augmentedArgs.add("--exection");
+            augmentedArgs.add(Presets.TEST_DEFAULT_EXECUTION);
+            augmentedArgs.addAll(List.of(args));
+
+            return augmentedArgs.toArray(s -> new String[s]);
+        }
+
+        return args;
+    }
+}

--- a/test/langtools/jdk/jshell/Presets.java
+++ b/test/langtools/jdk/jshell/Presets.java
@@ -26,19 +26,22 @@ import java.util.*;
 
 public class Presets {
     public static final String TEST_DEFAULT_EXECUTION;
+    public static final String TEST_STANDARD_EXECUTION;
 
     static {
         String loopback = InetAddress.getLoopbackAddress().getHostAddress();
 
         TEST_DEFAULT_EXECUTION = "failover:0(jdi:hostname(" + loopback + "))," +
                                  "1(jdi:launch(true)), 2(jdi), 3(local)";
+        TEST_STANDARD_EXECUTION = "failover:0(jdi:hostname(" + loopback + "))," +
+                                  "1(jdi:launch(true)), 2(jdi)";
     }
 
     public static String[] addExecutionIfMissing(String[] args) {
-        if (Arrays.stream(args).noneMatch(a -> "--execution".equals(a))) {
+        if (Arrays.stream(args).noneMatch(Presets::remoteRelatedOption)) {
             List<String> augmentedArgs = new ArrayList<>();
 
-            augmentedArgs.add("--exection");
+            augmentedArgs.add("--execution");
             augmentedArgs.add(Presets.TEST_DEFAULT_EXECUTION);
             augmentedArgs.addAll(List.of(args));
 
@@ -46,5 +49,11 @@ public class Presets {
         }
 
         return args;
+    }
+
+    private static boolean remoteRelatedOption(String option) {
+        return "--execution".equals(option) ||
+               "--add-modules".equals(option) ||
+               option.startsWith("-R");
     }
 }

--- a/test/langtools/jdk/jshell/ReplToolTesting.java
+++ b/test/langtools/jdk/jshell/ReplToolTesting.java
@@ -304,7 +304,7 @@ public class ReplToolTesting {
     private void testRaw(Locale locale, String[] args,
                          String expectedErrorOutput, ReplTest... tests) {
         testRawInit(tests);
-        testRawRun(locale, args);
+        testRawRun(locale, Presets.addExecutionIfMissing(args));
         testRawCheck(locale, expectedErrorOutput);
     }
 

--- a/test/langtools/jdk/jshell/StartOptionTest.java
+++ b/test/langtools/jdk/jshell/StartOptionTest.java
@@ -81,7 +81,7 @@ public class StartOptionTest {
     protected int runShell(String... args) {
         try {
             return builder()
-                    .start(args);
+                    .start(Presets.addExecutionIfMissing(args));
         } catch (Exception ex) {
             fail("Repl tool died with exception", ex);
         }

--- a/test/langtools/jdk/jshell/ToolReloadTest.java
+++ b/test/langtools/jdk/jshell/ToolReloadTest.java
@@ -201,7 +201,7 @@ public class ToolReloadTest extends ReplToolTesting {
     }
 
     public void testEnvBadModule() {
-        test(
+        test(new String[] {"--execution", Presets.TEST_STANDARD_EXECUTION},
                 (a) -> assertVariable(a, "int", "x", "5", "5"),
                 (a) -> assertMethod(a, "int m(int z) { return z * z; }",
                         "(int)int", "m"),

--- a/test/langtools/jdk/jshell/UITesting.java
+++ b/test/langtools/jdk/jshell/UITesting.java
@@ -93,7 +93,8 @@ public class UITesting {
                         .promptCapture(true)
                         .persistence(new HashMap<>())
                         .locale(Locale.US)
-                        .run("--no-startup");
+                        .run("--no-startup",
+                             "--execution", Presets.TEST_DEFAULT_EXECUTION);
             } catch (Exception ex) {
                 throw new IllegalStateException(ex);
             }


### PR DESCRIPTION
JShell by default runs the user's snippets in a separate JVM. This is usually reliable, but during tests, it sometimes happens the remote/separate JVM does not start properly, and the tests fail.

This patch tries to change the default JShell execution in tests so that if the start of the separate JVM fails, the "local" (in process) execution is used. This should improve the stability of the tests.

Non-test JShell execution remains unmodified.

Note that individual tests can override this behavior, for example when they want to test a specific execution.
