### PR TITLE
8318159: RISC-V: Improve itable_stub

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2544,8 +2544,7 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
   int ioffset_bytes = in_bytes(itableOffsetEntry::interface_offset());
   int ooffset_bytes = in_bytes(itableOffsetEntry::offset_offset());
   int itmentry_off_bytes = in_bytes(itableMethodEntry::method_offset());
-  int vte_size_bytes = vtableEntry::size_in_bytes();
-  const int vte_scale = 3;
+  const int vte_scale = exact_log2(vtableEntry::size_in_bytes());
 
   Label L_loop_search_resolved_entry, L_resolved_found, L_holder_found;
 
@@ -2553,13 +2552,11 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
   add(recv_klass, recv_klass, vtable_start_offset_bytes + ioffset_bytes);
   // itableOffsetEntry[] itable = recv_klass + Klass::vtable_start_offset()
   //                            + sizeof(vtableEntry) * (recv_klass->_vtable_len);
+  // scan_temp = &(itable[0]._interface)
   // temp_itbl_klass = itable[0]._interface;
-  assert(vte_size_bytes == wordSize, "else adjust vte_scale");
   shadd(scan_temp, scan_temp, recv_klass, scan_temp, vte_scale);
   ld(temp_itbl_klass, Address(scan_temp));
   mv(holder_offset, zr);
-  // scan_temp = &(itable[0]._interface)
-  la(scan_temp, Address(scan_temp));
 
   // Initial checks:
   //   - if (holder_klass != resolved_klass), go to "scan for resolved"

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -254,6 +254,15 @@ class MacroAssembler: public Assembler {
                                Label& no_such_interface,
                                bool return_method = true);
 
+  void lookup_interface_method_stub(Register recv_klass,
+                                    Register holder_klass,
+                                    Register resolved_klass,
+                                    Register method_result,
+                                    Register temp_reg,
+                                    Register temp_reg2,
+                                    int itable_index,
+                                    Label& L_no_such_interface);
+
   // virtual method calling
   // n.n. x86 allows RegisterOrConstant for vtable_index
   void lookup_virtual_method(Register recv_klass,

--- a/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
@@ -178,7 +178,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   // so all registers except arguments are free at this point.
   const Register recv_klass_reg     = x18;
   const Register holder_klass_reg   = x19; // declaring interface klass (DECC)
-  const Register resolved_klass_reg = xmethod; // resolved interface klass (REFC)
+  const Register resolved_klass_reg = x30; // resolved interface klass (REFC)
   const Register temp_reg           = x28;
   const Register temp_reg2          = x29;
   const Register icholder_reg       = t1;
@@ -195,28 +195,13 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   __ load_klass(recv_klass_reg, j_rarg0);
 
   // Receiver subtype check against REFC.
-  __ lookup_interface_method(// inputs: rec. class, interface
-                             recv_klass_reg, resolved_klass_reg, noreg,
-                             // outputs:  scan temp. reg1, scan temp. reg2
-                             temp_reg2, temp_reg,
-                             L_no_such_interface,
-                             /*return_method=*/false);
-
-  const ptrdiff_t typecheckSize = __ pc() - start_pc;
-  start_pc = __ pc();
-
   // Get selected method from declaring class and itable index
-  __ lookup_interface_method(// inputs: rec. class, interface, itable index
-                             recv_klass_reg, holder_klass_reg, itable_index,
-                             // outputs: method, scan temp. reg
-                             xmethod, temp_reg,
-                             L_no_such_interface);
-
-  const ptrdiff_t lookupSize = __ pc() - start_pc;
+  __ lookup_interface_method_stub(recv_klass_reg, holder_klass_reg, resolved_klass_reg, xmethod,
+                                  temp_reg, temp_reg2, itable_index, L_no_such_interface);
 
   // Reduce "estimate" such that "padding" does not drop below 8.
   const ptrdiff_t estimate = 256;
-  const ptrdiff_t codesize = typecheckSize + lookupSize;
+  const ptrdiff_t codesize = __ pc() - start_pc;
   slop_delta = (int)(estimate - codesize);
   slop_bytes += slop_delta;
   assert(slop_delta >= 0, "itable #%d: Code size estimate (%d) for lookup_interface_method too small, required: %d", itable_index, (int)estimate, (int)codesize);


### PR DESCRIPTION
Please review the change for RISC-V similar to #13792(AARCH64) and #13460(X86).

From #13792:
The change replaces two separate iterations over the itable with new algorithm
consisting of two loops. First, we look for a match with resolved_klass,
checking for a match with holder_klass along the way. Then we continue iterating
(not starting over) the itable using the second loop, checking only for a match
with holder_klass.

### Correctness checks

Testing: tier1 tests successfully passed on HiFive Unmatched board.

#### Performance results on RISC-V StarFive JH7110 board:

```
InterfaceCalls:                  before fix        after fix
-------------------------------------------------------------------
Benchmark         Mode  Cnt   Score   Error    Score   Error  Units
-------------------------------------------------------------------
test1stInt2Types  avgt  100  14.380 ? 0.017 | 14.370 ? 0.014  ns/op
test1stInt3Types  avgt  100  72.724 ? 0.552 | 66.290 ? 0.080  ns/op
test1stInt5Types  avgt  100  73.948 ? 0.524 | 68.781 ? 0.377  ns/op
test2ndInt2Types  avgt  100  15.705 ? 0.016 | 15.707 ? 0.018  ns/op
test2ndInt3Types  avgt  100  82.370 ? 0.453 | 75.363 ? 0.156  ns/op
test2ndInt5Types  avgt  100  85.266 ? 0.466 | 80.969 ? 0.752  ns/op
testIfaceCall     avgt  100  75.684 ? 0.648 | 72.603 ? 0.460  ns/op
testIfaceExtCall  avgt  100  86.293 ? 0.567 | 77.939 ? 0.340  ns/op
testMonomorphic   avgt  100  11.357 ? 0.007 | 11.359 ? 0.009  ns/op
-------------------------------------------------------------------
```

#### Performance results on RISC-V HiFive Unmatched board:

```
InterfaceCalls:                   before fix         after fix
---------------------------------------------------------------------
Benchmark         Mode  Cnt    Score   Error     Score   Error  Units
---------------------------------------------------------------------
test1stInt2Types  avgt  100   24.432 ? 1.811 |  23.205 ? 1.512  ns/op
test1stInt3Types  avgt  100  135.800 ? 3.991 | 127.112 ? 2.299  ns/op
test1stInt5Types  avgt  100  141.746 ? 4.272 | 136.069 ? 4.919  ns/op
test2ndInt2Types  avgt  100   31.474 ? 2.468 |  26.978 ? 1.951  ns/op
test2ndInt3Types  avgt  100  146.410 ? 3.575 | 139.443 ? 3.677  ns/op
test2ndInt5Types  avgt  100  156.083 ? 3.617 | 150.583 ? 2.909  ns/op
testIfaceCall     avgt  100  136.392 ? 2.546 | 129.632 ? 1.662  ns/op
testIfaceExtCall  avgt  100  155.602 ? 3.836 | 138.058 ? 2.147  ns/op
testMonomorphic   avgt  100   24.018 ? 1.888 |  21.522 ? 1.662  ns/op
---------------------------------------------------------------------
```

#### Performance results on RISC-V THead board:

```
InterfaceCalls:                   before fix         after fix
---------------------------------------------------------------------
Benchmark         Mode  Cnt    Score   Error     Score   Error  Units
---------------------------------------------------------------------
test1stInt2Types  avgt  100   33.326 ? 0.184 |  33.501 ? 0.237  ns/op
test1stInt3Types  avgt  100  111.881 ? 0.707 | 109.882 ? 0.664  ns/op
test1stInt5Types  avgt  100  115.059 ? 0.728 | 113.751 ? 0.532  ns/op
test2ndInt2Types  avgt  100   34.784 ? 0.437 |  34.725 ? 0.412  ns/op
test2ndInt3Types  avgt  100  115.042 ? 0.518 | 113.346 ? 0.543  ns/op
test2ndInt5Types  avgt  100  114.700 ? 1.214 | 112.871 ? 1.203  ns/op
testIfaceCall     avgt  100  114.211 ? 1.023 | 113.747 ? 1.323  ns/op
testIfaceExtCall  avgt  100  116.485 ? 0.864 | 113.872 ? 1.275  ns/op
testMonomorphic   avgt  100   31.404 ? 0.236 |  32.133 ? 0.802  ns/op
---------------------------------------------------------------------
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318159](https://bugs.openjdk.org/browse/JDK-8318159): RISC-V: Improve itable_stub (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [2155b9af](https://git.openjdk.org/jdk/pull/16657/files/2155b9af567d9225b2af34e895ddf240b95cd07d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16657/head:pull/16657` \
`$ git checkout pull/16657`

Update a local copy of the PR: \
`$ git checkout pull/16657` \
`$ git pull https://git.openjdk.org/jdk.git pull/16657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16657`

View PR using the GUI difftool: \
`$ git pr show -t 16657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16657.diff">https://git.openjdk.org/jdk/pull/16657.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16657#issuecomment-1810419858)