### PR TITLE
8308614: Enabling JVMTI ClassLoad event slows down vthread creation by factor 10

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -369,6 +369,8 @@ void JvmtiEventControllerPrivate::enter_interp_only_mode(JvmtiThreadState *state
   if (target == nullptr) { // an unmounted virtual thread
     return;  // EnterInterpOnlyModeClosure will be executed right after mount.
   }
+  // Protects any existing JavaThread's from being terminated while it is set.
+  // The FJP carrier thread compensating mechanism can create carrier threads concurrently.
   ThreadsListHandle tlh(current);
   EnterInterpOnlyModeClosure hs;
   if (target->is_handshake_safe_for(current)) {

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -369,9 +369,6 @@ void JvmtiEventControllerPrivate::enter_interp_only_mode(JvmtiThreadState *state
   if (target == nullptr) { // an unmounted virtual thread
     return;  // EnterInterpOnlyModeClosure will be executed right after mount.
   }
-  // Protects any existing JavaThread's from being terminated while it is set.
-  // The FJP carrier thread compensating mechanism can create carrier threads concurrently.
-  ThreadsListHandle tlh(current);
   EnterInterpOnlyModeClosure hs;
   if (target->is_handshake_safe_for(current)) {
     hs.do_thread(target);

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -369,6 +369,7 @@ void JvmtiEventControllerPrivate::enter_interp_only_mode(JvmtiThreadState *state
   if (target == nullptr) { // an unmounted virtual thread
     return;  // EnterInterpOnlyModeClosure will be executed right after mount.
   }
+  ThreadsListHandle tlh(current);
   EnterInterpOnlyModeClosure hs;
   if (target->is_handshake_safe_for(current)) {
     hs.do_thread(target);

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -527,20 +527,18 @@ JvmtiVTMSTransitionDisabler::VTMS_vthread_start(jobject vthread) {
   assert(!thread->is_in_VTMS_transition(), "sanity check");
   assert(!thread->is_in_tmp_VTMS_transition(), "sanity check");
 
-  // JvmtiThreadState objects for virtual thread filtered events enabled globally
-  // must be created eagerly if the interp_only_mode is enabled. Otherwise,
+  // If interp_only_mode is enabled then we must eagerly create JvmtiThreadState
+  // objects for globally enabled virtual thread filtered events. Otherwise,
   // it is an important optimization to create JvmtiThreadState objects lazily.
   if (JvmtiThreadState::seen_interp_only_mode()) {
     JvmtiEventController::thread_started(thread);
   }
-  if (JvmtiExport::can_support_virtual_threads()) {
-    if (JvmtiExport::should_post_vthread_start()) {
-      JvmtiExport::post_vthread_start(vthread);
-    }
-    // post VirtualThreadMount event after VirtualThreadStart
-    if (JvmtiExport::should_post_vthread_mount()) {
-      JvmtiExport::post_vthread_mount(vthread);
-    }
+  if (JvmtiExport::should_post_vthread_start()) {
+    JvmtiExport::post_vthread_start(vthread);
+  }
+  // post VirtualThreadMount event after VirtualThreadStart
+  if (JvmtiExport::should_post_vthread_mount()) {
+    JvmtiExport::post_vthread_mount(vthread);
   }
 }
 
@@ -551,14 +549,12 @@ JvmtiVTMSTransitionDisabler::VTMS_vthread_end(jobject vthread) {
   assert(!thread->is_in_VTMS_transition(), "sanity check");
   assert(!thread->is_in_tmp_VTMS_transition(), "sanity check");
 
-  if (JvmtiExport::can_support_virtual_threads()) {
-    // post VirtualThreadUnmount event before VirtualThreadEnd
-    if (JvmtiExport::should_post_vthread_unmount()) {
-      JvmtiExport::post_vthread_unmount(vthread);
-    }
-    if (JvmtiExport::should_post_vthread_end()) {
-      JvmtiExport::post_vthread_end(vthread);
-    }
+  // post VirtualThreadUnmount event before VirtualThreadEnd
+  if (JvmtiExport::should_post_vthread_unmount()) {
+    JvmtiExport::post_vthread_unmount(vthread);
+  }
+  if (JvmtiExport::should_post_vthread_end()) {
+    JvmtiExport::post_vthread_end(vthread);
   }
   VTMS_unmount_begin(vthread, /* last_unmount */ true);
   if (thread->jvmti_thread_state() != nullptr) {
@@ -575,8 +571,7 @@ JvmtiVTMSTransitionDisabler::VTMS_vthread_mount(jobject vthread, bool hide) {
     VTMS_mount_begin(vthread);
   } else {
     VTMS_mount_end(vthread);
-    if (JvmtiExport::can_support_virtual_threads() &&
-        JvmtiExport::should_post_vthread_mount()) {
+    if (JvmtiExport::should_post_vthread_mount()) {
       JvmtiExport::post_vthread_mount(vthread);
     }
   }
@@ -585,8 +580,7 @@ JvmtiVTMSTransitionDisabler::VTMS_vthread_mount(jobject vthread, bool hide) {
 void
 JvmtiVTMSTransitionDisabler::VTMS_vthread_unmount(jobject vthread, bool hide) {
   if (hide) {
-    if (JvmtiExport::can_support_virtual_threads() &&
-        JvmtiExport::should_post_vthread_unmount()) {
+    if (JvmtiExport::should_post_vthread_unmount()) {
       JvmtiExport::post_vthread_unmount(vthread);
     }
     VTMS_unmount_begin(vthread, /* last_unmount */ false);

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -527,7 +527,7 @@ JvmtiVTMSTransitionDisabler::VTMS_vthread_start(jobject vthread) {
   assert(!thread->is_in_VTMS_transition(), "sanity check");
   assert(!thread->is_in_tmp_VTMS_transition(), "sanity check");
 
-  // If interp_only_mode is enabled then we must eagerly create JvmtiThreadState
+  // If interp_only_mode has been enabled then we must eagerly create JvmtiThreadState
   // objects for globally enabled virtual thread filtered events. Otherwise,
   // it is an important optimization to create JvmtiThreadState objects lazily.
   if (JvmtiThreadState::seen_interp_only_mode()) {

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -231,7 +231,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   inline JvmtiEnvThreadState* head_env_thread_state();
   inline void set_head_env_thread_state(JvmtiEnvThreadState* ets);
 
-  static bool _seen_interp_only_mode; // needed for optimization
+  static bool _seen_interp_only_mode; // interp_only_mode was requested once
 
  public:
   ~JvmtiThreadState();
@@ -252,9 +252,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
 
   static void periodic_clean_up();
 
-  // JvmtiThreadState objects for virtual thread filtered events enabled globally
-  // must be created eagerly if the interp_only_mode is enabled. Otherwise,
-  // it is an important optimization to create JvmtiThreadState objects lazily.
+  // Return true if any thread has entered interp_only_mode at any point during the JVMs execution.
   static bool seen_interp_only_mode() {
     return _seen_interp_only_mode;
   }

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -231,7 +231,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   inline JvmtiEnvThreadState* head_env_thread_state();
   inline void set_head_env_thread_state(JvmtiEnvThreadState* ets);
 
-  static bool _seen_interp_only_mode; // interp_only_mode was requested once
+  static bool _seen_interp_only_mode; // interp_only_mode was requested at least once
 
  public:
   ~JvmtiThreadState();

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -231,6 +231,8 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   inline JvmtiEnvThreadState* head_env_thread_state();
   inline void set_head_env_thread_state(JvmtiEnvThreadState* ets);
 
+  static bool _seen_interp_only_mode; // needed for optimization
+
  public:
   ~JvmtiThreadState();
 
@@ -249,6 +251,13 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   inline JvmtiEnvThreadState* env_thread_state(JvmtiEnvBase *env);
 
   static void periodic_clean_up();
+
+  // JvmtiThreadState objects for virtual thread filtered events enabled globally
+  // must be created eagerly if the interp_only_mode is enabled. Otherwise,
+  // it is an important optimization to create JvmtiThreadState objects lazily.
+  static bool seen_interp_only_mode() {
+    return _seen_interp_only_mode;
+  }
 
   void add_env(JvmtiEnvBase *env);
 


### PR DESCRIPTION
This is a fix of a performance/scalability related issue. The `JvmtiThreadState` objects for virtual thread filtered events enabled globally are created eagerly because it is needed when the `interp_only_mode` is enabled. Otherwise, some events which are generated in `interp_only_mode` from the debugging version of interpreter chunks can be missed.
However, it has to be okay to avoid eager creation of these object if no `interp_only_mode` has ever been requested.
It seems to be an extremely important optimization to create JvmtiThreadState objects lazily in such cases.
It is done by introducing the flag `JvmtiThreadState::_seen_interp_only_mode` which indicates when the `JvmtiThreadState` objects have to be created eagerly.

Additionally, the fix includes the following related changes:
 - Use condition double checking idiom for `MutexLocker mu(JvmtiThreadState_lock)` in the function `JvmtiVTMSTransitionDisabler::VTMS_mount_end` which is on a performance-critical path and looks like this:
```
  JvmtiThreadState* state = thread->jvmti_thread_state();
  if (state != nullptr && state->is_pending_interp_only_mode()) {
    MutexLocker mu(JvmtiThreadState_lock);
    state = thread->jvmti_thread_state();
    if (state != nullptr && state->is_pending_interp_only_mode()) {
      JvmtiEventController::enter_interp_only_mode();
    }
  }
```

 - Add extra check of `JvmtiExport::can_support_virtual_threads()` when virtual thread mount and unmount are posted.
 - Minor: Added a `ThreadsListHandle` to the `JvmtiEventControllerPrivate::enter_interp_only_mode`. It is needed because of the dynamic creation of compensating carrier threads which is racy for JVMTI `SetEventNotificationMode` implementation.

Performance mesurements:
- Without this fix the test provided by the bug submitter gives execution numbers:
  - no ClassLoad events enabled:     3251 ms
  - ClassLoad events are enabled: 40534 ms
  
- With the fix:
  - no ClassLoad events enabled:    3270 ms
  - ClassLoad events are enabled:   3385 ms
  
Testing:
 - Ran mach5 tiers 1-6, no regressions are noticed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308614](https://bugs.openjdk.org/browse/JDK-8308614): Enabling JVMTI ClassLoad event slows down vthread creation by factor 10 (**Bug** - P3)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16686/head:pull/16686` \
`$ git checkout pull/16686`

Update a local copy of the PR: \
`$ git checkout pull/16686` \
`$ git pull https://git.openjdk.org/jdk.git pull/16686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16686`

View PR using the GUI difftool: \
`$ git pr show -t 16686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16686.diff">https://git.openjdk.org/jdk/pull/16686.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16686#issuecomment-1814250953)