### PR TITLE
8320272: Make method_entry_barrier address shared

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -55,7 +55,7 @@ int C2EntryBarrierStub::max_size() const {
 
 void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
-  __ movptr(rscratch1, (uintptr_t) StubRoutines::aarch64::method_entry_barrier());
+  __ lea(rscratch1, RuntimeAddress(StubRoutines::method_entry_barrier()));
   __ blr(rscratch1);
   __ b(continuation());
 

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -358,7 +358,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
   __ br(condition, barrier_target);
 
   if (slow_path == nullptr) {
-    __ movptr(rscratch1, (uintptr_t) StubRoutines::aarch64::method_entry_barrier());
+    __ lea(rscratch1, RuntimeAddress(StubRoutines::method_entry_barrier()));
     __ blr(rscratch1);
     __ b(skip_barrier);
 

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -8378,7 +8378,7 @@ class StubGenerator: public StubCodeGenerator {
 
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != nullptr) {
-      StubRoutines::aarch64::_method_entry_barrier = generate_method_entry_barrier();
+      StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
     }
 
     StubRoutines::aarch64::_spin_wait = generate_spin_wait();

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.cpp
@@ -56,7 +56,6 @@ address StubRoutines::aarch64::_string_indexof_linear_ll = nullptr;
 address StubRoutines::aarch64::_string_indexof_linear_uu = nullptr;
 address StubRoutines::aarch64::_string_indexof_linear_ul = nullptr;
 address StubRoutines::aarch64::_large_byte_array_inflate = nullptr;
-address StubRoutines::aarch64::_method_entry_barrier = nullptr;
 
 static void empty_spin_wait() { }
 address StubRoutines::aarch64::_spin_wait = CAST_FROM_FN_PTR(address, empty_spin_wait);

--- a/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/stubRoutines_aarch64.hpp
@@ -71,8 +71,6 @@ class aarch64 {
   static address _string_indexof_linear_ul;
   static address _large_byte_array_inflate;
 
-  static address _method_entry_barrier;
-
   static address _spin_wait;
 
   static bool _completed;
@@ -177,10 +175,6 @@ class aarch64 {
 
   static address large_byte_array_inflate() {
       return _large_byte_array_inflate;
-  }
-
-  static address method_entry_barrier() {
-    return _method_entry_barrier;
   }
 
   static address spin_wait() {

--- a/src/hotspot/cpu/arm/gc/shared/barrierSetAssembler_arm.cpp
+++ b/src/hotspot/cpu/arm/gc/shared/barrierSetAssembler_arm.cpp
@@ -227,7 +227,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   __ cmp(tmp0, tmp1);
   __ b(skip, eq);
 
-  __ mov_address(tmp0, StubRoutines::Arm::method_entry_barrier());
+  __ mov_address(tmp0, StubRoutines::method_entry_barrier());
   __ call(tmp0);
   __ b(skip);
 

--- a/src/hotspot/cpu/arm/stubGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/stubGenerator_arm.cpp
@@ -3188,7 +3188,7 @@ class StubGenerator: public StubCodeGenerator {
 
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != nullptr) {
-      StubRoutines::Arm::_method_entry_barrier = generate_method_entry_barrier();
+      StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
     }
 
   }

--- a/src/hotspot/cpu/arm/stubRoutines_arm.cpp
+++ b/src/hotspot/cpu/arm/stubRoutines_arm.cpp
@@ -33,5 +33,3 @@ address StubRoutines::Arm::_partial_subtype_check = nullptr;
 
 address StubRoutines::_atomic_load_long_entry = nullptr;
 address StubRoutines::_atomic_store_long_entry = nullptr;
-
-address StubRoutines::Arm::_method_entry_barrier = nullptr;

--- a/src/hotspot/cpu/arm/stubRoutines_arm.hpp
+++ b/src/hotspot/cpu/arm/stubRoutines_arm.hpp
@@ -45,13 +45,11 @@ class Arm {
 
   static address _idiv_irem_entry;
   static address _partial_subtype_check;
-  static address _method_entry_barrier;
 
  public:
 
   static address idiv_irem_entry() { return _idiv_irem_entry; }
   static address partial_subtype_check() { return _partial_subtype_check; }
-  static address method_entry_barrier() { return _method_entry_barrier; }
 };
 
   static bool returns_to_call_stub(address return_pc) {

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -188,7 +188,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Register t
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
   // Load stub address using toc (fixed instruction size, unlike load_const_optimized)
-  __ calculate_address_from_global_toc(tmp, StubRoutines::ppc::nmethod_entry_barrier(),
+  __ calculate_address_from_global_toc(tmp, StubRoutines::method_entry_barrier(),
                                        true, true, false); // 2 instructions
   __ mtctr(tmp);
 

--- a/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/stubGenerator_ppc.cpp
@@ -3558,7 +3558,7 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-  address generate_nmethod_entry_barrier() {
+  address generate_method_entry_barrier() {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", "nmethod_entry_barrier");
 
@@ -4806,7 +4806,7 @@ class StubGenerator: public StubCodeGenerator {
     // nmethod entry barriers for concurrent class unloading
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != nullptr) {
-      StubRoutines::ppc::_nmethod_entry_barrier            = generate_nmethod_entry_barrier();
+      StubRoutines::_method_entry_barrier            = generate_method_entry_barrier();
     }
 
     // arraycopy stubs used by compilers

--- a/src/hotspot/cpu/ppc/stubRoutines_ppc.hpp
+++ b/src/hotspot/cpu/ppc/stubRoutines_ppc.hpp
@@ -53,11 +53,7 @@ class ppc {
   friend class StubGenerator;
 
  private:
-  static address _nmethod_entry_barrier;
-
  public:
-  static address nmethod_entry_barrier();
-
   static address generate_crc_constants(juint reverse_poly);
 };
 

--- a/src/hotspot/cpu/ppc/stubRoutines_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/stubRoutines_ppc_64.cpp
@@ -206,8 +206,3 @@ address StubRoutines::ppc::generate_crc_constants(juint reverse_poly) {
 
   return consts;
 }
-
-address StubRoutines::ppc::_nmethod_entry_barrier = nullptr;
-address StubRoutines::ppc::nmethod_entry_barrier() {
-  return _nmethod_entry_barrier;
-}

--- a/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
@@ -60,10 +60,13 @@ int C2EntryBarrierStub::max_size() const {
 
 void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
+  RuntimeAddress target(StubRoutines::method_entry_barrier());
+  __ relocate(target.rspec(), [&] {
+    int32_t offset;
+    __ la_patchable(t0, target, offset);
+    __ jalr(ra, t0, offset);
+  });
 
-  int32_t offset = 0;
-  __ movptr(t0, StubRoutines::method_entry_barrier(), offset);
-  __ jalr(ra, t0, offset);
   __ j(continuation());
 
   // make guard value 4-byte aligned so that it can be accessed by atomic instructions on RISC-V

--- a/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
@@ -62,7 +62,7 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
 
   int32_t offset = 0;
-  __ movptr(t0, StubRoutines::riscv::method_entry_barrier(), offset);
+  __ movptr(t0, StubRoutines::method_entry_barrier(), offset);
   __ jalr(ra, t0, offset);
   __ j(continuation());
 

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -309,7 +309,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
     __ beq(t0, t1, skip_barrier);
 
     int32_t offset = 0;
-    __ movptr(t0, StubRoutines::riscv::method_entry_barrier(), offset);
+    __ movptr(t0, StubRoutines::method_entry_barrier(), offset);
     __ jalr(ra, t0, offset);
     __ j(skip_barrier);
 

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -308,9 +308,13 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
     Label skip_barrier;
     __ beq(t0, t1, skip_barrier);
 
-    int32_t offset = 0;
-    __ movptr(t0, StubRoutines::method_entry_barrier(), offset);
-    __ jalr(ra, t0, offset);
+    RuntimeAddress target(StubRoutines::method_entry_barrier());
+    __ relocate(target.rspec(), [&] {
+      int32_t offset;
+      __ la_patchable(t0, target, offset);
+      __ jalr(ra, t0, offset);
+    });
+
     __ j(skip_barrier);
 
     __ bind(local_guard);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4605,7 +4605,7 @@ class StubGenerator: public StubCodeGenerator {
 
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != nullptr) {
-      StubRoutines::riscv::_method_entry_barrier = generate_method_entry_barrier();
+      StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
     }
 
     StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
@@ -53,6 +53,5 @@ address StubRoutines::riscv::_string_indexof_linear_ll = nullptr;
 address StubRoutines::riscv::_string_indexof_linear_uu = nullptr;
 address StubRoutines::riscv::_string_indexof_linear_ul = nullptr;
 address StubRoutines::riscv::_large_byte_array_inflate = nullptr;
-address StubRoutines::riscv::_method_entry_barrier = nullptr;
 
 bool StubRoutines::riscv::_completed = false;

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -70,8 +70,6 @@ class riscv {
   static address _string_indexof_linear_ul;
   static address _large_byte_array_inflate;
 
-  static address _method_entry_barrier;
-
   static bool _completed;
 
  public:
@@ -146,10 +144,6 @@ class riscv {
 
   static address large_byte_array_inflate() {
     return _large_byte_array_inflate;
-  }
-
-  static address method_entry_barrier() {
-    return _method_entry_barrier;
   }
 
   static bool complete() {

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -132,7 +132,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm) {
   __ block_comment("nmethod_entry_barrier (nmethod_entry_barrier) {");
 
     // Load jump addr:
-    __ load_const(Z_R1_scratch, (uint64_t)StubRoutines::zarch::nmethod_entry_barrier()); // 2*6 bytes
+    __ load_const(Z_R1_scratch, (uint64_t)StubRoutines::method_entry_barrier()); // 2*6 bytes
 
     // Load value from current java object:
     __ z_lg(Z_R0_scratch, in_bytes(bs_nm->thread_disarmed_guard_value_offset()), Z_thread); // 6 bytes

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -3015,7 +3015,7 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-  address generate_nmethod_entry_barrier() {
+  address generate_method_entry_barrier() {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", "nmethod_entry_barrier");
 
@@ -3187,7 +3187,7 @@ class StubGenerator: public StubCodeGenerator {
     // nmethod entry barriers for concurrent class unloading
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != nullptr) {
-      StubRoutines::zarch::_nmethod_entry_barrier = generate_nmethod_entry_barrier();
+      StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
     }
 
     StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();

--- a/src/hotspot/cpu/s390/stubRoutines_s390.cpp
+++ b/src/hotspot/cpu/s390/stubRoutines_s390.cpp
@@ -38,8 +38,6 @@ address StubRoutines::zarch::_partial_subtype_check = nullptr;
 // Comapct string intrinsics: Translate table for string inflate intrinsic. Used by trot instruction.
 address StubRoutines::zarch::_trot_table_addr = nullptr;
 
-address StubRoutines::zarch::_nmethod_entry_barrier = nullptr;
-
 int StubRoutines::zarch::_atomic_memory_operation_lock = StubRoutines::zarch::unlocked;
 
 #define __ masm->

--- a/src/hotspot/cpu/s390/stubRoutines_s390.hpp
+++ b/src/hotspot/cpu/s390/stubRoutines_s390.hpp
@@ -80,8 +80,6 @@ class zarch {
   static address _trot_table_addr;
   static jlong   _trot_table[TROT_COLUMN_SIZE];
 
-  static address _nmethod_entry_barrier;
-
  public:
   // Global lock for everyone who needs to use atomic_compare_and_exchange
   // or atomic_increment -- should probably use more locks for more
@@ -102,8 +100,6 @@ class zarch {
 
   // Comapct string intrinsics: Translate table for string inflate intrinsic. Used by trot instruction.
   static void generate_load_trot_table_addr(MacroAssembler* masm, Register table);
-
-  static address nmethod_entry_barrier() { return _nmethod_entry_barrier; }
 };
 
 #endif // CPU_S390_STUBROUTINES_S390_HPP

--- a/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_CodeStubs_x86.cpp
@@ -69,7 +69,7 @@ int C2EntryBarrierStub::max_size() const {
 
 void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ bind(entry());
-  __ call(RuntimeAddress(StubRoutines::x86::method_entry_barrier()));
+  __ call(RuntimeAddress(StubRoutines::method_entry_barrier()));
   __ jmp(continuation(), false /* maybe_short */);
 }
 

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -402,7 +402,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label* slo
   } else {
     Label done;
     __ jccb(Assembler::equal, done);
-    __ call(RuntimeAddress(StubRoutines::x86::method_entry_barrier()));
+    __ call(RuntimeAddress(StubRoutines::method_entry_barrier()));
     __ bind(done);
   }
 }
@@ -423,7 +423,7 @@ void BarrierSetAssembler::nmethod_entry_barrier(MacroAssembler* masm, Label*, La
   __ cmpl_imm32(disarmed_addr, 0);
   __ pop(tmp);
   __ jcc(Assembler::equal, continuation);
-  __ call(RuntimeAddress(StubRoutines::x86::method_entry_barrier()));
+  __ call(RuntimeAddress(StubRoutines::method_entry_barrier()));
   __ bind(continuation);
 }
 #endif

--- a/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_32.cpp
@@ -4218,7 +4218,7 @@ class StubGenerator: public StubCodeGenerator {
 
     BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
     if (bs_nm != nullptr) {
-      StubRoutines::x86::_method_entry_barrier = generate_method_entry_barrier();
+      StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
     }
   }
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4052,7 +4052,7 @@ void StubGenerator::generate_final_stubs() {
 
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm != nullptr) {
-    StubRoutines::x86::_method_entry_barrier = generate_method_entry_barrier();
+    StubRoutines::_method_entry_barrier = generate_method_entry_barrier();
   }
 
   if (UseVectorizedMismatchIntrinsic) {

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -132,8 +132,6 @@ class x86 {
 
   static address _verify_mxcsr_entry;
 
-  static address _method_entry_barrier;
-
   // masks and table for CRC32
   static const uint64_t _crc_by128_masks[];
   static const juint    _crc_table[];

--- a/src/hotspot/cpu/x86/stubRoutines_x86_32.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86_32.cpp
@@ -32,7 +32,6 @@
 // a description of how to extend it, see the stubRoutines.hpp file.
 
 address StubRoutines::x86::_verify_fpu_cntrl_wrd_entry = nullptr;
-address StubRoutines::x86::_method_entry_barrier = nullptr;
 
 address StubRoutines::x86::_d2i_wrapper = nullptr;
 address StubRoutines::x86::_d2l_wrapper = nullptr;

--- a/src/hotspot/cpu/x86/stubRoutines_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86_64.cpp
@@ -44,5 +44,4 @@ address StubRoutines::x86::_float_sign_mask = nullptr;
 address StubRoutines::x86::_float_sign_flip = nullptr;
 address StubRoutines::x86::_double_sign_mask = nullptr;
 address StubRoutines::x86::_double_sign_flip = nullptr;
-address StubRoutines::x86::_method_entry_barrier = nullptr;
 

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -146,8 +146,7 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm != nullptr) {
     thread_disarmed_guard_value_offset = in_bytes(bs_nm->thread_disarmed_guard_value_offset());
-    AMD64_ONLY(nmethod_entry_barrier = StubRoutines::method_entry_barrier());
-    AARCH64_ONLY(nmethod_entry_barrier = StubRoutines::method_entry_barrier());
+    nmethod_entry_barrier = StubRoutines::method_entry_barrier();
     BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
     AARCH64_ONLY(BarrierSetAssembler_nmethod_patching_type = (int) bs_asm->nmethod_patching_type());
     AARCH64_ONLY(BarrierSetAssembler_patching_epoch_addr = bs_asm->patching_epoch_addr());

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -146,8 +146,8 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
   if (bs_nm != nullptr) {
     thread_disarmed_guard_value_offset = in_bytes(bs_nm->thread_disarmed_guard_value_offset());
-    AMD64_ONLY(nmethod_entry_barrier = StubRoutines::x86::method_entry_barrier());
-    AARCH64_ONLY(nmethod_entry_barrier = StubRoutines::aarch64::method_entry_barrier());
+    AMD64_ONLY(nmethod_entry_barrier = StubRoutines::method_entry_barrier());
+    AARCH64_ONLY(nmethod_entry_barrier = StubRoutines::method_entry_barrier());
     BarrierSetAssembler* bs_asm = BarrierSet::barrier_set()->barrier_set_assembler();
     AARCH64_ONLY(BarrierSetAssembler_nmethod_patching_type = (int) bs_asm->nmethod_patching_type());
     AARCH64_ONLY(BarrierSetAssembler_patching_epoch_addr = bs_asm->patching_epoch_addr());

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -176,6 +176,7 @@ address StubRoutines::_hf2f = nullptr;
 address StubRoutines::_vector_f_math[VectorSupport::NUM_VEC_SIZES][VectorSupport::NUM_SVML_OP] = {{nullptr}, {nullptr}};
 address StubRoutines::_vector_d_math[VectorSupport::NUM_VEC_SIZES][VectorSupport::NUM_SVML_OP] = {{nullptr}, {nullptr}};
 
+address StubRoutines::_method_entry_barrier = nullptr;
 address StubRoutines::_array_sort = nullptr;
 address StubRoutines::_array_partition  = nullptr;
 

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -256,6 +256,8 @@ class StubRoutines: AllStatic {
   static address _f2hf;
   static address _hf2f;
 
+  static address _method_entry_barrier;
+
   static address _cont_thaw;
   static address _cont_returnBarrier;
   static address _cont_returnBarrierExc;
@@ -459,6 +461,8 @@ class StubRoutines: AllStatic {
     typedef jfloat (*hf2f_stub_t)(jshort x);
     return ((hf2f_stub_t)_hf2f)(x);
   }
+
+  static address method_entry_barrier() { return _method_entry_barrier; }
 
   static address cont_thaw()           { return _cont_thaw; }
   static address cont_returnBarrier()  { return _cont_returnBarrier; }


### PR DESCRIPTION
Currently all platforms have declared their own address variable for method_entry_barrier stub. Some have even slightly different name: nmethod_entry_barrier. For Leyden project one address is preferable.
In aarch64 code changed `movptr` to `lea` instruction to get relocation info as on x86.

Tested x86 and aarch64, tier1-4, xcomp, stress.  I need help to test on other platforms. Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320272](https://bugs.openjdk.org/browse/JDK-8320272): Make method_entry_barrier address shared (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [359135e5](https://git.openjdk.org/jdk/pull/16708/files/359135e5a89976e08c70c6855e173bdf24eee9d1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16708/head:pull/16708` \
`$ git checkout pull/16708`

Update a local copy of the PR: \
`$ git checkout pull/16708` \
`$ git pull https://git.openjdk.org/jdk.git pull/16708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16708`

View PR using the GUI difftool: \
`$ git pr show -t 16708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16708.diff">https://git.openjdk.org/jdk/pull/16708.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16708#issuecomment-1816710500)