### PR TITLE
8320348: test/jdk/java/io/File/GetAbsolutePath.windowsDriveRelative fails if working directory is not on drive C

### DIFF
--- a/test/jdk/java/io/File/GetAbsolutePath.java
+++ b/test/jdk/java/io/File/GetAbsolutePath.java
@@ -88,7 +88,10 @@ public class GetAbsolutePath {
             File f = new File(z + ":.");
             if (f.exists()) {
                 String zUSER_DIR = f.getCanonicalPath();
-                assertEquals(z + ":foo", zUSER_DIR + "\\foo");
+                File path = new File(z + ":foo");
+                String p = path.getAbsolutePath();
+                String ans = zUSER_DIR + "\\foo";
+                assertEquals(0, p.compareToIgnoreCase(ans));
             }
         }
     }


### PR DESCRIPTION
The method `windowsDriveRelative` of the test `java/io/File/GetAbsolutePath` was incorrectly translated from its previous version to the current JUnit 5 version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320348](https://bugs.openjdk.org/browse/JDK-8320348): test/jdk/java/io/File/GetAbsolutePath.windowsDriveRelative fails if working directory is not on drive C (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16720/head:pull/16720` \
`$ git checkout pull/16720`

Update a local copy of the PR: \
`$ git checkout pull/16720` \
`$ git pull https://git.openjdk.org/jdk.git pull/16720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16720`

View PR using the GUI difftool: \
`$ git pr show -t 16720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16720.diff">https://git.openjdk.org/jdk/pull/16720.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16720#issuecomment-1817165437)