### PR TITLE
8320370: NMT: Change MallocMemorySnapshot to simplify code.

### DIFF
--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -43,7 +43,7 @@
 #include "utilities/ostream.hpp"
 #include "utilities/vmError.hpp"
 
-size_t MallocMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(MallocMemorySnapshot, size_t)];
+MallocMemorySnapshot MallocMemorySummary::_snapshot{};
 
 void MemoryCounter::update_peak(size_t size, size_t cnt) {
   size_t peak_sz = peak_size();
@@ -78,9 +78,7 @@ void MallocMemorySnapshot::make_adjustment() {
 }
 
 void MallocMemorySummary::initialize() {
-  assert(sizeof(_snapshot) >= sizeof(MallocMemorySnapshot), "Sanity Check");
   // Uses placement new operator to initialize static area.
-  ::new ((void*)_snapshot)MallocMemorySnapshot();
   MallocLimitHandler::initialize(MallocLimit);
 }
 

--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -43,7 +43,7 @@
 #include "utilities/ostream.hpp"
 #include "utilities/vmError.hpp"
 
-MallocMemorySnapshot MallocMemorySummary::_snapshot{};
+MallocMemorySnapshot MallocMemorySummary::_snapshot;
 
 void MemoryCounter::update_peak(size_t size, size_t cnt) {
   size_t peak_sz = peak_size();

--- a/src/hotspot/share/nmt/mallocTracker.hpp
+++ b/src/hotspot/share/nmt/mallocTracker.hpp
@@ -140,7 +140,7 @@ class MallocMemorySummary;
 
 // A snapshot of malloc'd memory, includes malloc memory
 // usage by types and memory used by tracking itself.
-class MallocMemorySnapshot : public AnyObj {
+class MallocMemorySnapshot {
   friend class MallocMemorySummary;
 
  private:

--- a/src/hotspot/share/nmt/mallocTracker.hpp
+++ b/src/hotspot/share/nmt/mallocTracker.hpp
@@ -140,7 +140,7 @@ class MallocMemorySummary;
 
 // A snapshot of malloc'd memory, includes malloc memory
 // usage by types and memory used by tracking itself.
-class MallocMemorySnapshot : public ResourceObj {
+class MallocMemorySnapshot : public AnyObj {
   friend class MallocMemorySummary;
 
  private:
@@ -198,7 +198,7 @@ class MallocMemorySnapshot : public ResourceObj {
 class MallocMemorySummary : AllStatic {
  private:
   // Reserve memory for placement of MallocMemorySnapshot object
-  static size_t _snapshot[CALC_OBJ_SIZE_IN_TYPE(MallocMemorySnapshot, size_t)];
+  static MallocMemorySnapshot _snapshot;
   static bool _have_limits;
 
   // Called when a total limit break was detected.
@@ -245,7 +245,7 @@ class MallocMemorySummary : AllStatic {
    }
 
   static MallocMemorySnapshot* as_snapshot() {
-    return (MallocMemorySnapshot*)_snapshot;
+    return &_snapshot;
   }
 
   // MallocLimit: returns true if allocating s bytes on f would trigger

--- a/src/hotspot/share/nmt/nmtCommon.hpp
+++ b/src/hotspot/share/nmt/nmtCommon.hpp
@@ -31,8 +31,6 @@
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-#define CALC_OBJ_SIZE_IN_TYPE(obj, type) (align_up(sizeof(obj), sizeof(type))/sizeof(type))
-
 // Native memory tracking level
 //
 // The meaning of the different states:

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -32,7 +32,7 @@
 #include "runtime/threadCritical.hpp"
 #include "utilities/ostream.hpp"
 
-VirtualMemorySnapshot VirtualMemorySummary::_snapshot{};
+VirtualMemorySnapshot VirtualMemorySummary::_snapshot;
 
 #ifdef ASSERT
 void VirtualMemory::update_peak(size_t size) {
@@ -47,9 +47,6 @@ void VirtualMemory::update_peak(size_t size) {
   }
 }
 #endif // ASSERT
-
-void VirtualMemorySummary::initialize() {
-}
 
 void VirtualMemorySummary::snapshot(VirtualMemorySnapshot* s) {
   // Only if thread stack is backed by virtual memory
@@ -333,7 +330,6 @@ address ReservedMemoryRegion::thread_stack_uncommitted_bottom() const {
 bool VirtualMemoryTracker::initialize(NMT_TrackingLevel level) {
   assert(_reserved_regions == nullptr, "only call once");
   if (level >= NMT_summary) {
-    VirtualMemorySummary::initialize();
     _reserved_regions = new (std::nothrow, mtNMT)
       SortedLinkedList<ReservedMemoryRegion, compare_reserved_region_base>();
     return (_reserved_regions != nullptr);

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -32,7 +32,7 @@
 #include "runtime/threadCritical.hpp"
 #include "utilities/ostream.hpp"
 
-size_t VirtualMemorySummary::_snapshot[CALC_OBJ_SIZE_IN_TYPE(VirtualMemorySnapshot, size_t)];
+VirtualMemorySnapshot VirtualMemorySummary::_snapshot{};
 
 #ifdef ASSERT
 void VirtualMemory::update_peak(size_t size) {
@@ -49,9 +49,6 @@ void VirtualMemory::update_peak(size_t size) {
 #endif // ASSERT
 
 void VirtualMemorySummary::initialize() {
-  assert(sizeof(_snapshot) >= sizeof(VirtualMemorySnapshot), "Sanity Check");
-  // Use placement operator new to initialize static data area.
-  ::new ((void*)_snapshot) VirtualMemorySnapshot();
 }
 
 void VirtualMemorySummary::snapshot(VirtualMemorySnapshot* s) {

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -95,7 +95,7 @@ class VirtualMemorySummary;
 
 // This class represents a snapshot of virtual memory at a given time.
 // The latest snapshot is saved in a static area.
-class VirtualMemorySnapshot : public ResourceObj {
+class VirtualMemorySnapshot : public AnyObj {
   friend class VirtualMemorySummary;
 
  private:
@@ -172,11 +172,11 @@ class VirtualMemorySummary : AllStatic {
   static void snapshot(VirtualMemorySnapshot* s);
 
   static VirtualMemorySnapshot* as_snapshot() {
-    return (VirtualMemorySnapshot*)_snapshot;
+    return &_snapshot;
   }
 
  private:
-  static size_t _snapshot[CALC_OBJ_SIZE_IN_TYPE(VirtualMemorySnapshot, size_t)];
+  static VirtualMemorySnapshot _snapshot;
 };
 
 

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -95,7 +95,7 @@ class VirtualMemorySummary;
 
 // This class represents a snapshot of virtual memory at a given time.
 // The latest snapshot is saved in a static area.
-class VirtualMemorySnapshot : public AnyObj {
+class VirtualMemorySnapshot {
   friend class VirtualMemorySummary;
 
  private:

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -95,7 +95,7 @@ class VirtualMemorySummary;
 
 // This class represents a snapshot of virtual memory at a given time.
 // The latest snapshot is saved in a static area.
-class VirtualMemorySnapshot {
+class VirtualMemorySnapshot : public ResourceObj {
   friend class VirtualMemorySummary;
 
  private:

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -137,7 +137,6 @@ class VirtualMemorySnapshot : public AnyObj {
 
 class VirtualMemorySummary : AllStatic {
  public:
-  static void initialize();
 
   static inline void record_reserved_memory(size_t size, MEMFLAGS flag) {
     as_snapshot()->by_type(flag)->reserve_memory(size);


### PR DESCRIPTION
Hi,

`MallocMemorySnapshot` used to be initialized in a quite non-standard way, using global placement new on an array of `size_t` of the size required to fit `MallocMemorySnapshot`. This looks like it was intended to circumvent some `ResourceObj` internals, but I'm unsure of its purpose. This change does what you expect a regular initialization of a global variable to look like.

~Currently running through tier1.~ GHA passed and so did tier1 on Oracle CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320370](https://bugs.openjdk.org/browse/JDK-8320370): NMT: Change MallocMemorySnapshot to simplify code. (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [b0c547b4](https://git.openjdk.org/jdk/pull/16724/files/b0c547b444fe3b5dcbbbd6e0a0c17fd0c417dde9)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16724/head:pull/16724` \
`$ git checkout pull/16724`

Update a local copy of the PR: \
`$ git checkout pull/16724` \
`$ git pull https://git.openjdk.org/jdk.git pull/16724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16724`

View PR using the GUI difftool: \
`$ git pr show -t 16724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16724.diff">https://git.openjdk.org/jdk/pull/16724.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16724#issuecomment-1818614476)