### PR TITLE
8320234: Merge doclint.Env.AccessKind with tool.AccessKind

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
@@ -73,7 +73,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils.Pair;
 import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberCache;
 import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable;
 import jdk.javadoc.internal.doclint.DocLint;
-import jdk.javadoc.internal.tool.AccessKind;
+import jdk.javadoc.internal.tool.AccessLevel;
 
 /**
  * Configure the output based on the options. Doclets should subclass
@@ -654,10 +654,10 @@ public abstract class BaseConfiguration {
 
     private boolean isDocLintGroupEnabled(jdk.javadoc.internal.doclint.Messages.Group group) {
         // Use AccessKind.PUBLIC as a stand-in, since it is not common to
-        // set DocLint options per access kind (as is common with javac.)
-        // A more sophisticated solution might be to derive the access kind from the
+        // set DocLint options per access level (as is common with javac.)
+        // A more sophisticated solution might be to derive the access level from the
         // element owning the comment, and its enclosing elements.
-        return doclint != null && doclint.isGroupEnabled(group, AccessKind.PUBLIC);
+        return doclint != null && doclint.isGroupEnabled(group, AccessLevel.PUBLIC);
     }
     //</editor-fold>
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/BaseConfiguration.java
@@ -73,7 +73,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils.Pair;
 import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberCache;
 import jdk.javadoc.internal.doclets.toolkit.util.VisibleMemberTable;
 import jdk.javadoc.internal.doclint.DocLint;
-import jdk.javadoc.internal.doclint.Env;
+import jdk.javadoc.internal.tool.AccessKind;
 
 /**
  * Configure the output based on the options. Doclets should subclass
@@ -657,7 +657,7 @@ public abstract class BaseConfiguration {
         // set DocLint options per access kind (as is common with javac.)
         // A more sophisticated solution might be to derive the access kind from the
         // element owning the comment, and its enclosing elements.
-        return doclint != null && doclint.isGroupEnabled(group, Env.AccessKind.PUBLIC);
+        return doclint != null && doclint.isGroupEnabled(group, AccessKind.PUBLIC);
     }
     //</editor-fold>
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/DocLint.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/DocLint.java
@@ -64,7 +64,7 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.DefinedBy;
 import com.sun.tools.javac.util.DefinedBy.Api;
 import com.sun.tools.javac.util.StringUtils.DamerauLevenshteinDistance;
-import jdk.javadoc.internal.tool.AccessKind;
+import jdk.javadoc.internal.tool.AccessLevel;
 
 /**
  * Multi-function entry point for the doc check utility.
@@ -411,8 +411,8 @@ public class DocLint extends com.sun.tools.doclint.DocLint {
         return false;
     }
 
-    public boolean isGroupEnabled(Messages.Group group, AccessKind accessKind) {
-        return env.messages.isEnabled(group, accessKind);
+    public boolean isGroupEnabled(Messages.Group group, AccessLevel accessLevel) {
+        return env.messages.isEnabled(group, accessLevel);
     }
 
     private String localize(String code, Object... args) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/DocLint.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/DocLint.java
@@ -64,6 +64,7 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.DefinedBy;
 import com.sun.tools.javac.util.DefinedBy.Api;
 import com.sun.tools.javac.util.StringUtils.DamerauLevenshteinDistance;
+import jdk.javadoc.internal.tool.AccessKind;
 
 /**
  * Multi-function entry point for the doc check utility.
@@ -410,7 +411,7 @@ public class DocLint extends com.sun.tools.doclint.DocLint {
         return false;
     }
 
-    public boolean isGroupEnabled(Messages.Group group, Env.AccessKind accessKind) {
+    public boolean isGroupEnabled(Messages.Group group, AccessKind accessKind) {
         return env.messages.isEnabled(group, accessKind);
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Env.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Env.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,32 +62,13 @@ import com.sun.tools.javac.model.JavacTypes;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.MatchingUtils;
 import com.sun.tools.javac.util.StringUtils;
+import jdk.javadoc.internal.tool.AccessKind;
 
 /**
  * Utility container for current execution environment,
  * providing the current declaration and its doc comment.
  */
 public class Env {
-    /**
-     * Access kinds for declarations.
-     */
-    public enum AccessKind {
-        PRIVATE,
-        PACKAGE,
-        PROTECTED,
-        PUBLIC;
-
-        static AccessKind of(Set<Modifier> mods) {
-            if (mods.contains(Modifier.PUBLIC))
-                return AccessKind.PUBLIC;
-            else if (mods.contains(Modifier.PROTECTED))
-                return AccessKind.PROTECTED;
-            else if (mods.contains(Modifier.PRIVATE))
-                return AccessKind.PRIVATE;
-            else
-                return AccessKind.PACKAGE;
-        }
-    }
 
     /** Message handler. */
     final Messages messages;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Env.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Env.java
@@ -194,18 +194,14 @@ public class Env {
         currElement = trees.getElement(currPath);
         currOverriddenMethods = ((JavacTypes) types).getOverriddenMethods(currElement);
 
-        AccessLevel al = AccessLevel.PUBLIC;
+        var level = AccessLevel.PUBLIC;
         for (TreePath p = path; p != null; p = p.getParentPath()) {
             Element e = trees.getElement(p);
             if (e != null && e.getKind() != ElementKind.PACKAGE && e.getKind() != ElementKind.MODULE) {
-                al = min(al, AccessLevel.of(e.getModifiers()));
+                level = min(level, AccessLevel.of(e.getModifiers()));
             }
         }
-        currAccess = al;
-    }
-
-    AccessLevel getAccessLevel() {
-        return currAccess;
+        currAccess = level;
     }
 
     long getPos(TreePath p) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Env.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Env.java
@@ -62,7 +62,7 @@ import com.sun.tools.javac.model.JavacTypes;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.MatchingUtils;
 import com.sun.tools.javac.util.StringUtils;
-import jdk.javadoc.internal.tool.AccessKind;
+import jdk.javadoc.internal.tool.AccessLevel;
 
 /**
  * Utility container for current execution environment,
@@ -111,12 +111,12 @@ public class Env {
     /** The comment current being analyzed. */
     DocCommentTree currDocComment;
     /**
-     * The access kind of the declaration containing the comment currently being analyzed.
-     * This is the minimum (most restrictive) access kind of the declaration itself
+     * The access level of the declaration containing the comment currently being analyzed.
+     * This is the minimum (most restrictive) access level of the declaration itself
      * and that of its containers. For example, a public method in a private class is
      * noted as private.
      */
-    AccessKind currAccess;
+    AccessLevel currAccess;
     /** The set of methods, if any, that the current declaration overrides. */
     Set<? extends ExecutableElement> currOverriddenMethods;
 
@@ -194,17 +194,17 @@ public class Env {
         currElement = trees.getElement(currPath);
         currOverriddenMethods = ((JavacTypes) types).getOverriddenMethods(currElement);
 
-        AccessKind ak = AccessKind.PUBLIC;
+        AccessLevel al = AccessLevel.PUBLIC;
         for (TreePath p = path; p != null; p = p.getParentPath()) {
             Element e = trees.getElement(p);
             if (e != null && e.getKind() != ElementKind.PACKAGE && e.getKind() != ElementKind.MODULE) {
-                ak = min(ak, AccessKind.of(e.getModifiers()));
+                al = min(al, AccessLevel.of(e.getModifiers()));
             }
         }
-        currAccess = ak;
+        currAccess = al;
     }
 
-    AccessKind getAccessKind() {
+    AccessLevel getAccessLevel() {
         return currAccess;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Env.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Env.java
@@ -77,12 +77,6 @@ public class Env {
         PROTECTED,
         PUBLIC;
 
-        static boolean accepts(String opt) {
-            for (AccessKind g: values())
-                if (opt.equals(StringUtils.toLowerCase(g.name()))) return true;
-            return false;
-        }
-
         static AccessKind of(Set<Modifier> mods) {
             if (mods.contains(Modifier.PUBLIC))
                 return AccessKind.PUBLIC;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
@@ -43,7 +43,7 @@ import com.sun.source.doctree.DocTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.util.StringUtils;
-import jdk.javadoc.internal.tool.AccessKind;
+import jdk.javadoc.internal.tool.AccessLevel;
 
 /**
  * Message reporting for DocLint.
@@ -109,8 +109,8 @@ public class Messages {
         stats.setEnabled(b);
     }
 
-    boolean isEnabled(Group group, AccessKind ak) {
-        return options.isEnabled(group, ak);
+    boolean isEnabled(Group group, AccessLevel al) {
+        return options.isEnabled(group, al);
     }
 
     void reportStats(PrintWriter out) {
@@ -176,7 +176,7 @@ public class Messages {
      * Handler for (sub)options specific to message handling.
      */
     static class Options {
-        Map<String, AccessKind> map = new HashMap<>();
+        Map<String, AccessLevel> map = new HashMap<>();
         private final Stats stats;
 
         static boolean isValidOptions(String opts) {
@@ -199,7 +199,7 @@ public class Messages {
         }
 
         static boolean accepts(String opt) {
-            for (AccessKind g: AccessKind.values())
+            for (AccessLevel g: AccessLevel.values())
                 if (opt.equals(StringUtils.toLowerCase(g.name()))) return true;
             return false;
         }
@@ -209,18 +209,18 @@ public class Messages {
         }
 
         /** Determine if a message group is enabled for a particular access level. */
-        boolean isEnabled(Group g, AccessKind access) {
+        boolean isEnabled(Group g, AccessLevel access) {
             if (map.isEmpty())
-                map.put("all", AccessKind.PROTECTED);
+                map.put("all", AccessLevel.PROTECTED);
 
-            AccessKind ak = map.get(g.optName());
-            if (ak != null && access.compareTo(ak) >= 0)
+            AccessLevel al = map.get(g.optName());
+            if (al != null && access.compareTo(al) >= 0)
                 return true;
 
-            ak = map.get(ALL);
-            if (ak != null && access.compareTo(ak) >= 0) {
-                ak = map.get(g.notOptName());
-                if (ak == null || access.compareTo(ak) > 0) // note >, not >=
+            al = map.get(ALL);
+            if (al != null && access.compareTo(al) >= 0) {
+                al = map.get(g.notOptName());
+                if (al == null || access.compareTo(al) > 0) // note >, not >=
                     return true;
             }
 
@@ -229,7 +229,7 @@ public class Messages {
 
         void setOptions(String opts) {
             if (opts == null)
-                setOption(ALL, AccessKind.PRIVATE);
+                setOption(ALL, AccessLevel.PRIVATE);
             else {
                 for (String opt: opts.split(","))
                     setOption(StringUtils.toLowerCase(opt.trim()));
@@ -244,16 +244,16 @@ public class Messages {
 
             int sep = arg.indexOf("/");
             if (sep > 0) {
-                AccessKind ak = AccessKind.valueOf(StringUtils.toUpperCase(arg.substring(sep + 1)));
-                setOption(arg.substring(0, sep), ak);
+                AccessLevel al = AccessLevel.valueOf(StringUtils.toUpperCase(arg.substring(sep + 1)));
+                setOption(arg.substring(0, sep), al);
             } else {
                 setOption(arg, null);
             }
         }
 
-        private void setOption(String opt, AccessKind ak) {
-            map.put(opt, (ak != null) ? ak
-                    : opt.startsWith("-") ? AccessKind.PUBLIC : AccessKind.PRIVATE);
+        private void setOption(String opt, AccessLevel al) {
+            map.put(opt, (al != null) ? al
+                    : opt.startsWith("-") ? AccessLevel.PUBLIC : AccessLevel.PRIVATE);
         }
 
         private static final String ALL = "all";

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
@@ -43,7 +43,7 @@ import com.sun.source.doctree.DocTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.util.StringUtils;
-import jdk.javadoc.internal.doclint.Env.AccessKind;
+import jdk.javadoc.internal.tool.AccessKind;
 
 /**
  * Message reporting for DocLint.
@@ -109,7 +109,7 @@ public class Messages {
         stats.setEnabled(b);
     }
 
-    boolean isEnabled(Group group, Env.AccessKind ak) {
+    boolean isEnabled(Group group, AccessKind ak) {
         return options.isEnabled(group, ak);
     }
 
@@ -176,7 +176,7 @@ public class Messages {
      * Handler for (sub)options specific to message handling.
      */
     static class Options {
-        Map<String, Env.AccessKind> map = new HashMap<>();
+        Map<String, AccessKind> map = new HashMap<>();
         private final Stats stats;
 
         static boolean isValidOptions(String opts) {
@@ -209,11 +209,11 @@ public class Messages {
         }
 
         /** Determine if a message group is enabled for a particular access level. */
-        boolean isEnabled(Group g, Env.AccessKind access) {
+        boolean isEnabled(Group g, AccessKind access) {
             if (map.isEmpty())
-                map.put("all", Env.AccessKind.PROTECTED);
+                map.put("all", AccessKind.PROTECTED);
 
-            Env.AccessKind ak = map.get(g.optName());
+            AccessKind ak = map.get(g.optName());
             if (ak != null && access.compareTo(ak) >= 0)
                 return true;
 
@@ -229,7 +229,7 @@ public class Messages {
 
         void setOptions(String opts) {
             if (opts == null)
-                setOption(ALL, Env.AccessKind.PRIVATE);
+                setOption(ALL, AccessKind.PRIVATE);
             else {
                 for (String opt: opts.split(","))
                     setOption(StringUtils.toLowerCase(opt.trim()));
@@ -244,16 +244,16 @@ public class Messages {
 
             int sep = arg.indexOf("/");
             if (sep > 0) {
-                Env.AccessKind ak = Env.AccessKind.valueOf(StringUtils.toUpperCase(arg.substring(sep + 1)));
+                AccessKind ak = AccessKind.valueOf(StringUtils.toUpperCase(arg.substring(sep + 1)));
                 setOption(arg.substring(0, sep), ak);
             } else {
                 setOption(arg, null);
             }
         }
 
-        private void setOption(String opt, Env.AccessKind ak) {
+        private void setOption(String opt, AccessKind ak) {
             map.put(opt, (ak != null) ? ak
-                    : opt.startsWith("-") ? Env.AccessKind.PUBLIC : Env.AccessKind.PRIVATE);
+                    : opt.startsWith("-") ? AccessKind.PUBLIC : AccessKind.PRIVATE);
         }
 
         private static final String ALL = "all";

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
@@ -199,8 +199,8 @@ public class Messages {
         }
 
         static boolean accepts(String opt) {
-            for (AccessLevel g: AccessLevel.values())
-                if (opt.equals(StringUtils.toLowerCase(g.name()))) return true;
+            for (var level: AccessLevel.values())
+                if (opt.equals(StringUtils.toLowerCase(level.name()))) return true;
             return false;
         }
 
@@ -244,7 +244,7 @@ public class Messages {
 
             int sep = arg.indexOf("/");
             if (sep > 0) {
-                AccessLevel al = AccessLevel.valueOf(StringUtils.toUpperCase(arg.substring(sep + 1)));
+                var al = AccessLevel.valueOf(StringUtils.toUpperCase(arg.substring(sep + 1)));
                 setOption(arg.substring(0, sep), al);
             } else {
                 setOption(arg, null);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
@@ -195,7 +195,13 @@ public class Messages {
             int sep = opt.indexOf("/");
             String grp = opt.substring(begin, (sep != -1) ? sep : opt.length());
             return ((begin == 0 && grp.equals("all")) || Group.accepts(grp))
-                    && ((sep == -1) || AccessKind.accepts(opt.substring(sep + 1)));
+                    && ((sep == -1) || accepts(opt.substring(sep + 1)));
+        }
+
+        static boolean accepts(String opt) {
+            for (AccessKind g: AccessKind.values())
+                if (opt.equals(StringUtils.toLowerCase(g.name()))) return true;
+            return false;
         }
 
         Options(Stats stats) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Messages.java
@@ -176,7 +176,7 @@ public class Messages {
      * Handler for (sub)options specific to message handling.
      */
     static class Options {
-        Map<String, AccessLevel> map = new HashMap<>();
+        private final Map<String, AccessLevel> map = new HashMap<>();
         private final Stats stats;
 
         static boolean isValidOptions(String opts) {
@@ -211,7 +211,7 @@ public class Messages {
         /** Determine if a message group is enabled for a particular access level. */
         boolean isEnabled(Group g, AccessLevel access) {
             if (map.isEmpty())
-                map.put("all", AccessLevel.PROTECTED);
+                map.put(ALL, AccessLevel.PROTECTED);
 
             AccessLevel al = map.get(g.optName());
             if (al != null && access.compareTo(al) >= 0)
@@ -220,8 +220,7 @@ public class Messages {
             al = map.get(ALL);
             if (al != null && access.compareTo(al) >= 0) {
                 al = map.get(g.notOptName());
-                if (al == null || access.compareTo(al) > 0) // note >, not >=
-                    return true;
+                return al == null || access.compareTo(al) > 0; // note >, not >=
             }
 
             return false;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessKind.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessKind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,16 +25,33 @@
 
 package jdk.javadoc.internal.tool;
 
+import java.util.Set;
+import javax.lang.model.element.Modifier;
+
 /**
  * The access value kinds.
  */
 public enum AccessKind {
-    /** Limits access to public entities */
-    PUBLIC,
-    /** Limits access to public and protected entities */
-    PROTECTED,
+
+    // DO NOT REORDER THESE CONSTANTS OR CODE WILL BREAK
+
+    /** No limits */
+    PRIVATE,
     /** Limits access to public, protected and package private entities */
     PACKAGE,
-    /** No limits */
-    PRIVATE;
+    /** Limits access to public and protected entities */
+    PROTECTED,
+    /** Limits access to public entities */
+    PUBLIC;
+
+    public static AccessKind of(Set<Modifier> mods) {
+        if (mods.contains(Modifier.PUBLIC))
+            return AccessKind.PUBLIC;
+        else if (mods.contains(Modifier.PROTECTED))
+            return AccessKind.PROTECTED;
+        else if (mods.contains(Modifier.PRIVATE))
+            return AccessKind.PRIVATE;
+        else
+            return AccessKind.PACKAGE;
+    }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessLevel.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessLevel.java
@@ -40,7 +40,7 @@ import javax.lang.model.element.Modifier;
  * {@code AccessLevel.values()[values.length() - 1] and the constants with the
  * smallest and the biggest limiting powers respectively.
  */
-public enum AccessLevel {
+public enum AccessLevel implements Comparable<AccessLevel> {
 
     /** Does not limit access */
     PRIVATE,
@@ -50,13 +50,6 @@ public enum AccessLevel {
     PROTECTED,
     /** Limits access to public entities */
     PUBLIC;
-
-    static { // self-test to catch unintended reordering of the constants
-        assert PRIVATE.ordinal() == 0
-                && PACKAGE.ordinal() == 1
-                && PROTECTED.ordinal() == 2
-                && PUBLIC.ordinal() == 3;
-    }
 
     public static AccessLevel of(Set<Modifier> mods) {
         if (mods.contains(Modifier.PUBLIC))

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessLevel.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessLevel.java
@@ -30,19 +30,33 @@ import javax.lang.model.element.Modifier;
 
 /**
  * The access levels.
+ *
+ * These constants are ordered by their access limiting power. The bigger the
+ * {@link #ordinal() ordinal} of a constant, the more limiting power that
+ * constant has.
+ *
+ * That has a few useful implications. For example, the levels can be compared
+ * by {@link #compareTo}. It also means that {@code AccessLevel.values()[0]} and
+ * {@code AccessLevel.values()[values.length() - 1] and the constants with the
+ * smallest and the biggest limiting powers respectively.
  */
 public enum AccessLevel {
 
-    // DO NOT REORDER THESE CONSTANTS OR CODE WILL BREAK
-
-    /** No limits */
+    /** Does not limit access */
     PRIVATE,
-    /** Limits access to public, protected and package private entities */
+    /** Limits access to entities that are public, protected, or declared with package access */
     PACKAGE,
     /** Limits access to public and protected entities */
     PROTECTED,
     /** Limits access to public entities */
     PUBLIC;
+
+    static { // self-test to catch unintended reordering of the constants
+        assert PRIVATE.ordinal() == 0
+                && PACKAGE.ordinal() == 1
+                && PROTECTED.ordinal() == 2
+                && PUBLIC.ordinal() == 3;
+    }
 
     public static AccessLevel of(Set<Modifier> mods) {
         if (mods.contains(Modifier.PUBLIC))

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessLevel.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/AccessLevel.java
@@ -29,9 +29,9 @@ import java.util.Set;
 import javax.lang.model.element.Modifier;
 
 /**
- * The access value kinds.
+ * The access levels.
  */
-public enum AccessKind {
+public enum AccessLevel {
 
     // DO NOT REORDER THESE CONSTANTS OR CODE WILL BREAK
 
@@ -44,14 +44,14 @@ public enum AccessKind {
     /** Limits access to public entities */
     PUBLIC;
 
-    public static AccessKind of(Set<Modifier> mods) {
+    public static AccessLevel of(Set<Modifier> mods) {
         if (mods.contains(Modifier.PUBLIC))
-            return AccessKind.PUBLIC;
+            return AccessLevel.PUBLIC;
         else if (mods.contains(Modifier.PROTECTED))
-            return AccessKind.PROTECTED;
+            return AccessLevel.PROTECTED;
         else if (mods.contains(Modifier.PRIVATE))
-            return AccessKind.PRIVATE;
+            return AccessLevel.PRIVATE;
         else
-            return AccessKind.PACKAGE;
+            return AccessLevel.PACKAGE;
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -1199,10 +1199,8 @@ public class ElementsTable {
          * @param options the tool options
          */
         ModifierFilter(ToolOptions options) {
-
-            AccessLevel accessValue = null;
             for (ElementKind kind : ALLOWED_KINDS) {
-                accessValue = switch (kind) {
+                var accessValue = switch (kind) {
                     case METHOD  -> options.showMembersAccess();
                     case CLASS   -> options.showTypesAccess();
                     case PACKAGE -> options.showPackagesAccess();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -192,7 +192,7 @@ public class ElementsTable {
 
     private final ModifierFilter accessFilter;
 
-    private final AccessKind expandRequires;
+    private final AccessLevel expandRequires;
 
     final boolean xclasses;
 
@@ -605,8 +605,8 @@ public class ElementsTable {
             return;
         }
 
-        final boolean expandAll = expandRequires.equals(AccessKind.PRIVATE)
-                || expandRequires.equals(AccessKind.PACKAGE);
+        final boolean expandAll = expandRequires.equals(AccessLevel.PRIVATE)
+                || expandRequires.equals(AccessLevel.PACKAGE);
 
         Set<ModuleElement> result = new LinkedHashSet<>();
         ListBuffer<ModuleElement> queue = new ListBuffer<>();
@@ -657,13 +657,13 @@ public class ElementsTable {
     }
 
     private Set<PackageElement> computeModulePackages() throws ToolException {
-        AccessKind accessValue = accessFilter.getAccessValue(ElementKind.PACKAGE);
-        final boolean documentAllModulePackages = (accessValue == AccessKind.PACKAGE ||
-                accessValue == AccessKind.PRIVATE);
+        AccessLevel accessValue = accessFilter.getAccessValue(ElementKind.PACKAGE);
+        final boolean documentAllModulePackages = (accessValue == AccessLevel.PACKAGE ||
+                accessValue == AccessLevel.PRIVATE);
 
         accessValue = accessFilter.getAccessValue(ElementKind.MODULE);
-        final boolean moduleDetailedMode = (accessValue == AccessKind.PACKAGE ||
-                accessValue == AccessKind.PRIVATE);
+        final boolean moduleDetailedMode = (accessValue == AccessLevel.PACKAGE ||
+                accessValue == AccessLevel.PRIVATE);
         Set<PackageElement> expandedModulePackages = new LinkedHashSet<>();
 
         for (ModuleElement mdle : specifiedModuleElements) {
@@ -1186,11 +1186,11 @@ public class ElementsTable {
                                                     ElementKind.MODULE);
 
         // all possible access levels allowed for each element
-        private final EnumMap<ElementKind, EnumSet<AccessKind>> filterMap =
+        private final EnumMap<ElementKind, EnumSet<AccessLevel>> filterMap =
                 new EnumMap<>(ElementKind.class);
 
         // the specified access level for each element
-        private final EnumMap<ElementKind, AccessKind> accessMap =
+        private final EnumMap<ElementKind, AccessLevel> accessMap =
                 new EnumMap<>(ElementKind.class);
 
         /**
@@ -1200,7 +1200,7 @@ public class ElementsTable {
          */
         ModifierFilter(ToolOptions options) {
 
-            AccessKind accessValue = null;
+            AccessLevel accessValue = null;
             for (ElementKind kind : ALLOWED_KINDS) {
                 accessValue = switch (kind) {
                     case METHOD  -> options.showMembersAccess();
@@ -1214,20 +1214,20 @@ public class ElementsTable {
             }
         }
 
-        static EnumSet<AccessKind> getFilterSet(AccessKind accessValue) {
+        static EnumSet<AccessLevel> getFilterSet(AccessLevel accessValue) {
             return switch (accessValue) {
-                case PUBLIC    -> EnumSet.of(AccessKind.PUBLIC);
-                case PROTECTED -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED);
-                case PACKAGE   -> EnumSet.of(AccessKind.PUBLIC, AccessKind.PROTECTED, AccessKind.PACKAGE);
-                case PRIVATE   -> EnumSet.allOf(AccessKind.class);
+                case PUBLIC    -> EnumSet.of(AccessLevel.PUBLIC);
+                case PROTECTED -> EnumSet.of(AccessLevel.PUBLIC, AccessLevel.PROTECTED);
+                case PACKAGE   -> EnumSet.of(AccessLevel.PUBLIC, AccessLevel.PROTECTED, AccessLevel.PACKAGE);
+                case PRIVATE   -> EnumSet.allOf(AccessLevel.class);
             };
         }
 
-        public AccessKind getAccessValue(ElementKind kind) {
+        public AccessLevel getAccessValue(ElementKind kind) {
             if (!ALLOWED_KINDS.contains(kind)) {
                 throw new IllegalArgumentException("not allowed: " + kind);
             }
-            return accessMap.getOrDefault(kind, AccessKind.PROTECTED);
+            return accessMap.getOrDefault(kind, AccessLevel.PROTECTED);
         }
 
         /**
@@ -1238,15 +1238,15 @@ public class ElementsTable {
          */
         public boolean checkModifier(Element e) {
             Set<Modifier> modifiers = e.getModifiers();
-            AccessKind fflag = AccessKind.PACKAGE;
+            AccessLevel fflag = AccessLevel.PACKAGE;
             if (modifiers.contains(Modifier.PUBLIC)) {
-                fflag = AccessKind.PUBLIC;
+                fflag = AccessLevel.PUBLIC;
             } else if (modifiers.contains(Modifier.PROTECTED)) {
-                fflag = AccessKind.PROTECTED;
+                fflag = AccessLevel.PROTECTED;
             } else if (modifiers.contains(Modifier.PRIVATE)) {
-                fflag = AccessKind.PRIVATE;
+                fflag = AccessLevel.PRIVATE;
             }
-            EnumSet<AccessKind> filterSet = filterMap.get(getAllowedKind(e.getKind()));
+            EnumSet<AccessLevel> filterSet = filterMap.get(getAllowedKind(e.getKind()));
             return filterSet.contains(fflag);
         }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
@@ -935,9 +935,7 @@ public class ToolOptions {
      */
     private AccessLevel getAccessValue(String arg) throws OptionException {
         int colon = arg.indexOf(':');
-        String value = (colon > 0)
-                ? arg.substring(colon + 1)
-                : arg;
+        String value = (colon > 0) ? arg.substring(colon + 1) : arg;
         return switch (value) {
             case "public" -> AccessLevel.PUBLIC;
             case "protected" -> AccessLevel.PROTECTED;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
@@ -85,7 +85,7 @@ public class ToolOptions {
     /**
      * Argument for command-line option {@code --expand-requires}.
      */
-    private AccessKind expandRequires;
+    private AccessLevel expandRequires;
 
     /**
      * Argument for command-line option {@code --ignore-source-errors}.
@@ -106,22 +106,22 @@ public class ToolOptions {
     /**
      * Argument for command-line option {@code --show-members}.
      */
-    private AccessKind showMembersAccess;
+    private AccessLevel showMembersAccess;
 
     /**
      * Argument for command-line option {@code --show-types}.
      */
-    private AccessKind showTypesAccess;
+    private AccessLevel showTypesAccess;
 
     /**
      * Argument for command-line option {@code --show-packages}.
      */
-    private AccessKind showPackagesAccess;
+    private AccessLevel showPackagesAccess;
 
     /**
      * Argument for command-line option {@code --show-module-contents}.
      */
-    private AccessKind showModuleContents;
+    private AccessLevel showModuleContents;
 
     /**
      * Argument for command-line option {@code -quiet}.
@@ -717,7 +717,7 @@ public class ToolOptions {
     /**
      * Argument for command-line option {@code --expand-requires}.
      */
-    AccessKind expandRequires() {
+    AccessLevel expandRequires() {
         return expandRequires;
     }
 
@@ -746,28 +746,28 @@ public class ToolOptions {
     /**
      * Argument for command-line option {@code --show-members}.
      */
-    AccessKind showMembersAccess() {
+    AccessLevel showMembersAccess() {
         return showMembersAccess;
     }
 
     /**
      * Argument for command-line option {@code --show-types}.
      */
-    AccessKind showTypesAccess() {
+    AccessLevel showTypesAccess() {
         return showTypesAccess;
     }
 
     /**
      * Argument for command-line option {@code --show-packages}.
      */
-    AccessKind showPackagesAccess() {
+    AccessLevel showPackagesAccess() {
         return showPackagesAccess;
     }
 
     /**
      * Argument for command-line option {@code --show-module-contents}.
      */
-    AccessKind showModuleContents() {
+    AccessLevel showModuleContents() {
         return showModuleContents;
     }
 
@@ -886,10 +886,10 @@ public class ToolOptions {
     private void setExpandRequires(String arg) throws OptionException {
         switch (arg) {
             case "transitive":
-                expandRequires = AccessKind.PUBLIC;
+                expandRequires = AccessLevel.PUBLIC;
                 break;
             case "all":
-                expandRequires = AccessKind.PRIVATE;
+                expandRequires = AccessLevel.PRIVATE;
                 break;
             default:
                 throw illegalOptionValue(arg);
@@ -899,10 +899,10 @@ public class ToolOptions {
     private void setShowModuleContents(String arg) throws OptionException {
         switch (arg) {
             case "api":
-                showModuleContents = AccessKind.PUBLIC;
+                showModuleContents = AccessLevel.PUBLIC;
                 break;
             case "all":
-                showModuleContents = AccessKind.PRIVATE;
+                showModuleContents = AccessLevel.PRIVATE;
                 break;
             default:
                 throw illegalOptionValue(arg);
@@ -912,10 +912,10 @@ public class ToolOptions {
     private void setShowPackageAccess(String arg) throws OptionException {
         switch (arg) {
             case "exported":
-                showPackagesAccess = AccessKind.PUBLIC;
+                showPackagesAccess = AccessLevel.PUBLIC;
                 break;
             case "all":
-                showPackagesAccess = AccessKind.PRIVATE;
+                showPackagesAccess = AccessLevel.PRIVATE;
                 break;
             default:
                 throw illegalOptionValue(arg);
@@ -948,20 +948,20 @@ public class ToolOptions {
      * -private, so on, in addition to the new ones such as
      * --show-types:public and so on.
      */
-    private AccessKind getAccessValue(String arg) throws OptionException {
+    private AccessLevel getAccessValue(String arg) throws OptionException {
         int colon = arg.indexOf(':');
         String value = (colon > 0)
                 ? arg.substring(colon + 1)
                 : arg;
         switch (value) {
             case "public":
-                return AccessKind.PUBLIC;
+                return AccessLevel.PUBLIC;
             case "protected":
-                return AccessKind.PROTECTED;
+                return AccessLevel.PROTECTED;
             case "package":
-                return AccessKind.PACKAGE;
+                return AccessLevel.PACKAGE;
             case "private":
-                return AccessKind.PRIVATE;
+                return AccessLevel.PRIVATE;
             default:
                 throw illegalOptionValue(value);
         }
@@ -971,14 +971,14 @@ public class ToolOptions {
      * Sets all access members to PROTECTED; this is the default.
      */
     private void setAccessDefault() {
-        setAccess(AccessKind.PROTECTED);
+        setAccess(AccessLevel.PROTECTED);
     }
 
     /*
      * This sets access to all the allowed kinds in the
      * access members.
      */
-    private void setAccess(AccessKind accessValue) {
+    private void setAccess(AccessLevel accessValue) {
         for (ElementKind kind : ElementsTable.ModifierFilter.ALLOWED_KINDS) {
             switch (kind) {
                 case METHOD:

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ToolOptions.java
@@ -885,40 +885,25 @@ public class ToolOptions {
 
     private void setExpandRequires(String arg) throws OptionException {
         switch (arg) {
-            case "transitive":
-                expandRequires = AccessLevel.PUBLIC;
-                break;
-            case "all":
-                expandRequires = AccessLevel.PRIVATE;
-                break;
-            default:
-                throw illegalOptionValue(arg);
+            case "transitive" -> expandRequires = AccessLevel.PUBLIC;
+            case "all" -> expandRequires = AccessLevel.PRIVATE;
+            default -> throw illegalOptionValue(arg);
         }
     }
 
     private void setShowModuleContents(String arg) throws OptionException {
         switch (arg) {
-            case "api":
-                showModuleContents = AccessLevel.PUBLIC;
-                break;
-            case "all":
-                showModuleContents = AccessLevel.PRIVATE;
-                break;
-            default:
-                throw illegalOptionValue(arg);
+            case "api" -> showModuleContents = AccessLevel.PUBLIC;
+            case "all" -> showModuleContents = AccessLevel.PRIVATE;
+            default -> throw illegalOptionValue(arg);
         }
     }
 
     private void setShowPackageAccess(String arg) throws OptionException {
         switch (arg) {
-            case "exported":
-                showPackagesAccess = AccessLevel.PUBLIC;
-                break;
-            case "all":
-                showPackagesAccess = AccessLevel.PRIVATE;
-                break;
-            default:
-                throw illegalOptionValue(arg);
+            case "exported" -> showPackagesAccess = AccessLevel.PUBLIC;
+            case "all" -> showPackagesAccess = AccessLevel.PRIVATE;
+            default -> throw illegalOptionValue(arg);
         }
     }
 
@@ -953,18 +938,13 @@ public class ToolOptions {
         String value = (colon > 0)
                 ? arg.substring(colon + 1)
                 : arg;
-        switch (value) {
-            case "public":
-                return AccessLevel.PUBLIC;
-            case "protected":
-                return AccessLevel.PROTECTED;
-            case "package":
-                return AccessLevel.PACKAGE;
-            case "private":
-                return AccessLevel.PRIVATE;
-            default:
-                throw illegalOptionValue(value);
-        }
+        return switch (value) {
+            case "public" -> AccessLevel.PUBLIC;
+            case "protected" -> AccessLevel.PROTECTED;
+            case "package" -> AccessLevel.PACKAGE;
+            case "private" -> AccessLevel.PRIVATE;
+            default -> throw illegalOptionValue(value);
+        };
     }
 
     /*
@@ -975,26 +955,17 @@ public class ToolOptions {
     }
 
     /*
-     * This sets access to all the allowed kinds in the
+     * Sets access level to all the allowed kinds in the
      * access members.
      */
     private void setAccess(AccessLevel accessValue) {
         for (ElementKind kind : ElementsTable.ModifierFilter.ALLOWED_KINDS) {
             switch (kind) {
-                case METHOD:
-                    showMembersAccess = accessValue;
-                    break;
-                case CLASS:
-                    showTypesAccess = accessValue;
-                    break;
-                case PACKAGE:
-                    showPackagesAccess = accessValue;
-                    break;
-                case MODULE:
-                    showModuleContents = accessValue;
-                    break;
-                default:
-                    throw new AssertionError("unknown element kind:" + kind);
+                case METHOD -> showMembersAccess = accessValue;
+                case CLASS -> showTypesAccess = accessValue;
+                case PACKAGE -> showPackagesAccess = accessValue;
+                case MODULE -> showModuleContents = accessValue;
+                default -> throw new AssertionError("unknown element kind:" + kind);
             }
         }
     }


### PR DESCRIPTION
Back when DocLint lived in jdk.compiler, neither jdk.javadoc had access to DocLint, nor DocLint had access to jdk.javadoc. Since DocLint moved to jdk.javadoc, some redundancy can be eliminated and functionality shared; AccessKind is one such functionality.

There's more that could be done here. For example, jdk.javadoc.internal.doclint.Messages.Options can be simplified more. However, it's a separate issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320234](https://bugs.openjdk.org/browse/JDK-8320234): Merge doclint.Env.AccessKind with tool.AccessKind (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16714/head:pull/16714` \
`$ git checkout pull/16714`

Update a local copy of the PR: \
`$ git checkout pull/16714` \
`$ git pull https://git.openjdk.org/jdk.git pull/16714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16714`

View PR using the GUI difftool: \
`$ git pr show -t 16714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16714.diff">https://git.openjdk.org/jdk/pull/16714.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16714#issuecomment-1816889634)