### PR TITLE
8320053: GHA: Cross-compile gtest code

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -100,6 +100,10 @@ jobs:
         with:
           platform: linux-x64
 
+      - name: 'Get GTest'
+        id: gtest
+        uses: ./.github/actions/get-gtest
+
         # Upgrading apt to solve libc6 installation bugs, see JDK-8260460.
       - name: 'Install toolchain and dependencies'
         run: |

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -155,6 +155,7 @@ jobs:
           --with-conf-name=linux-${{ matrix.target-cpu }}
           --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
           --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
+          --with-gtest=${{ steps.gtest.outputs.path }}
           --with-zlib=system
           --enable-debug
           --disable-precompiled-headers


### PR DESCRIPTION
Looking at why GHA did not catch [JDK-8320050](https://bugs.openjdk.org/browse/JDK-8320050), even though it builds hotspot, I realized we do not configure the build with gtest, which means we skip the build checks for gtest VM. It would be useful to cross-compile with all tests enabled, even without running them.

(This would probably make sense to do for JDK native code, but AFAICS it would require defining a few new make targets).

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320053](https://bugs.openjdk.org/browse/JDK-8320053): GHA: Cross-compile gtest code (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16652/head:pull/16652` \
`$ git checkout pull/16652`

Update a local copy of the PR: \
`$ git checkout pull/16652` \
`$ git pull https://git.openjdk.org/jdk.git pull/16652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16652`

View PR using the GUI difftool: \
`$ git pr show -t 16652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16652.diff">https://git.openjdk.org/jdk/pull/16652.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16652#issuecomment-1809911485)