### PR TITLE
JDK-8320382: Remove CompressedKlassPointers::is_valid_base()

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -39,7 +39,6 @@ size_t CompressedKlassPointers::_range = 0;
 // set this encoding scheme. Used by CDS at runtime to re-instate the scheme used to pre-compute klass ids for
 // archived heap objects.
 void CompressedKlassPointers::initialize_for_given_encoding(address addr, size_t len, address requested_base, int requested_shift) {
-  assert(is_valid_base(requested_base), "Address must be a valid encoding base");
   address const end = addr + len;
 
   const int narrow_klasspointer_bits = sizeof(narrowKlass) * 8;
@@ -89,23 +88,6 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
   set_base(base);
   set_shift(shift);
   set_range(range);
-
-  assert(is_valid_base(_base), "Address must be a valid encoding base");
-}
-
-// Given an address p, return true if p can be used as an encoding base.
-//  (Some platforms have restrictions of what constitutes a valid base address).
-bool CompressedKlassPointers::is_valid_base(address p) {
-#ifdef AARCH64
-  // Below 32G, base must be aligned to 4G.
-  // Above that point, base must be aligned to 32G
-  if (p < (address)(32 * G)) {
-    return is_aligned(p, 4 * G);
-  }
-  return is_aligned(p, (4 << LogKlassAlignmentInBytes) * G);
-#else
-  return true;
-#endif
 }
 
 void CompressedKlassPointers::print_mode(outputStream* st) {

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -62,11 +62,6 @@ class CompressedKlassPointers : public AllStatic {
 
 public:
 
-  // Given an address p, return true if p can be used as an encoding base.
-  //  (Some platforms have restrictions of what constitutes a valid base
-  //   address).
-  static bool is_valid_base(address p);
-
   // Given a klass range [addr, addr+len) and a given encoding scheme, assert that this scheme covers the range, then
   // set this encoding scheme. Used by CDS at runtime to re-instate the scheme used to pre-compute klass ids for
   // archived heap objects.


### PR DESCRIPTION
`CompressedKlassPointers::is_valid_base(addr)` abstracts away platform-specific requirements that may limit the use of an address as narrow Klass encoding base. It only ever mattered on aarch64, where we cannot use any arbitrary address as 64-bit immediate for the base.

Experience shows that this is a case where the abstraction does not help much. Hiding a very CPU-specific limitation under a generic function made arguing about it difficult. We therefore decided to scrap that function.

It is only used for two things:
- asserts at runtime; those are unnecessary since we have an assert in macroAssembler_aarch64.cpp that will fire if the base is not correct. Both asserts fire at VM initialization; neither of these asserts is much clearer than the other, so no reason to keep asserting for is_valid_base()
- the one legitimate use case is checking the user input for -XX:SharedBaseAddress at dump time. We can just express the aarch64 requirement directly, which is clearer to understand.

Note that the function has also been incorrect, since it ignored aarch64 EOR mode, and required 32GB alignment for addresses beyond 32GB. However, we can make any 4GB aligned address to work with movk, so the requirement can be simplified to "is 4GB-aligned".

(this is a preparatory patch for [JDK-8320368](https://bugs.openjdk.org/browse/JDK-8320368) and further Lilliput-related changes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320382](https://bugs.openjdk.org/browse/JDK-8320382): Remove CompressedKlassPointers::is_valid_base() (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16727/head:pull/16727` \
`$ git checkout pull/16727`

Update a local copy of the PR: \
`$ git checkout pull/16727` \
`$ git pull https://git.openjdk.org/jdk.git pull/16727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16727`

View PR using the GUI difftool: \
`$ git pr show -t 16727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16727.diff">https://git.openjdk.org/jdk/pull/16727.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16727#issuecomment-1818743677)