### PR TITLE
8320052: Zero: Use __atomic built-ins for atomic RMW operations

### DIFF
--- a/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/atomic_bsd_zero.hpp
@@ -31,135 +31,6 @@
 
 // Implementation of class atomic
 
-#ifdef M68K
-
-/*
- * __m68k_cmpxchg
- *
- * Atomically store newval in *ptr if *ptr is equal to oldval for user space.
- * Returns newval on success and oldval if no exchange happened.
- * This implementation is processor specific and works on
- * 68020 68030 68040 and 68060.
- *
- * It will not work on ColdFire, 68000 and 68010 since they lack the CAS
- * instruction.
- * Using a kernelhelper would be better for arch complete implementation.
- *
- */
-
-static inline int __m68k_cmpxchg(int oldval, int newval, volatile int *ptr) {
-  int ret;
-  __asm __volatile ("cas%.l %0,%2,%1"
-                   : "=d" (ret), "+m" (*(ptr))
-                   : "d" (newval), "0" (oldval));
-  return ret;
-}
-
-/* Perform an atomic compare and swap: if the current value of `*PTR'
-   is OLDVAL, then write NEWVAL into `*PTR'.  Return the contents of
-   `*PTR' before the operation.*/
-static inline int m68k_compare_and_swap(int newval,
-                                        volatile int *ptr,
-                                        int oldval) {
-  for (;;) {
-      int prev = *ptr;
-      if (prev != oldval)
-        return prev;
-
-      if (__m68k_cmpxchg (prev, newval, ptr) == newval)
-        // Success.
-        return prev;
-
-      // We failed even though prev == oldval.  Try again.
-    }
-}
-
-/* Atomically add an int to memory.  */
-static inline int m68k_add_then_fetch(int add_value, volatile int *ptr) {
-  for (;;) {
-      // Loop until success.
-
-      int prev = *ptr;
-
-      if (__m68k_cmpxchg (prev, prev + add_value, ptr) == prev + add_value)
-        return prev + add_value;
-    }
-}
-
-/* Atomically write VALUE into `*PTR' and returns the previous
-   contents of `*PTR'.  */
-static inline int m68k_lock_test_and_set(int newval, volatile int *ptr) {
-  for (;;) {
-      // Loop until success.
-      int prev = *ptr;
-
-      if (__m68k_cmpxchg (prev, newval, ptr) == prev)
-        return prev;
-    }
-}
-#endif // M68K
-
-#ifdef ARM
-
-/*
- * __kernel_cmpxchg
- *
- * Atomically store newval in *ptr if *ptr is equal to oldval for user space.
- * Return zero if *ptr was changed or non-zero if no exchange happened.
- * The C flag is also set if *ptr was changed to allow for assembly
- * optimization in the calling code.
- *
- */
-
-typedef int (__kernel_cmpxchg_t)(int oldval, int newval, volatile int *ptr);
-#define __kernel_cmpxchg (*(__kernel_cmpxchg_t *) 0xffff0fc0)
-
-
-
-/* Perform an atomic compare and swap: if the current value of `*PTR'
-   is OLDVAL, then write NEWVAL into `*PTR'.  Return the contents of
-   `*PTR' before the operation.*/
-static inline int arm_compare_and_swap(int newval,
-                                       volatile int *ptr,
-                                       int oldval) {
-  for (;;) {
-      int prev = *ptr;
-      if (prev != oldval)
-        return prev;
-
-      if (__kernel_cmpxchg (prev, newval, ptr) == 0)
-        // Success.
-        return prev;
-
-      // We failed even though prev == oldval.  Try again.
-    }
-}
-
-/* Atomically add an int to memory.  */
-static inline int arm_add_then_fetch(int add_value, volatile int *ptr) {
-  for (;;) {
-      // Loop until a __kernel_cmpxchg succeeds.
-
-      int prev = *ptr;
-
-      if (__kernel_cmpxchg (prev, prev + add_value, ptr) == 0)
-        return prev + add_value;
-    }
-}
-
-/* Atomically write VALUE into `*PTR' and returns the previous
-   contents of `*PTR'.  */
-static inline int arm_lock_test_and_set(int newval, volatile int *ptr) {
-  for (;;) {
-      // Loop until a __kernel_cmpxchg succeeds.
-      int prev = *ptr;
-
-      if (__kernel_cmpxchg (prev, newval, ptr) == 0)
-        return prev;
-    }
-}
-#endif // ARM
-
 template<size_t byte_size>
 struct Atomic::PlatformAdd {
   template<typename D, typename I>
@@ -178,17 +49,9 @@ inline D Atomic::PlatformAdd<4>::add_then_fetch(D volatile* dest, I add_value,
   STATIC_ASSERT(4 == sizeof(I));
   STATIC_ASSERT(4 == sizeof(D));
 
-#ifdef ARM
-  return add_using_helper<int>(arm_add_then_fetch, dest, add_value);
-#else
-#ifdef M68K
-  return add_using_helper<int>(m68k_add_then_fetch, dest, add_value);
-#else
   D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
   FULL_MEM_BARRIER;
   return res;
-#endif // M68K
-#endif // ARM
 }
 
 template<>
@@ -209,18 +72,10 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
                                              T exchange_value,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(4 == sizeof(T));
-#ifdef ARM
-  return xchg_using_helper<int>(arm_lock_test_and_set, dest, exchange_value);
-#else
-#ifdef M68K
-  return xchg_using_helper<int>(m68k_lock_test_and_set, dest, exchange_value);
-#else
   FULL_MEM_BARRIER;
   T result = __atomic_exchange_n(dest, exchange_value, __ATOMIC_RELAXED);
   FULL_MEM_BARRIER;
   return result;
-#endif // M68K
-#endif // ARM
 }
 
 template<>
@@ -246,20 +101,12 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
                                                 T exchange_value,
                                                 atomic_memory_order order) const {
   STATIC_ASSERT(4 == sizeof(T));
-#ifdef ARM
-  return cmpxchg_using_helper<int>(arm_compare_and_swap, dest, compare_value, exchange_value);
-#else
-#ifdef M68K
-  return cmpxchg_using_helper<int>(m68k_compare_and_swap, dest, compare_value, exchange_value);
-#else
   T value = compare_value;
   FULL_MEM_BARRIER;
   __atomic_compare_exchange(dest, &value, &exchange_value, /*weak*/false,
                             __ATOMIC_RELAXED, __ATOMIC_RELAXED);
   FULL_MEM_BARRIER;
   return value;
-#endif // M68K
-#endif // ARM
 }
 
 template<>

--- a/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
+++ b/src/hotspot/os_cpu/bsd_zero/os_bsd_zero.cpp
@@ -311,22 +311,6 @@ extern "C" {
   }
 };
 
-/////////////////////////////////////////////////////////////////////////////
-// Implementations of atomic operations not supported by processors.
-//  -- http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Atomic-Builtins.html
-
-#ifndef _LP64
-extern "C" {
-  long long unsigned int __sync_val_compare_and_swap_8(
-    volatile void *ptr,
-    long long unsigned int oldval,
-    long long unsigned int newval) {
-    ShouldNotCallThis();
-    return 0; // silence compiler warnings
-  }
-};
-#endif // !_LP64
-
 #ifndef PRODUCT
 void os::verify_stack_alignment() {
 }

--- a/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/atomic_linux_zero.hpp
@@ -71,17 +71,9 @@ inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
                                              T exchange_value,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(4 == sizeof(T));
-  // __sync_lock_test_and_set is a bizarrely named atomic exchange
-  // operation.  Note that some platforms only support this with the
-  // limitation that the only valid value to store is the immediate
-  // constant 1.  There is a test for this in JNI_CreateJavaVM().
-  T result = __sync_lock_test_and_set (dest, exchange_value);
-  // All atomic operations are expected to be full memory barriers
-  // (see atomic.hpp). However, __sync_lock_test_and_set is not
-  // a full memory barrier, but an acquire barrier. Hence, this added
-  // barrier. Some platforms (notably ARM) have peculiarities with
-  // their barrier implementations, delegate it to OrderAccess.
-  OrderAccess::fence();
+  FULL_MEM_BARRIER;
+  T result = __atomic_exchange_n(dest, exchange_value, __ATOMIC_RELAXED);
+  FULL_MEM_BARRIER;
   return result;
 }
 
@@ -91,8 +83,9 @@ inline T Atomic::PlatformXchg<8>::operator()(T volatile* dest,
                                              T exchange_value,
                                              atomic_memory_order order) const {
   STATIC_ASSERT(8 == sizeof(T));
-  T result = __sync_lock_test_and_set (dest, exchange_value);
-  OrderAccess::fence();
+  FULL_MEM_BARRIER;
+  T result = __atomic_exchange_n(dest, exchange_value, __ATOMIC_RELAXED);
+  FULL_MEM_BARRIER;
   return result;
 }
 

--- a/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
+++ b/src/hotspot/os_cpu/linux_zero/os_linux_zero.cpp
@@ -471,22 +471,6 @@ extern "C" {
   }
 };
 
-/////////////////////////////////////////////////////////////////////////////
-// Implementations of atomic operations not supported by processors.
-//  -- http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Atomic-Builtins.html
-
-#ifndef _LP64
-extern "C" {
-  long long unsigned int __sync_val_compare_and_swap_8(
-    volatile void *ptr,
-    long long unsigned int oldval,
-    long long unsigned int newval) {
-    ShouldNotCallThis();
-    return 0; // silence compiler warnings
-  }
-};
-#endif // !_LP64
-
 #ifndef PRODUCT
 void os::verify_stack_alignment() {
 }


### PR DESCRIPTION
GCC defines `__sync*` built-ins as legacy implementations of atomic support routines, and recommends using `__atomic*` built-ins in new code: https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html

The crucial difference between these two families of built-ins is that `__atomic*` 64-bit CAS/CAE is guaranteed to be supported ("The ‘__atomic’ builtins can be used with any integral scalar or pointer type that is 1, 2, 4, or 8 bytes in length"), whereas `__sync*` 64-bit CAS/CAE can be unimplemented. We are seeing Zero build failures for some platforms because of this.

This PR also cleans up the platform-specific hacks, and delegates wholesale to built-ins. I have chosen the form of `PlatformCmpxchg` -- a relaxed CAS framed by full memory barriers. This is probably overkill, but for Zero we want correctness first and foremost.

This work is important for making sure [JDK-8316961](https://bugs.openjdk.org/browse/JDK-8316961) works on all platforms, and allows [JDK-8318776](https://bugs.openjdk.org/browse/JDK-8318776) to proceed.

Additional testing:
 - [x] MacOS AArch64 Zero fastdebug; light jcstress tests still pass
 - [x] Linux x86_32 Zero release; jcstress tests pass
 - [x] Linux x86_32 Zero fastdebug, `compiler/unsafe java/lang/invoke/VarHandles`
 - [x] Linux x86_32 Zero fastdebug, bootcycle-images
 - [x] Lots of Zero builds still pass:
   * zero-fastdebug-aarch64-linux-gnu-10
   * zero-fastdebug-i686-linux-gnu-10
   * zero-fastdebug-mips64el-linux-gnuabi64-10 
   * zero-fastdebug-powerpc64le-linux-gnu-10
   * zero-fastdebug-powerpc64-linux-gnu-10
   * zero-fastdebug-riscv64-linux-gnu-10
   * zero-fastdebug-s390x-linux-gnu-10
   * zero-fastdebug-sparc64-linux-gnu-10
   * zero-fastdebug-x86_64-linux-gnu-10
 - [x] Previously broken Zero builds now pass:
   * zero-fastdebug-arm-linux-gnueabi-10
   * zero-fastdebug-arm-linux-gnueabihf-10
   * zero-fastdebug-mipsel-linux-gnu-10
   * zero-fastdebug-m68k-linux-gnu-10
   * zero-fastdebug-powerpc-linux-gnu-10
   * zero-fastdebug-sh4-linux-gnu-10

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320052](https://bugs.openjdk.org/browse/JDK-8320052): Zero: Use __atomic built-ins for atomic RMW operations (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16654/head:pull/16654` \
`$ git checkout pull/16654`

Update a local copy of the PR: \
`$ git checkout pull/16654` \
`$ git pull https://git.openjdk.org/jdk.git pull/16654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16654`

View PR using the GUI difftool: \
`$ git pr show -t 16654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16654.diff">https://git.openjdk.org/jdk/pull/16654.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16654#issuecomment-1811091437)