### PR TITLE
8319825: jdk.net/jdk.net.ExtendedSocketOptions::IP_DONTFRAGMENT is missing @since 19

### DIFF
--- a/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
+++ b/src/jdk.net/share/classes/jdk/net/ExtendedSocketOptions.java
@@ -220,6 +220,8 @@ public final class ExtendedSocketOptions {
      * by the sending and receiving nodes exclusively. Setting this option for
      * an IPv6 socket ensures that packets to be sent are never fragmented, in
      * which case, the local network MTU must be observed.
+     *
+     * @since 19
      */
     public static final SocketOption<Boolean> IP_DONTFRAGMENT =
         new ExtSocketOption<Boolean>("IP_DONTFRAGMENT", Boolean.class);


### PR DESCRIPTION
`ExtendedSocketOptions::IP_DONTFRAGMENT` is currently missing `@since 19`, this PR adds it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319825](https://bugs.openjdk.org/browse/JDK-8319825): jdk.net/jdk.net.ExtendedSocketOptions::IP_DONTFRAGMENT is missing @<!---->since 19 (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16677/head:pull/16677` \
`$ git checkout pull/16677`

Update a local copy of the PR: \
`$ git checkout pull/16677` \
`$ git pull https://git.openjdk.org/jdk.git pull/16677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16677`

View PR using the GUI difftool: \
`$ git pr show -t 16677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16677.diff">https://git.openjdk.org/jdk/pull/16677.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16677#issuecomment-1812754122)