### PR TITLE
8317834: java/lang/Thread/IsAlive.java timed out

### DIFF
--- a/test/jdk/java/lang/Thread/IsAlive.java
+++ b/test/jdk/java/lang/Thread/IsAlive.java
@@ -25,7 +25,7 @@
  * @test
  * @bug     8305425
  * @summary Check Thread.isAlive
- * @run main/othervm/timeout=25 IsAlive
+ * @run main/othervm IsAlive
  */
 
 public class IsAlive {

--- a/test/jdk/java/lang/Thread/IsAlive.java
+++ b/test/jdk/java/lang/Thread/IsAlive.java
@@ -25,7 +25,7 @@
  * @test
  * @bug     8305425
  * @summary Check Thread.isAlive
- * @run main/othervm/timeout=10 IsAlive
+ * @run main/othervm/timeout=25 IsAlive
  */
 
 public class IsAlive {


### PR DESCRIPTION
Currently the `IsAlive` test occasionally times out.

This PR changes the timeout from `10` to `25` which I think is an adequate increase based on the failures I've seen. Though I'd be happy to change it to another value if someone thinks `25` isn't ideal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317834](https://bugs.openjdk.org/browse/JDK-8317834): java/lang/Thread/IsAlive.java timed out (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [cd13a00c](https://git.openjdk.org/jdk/pull/16659/files/cd13a00c800491850fc27ba93129856490031ab0)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16659/head:pull/16659` \
`$ git checkout pull/16659`

Update a local copy of the PR: \
`$ git checkout pull/16659` \
`$ git pull https://git.openjdk.org/jdk.git pull/16659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16659`

View PR using the GUI difftool: \
`$ git pr show -t 16659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16659.diff">https://git.openjdk.org/jdk/pull/16659.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16659#issuecomment-1810674659)