### PR TITLE
8320049: PKCS10 would not discard the cause when throw SignatureException on invalid key

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs10/PKCS10.java
+++ b/src/java.base/share/classes/sun/security/pkcs10/PKCS10.java
@@ -23,7 +23,6 @@
  * questions.
  */
 
-
 package sun.security.pkcs10;
 
 import java.io.PrintStream;
@@ -174,7 +173,7 @@ public class PKCS10 {
                 throw new SignatureException("Invalid PKCS #10 signature");
             }
         } catch (InvalidKeyException e) {
-            throw new SignatureException("Invalid key");
+            throw new SignatureException("Invalid key", e);
         } catch (InvalidAlgorithmParameterException e) {
             throw new SignatureException("Invalid signature parameters", e);
         } catch (ProviderException e) {


### PR DESCRIPTION
When throw SignatureException on invalid key, it may be better to contain the cause exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320049](https://bugs.openjdk.org/browse/JDK-8320049): PKCS10 would not discard the cause when throw SignatureException on invalid key (**Enhancement** - P4)


### Reviewers
 * @1keep2keepFaith (no known openjdk.org user name / role)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16649/head:pull/16649` \
`$ git checkout pull/16649`

Update a local copy of the PR: \
`$ git checkout pull/16649` \
`$ git pull https://git.openjdk.org/jdk.git pull/16649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16649`

View PR using the GUI difftool: \
`$ git pr show -t 16649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16649.diff">https://git.openjdk.org/jdk/pull/16649.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16649#issuecomment-1809802737)