### PR TITLE
8319962: (dc) DatagramChannel.connect undocumented behavior

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/DatagramChannel.java
@@ -655,7 +655,11 @@ public abstract class DatagramChannel
      * @return  The {@code SocketAddress} that the socket is bound to, or the
      *          {@code SocketAddress} representing the loopback address if
      *          denied by the security manager, or {@code null} if the
-     *          channel's socket is not bound
+     *          channel's socket is not bound. If {@link #connect(SocketAddress)
+     *          connect} was called, and the socket was bound to the wildcard
+     *          address, then the address returned may be the local address
+     *          selected as source address for outgoing datagrams sent on the
+     *          channel while it is connected.
      *
      * @throws  ClosedChannelException     {@inheritDoc}
      * @throws  IOException                {@inheritDoc}


### PR DESCRIPTION
Hi,

This a small doc change to DatagramChannel::getLocalAddress() which documents some useful behavior which is currently not documented.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Issue of type `CSR` is not allowed for integrations

### Issue
 * [JDK-8319962](https://bugs.openjdk.org/browse/JDK-8319962): (dc) DatagramChannel.connect undocumented behavior (**CSR** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16634/head:pull/16634` \
`$ git checkout pull/16634`

Update a local copy of the PR: \
`$ git checkout pull/16634` \
`$ git pull https://git.openjdk.org/jdk.git pull/16634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16634`

View PR using the GUI difftool: \
`$ git pr show -t 16634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16634.diff">https://git.openjdk.org/jdk/pull/16634.diff</a>

</details>
