### PR TITLE
8319542: Fix boundaries of region to be tested with os::is_readable_range

### DIFF
--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -212,7 +212,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
     const uint8_t* const end = here - (0x1000 + sizeof(MallocHeader)); // stop searching after 4k
     for (; here >= end; here -= smallest_possible_alignment) {
       // JDK-8306561: cast to a MallocHeader needs to guarantee it can reside in readable memory
-      if (!os::is_readable_range(here, here + sizeof(MallocHeader) - 1)) {
+      if (!os::is_readable_range(here, here + sizeof(MallocHeader))) {
         // Probably OOB, give up
         break;
       }


### PR DESCRIPTION
PR https://github.com/openjdk/jdk/pull/16381 was already closed when it became obvious that usage of os::is_readable_range() was slightly wrong:

the " - 1" looks wrong here, because is_readable_range() checks for < to, not <= to.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319542](https://bugs.openjdk.org/browse/JDK-8319542): Fix boundaries of region to be tested with os::is_readable_range (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16676/head:pull/16676` \
`$ git checkout pull/16676`

Update a local copy of the PR: \
`$ git checkout pull/16676` \
`$ git pull https://git.openjdk.org/jdk.git pull/16676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16676`

View PR using the GUI difftool: \
`$ git pr show -t 16676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16676.diff">https://git.openjdk.org/jdk/pull/16676.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16676#issuecomment-1812554773)