### PR TITLE
8320199: Fix HTML 5 errors in java.math.BigInteger

### DIFF
--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -119,7 +119,7 @@ import jdk.internal.vm.annotation.Stable;
  * The range must be at least 1 to 2<sup>500000000</sup>.
  *
  * @apiNote
- * <a id=algorithmicComplexity>As {@code BigInteger} values are
+ * <span id="algorithmicComplexity">As {@code BigInteger} values are
  * arbitrary precision integers, the algorithmic complexity of the
  * methods of this class varies and may be superlinear in the size of
  * the input. For example, a method like {@link intValue()} would be
@@ -138,7 +138,7 @@ import jdk.internal.vm.annotation.Stable;
  * algorithms between the bounds of the naive and theoretical cases
  * include the Karatsuba multiplication
  * (<i>O</i>(<i>n<sup>1.585</sup></i>)) and 3-way Toom-Cook
- * multiplication (<i>O</i>(<i>n<sup>1.465</sup></i>)).</a>
+ * multiplication (<i>O</i>(<i>n<sup>1.465</sup></i>)).</span>
  *
  * <p>A particular implementation of {@link multiply(BigInteger)
  * multiply} is free to switch between different algorithms for


### PR DESCRIPTION
Clean up HTML error due to nested anchor (`<a>`) elements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320199](https://bugs.openjdk.org/browse/JDK-8320199): Fix HTML 5 errors in java.math.BigInteger (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16679/head:pull/16679` \
`$ git checkout pull/16679`

Update a local copy of the PR: \
`$ git checkout pull/16679` \
`$ git pull https://git.openjdk.org/jdk.git pull/16679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16679`

View PR using the GUI difftool: \
`$ git pr show -t 16679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16679.diff">https://git.openjdk.org/jdk/pull/16679.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16679#issuecomment-1813338909)