### PR TITLE
8319103: Popups that request focus are not shown on Linux with Wayland

### DIFF
--- a/test/jdk/javax/swing/JPopupMenu/FocusablePopupDismissTest.java
+++ b/test/jdk/javax/swing/JPopupMenu/FocusablePopupDismissTest.java
@@ -56,7 +56,7 @@ public class FocusablePopupDismissTest {
             Click on the "Click me" button if the popup is not displayed
             on the screen.
 
-            While the popup is displayed, click on a some system window.
+            While the popup is displayed, click on some other window on the desktop.
             If the popup has disappeared, click Pass, otherwise click Fail.
             """;
 

--- a/test/jdk/javax/swing/JPopupMenu/FocusablePopupDismissTest.java
+++ b/test/jdk/javax/swing/JPopupMenu/FocusablePopupDismissTest.java
@@ -70,7 +70,7 @@ public class FocusablePopupDismissTest {
                 .title("FocusablePopupDismissTest")
                 .instructions(INSTRUCTIONS)
                 .rows(20)
-                .columns(40)
+                .columns(45)
                 .testUI(FocusablePopupDismissTest::createTestUI)
                 .build()
                 .awaitAndCheck();

--- a/test/jdk/javax/swing/JPopupMenu/FocusablePopupDismissTest.java
+++ b/test/jdk/javax/swing/JPopupMenu/FocusablePopupDismissTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ /*
+  * @test
+  * @key headful
+  * @bug 8319103
+  * @requires (os.family == "linux")
+  * @library /java/awt/regtesthelpers
+  * @build PassFailJFrame
+  * @summary Tests if the focusable popup can be dismissed when the parent
+  *          window or the popup itself loses focus in Wayland.
+  * @run main/manual FocusablePopupDismissTest
+  */
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPopupMenu;
+import javax.swing.JTextField;
+import java.awt.Window;
+import java.util.List;
+
+public class FocusablePopupDismissTest {
+    private static final String INSTRUCTIONS = """
+            A frame with a "Click me" button should appear next to the window
+            with this instruction.
+
+            Click on the "Click me" button.
+
+            If the JTextField popup with "Some text" is not showing on the screen,
+            click Fail.
+
+            The following steps require some focusable system window to be displayed
+            on the screen. This could be a system settings window, file manager, etc.
+
+            Click on the "Click me" button if the popup is not displayed
+            on the screen.
+
+            While the popup is displayed, click on a some system window.
+            If the popup has disappeared, click Pass, otherwise click Fail.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        if (System.getenv("WAYLAND_DISPLAY") == null) {
+            //test is valid only when running on Wayland.
+            return;
+        }
+
+        PassFailJFrame.builder()
+                .title("FocusablePopupDismissTest")
+                .instructions(INSTRUCTIONS)
+                .rows(20)
+                .columns(40)
+                .testUI(FocusablePopupDismissTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    static List<Window> createTestUI() {
+        JFrame frame = new JFrame("FocusablePopupDismissTest");
+        JButton button = new JButton("Click me");
+        frame.add(button);
+
+        button.addActionListener(e -> {
+            JPopupMenu popupMenu = new JPopupMenu();
+            JTextField textField = new JTextField("Some text", 10);
+            popupMenu.add(textField);
+            popupMenu.show(button, 0, button.getHeight());
+        });
+        frame.pack();
+
+        return List.of(frame);
+    }
+}


### PR DESCRIPTION
This is the fix for the regression introduced in [JDK-8280993](https://bugs.openjdk.org/browse/JDK-8280993).

That fix was to dismiss a popup if the owner loses the window focus when running in Wayland, and didn't take into account that the popup itself can be focusable.

This fix closes the popup only if the focus moves away from the calling window and the popup itself.

There is no jtreg test provided because it requires transferring the window focus to a non-X11 window, and our current robot implementation [does not allow this](https://bugs.openjdk.org/browse/JDK-8280983).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319103](https://bugs.openjdk.org/browse/JDK-8319103): Popups that request focus are not shown on Linux with Wayland (**Bug** - P3)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [06850c0d](https://git.openjdk.org/jdk/pull/16636/files/06850c0d2452a222f787ec6280f28938fe4a1d82)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [6590a995](https://git.openjdk.org/jdk/pull/16636/files/6590a995ab415799aaea8f02163647760e2444e2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16636/head:pull/16636` \
`$ git checkout pull/16636`

Update a local copy of the PR: \
`$ git checkout pull/16636` \
`$ git pull https://git.openjdk.org/jdk.git pull/16636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16636`

View PR using the GUI difftool: \
`$ git pr show -t 16636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16636.diff">https://git.openjdk.org/jdk/pull/16636.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16636#issuecomment-1808654419)