### PR TITLE
8319938: com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java fails with "getSelectedFiles returned empty array for LAF: javax.swing.plaf.metal.MetalLookAndFeel"

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKEngine.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKEngine.java
@@ -337,7 +337,8 @@ class GTKEngine {
                 return widgets[0];
             }
         } else if (id == Region.ARROW_BUTTON) {
-            if (c.getParent() instanceof JScrollBar) {
+            if (c.getParent() instanceof JScrollBar
+                || c.getParent() instanceof JTabbedPane) {
                 Integer prop = (Integer)
                     c.getClientProperty("__arrow_direction__");
                 int dir = (prop != null) ?

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
@@ -23,11 +23,11 @@
 
 /*
  * @test
- * @bug 6972078
+ * @bug 6972078 8319938
  * @key headful
  * @requires (os.family == "linux")
  * @summary Verifies if user is able to select single directory if multi selection
- * is enabled for JFileChooser.
+ *          is enabled for JFileChooser.
  * @run main TestFileChooserSingleDirectorySelection
  */
 
@@ -51,8 +51,10 @@ public class TestFileChooserSingleDirectorySelection {
     private static JButton getSelectedFilesButton;
     private static Robot robot;
     private static boolean passed;
-    private static File[] testDir;
-    private static File[] tempFile;
+    private static File testDir;
+    private static File testFile;
+    private static File[] SubDirs;
+    private static File[] subFiles;
 
     public static void main(String[] args) throws Exception {
         System.setProperty("sun.java2d.uiScale", "1.0");
@@ -62,18 +64,35 @@ public class TestFileChooserSingleDirectorySelection {
         try {
             // create test directory
             String tmpDir = System.getProperty("user.home");
-            testDir = new File[1];
-            testDir[0] = new File(tmpDir, "testDir");
-            if (!testDir[0].exists())
-                testDir[0].mkdir();
-            testDir[0].deleteOnExit();
 
-            // create temporary files inside testDir
-            tempFile = new File[5];
+            // Create a test directory that contains only folders
+            testDir = new File(tmpDir, "testDir");
+            if (!testDir.exists()) {
+                testDir.mkdir();
+            }
+            testDir.deleteOnExit();
+
+            // create sub directories inside test directory
+            SubDirs = new File[5];
             for (int i = 0; i < 5; ++i) {
-                tempFile[i] = File.createTempFile("temp", ".txt",
-                        new File(testDir[0].getAbsolutePath()));
-                tempFile[i].deleteOnExit();
+                SubDirs[i] = new File(testDir, "subDir_" + (i+1));
+                SubDirs[i].mkdir();
+                SubDirs[i].deleteOnExit();
+            }
+
+            // Create a test directory that contains only files
+            testFile = new File(tmpDir, "testFile");
+            if (!testFile.exists()) {
+                testFile.mkdir();
+            }
+            testFile.deleteOnExit();
+
+            // create temporary files inside testFile
+            subFiles = new File[5];
+            for (int i = 0; i < 5; ++i) {
+                subFiles[i] = File.createTempFile("subFiles_" + (i+1),
+                        ".txt", new File(testFile.getAbsolutePath()));
+                subFiles[i].deleteOnExit();
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -95,7 +114,7 @@ public class TestFileChooserSingleDirectorySelection {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 createAndShowUI();
-                fileChooser.setCurrentDirectory(testDir[0]);
+                fileChooser.setCurrentDirectory(testFile);
             });
 
             robot.waitForIdle();
@@ -117,6 +136,7 @@ public class TestFileChooserSingleDirectorySelection {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 createAndShowUI();
+                fileChooser.setCurrentDirectory(testDir);
             });
             robot.waitForIdle();
             robot.delay(1000);
@@ -137,6 +157,7 @@ public class TestFileChooserSingleDirectorySelection {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 createAndShowUI();
+                fileChooser.setCurrentDirectory(testDir);
             });
             robot.waitForIdle();
             robot.delay(1000);
@@ -154,7 +175,7 @@ public class TestFileChooserSingleDirectorySelection {
     private static void createAndShowUI() {
         frame = new JFrame("Test File Chooser Single Directory Selection");
         frame.getContentPane().setLayout(new BorderLayout());
-        fileChooser = new JFileChooser("user.home");
+        fileChooser = new JFileChooser(testDir);
         fileChooser.setMultiSelectionEnabled(true);
         fileChooser.setControlButtonsAreShown(false);
 

--- a/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
@@ -58,24 +58,16 @@ public class TestJTabbedPaneArrowDirection {
     public static void main(String[] args) throws Exception {
         UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
         PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
-                        .title("JTabbedPane Arrow Direction Test Instructions")
-                        .instructions(INSTRUCTIONS)
-                        .testTimeOut(5)
-                        .rows(12)
-                        .columns(40)
-                        .screenCapture()
-                        .build();
-        try {
-            SwingUtilities.invokeAndWait(
-                    TestJTabbedPaneArrowDirection::createAndShowUI);
-            passFailJFrame.awaitAndCheck();
-        } finally {
-            SwingUtilities.invokeAndWait(() -> {
-                if (frame != null) {
-                    frame.dispose();
-                }
-            });
-        }
+                .title("JTabbedPane Arrow Direction Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(5)
+                .rows(12)
+                .columns(40)
+                .screenCapture()
+                .build();
+        SwingUtilities.invokeAndWait(
+                TestJTabbedPaneArrowDirection::createAndShowUI);
+        passFailJFrame.awaitAndCheck();
     }
 
     private static void createAndShowUI() {

--- a/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.GridLayout;
+import javax.swing.AbstractAction;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+/*
+ * @test
+ * @bug 8225220
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "linux")
+ * @summary JTabbedPane arrow should point to left or right direction
+ *          when tab layout policy is set to SCROLL_TAB_LAYOUT and tab
+ *          placement is set to either TOP or BOTTOM
+ * @run main/manual TestJTabbedPaneArrowDirection
+ */
+
+public class TestJTabbedPaneArrowDirection {
+    private static JFrame frame;
+    private static JTabbedPane tabPane;
+    private static final String INSTRUCTIONS =
+            "1. Observe the arrows are ponting to left and right direction\n" +
+               " for tab placement set to TOP. Default tab placement is TOP.\n\n" +
+            "2. Press BOTTOM to change the tab placement to bottom.\n\n" +
+            "3. Observe arrows are pointing to the left and right direction.\n\n" +
+            "4. If the behaviour is correct, press Pass else Fail.";
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                        .title("JTabbedPane Arrow Direction Test Instructions")
+                        .instructions(INSTRUCTIONS)
+                        .testTimeOut(5)
+                        .rows(12)
+                        .columns(40)
+                        .screenCapture()
+                        .build();
+        try {
+            SwingUtilities.invokeAndWait(
+                    TestJTabbedPaneArrowDirection::createAndShowUI);
+            passFailJFrame.awaitAndCheck();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        int NUM_TABS = 15;
+        frame = new JFrame("Test JTabbedPane Arrow Direction");
+        JTabbedPane tabPane = new JTabbedPane();
+        tabPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+        tabPane.setTabPlacement(JTabbedPane.TOP);
+        PassFailJFrame.addTestWindow(frame);
+        PassFailJFrame.positionTestWindow(
+                frame, PassFailJFrame.Position.HORIZONTAL);
+        for( int i = 0; i < NUM_TABS; ++i) {
+            tabPane.addTab("Tab " + i , new JLabel("Content Area"));
+        }
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(tabPane, BorderLayout.CENTER);
+        JButton topButton = new JButton(new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+                tabPane.setTabPlacement(JTabbedPane.TOP);
+            }
+        });
+        topButton.setText("TOP");
+        JButton bottomButton = new JButton(new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+                tabPane.setTabPlacement(JTabbedPane.BOTTOM);
+            }
+        });
+        bottomButton.setText("BOTTOM");
+        JPanel buttonPanel = new JPanel(new GridLayout(1, 2));
+        buttonPanel.add(topButton);
+        buttonPanel.add(bottomButton);
+        panel.add(buttonPanel, BorderLayout.SOUTH);
+        frame.add(panel);
+        frame.setSize(500, 500);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+    }
+}


### PR DESCRIPTION
The test fails for filechooser selection mode set to `DIRECTORIES_ONLY`. For DIRECTORIES_ONLY mode, there may not be any directories in home directory and due to that test failed. Added the code to create temporary directories and files for the test.
Tested the current change on the machine it failed for multiple times, no failure observed.
CI link attached in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319938](https://bugs.openjdk.org/browse/JDK-8319938): com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java fails with "getSelectedFiles returned empty array for LAF: javax.swing.plaf.metal.MetalLookAndFeel" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16671/head:pull/16671` \
`$ git checkout pull/16671`

Update a local copy of the PR: \
`$ git checkout pull/16671` \
`$ git pull https://git.openjdk.org/jdk.git pull/16671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16671`

View PR using the GUI difftool: \
`$ git pr show -t 16671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16671.diff">https://git.openjdk.org/jdk/pull/16671.diff</a>

</details>
