### PR TITLE
8319817: Charset constructor should make defensive copy of aliases

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -705,12 +705,12 @@ public abstract class Charset
      *         If the canonical name or any of the aliases are illegal
      */
     protected Charset(String canonicalName, String[] aliases) {
-        String[] as = aliases == null ?
+        String[] as =
+            aliases == null ?
                 zeroAliases :
-                (this.getClass().getClassLoader() == null ||
-                 this.getClass().getClassLoader() == ClassLoader.getPlatformClassLoader()) ?
-                        aliases :
-                        Arrays.copyOf(aliases, aliases.length);
+                VM.isSystemDomainLoader(getClass().getClassLoader()) ?
+                    aliases :
+                    Arrays.copyOf(aliases, aliases.length);
 
         // Skip checks for the standard, built-in Charsets we always load
         // during initialization.

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -719,7 +719,7 @@ public abstract class Charset
             }
         }
         this.name = canonicalName;
-        this.aliases = as;
+        this.aliases = Arrays.copyOf(as, as.length);
     }
 
     /**

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -42,7 +42,6 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -706,7 +705,12 @@ public abstract class Charset
      *         If the canonical name or any of the aliases are illegal
      */
     protected Charset(String canonicalName, String[] aliases) {
-        String[] as = Objects.requireNonNullElse(aliases, zeroAliases);
+        String[] as = aliases == null ?
+                zeroAliases :
+                (this.getClass().getClassLoader() == null ||
+                 this.getClass().getClassLoader() == ClassLoader.getPlatformClassLoader()) ?
+                        aliases :
+                        Arrays.copyOf(aliases, aliases.length);
 
         // Skip checks for the standard, built-in Charsets we always load
         // during initialization.
@@ -719,7 +723,7 @@ public abstract class Charset
             }
         }
         this.name = canonicalName;
-        this.aliases = Arrays.copyOf(as, as.length);
+        this.aliases = as;
     }
 
     /**

--- a/test/jdk/java/nio/charset/Charset/AliasesCopy.java
+++ b/test/jdk/java/nio/charset/Charset/AliasesCopy.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) , 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8319817
+ * @summary Check that aliases cannot be mutated
+ * @run junit AliasesCopy
+ */
+
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+public class AliasesCopy {
+    private static final Set<String> ALIASES_SET = Set.of("foo-alias");
+    private static final String[] MUTABLE_ALIASES = ALIASES_SET.toArray(String[]::new);
+
+    @Test
+    public void aliasesCopy() {
+        final FooCharset cs = new FooCharset();
+        cs.changeAliasesAfterConstruction();
+        assertIterableEquals(ALIASES_SET, cs.aliases());
+    }
+
+    private static final class FooCharset extends Charset {
+        private FooCharset() {
+            super("foo", MUTABLE_ALIASES);
+        }
+
+        private void changeAliasesAfterConstruction() {
+            MUTABLE_ALIASES[0] = "bar-alias";
+        }
+
+        @Override
+        public CharsetEncoder newEncoder() {
+            throw new RuntimeException("not implemented");
+        }
+
+        @Override
+        public CharsetDecoder newDecoder() {
+            throw new RuntimeException("not implemented");
+        }
+
+        @Override
+        public boolean contains(Charset cs) {
+            throw new RuntimeException("not implemented");
+        }
+    }
+}

--- a/test/jdk/java/nio/charset/Charset/AliasesCopy.java
+++ b/test/jdk/java/nio/charset/Charset/AliasesCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) , 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/nio/charset/Charset/AliasesCopy.java
+++ b/test/jdk/java/nio/charset/Charset/AliasesCopy.java
@@ -33,27 +33,22 @@ import java.nio.charset.CharsetEncoder;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 public class AliasesCopy {
     private static final Set<String> ALIASES_SET = Set.of("foo-alias");
-    private static final String[] MUTABLE_ALIASES = ALIASES_SET.toArray(String[]::new);
+    private static final String[] ALIASES_ARRAY = ALIASES_SET.toArray(String[]::new);
 
     @Test
     public void aliasesCopy() {
-        final FooCharset cs = new FooCharset();
-        cs.changeAliasesAfterConstruction();
+        final FooCharset cs = new FooCharset(ALIASES_ARRAY);
+        ALIASES_ARRAY[0] = "bar-alias";
         assertIterableEquals(ALIASES_SET, cs.aliases());
     }
 
     private static final class FooCharset extends Charset {
-        private FooCharset() {
-            super("foo", MUTABLE_ALIASES);
-        }
-
-        private void changeAliasesAfterConstruction() {
-            MUTABLE_ALIASES[0] = "bar-alias";
+        private FooCharset(String[] aliases) {
+            super("foo", aliases);
         }
 
         @Override


### PR DESCRIPTION
Fixing `Charset(String, String[])` to make a defensive copy of the given `aliases` when necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319817](https://bugs.openjdk.org/browse/JDK-8319817): Charset constructor should make defensive copy of aliases (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16715/head:pull/16715` \
`$ git checkout pull/16715`

Update a local copy of the PR: \
`$ git checkout pull/16715` \
`$ git pull https://git.openjdk.org/jdk.git pull/16715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16715`

View PR using the GUI difftool: \
`$ git pr show -t 16715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16715.diff">https://git.openjdk.org/jdk/pull/16715.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16715#issuecomment-1816945370)