### PR TITLE
JDK-8319569: Several java/util tests should be updated to accept VM flags

### DIFF
--- a/test/jdk/java/util/Calendar/SupplementalJapaneseEraTestRun.java
+++ b/test/jdk/java/util/Calendar/SupplementalJapaneseEraTestRun.java
@@ -30,7 +30,6 @@
  * @run testng/othervm SupplementalJapaneseEraTestRun
  */
 
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
@@ -98,7 +97,7 @@ public class SupplementalJapaneseEraTestRun {
 
     private static void testRun(String property, List<String> javaParam)
             throws Throwable {
-        List<String> params = Arrays.asList(
+        List<String> params = List.of(
                 "-ea", "-esa",
                 "-cp", Utils.TEST_CLASS_PATH,
                 "-Djdk.calendar.japanese.supplemental.era=" + property,

--- a/test/jdk/java/util/Calendar/SupplementalJapaneseEraTestRun.java
+++ b/test/jdk/java/util/Calendar/SupplementalJapaneseEraTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,20 @@
  * @run testng/othervm SupplementalJapaneseEraTestRun
  */
 
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
-import static java.util.Calendar.*;
+import java.util.stream.Stream;
+
+import static java.util.Calendar.DAY_OF_YEAR;
+import static java.util.Calendar.ERA;
+import static java.util.Calendar.FEBRUARY;
+import static java.util.Calendar.LONG;
+import static java.util.Calendar.YEAR;
 
 import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
 
 import org.testng.annotations.DataProvider;
@@ -91,19 +97,18 @@ public class SupplementalJapaneseEraTestRun {
     }
 
     private static void testRun(String property, List<String> javaParam)
-            throws Throwable{
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-cp")
-                .addToolArg(Utils.TEST_CLASS_PATH)
-                .addToolArg("-Djdk.calendar.japanese.supplemental.era=" + property)
-                .addToolArg("SupplementalJapaneseEraTest");
-        for (String para: javaParam) {
-            launcher.addToolArg(para);
-        }
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                .getExitValue();
+            throws Throwable {
+        List<String> params = Arrays.asList(
+                "-ea", "-esa",
+                "-cp", Utils.TEST_CLASS_PATH,
+                "-Djdk.calendar.japanese.supplemental.era=" + property,
+                "SupplementalJapaneseEraTest");
+        // Build process (with VM flags)
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                Stream.concat(params.stream(), javaParam.stream()).toList());
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
+
         System.out.println(property + ":pass");
         if (exitCode != 0) {
             System.out.println(property + ":fail");

--- a/test/jdk/java/util/Currency/PropertiesTest.sh
+++ b/test/jdk/java/util/Currency/PropertiesTest.sh
@@ -27,6 +27,7 @@
 #      8157138 8190904
 # @summary tests the capability of replacing the currency data with user
 #     specified currency properties file
+# @requires vm.flagless
 # @build PropertiesTest
 # @run shell/timeout=600 PropertiesTest.sh
 

--- a/test/jdk/java/util/Currency/PropertiesTest.sh
+++ b/test/jdk/java/util/Currency/PropertiesTest.sh
@@ -27,7 +27,6 @@
 #      8157138 8190904
 # @summary tests the capability of replacing the currency data with user
 #     specified currency properties file
-# @requires vm.flagless
 # @build PropertiesTest
 # @run shell/timeout=600 PropertiesTest.sh
 
@@ -77,7 +76,7 @@ failures=0
 
 run() {
     echo ''
-    ${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} -cp ${TESTCLASSES} $* 2>&1
+    ${TESTJAVA}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS} -cp ${TESTCLASSES} $* 2>&1
     if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
 }
 
@@ -111,23 +110,23 @@ echo "Properties location: ${PROPLOCATION}"
 
 # run
 echo ''
-${WRITABLEJDK}${FS}bin${FS}java ${TESTVMOPTS} -cp ${TESTCLASSES} PropertiesTest -d dump3
+${WRITABLEJDK}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS} -cp ${TESTCLASSES} PropertiesTest -d dump3
 if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
 if [ ! -f dump3 ]; then  echo "file dump3 not created. Test cannot execute.  Failed."; exit 1; fi
 
 # run bug7102969 test
 echo ''
-${WRITABLEJDK}${FS}bin${FS}java ${TESTVMOPTS} -cp ${TESTCLASSES} PropertiesTest bug7102969
+${WRITABLEJDK}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS} -cp ${TESTCLASSES} PropertiesTest bug7102969
 if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
 
 # run bug8157138 test
 echo ''
-${WRITABLEJDK}${FS}bin${FS}java ${TESTVMOPTS} -cp ${TESTCLASSES} PropertiesTest bug8157138
+${WRITABLEJDK}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS} -cp ${TESTCLASSES} PropertiesTest bug8157138
 if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
 
 # run bug8190904 test
 echo ''
-${WRITABLEJDK}${FS}bin${FS}java ${TESTVMOPTS} -cp ${TESTCLASSES} PropertiesTest bug8190904
+${WRITABLEJDK}${FS}bin${FS}java ${TESTVMOPTS} ${TESTJAVAOPTS} -cp ${TESTCLASSES} PropertiesTest bug8190904
 if [ $? != 0 ]; then failures=`expr $failures + 1`; fi
 
 # Cleanup

--- a/test/jdk/java/util/Currency/PropertiesTest.sh
+++ b/test/jdk/java/util/Currency/PropertiesTest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@
 
 import java.util.Locale;
 
-import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.Utils;
 
@@ -178,22 +177,18 @@ public class LocaleProvidersRun {
     }
 
     private static void testRun(String prefList, String methodName,
-            String param1, String param2, String param3) throws Throwable{
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-cp")
-                .addToolArg(Utils.TEST_CLASS_PATH)
-                .addToolArg("-Djava.util.logging.config.class=LocaleProviders$LogConfig")
-                .addToolArg("-Djava.locale.providers=" + prefList)
-                .addToolArg("--add-exports=java.base/sun.util.locale.provider=ALL-UNNAMED")
-                .addToolArg("LocaleProviders")
-                .addToolArg(methodName)
-                .addToolArg(param1)
-                .addToolArg(param2)
-                .addToolArg(param3);
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                .getExitValue();
+            String param1, String param2, String param3) throws Throwable {
+
+        // Build process (with VM flags)
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-ea", "-esa",
+                "-cp", Utils.TEST_CLASS_PATH,
+                "-Djava.util.logging.config.class=LocaleProviders$LogConfig",
+                "-Djava.locale.providers=" + prefList,
+                "--add-exports=java.base/sun.util.locale.provider=ALL-UNNAMED",
+                "LocaleProviders", methodName, param1, param2, param3);
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
         if (exitCode != 0) {
             throw new RuntimeException("Unexpected exit code: " + exitCode);
         }

--- a/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
+++ b/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,15 +84,13 @@ public class MissingResourceCauseTestRun {
         // UnreadableRB.properties is in current directory
         String cp = Utils.TEST_CLASSES + File.pathSeparator + Utils.TEST_SRC
                 + File.pathSeparator + ".";
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-cp")
-                .addToolArg(cp)
-                .addToolArg("MissingResourceCauseTest");
-
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                .getExitValue();
+        // Build process (with VM flags)
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-ea", "-esa",
+                "-cp", cp,
+                "MissingResourceCauseTest");
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
         if (exitCode != 0) {
             throw new RuntimeException("Execution of the test failed. "
                     + "Unexpected exit code: " + exitCode);

--- a/test/jdk/java/util/ResourceBundle/modules/ModuleTestUtil.java
+++ b/test/jdk/java/util/ResourceBundle/modules/ModuleTestUtil.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -135,7 +134,7 @@ public class ModuleTestUtil {
      */
     public static void runModule(String mp, String mn, List<String> localeList)
             throws Throwable {
-        List<String> args = Arrays.asList(
+        List<String> args = List.of(
                 "-ea", "-esa",
                 "-p", mp,
                 "-m", mn);
@@ -161,7 +160,7 @@ public class ModuleTestUtil {
      */
     public static void runModuleWithCp(String cp, String mp, String mn,
             List<String> localeList, boolean expected) throws Throwable {
-        List<String> args = Arrays.asList(
+        List<String> args = List.of(
                 "-ea", "-esa",
                 "-cp", cp,
                 "-p", mp,
@@ -196,7 +195,7 @@ public class ModuleTestUtil {
      */
     public static void runModuleWithLegacyCode(String mp, String mn, List<String> localeList)
             throws Throwable {
-        List<String> args = Arrays.asList(
+        List<String> args = List.of(
                 "-ea", "-esa",
                 "-Djava.locale.useOldISOCodes=true",
                 "-p", mp,

--- a/test/jdk/java/util/ResourceBundle/modules/ModuleTestUtil.java
+++ b/test/jdk/java/util/ResourceBundle/modules/ModuleTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
 import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.Utils;
 import jdk.test.lib.compiler.CompilerUtils;
 import jdk.test.lib.process.ProcessTools;
 
@@ -133,17 +135,15 @@ public class ModuleTestUtil {
      */
     public static void runModule(String mp, String mn, List<String> localeList)
             throws Throwable {
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-p")
-                .addToolArg(mp)
-                .addToolArg("-m")
-                .addToolArg(mn);
-        localeList.forEach(launcher::addToolArg);
-
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                                   .getExitValue();
+        List<String> args = Arrays.asList(
+                "-ea", "-esa",
+                "-p", mp,
+                "-m", mn);
+        // Build process (with VM flags)
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                Stream.concat(args.stream(), localeList.stream()).toList());
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
         if (exitCode != 0) {
             throw new RuntimeException("Execution of the test failed. "
                     + "Unexpected exit code: " + exitCode);
@@ -161,19 +161,17 @@ public class ModuleTestUtil {
      */
     public static void runModuleWithCp(String cp, String mp, String mn,
             List<String> localeList, boolean expected) throws Throwable {
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-cp")
-                .addToolArg(cp)
-                .addToolArg("-p")
-                .addToolArg(mp)
-                .addToolArg("-m")
-                .addToolArg(mn);
-        localeList.forEach(launcher::addToolArg);
+        List<String> args = Arrays.asList(
+                "-ea", "-esa",
+                "-cp", cp,
+                "-p", mp,
+                "-m", mn);
+        // Build process (with VM flags)
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                Stream.concat(args.stream(), localeList.stream()).toList());
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
 
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                                   .getExitValue();
         if (expected) {
             if (exitCode != 0) {
                 throw new RuntimeException("Execution of the test loads bundles "
@@ -198,18 +196,17 @@ public class ModuleTestUtil {
      */
     public static void runModuleWithLegacyCode(String mp, String mn, List<String> localeList)
             throws Throwable {
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-Djava.locale.useOldISOCodes=true")
-                .addToolArg("-p")
-                .addToolArg(mp)
-                .addToolArg("-m")
-                .addToolArg(mn);
-        localeList.forEach(launcher::addToolArg);
+        List<String> args = Arrays.asList(
+                "-ea", "-esa",
+                "-Djava.locale.useOldISOCodes=true",
+                "-p", mp,
+                "-m", mn);
+        // Build process (with VM flags)
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                Stream.concat(args.stream(), localeList.stream()).toList());
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
 
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                .getExitValue();
         if (exitCode != 0) {
             throw new RuntimeException("Execution of the test failed. "
                     + "Unexpected exit code: " + exitCode);

--- a/test/jdk/java/util/ResourceBundle/modules/layer/LayerTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/layer/LayerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,16 +71,13 @@ public class LayerTest {
     }
 
     private static void runCmd() throws Throwable {
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-cp")
-                .addToolArg(Utils.TEST_CLASSES)
-                .addToolArg("Main")
-                .addToolArg(Utils.TEST_CLASSES);
-
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                                   .getExitValue();
+        // Build process (with VM flags)
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-ea", "-esa",
+                "-cp", Utils.TEST_CLASSES,
+                "Main", Utils.TEST_CLASSES);
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
         if (exitCode != 0) {
             throw new RuntimeException("Execution of the test failed. "
                     + "Unexpected exit code: " + exitCode);

--- a/test/jdk/java/util/ResourceBundle/modules/unnamed/UnNamedTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/unnamed/UnNamedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,9 @@
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
@@ -73,42 +75,34 @@ public class UnNamedTest {
 
     private static void runCmd() throws Throwable {
         // access resource bundles that are exported private unconditionally.
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-cp")
-                .addToolArg(Utils.TEST_CLASSES)
-                .addToolArg("--module-path")
-                .addToolArg(MODS_DIR.toString())
-                .addToolArg("--add-modules")
-                .addToolArg("bundles")
-                .addToolArg("Main");
-        LOCALE_LIST.forEach(launcher::addToolArg);
-
-        int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                                   .getExitValue();
+        List<String> args = Arrays.asList(
+                "-ea", "-esa",
+                "-cp", Utils.TEST_CLASSES,
+                "--module-path", MODS_DIR.toString(),
+                "--add-modules", "bundles",
+                "Main");
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                Stream.concat(args.stream(), LOCALE_LIST.stream()).toList());
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
         if (exitCode != 0) {
             throw new RuntimeException("Execution of the test1 failed. "
                     + "Unexpected exit code: " + exitCode);
         }
 
         // --add-exports can't open resources
-        launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa")
-                .addToolArg("-cp")
-                .addToolArg(Utils.TEST_CLASSES)
-                .addToolArg("--module-path")
-                .addToolArg(MODS_DIR.toString())
-                .addToolArg("--add-modules")
-                .addToolArg("bundles")
-                .addToolArg("--add-opens")
-                .addToolArg("bundles/jdk.test.internal.resources=ALL-UNNAMED")
-                .addToolArg("Main");
-        LOCALE_LIST.forEach(launcher::addToolArg);
+        List<String> argsWithOpens = Arrays.asList(
+                "-ea", "-esa",
+                "-cp", Utils.TEST_CLASSES,
+                "--module-path", MODS_DIR.toString(),
+                "--add-modules", "bundles",
+                "--add-opens", "bundles/jdk.test.internal.resources=ALL-UNNAMED",
+                "Main");
+        pb = ProcessTools.createTestJavaProcessBuilder(
+                Stream.concat(argsWithOpens.stream(), LOCALE_LIST.stream()).toList());
 
-        exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                               .getExitValue();
+        // Evaluate process status
+        exitCode = ProcessTools.executeCommand(pb).getExitValue();
         if (exitCode != 0) {
             throw new RuntimeException("Execution of the test2 failed. "
                     + "Unexpected exit code: " + exitCode);

--- a/test/jdk/java/util/ResourceBundle/modules/unnamed/UnNamedTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/unnamed/UnNamedTest.java
@@ -38,7 +38,6 @@
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -75,7 +74,7 @@ public class UnNamedTest {
 
     private static void runCmd() throws Throwable {
         // access resource bundles that are exported private unconditionally.
-        List<String> args = Arrays.asList(
+        List<String> args = List.of(
                 "-ea", "-esa",
                 "-cp", Utils.TEST_CLASSES,
                 "--module-path", MODS_DIR.toString(),
@@ -91,7 +90,7 @@ public class UnNamedTest {
         }
 
         // --add-exports can't open resources
-        List<String> argsWithOpens = Arrays.asList(
+        List<String> argsWithOpens = List.of(
                 "-ea", "-esa",
                 "-cp", Utils.TEST_CLASSES,
                 "--module-path", MODS_DIR.toString(),

--- a/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,10 +39,12 @@
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.stream.Stream;
 
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
+
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -328,11 +330,10 @@ public class VisibilityTest {
     }
 
     private int runCmd(List<String> argsList) throws Throwable {
-        JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-        launcher.addToolArg("-ea")
-                .addToolArg("-esa");
-        argsList.forEach(launcher::addToolArg);
-
-        return ProcessTools.executeCommand(launcher.getCommand()).getExitValue();
+        // Build process (with VM flags)
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                Stream.concat(Stream.of("-ea", "-esa"), argsList.stream()).toList());
+        // Evaluate process status
+        return ProcessTools.executeCommand(pb).getExitValue();
     }
 }

--- a/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
+++ b/test/jdk/java/util/TimeZone/CustomTzIDCheckDST.java
@@ -29,16 +29,18 @@
  * @requires os.family != "windows"
  * @run main/othervm CustomTzIDCheckDST
  */
+
 import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
+
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
+
 public class CustomTzIDCheckDST {
     // Northern Hemisphere
     private static String CUSTOM_TZ = "MEZ-1MESZ,M3.5.0,M10.5.0/3";
@@ -46,7 +48,7 @@ public class CustomTzIDCheckDST {
     private static String CUSTOM_TZ2 = "MEZ-1MESZ,M10.5.0,M3.5.0/3";
     public static void main(String args[]) throws Throwable {
         if (args.length == 0) {
-            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(List.of("CustomTzIDCheckDST", "runTZTest"));
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("CustomTzIDCheckDST", "runTZTest");
             pb.environment().put("TZ", CUSTOM_TZ);
             OutputAnalyzer output = ProcessTools.executeProcess(pb);
             output.shouldHaveExitValue(0);

--- a/test/jdk/java/util/TimeZone/TimeZoneDatePermissionCheckRun.java
+++ b/test/jdk/java/util/TimeZone/TimeZoneDatePermissionCheckRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,17 +66,15 @@ public class TimeZoneDatePermissionCheckRun {
             //run it with the security manager on, plus accesscontroller debugging
             //will go into infinite recursion trying to get enough permissions for
             //printing Date of failing certificate unless fix is applied.
-            JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("java");
-            launcher.addToolArg("-Djava.security.manager")
-                    .addToolArg("-Djava.security.debug=access,failure,policy")
-                    .addToolArg("-ea")
-                    .addToolArg("-esa")
-                    .addToolArg("-cp")
-                    .addToolArg(jarPath)
-                    .addToolArg("TimeZoneDatePermissionCheck");
-
-            int exitCode = ProcessTools.executeCommand(launcher.getCommand())
-                    .getExitValue();
+            // Build process (with VM flags)
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                    "-Djava.security.manager",
+                    "-Djava.security.debug=access,failure,policy",
+                    "-ea", "-esa",
+                    "-cp", jarPath,
+                    "TimeZoneDatePermissionCheck");
+            // Evaluate process status
+            int exitCode = ProcessTools.executeCommand(pb).getExitValue();
             if (exitCode != 0) {
                 throw new RuntimeException("Unexpected exit code: " + exitCode);
             }

--- a/test/jdk/java/util/logging/LoggingDeadlock2.java
+++ b/test/jdk/java/util/logging/LoggingDeadlock2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,12 @@
  * @test
  * @bug     6467152 6716076 6829503 8132550
  * @summary deadlock occurs in LogManager initialization and JVM termination
+ * @key randomness
+ * @library /test/lib
  * @author  Serguei Spitsyn / Hitachi / Martin Buchholz
  *
  * @build    LoggingDeadlock2
  * @run  main LoggingDeadlock2
- * @key randomness
  */
 
 /*
@@ -63,6 +64,8 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.concurrent.TimeUnit;
 
+import jdk.test.lib.process.ProcessTools;
+
 public class LoggingDeadlock2 {
 
     // ask child process to dumpstack after 60secs
@@ -74,7 +77,9 @@ public class LoggingDeadlock2 {
     public static void realMain(String arg[]) throws Throwable {
         try {
             System.out.println(javaChildArgs);
-            ProcessBuilder pb = new ProcessBuilder(javaChildArgs);
+            // Build process (with VM flags)
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                    javaChildArgs);
             ProcessResults r = run(pb.start());
             equal(r.exitValue(), 99);
 
@@ -151,9 +156,6 @@ public class LoggingDeadlock2 {
     //----------------------------------------------------------------
     // The rest of this test is copied from ProcessBuilder/Basic.java
     //----------------------------------------------------------------
-    private static final String javaExe =
-        System.getProperty("java.home") +
-        File.separator + "bin" + File.separator + "java";
     private static final String jstackExe =
         System.getProperty("java.home") +
         File.separator + "bin" + File.separator + "jstack";
@@ -161,10 +163,8 @@ public class LoggingDeadlock2 {
     private static final String classpath =
         System.getProperty("java.class.path");
 
-    private static final List<String> javaChildArgs =
-        Arrays.asList(new String[]
-            { javaExe, "-classpath", classpath,
-              "LoggingDeadlock2$JavaChild"});
+   private static final List<String> javaChildArgs = Arrays.asList(
+       "-classpath", classpath, "LoggingDeadlock2$JavaChild");
 
     private static class ProcessResults {
         private final String out;

--- a/test/jdk/java/util/logging/LoggingDeadlock2.java
+++ b/test/jdk/java/util/logging/LoggingDeadlock2.java
@@ -51,7 +51,6 @@
  * This is a regression test for this bug.
  */
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CyclicBarrier;
@@ -163,7 +162,7 @@ public class LoggingDeadlock2 {
     private static final String classpath =
         System.getProperty("java.class.path");
 
-   private static final List<String> javaChildArgs = Arrays.asList(
+   private static final List<String> javaChildArgs = List.of(
        "-classpath", classpath, "LoggingDeadlock2$JavaChild");
 
     private static class ProcessResults {

--- a/test/jdk/java/util/zip/EntryCount64k.java
+++ b/test/jdk/java/util/zip/EntryCount64k.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013 Google Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +38,6 @@ import java.nio.file.Files;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.RandomAccessFile;
-import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -161,11 +161,7 @@ public class EntryCount64k {
         }
 
         // Check java -jar
-        String javaHome = System.getProperty("java.home");
-        String java = Paths.get(javaHome, "bin", "java").toString();
-        String[] cmd = { java, "-jar", zipFile.getName() };
-        ProcessBuilder pb = new ProcessBuilder(cmd);
-        OutputAnalyzer a = ProcessTools.executeProcess(pb);
+        OutputAnalyzer a = ProcessTools.executeTestJvm("-jar", zipFile.getName());
         a.shouldHaveExitValue(0);
         a.stdoutShouldMatch("\\AMain\\Z");
         a.stderrShouldMatch("\\A\\Z");

--- a/test/jdk/java/util/zip/EntryCount64k.java
+++ b/test/jdk/java/util/zip/EntryCount64k.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2013 Google Inc. All rights reserved.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this PR which allows these _j.util_ tests to launch new JVM processes with VM flags,

This is primarily done using by switching to `ProcessTools::createTestJavaProcessBuilder`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319569](https://bugs.openjdk.org/browse/JDK-8319569): Several java/util tests should be updated to accept VM flags (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16705/head:pull/16705` \
`$ git checkout pull/16705`

Update a local copy of the PR: \
`$ git checkout pull/16705` \
`$ git pull https://git.openjdk.org/jdk.git pull/16705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16705`

View PR using the GUI difftool: \
`$ git pr show -t 16705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16705.diff">https://git.openjdk.org/jdk/pull/16705.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16705#issuecomment-1816030776)