### PR TITLE
JDK-8320361: Doc error in RemoteRecordingStream.java

### DIFF
--- a/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
+++ b/src/jdk.management.jfr/share/classes/jdk/management/jfr/RemoteRecordingStream.java
@@ -565,7 +565,6 @@ public final class RemoteRecordingStream implements EventStream {
      * The following code snippet illustrates how this method can be used in
      * conjunction with the {@link #startAsync()} method to monitor what happens
      * during a test method:
-     * <p>
      * {@snippet :
      *   AtomicLong bytesWritten = new AtomicLong();
      *   try (var r = new RemoteRecordingStream(connection)) {


### PR DESCRIPTION
Please review a trivial `noreg-doc` fix to remove a redundant `<p>` tag before `{@snippet}`.  While mostly harmless, the empty paragraph does show up in HTML reports.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320361](https://bugs.openjdk.org/browse/JDK-8320361): Doc error in RemoteRecordingStream.java (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16721/head:pull/16721` \
`$ git checkout pull/16721`

Update a local copy of the PR: \
`$ git checkout pull/16721` \
`$ git pull https://git.openjdk.org/jdk.git pull/16721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16721`

View PR using the GUI difftool: \
`$ git pr show -t 16721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16721.diff">https://git.openjdk.org/jdk/pull/16721.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16721#issuecomment-1817274278)