### PR TITLE
8320050: Zero: Build failures due to duplicate definition of __sync_val_compare_and_swap_8

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -315,7 +315,7 @@ extern "C" {
 // Implementations of atomic operations not supported by processors.
 //  -- http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Atomic-Builtins.html
 
-#ifndef _LP64
+#if !defined(_LP64) && !defined(__sync_val_compare_and_swap_8)
 extern "C" {
   long long unsigned int __sync_val_compare_and_swap_8(
     volatile void *ptr,
@@ -325,7 +325,7 @@ extern "C" {
     return 0; // silence compiler warnings
   }
 };
-#endif // !_LP64
+#endif // !_LP64 && !__sync_val_compare_and_swap_8
 
 #ifndef PRODUCT
 void os::verify_stack_alignment() {

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -475,7 +475,7 @@ extern "C" {
 // Implementations of atomic operations not supported by processors.
 //  -- http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Atomic-Builtins.html
 
-#ifndef _LP64
+#if !defined(_LP64) && !defined(__sync_val_compare_and_swap_8)
 extern "C" {
   long long unsigned int __sync_val_compare_and_swap_8(
     volatile void *ptr,
@@ -485,7 +485,7 @@ extern "C" {
     return 0; // silence compiler warnings
   }
 };
-#endif // !_LP64
+#endif // !_LP64 && !__sync_val_compare_and_swap_8
 
 #ifndef PRODUCT
 void os::verify_stack_alignment() {


### PR DESCRIPTION
See the sample build failure log in the bug. This provides a conservative fix that avoids the clash when `libatomic` provides us with the `__sync_val_compare_and_swap_8` implementation. The rest should be handled by moving to `__atomic` built-ins, see related issue.

For sanity, checked that all these build configurations are building fine:
  * server-fastdebug-aarch64-linux-gnu-10
  * server-fastdebug-arm-linux-gnueabihf-10
  * server-fastdebug-i686-linux-gnu-10
  * server-fastdebug-powerpc64le-linux-gnu-10
  * server-fastdebug-powerpc64-linux-gnu-10
  * server-fastdebug-riscv64-linux-gnu-10
  * server-fastdebug-s390x-linux-gnu-10
  * server-fastdebug-x86_64-linux-gnu-10
  * zero-fastdebug-aarch64-linux-gnu-10
  * zero-fastdebug-arm-linux-gnueabi-10
  * zero-fastdebug-arm-linux-gnueabihf-10
  * zero-fastdebug-i686-linux-gnu-10
  * zero-fastdebug-mips64el-linux-gnuabi64-10 
  * zero-fastdebug-powerpc64le-linux-gnu-10
  * zero-fastdebug-powerpc64-linux-gnu-10
  * zero-fastdebug-riscv64-linux-gnu-10
  * zero-fastdebug-s390x-linux-gnu-10
  * zero-fastdebug-sparc64-linux-gnu-10
  * zero-fastdebug-x86_64-linux-gnu-10

Configurations that are still broken due to undefined symbol:
  * zero-fastdebug-mipsel-linux-gnu-10
  * zero-fastdebug-m68k-linux-gnu-10
  * zero-fastdebug-powerpc-linux-gnu-10
  * zero-fastdebug-sh4-linux-gnu-10

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320050](https://bugs.openjdk.org/browse/JDK-8320050): Zero: Build failures due to duplicate definition of __sync_val_compare_and_swap_8 (**Bug** - P3) ⚠️ Issue is not open.


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16651/head:pull/16651` \
`$ git checkout pull/16651`

Update a local copy of the PR: \
`$ git checkout pull/16651` \
`$ git pull https://git.openjdk.org/jdk.git pull/16651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16651`

View PR using the GUI difftool: \
`$ git pr show -t 16651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16651.diff">https://git.openjdk.org/jdk/pull/16651.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16651#issuecomment-1809922579)