### PR TITLE
8318562: Computational test more than 2x slower when AVX instructions are used

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1871,6 +1871,90 @@ void MacroAssembler::cmpoop(Register src1, jobject src2, Register rscratch) {
 }
 #endif
 
+void MacroAssembler::cvtss2sd(XMMRegister dst, XMMRegister src) {
+  if ((UseAVX > 0) && (dst != src)) {
+    xorpd(dst, dst);
+  }
+  Assembler::cvtss2sd(dst, src);
+}
+
+void MacroAssembler::cvtss2sd(XMMRegister dst, Address src) {
+  if (UseAVX > 0) {
+    xorpd(dst, dst);
+  }
+  Assembler::cvtss2sd(dst, src);
+}
+
+void MacroAssembler::cvtsd2ss(XMMRegister dst, XMMRegister src) {
+  if ((UseAVX > 0) && (dst != src)) {
+    xorps(dst, dst);
+  }
+  Assembler::cvtsd2ss(dst, src);
+}
+
+void MacroAssembler::cvtsd2ss(XMMRegister dst, Address src) {
+  if (UseAVX > 0) {
+    xorps(dst, dst);
+  }
+  Assembler::cvtsd2ss(dst, src);
+}
+
+void MacroAssembler::cvtsi2sdl(XMMRegister dst, Register src) {
+  if (UseAVX > 0) {
+    xorpd(dst, dst);
+  }
+  Assembler::cvtsi2sdl(dst, src);
+}
+
+void MacroAssembler::cvtsi2sdl(XMMRegister dst, Address src) {
+  if (UseAVX > 0) {
+    xorpd(dst, dst);
+  }
+  Assembler::cvtsi2sdl(dst, src);
+}
+
+void MacroAssembler::cvtsi2ssl(XMMRegister dst, Register src) {
+  if (UseAVX > 0) {
+    xorps(dst, dst);
+  }
+  Assembler::cvtsi2ssl(dst, src);
+}
+
+void MacroAssembler::cvtsi2ssl(XMMRegister dst, Address src) {
+  if (UseAVX > 0) {
+    xorps(dst, dst);
+  }
+  Assembler::cvtsi2ssl(dst, src);
+}
+
+void MacroAssembler::cvtsi2sdq(XMMRegister dst, Register src) {
+  if (UseAVX > 0) {
+    xorpd(dst, dst);
+  }
+  Assembler::cvtsi2sdq(dst, src);
+}
+
+void MacroAssembler::cvtsi2sdq(XMMRegister dst, Address src) {
+  if (UseAVX > 0) {
+    xorpd(dst, dst);
+  }
+  Assembler::cvtsi2sdq(dst, src);
+}
+
+void MacroAssembler::cvtsi2ssq(XMMRegister dst, Register src) {
+  if (UseAVX > 0) {
+    xorps(dst, dst);
+  }
+  Assembler::cvtsi2ssq(dst, src);
+}
+
+void MacroAssembler::cvtsi2ssq(XMMRegister dst, Address src) {
+  if (UseAVX > 0) {
+    xorps(dst, dst);
+  }
+  Assembler::cvtsi2ssq(dst, src);
+}
+
 void MacroAssembler::locked_cmpxchgptr(Register reg, AddressLiteral adr, Register rscratch) {
   assert(rscratch != noreg || always_reachable(adr), "missing");
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1927,6 +1927,7 @@ void MacroAssembler::cvtsi2ssl(XMMRegister dst, Address src) {
   Assembler::cvtsi2ssl(dst, src);
 }
 
+#ifdef _LP64
 void MacroAssembler::cvtsi2sdq(XMMRegister dst, Register src) {
   if (UseAVX > 0) {
     xorpd(dst, dst);
@@ -1954,6 +1955,7 @@ void MacroAssembler::cvtsi2ssq(XMMRegister dst, Address src) {
   }
   Assembler::cvtsi2ssq(dst, src);
 }
+#endif  // _LP64
 
 void MacroAssembler::locked_cmpxchgptr(Register reg, AddressLiteral adr, Register rscratch) {
   assert(rscratch != noreg || always_reachable(adr), "missing");

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -800,6 +800,21 @@ public:
 
   void cmpxchgptr(Register reg, Address adr);
 
+
+  // cvt instructions
+  void cvtss2sd(XMMRegister dst, XMMRegister src);
+  void cvtss2sd(XMMRegister dst, Address src);
+  void cvtsd2ss(XMMRegister dst, XMMRegister src);
+  void cvtsd2ss(XMMRegister dst, Address src);
+  void cvtsi2sdl(XMMRegister dst, Register src);
+  void cvtsi2sdl(XMMRegister dst, Address src);
+  void cvtsi2ssl(XMMRegister dst, Register src);
+  void cvtsi2ssl(XMMRegister dst, Address src);
+  void cvtsi2sdq(XMMRegister dst, Register src);
+  void cvtsi2sdq(XMMRegister dst, Address src);
+  void cvtsi2ssq(XMMRegister dst, Register src);
+  void cvtsi2ssq(XMMRegister dst, Address src);
+
   void locked_cmpxchgptr(Register reg, AddressLiteral adr, Register rscratch = noreg);
 
   void imulptr(Register dst, Register src) { LP64_ONLY(imulq(dst, src)) NOT_LP64(imull(dst, src)); }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -810,10 +810,12 @@ public:
   void cvtsi2sdl(XMMRegister dst, Address src);
   void cvtsi2ssl(XMMRegister dst, Register src);
   void cvtsi2ssl(XMMRegister dst, Address src);
+#ifdef _LP64
   void cvtsi2sdq(XMMRegister dst, Register src);
   void cvtsi2sdq(XMMRegister dst, Address src);
   void cvtsi2ssq(XMMRegister dst, Register src);
   void cvtsi2ssq(XMMRegister dst, Address src);
+#endif
 
   void locked_cmpxchgptr(Register reg, AddressLiteral adr, Register rscratch = noreg);
 

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -11067,7 +11067,7 @@ instruct cmpD_imm(rRegI dst, regD src, immD con, rFlagsReg cr) %{
 instruct convF2D_reg_reg(regD dst, regF src)
 %{
   match(Set dst (ConvF2D src));
-
+  effect(TEMP dst);
   format %{ "cvtss2sd $dst, $src" %}
   ins_encode %{
     __ cvtss2sd ($dst$$XMMRegister, $src$$XMMRegister);
@@ -11089,7 +11089,7 @@ instruct convF2D_reg_mem(regD dst, memory src)
 instruct convD2F_reg_reg(regF dst, regD src)
 %{
   match(Set dst (ConvD2F src));
-
+  effect(TEMP dst);
   format %{ "cvtsd2ss $dst, $src" %}
   ins_encode %{
     __ cvtsd2ss ($dst$$XMMRegister, $src$$XMMRegister);

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/ComputePI.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/ComputePI.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+public class ComputePI {
+
+  @Benchmark
+  public double compute_pi_int_dbl() {
+    double pi = 4.0;
+    boolean sign = false;
+
+    for (int i = 3; i < 1000; i += 2) {
+      if (sign) {
+        pi += 4.0 / i;
+      } else {
+        pi -= 4.0 / i;
+      }
+      sign = !sign;
+    }
+    return pi;
+  }
+
+  @Benchmark
+  public double compute_pi_int_flt() {
+    float pi = 4.0f;
+    boolean sign = false;
+
+    for (int i = 3; i < 1000; i += 2) {
+      if (sign) {
+        pi += 4.0f / i;
+      } else {
+        pi -= 4.0f / i;
+      }
+      sign = !sign;
+    }
+    return pi;
+  }
+
+  @Benchmark
+  public double compute_pi_long_dbl() {
+    double pi = 4.0;
+    boolean sign = false;
+
+    for (long i = 3; i < 1000; i += 2) {
+      if (sign) {
+        pi += 4.0 / i;
+      } else {
+        pi -= 4.0 / i;
+      }
+      sign = !sign;
+    }
+    return pi;
+  }
+
+  @Benchmark
+  public double compute_pi_long_flt() {
+    float pi = 4.0f;
+    boolean sign = false;
+
+    for (long i = 3; i < 1000; i += 2) {
+      if (sign) {
+        pi += 4.0f / i;
+      } else {
+        pi -= 4.0f / i;
+      }
+      sign = !sign;
+    }
+    return pi;
+  }
+
+  @Benchmark
+  public double compute_pi_flt_dbl() {
+    double pi = 4.0;
+    boolean sign = false;
+
+    for (float i = 3.0f; i < 1000.0f; i += 2.0f) {
+      if (sign) {
+        pi += 4.0 / i;
+      } else {
+        pi -= 4.0 / i;
+      }
+      sign = !sign;
+    }
+    return pi;
+  }
+
+  @Benchmark
+  public double compute_pi_dbl_flt() {
+    float pi = 4.0f;
+    boolean sign = false;
+
+    for (float i = 3.0f; i < 1000.0f; i += 2.0f) {
+      if (sign) {
+        pi += 4.0f / i;
+      } else {
+        pi -= 4.0f / i;
+      }
+      sign = !sign;
+    }
+    return pi;
+  }
+}


### PR DESCRIPTION
This PR fixes the perf regression seen on AVX for floating point conversions.

In AVX the cvt instructions have three operands cvtxx dst, src1, src2.  Where src2 is the one being converted. The dst gets the lower bits as the converted value and upper bits (up to 128) from src1.

The C2 jit uses the cvtxx dst, dst, src2 flavor. Here the problem was due to uninitialized upper bits of the dst XMM register.
Doing an xor dst, dst  before the conversion instruction fixes the perf regression. 

Perf before the patch on UseAVX=3 platform:
ComputePI.compute_pi_dbl_flt   avgt    5   471.875 ±  0.400  ns/op
ComputePI.compute_pi_flt_dbl   avgt    5  1877.174 ±  0.557  ns/op
ComputePI.compute_pi_int_dbl   avgt    5   655.222 ± 28.082  ns/op
ComputePI.compute_pi_int_flt   avgt    5   737.178 ±  0.077  ns/op
ComputePI.compute_pi_long_dbl  avgt    5   767.364 ±  0.027  ns/op
ComputePI.compute_pi_long_flt  avgt    5   587.854 ± 10.068  ns/op

Perf after the patch on UseAVX=3 platform:
Benchmark                      Mode  Cnt    Score   Error  Units
ComputePI.compute_pi_dbl_flt   avgt    5  468.328 ± 0.141  ns/op
ComputePI.compute_pi_flt_dbl   avgt    5  435.430 ± 0.259  ns/op
ComputePI.compute_pi_int_dbl   avgt    5  424.088 ± 0.050  ns/op
ComputePI.compute_pi_int_flt   avgt    5  417.345 ± 0.207  ns/op
ComputePI.compute_pi_long_dbl  avgt    5  425.751 ± 0.006  ns/op
ComputePI.compute_pi_long_flt  avgt    5  430.199 ± 0.736  ns/op

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318562](https://bugs.openjdk.org/browse/JDK-8318562): Computational test more than 2x slower when AVX instructions are used (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16701/head:pull/16701` \
`$ git checkout pull/16701`

Update a local copy of the PR: \
`$ git checkout pull/16701` \
`$ git pull https://git.openjdk.org/jdk.git pull/16701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16701`

View PR using the GUI difftool: \
`$ git pr show -t 16701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16701.diff">https://git.openjdk.org/jdk/pull/16701.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16701#issuecomment-1815530798)