### PR TITLE
8319764: C2 compilation asserts during incremental inlining because Phi input is out of bounds

### DIFF
--- a/src/hotspot/share/opto/replacednodes.cpp
+++ b/src/hotspot/share/opto/replacednodes.cpp
@@ -152,14 +152,16 @@ void ReplacedNodes::apply(Compile* C, Node* ctl) {
       } else if (n->outcnt() != 0 && n != improved) {
         if (n->is_Phi()) {
           Node* region = n->in(0);
-          Node* prev = stack.node_at(stack.size() - 2);
-          for (uint j = 1; j < region->req(); ++j) {
-            if (n->in(j) == prev) {
-              Node* in = region->in(j);
-              if (in != nullptr && !in->is_top()) {
-                if (is_dominator(ctl, in)) {
-                  valid_control.set(in->_idx);
-                  collect_nodes_to_clone(stack, to_fix);
+          if (n->req() == region->req()) { // dead phi?
+            Node* prev = stack.node_at(stack.size() - 2);
+            for (uint j = 1; j < region->req(); ++j) {
+              if (n->in(j) == prev) {
+                Node* in = region->in(j);
+                if (in != nullptr && !in->is_top()) {
+                  if (is_dominator(ctl, in)) {
+                    valid_control.set(in->_idx);
+                    collect_nodes_to_clone(stack, to_fix);
+                  }
                 }
               }
             }

--- a/src/hotspot/share/opto/replacednodes.cpp
+++ b/src/hotspot/share/opto/replacednodes.cpp
@@ -152,16 +152,14 @@ void ReplacedNodes::apply(Compile* C, Node* ctl) {
       } else if (n->outcnt() != 0 && n != improved) {
         if (n->is_Phi()) {
           Node* region = n->in(0);
-          if (n->req() == region->req()) { // dead phi?
+          if (n->req() == region->req()) { // ignore dead phis
             Node* prev = stack.node_at(stack.size() - 2);
             for (uint j = 1; j < region->req(); ++j) {
               if (n->in(j) == prev) {
                 Node* in = region->in(j);
-                if (in != nullptr && !in->is_top()) {
-                  if (is_dominator(ctl, in)) {
-                    valid_control.set(in->_idx);
-                    collect_nodes_to_clone(stack, to_fix);
-                  }
+                if (in != nullptr && !in->is_top() && is_dominator(ctl, in)) {
+                  valid_control.set(in->_idx);
+                  collect_nodes_to_clone(stack, to_fix);
                 }
               }
             }

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * bug 8319764
+ * @bug 8319764
  * @summary C2 compilation asserts during incremental inlining because Phi input is out of bounds
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=1246687813 TestLateInlineReplacedNodesExceptionPath

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
@@ -26,7 +26,7 @@
  * @bug 8319764
  * @summary C2 compilation asserts during incremental inlining because Phi input is out of bounds
  * @requires vm.compiler2.enabled
-  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=1246687813 TestLateInlineReplacedNodesExceptionPath
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestLateInlineReplacedNodesExceptionPath

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
@@ -26,9 +26,9 @@
  * bug 8319764
  * @summary C2 compilation asserts during incremental inlining because Phi input is out of bounds
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
- *                   -XX:+StressIGVN -XX:StressSeed=1246687813 TestLateInlineReplacedNodesExceptionPath
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=1246687813 TestLateInlineReplacedNodesExceptionPath
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
- *                   -XX:+StressIGVN TestLateInlineReplacedNodesExceptionPath
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestLateInlineReplacedNodesExceptionPath
  */
 
 import java.lang.invoke.MethodHandle;

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
@@ -25,7 +25,8 @@
  * @test
  * @bug 8319764
  * @summary C2 compilation asserts during incremental inlining because Phi input is out of bounds
- * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
+ * @requires vm.compiler2.enabled
+  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=1246687813 TestLateInlineReplacedNodesExceptionPath
  * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
  *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestLateInlineReplacedNodesExceptionPath

--- a/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
+++ b/test/hotspot/jtreg/compiler/inlining/TestLateInlineReplacedNodesExceptionPath.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * bug 8319764
+ * @summary C2 compilation asserts during incremental inlining because Phi input is out of bounds
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
+ *                   -XX:+StressIGVN -XX:StressSeed=1246687813 TestLateInlineReplacedNodesExceptionPath
+ * @run main/othervm -XX:-TieredCompilation -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestLateInlineReplacedNodesExceptionPath::notInlined
+ *                   -XX:+StressIGVN TestLateInlineReplacedNodesExceptionPath
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class TestLateInlineReplacedNodesExceptionPath {
+    private static A fieldA;
+    private static C fieldC = new C();
+
+    public static void main(String[] args) throws Throwable {
+        A a = new A();
+        B b = new B();
+        for (int i = 0; i < 20_000; i++) {
+            fieldA = a;
+            test1(true);
+            fieldA = b;
+            test1(true);
+            inlined1(true);
+            inlined1(false);
+            inlined2(true);
+            inlined2(false);
+        }
+    }
+
+    static final MethodHandle mh1;
+    static MethodHandle mh2;
+    static final MethodHandle mh3;
+    static MethodHandle mh4;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            mh1 = lookup.findStatic(TestLateInlineReplacedNodesExceptionPath.class, "lateInlined1", MethodType.methodType(void.class, C.class));
+            mh2 = mh1;
+            mh3 = lookup.findStatic(TestLateInlineReplacedNodesExceptionPath.class, "lateInlined2", MethodType.methodType(void.class, C.class));
+            mh4 = mh3;
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Method handle lookup failed");
+        }
+    }
+
+    private static void lateInlined1(C c) {
+        fieldA.m(c);
+        c.field++;
+        fieldA.m(c);
+    }
+
+    private static void lateInlined2(C c) {
+        c.field++;
+    }
+
+    private static void test1(boolean flag) throws Throwable {
+        final C c = fieldC;
+        MethodHandle mh = null;
+        if (flag) {
+            mh = inlined1(flag);
+        }
+        mh.invokeExact(c);
+        mh = null;
+        if (flag) {
+            mh = inlined2(flag);
+        }
+        mh.invokeExact(c);
+    }
+
+    private static MethodHandle inlined1(boolean flag) {
+        if (flag) {
+            return mh1;
+        }
+        return mh2;
+    }
+
+    private static MethodHandle inlined2(boolean flag) {
+        if (flag) {
+            return mh3;
+        }
+        return mh4;
+    }
+
+    private static void notInlined() {
+    }
+
+    private static class A {
+        public void m(C c) {
+            c.field++;
+            notInlined();
+        }
+
+    }
+
+    private static class B extends A {
+
+        public void m(C c) {
+            notInlined();
+        }
+    }
+
+    private static class C {
+        public int field;
+    }
+}


### PR DESCRIPTION
In the test case:

`lateInlined1()` and `lateInlined2()` are inlined incrementally
because they are invoked wih a method handle which is known constant
only after igvn. For the failure to reproduce, `lateInlined2()` must
be inlined after `lateInlined1()` which depends on igvn processing
order (that's why the test needs `StressIGVN`). `lateInlined1()` has 2
virtual calls that are inlined with bimorphic inlining. At each call
site, exception state is merged from `A.m()` and `B.m()`, the 2
methods that are inlined. `c` is casted to non null in `A.m()`. At the
first call site, `c` is live and merging the exception states causes
the creation of a `Phi` for `c` that merges `c` and the cast to non
null of `c`. At the second call site, `c` is not live so it's ignored
when merging exception states. When the exception states for the 2
call sites are combined, the region that merges the states at the
first call site is extended to have 4 inputs but the `Phi` for `c` at
the first call site is left with 2 inputs. When `lateInlined2()` is
inlined, it records a replaced node for a cast of `c` to non null. On
completion of incremental inlining, that replaced nodes is "applied".
In the process, the dead `Phi` for `c` created at the previous
incremental inline is found and because it has less inputs that its
region, the crash occurs.

The fix I propose is to simply ignore phi nodes that don't have the
same number of inputs as their region because they can only be a dead
Phi.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319764](https://bugs.openjdk.org/browse/JDK-8319764): C2 compilation asserts during incremental inlining because Phi input is out of bounds (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [f598fe25](https://git.openjdk.org/jdk/pull/16648/files/f598fe2568273560f1b1fdaaca538fa8a70fa9d6)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [f598fe25](https://git.openjdk.org/jdk/pull/16648/files/f598fe2568273560f1b1fdaaca538fa8a70fa9d6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16648/head:pull/16648` \
`$ git checkout pull/16648`

Update a local copy of the PR: \
`$ git checkout pull/16648` \
`$ git pull https://git.openjdk.org/jdk.git pull/16648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16648`

View PR using the GUI difftool: \
`$ git pr show -t 16648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16648.diff">https://git.openjdk.org/jdk/pull/16648.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16648#issuecomment-1809807592)