### PR TITLE
JDK-8319988: Wrong heading for inherited nested classes

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/NestedClassWriter.java
@@ -114,7 +114,7 @@ public class NestedClassWriter extends AbstractMemberWriter {
                     ? resources.getText("doclet.Nested_Classes_Interfaces_Inherited_From_Interface")
                     : resources.getText("doclet.Nested_Classes_Interfaces_Inherited_From_Class"));
         }
-        var labelHeading = HtmlTree.HEADING(Headings.TypeDeclaration.SUMMARY_HEADING, label);
+        var labelHeading = HtmlTree.HEADING(Headings.TypeDeclaration.INHERITED_SUMMARY_HEADING, label);
         labelHeading.setId(htmlIds.forInheritedClasses(typeElement));
         labelHeading.add(Entity.NO_BREAK_SPACE);
         labelHeading.add(classLink);

--- a/test/langtools/jdk/javadoc/doclet/testHiddenTag/TestHiddenTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testHiddenTag/TestHiddenTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,8 +72,8 @@ public class TestHiddenTag extends JavadocTester {
                 """
                     <code><a href="A.html#visibleMethod()">visibleMethod</a></code>""",
                 """
-                    <h2 id="nested-classes-inherited-from-class-pkg1.A">Nested classes/interfaces in\
-                    herited from class&nbsp;pkg1.<a href="A.html" title="class in pkg1">A</a></h2>
+                    <h3 id="nested-classes-inherited-from-class-pkg1.A">Nested classes/interfaces in\
+                    herited from class&nbsp;pkg1.<a href="A.html" title="class in pkg1">A</a></h3>
                     <code><a href="A.VisibleInner.html" title="class in pkg1">A.VisibleInner</a>, <a\
                      href="A.VisibleInnerExtendsInvisibleInner.html" title="class in pkg1">A.Visible\
                     InnerExtendsInvisibleInner</a></code></div>

--- a/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
+++ b/test/langtools/jdk/javadoc/doclet/testInterface/TestInterface.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      4682448 4947464 5029946 8025633 8026567 8035473 8139101 8175200
-             8186332 8186703 8182765 8187288 8261976 8303349
+             8186332 8186703 8182765 8187288 8261976 8303349 8319988
  * @summary  Verify that the public modifier does not show up in the
  *           documentation for public methods, as recommended by the JLS.
  *           If A implements I and B extends A, B should be in the list of
@@ -204,9 +204,9 @@ public class TestInterface extends JavadocTester {
         checkOutput("pkg2/Spliterator.OfDouble.html", true,
             // Ensure the correct type parameters are displayed correctly
             """
-                <h2 id="nested-classes-inherited-from-class-pkg2.Spliterator">Nested classes/int\
+                <h3 id="nested-classes-inherited-from-class-pkg2.Spliterator">Nested classes/int\
                 erfaces inherited from interface&nbsp;pkg2.<a href="Spliterator.html" title="int\
-                erface in pkg2">Spliterator</a></h2>
+                erface in pkg2">Spliterator</a></h3>
                 <code><a href="Spliterator.OfDouble.html" title="interface in pkg2">Spliterator.\
                 OfDouble</a>, <a href="Spliterator.OfInt.html" title="interface in pkg2">Spliter\
                 ator.OfInt</a>&lt;<a href="Spliterator.OfInt.html" title="type parameter in Spli\


### PR DESCRIPTION
Please review a trivial fix to make javadoc use the correct heading for listings of inherited nested classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319988](https://bugs.openjdk.org/browse/JDK-8319988): Wrong heading for inherited nested classes (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16641/head:pull/16641` \
`$ git checkout pull/16641`

Update a local copy of the PR: \
`$ git checkout pull/16641` \
`$ git pull https://git.openjdk.org/jdk.git pull/16641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16641`

View PR using the GUI difftool: \
`$ git pr show -t 16641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16641.diff">https://git.openjdk.org/jdk/pull/16641.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16641#issuecomment-1809188099)