### PR TITLE
8320209: VectorMaskGen clobbers rflags on x86_64

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -8990,9 +8990,9 @@ instruct vmask_cmp_node(rRegI dst, vec src1, vec src2, kReg mask, kReg ktmp1, kR
 %}
 
 
-instruct vmask_gen(kReg dst, rRegL len, rRegL temp) %{
+instruct vmask_gen(kReg dst, rRegL len, rRegL temp, rFlagsReg cr) %{
   match(Set dst (VectorMaskGen len));
-  effect(TEMP temp);
+  effect(TEMP temp, KILL cr);
   format %{ "vector_mask_gen32 $dst, $len \t! vector mask generator" %}
   ins_encode %{
     __ genmask($dst$$KRegister, $len$$Register, $temp$$Register);


### PR DESCRIPTION
VectorMaskGen clobbers rflags on x86_64 but the corresponding instruct in x86.ad file doesn't list the rflags as being killed.
Adding rFlagsReg cr as being killed in effects for vmask_gen instruct.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320209](https://bugs.openjdk.org/browse/JDK-8320209): VectorMaskGen clobbers rflags on x86_64 (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16680/head:pull/16680` \
`$ git checkout pull/16680`

Update a local copy of the PR: \
`$ git checkout pull/16680` \
`$ git pull https://git.openjdk.org/jdk.git pull/16680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16680`

View PR using the GUI difftool: \
`$ git pr show -t 16680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16680.diff">https://git.openjdk.org/jdk/pull/16680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16680#issuecomment-1813458256)