### PR TITLE
8320212: Disable GCC stringop-overflow warning for affected files

### DIFF
--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -88,13 +88,6 @@ DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     maybe-uninitialized missing-field-initializers parentheses \
     shift-negative-value unknown-pragmas
 
-ifeq ($(DEBUG_LEVEL), fastdebug)
-  ifeq ($(call And, $(call isTargetOs, linux) $(call isTargetCpu, aarch64)), true)
-    # False positive warnings for atomic_linux_aarch64.hpp on GCC >= 13
-    DISABLED_WARNINGS_gcc += stringop-overflow
-  endif
-endif
-
 DISABLED_WARNINGS_clang := sometimes-uninitialized \
     missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas
 
@@ -171,8 +164,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_ad_$(HOTSPOT_TARGET_CPU_ARCH).cpp := nonnull, \
     DISABLED_WARNINGS_gcc_cgroupV1Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
+    DISABLED_WARNINGS_gcc_handshake.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_interp_masm_x86.cpp := uninitialized, \
+    DISABLED_WARNINGS_gcc_jvmciCodeInstaller.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_jvmtiTagMap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
+    DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_clang_arguments.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_codeBuffer.cpp := tautological-undefined-compare, \


### PR DESCRIPTION
In JDK-8319818 the stringop-overflow warnings were disabled for linux-aarch64 (fastdebug). With the changes in JDK-8319883 additional stringop-overflow warnings are produced with GCC 13.2.0, this time for linux-x64-zero (fastdebug). The warnings are related to GCC thinking JavaThread:current (and Thread::current) may return nullptr where in fact they can't. I tried several ways to convince GCC about this fact but in the end failed.

This change disables the warning for the affected files (only). I'm not in love with that solution but I've run out of ideas at this point. An alternative would be to disable the warning globally, which has its own set of pros and cons.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320212](https://bugs.openjdk.org/browse/JDK-8320212): Disable GCC stringop-overflow warning for affected files (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16702/head:pull/16702` \
`$ git checkout pull/16702`

Update a local copy of the PR: \
`$ git checkout pull/16702` \
`$ git pull https://git.openjdk.org/jdk.git pull/16702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16702`

View PR using the GUI difftool: \
`$ git pr show -t 16702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16702.diff">https://git.openjdk.org/jdk/pull/16702.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16702#issuecomment-1815551992)