### PR TITLE
8320239: add dynamic switch for JvmtiVTMSTransitionDisabler sync protocol

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -228,6 +228,12 @@ volatile bool JvmtiVTMSTransitionDisabler::_SR_mode = false;
 // Notifications from VirtualThread about VTMS events are enabled.
 bool JvmtiVTMSTransitionDisabler::_VTMS_notify_jvmti_events = false;
 
+// The JvmtiVTMSTransitionDisabler sync protocol is enabled if this count > 0.
+int JvmtiVTMSTransitionDisabler::_sync_protocol_enabled_count = 0;
+
+// JvmtiVTMSTraansitionDisabler sync protocol is enabled permanently after seeing a suspender.
+bool JvmtiVTMSTransitionDisabler::_sync_protocol_enabled_permanently = false;
+
 #ifdef ASSERT
 void
 JvmtiVTMSTransitionDisabler::print_info() {
@@ -255,6 +261,9 @@ JvmtiVTMSTransitionDisabler::JvmtiVTMSTransitionDisabler(jthread thread)
   if (Thread::current_or_null() == nullptr) {
     return;  // Detached thread, can be a call from Agent_OnLoad.
   }
+  if (!_sync_protocol_enabled_permanently) {
+    JvmtiVTMSTransitionDisabler::inc_sync_protocol_enabled_count();
+  }
   if (_thread != nullptr) {
     VTMS_transition_disable_for_one(); // disable VTMS transitions for one virtual thread
   } else {
@@ -272,6 +281,12 @@ JvmtiVTMSTransitionDisabler::JvmtiVTMSTransitionDisabler(bool is_SR)
   if (Thread::current_or_null() == nullptr) {
     return;  // Detached thread, can be a call from Agent_OnLoad.
   }
+  if (!_sync_protocol_enabled_permanently) {
+    JvmtiVTMSTransitionDisabler::inc_sync_protocol_enabled_count();
+    if (is_SR) {
+      _sync_protocol_enabled_permanently = true;
+    }
+  }
   VTMS_transition_disable_for_all();
 }
 
@@ -286,6 +301,9 @@ JvmtiVTMSTransitionDisabler::~JvmtiVTMSTransitionDisabler() {
     VTMS_transition_enable_for_one(); // enable VTMS transitions for one virtual thread
   } else {
     VTMS_transition_enable_for_all(); // enable VTMS transitions for all virtual threads
+  }
+  if (!_sync_protocol_enabled_permanently) {
+    JvmtiVTMSTransitionDisabler::dec_sync_protocol_enabled_count();
   }
 }
 
@@ -404,8 +422,17 @@ JvmtiVTMSTransitionDisabler::VTMS_transition_enable_for_all() {
 void
 JvmtiVTMSTransitionDisabler::start_VTMS_transition(jthread vthread, bool is_mount) {
   JavaThread* thread = JavaThread::current();
+  oop vt = JNIHandles::resolve_external_guard(vthread);
+
+  if (!sync_protocol_enabled()) {
+    assert(!thread->is_in_VTMS_transition(), "VTMS_transition sanity check");
+    thread->set_is_in_VTMS_transition(true);
+     java_lang_Thread::set_is_in_VTMS_transition(vt, true);
+    Atomic::inc(&_VTMS_transition_count);
+    return;
+  }
   HandleMark hm(thread);
-  Handle vth = Handle(thread, JNIHandles::resolve_external_guard(vthread));
+  Handle vth = Handle(thread, vt);
   int attempts = 50000;
 
   // Avoid using MonitorLocker on performance critical path, use
@@ -469,10 +496,13 @@ JvmtiVTMSTransitionDisabler::finish_VTMS_transition(jthread vthread, bool is_mou
   assert(thread->is_in_VTMS_transition(), "sanity check");
   thread->set_is_in_VTMS_transition(false);
   oop vt = JNIHandles::resolve_external_guard(vthread);
-  int64_t thread_id = java_lang_Thread::thread_id(vt);
   java_lang_Thread::set_is_in_VTMS_transition(vt, false);
-
   Atomic::dec(&_VTMS_transition_count);
+
+  if (!sync_protocol_enabled()) {
+    return;
+  }
+  int64_t thread_id = java_lang_Thread::thread_id(vt);
 
   // Unblock waiting VTMS transition disablers.
   if (_VTMS_transition_disable_for_one_count > 0 ||

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -83,6 +83,8 @@ class JvmtiVTMSTransitionDisabler {
   static volatile int _VTMS_transition_disable_for_all_count; // transitions for all virtual threads are disabled while it is positive
   static volatile bool _SR_mode;                         // there is an active suspender or resumer
   static volatile int _VTMS_transition_count;            // current number of VTMS transitions
+  static int  _sync_protocol_enabled_count;              // current number of JvmtiVTMSTransitionDisablers enabled sync protocol
+  static bool _sync_protocol_enabled_permanently;        // seen a suspender: JvmtiVTMSTraansitionDisabler protocol is enabled permanently
 
   bool _is_SR;                                           // is suspender or resumer
   jthread _thread;                                       // virtual thread to disable transitions for, no-op if it is a platform thread
@@ -99,6 +101,10 @@ class JvmtiVTMSTransitionDisabler {
   static void set_VTMS_notify_jvmti_events(bool val) { _VTMS_notify_jvmti_events = val; }
 
   static void set_VTMS_transition_count(bool val)    { _VTMS_transition_count = val; }
+
+  static void inc_sync_protocol_enabled_count()      { _sync_protocol_enabled_count++; }
+  static void dec_sync_protocol_enabled_count()      { _sync_protocol_enabled_count--; }
+  static bool sync_protocol_enabled()                { return _sync_protocol_enabled_count > 0 || _sync_protocol_enabled_permanently; }
 
   // parameter is_SR: suspender or resumer
   JvmtiVTMSTransitionDisabler(bool is_SR = false);


### PR DESCRIPTION
This is an update for a performance/scalability enhancement.

The `JvmtiVTMSTransitionDisabler`sync protocol is on a performance critical path of the virtual threads mount state transitions (VTMS transitions). It has a noticeable performance overhead (about 10%) which contributes to the combined JVMTI performance overhead when Java apps are executed with loaded JVMTI agents.

Please, also see another/related performance issue which contributes around 70% of total performance overhead:
[8308614](https://bugs.openjdk.org/browse/JDK-8308614): Enabling JVMTI ClassLoad event slows down vthread creation by factor 10

Testing:
 - Ran mach5 tiers 1-6 with no regressions noticed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320239](https://bugs.openjdk.org/browse/JDK-8320239): add dynamic switch for JvmtiVTMSTransitionDisabler sync protocol (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [a81218fd](https://git.openjdk.org/jdk/pull/16688/files/a81218fdc4ba4a47904fbefe069e74a173e5ac0f)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [a81218fd](https://git.openjdk.org/jdk/pull/16688/files/a81218fdc4ba4a47904fbefe069e74a173e5ac0f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16688/head:pull/16688` \
`$ git checkout pull/16688`

Update a local copy of the PR: \
`$ git checkout pull/16688` \
`$ git pull https://git.openjdk.org/jdk.git pull/16688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16688`

View PR using the GUI difftool: \
`$ git pr show -t 16688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16688.diff">https://git.openjdk.org/jdk/pull/16688.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16688#issuecomment-1814365587)