### PR TITLE
8313367: SunMSCAPI cannot read Local Computer certs w/o Windows elevation

### DIFF
--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -444,7 +444,7 @@ JNIEXPORT void JNICALL Java_sun_security_mscapi_CKeyStore_loadKeysOrCertificateC
         }
         else if (jCertStoreLocation == KEYSTORE_LOCATION_LOCALMACHINE) {
             hCertStore = ::CertOpenStore(CERT_STORE_PROV_SYSTEM_A, 0, NULL,
-                CERT_SYSTEM_STORE_LOCAL_MACHINE, pszCertStoreName);
+                CERT_SYSTEM_STORE_LOCAL_MACHINE | CERT_STORE_MAXIMUM_ALLOWED_FLAG, pszCertStoreName);
         }
         else {
             PP("jCertStoreLocation is not a valid value");

--- a/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
+++ b/src/jdk.crypto.mscapi/windows/native/libsunmscapi/security.cpp
@@ -798,9 +798,10 @@ JNIEXPORT jbyteArray JNICALL Java_sun_security_mscapi_CSignature_signHash
             ::CryptGetProvParam((HCRYPTPROV)hCryptProv, PP_CONTAINER, //deprecated
                 (BYTE *)pbData, &cbData, 0);
 
-            DWORD keysetType;
+            DWORD keysetType = 0;
+            DWORD keysetTypeLen = sizeof(keysetType);
             ::CryptGetProvParam((HCRYPTPROV)hCryptProv, PP_KEYSET_TYPE, //deprecated
-                (BYTE*)&keysetType, &cbData, 0);
+                (BYTE*)&keysetType, &keysetTypeLen, 0);
 
             // Acquire an alternative CSP handle
             if (::CryptAcquireContext(&hCryptProvAlt, LPCSTR(pbData), NULL, //deprecated

--- a/test/jdk/sun/security/mscapi/AllTypes.java
+++ b/test/jdk/sun/security/mscapi/AllTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,31 +45,10 @@ public class AllTypes {
         var nr = test("windows-root");
         var nmu = test("windows-my-currentuser");
         var nru = test("windows-root-currentuser");
-        var hasAdminPrivileges = detectIfRunningWithAdminPrivileges();
-        var nmm = adminTest("windows-my-localmachine", hasAdminPrivileges);
-        var nrm = adminTest("windows-root-localmachine", hasAdminPrivileges);
+        var nmm = test("windows-my-localmachine");
+        var nrm = test("windows-root-localmachine");
         Asserts.assertEQ(nm, nmu);
         Asserts.assertEQ(nr, nru);
-    }
-
-    private static boolean detectIfRunningWithAdminPrivileges() {
-        try {
-            Process p = Runtime.getRuntime().exec("reg query \"HKU\\S-1-5-19\"");
-            p.waitFor();
-            return (p.exitValue() == 0);
-        }
-        catch (Exception ex) {
-            System.out.println("Warning: unable to detect admin privileges, assuming none");
-            return false;
-        }
-    }
-
-    private static List<String> adminTest(String type, boolean hasAdminPrivileges) throws Exception {
-        if (hasAdminPrivileges) {
-            return test(type);
-        }
-        System.out.println("Ignoring: " + type + " as it requires admin privileges");
-        return null;
     }
 
     private static List<String> test(String type) throws Exception {

--- a/test/jdk/sun/security/mscapi/AllTypes.java
+++ b/test/jdk/sun/security/mscapi/AllTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This fixes the defect described at https://bugs.openjdk.org/browse/JDK-8313367

If the process does not have write permissions, the store is opened as read-only (instead of failing).

Please note that permissions to use a certificate in a local machine store must be granted - in a management console, select a certificate, right-click -> All tasks... -> Manage Private Keys... -> add Full control to user.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313367](https://bugs.openjdk.org/browse/JDK-8313367): SunMSCAPI cannot read Local Computer certs w/o Windows elevation (**Bug** - P3)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16687/head:pull/16687` \
`$ git checkout pull/16687`

Update a local copy of the PR: \
`$ git checkout pull/16687` \
`$ git pull https://git.openjdk.org/jdk.git pull/16687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16687`

View PR using the GUI difftool: \
`$ git pr show -t 16687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16687.diff">https://git.openjdk.org/jdk/pull/16687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16687#issuecomment-1819978384)
</details>
