### PR TITLE
8310807: java/nio/channels/DatagramChannel/Connect.java timed out

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -31,7 +31,6 @@ import java.io.*;
 import java.net.*;
 import java.nio.*;
 import java.nio.channels.*;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -209,7 +208,7 @@ public class Connect {
                     bb.clear();
                     bb.put(RESPONSE.getBytes(US_ASCII));
                     bb.flip();
-                    log.println("Responder attempting to write: " + dc.getRemoteAddress().toString());
+                    log.println("Responder attempting to write: " + dc.getRemoteAddress());
                     dc.write(bb);
                     bb.flip();
                     break;

--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -216,10 +216,9 @@ public class Connect {
                 } catch (Exception ex) {
                     err.println("Responder threw exception: " + ex);
                     throw new RuntimeException(ex);
-                } finally {
-                    err.println("Responder finished");
                 }
             }
+            err.println("Responder finished");
         }
 
         @Override

--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -187,8 +187,8 @@ public class Connect {
         }
 
         public void run() {
+            ByteBuffer bb = ByteBuffer.allocateDirect(MAX);
             while (true) {
-                ByteBuffer bb = ByteBuffer.allocateDirect(MAX);
                 try {
                     // Listen for a message
                     log.println("Responder waiting to receive");

--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -42,11 +42,11 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public class Connect {
 
-    static final PrintStream log = System.err;
-    static final String NOW = Instant.now().toString();
-    static final String MESSAGE = "Hello " + NOW;
-    static final String OTHER = "Hey " + NOW;
-    static final String RESPONSE = "Hi " + NOW;
+    static final PrintStream err = System.err;
+    static final String TIME_STAMP = Instant.now().toString();
+    static final String MESSAGE = "Hello " + TIME_STAMP;
+    static final String OTHER = "Hey " + TIME_STAMP;
+    static final String RESPONSE = "Hi " + TIME_STAMP;
     static final int MAX = Math.max(256, MESSAGE.getBytes(US_ASCII).length + 16);
 
     public static void main(String[] args) throws Exception {
@@ -114,12 +114,12 @@ public class Connect {
                 ByteBuffer bb = ByteBuffer.allocateDirect(MAX);
                 bb.put(bytes);
                 bb.flip();
-                log.println("Initiator connecting to: " + connectSocketAddress);
+                err.println("Initiator connecting to: " + connectSocketAddress);
                 dc.connect(connectSocketAddress);
-                log.println("Initiator bound to: " + dc.getLocalAddress());
+                err.println("Initiator bound to: " + dc.getLocalAddress());
 
                 // Send a message
-                log.println("Initiator attempting to write to Responder at " + connectSocketAddress);
+                err.println("Initiator attempting to write to Responder at " + connectSocketAddress);
                 dc.write(bb);
 
                 // Try to send to some other address
@@ -129,17 +129,17 @@ public class Connect {
                     try (DatagramChannel other = DatagramChannel.open()) {
                         InetSocketAddress otherAddress = new InetSocketAddress(loopback, 0);
                         other.bind(otherAddress);
-                        log.println("Testing if Initiator throws AlreadyConnectedException");
+                        err.println("Testing if Initiator throws AlreadyConnectedException");
                         otherAddress = (InetSocketAddress) other.getLocalAddress();
                         assert port != otherAddress.getPort();
                         assert !connectSocketAddress.equals(otherAddress);
-                        log.printf("Initiator sending \"%s\" to other address %s%n", OTHER, otherAddress);
+                        err.printf("Initiator sending \"%s\" to other address %s%n", OTHER, otherAddress);
                         dc.send(ByteBuffer.wrap(OTHER.getBytes(US_ASCII)), otherAddress);
                     }
                     throw new RuntimeException("Initiator allowed send to other address while already connected");
                 } catch (AlreadyConnectedException ace) {
                     // Correct behavior
-                    log.println("Initiator got expected " + ace);
+                    err.println("Initiator got expected " + ace);
                 }
 
                 // wait for response
@@ -150,22 +150,22 @@ public class Connect {
                     bb.flip();
 
                     // Read a reply
-                    log.println("Initiator waiting to read");
+                    err.println("Initiator waiting to read");
                     dc.read(bb);
                     bb.flip();
                     CharBuffer cb = US_ASCII.newDecoder().decode(bb);
-                    log.println("Initiator received from Responder at " + connectSocketAddress + ": " + cb);
+                    err.println("Initiator received from Responder at " + connectSocketAddress + ": " + cb);
                     if (!RESPONSE.equals(cb.toString())) {
-                        log.println("Initiator received unexpected message: continue waiting");
+                        err.println("Initiator received unexpected message: continue waiting");
                         continue;
                     }
                     break;
                 }
             } catch (Exception ex) {
-                log.println("Initiator threw exception: " + ex);
+                err.println("Initiator threw exception: " + ex);
                 throw new RuntimeException(ex);
             } finally {
-                log.println("Initiator finished");
+                err.println("Initiator finished");
             }
         }
 
@@ -192,14 +192,14 @@ public class Connect {
             while (true) {
                 try {
                     // Listen for a message
-                    log.println("Responder waiting to receive");
+                    err.println("Responder waiting to receive");
                     SocketAddress sa = dc.receive(bb);
                     bb.flip();
                     CharBuffer cb = US_ASCII.
                             newDecoder().decode(bb);
-                    log.println("Responder received from Initiator at " + sa + ": " + cb);
+                    err.println("Responder received from Initiator at " + sa + ": " + cb);
                     if (!MESSAGE.equals(cb.toString())) {
-                        log.println("Responder received unexpected message: continue waiting");
+                        err.println("Responder received unexpected message: continue waiting");
                         bb.clear();
                         continue;
                     }
@@ -209,15 +209,15 @@ public class Connect {
                     bb.clear();
                     bb.put(RESPONSE.getBytes(US_ASCII));
                     bb.flip();
-                    log.println("Responder attempting to write: " + dc.getRemoteAddress());
+                    err.println("Responder attempting to write: " + dc.getRemoteAddress());
                     dc.write(bb);
                     bb.flip();
                     break;
                 } catch (Exception ex) {
-                    log.println("Responder threw exception: " + ex);
+                    err.println("Responder threw exception: " + ex);
                     throw new RuntimeException(ex);
                 } finally {
-                    log.println("Responder finished");
+                    err.println("Responder finished");
                 }
             }
         }

--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -130,10 +130,11 @@ public class Connect {
                         InetSocketAddress otherAddress = new InetSocketAddress(loopback, 0);
                         other.bind(otherAddress);
                         log.println("Testing if Initiator throws AlreadyConnectedException");
-
-                        log.printf("Initiator sending \"%s\" to other address %s%n", OTHER, other.getLocalAddress());
-                        dc.send(ByteBuffer.wrap(OTHER.getBytes(US_ASCII)),
-                                other.getLocalAddress());
+                        otherAddress = (InetSocketAddress) other.getLocalAddress();
+                        assert port != otherAddress.getPort();
+                        assert !connectSocketAddress.equals(otherAddress);
+                        log.printf("Initiator sending \"%s\" to other address %s%n", OTHER, otherAddress);
+                        dc.send(ByteBuffer.wrap(OTHER.getBytes(US_ASCII)), otherAddress);
                     }
                     throw new RuntimeException("Initiator allowed send to other address while already connected");
                 } catch (AlreadyConnectedException ace) {

--- a/test/jdk/java/nio/channels/DatagramChannel/Connect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Connect.java
@@ -189,8 +189,8 @@ public class Connect {
 
         public void run() {
             ByteBuffer bb = ByteBuffer.allocateDirect(MAX);
-            while (true) {
-                try {
+            try {
+                while (true) {
                     // Listen for a message
                     err.println("Responder waiting to receive");
                     SocketAddress sa = dc.receive(bb);
@@ -213,12 +213,13 @@ public class Connect {
                     dc.write(bb);
                     bb.flip();
                     break;
-                } catch (Exception ex) {
-                    err.println("Responder threw exception: " + ex);
-                    throw new RuntimeException(ex);
                 }
+            } catch (Exception ex) {
+                err.println("Responder threw exception: " + ex);
+                throw new RuntimeException(ex);
+            } finally {
+                err.println("Responder finished");
             }
-            err.println("Responder finished");
         }
 
         @Override


### PR DESCRIPTION
Please find here a fix for a timeout issue observed in DatagramChannel/Connect.java

The suspicion is that the responder may have received some message from some other source and replied to that, leaving the initiator waiting forever.

The proposed fix makes sure the messages exchanged are unique and identifiable and ensure that both the initiator and responder will discard any message that do not have the expected content.

Additional logging should help with diagnosis if the test fails again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310807](https://bugs.openjdk.org/browse/JDK-8310807): java/nio/channels/DatagramChannel/Connect.java timed out (**Bug** - P4)


### Reviewers
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**) ⚠️ Review applies to [958d5b76](https://git.openjdk.org/jdk/pull/16661/files/958d5b76d4882e7ab9f36d6543f767e9bf739b4f)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16661/head:pull/16661` \
`$ git checkout pull/16661`

Update a local copy of the PR: \
`$ git checkout pull/16661` \
`$ git pull https://git.openjdk.org/jdk.git pull/16661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16661`

View PR using the GUI difftool: \
`$ git pr show -t 16661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16661.diff">https://git.openjdk.org/jdk/pull/16661.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16661#issuecomment-1810830814)