### PR TITLE
8311932: Suboptimal compiled code of nested loop over memory segment

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -857,13 +857,13 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
   }
 
   if (range_checks.size() > 0) {
-    // This transformation requires peeling one iteration. Also, if it has range checks and they are eliminated by
-    // Loop Predication, then 2 Hoisted Check Predicates are added for one range check. Finally, transforming a long range check requires
-    // extra logic to be executed before the loop is entered and for the outer loop. As a result, the transformations
-    // can't pay off for a small number of iterations: roughly, if the loop runs for 3 iterations, it's going to execute
-    // as many range checks once transformed with range checks eliminated (1 peeled iteration with range checks
-    // + 2 predicates per range checks) as it would have not transformed. It also has to pay for the extra logic on loop
-    // entry and for the outer loop.
+    // This transformation requires peeling one iteration. Also, if it has range checks and they are eliminated by Loop
+    // Predication, then 2 Hoisted Check Predicates are added for one range check. Finally, transforming a long range
+    // check requires extra logic to be executed before the loop is entered and for the outer loop. As a result, the
+    // transformations can't pay off for a small number of iterations: roughly, if the loop runs for 3 iterations, it's
+    // going to execute as many range checks once transformed with range checks eliminated (1 peeled iteration with
+    // range checks + 2 predicates per range checks) as it would have not transformed. It also has to pay for the extra
+    // logic on loop entry and for the outer loop.
     loop->compute_trip_count(this);
     if (head->is_CountedLoop() && head->as_CountedLoop()->has_exact_trip_count()) {
       if (head->as_CountedLoop()->trip_count() <= 3) {

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -855,6 +855,28 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
     // not a loop after all
     return false;
   }
+
+  if (range_checks.size() > 0) {
+    // This transformation requires peeling one iteration. Also, if it has range checks and they are eliminated by
+    // predication, then 2 predicates are added for one range check. Finally, transforming a long range check requires
+    // extra logic to be executed before the loop is entered and for the outer loop. As a result, the transformations
+    // can't pay off for a small number of iterations: roughly, if the loop runs for 3 iterations, it's going to execute
+    // as many range checks once transformed with range checks eliminated (1 peeled iteration with range checks
+    // + 2 predicates per range checks) as it would have not transformed. It also has to pay for the extra logic on loop
+    // entry and for the outer loop.
+    loop->compute_trip_count(this);
+    if (head->is_CountedLoop() && head->as_CountedLoop()->has_exact_trip_count()) {
+      if (head->as_CountedLoop()->trip_count() <= 3) {
+        return false;
+      }
+    } else {
+      loop->compute_profile_trip_cnt(this);
+      if (!head->is_profile_trip_failed() && head->profile_trip_cnt() <= 3) {
+        return false;
+      }
+    }
+  }
+
   julong orig_iters = (julong)hi->hi_as_long() - lo->lo_as_long();
   iters_limit = checked_cast<int>(MIN2((julong)iters_limit, orig_iters));
 

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -858,7 +858,7 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
 
   if (range_checks.size() > 0) {
     // This transformation requires peeling one iteration. Also, if it has range checks and they are eliminated by
-    // predication, then 2 predicates are added for one range check. Finally, transforming a long range check requires
+    // Loop Predication, then 2 Hoisted Check Predicates are added for one range check. Finally, transforming a long range check requires
     // extra logic to be executed before the loop is entered and for the outer loop. As a result, the transformations
     // can't pay off for a small number of iterations: roughly, if the loop runs for 3 iterations, it's going to execute
     // as many range checks once transformed with range checks eliminated (1 peeled iteration with range checks

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -38,9 +38,9 @@ import java.util.Objects;
 
 public class TestLongRangeChecks {
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:-UseCountedLoopSafepoints");
-        TestFramework.runWithFlags("-XX:+UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=1");
-        TestFramework.runWithFlags("-XX:+UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=1000");
+        TestFramework.runWithFlags("-XX:-UseCountedLoopSafepoints", "-XX:LoopUnrollLimit=0");
+        TestFramework.runWithFlags("-XX:+UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=1", "-XX:LoopUnrollLimit=0");
+        TestFramework.runWithFlags("-XX:+UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=1000", "-XX:LoopUnrollLimit=0");
     }
 
 
@@ -245,5 +245,59 @@ public class TestLongRangeChecks {
     @Run(test = "testStridePosScaleNegInIntLoop2")
     private void testStridePosScaleNegInIntLoop2_runner() {
         testStridePosScaleNegInIntLoop2(0, 100, 200, 198);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LONG_COUNTED_LOOP, "1" })
+    @IR(failOn = { IRNode.COUNTED_LOOP, IRNode.LOOP })
+    public static void testStridePosScalePosShortLoop(long start, long stop, long length, long offset) {
+        final long scale = 1;
+        final long stride = 1;
+
+        // Loop runs for too few iterations. Transforming it wouldn't pay off.
+        for (long i = start; i < stop; i += stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStridePosScalePosShortLoop")
+    private void testStridePosScalePosShortLoop_runner() {
+        testStridePosScalePosShortLoop(0, 2, 2, 0);
+    }
+
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1" })
+    @IR(failOn = { IRNode.LOOP})
+    public static void testStridePosScalePosInIntLoopShortLoop1(int start, int stop, long length, long offset) {
+        final long scale = 2;
+        final int stride = 1;
+
+        // Same but with int loop
+        for (int i = start; i < stop; i += stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStridePosScalePosInIntLoopShortLoop1")
+    private void testStridePosScalePosInIntLoopShortLoop1_runner() {
+        testStridePosScalePosInIntLoopShortLoop1(0, 2, 4, 0);
+    }
+
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1" })
+    @IR(failOn = { IRNode.LOOP})
+    public static void testStridePosScalePosInIntLoopShortLoop2(long length, long offset) {
+        final long scale = 2;
+        final int stride = 1;
+
+        // Same but with int loop
+        for (int i = 0; i < 3; i += stride) {
+            Objects.checkIndex(scale * i + offset, length);
+        }
+    }
+
+    @Run(test = "testStridePosScalePosInIntLoopShortLoop2")
+    private void testStridePosScalePosInIntLoopShortLoop2_runner() {
+        testStridePosScalePosInIntLoopShortLoop2(6, 0);
     }
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -267,7 +267,7 @@ public class TestLongRangeChecks {
 
     @Test
     @IR(counts = { IRNode.COUNTED_LOOP, "1" })
-    @IR(failOn = { IRNode.LOOP})
+    @IR(failOn = { IRNode.LOOP })
     public static void testStridePosScalePosInIntLoopShortLoop1(int start, int stop, long length, long offset) {
         final long scale = 2;
         final int stride = 1;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -285,7 +285,7 @@ public class TestLongRangeChecks {
 
     @Test
     @IR(counts = { IRNode.COUNTED_LOOP, "1" })
-    @IR(failOn = { IRNode.LOOP})
+    @IR(failOn = { IRNode.LOOP })
     public static void testStridePosScalePosInIntLoopShortLoop2(long length, long offset) {
         final long scale = 2;
         final int stride = 1;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 /*
  * @test
- * @bug 8259609 8276116
+ * @bug 8259609 8276116 8311932
  * @summary C2: optimize long range checks in long counted loops
  * @library /test/lib /
  * @requires vm.compiler2.enabled

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestLongRangeChecks.java
@@ -38,9 +38,9 @@ import java.util.Objects;
 
 public class TestLongRangeChecks {
     public static void main(String[] args) {
-        TestFramework.runWithFlags("-XX:-UseCountedLoopSafepoints", "-XX:LoopUnrollLimit=0");
-        TestFramework.runWithFlags("-XX:+UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=1", "-XX:LoopUnrollLimit=0");
-        TestFramework.runWithFlags("-XX:+UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=1000", "-XX:LoopUnrollLimit=0");
+        TestFramework.runWithFlags("-XX:+TieredCompilation", "-XX:-UseCountedLoopSafepoints", "-XX:LoopUnrollLimit=0");
+        TestFramework.runWithFlags("-XX:+TieredCompilation", "-XX:+UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=1", "-XX:LoopUnrollLimit=0");
+        TestFramework.runWithFlags("-XX:+TieredCompilation", "-XX:+UseCountedLoopSafepoints", "-XX:LoopStripMiningIter=1000", "-XX:LoopUnrollLimit=0");
     }
 
 


### PR DESCRIPTION
To enable the elimination of long range checks, the loop that contains
the range checks is transformed into a loop nest and the range checks
are changed to operate on int values computed before the loop is
entered. This causes extra overhead out of loop and once, the range
checks are eliminated, can only pay off if the loop is executed for
long enough. This change disable the transformation if the trip count
computed from profile data is too low. This came up with a
MemorySegment API micro benchmarks and improves performance
significantly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311932](https://bugs.openjdk.org/browse/JDK-8311932): Suboptimal compiled code of nested loop over memory segment (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [a221320e](https://git.openjdk.org/jdk/pull/16650/files/a221320e82b61578b5be83d675a37aa5a9599f27)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16650/head:pull/16650` \
`$ git checkout pull/16650`

Update a local copy of the PR: \
`$ git checkout pull/16650` \
`$ git pull https://git.openjdk.org/jdk.git pull/16650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16650`

View PR using the GUI difftool: \
`$ git pr show -t 16650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16650.diff">https://git.openjdk.org/jdk/pull/16650.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16650#issuecomment-1809807337)