### PR TITLE
8319966: AIX: expected [[0:i4]] but found [[0:I4]] after JDK-8319882

### DIFF
--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -32,6 +32,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.LongFunction;
 import java.util.stream.Stream;
 
@@ -219,10 +220,10 @@ public class TestLayouts {
     @Test
     public void testSequenceLayoutWithZeroLength() {
         SequenceLayout layout = MemoryLayout.sequenceLayout(0, JAVA_INT);
-        assertEquals(layout.toString(), "[0:i4]");
+        assertEquals(layout.toString().toLowerCase(Locale.ROOT), "[0:i4]");
 
         SequenceLayout nested = MemoryLayout.sequenceLayout(0, layout);
-        assertEquals(nested.toString(), "[0:[0:i4]]");
+        assertEquals(nested.toString().toLowerCase(Locale.ROOT), "[0:[0:i4]]");
 
         SequenceLayout layout2 = MemoryLayout.sequenceLayout(0, JAVA_INT);
         assertEquals(layout, layout2);


### PR DESCRIPTION
This PR proposes to fix a failing test on big endian architectures like AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319966](https://bugs.openjdk.org/browse/JDK-8319966): AIX: expected [[0:i4]] but found [[0:I4]] after JDK-8319882 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16672/head:pull/16672` \
`$ git checkout pull/16672`

Update a local copy of the PR: \
`$ git checkout pull/16672` \
`$ git pull https://git.openjdk.org/jdk.git pull/16672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16672`

View PR using the GUI difftool: \
`$ git pr show -t 16672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16672.diff">https://git.openjdk.org/jdk/pull/16672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16672#issuecomment-1812001476)