### PR TITLE
8319938: TestFileChooserSingleDirectorySelection.java fails with "getSelectedFiles returned empty array"

### DIFF
--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
@@ -60,51 +60,54 @@ public class TestFileChooserSingleDirectorySelection {
         System.setProperty("sun.java2d.uiScale", "1.0");
         robot = new Robot();
         robot.setAutoDelay(100);
-
-        try {
-            // create test directory
-            String tmpDir = System.getProperty("java.io.tmpdir");
-
-            // Create a test directory that contains only folders
-            testDir = new File(tmpDir, "testDir");
-            if (!testDir.exists()) {
-                testDir.mkdir();
-            }
-            testDir.deleteOnExit();
-
-            // create sub directories inside test directory
-            SubDirs = new File[5];
-            for (int i = 0; i < 5; ++i) {
-                SubDirs[i] = new File(testDir, "subDir_" + (i+1));
-                SubDirs[i].mkdir();
-                SubDirs[i].deleteOnExit();
-            }
-
-            // Create a test directory that contains only files
-            testFile = new File(tmpDir, "testFile");
-            if (!testFile.exists()) {
-                testFile.mkdir();
-            }
-            testFile.deleteOnExit();
-
-            // create temporary files inside testFile
-            subFiles = new File[5];
-            for (int i = 0; i < 5; ++i) {
-                subFiles[i] = File.createTempFile("subFiles_" + (i+1),
-                        ".txt", new File(testFile.getAbsolutePath()));
-                subFiles[i].deleteOnExit();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        createFoldersOnlyDir();
+        createFilesOnlyDir();
+        populateDirs();
+        populateFiles();
         for (UIManager.LookAndFeelInfo laf :
-                        UIManager.getInstalledLookAndFeels()) {
+                UIManager.getInstalledLookAndFeels()) {
             System.out.println("Testing LAF: " + laf.getClassName());
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
             checkFileOnlyTest(laf);
             checkDirectoriesOnlyTest(laf);
             checkFilesAndDirectoriesTest(laf);
             System.out.println("Passed");
+        }
+    }
+
+    private static void createFoldersOnlyDir() {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        testDir = new File(tmpDir, "testDir");
+        if (!testDir.exists()) {
+            testDir.mkdir();
+        }
+        testDir.deleteOnExit();
+    }
+
+    private static void populateDirs() {
+        SubDirs = new File[10];
+        for (int i = 0; i < 10; ++i) {
+            SubDirs[i] = new File(testDir, "subDir_" + (i+1));
+            SubDirs[i].mkdir();
+            SubDirs[i].deleteOnExit();
+        }
+    }
+
+    private static void createFilesOnlyDir() {
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        testFile = new File(tmpDir, "testFile");
+        if (!testFile.exists()) {
+            testFile.mkdir();
+        }
+        testFile.deleteOnExit();
+    }
+
+    private static void populateFiles() throws Exception {
+        subFiles = new File[10];
+        for (int i = 0; i < 10; ++i) {
+            subFiles[i] = File.createTempFile("subFiles_" + (i+1),
+                    ".txt", new File(testFile.getAbsolutePath()));
+            subFiles[i].deleteOnExit();
         }
     }
 
@@ -229,6 +232,7 @@ public class TestFileChooserSingleDirectorySelection {
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(100);
+        robot.waitForIdle();
     }
 
     private static void checkResult(UIManager.LookAndFeelInfo laf) {

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
@@ -20,19 +20,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-import java.awt.BorderLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
-import java.awt.Point;
-import java.awt.Robot;
-import java.io.File;
-import javax.swing.JButton;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 
 /*
  * @test
@@ -40,9 +27,23 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @key headful
  * @requires (os.family == "linux")
  * @summary Verifies if user is able to select single directory if multi selection
- *          is enabled for JFileChooser.
+ * is enabled for JFileChooser.
  * @run main TestFileChooserSingleDirectorySelection
  */
+
+import java.io.File;
+import java.awt.BorderLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.Point;
+import java.awt.Robot;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 public class TestFileChooserSingleDirectorySelection {
     private static JFrame frame;
@@ -62,7 +63,7 @@ public class TestFileChooserSingleDirectorySelection {
 
         try {
             // create test directory
-            String tmpDir = System.getProperty("user.home");
+            String tmpDir = System.getProperty("java.io.tmpdir");
 
             // Create a test directory that contains only folders
             testDir = new File(tmpDir, "testDir");

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
@@ -20,24 +20,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-/*
- * @test
- * @bug 6972078
- * @key headful
- * @requires (os.family == "linux")
- * @summary Verifies if user is able to select single directory if multi selection
- * is enabled for JFileChooser.
- * @run main TestFileChooserSingleDirectorySelection
- */
-
-import java.io.File;
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.Point;
 import java.awt.Robot;
+import java.io.File;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
@@ -45,14 +34,26 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
+/*
+ * @test
+ * @bug 6972078 8319938
+ * @key headful
+ * @requires (os.family == "linux")
+ * @summary Verifies if user is able to select single directory if multi selection
+ *          is enabled for JFileChooser.
+ * @run main TestFileChooserSingleDirectorySelection
+ */
+
 public class TestFileChooserSingleDirectorySelection {
     private static JFrame frame;
     private static JFileChooser fileChooser;
     private static JButton getSelectedFilesButton;
     private static Robot robot;
     private static boolean passed;
-    private static File[] testDir;
-    private static File[] tempFile;
+    private static File testDir;
+    private static File testFile;
+    private static File[] SubDirs;
+    private static File[] subFiles;
 
     public static void main(String[] args) throws Exception {
         System.setProperty("sun.java2d.uiScale", "1.0");
@@ -62,18 +63,35 @@ public class TestFileChooserSingleDirectorySelection {
         try {
             // create test directory
             String tmpDir = System.getProperty("user.home");
-            testDir = new File[1];
-            testDir[0] = new File(tmpDir, "testDir");
-            if (!testDir[0].exists())
-                testDir[0].mkdir();
-            testDir[0].deleteOnExit();
 
-            // create temporary files inside testDir
-            tempFile = new File[5];
+            // Create a test directory that contains only folders
+            testDir = new File(tmpDir, "testDir");
+            if (!testDir.exists()) {
+                testDir.mkdir();
+            }
+            testDir.deleteOnExit();
+
+            // create sub directories inside test directory
+            SubDirs = new File[5];
             for (int i = 0; i < 5; ++i) {
-                tempFile[i] = File.createTempFile("temp", ".txt",
-                        new File(testDir[0].getAbsolutePath()));
-                tempFile[i].deleteOnExit();
+                SubDirs[i] = new File(testDir, "subDir_" + (i+1));
+                SubDirs[i].mkdir();
+                SubDirs[i].deleteOnExit();
+            }
+
+            // Create a test directory that contains only files
+            testFile = new File(tmpDir, "testFile");
+            if (!testFile.exists()) {
+                testFile.mkdir();
+            }
+            testFile.deleteOnExit();
+
+            // create temporary files inside testFile
+            subFiles = new File[5];
+            for (int i = 0; i < 5; ++i) {
+                subFiles[i] = File.createTempFile("subFiles_" + (i+1),
+                        ".txt", new File(testFile.getAbsolutePath()));
+                subFiles[i].deleteOnExit();
             }
         } catch (Exception e) {
             e.printStackTrace();
@@ -95,7 +113,7 @@ public class TestFileChooserSingleDirectorySelection {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 createAndShowUI();
-                fileChooser.setCurrentDirectory(testDir[0]);
+                fileChooser.setCurrentDirectory(testFile);
             });
 
             robot.waitForIdle();
@@ -117,6 +135,7 @@ public class TestFileChooserSingleDirectorySelection {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 createAndShowUI();
+                fileChooser.setCurrentDirectory(testDir);
             });
             robot.waitForIdle();
             robot.delay(1000);
@@ -137,6 +156,7 @@ public class TestFileChooserSingleDirectorySelection {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 createAndShowUI();
+                fileChooser.setCurrentDirectory(testDir);
             });
             robot.waitForIdle();
             robot.delay(1000);
@@ -154,7 +174,7 @@ public class TestFileChooserSingleDirectorySelection {
     private static void createAndShowUI() {
         frame = new JFrame("Test File Chooser Single Directory Selection");
         frame.getContentPane().setLayout(new BorderLayout());
-        fileChooser = new JFileChooser("user.home");
+        fileChooser = new JFileChooser(testDir);
         fileChooser.setMultiSelectionEnabled(true);
         fileChooser.setControlButtonsAreShown(false);
 

--- a/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/TestFileChooserSingleDirectorySelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,6 @@
 
 import java.io.File;
 import java.awt.BorderLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.Point;
 import java.awt.Robot;
@@ -207,7 +205,7 @@ public class TestFileChooserSingleDirectorySelection {
 
     private static void checkResult(UIManager.LookAndFeelInfo laf) throws Exception {
         SwingUtilities.invokeAndWait(() -> {
-            File files[] = fileChooser.getSelectedFiles();
+            File[] files = fileChooser.getSelectedFiles();
             if (files.length == 0) {
                 throw new RuntimeException("getSelectedFiles returned " +
                         "empty array for LAF: " + laf.getClassName());


### PR DESCRIPTION
The test fails for JFileChooser selection mode set to `DIRECTORIES_ONLY`. For `DIRECTORIES_ONLY `mode, there may not be any directories in home directory and due to that test failed. Added the code to create temporary directories and files for the test.
Tested the current change on the machine it failed for multiple times, no failure observed.
CI link attached in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319938](https://bugs.openjdk.org/browse/JDK-8319938): TestFileChooserSingleDirectorySelection.java fails with "getSelectedFiles returned empty array" (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16674/head:pull/16674` \
`$ git checkout pull/16674`

Update a local copy of the PR: \
`$ git checkout pull/16674` \
`$ git pull https://git.openjdk.org/jdk.git pull/16674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16674`

View PR using the GUI difftool: \
`$ git pr show -t 16674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16674.diff">https://git.openjdk.org/jdk/pull/16674.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16674#issuecomment-1812135442)