### PR TITLE
8319970: AArch64: enable tests compiler/intrinsics/Test(Long|Integer)UnsignedDivMod.java on aarch64

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/TestIntegerUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestIntegerUnsignedDivMod.java
@@ -24,7 +24,7 @@
 /**
 * @test
 * @summary Test intrinsic for divideUnsigned() and remainderUnsigned() methods for Integer
-* @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="riscv64"
+* @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="riscv64" | os.arch=="aarch64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestIntegerUnsignedDivMod
 */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestLongUnsignedDivMod.java
@@ -24,7 +24,7 @@
 /**
 * @test
 * @summary Test intrinsic for divideUnsigned() and remainderUnsigned() methods for Long
-* @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="riscv64"
+* @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="riscv64" | os.arch=="aarch64"
 * @library /test/lib /
 * @run driver compiler.intrinsics.TestLongUnsignedDivMod
 */


### PR DESCRIPTION
Hi,
Can you review the simple patch to enble tests compiler/intrinsics/Test(Long|Integer)UnsignedDivMod.java on aarch64?
Thanks!

NOTE:
1. The intrinsics are also implemented on ppc, but as I don't have the environment to test it, so did not enable it for ppc.
2. This fix depends on the fix in https://github.com/openjdk/jdk/pull/16630, else the tests will fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319970](https://bugs.openjdk.org/browse/JDK-8319970): AArch64: enable tests compiler/intrinsics/Test(Long|Integer)UnsignedDivMod.java on aarch64 (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16633/head:pull/16633` \
`$ git checkout pull/16633`

Update a local copy of the PR: \
`$ git checkout pull/16633` \
`$ git pull https://git.openjdk.org/jdk.git pull/16633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16633`

View PR using the GUI difftool: \
`$ git pr show -t 16633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16633.diff">https://git.openjdk.org/jdk/pull/16633.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16633#issuecomment-1808461073)