### PR TITLE
8319987: compilation of sealed classes leads to infinite recursion

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1677,11 +1677,8 @@ public class Types {
                 /* if we are seeing the same pair again then there is an issue with the sealed hierarchy
                  * bail out, a detailed error will be reported downstream
                  */
-                if (pairsSeen.contains(newPair)) {
+                if (!pairsSeen.add(newPair))
                     return false;
-                } else {
-                    pairsSeen.add(newPair);
-                }
                 if (isSubtype(erasure(ts.type), erasure(ss.type))) {
                     return false;
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1665,37 +1665,49 @@ public class Types {
                 && (t.tsym.isSealed() || s.tsym.isSealed())) {
             return (t.isCompound() || s.isCompound()) ?
                     true :
-                    !areDisjoint((ClassSymbol)t.tsym, (ClassSymbol)s.tsym);
+                    !(new DisjointChecker().areDisjoint((ClassSymbol)t.tsym, (ClassSymbol)s.tsym));
         }
         return result;
     }
     // where
-        private boolean areDisjoint(ClassSymbol ts, ClassSymbol ss) {
-            if (isSubtype(erasure(ts.type), erasure(ss.type))) {
-                return false;
-            }
-            // if both are classes or both are interfaces, shortcut
-            if (ts.isInterface() == ss.isInterface() && isSubtype(erasure(ss.type), erasure(ts.type))) {
-                return false;
-            }
-            if (ts.isInterface() && !ss.isInterface()) {
-                /* so ts is interface but ss is a class
-                 * an interface is disjoint from a class if the class is disjoint form the interface
+        class DisjointChecker {
+            Set<Pair<ClassSymbol, ClassSymbol>> pairsSeen = new HashSet<>();
+            private boolean areDisjoint(ClassSymbol ts, ClassSymbol ss) {
+                Pair<ClassSymbol, ClassSymbol> newPair = new Pair<>(ts, ss);
+                /* if we are seeing the same pair again then there is an issue with the sealed hierarchy
+                 * bail out, a detailed error will be reported downstream
                  */
-                return areDisjoint(ss, ts);
+                if (pairsSeen.contains(newPair)) {
+                    return false;
+                } else {
+                    pairsSeen.add(newPair);
+                }
+                if (isSubtype(erasure(ts.type), erasure(ss.type))) {
+                    return false;
+                }
+                // if both are classes or both are interfaces, shortcut
+                if (ts.isInterface() == ss.isInterface() && isSubtype(erasure(ss.type), erasure(ts.type))) {
+                    return false;
+                }
+                if (ts.isInterface() && !ss.isInterface()) {
+                    /* so ts is interface but ss is a class
+                     * an interface is disjoint from a class if the class is disjoint form the interface
+                     */
+                    return areDisjoint(ss, ts);
+                }
+                // a final class that is not subtype of ss is disjoint
+                if (!ts.isInterface() && ts.isFinal()) {
+                    return true;
+                }
+                // if at least one is sealed
+                if (ts.isSealed() || ss.isSealed()) {
+                    // permitted subtypes have to be disjoint with the other symbol
+                    ClassSymbol sealedOne = ts.isSealed() ? ts : ss;
+                    ClassSymbol other = sealedOne == ts ? ss : ts;
+                    return sealedOne.permitted.stream().allMatch(sym -> areDisjoint((ClassSymbol)sym, other));
+                }
+                return false;
             }
-            // a final class that is not subtype of ss is disjoint
-            if (!ts.isInterface() && ts.isFinal()) {
-                return true;
-            }
-            // if at least one is sealed
-            if (ts.isSealed() || ss.isSealed()) {
-                // permitted subtypes have to be disjoint with the other symbol
-                ClassSymbol sealedOne = ts.isSealed() ? ts : ss;
-                ClassSymbol other = sealedOne == ts ? ss : ts;
-                return sealedOne.permitted.stream().allMatch(sym -> areDisjoint((ClassSymbol)sym, other));
-            }
-            return false;
         }
 
         private TypeRelation isCastable = new TypeRelation() {

--- a/test/langtools/tools/javac/sealed/erroneous_hierarchy/CyclicHierarchyTest.java
+++ b/test/langtools/tools/javac/sealed/erroneous_hierarchy/CyclicHierarchyTest.java
@@ -1,0 +1,12 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8319987
+ * @summary compilation of sealed classes leads to infinite recursion
+ * @compile/fail/ref=CyclicHierarchyTest.out -XDrawDiagnostics CyclicHierarchyTest.java
+ */
+
+class CyclicHierarchyTest {
+    sealed interface Action permits Add {}
+    sealed interface MathOp permits Add {}
+    sealed static class Add implements MathOp permits Add {}
+}

--- a/test/langtools/tools/javac/sealed/erroneous_hierarchy/CyclicHierarchyTest.out
+++ b/test/langtools/tools/javac/sealed/erroneous_hierarchy/CyclicHierarchyTest.out
@@ -1,0 +1,3 @@
+CyclicHierarchyTest.java:9:37: compiler.err.invalid.permits.clause: (compiler.misc.doesnt.extend.sealed: CyclicHierarchyTest.Add)
+CyclicHierarchyTest.java:11:55: compiler.err.invalid.permits.clause: (compiler.misc.must.not.be.same.class)
+2 errors


### PR DESCRIPTION
The compiler can throw a SOE when trying to compile an incorrect sealed classes hierarchy like:
```
    sealed interface Action permits Add {}
    sealed interface MathOp permits Add {}
    sealed static class Add implements MathOp permits Add {}
```
The error is thrown while trying to prove if two classes are disjoint or not. The proposed solution is to keep a set with the pairs of classes analyzed so far and stop as soon as a the current pair of classes is already in the set.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319987](https://bugs.openjdk.org/browse/JDK-8319987): compilation of sealed classes leads to infinite recursion (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16668/head:pull/16668` \
`$ git checkout pull/16668`

Update a local copy of the PR: \
`$ git checkout pull/16668` \
`$ git pull https://git.openjdk.org/jdk.git pull/16668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16668`

View PR using the GUI difftool: \
`$ git pr show -t 16668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16668.diff">https://git.openjdk.org/jdk/pull/16668.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16668#issuecomment-1811790572)