### PR TITLE
JDK-8320168: handle setsocktopt return values

### DIFF
--- a/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
@@ -263,7 +263,11 @@ tcp_ping4(JNIEnv *env, SOCKETADDRESS *sa, SOCKETADDRESS *netif, jint timeout,
 
     // set TTL
     if (ttl > 0) {
-        setsockopt(fd, IPPROTO_IP, IP_TTL, &ttl, sizeof(ttl));
+        if (setsockopt(fd, IPPROTO_IP, IP_TTL, &ttl, sizeof(ttl)) < 0) {
+            NET_ThrowNew(env, errno, "setsockopt IP_TTL failed");
+            close(fd);
+            return JNI_FALSE;
+        }
     }
 
     // A network interface was specified, so let's bind to it.
@@ -349,11 +353,19 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
     struct timeval tv = { 0, 0 };
     const size_t plen = ICMP_MINLEN + sizeof(tv);
 
-    setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) < 0) {
+        NET_ThrowNew(env, errno, "setsockopt SO_RCVBUF failed");
+        close(fd);
+        return JNI_FALSE;
+    }
 
     // sets the ttl (max number of hops)
     if (ttl > 0) {
-        setsockopt(fd, IPPROTO_IP, IP_TTL, &ttl, sizeof(ttl));
+        if (setsockopt(fd, IPPROTO_IP, IP_TTL, &ttl, sizeof(ttl)) < 0) {
+            NET_ThrowNew(env, errno, "setsockopt IP_TTL failed");
+            close(fd);
+            return JNI_FALSE;
+        }
     }
 
     // a specific interface was specified, so let's bind the socket

--- a/src/java.base/unix/native/libnet/Inet6AddressImpl.c
+++ b/src/java.base/unix/native/libnet/Inet6AddressImpl.c
@@ -463,12 +463,16 @@ tcp_ping6(JNIEnv *env, SOCKETADDRESS *sa, SOCKETADDRESS *netif, jint timeout,
 
     // set TTL
     if (ttl > 0) {
-        setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &ttl, sizeof(ttl));
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &ttl, sizeof(ttl)) < 0) {
+            NET_ThrowNew(env, errno, "setsockopt IPV6_UNICAST_HOPS failed");
+            close(fd);
+            return JNI_FALSE;
+        }
     }
 
     // A network interface was specified, so let's bind to it.
     if (netif != NULL) {
-        if (bind(fd, &netif->sa, sizeof(struct sockaddr_in6)) <0) {
+        if (bind(fd, &netif->sa, sizeof(struct sockaddr_in6)) < 0) {
             NET_ThrowNew(env, errno, "Can't bind socket");
             close(fd);
             return JNI_FALSE;
@@ -557,11 +561,19 @@ ping6(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
     setsockopt(fd, SOL_RAW, IPV6_CHECKSUM, &csum_offset, sizeof(int));
 #endif
 
-    setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size));
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)) < 0) {
+        NET_ThrowNew(env, errno, "setsockopt SO_RCVBUF failed");
+        close(fd);
+        return JNI_FALSE;
+    }
 
     // sets the ttl (max number of hops)
     if (ttl > 0) {
-        setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &ttl, sizeof(ttl));
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &ttl, sizeof(ttl)) < 0) {
+            NET_ThrowNew(env, errno, "setsockopt IPV6_UNICAST_HOPS failed");
+            close(fd);
+            return JNI_FALSE;
+        }
     }
 
     // a specific interface was specified, so let's bind the socket

--- a/src/java.base/unix/native/libnet/SdpSupport.c
+++ b/src/java.base/unix/native/libnet/SdpSupport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,27 +95,19 @@ Java_sun_net_sdp_SdpSupport_convert0(JNIEnv *env, jclass cls, int fd)
 
         /* copy socket options that are relevant to SDP */
         len = sizeof(arg);
-        if (getsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, &len) == 0) {
-            res = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, len);
-            if (res < 0) JNU_ThrowIOExceptionWithLastError(env, "setsockopt SO_REUSEADDR");
-        }
+        if (getsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, &len) == 0)
+            setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, len);
 #ifdef SO_REUSEPORT
         len = sizeof(arg);
-        if (getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, (char*)&arg, &len) == 0) {
-            res = setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char*)&arg, len);
-            if (res < 0) JNU_ThrowIOExceptionWithLastError(env, "setsockopt SO_REUSEPORT");
-        }
+        if (getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, (char*)&arg, &len) == 0)
+            setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char*)&arg, len);
 #endif
         len = sizeof(arg);
-        if (getsockopt(fd, SOL_SOCKET, SO_OOBINLINE, (char*)&arg, &len) == 0) {
-            res = setsockopt(s, SOL_SOCKET, SO_OOBINLINE, (char*)&arg, len);
-            if (res < 0) JNU_ThrowIOExceptionWithLastError(env, "setsockopt SO_OOBINLINE");
-        }
+        if (getsockopt(fd, SOL_SOCKET, SO_OOBINLINE, (char*)&arg, &len) == 0)
+            setsockopt(s, SOL_SOCKET, SO_OOBINLINE, (char*)&arg, len);
         len = sizeof(linger);
-        if (getsockopt(fd, SOL_SOCKET, SO_LINGER, (void*)&linger, &len) == 0) {
-            res = setsockopt(s, SOL_SOCKET, SO_LINGER, (char*)&linger, len);
-            if (res < 0) JNU_ThrowIOExceptionWithLastError(env, "setsockopt SO_LINGER");
-        }
+        if (getsockopt(fd, SOL_SOCKET, SO_LINGER, (void*)&linger, &len) == 0)
+            setsockopt(s, SOL_SOCKET, SO_LINGER, (char*)&linger, len);
 
         RESTARTABLE(dup2(s, fd), res);
         if (res < 0)

--- a/src/java.base/unix/native/libnet/SdpSupport.c
+++ b/src/java.base/unix/native/libnet/SdpSupport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,19 +95,27 @@ Java_sun_net_sdp_SdpSupport_convert0(JNIEnv *env, jclass cls, int fd)
 
         /* copy socket options that are relevant to SDP */
         len = sizeof(arg);
-        if (getsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, &len) == 0)
-            setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, len);
+        if (getsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, &len) == 0) {
+            res = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*)&arg, len);
+            if (res < 0) JNU_ThrowIOExceptionWithLastError(env, "setsockopt SO_REUSEADDR");
+        }
 #ifdef SO_REUSEPORT
         len = sizeof(arg);
-        if (getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, (char*)&arg, &len) == 0)
-            setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char*)&arg, len);
+        if (getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, (char*)&arg, &len) == 0) {
+            res = setsockopt(s, SOL_SOCKET, SO_REUSEPORT, (char*)&arg, len);
+            if (res < 0) JNU_ThrowIOExceptionWithLastError(env, "setsockopt SO_REUSEPORT");
+        }
 #endif
         len = sizeof(arg);
-        if (getsockopt(fd, SOL_SOCKET, SO_OOBINLINE, (char*)&arg, &len) == 0)
-            setsockopt(s, SOL_SOCKET, SO_OOBINLINE, (char*)&arg, len);
+        if (getsockopt(fd, SOL_SOCKET, SO_OOBINLINE, (char*)&arg, &len) == 0) {
+            res = setsockopt(s, SOL_SOCKET, SO_OOBINLINE, (char*)&arg, len);
+            if (res < 0) JNU_ThrowIOExceptionWithLastError(env, "setsockopt SO_OOBINLINE");
+        }
         len = sizeof(linger);
-        if (getsockopt(fd, SOL_SOCKET, SO_LINGER, (void*)&linger, &len) == 0)
-            setsockopt(s, SOL_SOCKET, SO_LINGER, (char*)&linger, len);
+        if (getsockopt(fd, SOL_SOCKET, SO_LINGER, (void*)&linger, &len) == 0) {
+            res = setsockopt(s, SOL_SOCKET, SO_LINGER, (char*)&linger, len);
+            if (res < 0) JNU_ThrowIOExceptionWithLastError(env, "setsockopt SO_LINGER");
+        }
 
         RESTARTABLE(dup2(s, fd), res);
         if (res < 0)

--- a/src/java.base/unix/native/libnet/net_util_md.c
+++ b/src/java.base/unix/native/libnet/net_util_md.c
@@ -536,7 +536,9 @@ NET_SetSockOpt(int fd, int level, int  opt, const void *arg,
         }
 
         if (sotype == SOCK_DGRAM) {
-            setsockopt(fd, level, SO_REUSEPORT, arg, len);
+            if (setsockopt(fd, level, SO_REUSEPORT, arg, len) < 0) {
+                return -1;
+            }
         }
     }
 #endif

--- a/src/java.base/windows/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/windows/native/libnet/Inet4AddressImpl.c
@@ -232,7 +232,7 @@ tcp_ping4(JNIEnv *env, SOCKETADDRESS *sa, SOCKETADDRESS *netif, jint timeout,
 
     // set TTL
     if (ttl > 0) {
-        if (setsockopt(fd, IPPROTO_IP, IP_TTL, (const char *)&ttl, sizeof(ttl)) < 0) {
+        if (setsockopt(fd, IPPROTO_IP, IP_TTL, (const char *)&ttl, sizeof(ttl)) == SOCKET_ERROR) {
             NET_ThrowNew(env, WSAGetLastError(), "setsockopt IP_TTL failed");
             closesocket(fd);
             return JNI_FALSE;

--- a/src/java.base/windows/native/libnet/Inet4AddressImpl.c
+++ b/src/java.base/windows/native/libnet/Inet4AddressImpl.c
@@ -232,7 +232,11 @@ tcp_ping4(JNIEnv *env, SOCKETADDRESS *sa, SOCKETADDRESS *netif, jint timeout,
 
     // set TTL
     if (ttl > 0) {
-        setsockopt(fd, IPPROTO_IP, IP_TTL, (const char *)&ttl, sizeof(ttl));
+        if (setsockopt(fd, IPPROTO_IP, IP_TTL, (const char *)&ttl, sizeof(ttl)) < 0) {
+            NET_ThrowNew(env, WSAGetLastError(), "setsockopt IP_TTL failed");
+            closesocket(fd);
+            return JNI_FALSE;
+        }
     }
 
     // A network interface was specified, so let's bind to it.

--- a/src/java.base/windows/native/libnet/Inet6AddressImpl.c
+++ b/src/java.base/windows/native/libnet/Inet6AddressImpl.c
@@ -310,7 +310,7 @@ tcp_ping6(JNIEnv *env, SOCKETADDRESS *sa, SOCKETADDRESS *netif, jint timeout,
 
     // set TTL
     if (ttl > 0) {
-        if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const char *)&ttl, sizeof(ttl)) < 0) {
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const char *)&ttl, sizeof(ttl)) == SOCKET_ERROR) {
             NET_ThrowNew(env, WSAGetLastError(), "setsockopt IPV6_UNICAST_HOPS failed");
             closesocket(fd);
             return JNI_FALSE;

--- a/src/java.base/windows/native/libnet/Inet6AddressImpl.c
+++ b/src/java.base/windows/native/libnet/Inet6AddressImpl.c
@@ -310,7 +310,11 @@ tcp_ping6(JNIEnv *env, SOCKETADDRESS *sa, SOCKETADDRESS *netif, jint timeout,
 
     // set TTL
     if (ttl > 0) {
-        setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const char *)&ttl, sizeof(ttl));
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const char *)&ttl, sizeof(ttl)) < 0) {
+            NET_ThrowNew(env, WSAGetLastError(), "setsockopt IPV6_UNICAST_HOPS failed");
+            closesocket(fd);
+            return JNI_FALSE;
+        }
     }
 
     // A network interface was specified, so let's bind to it.

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -157,6 +157,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
         SetHandleInformation((HANDLE)s, HANDLE_FLAG_INHERIT, 0);
 
         /* IPV6_V6ONLY is true by default */
+        /* attempt to disable IPV6_V6ONLY to ensure dual-socket support; ignore errors */
         if (domain == AF_INET6) {
             int opt = 0;
             setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY,

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -156,8 +156,9 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
     if (s != INVALID_SOCKET) {
         SetHandleInformation((HANDLE)s, HANDLE_FLAG_INHERIT, 0);
 
-        /* IPV6_V6ONLY is true by default */
-        /* attempt to disable IPV6_V6ONLY to ensure dual-socket support; ignore errors */
+        /* IPV6_V6ONLY is true by default
+         * attempt to disable IPV6_V6ONLY to ensure dual-socket support; ignore errors
+         */
         if (domain == AF_INET6) {
             int opt = 0;
             setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY,

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -156,9 +156,7 @@ Java_sun_nio_ch_Net_socket0(JNIEnv *env, jclass cl, jboolean preferIPv6,
     if (s != INVALID_SOCKET) {
         SetHandleInformation((HANDLE)s, HANDLE_FLAG_INHERIT, 0);
 
-        /* IPV6_V6ONLY is true by default
-         * attempt to disable IPV6_V6ONLY to ensure dual-socket support; ignore errors
-         */
+        /* Attempt to disable IPV6_V6ONLY to ensure dual-socket support; ignore errors */
         if (domain == AF_INET6) {
             int opt = 0;
             setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY,

--- a/src/java.base/windows/native/libnio/ch/WindowsAsynchronousServerSocketChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/WindowsAsynchronousServerSocketChannelImpl.c
@@ -131,7 +131,7 @@ Java_sun_nio_ch_WindowsAsynchronousServerSocketChannelImpl_updateAcceptContext(J
     SOCKET s1 = (SOCKET)jlong_to_ptr(listenSocket);
     SOCKET s2 = (SOCKET)jlong_to_ptr(acceptSocket);
 
-    if (setsockopt(s2, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, (char *)&s1, sizeof(s1)) < 0) {
+    if (setsockopt(s2, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, (char *)&s1, sizeof(s1)) == SOCKET_ERROR) {
         JNU_ThrowIOExceptionWithLastError(env, "setsockopt failed");
     }
 }

--- a/src/java.base/windows/native/libnio/ch/WindowsAsynchronousServerSocketChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/WindowsAsynchronousServerSocketChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,7 +131,9 @@ Java_sun_nio_ch_WindowsAsynchronousServerSocketChannelImpl_updateAcceptContext(J
     SOCKET s1 = (SOCKET)jlong_to_ptr(listenSocket);
     SOCKET s2 = (SOCKET)jlong_to_ptr(acceptSocket);
 
-    setsockopt(s2, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, (char *)&s1, sizeof(s1));
+    if (setsockopt(s2, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, (char *)&s1, sizeof(s1)) < 0) {
+        JNU_ThrowIOExceptionWithLastError(env, "setsockopt failed");
+    }
 }
 
 

--- a/src/java.base/windows/native/libnio/ch/WindowsAsynchronousSocketChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/WindowsAsynchronousSocketChannelImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,9 @@ Java_sun_nio_ch_WindowsAsynchronousSocketChannelImpl_updateConnectContext(JNIEnv
     jlong socket)
 {
     SOCKET s = (SOCKET)jlong_to_ptr(socket);
-    setsockopt(s, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0);
+    if (setsockopt(s, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0) < 0) {
+        JNU_ThrowIOExceptionWithLastError(env, "setsockopt failed");
+    }
 }
 
 

--- a/src/java.base/windows/native/libnio/ch/WindowsAsynchronousSocketChannelImpl.c
+++ b/src/java.base/windows/native/libnio/ch/WindowsAsynchronousSocketChannelImpl.c
@@ -123,7 +123,7 @@ Java_sun_nio_ch_WindowsAsynchronousSocketChannelImpl_updateConnectContext(JNIEnv
     jlong socket)
 {
     SOCKET s = (SOCKET)jlong_to_ptr(socket);
-    if (setsockopt(s, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0) < 0) {
+    if (setsockopt(s, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT, NULL, 0) == SOCKET_ERROR) {
         JNU_ThrowIOExceptionWithLastError(env, "setsockopt failed");
     }
 }


### PR DESCRIPTION
There are a few places in the JDK C coding where the setsocktopt return value is not handled but better should be handled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320168](https://bugs.openjdk.org/browse/JDK-8320168): handle setsocktopt return values (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [ecd11c71](https://git.openjdk.org/jdk/pull/16684/files/ecd11c71157f34dcd113265b3ab236cfff5d8308)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16684/head:pull/16684` \
`$ git checkout pull/16684`

Update a local copy of the PR: \
`$ git checkout pull/16684` \
`$ git pull https://git.openjdk.org/jdk.git pull/16684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16684`

View PR using the GUI difftool: \
`$ git pr show -t 16684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16684.diff">https://git.openjdk.org/jdk/pull/16684.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16684#issuecomment-1814018285)