### PR TITLE
8309067: gtest/AsyncLogGtest.java fails again in stderrOutput_vm

### DIFF
--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -244,8 +244,9 @@ TEST_VM_F(AsyncLogTest, logBuffer) {
 }
 
 TEST_VM_F(AsyncLogTest, droppingMessage) {
-  if (AsyncLogWriter::instance() == nullptr)
+  if (AsyncLogWriter::instance() == nullptr) {
     return;
+  }
 
   set_log_config(TestLogFileName, "logging=debug");
   test_asynclog_drop_messages();

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -69,21 +69,22 @@ LOG_LEVEL_LIST
     log_debug(logging)("log_debug-test");
   }
 
+  // Caveat: BufferUpdater is not MT-safe. We use it only for testing.
+  // We would observe missing loglines if we interleaved buffers.
+  // Emit all logs between constructor and destructor of BufferUpdater.
   void test_asynclog_drop_messages() {
-    auto writer = AsyncLogWriter::instance();
-    if (writer != nullptr) {
-      const size_t sz = 2000;
+    const size_t sz = 2000;
 
-      // shrink async buffer.
-      AsyncLogWriter::BufferUpdater saver(1024);
-      LogMessage(logging) lm;
+    // shrink async buffer.
+    AsyncLogWriter::BufferUpdater saver(1024);
+    test_asynclog_ls(); // roughly 200 bytes.
+    LogMessage(logging) lm;
 
-      // write more messages than its capacity in burst
-      for (size_t i = 0; i < sz; ++i) {
-        lm.debug("a lot of log...");
-      }
-      lm.flush();
+    // write more messages than its capacity in burst
+    for (size_t i = 0; i < sz; ++i) {
+      lm.debug("a lot of log...");
     }
+    lm.flush();
   }
 
   // stdout/stderr support
@@ -93,8 +94,7 @@ LOG_LEVEL_LIST
     if (f != NULL) {
       size_t sz = output.size();
       size_t written = fwrite(output.c_str(), sizeof(char), output.size(), f);
-      // at least see "header"
-      return fclose(f) == 0 && sz == written && sz >= 6;
+      return fclose(f) == 0 && sz == written;
     }
 
     return false;
@@ -244,67 +244,68 @@ TEST_VM_F(AsyncLogTest, logBuffer) {
 }
 
 TEST_VM_F(AsyncLogTest, droppingMessage) {
+  if (AsyncLogWriter::instance() == nullptr)
+    return;
+
   set_log_config(TestLogFileName, "logging=debug");
   test_asynclog_drop_messages();
-
-  AsyncLogWriter::flush();
-  if (AsyncLogWriter::instance() != nullptr) {
-    EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
-  }
+  EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
 }
 
 TEST_VM_F(AsyncLogTest, stdoutOutput) {
   testing::internal::CaptureStdout();
-  fprintf(stdout, "header");
 
   if (!set_log_config("stdout", "logging=debug")) {
     return;
   }
 
-  test_asynclog_ls();
-  test_asynclog_drop_messages();
+  bool async = AsyncLogWriter::instance() != nullptr;
+  if (async) {
+    test_asynclog_drop_messages();
+    AsyncLogWriter::flush();
+  } else {
+    test_asynclog_ls();
+  }
 
-  AsyncLogWriter::flush();
   fflush(nullptr);
-
   if (!write_to_file(testing::internal::GetCapturedStdout())) {
     return;
   }
 
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
   EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
   EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
   EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
-  if (AsyncLogWriter::instance() != nullptr) {
+  if (async) {
     EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
   }
 }
 
 TEST_VM_F(AsyncLogTest, stderrOutput) {
   testing::internal::CaptureStderr();
-  fprintf(stderr, "header");
 
   if (!set_log_config("stderr", "logging=debug")) {
     return;
   }
 
-  test_asynclog_ls();
-  test_asynclog_drop_messages();
+  bool async = AsyncLogWriter::instance() != nullptr;
+  if (async) {
+    test_asynclog_drop_messages();
+    AsyncLogWriter::flush();
+  } else {
+    test_asynclog_ls();
+  }
 
-  AsyncLogWriter::flush();
   fflush(nullptr);
-
   if (!write_to_file(testing::internal::GetCapturedStderr())) {
     return;
   }
 
-  EXPECT_TRUE(file_contains_substring(TestLogFileName, "header"));
   EXPECT_TRUE(file_contains_substring(TestLogFileName, "LogStreamWithAsyncLogImpl"));
   EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream msg1-msg2-msg3"));
   EXPECT_TRUE(file_contains_substring(TestLogFileName, "logStream newline"));
 
-  if (AsyncLogWriter::instance() != nullptr) {
+  if (async) {
     EXPECT_TRUE(file_contains_substring(TestLogFileName, "messages dropped due to async logging"));
   }
 }


### PR DESCRIPTION
This patch fixes the flaky test AsyncLogTest. The race condition only occurs in async 
logging mode in combination of BufferUpdater. BufferUpdater is introduced for testing 
only. It installs smaller buffers so test code can reliably observe messages dropped.
AsyncLog drops messages when the current buffer is overflown. 

In stdout/stderrOutput testcases, we used to mix test_asynclog_ls() and 
test_asynclog_drop_messages(). The later function uses BufferUpdater. As a result, log
messages distribute in both old buffer and new buffer. 

A race condition unfolds in the sequences. Thread names are in brackets.
1. [AsyncLogWriter] just calls write().
2. [Test] calls the constructor of BufferUpdater. It updates AsyncLogWriter->_buffer_staging.
3. [AsyncLogWriter] sees the latest _buffer_staging. It emits nothing. 
4. [Test] call the destructor of BufferUpdater. _buffer_staging resumes to 
the original buffer.
5. [AsyncLogWriter] is waken up from _lock.wait. It proceeds to swaps _buffer and _buffer_staging.
at this point, we lost the log messages in the original buffer. AsyncLogWriter was about to dump them
at 1.

Only stdout/stderrOutput testcases interleave the original buffer and small buffer. That's why
we only encounter flaky failures on them. It's up to the OS scheduling. 

To eliminate the race condition, we must ensure that all messages write after BufferUpdater.
test_asynclog_drop_messages() fuses test_asynclog_ls().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309067](https://bugs.openjdk.org/browse/JDK-8309067): gtest/AsyncLogGtest.java fails again in stderrOutput_vm (**Bug** - P3)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [1c1dca2e](https://git.openjdk.org/jdk/pull/16728/files/1c1dca2ea0d68a163651f723a55331456cdb993b)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16728/head:pull/16728` \
`$ git checkout pull/16728`

Update a local copy of the PR: \
`$ git checkout pull/16728` \
`$ git pull https://git.openjdk.org/jdk.git pull/16728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16728`

View PR using the GUI difftool: \
`$ git pr show -t 16728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16728.diff">https://git.openjdk.org/jdk/pull/16728.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16728#issuecomment-1818453680)