### PR TITLE
8317007: Add bulk removal of dead nmethods during class unloading

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -599,7 +599,7 @@ void ClassLoaderData::unload() {
   free_deallocate_list_C_heap_structures();
 
   // Clean up class dependencies and tell serviceability tools
-  // these classes are unloading.  Must be called
+  // these classes are unloading.  This must be called
   // after erroneous classes are released.
   classes_do(InstanceKlass::unload_class);
 

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -186,12 +186,16 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   ClassLoaderData* next() const;
   void unlink_next();
 
-  void set_unloading_next(ClassLoaderData* unloading_next);
-  ClassLoaderData* unloading_next() const;
-
   ClassLoaderData(Handle h_class_loader, bool has_class_mirror_holder);
+
+public:
   ~ClassLoaderData();
 
+  void set_unloading_next(ClassLoaderData* unloading_next);
+  ClassLoaderData* unloading_next() const;
+  void unload();
+
+private:
   // The CLD are not placed in the Heap, so the Card Table or
   // the Mod Union Table can't be used to mark when CLD have modified oops.
   // The CT and MUT bits saves this information for the whole class loader data.
@@ -203,11 +207,11 @@ class ClassLoaderData : public CHeapObj<mtClass> {
   oop holder_no_keepalive() const;
   oop holder() const;
 
+  void classes_do(void f(Klass* const));
+
  private:
-  void unload();
   bool keep_alive() const       { return _keep_alive > 0; }
 
-  void classes_do(void f(Klass* const));
   void loaded_classes_do(KlassClosure* klass_closure);
   void classes_do(void f(InstanceKlass*));
   void methods_do(void f(Method*));

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -31,6 +31,7 @@
 #include "classfile/moduleEntry.hpp"
 #include "classfile/packageEntry.hpp"
 #include "code/dependencyContext.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "logging/log.hpp"
 #include "logging/logStream.hpp"
 #include "memory/allocation.inline.hpp"
@@ -124,7 +125,6 @@ void ClassLoaderDataGraph::walk_metadata_and_clean_metaspaces() {
 
 // List head of all class loader data.
 ClassLoaderData* volatile ClassLoaderDataGraph::_head = nullptr;
-ClassLoaderData* ClassLoaderDataGraph::_unloading_head = nullptr;
 
 bool ClassLoaderDataGraph::_should_clean_deallocate_lists = false;
 bool ClassLoaderDataGraph::_safepoint_cleanup_needed = false;
@@ -342,11 +342,7 @@ void ClassLoaderDataGraph::loaded_classes_do(KlassClosure* klass_closure) {
 }
 
 void ClassLoaderDataGraph::classes_unloading_do(void f(Klass* const)) {
-  assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
-  for (ClassLoaderData* cld = _unloading_head; cld != nullptr; cld = cld->unloading_next()) {
-    assert(cld->is_unloading(), "invariant");
-    cld->classes_do(f);
-  }
+  ClassUnloadingContext::context()->classes_unloading_do(f);
 }
 
 void ClassLoaderDataGraph::verify_dictionary() {
@@ -425,7 +421,8 @@ bool ClassLoaderDataGraph::do_unloading() {
     } else {
       // Found dead CLD.
       loaders_removed++;
-      data->unload();
+
+      ClassUnloadingContext::context()->register_unloading_class_loader_data(data);
 
       // Move dead CLD to unloading list.
       if (prev != nullptr) {
@@ -435,8 +432,6 @@ bool ClassLoaderDataGraph::do_unloading() {
         // The GC might be walking this concurrently
         Atomic::store(&_head, data->next());
       }
-      data->set_unloading_next(_unloading_head);
-      _unloading_head = data;
     }
   }
 
@@ -469,16 +464,9 @@ void ClassLoaderDataGraph::clean_module_and_package_info() {
 }
 
 void ClassLoaderDataGraph::purge(bool at_safepoint) {
-  ClassLoaderData* list = _unloading_head;
-  _unloading_head = nullptr;
-  ClassLoaderData* next = list;
-  bool classes_unloaded = false;
-  while (next != nullptr) {
-    ClassLoaderData* purge_me = next;
-    next = purge_me->unloading_next();
-    delete purge_me;
-    classes_unloaded = true;
-  }
+  ClassUnloadingContext::context()->purge_class_loader_data();
+
+  bool classes_unloaded = ClassUnloadingContext::context()->has_unloaded_classes();
 
   Metaspace::purge(classes_unloaded);
   if (classes_unloaded) {

--- a/src/hotspot/share/classfile/classLoaderDataGraph.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.hpp
@@ -43,8 +43,6 @@ class ClassLoaderDataGraph : public AllStatic {
  private:
   // All CLDs (except unlinked CLDs) can be reached by walking _head->_next->...
   static ClassLoaderData* volatile _head;
-  // All unlinked CLDs
-  static ClassLoaderData* _unloading_head;
 
   // Set if there's anything to purge in the deallocate lists or previous versions
   // during a safepoint after class unloading in a full GC.

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -164,7 +164,7 @@ RuntimeBlob::RuntimeBlob(
 void RuntimeBlob::free(RuntimeBlob* blob) {
   assert(blob != nullptr, "caller must check for nullptr");
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
-  blob->flush();
+  blob->purge();
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
     CodeCache::free(blob);
@@ -173,7 +173,7 @@ void RuntimeBlob::free(RuntimeBlob* blob) {
   MemoryService::track_code_cache_memory_usage();
 }
 
-void CodeBlob::flush() {
+void CodeBlob::purge(bool free_code_cache_data) {
   if (_oop_maps != nullptr) {
     delete _oop_maps;
     _oop_maps = nullptr;

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -173,7 +173,7 @@ void RuntimeBlob::free(RuntimeBlob* blob) {
   MemoryService::track_code_cache_memory_usage();
 }
 
-void CodeBlob::purge(bool free_code_cache_data) {
+void CodeBlob::purge(bool free_code_cache_data, bool unregister_nmethods) {
   if (_oop_maps != nullptr) {
     delete _oop_maps;
     _oop_maps = nullptr;

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -143,7 +143,7 @@ public:
   static unsigned int align_code_offset(int offset);
 
   // Deletion
-  virtual void flush();
+  virtual void purge(bool free_code_cache_data = true);
 
   // Typing
   virtual bool is_buffer_blob() const                 { return false; }

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -143,7 +143,7 @@ public:
   static unsigned int align_code_offset(int offset);
 
   // Deletion
-  virtual void purge(bool free_code_cache_data = true);
+  virtual void purge(bool free_code_cache_data = true, bool unregister_nmethods = true);
 
   // Typing
   virtual bool is_buffer_blob() const                 { return false; }

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -37,6 +37,7 @@
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "jvm_io.h"
@@ -609,7 +610,7 @@ void CodeCache::free(CodeBlob* cb) {
 
   cb->~CodeBlob();
   // Get heap for given CodeBlob and deallocate
-  get_code_heap(cb)->deallocate(cb);
+  heap->deallocate(cb);
 
   assert(heap->blob_count() >= 0, "sanity check");
 }
@@ -965,36 +966,8 @@ void CodeCache::purge_exception_caches() {
   _exception_cache_purge_list = nullptr;
 }
 
-// Register an is_unloading nmethod to be flushed after unlinking
-void CodeCache::register_unlinked(nmethod* nm) {
-  assert(nm->unlinked_next() == nullptr, "Only register for unloading once");
-  for (;;) {
-    // Only need acquire when reading the head, when the next
-    // pointer is walked, which it is not here.
-    nmethod* head = Atomic::load(&_unlinked_head);
-    nmethod* next = head != nullptr ? head : nm; // Self looped means end of list
-    nm->set_unlinked_next(next);
-    if (Atomic::cmpxchg(&_unlinked_head, head, nm) == head) {
-      break;
-    }
-  }
-}
-
-// Flush all the nmethods the GC unlinked
-void CodeCache::flush_unlinked_nmethods() {
-  nmethod* nm = _unlinked_head;
-  _unlinked_head = nullptr;
-  size_t freed_memory = 0;
-  while (nm != nullptr) {
-    nmethod* next = nm->unlinked_next();
-    freed_memory += nm->total_size();
-    nm->flush();
-    if (next == nm) {
-      // Self looped means end of list
-      break;
-    }
-    nm = next;
-  }
+// Restart compiler if possible and required..
+void CodeCache::maybe_restart_compiler(size_t freed_memory) {
 
   // Try to start the compiler again if we freed any memory
   if (!CompileBroker::should_compile_new_jobs() && freed_memory != 0) {
@@ -1008,7 +981,6 @@ void CodeCache::flush_unlinked_nmethods() {
 }
 
 uint8_t CodeCache::_unloading_cycle = 1;
-nmethod* volatile CodeCache::_unlinked_head = nullptr;
 
 void CodeCache::increment_unloading_cycle() {
   // 2-bit value (see IsUnloadingState in nmethod.cpp for details)

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -106,7 +106,6 @@ class CodeCache : AllStatic {
   static TruncatedSeq      _unloading_gc_intervals;
   static TruncatedSeq      _unloading_allocation_rates;
   static volatile bool     _unloading_threshold_gc_requested;
-  static nmethod* volatile _unlinked_head;
 
   static ExceptionCache* volatile _exception_cache_purge_list;
 
@@ -211,8 +210,7 @@ class CodeCache : AllStatic {
   //    nmethod::is_cold.
   static void arm_all_nmethods();
 
-  static void flush_unlinked_nmethods();
-  static void register_unlinked(nmethod* nm);
+  static void maybe_restart_compiler(size_t freed_memory);
   static void do_unloading(bool unloading_occurred);
   static uint8_t unloading_cycle() { return _unloading_cycle; }
 

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -174,7 +174,7 @@ protected:
 
   void* _gc_data;
 
-  virtual void flush() = 0;
+  virtual void purge(bool free_code_cache_data = true) = 0;
 
 private:
   DeoptimizationStatus deoptimization_status() const {

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -174,7 +174,7 @@ protected:
 
   void* _gc_data;
 
-  virtual void purge(bool free_code_cache_data = true) = 0;
+  virtual void purge(bool free_code_cache_data = true, bool unregister_nmethods = true) = 0;
 
 private:
   DeoptimizationStatus deoptimization_status() const {

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1444,7 +1444,7 @@ void nmethod::unlink() {
   ClassUnloadingContext::context()->register_unlinked_nmethod(this);
 }
 
-void nmethod::purge(bool free_code_cache_data) {
+void nmethod::purge(bool free_code_cache_data, bool unregister_nmethods) {
   MutexLocker ml(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
   // completely deallocate this method
@@ -1464,7 +1464,10 @@ void nmethod::purge(bool free_code_cache_data) {
     ec = next;
   }
 
-  Universe::heap()->unregister_nmethod(this);
+  if (unregister_nmethods) {
+    Universe::heap()->unregister_nmethod(this);
+  }
+
   CodeCache::unregister_old_nmethod(this);
 
   CodeBlob::purge();

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -196,7 +196,7 @@ class nmethod : public CompiledMethod {
   address _verified_entry_point;             // entry point without class check
   address _osr_entry_point;                  // entry point for on stack replacement
 
-  nmethod* _unlinked_next;
+  bool _is_unlinked;
 
   // Shared fields for all nmethod's
   int _entry_bci;      // != InvocationEntryBci if this nmethod is an on-stack replacement method
@@ -441,8 +441,8 @@ class nmethod : public CompiledMethod {
   virtual bool is_unloading();
   virtual void do_unloading(bool unloading_occurred);
 
-  nmethod* unlinked_next() const                  { return _unlinked_next; }
-  void set_unlinked_next(nmethod* next)           { _unlinked_next = next; }
+  bool is_unlinked() const                        { return _is_unlinked; }
+  void set_is_unlinked()                          { assert(!_is_unlinked, "already unlinked"); _is_unlinked = true; }
 
 #if INCLUDE_RTM_OPT
   // rtm state accessing and manipulating
@@ -522,7 +522,7 @@ public:
   void unlink();
 
   // Deallocate this nmethod - called by the GC
-  void flush();
+  void purge(bool free_code_cache_data = true);
 
   // See comment at definition of _last_seen_on_stack
   void mark_as_maybe_on_stack();

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -522,7 +522,7 @@ public:
   void unlink();
 
   // Deallocate this nmethod - called by the GC
-  void purge(bool free_code_cache_data = true);
+  void purge(bool free_code_cache_data = true, bool unregister_nmethods = true);
 
   // See comment at definition of _last_seen_on_stack
   void mark_as_maybe_on_stack();

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1794,7 +1794,7 @@ bool CompileBroker::init_compiler_runtime() {
 void CompileBroker::free_buffer_blob_if_allocated(CompilerThread* thread) {
   BufferBlob* blob = thread->get_buffer_blob();
   if (blob != nullptr) {
-    blob->flush();
+    blob->purge();
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
     CodeCache::free(blob);
   }

--- a/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CodeRootSet.cpp
@@ -187,6 +187,15 @@ public:
     }
   }
 
+  // Removes dead/unlinked entries.
+  void remove_unlinked_entries() {
+    auto delete_check = [&] (nmethod** value) {
+      return (*value)->is_unlinked();
+    };
+
+    clean(delete_check);
+  }
+
   // Calculate the log2 of the table size we want to shrink to.
   size_t log2_target_shrink_size(size_t current_size) const {
     // A table with the new size should be at most filled by this factor. Otherwise
@@ -253,6 +262,11 @@ G1CodeRootSet::~G1CodeRootSet() {
 bool G1CodeRootSet::remove(nmethod* method) {
   assert(!_is_iterating, "should not mutate while iterating the table");
   return _table->remove(method);
+}
+
+void G1CodeRootSet::remove_unlinked_entries() {
+  assert(!_is_iterating, "should not mutate while iterating the table");
+  _table->remove_unlinked_entries();
 }
 
 bool G1CodeRootSet::contains(nmethod* method) {

--- a/src/hotspot/share/gc/g1/g1CodeRootSet.hpp
+++ b/src/hotspot/share/gc/g1/g1CodeRootSet.hpp
@@ -44,6 +44,7 @@ class G1CodeRootSet {
 
   void add(nmethod* method);
   bool remove(nmethod* method);
+  void remove_unlinked_entries();
   bool contains(nmethod* method);
   void clear();
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2765,7 +2765,7 @@ bool G1CollectedHeap::check_young_list_empty() {
 
 // Remove the given HeapRegion from the appropriate region set.
 void G1CollectedHeap::prepare_region_for_full_compaction(HeapRegion* hr) {
-   if (hr->is_humongous()) {
+  if (hr->is_humongous()) {
     _humongous_set.remove(hr);
   } else if (hr->is_old()) {
     _old_set.remove(hr);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1264,6 +1264,8 @@ public:
   // Performs cleaning of data structures after class unloading.
   void complete_cleaning(bool class_unloading_occurred);
 
+  void unload_classes_and_code(const char* description, BoolObjectClosure* cl, GCTimer* timer);
+
   // Verification
 
   // Perform any cleanup actions necessary before allowing a verification.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -1266,6 +1266,8 @@ public:
 
   void unload_classes_and_code(const char* description, BoolObjectClosure* cl, GCTimer* timer);
 
+  void remove_unlinked_nmethods_from_code_root_sets();
+
   // Verification
 
   // Perform any cleanup actions necessary before allowing a verification.

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -24,9 +24,6 @@
 
 #include "precompiled.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
-#include "classfile/systemDictionary.hpp"
-#include "code/codeCache.hpp"
-#include "compiler/oopMap.hpp"
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1FullCollector.inline.hpp"
 #include "gc/g1/g1FullGCAdjustTask.hpp"
@@ -41,6 +38,7 @@
 #include "gc/g1/g1RegionMarkStatsCache.inline.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/preservedMarks.inline.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/referenceProcessor.hpp"
 #include "gc/shared/verifyOption.hpp"
 #include "gc/shared/weakProcessor.inline.hpp"
@@ -319,14 +317,7 @@ void G1FullCollector::phase1_mark_live_objects() {
 
   // Class unloading and cleanup.
   if (ClassUnloading) {
-    GCTraceTime(Debug, gc, phases) debug("Phase 1: Class Unloading and Cleanup", scope()->timer());
-    {
-      CodeCache::UnlinkingScope unloading_scope(&_is_alive);
-      // Unload classes and purge the SystemDictionary.
-      bool unloading_occurred = SystemDictionary::do_unloading(scope()->timer());
-      _heap->complete_cleaning(unloading_occurred);
-    }
-    CodeCache::flush_unlinked_nmethods();
+    _heap->unload_classes_and_code("Phase 1: Class Unloading and Cleanup", &_is_alive, scope()->timer());
   }
 
   {

--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -171,6 +171,7 @@ public:
   PrepareRegionsClosure(G1FullCollector* collector) : _collector(collector) { }
 
   bool do_heap_region(HeapRegion* hr) {
+    hr->prepare_for_full_gc();
     G1CollectedHeap::heap()->prepare_region_for_full_compaction(hr);
     _collector->before_marking_update_attribute_table(hr);
     return false;

--- a/src/hotspot/share/gc/g1/heapRegion.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.hpp
@@ -174,6 +174,7 @@ public:
 
   void update_bot_for_block(HeapWord* start, HeapWord* end);
 
+  void prepare_for_full_gc();
   // Update heap region that has been compacted to be consistent after Full GC.
   void reset_compacted_after_full_gc(HeapWord* new_top);
   // Update skip-compacting heap region to be consistent after Full GC.

--- a/src/hotspot/share/gc/g1/heapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/heapRegion.inline.hpp
@@ -167,6 +167,10 @@ inline size_t HeapRegion::block_size(const HeapWord* p, HeapWord* const pb) cons
   return cast_to_oop(p)->size();
 }
 
+inline void HeapRegion::prepare_for_full_gc() {
+  _parsable_bottom = top();
+}
+
 inline void HeapRegion::reset_compacted_after_full_gc(HeapWord* new_top) {
   set_top(new_top);
   // After a compaction the mark bitmap in a movable region is invalid.
@@ -188,7 +192,7 @@ inline void HeapRegion::reset_skip_compacting_after_full_gc() {
 
 inline void HeapRegion::reset_after_full_gc_common() {
   // Everything above bottom() is parsable and live.
-  _parsable_bottom = bottom();
+  reset_parsable_bottom();
 
   // Clear unused heap memory in debug builds.
   if (ZapUnusedHeapArea) {

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.cpp
@@ -115,6 +115,10 @@ void HeapRegionRemSet::remove_code_root(nmethod* nm) {
   guarantee(!_code_roots.contains(nm), "duplicate entry found");
 }
 
+void HeapRegionRemSet::remove_unlinked_nmethods() {
+  _code_roots.remove_unlinked_entries();
+}
+
 void HeapRegionRemSet::code_roots_do(CodeBlobClosure* blk) const {
   _code_roots.nmethods_do(blk);
 }

--- a/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
+++ b/src/hotspot/share/gc/g1/heapRegionRemSet.hpp
@@ -150,6 +150,7 @@ public:
   // the heap region that owns this RSet.
   void add_code_root(nmethod* nm);
   void remove_code_root(nmethod* nm);
+  void remove_unlinked_nmethods();
 
   // Applies blk->do_code_blob() to each of the entries in _code_roots
   void code_roots_do(CodeBlobClosure* blk) const;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -527,6 +527,14 @@ void ParallelScavengeHeap::resize_all_tlabs() {
   CollectedHeap::resize_all_tlabs();
 }
 
+void ParallelScavengeHeap::prune_scavengable_nmethods() {
+  ScavengableNMethods::prune_nmethods_not_into_young();
+}
+
+void ParallelScavengeHeap::prune_unlinked_nmethods() {
+  ScavengableNMethods::prune_unlinked_nmethods();
+}
+
 // This method is used by System.gc() and JVMTI.
 void ParallelScavengeHeap::collect(GCCause::Cause cause) {
   assert(!Heap_lock->owned_by_self(),
@@ -856,10 +864,6 @@ void ParallelScavengeHeap::unregister_nmethod(nmethod* nm) {
 
 void ParallelScavengeHeap::verify_nmethod(nmethod* nm) {
   ScavengableNMethods::verify_nmethod(nm);
-}
-
-void ParallelScavengeHeap::prune_scavengable_nmethods() {
-  ScavengableNMethods::prune_nmethods();
 }
 
 GrowableArray<GCMemoryManager*> ParallelScavengeHeap::memory_managers() {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -174,6 +174,7 @@ class ParallelScavengeHeap : public CollectedHeap {
   void verify_nmethod(nmethod* nm) override;
 
   void prune_scavengable_nmethods();
+  void prune_unlinked_nmethods();
 
   size_t max_capacity() const override;
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2082,6 +2082,10 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
       GCTraceTime(Debug, gc, phases) t("Free Code Blobs", gc_timer());
       ctx->free_code_blobs();
     }
+    {
+      GCTraceTime(Debug, gc, phases) ur("Unregister NMethods", &_gc_timer);
+      ParallelScavengeHeap::heap()->prune_unlinked_nmethods();
+    }
 
     // Prune dead klasses from subklass/sibling/implementor lists.
     Klass::clean_weak_klass_links(unloading_occurred);

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -42,6 +42,7 @@
 #include "gc/parallel/psScavenge.hpp"
 #include "gc/parallel/psStringDedup.hpp"
 #include "gc/parallel/psYoungGen.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/gcCause.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
 #include "gc/shared/gcId.hpp"
@@ -1024,9 +1025,12 @@ void PSParallelCompact::post_compact()
     ct->dirty_MemRegion(old_mr);
   }
 
-  // Delete metaspaces for unloaded class loaders and clean up loader_data graph
-  ClassLoaderDataGraph::purge(/*at_safepoint*/true);
-  DEBUG_ONLY(MetaspaceUtils::verify();)
+  {
+    // Delete metaspaces for unloaded class loaders and clean up loader_data graph
+    GCTraceTime(Debug, gc, phases) t("Purge Class Loader Data", gc_timer());
+    ClassLoaderDataGraph::purge(true /* at_safepoint */);
+    DEBUG_ONLY(MetaspaceUtils::verify();)
+  }
 
   // Need to clear claim bits for the next mark.
   ClassLoaderDataGraph::clear_claimed_marks();
@@ -1764,6 +1768,9 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
 
     ref_processor()->start_discovery(maximum_heap_compaction);
 
+    DefaultClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
+                                     false /* lock_codeblob_free_separately */);
+
     marking_phase(&_gc_tracer);
 
     bool max_on_system_gc = UseMaximumCompactionOnSystemGC
@@ -2053,6 +2060,8 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
   {
     GCTraceTime(Debug, gc, phases) tm_m("Class Unloading", &_gc_timer);
 
+    ClassUnloadingContext* ctx = ClassUnloadingContext::context();
+
     bool unloading_occurred;
     {
       CodeCache::UnlinkingScope scope(is_alive_closure());
@@ -2064,8 +2073,15 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
       CodeCache::do_unloading(unloading_occurred);
     }
 
-    // Release unloaded nmethods's memory.
-    CodeCache::flush_unlinked_nmethods();
+    {
+      GCTraceTime(Debug, gc, phases) t("Purge Unlinked NMethods", gc_timer());
+      // Release unloaded nmethod's memory.
+      ctx->purge_nmethods();
+    }
+    {
+      GCTraceTime(Debug, gc, phases) t("Free Code Blobs", gc_timer());
+      ctx->free_code_blobs();
+    }
 
     // Prune dead klasses from subklass/sibling/implementor lists.
     Klass::clean_weak_klass_links(unloading_occurred);

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -38,6 +38,7 @@
 #include "gc/serial/genMarkSweep.hpp"
 #include "gc/serial/serialGcRefProcProxyTask.hpp"
 #include "gc/serial/serialHeap.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
 #include "gc/shared/gcTimer.hpp"
@@ -200,6 +201,8 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
   {
     GCTraceTime(Debug, gc, phases) tm_m("Class Unloading", gc_timer());
 
+    ClassUnloadingContext* ctx = ClassUnloadingContext::context();
+
     bool unloading_occurred;
     {
       CodeCache::UnlinkingScope scope(&is_alive);
@@ -211,8 +214,15 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
       CodeCache::do_unloading(unloading_occurred);
     }
 
-    // Release unloaded nmethod's memory.
-    CodeCache::flush_unlinked_nmethods();
+    {
+      GCTraceTime(Debug, gc, phases) t("Purge Unlinked NMethods", gc_timer());
+      // Release unloaded nmethod's memory.
+      ctx->purge_nmethods();
+    }
+    {
+      GCTraceTime(Debug, gc, phases) t("Free Code Blobs", gc_timer());
+      ctx->free_code_blobs();
+    }
 
     // Prune dead klasses from subklass/sibling/implementor lists.
     Klass::clean_weak_klass_links(unloading_occurred);

--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -223,6 +223,10 @@ void GenMarkSweep::mark_sweep_phase1(bool clear_all_softrefs) {
       GCTraceTime(Debug, gc, phases) t("Free Code Blobs", gc_timer());
       ctx->free_code_blobs();
     }
+    {
+      GCTraceTime(Debug, gc, phases) ur("Unregister NMethods", gc_timer());
+      gch->prune_unlinked_nmethods();
+    }
 
     // Prune dead klasses from subklass/sibling/implementor lists.
     Klass::clean_weak_klass_links(unloading_occurred);

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -28,6 +28,7 @@
 #include "gc/serial/tenuredGeneration.inline.hpp"
 #include "gc/shared/gcLocker.inline.hpp"
 #include "gc/shared/genMemoryPools.hpp"
+#include "gc/shared/scavengableNMethods.hpp"
 #include "gc/shared/strongRootsScope.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "memory/universe.hpp"

--- a/src/hotspot/share/gc/shared/classUnloadingContext.cpp
+++ b/src/hotspot/share/gc/shared/classUnloadingContext.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+
+#include "classfile/classLoaderData.inline.hpp"
+#include "code/nmethod.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "utilities/growableArray.hpp"
+
+ClassUnloadingContext* ClassUnloadingContext::_context = nullptr;
+
+ClassUnloadingContext::ClassUnloadingContext() {
+  assert(_context == nullptr, "context already set");
+  _context = this;
+}
+
+ClassUnloadingContext::~ClassUnloadingContext() {
+  assert(_context == this, "context not set correctly");
+  _context = nullptr;
+}
+
+
+DefaultClassUnloadingContext::DefaultClassUnloadingContext(uint num_workers, bool lock_codeblob_free_separately) :
+  ClassUnloadingContext(),
+  _cld_head(nullptr),
+  _num_nmethod_unlink_workers(num_workers),
+  _unlinked_nmethods(nullptr),
+  _lock_codeblob_free_separately(lock_codeblob_free_separately) {
+
+  assert(num_workers > 0, "must be");
+
+  _unlinked_nmethods = NEW_C_HEAP_ARRAY(NmethodSet*, num_workers, mtGC);
+  for (uint i = 0; i < num_workers; ++i) {
+    _unlinked_nmethods[i] = new NmethodSet();
+  }
+}
+
+DefaultClassUnloadingContext::~DefaultClassUnloadingContext() {
+  for (uint i = 0; i < _num_nmethod_unlink_workers; ++i) {
+    delete _unlinked_nmethods[i];
+  }
+  FREE_C_HEAP_ARRAY(NmethodSet*, _unlinked_nmethods);
+}
+
+bool DefaultClassUnloadingContext::has_unloaded_classes() const {
+  return _cld_head != nullptr;
+}
+
+void DefaultClassUnloadingContext::register_unloading_class_loader_data(ClassLoaderData* cld) {
+  assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
+
+  cld->unload();
+
+  cld->set_unloading_next(_cld_head);
+  _cld_head = cld;
+}
+
+void DefaultClassUnloadingContext::purge_class_loader_data() {
+  for (ClassLoaderData* cld = _cld_head; cld != nullptr;) {
+    assert(cld->is_unloading(), "invariant");
+
+    ClassLoaderData* next = cld->unloading_next();
+    delete cld;
+    cld = next;
+  }
+}
+
+void DefaultClassUnloadingContext::classes_unloading_do(void f(Klass* const)) {
+  assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
+  for (ClassLoaderData* cld = _cld_head; cld != nullptr; cld = cld->unloading_next()) {
+    assert(cld->is_unloading(), "invariant");
+    cld->classes_do(f);
+  }
+}
+
+void DefaultClassUnloadingContext::register_unlinked_nmethod(nmethod* nm) {
+  assert(_context != nullptr, "no context set");
+
+  assert(!nm->is_unlinked(), "Only register for unloading once");
+  assert(_num_nmethod_unlink_workers == 1 || Thread::current()->is_Worker_thread(), "must be worker thread if parallel");
+
+  uint worker_id = _num_nmethod_unlink_workers == 1 ? 0 : WorkerThread::worker_id();
+  assert(worker_id < _num_nmethod_unlink_workers, "larger than expected worker id %u", worker_id);
+
+  _unlinked_nmethods[worker_id]->append(nm);
+
+  nm->set_is_unlinked();
+}
+
+void DefaultClassUnloadingContext::purge_nmethods() {
+  assert(_context != nullptr, "no context set");
+
+  size_t freed_memory = 0;
+
+  for (uint i = 0; i < _num_nmethod_unlink_workers; ++i) {
+    NmethodSet* set = _unlinked_nmethods[i];
+    for (int j = 0; j < set->length(); ++j) {
+      nmethod* nm = set->at(j);
+      freed_memory += nm->size();
+      nm->purge(false /* free_code_cache_data */);
+    }
+  }
+
+  CodeCache::maybe_restart_compiler(freed_memory);
+}
+
+void DefaultClassUnloadingContext::free_code_blobs() {
+  assert(_context != nullptr, "no context set");
+
+  // Sort nmethods before freeing to benefit from optimizations. If Nmethods were
+  // collected in parallel, use a new temporary buffer for the result, otherwise
+  // sort in-place.
+  NmethodSet* all = nullptr;
+
+  bool is_parallel = _num_nmethod_unlink_workers != 1;
+
+  // Merge all collected nmethods into a huge array.
+  if (is_parallel) {
+    int num_nmethods = 0;
+
+    for (uint i = 0; i < _num_nmethod_unlink_workers; ++i) {
+      num_nmethods += _unlinked_nmethods[i]->length();
+    }
+    all = new NmethodSet(num_nmethods);
+    for (uint i = 0; i < _num_nmethod_unlink_workers; ++i) {
+      all->appendAll(_unlinked_nmethods[i]);
+    }
+  } else {
+    all = _unlinked_nmethods[0];
+  }
+
+  // Sort by ascending address.
+  auto sort_nmethods = [] (nmethod** a, nmethod** b) -> int {
+    uintptr_t u_a = (uintptr_t)*a;
+    uintptr_t u_b = (uintptr_t)*b;
+    if (u_a == u_b) return 0;
+    if (u_a < u_b) return -1;
+    return 1;
+  };
+  all->sort(sort_nmethods);
+
+  // And free.
+  {
+    ConditionalMutexLocker ml_outer(CodeCache_lock, !_lock_codeblob_free_separately, Mutex::_no_safepoint_check_flag);
+    for (int i = 0; i < all->length(); ++i) {
+      ConditionalMutexLocker ml_inner(CodeCache_lock, _lock_codeblob_free_separately, Mutex::_no_safepoint_check_flag);
+      CodeCache::free(all->at(i));
+    }
+  }
+
+  if (is_parallel) {
+    delete all;
+  }
+}

--- a/src/hotspot/share/gc/shared/classUnloadingContext.hpp
+++ b/src/hotspot/share/gc/shared/classUnloadingContext.hpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHARED_CLASSUNLOADINGCONTEXT_HPP
+#define SHARE_GC_SHARED_CLASSUNLOADINGCONTEXT_HPP
+
+#include "utilities/growableArray.hpp"
+
+class ClassLoaderData;
+class Klass;
+class nmethod;
+
+class ClassUnloadingContext : public CHeapObj<mtGC> {
+protected:
+  static ClassUnloadingContext* _context;
+
+  ClassUnloadingContext();
+  virtual ~ClassUnloadingContext();
+
+public:
+  static ClassUnloadingContext* context() { assert(_context != nullptr, "context not set"); return _context; }
+
+  // Has class unloading occurred?
+  virtual bool has_unloaded_classes() const = 0;
+
+  virtual void register_unloading_class_loader_data(ClassLoaderData* cld) = 0;
+  virtual void purge_class_loader_data() = 0;
+
+  // Apply f on all Klasses of all unloading ClassLoaderDatas.
+  virtual void classes_unloading_do(void f(Klass* const)) = 0;
+
+  virtual void register_unlinked_nmethod(nmethod* nm) = 0;
+  virtual void purge_nmethods() = 0;
+  virtual void free_code_blobs() = 0;
+
+  void purge_and_free_nmethods() {
+    purge_nmethods();
+    free_code_blobs();
+  }
+};
+
+class DefaultClassUnloadingContext : public ClassUnloadingContext {
+  ClassLoaderData* volatile _cld_head;
+
+  uint _num_nmethod_unlink_workers;
+
+  using NmethodSet = GrowableArrayCHeap<nmethod*, mtGC>;
+  NmethodSet** _unlinked_nmethods;
+
+  bool _lock_codeblob_free_separately;
+
+public:
+  // Num_nmethod_unlink_workers configures the maximum numbers of threads unlinking
+  //     nmethods.
+  // lock_codeblob_free_separately determines whether freeing the code blobs takes
+  //     the CodeCache_lock during the whole operation or per code blob free operation.
+  DefaultClassUnloadingContext(uint num_nmethod_unlink_workers,
+                               bool lock_codeblob_free_separately);
+  ~DefaultClassUnloadingContext();
+
+  bool has_unloaded_classes() const override;
+
+  void register_unloading_class_loader_data(ClassLoaderData* cld) override;
+  void purge_class_loader_data() override;
+
+  void classes_unloading_do(void f(Klass* const)) override;
+
+  // Register unloading nmethods, potentially in parallel.
+  void register_unlinked_nmethod(nmethod* nm) override;
+  void purge_nmethods() override;
+  void free_code_blobs() override;
+};
+
+#endif // SHARE_GC_SHARED_CLASSUNLOADINGCONTEXT_HPP

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -35,6 +35,7 @@
 #include "gc/serial/genMarkSweep.hpp"
 #include "gc/serial/markSweep.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/collectorCounters.hpp"
 #include "gc/shared/continuationGCSupport.inline.hpp"
@@ -538,6 +539,9 @@ void GenCollectedHeap::do_collection(bool           full,
 
     CodeCache::on_gc_marking_cycle_start();
 
+    DefaultClassUnloadingContext ctx(1 /* num_nmethod_unlink_workers */,
+                                     false /* lock_codeblob_free_separately */);
+
     collect_generation(_old_gen,
                        full,
                        size,
@@ -553,7 +557,7 @@ void GenCollectedHeap::do_collection(bool           full,
     _young_gen->compute_new_size();
 
     // Delete metaspaces for unloaded class loaders and clean up loader_data graph
-    ClassLoaderDataGraph::purge(/*at_safepoint*/true);
+    ClassLoaderDataGraph::purge(true /* at_safepoint */);
     DEBUG_ONLY(MetaspaceUtils::verify();)
 
     // Need to clear claim bits for the next mark.

--- a/src/hotspot/share/gc/shared/genCollectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.cpp
@@ -598,7 +598,11 @@ void GenCollectedHeap::verify_nmethod(nmethod* nm) {
 }
 
 void GenCollectedHeap::prune_scavengable_nmethods() {
-  ScavengableNMethods::prune_nmethods();
+  ScavengableNMethods::prune_nmethods_not_into_young();
+}
+
+void GenCollectedHeap::prune_unlinked_nmethods() {
+  ScavengableNMethods::prune_unlinked_nmethods();
 }
 
 HeapWord* GenCollectedHeap::satisfy_failed_allocation(size_t size, bool is_tlab) {

--- a/src/hotspot/share/gc/shared/genCollectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/genCollectedHeap.hpp
@@ -189,6 +189,7 @@ public:
   void verify_nmethod(nmethod* nm) override;
 
   void prune_scavengable_nmethods();
+  void prune_unlinked_nmethods();
 
   // Iteration functions.
   void object_iterate(ObjectClosure* cl) override;

--- a/src/hotspot/share/gc/shared/scavengableNMethods.hpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,8 +46,10 @@ public:
   static void unregister_nmethod(nmethod* nm);
   static void verify_nmethod(nmethod* nm);
 
-  // Remove nmethods that no longer have scavengable oops.
-  static void prune_nmethods();
+  // Remove nmethods that no longer have oops into young gen.
+  static void prune_nmethods_not_into_young();
+  // Remvoe unlinked (dead) nmethods.
+  static void prune_unlinked_nmethods();
 
   // Apply closure to every scavengable nmethod.
   // Remove nmethods that no longer have scavengable oops.

--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -26,6 +26,7 @@
 #include "code/codeCache.hpp"
 #include "code/icBuffer.hpp"
 #include "code/nmethod.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shenandoah/shenandoahClosures.inline.hpp"
 #include "gc/shenandoah/shenandoahEvacOOMHandler.inline.hpp"
 #include "gc/shenandoah/shenandoahHeap.inline.hpp"
@@ -235,7 +236,7 @@ void ShenandoahCodeRoots::unlink(WorkerThreads* workers, bool unloading_occurred
 void ShenandoahCodeRoots::purge() {
   assert(ShenandoahHeap::heap()->unload_classes(), "Only when running concurrent class unloading");
 
-  CodeCache::flush_unlinked_nmethods();
+  ClassUnloadingContext::context()->purge_and_free_nmethods();
 }
 
 ShenandoahCodeRootsIterator::ShenandoahCodeRootsIterator() :

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -27,6 +27,7 @@
 #include "memory/allocation.hpp"
 #include "memory/universe.hpp"
 
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/gcArguments.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
@@ -1824,6 +1825,9 @@ void ShenandoahHeap::stop() {
 
 void ShenandoahHeap::stw_unload_classes(bool full_gc) {
   if (!unload_classes()) return;
+  DefaultClassUnloadingContext ctx(_workers->active_workers(),
+                                   false /* lock_codeblob_free_separately */);
+
   // Unload classes and purge SystemDictionary.
   {
     ShenandoahPhaseTimings::Phase phase = full_gc ?
@@ -1841,14 +1845,14 @@ void ShenandoahHeap::stw_unload_classes(bool full_gc) {
       _workers->run_task(&unlink_task);
     }
     // Release unloaded nmethods's memory.
-    CodeCache::flush_unlinked_nmethods();
+    ClassUnloadingContext::context()->purge_and_free_nmethods();
   }
 
   {
     ShenandoahGCPhase phase(full_gc ?
                             ShenandoahPhaseTimings::full_gc_purge_cldg :
                             ShenandoahPhaseTimings::degen_gc_purge_cldg);
-    ClassLoaderDataGraph::purge(/*at_safepoint*/true);
+    ClassLoaderDataGraph::purge(true /* at_safepoint */);
   }
   // Resize and verify metaspace
   MetaspaceGC::compute_new_size();

--- a/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
@@ -30,6 +30,7 @@
 #include "code/codeCache.hpp"
 #include "code/dependencyContext.hpp"
 #include "gc/shared/gcBehaviours.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "gc/shenandoah/shenandoahNMethod.inline.hpp"
 #include "gc/shenandoah/shenandoahLock.hpp"
@@ -138,6 +139,9 @@ void ShenandoahUnload::unload() {
   assert(ClassUnloading, "Filtered by caller");
   assert(heap->is_concurrent_weak_root_in_progress(), "Filtered by caller");
 
+  DefaultClassUnloadingContext ctx(heap->workers()->active_workers(),
+                                   true /* lock_codeblob_free_separately */);
+
   // Unlink stale metadata and nmethods
   {
     ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_class_unload_unlink);
@@ -181,7 +185,7 @@ void ShenandoahUnload::unload() {
 
     {
       ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_class_unload_purge_cldg);
-      ClassLoaderDataGraph::purge(/*at_safepoint*/false);
+      ClassLoaderDataGraph::purge(false /* at_safepoint */);
     }
 
     {

--- a/src/hotspot/share/gc/x/xHeap.cpp
+++ b/src/hotspot/share/gc/x/xHeap.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "gc/shared/gc_globals.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/locationPrinter.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "gc/x/xAddress.inline.hpp"
@@ -319,6 +320,9 @@ void XHeap::process_non_strong_references() {
 
   // Process weak roots
   _weak_roots_processor.process_weak_roots();
+
+  DefaultClassUnloadingContext ctx(_workers.active_workers(),
+                                   true /* lock_codeblob_free_separately */);
 
   // Unlink stale metadata and nmethods
   _unload.unlink();

--- a/src/hotspot/share/gc/x/xNMethod.cpp
+++ b/src/hotspot/share/gc/x/xNMethod.cpp
@@ -27,6 +27,7 @@
 #include "code/icBuffer.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "gc/x/xBarrier.inline.hpp"
 #include "gc/x/xGlobals.hpp"
@@ -362,5 +363,5 @@ void XNMethod::unlink(XWorkers* workers, bool unloading_occurred) {
 }
 
 void XNMethod::purge() {
-  CodeCache::flush_unlinked_nmethods();
+  ClassUnloadingContext::context()->purge_and_free_nmethods();
 }

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "code/nmethod.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/gcLocker.hpp"
 #include "gc/shared/gcVMOperations.hpp"
 #include "gc/shared/isGCActiveMark.hpp"
@@ -1315,6 +1316,9 @@ void ZGenerationOld::process_non_strong_references() {
 
   // Process weak roots
   _weak_roots_processor.process_weak_roots();
+
+  DefaultClassUnloadingContext ctx(_workers.active_workers(),
+                                   true /* lock_codeblob_free_separately */);
 
   // Unlink stale metadata and nmethods
   _unload.unlink();

--- a/src/hotspot/share/gc/z/zNMethod.cpp
+++ b/src/hotspot/share/gc/z/zNMethod.cpp
@@ -28,6 +28,7 @@
 #include "code/icBuffer.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetNMethod.hpp"
+#include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/suspendibleThreadSet.hpp"
 #include "gc/z/zAddress.hpp"
 #include "gc/z/zArray.inline.hpp"
@@ -443,5 +444,5 @@ void ZNMethod::unlink(ZWorkers* workers, bool unloading_occurred) {
 }
 
 void ZNMethod::purge() {
-  CodeCache::flush_unlinked_nmethods();
+  ClassUnloadingContext::context()->purge_and_free_nmethods();
 }

--- a/test/hotspot/jtreg/runtime/Metaspace/FragmentMetaspace.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/FragmentMetaspace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,15 @@
  * @modules java.base/jdk.internal.misc
  * @modules java.compiler
  * @run main/othervm/timeout=200 -Xmx1g FragmentMetaspace
+ */
+
+/**
+ * @test id=8320331
+ * @bug 8320331
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @modules java.compiler
+ * @run main/othervm/timeout=200 -XX:+UnlockDiagnosticVMOptions -XX:+VerifyDuringGC -Xmx1g FragmentMetaspace
  */
 
 import java.io.IOException;

--- a/test/hotspot/jtreg/runtime/Metaspace/FragmentMetaspace.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/FragmentMetaspace.java
@@ -32,6 +32,7 @@
 /**
  * @test id=8320331
  * @bug 8320331
+ * @requires vm.debug
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  * @modules java.compiler


### PR DESCRIPTION
Hi all,

  please review this change that bulk-removes dead nmethods for the STW collectors instead of unregistering nmethod by nmethod. This significantly speeds up the class unloading phase.

For G1, this is almost 100% the code that has been removed from the review for [JDK-8315503](https://bugs.openjdk.org/browse/JDK-8315503).

For Serial and Parallel GC, the code is new.

This change does not try to improve the situation for concurrent collectors - this would at first glance require extending the scope of the `CodeCache_lock` which I did not want to do. See the CR for more details.

Also, no parallelism for Parallel GC: the existing data structure for code root remembered set is a linked list. There is in almost all cases no point in trying to parallelize what is basically a traversal of the linked list (with each element not having a lot of work to do). I file [JDK-8320067](https://bugs.openjdk.org/browse/JDK-8320067). There should still be a significant speedup, as each `unregister_nmethod` call previously traversed the entire linked list to find that element (i.e. complexity reduction of O(n^2) -> O(n)).

One more comment:
So it would be possible to merge the `ScavengableNMethod::prune_nmethods` which removes elements from the code root sets that do no longer need to be remembered (due to object movement) and removing dead nmethods.
However, this would mean to put that code at the end of gc (where `prune_nmethods` is called now) as during phase 1 the new locations which are relevant for pruning uninteresting code root remembered set entries did not move yet. I wanted to keep determining the dead nmethods and removing them together in the code, but I could be convinced to move it.

Testing: tier1-4

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317007](https://bugs.openjdk.org/browse/JDK-8317007): Add bulk removal of dead nmethods during class unloading (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16655/head:pull/16655` \
`$ git checkout pull/16655`

Update a local copy of the PR: \
`$ git checkout pull/16655` \
`$ git pull https://git.openjdk.org/jdk.git pull/16655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16655`

View PR using the GUI difftool: \
`$ git pr show -t 16655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16655.diff">https://git.openjdk.org/jdk/pull/16655.diff</a>

</details>
