### PR TITLE
JDK-8320368: Per-CPU optimization of Klass range reservation

### DIFF
--- a/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "logging/log.hpp"
+#include "oops/compressedKlass.hpp"
+#include "runtime/os.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size_t size, bool aslr, bool optimize_for_zero_base) {
+
+  char* result = nullptr;
+
+  // Optimize for base=0 shift=0
+  if (optimize_for_zero_base) {
+    result = reserve_address_space_for_unscaled_encoding(size, aslr);
+  }
+
+  // If this fails, we don't bother aiming for zero-based encoding (base=0 shift>0), since it has no
+  // advantages over movk mode. A single movk is as fast as an lsl.
+
+  // Allocate for movk mode: we aim for a base address that can be be combined with a 32-bit
+  // narrow Klass ID using a single movk into the third quadrant - addresses with bits only in [32,48).
+  // These are addresses that are 4G-aligned and smaller than 256TB.
+  if (result == nullptr) {
+    result = reserve_address_space_for_16bit_move(size, aslr);
+  }
+
+  // If that failed, attempt to allocate at any 4G-aligned address. Let the system decide where. For ASLR,
+  // we now rely on the system.
+  // Compared with the probing done above, this has two disadvantages:
+  // - on a kernel with 52-bit address space we may get an address that has bits set between [48, 52).
+  //   In that case, we may need two movk moves (not yet implemented).
+  // - this technique leads to temporary over-reservation of address space; it will spike the vsize of
+  //   the process. Therefore it may fail if a vsize limit is in place (e.g. ulimit -v).
+  if (result == nullptr) {
+    constexpr size_t alignment = nth_bit(32);
+    log_debug(metaspace, map)("Trying to reserve at a 32-bit-aligned address");
+    result = os::reserve_memory_aligned(size, alignment, false);
+  }
+
+  return result;
+}
+
+void CompressedKlassPointers::initialize(address addr, size_t len) {
+  constexpr uintptr_t unscaled_max = nth_bit(32);
+  assert(len <= unscaled_max, "Klass range larger than 32 bits?");
+
+  // Shift is always 0 on aarch64.
+  _shift = 0;
+
+  // On aarch64, we don't bother with zero-based encoding (base=0 shift>0).
+  address const end = addr + len;
+  _base = (end <= (address)unscaled_max) ? nullptr : addr;
+
+  _range = end - _base;
+}

--- a/src/hotspot/cpu/ppc/compressedKlass_ppc.cpp
+++ b/src/hotspot/cpu/ppc/compressedKlass_ppc.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "oops/compressedKlass.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size_t size, bool aslr, bool optimize_for_zero_base) {
+
+  char* result = nullptr;
+
+  // Optimize for base=0 shift=0; failing that, for base=0 shift>0
+  if (optimize_for_zero_base) {
+    result = reserve_address_space_for_unscaled_encoding(size, aslr);
+    if (result == nullptr) {
+      result = reserve_address_space_for_zerobased_encoding(size, aslr);
+    }
+  }
+
+  // Optimize for a single 16-bit move: a base that has only bits set in its third quadrant [32..48).
+  if (result == nullptr) {
+    result = reserve_address_space_for_16bit_move(size, aslr);
+  }
+
+  return result;
+}

--- a/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compressedKlass_riscv.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "oops/compressedKlass.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size_t size, bool aslr, bool optimize_for_zero_base) {
+
+  char* result = nullptr;
+
+  // RiscV loads a 64-bit immediate in up to four separate steps, splitting it into four different sections
+  // (two 32-bit sections, each split into two subsections of 20/12 bits).
+  //
+  // 63 ....... 44 43 ... 32 31 ....... 12 11 ... 0
+  //       D           C          B           A
+  //
+  // A "good" base is, in this order:
+  // 1) only bits in A; this would be an address < 2KB, which is unrealistic on normal Linux boxes since
+  //    the typical default for vm.mmap_min_address is 64KB. We ignore that.
+  // 2) only bits in B: a 12-bit-aligned address below 4GB. 12 bit = 2KB, but mmap reserves at
+  //    page boundaries, smallest page size is 4KB, so we can ignore the 12-bit alignment.
+  // 3) only bits in C: a 4GB-aligned address that is lower than 16TB.
+  // 4) only bits in D: a 16TB-aligned address.
+
+  // First, attempt to allocate < 4GB. We do this unconditionally:
+  // - if can_optimize_for_zero_base, a <4GB mapping start would allow us to run unscaled (base = 0, shift = 0)
+  // - if !can_optimize_for_zero_base, a <4GB mapping start is still good, the resulting immediate can be encoded
+  //   with one instruction (2)
+  result = reserve_address_space_for_unscaled_encoding(size, aslr);
+
+  // Failing that, attempt to reserve for base=zero shift>0
+  if (result == nullptr && optimize_for_zero_base) {
+    result = reserve_address_space_for_zerobased_encoding(size, aslr);
+  }
+
+  // Failing that, optimize for case (3) - a base with only bits set between [33-44)
+  if (result == nullptr) {
+    const uintptr_t from = nth_bit(32 + (optimize_for_zero_base ? LogKlassAlignmentInBytes : 0));
+    constexpr uintptr_t to = nth_bit(44);
+    constexpr size_t alignment = nth_bit(32);
+    result = reserve_address_space_X(from, to, size, alignment, aslr);
+  }
+
+  // Failing that, optimize for case (4) - a base with only bits set between [44-64)
+  if (result == nullptr) {
+    constexpr uintptr_t from = nth_bit(44);
+    constexpr uintptr_t to = UINT64_MAX;
+    constexpr size_t alignment = nth_bit(44);
+    result = reserve_address_space_X(from, to, size, alignment, aslr);
+  }
+
+  return result;
+}

--- a/src/hotspot/cpu/s390/compressedKlass_s390.cpp
+++ b/src/hotspot/cpu/s390/compressedKlass_s390.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "oops/compressedKlass.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size_t size, bool aslr, bool optimize_for_zero_base) {
+
+  char* result = nullptr;
+
+  uintptr_t tried_below = 0;
+
+  // First, attempt to allocate < 4GB. We do this unconditionally:
+  // - if optimize_for_zero_base, a <4GB mapping start allows us to use base=0 shift=0
+  // - if !optimize_for_zero_base, a <4GB mapping start allows us to use algfi
+  result = reserve_address_space_for_unscaled_encoding(size, aslr);
+
+  // Failing that, try optimized for base=0 shift>0
+  if (result == nullptr && optimize_for_zero_base) {
+    result = reserve_address_space_for_zerobased_encoding(size, aslr);
+  }
+
+  // Failing that, aim for a base that is 4G-aligned; such a base can be set with aih.
+  if (result == nullptr) {
+    result = reserve_address_space_for_16bit_move(size, aslr);
+  }
+
+  return result;
+}

--- a/src/hotspot/cpu/x86/compressedKlass_x86.cpp
+++ b/src/hotspot/cpu/x86/compressedKlass_x86.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "oops/compressedKlass.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size_t size, bool aslr, bool optimize_for_zero_base) {
+
+  char* result = nullptr;
+
+  // Optimize for unscaled encoding; failing that, for zero-based encoding:
+  if (optimize_for_zero_base) {
+    result = reserve_address_space_for_unscaled_encoding(size, aslr);
+    if (result == nullptr) {
+      result = reserve_address_space_for_zerobased_encoding(size, aslr);
+    }
+  } // end: low-address reservation
+
+  // Nothing more to optimize for on x64. If base != 0, we will always emit the full 64-bit immediate.
+  return result;
+}

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4037,6 +4037,7 @@ char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, i
 // available (and not reserved for something else).
 
 char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec) {
+
   // Assert only that the size is a multiple of the page size, since
   // that's all that mmap requires, and since that's all we really know
   // about at this low abstraction level.  If we need higher alignment,

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -343,9 +343,10 @@ char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, in
 }
 
 static size_t calculate_aligned_extra_size(size_t size, size_t alignment) {
-  assert((alignment & (os::vm_allocation_granularity() - 1)) == 0,
+  assert(is_aligned(alignment, os::vm_allocation_granularity()),
       "Alignment must be a multiple of allocation granularity (page size)");
-  assert((size & (alignment -1)) == 0, "size must be 'alignment' aligned");
+  assert(is_aligned(size, os::vm_allocation_granularity()),
+      "Size must be a multiple of allocation granularity (page size)");
 
   size_t extra_size = size + alignment;
   assert(extra_size >= size, "overflow, size is too large to allow alignment");

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3328,9 +3328,10 @@ char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, in
 // virtual space to get requested alignment, like posix-like os's.
 // Windows prevents multiple thread from remapping over each other so this loop is thread-safe.
 static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int file_desc) {
-  assert((alignment & (os::vm_allocation_granularity() - 1)) == 0,
-         "Alignment must be a multiple of allocation granularity (page size)");
-  assert((size & (alignment -1)) == 0, "size must be 'alignment' aligned");
+  assert(is_aligned(alignment, os::vm_allocation_granularity()),
+      "Alignment must be a multiple of allocation granularity (page size)");
+  assert(is_aligned(size, os::vm_allocation_granularity()),
+      "Size must be a multiple of allocation granularity (page size)");
 
   size_t extra_size = size + alignment;
   assert(extra_size >= size, "overflow, size is too large to allow alignment");

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -577,54 +578,13 @@ bool Metaspace::class_space_is_initialized() {
 
 // Reserve a range of memory that is to contain narrow Klass IDs. If "try_in_low_address_ranges"
 // is true, we will attempt to reserve memory suitable for zero-based encoding.
-ReservedSpace Metaspace::reserve_address_space_for_compressed_classes(size_t size, bool try_in_low_address_ranges) {
+ReservedSpace Metaspace::reserve_address_space_for_compressed_classes(size_t size, bool optimize_for_zero_base) {
 
-  char* result = nullptr;
-  const bool randomize = RandomizeClassSpaceLocation;
-
-  // First try to reserve in low address ranges.
-  if (try_in_low_address_ranges) {
-    constexpr uintptr_t unscaled_max = ((uintptr_t)UINT_MAX + 1);
-    log_debug(metaspace, map)("Trying below " SIZE_FORMAT_X " for unscaled narrow Klass encoding", unscaled_max);
-    result = os::attempt_reserve_memory_between(nullptr, (char*)unscaled_max,
-                                                size, Metaspace::reserve_alignment(), randomize);
-    if (result == nullptr) {
-      constexpr uintptr_t zerobased_max = unscaled_max << LogKlassAlignmentInBytes;
-      log_debug(metaspace, map)("Trying below " SIZE_FORMAT_X " for zero-based narrow Klass encoding", zerobased_max);
-      result = os::attempt_reserve_memory_between((char*)unscaled_max, (char*)zerobased_max,
-                                                  size, Metaspace::reserve_alignment(), randomize);
-    }
-  } // end: low-address reservation
-
-#if defined(AARCH64) || defined(PPC64) || defined(S390)
-  if (result == nullptr) {
-    // Failing zero-based allocation, or in strict_base mode, try to come up with
-    // an optimized start address that is amenable to JITs that use 16-bit moves to
-    // load the encoding base as a short immediate.
-    // Therefore we try here for an address that when right-shifted by
-    // LogKlassAlignmentInBytes has only 1s in the third 16-bit quadrant.
-    //
-    // Example: for shift=3, the address space searched would be
-    // [0x0080_0000_0000 - 0xFFF8_0000_0000].
-
-    // Number of least significant bits that should be zero
-    constexpr int lo_zero_bits = 32 + LogKlassAlignmentInBytes;
-    // Number of most significant bits that should be zero
-    constexpr int hi_zero_bits = 16;
-
-    constexpr size_t alignment = nth_bit(lo_zero_bits);
-    assert(alignment >= Metaspace::reserve_alignment(), "Sanity");
-    constexpr uint64_t min = alignment;
-    constexpr uint64_t max = nth_bit(64 - hi_zero_bits);
-
-    log_debug(metaspace, map)("Trying between " UINT64_FORMAT_X " and " UINT64_FORMAT_X
-                              " with " SIZE_FORMAT_X " alignment", min, max, alignment);
-    result = os::attempt_reserve_memory_between((char*)min, (char*)max, size, alignment, randomize);
-  }
-#endif // defined(AARCH64) || defined(PPC64) || defined(S390)
+  char* result = (char*) CompressedKlassPointers::reserve_address_space_for_compressed_classes(size, RandomizeClassSpaceLocation,
+                                                                                               optimize_for_zero_base);
 
   if (result == nullptr) {
-    // Fallback: reserve anywhere and hope the resulting block is usable.
+    // Fallback: reserve anywhere
     log_debug(metaspace, map)("Trying anywhere...");
     result = os::reserve_memory_aligned(size, Metaspace::reserve_alignment(), false);
   }
@@ -632,10 +592,12 @@ ReservedSpace Metaspace::reserve_address_space_for_compressed_classes(size_t siz
   // Wrap resulting range in ReservedSpace
   ReservedSpace rs;
   if (result != nullptr) {
+    log_debug(metaspace, map)("Mapped at " PTR_FORMAT, p2i(result));
     assert(is_aligned(result, Metaspace::reserve_alignment()), "Alignment too small for metaspace");
     rs = ReservedSpace::space_for_range(result, size, Metaspace::reserve_alignment(),
                                                       os::vm_page_size(), false, false);
   } else {
+    log_debug(metaspace, map)("Failed to map.");
     rs = ReservedSpace();
   }
   return rs;

--- a/src/hotspot/share/memory/metaspace.hpp
+++ b/src/hotspot/share/memory/metaspace.hpp
@@ -76,7 +76,7 @@ public:
 
   // Reserve a range of memory that is to contain narrow Klass IDs. If "try_in_low_address_ranges"
   // is true, we will attempt to reserve memory suitable for zero-based encoding.
-  static ReservedSpace reserve_address_space_for_compressed_classes(size_t size, bool try_in_low_address_ranges);
+  static ReservedSpace reserve_address_space_for_compressed_classes(size_t size, bool optimize_for_zero_base);
 
   // Given a prereserved space, use that to set up the compressed class space list.
   static void initialize_class_space(ReservedSpace rs);

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -39,7 +39,6 @@ size_t CompressedKlassPointers::_range = 0;
 // set this encoding scheme. Used by CDS at runtime to re-instate the scheme used to pre-compute klass ids for
 // archived heap objects.
 void CompressedKlassPointers::initialize_for_given_encoding(address addr, size_t len, address requested_base, int requested_shift) {
-  assert(is_valid_base(requested_base), "Address must be a valid encoding base");
   address const end = addr + len;
 
   const int narrow_klasspointer_bits = sizeof(narrowKlass) * 8;
@@ -89,23 +88,6 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
   set_base(base);
   set_shift(shift);
   set_range(range);
-
-  assert(is_valid_base(_base), "Address must be a valid encoding base");
-}
-
-// Given an address p, return true if p can be used as an encoding base.
-//  (Some platforms have restrictions of what constitutes a valid base address).
-bool CompressedKlassPointers::is_valid_base(address p) {
-#ifdef AARCH64
-  // Below 32G, base must be aligned to 4G.
-  // Above that point, base must be aligned to 32G
-  if (p < (address)(32 * G)) {
-    return is_aligned(p, 4 * G);
-  }
-  return is_aligned(p, (4 << LogKlassAlignmentInBytes) * G);
-#else
-  return true;
-#endif
 }
 
 void CompressedKlassPointers::print_mode(outputStream* st) {

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -23,8 +23,11 @@
  */
 
 #include "precompiled.hpp"
+#include "logging/log.hpp"
+#include "memory/metaspace.hpp"
 #include "oops/compressedKlass.hpp"
 #include "runtime/globals.hpp"
+#include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/ostream.hpp"
@@ -34,6 +37,13 @@ int CompressedKlassPointers::_shift = 0;
 size_t CompressedKlassPointers::_range = 0;
 
 #ifdef _LP64
+
+#ifdef ASSERT
+void CompressedKlassPointers::assert_is_valid_encoding(address addr, size_t len, address base, int shift) {
+  assert(base + nth_bit(32 + shift) >= addr + len, "Encoding (base=" PTR_FORMAT ", shift=%d) does not "
+         "fully cover the class range " PTR_FORMAT "-" PTR_FORMAT, p2i(base), shift, p2i(addr), p2i(addr + len));
+}
+#endif
 
 // Given a klass range [addr, addr+len) and a given encoding scheme, assert that this scheme covers the range, then
 // set this encoding scheme. Used by CDS at runtime to re-instate the scheme used to pre-compute klass ids for
@@ -50,65 +60,67 @@ void CompressedKlassPointers::initialize_for_given_encoding(address addr, size_t
   assert(requested_base == addr, "Invalid requested base");
   assert(encoding_range_end >= end, "Encoding does not cover the full Klass range");
 
-  set_base(requested_base);
-  set_shift(requested_shift);
-  set_range(encoding_range_size);
+  _base = requested_base;
+  _shift = requested_shift;
+  _range = encoding_range_size;
+
+  DEBUG_ONLY(assert_is_valid_encoding(_base, _shift, addr, len);)
 }
 
-// Given an address range [addr, addr+len) which the encoding is supposed to
-//  cover, choose base, shift and range.
-//  The address range is the expected range of uncompressed Klass pointers we
-//  will encounter (and the implicit promise that there will be no Klass
-//  structures outside this range).
+char* CompressedKlassPointers::reserve_address_space_X(uintptr_t from, uintptr_t to, size_t size, size_t alignment, bool aslr) {
+  alignment = MAX2(Metaspace::reserve_alignment(), alignment);
+  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr);
+}
+
+char* CompressedKlassPointers::reserve_address_space_for_unscaled_encoding(size_t size, bool aslr) {
+  return reserve_address_space_X(0, nth_bit(32), size, Metaspace::reserve_alignment(), aslr);
+}
+
+char* CompressedKlassPointers::reserve_address_space_for_zerobased_encoding(size_t size, bool aslr) {
+  return reserve_address_space_X(nth_bit(32), nth_bit(32 + LogKlassAlignmentInBytes), size, Metaspace::reserve_alignment(), aslr);
+}
+
+char* CompressedKlassPointers::reserve_address_space_for_16bit_move(size_t size, bool aslr) {
+  return reserve_address_space_X(nth_bit(32), nth_bit(48), size, nth_bit(32), aslr);
+}
+
+#ifndef AARCH64
+// On aarch64 we have an own version; all other platforms use the default version
 void CompressedKlassPointers::initialize(address addr, size_t len) {
+  // The default version of this code tries, in order of preference:
+  // -unscaled    (base=0 shift=0)
+  // -zero-based  (base=0 shift>0)
+  // -nonzero-base (base>0 shift=0)
+  // Note that base>0 shift>0 should never be needed, since the klass range will
+  // never exceed 4GB.
+  constexpr uintptr_t unscaled_max = nth_bit(32);
+  assert(len <= unscaled_max, "Klass range larger than 32 bits?");
+
+  constexpr uintptr_t zerobased_max = nth_bit(32 + LogKlassAlignmentInBytes);
+
   address const end = addr + len;
-
-  address base;
-  int shift;
-  size_t range;
-
-  // Attempt to run with encoding base == zero
-  if (end <= (address)KlassEncodingMetaspaceMax) {
-    base = 0;
+  if (end <= (address)unscaled_max) {
+    _base = nullptr;
+    _shift = 0;
   } else {
-    base = addr;
+    if (end <= (address)zerobased_max) {
+      _base = nullptr;
+      _shift = LogKlassAlignmentInBytes;
+    } else {
+      _base = addr;
+      _shift = 0;
+    }
   }
+  _range = end - _base;
 
-  // Highest offset a Klass* can ever have in relation to base.
-  range = end - base;
-
-  // We may not even need a shift if the range fits into 32bit:
-  const uint64_t UnscaledClassSpaceMax = (uint64_t(max_juint) + 1);
-  if (range <= UnscaledClassSpaceMax) {
-    shift = 0;
-  } else {
-    shift = LogKlassAlignmentInBytes;
-  }
-
-  set_base(base);
-  set_shift(shift);
-  set_range(range);
+  DEBUG_ONLY(assert_is_valid_encoding(_base, _shift, addr, len);)
 }
+#endif // !AARCH64
 
 void CompressedKlassPointers::print_mode(outputStream* st) {
   st->print_cr("Narrow klass base: " PTR_FORMAT ", Narrow klass shift: %d, "
                "Narrow klass range: " SIZE_FORMAT_X, p2i(base()), shift(),
                range());
-}
-
-void CompressedKlassPointers::set_base(address base) {
-  assert(UseCompressedClassPointers, "no compressed klass ptrs?");
-  _base   = base;
-}
-
-void CompressedKlassPointers::set_shift(int shift)       {
-  assert(shift == 0 || shift == LogKlassAlignmentInBytes, "invalid shift for klass ptrs");
-  _shift   = shift;
-}
-
-void CompressedKlassPointers::set_range(size_t range) {
-  assert(UseCompressedClassPointers, "no compressed klass ptrs?");
-  _range = range;
 }
 
 #endif // _LP64

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -56,15 +56,24 @@ class CompressedKlassPointers : public AllStatic {
   //  could use this info to optimize encoding.
   static size_t _range;
 
-  static void set_base(address base);
-  static void set_range(size_t range);
-  static void set_shift(int shift);
+  // Helper function for common cases.
+  static char* reserve_address_space_X(uintptr_t from, uintptr_t to, size_t size, size_t alignment, bool aslr);
+  static char* reserve_address_space_for_unscaled_encoding(size_t size, bool aslr);
+  static char* reserve_address_space_for_zerobased_encoding(size_t size, bool aslr);
+  static char* reserve_address_space_for_16bit_move(size_t size, bool aslr);
+
+  DEBUG_ONLY(static void assert_is_valid_encoding(address addr, size_t len, address base, int shift);)
 
 public:
 
+  // Reserve a range of memory that is to contain Klass strucutures which are referenced by narrow Klass IDs.
+  // If optimize_for_zero_base is true, the implementation will attempt to reserve optimized for zero-based encoding.
+  static char* reserve_address_space_for_compressed_classes(size_t size, bool aslr, bool optimize_for_zero_base);
+
   // Given a klass range [addr, addr+len) and a given encoding scheme, assert that this scheme covers the range, then
   // set this encoding scheme. Used by CDS at runtime to re-instate the scheme used to pre-compute klass ids for
-  // archived heap objects.
+  // archived heap objects. In this case, we don't have the freedom to choose base and shift; they are handed to
+  // us from CDS.
   static void initialize_for_given_encoding(address addr, size_t len, address requested_base, int requested_shift);
 
   // Given an address range [addr, addr+len) which the encoding is supposed to

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -62,11 +62,6 @@ class CompressedKlassPointers : public AllStatic {
 
 public:
 
-  // Given an address p, return true if p can be used as an encoding base.
-  //  (Some platforms have restrictions of what constitutes a valid base
-  //   address).
-  static bool is_valid_base(address p);
-
   // Given a klass range [addr, addr+len) and a given encoding scheme, assert that this scheme covers the range, then
   // set this encoding scheme. Used by CDS at runtime to re-instate the scheme used to pre-compute klass ids for
   // archived heap objects.

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1873,10 +1873,10 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   // we attempt to minimize fragmentation.
   constexpr unsigned total_shuffle_threshold = 1024;
 
-#define ARGSFMT " range [" PTR_FORMAT "-" PTR_FORMAT "), size " SIZE_FORMAT_X ", alignment " SIZE_FORMAT_X ", randomize: %d"
+#define ARGSFMT "range [" PTR_FORMAT "-" PTR_FORMAT "), size " SIZE_FORMAT_X ", alignment " SIZE_FORMAT_X ", randomize: %d"
 #define ARGSFMTARGS p2i(min), p2i(max), bytes, alignment, randomize
 
-  log_trace(os, map) ("reserve_between (" ARGSFMT ")", ARGSFMTARGS);
+  log_debug(os, map) ("reserve_between (" ARGSFMT ")", ARGSFMTARGS);
 
   assert(is_power_of_2(alignment), "alignment invalid (" ARGSFMT ")", ARGSFMTARGS);
   assert(alignment < SIZE_MAX / 2, "alignment too large (" ARGSFMT ")", ARGSFMTARGS);
@@ -2004,6 +2004,8 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
     log_trace(os, map)(ERRFMT, ERRFMTARGS);
     log_debug(os, map)("successfully attached at " PTR_FORMAT, p2i(result));
     MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
+  } else {
+    log_debug(os, map)("failed to attach anywhere in [" PTR_FORMAT "-" PTR_FORMAT ")", p2i(min), p2i(max));
   }
   return result;
 #undef ARGSFMT


### PR DESCRIPTION
In `Metaspace::reserve_address_space_for_compressed_classes`, we reserve space for the future Klass range - either class space alone or class space + CDS. We place the Klass range somewhere that allows us to use "good" narrow Klass decoding later when initializing the encoding scheme.

Since narrow Klass decoding is inherently CPU-specific (see the various variants of MacroAssembler::decode_klass()), this is awkward. It leads to many ifdefs, vague code comments that are difficult to grok, and missed optimization opportunities. It would be much better to have this section per CPU so that every CPU can implement its perfect and perfectly documented version. A bit of code duplication is a good price for code clarity.

(This results from lengthy discussions with Andrew Haley and many exhausting attempts to get this shared coding into a form that fits all CPUs and satisfies all reviewers).

If we do that, we also can do more targeted optimizations per CPU; see below.

-------------

This patch splits out `Metaspace::reserve_address_space_for_compressed_classes` into five variants, one per CPU; it also splits out `CompressedKlassPointers::initialize` into two variants, one for aarch64, one for all other platforms. 


Per-CPU optimizations:

#### aarch64:

We used to first go for unscaled (<4GB), then go for zero-based (4GB..32GB). I removed the latter attempt. The reason is that zero-based encoding (base=0 shift>0) holds no advantage over nonzero base mode if the base can be set with a single movk. Cycle count for movk and lsl are the same; historically, I was told lsl was even slower. 

A second functional change is that if we fail to reserve for movk mode - which we do by random probing - we attempt that again with `os::reserve_memory_aligned()`. That is a last-ditch attempt to reserve movk-optimized - and we only do this on aarch64 to prevent errors like this one JDK-8318119: "Invalid narrow Klass base on aarch64 post 8312018"

So, today we:

- go for unscaled (<4GB) if CDS is off
- go for a base address that can be set with a single movk into the third quadrant (4GB..256TB); first by probing, then via over-allocation.

#### ppc:

Functionally, nothing changed on ppc.

#### riscv:

On Riscv, failing unscaled (<4GB) or zero-based (<32GB) reservation, we now go for a "good" base address. 64-bit immediates on riscv are loaded with - at most - four operations. We try to minimize the number of operations needed. See comment in the code for details.

Another change is that we attempt to go for unscaled (<4GB) even if CDS is off, since an immediate <4GB can be cheaper set.

So, we:

- First go for <4GB, unconditionally - if CDS is off, we then use unscaled encoding, if CDS is on, we can use a 32-bit addi 
- Then go for (4GB..32GB), only if CDS is on, to get zero-based encoding with only shift
- Then go for a base address that has bits only set in the first 12 bits of the upper 32 bits
- Then go for a base address that has bits only set in the upper 20 bits

#### s390:

A minor change in s390:

- First we go for <4GB, but unconditionally. If CDS is off, we then go unscaled. If CDS is on, we can use algfi to add the base address.
- Then go for (4GB..32GB), only if CDS is on, to get zero-based encoding with only shift
- We then go for a base address that has only bits set in the high word.

#### x64:

Functionally, nothing changed on x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320368](https://bugs.openjdk.org/browse/JDK-8320368): Per-CPU optimization of Klass range reservation (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16723/head:pull/16723` \
`$ git checkout pull/16723`

Update a local copy of the PR: \
`$ git checkout pull/16723` \
`$ git pull https://git.openjdk.org/jdk.git pull/16723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16723`

View PR using the GUI difftool: \
`$ git pr show -t 16723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16723.diff">https://git.openjdk.org/jdk/pull/16723.diff</a>

</details>
