### PR TITLE
8316734: URLEncoder should specify that replacement bytes will be used in case of coding error

### DIFF
--- a/src/java.base/share/classes/java/net/URLDecoder.java
+++ b/src/java.base/share/classes/java/net/URLDecoder.java
@@ -144,24 +144,28 @@ public class URLDecoder {
      * Decodes an {@code application/x-www-form-urlencoded} string using
      * a specific {@linkplain Charset Charset}.
      * The supplied charset is used to determine
-     * what characters are represented by any consecutive sequences of the
-     * form "<i>{@code %xy}</i>".
+     * what characters are represented by any consecutive escape sequences of
+     * the form "<i>{@code %xy}</i>".
      * <p>
      * <em><strong>Note:</strong> The <a href=
      * "http://www.w3.org/TR/html40/appendix/notes.html#non-ascii-chars">
      * World Wide Web Consortium Recommendation</a> states that
      * UTF-8 should be used. Not doing so may introduce
      * incompatibilities.</em>
+     * <p>
+     * If any consecutive well-formed escape sequences cannot
+     * be decoded as a sequence of characters in the supplied {@code Charset}
+     * {@linkplain java.nio.charset.CharsetDecoder##cae the replacement character} will be used.
      *
      * @implNote This implementation will throw an {@link java.lang.IllegalArgumentException}
-     * when illegal strings are encountered.
+     * when malformed escape sequences are encountered.
      *
      * @param s the {@code String} to decode
      * @param charset the given charset
      * @return the newly decoded {@code String}
      * @throws NullPointerException if {@code s} or {@code charset} is {@code null}
-     * @throws IllegalArgumentException if the implementation encounters illegal
-     * characters
+     * @throws IllegalArgumentException if the implementation encounters malformed
+     * escape sequences
      *
      * @spec https://www.w3.org/TR/html4 HTML 4.01 Specification
      * @see URLEncoder#encode(java.lang.String, Charset)

--- a/src/java.base/share/classes/java/net/URLDecoder.java
+++ b/src/java.base/share/classes/java/net/URLDecoder.java
@@ -155,7 +155,6 @@ public class URLDecoder {
      * World Wide Web Consortium Recommendation</a> states that
      * UTF-8 should be used. Not doing so may introduce
      * incompatibilities.</em>
-     * <p>
      *
      * @param s the {@code String} to decode
      * @param charset the given charset

--- a/src/java.base/share/classes/java/net/URLDecoder.java
+++ b/src/java.base/share/classes/java/net/URLDecoder.java
@@ -98,6 +98,8 @@ public class URLDecoder {
      *          default charset. Instead, use the decode(String,String) method
      *          to specify the encoding.
      * @return the newly decoded {@code String}
+     * @throws IllegalArgumentException if the implementation encounters malformed
+     * escape sequences
      */
     @Deprecated
     public static String decode(String s) {
@@ -113,9 +115,6 @@ public class URLDecoder {
      * except that it will {@linkplain Charset#forName look up the charset}
      * using the given encoding name.
      *
-     * @implNote This implementation will throw an {@link java.lang.IllegalArgumentException}
-     * when illegal strings are encountered.
-     *
      * @param s the {@code String} to decode
      * @param enc   The name of a supported
      *    <a href="../lang/package-summary.html#charenc">character
@@ -124,6 +123,8 @@ public class URLDecoder {
      * @throws UnsupportedEncodingException
      *             If character encoding needs to be consulted, but
      *             named character encoding is not supported
+     * @throws IllegalArgumentException if the implementation encounters malformed
+     * escape sequences
      * @see URLEncoder#encode(java.lang.String, java.lang.String)
      * @since 1.4
      */
@@ -145,7 +146,9 @@ public class URLDecoder {
      * a specific {@linkplain Charset Charset}.
      * The supplied charset is used to determine
      * what characters are represented by any consecutive escape sequences of
-     * the form "<i>{@code %xy}</i>".
+     * the form "<i>{@code %xy}</i>". Erroneous bytes are replaced with the
+     * supplied {@code Charset}'s {@linkplain java.nio.charset.CharsetDecoder##cae
+     * replacement value}.
      * <p>
      * <em><strong>Note:</strong> The <a href=
      * "http://www.w3.org/TR/html40/appendix/notes.html#non-ascii-chars">
@@ -153,12 +156,6 @@ public class URLDecoder {
      * UTF-8 should be used. Not doing so may introduce
      * incompatibilities.</em>
      * <p>
-     * If any consecutive well-formed escape sequences cannot
-     * be decoded as a sequence of characters in the supplied {@code Charset}
-     * {@linkplain java.nio.charset.CharsetDecoder##cae the replacement character} will be used.
-     *
-     * @implNote This implementation will throw an {@link java.lang.IllegalArgumentException}
-     * when malformed escape sequences are encountered.
      *
      * @param s the {@code String} to decode
      * @param charset the given charset

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -204,6 +204,9 @@ public class URLEncoder {
      * "http://www.w3.org/TR/html40/appendix/notes.html#non-ascii-chars">
      * World Wide Web Consortium Recommendation</a> states that
      * UTF-8 should be used. Not doing so may introduce incompatibilities.</em>
+     * <p>
+     * If a character needs encoding but cannot be encoded, the
+     * {@linkplain CharsetEncoder##cae replacement bytes} will be used.
      *
      * @param   s   {@code String} to be translated.
      * @param charset the given charset

--- a/src/java.base/share/classes/java/net/URLEncoder.java
+++ b/src/java.base/share/classes/java/net/URLEncoder.java
@@ -200,14 +200,15 @@ public class URLEncoder {
      * This method uses the supplied charset to obtain the bytes for unsafe
      * characters.
      * <p>
-     * <em><strong>Note:</strong> The <a href=
+     * If the input string is malformed, or if the input cannot be mapped
+     * to a valid byte sequence in the given {@code Charset}, then the
+     * erroneous input will be replaced with the {@code Charset}'s
+     * {@linkplain CharsetEncoder##cae replacement values}.
+     *
+     * @apiNote The <a href=
      * "http://www.w3.org/TR/html40/appendix/notes.html#non-ascii-chars">
      * World Wide Web Consortium Recommendation</a> states that
-     * UTF-8 should be used. Not doing so may introduce incompatibilities.</em>
-     * <p>
-     * If a character needs encoding but cannot be encoded, the
-     * {@linkplain CharsetEncoder##cae replacement bytes} will be used.
-     *
+     * UTF-8 should be used. Not doing so may introduce incompatibilities.
      * @param   s   {@code String} to be translated.
      * @param charset the given charset
      * @return  the translated {@code String}.


### PR DESCRIPTION
Currently the descriptions of `URLEncoder.encode` and `URLDecoder.decode` don't specify their use of replacement bytes or replacement character when they cannot handle a character or sequence of bytes. This is longstanding behavior but needs to be documented.

**Solution**
- Added a new line to `URLEncoder.encode` API documentation to document that the charset's replacement bytes are used.

- Also changed `URLDecoder.decode` API documentation to document its use of the charset's replacement character, also changed some wording.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8318004](https://bugs.openjdk.org/browse/JDK-8318004) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8316734](https://bugs.openjdk.org/browse/JDK-8316734): URLEncoder should specify that replacement bytes will be used in case of coding error (**Bug** - P4)
 * [JDK-8318004](https://bugs.openjdk.org/browse/JDK-8318004): URLEncoder should specify that replacement bytes will be used in case of coding error (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16709/head:pull/16709` \
`$ git checkout pull/16709`

Update a local copy of the PR: \
`$ git checkout pull/16709` \
`$ git pull https://git.openjdk.org/jdk.git pull/16709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16709`

View PR using the GUI difftool: \
`$ git pr show -t 16709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16709.diff">https://git.openjdk.org/jdk/pull/16709.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16709#issuecomment-1816719768)