### PR TITLE
8319813: Remove upper limit on number of compiler phases in phasetype.hpp

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -433,11 +433,10 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
       // Parse ccstr and create mask
       ccstrlist option;
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
-        CHeapBitMap mask(PHASE_NUM_TYPES, mtCompiler);
-        PhaseNameValidator validator(option, mask);
+        PhaseNameValidator validator(option);
         if (validator.is_valid()) {
           assert(validator.is_set(), "Must be set");
-          set.cloned()->_ideal_phase_name_mask.set_from(mask);
+          set.cloned()->set_ideal_phase_mask(validator);
         }
       }
     }

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -297,7 +297,11 @@ void DirectiveSet::init_control_intrinsic() {
   }
 }
 
-DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d), _ideal_phase_name_set(PHASE_NUM_TYPES, mtCompiler) {
+DirectiveSet::DirectiveSet(CompilerDirectives* d) :
+  _inlinematchers(nullptr),
+  _directive(d),
+  _ideal_phase_name_set(PHASE_NUM_TYPES, mtCompiler)
+{
 #define init_defaults_definition(name, type, dvalue, compiler) this->name##Option = dvalue;
   compilerdirectives_common_flags(init_defaults_definition)
   compilerdirectives_c2_flags(init_defaults_definition)
@@ -436,7 +440,7 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
         PhaseNameValidator validator(option);
         if (validator.is_valid()) {
           assert(!validator.phase_name_set().is_empty(), "Phase name set must be non-empty");
-          set.cloned()->set_ideal_phase_name_set(validator);
+          set.cloned()->set_ideal_phase_name_set(validator.phase_name_set());
         }
       }
     }
@@ -619,7 +623,7 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
 #undef copy_string_members_definition
 
   set->_intrinsic_control_words = src->_intrinsic_control_words;
-  set->_ideal_phase_name_set.set_from(src->_ideal_phase_name_set);
+  set->set_ideal_phase_name_set(src->_ideal_phase_name_set);
   return set;
 }
 

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -435,7 +435,7 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
         PhaseNameValidator validator(option);
         if (validator.is_valid()) {
-          assert(!validator.is_phase_name_set_empty(), "Phase name set must be non-empty");
+          assert(!validator.phase_name_set().is_empty(), "Phase name set must be non-empty");
           set.cloned()->set_ideal_phase_name_set(validator);
         }
       }

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -297,7 +297,7 @@ void DirectiveSet::init_control_intrinsic() {
   }
 }
 
-DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d), _ideal_phase_name_mask(PHASE_NUM_TYPES, mtCompiler) {
+DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d), _ideal_phase_name_set(PHASE_NUM_TYPES, mtCompiler) {
 #define init_defaults_definition(name, type, dvalue, compiler) this->name##Option = dvalue;
   compilerdirectives_common_flags(init_defaults_definition)
   compilerdirectives_c2_flags(init_defaults_definition)
@@ -435,8 +435,8 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
         PhaseNameValidator validator(option);
         if (validator.is_valid()) {
-          assert(validator.is_mask_set(), "Must be set");
-          set.cloned()->set_ideal_phase_mask(validator);
+          assert(!validator.is_phase_name_set_empty(), "Phase name set must be non-empty");
+          set.cloned()->set_ideal_phase_name_set(validator);
         }
       }
     }
@@ -619,7 +619,7 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
 #undef copy_string_members_definition
 
   set->_intrinsic_control_words = src->_intrinsic_control_words;
-  set->_ideal_phase_name_mask.set_from(src->_ideal_phase_name_mask);
+  set->_ideal_phase_name_set.set_from(src->_ideal_phase_name_set);
   return set;
 }
 

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -435,7 +435,7 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
         PhaseNameValidator validator(option);
         if (validator.is_valid()) {
-          assert(validator.is_set(), "Must be set");
+          assert(validator.is_mask_set(), "Must be set");
           set.cloned()->set_ideal_phase_mask(validator);
         }
       }

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -297,7 +297,7 @@ void DirectiveSet::init_control_intrinsic() {
   }
 }
 
-DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d), _ideal_phase_name_mask(PHASE_NUM_TYPES) {
+DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d), _ideal_phase_name_mask(PHASE_NUM_TYPES, mtCompiler) {
 #define init_defaults_definition(name, type, dvalue, compiler) this->name##Option = dvalue;
   compilerdirectives_common_flags(init_defaults_definition)
   compilerdirectives_c2_flags(init_defaults_definition)
@@ -433,7 +433,7 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
       // Parse ccstr and create mask
       ccstrlist option;
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
-        ResourceBitMap mask(PHASE_NUM_TYPES);
+        CHeapBitMap mask(PHASE_NUM_TYPES, mtCompiler);
         PhaseNameValidator validator(option, mask);
         if (validator.is_valid()) {
           assert(validator.is_set(), "Must be set");

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -297,8 +297,7 @@ void DirectiveSet::init_control_intrinsic() {
   }
 }
 
-DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d) {
-  memset(_ideal_phase_name_mask, false, sizeof(_ideal_phase_name_mask));
+DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d), _ideal_phase_name_mask(PHASE_NUM_TYPES) {
 #define init_defaults_definition(name, type, dvalue, compiler) this->name##Option = dvalue;
   compilerdirectives_common_flags(init_defaults_definition)
   compilerdirectives_c2_flags(init_defaults_definition)
@@ -434,10 +433,11 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
       // Parse ccstr and create mask
       ccstrlist option;
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
-        phase_mask& mask = set.cloned()->_ideal_phase_name_mask;
+        ResourceBitMap mask(PHASE_NUM_TYPES);
         PhaseNameValidator validator(option, mask);
         if (validator.is_valid()) {
           assert(validator.is_set(), "Must be set");
+          set.cloned()->_ideal_phase_name_mask.set_from(mask);
         }
       }
     }
@@ -620,7 +620,7 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
 #undef copy_string_members_definition
 
   set->_intrinsic_control_words = src->_intrinsic_control_words;
-  memcpy(set->_ideal_phase_name_mask, src->_ideal_phase_name_mask, sizeof(set->_ideal_phase_name_mask));
+  set->_ideal_phase_name_mask.set_from(src->_ideal_phase_name_mask);
   return set;
 }
 

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -434,7 +434,7 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
       // Parse ccstr and create mask
       ccstrlist option;
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
-        bool (&mask)[PHASE_NUM_TYPES] = set.cloned()->_ideal_phase_name_mask;
+        phase_mask& mask = set.cloned()->_ideal_phase_name_mask;
         PhaseNameValidator validator(option, mask);
         if (validator.is_valid()) {
           assert(validator.is_set(), "Must be set");
@@ -620,7 +620,7 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
 #undef copy_string_members_definition
 
   set->_intrinsic_control_words = src->_intrinsic_control_words;
-  memcpy(set->_ideal_phase_name_mask, src->_ideal_phase_name_mask, sizeof(src->_ideal_phase_name_mask));
+  memcpy(set->_ideal_phase_name_mask, src->_ideal_phase_name_mask, sizeof(set->_ideal_phase_name_mask));
   return set;
 }
 

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -430,11 +430,11 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
     compilerdirectives_c1_flags(init_default_cc)
 #undef init_default_cc
 
-    // Parse PrintIdealPhaseName and create an efficient lookup mask
+    // Parse PrintIdealPhaseName and create a lookup set
 #ifndef PRODUCT
 #ifdef COMPILER2
     if (!_modified[PrintIdealPhaseIndex]) {
-      // Parse ccstr and create mask
+      // Parse ccstr and create set
       ccstrlist option;
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
         PhaseNameValidator validator(option);

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -298,7 +298,7 @@ void DirectiveSet::init_control_intrinsic() {
 }
 
 DirectiveSet::DirectiveSet(CompilerDirectives* d) :_inlinematchers(nullptr), _directive(d) {
-  _ideal_phase_name_mask = 0;
+  memset(_ideal_phase_name_mask, false, sizeof(_ideal_phase_name_mask));
 #define init_defaults_definition(name, type, dvalue, compiler) this->name##Option = dvalue;
   compilerdirectives_common_flags(init_defaults_definition)
   compilerdirectives_c2_flags(init_defaults_definition)
@@ -434,11 +434,10 @@ DirectiveSet* DirectiveSet::compilecommand_compatibility_init(const methodHandle
       // Parse ccstr and create mask
       ccstrlist option;
       if (CompilerOracle::has_option_value(method, CompileCommand::PrintIdealPhase, option)) {
-        uint64_t mask = 0;
+        bool (&mask)[PHASE_NUM_TYPES] = set.cloned()->_ideal_phase_name_mask;
         PhaseNameValidator validator(option, mask);
         if (validator.is_valid()) {
-          assert(mask != 0, "Must be set");
-          set.cloned()->_ideal_phase_name_mask = mask;
+          assert(validator.is_set(), "Must be set");
         }
       }
     }
@@ -621,7 +620,7 @@ DirectiveSet* DirectiveSet::clone(DirectiveSet const* src) {
 #undef copy_string_members_definition
 
   set->_intrinsic_control_words = src->_intrinsic_control_words;
-  set->_ideal_phase_name_mask = src->_ideal_phase_name_mask;
+  memcpy(set->_ideal_phase_name_mask, src->_ideal_phase_name_mask, sizeof(src->_ideal_phase_name_mask));
   return set;
 }
 

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -130,7 +130,7 @@ private:
   InlineMatcher* _inlinematchers;
   CompilerDirectives* _directive;
   TriBoolArray<(size_t)vmIntrinsics::number_of_intrinsics(), int> _intrinsic_control_words;
-  CHeapBitMap _ideal_phase_name_mask;
+  CHeapBitMap _ideal_phase_name_set;
 
 public:
   DirectiveSet(CompilerDirectives* directive);
@@ -199,11 +199,11 @@ void set_##name(void* value) {                                      \
   compilerdirectives_c1_string_flags(set_string_function_definition)
 #undef set_string_function_definition
 
-  void set_ideal_phase_mask(const PhaseNameValidator& v) {
-    _ideal_phase_name_mask.set_from(v.mask());
+  void set_ideal_phase_name_set(const PhaseNameValidator& v) {
+    _ideal_phase_name_set.set_from(v.phase_name_set());
   };
   bool should_print_phase(const CompilerPhaseType cpt) const {
-    return _ideal_phase_name_mask.at(cpt);
+    return _ideal_phase_name_set.at(cpt);
   };
 
   void print_intx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" INTX_FORMAT " ", n, v); } }

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -129,7 +129,7 @@ private:
   InlineMatcher* _inlinematchers;
   CompilerDirectives* _directive;
   TriBoolArray<(size_t)vmIntrinsics::number_of_intrinsics(), int> _intrinsic_control_words;
-  bool _ideal_phase_name_mask[PHASE_NUM_TYPES];
+  phase_mask _ideal_phase_name_mask;
 
 public:
   DirectiveSet(CompilerDirectives* directive);
@@ -198,7 +198,7 @@ void set_##name(void* value) {                                      \
   compilerdirectives_c1_string_flags(set_string_function_definition)
 #undef set_string_function_definition
 
-  bool (&ideal_phase_mask())[PHASE_NUM_TYPES] { return _ideal_phase_name_mask; };
+  phase_mask& ideal_phase_mask() { return _ideal_phase_name_mask; };
 
   void print_intx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" INTX_FORMAT " ", n, v); } }
   void print_uintx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" UINTX_FORMAT " ", n, v); } }

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -129,7 +129,7 @@ private:
   InlineMatcher* _inlinematchers;
   CompilerDirectives* _directive;
   TriBoolArray<(size_t)vmIntrinsics::number_of_intrinsics(), int> _intrinsic_control_words;
-  ResourceBitMap _ideal_phase_name_mask;
+  CHeapBitMap _ideal_phase_name_mask;
 
 public:
   DirectiveSet(CompilerDirectives* directive);

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -199,8 +199,12 @@ void set_##name(void* value) {                                      \
   compilerdirectives_c1_string_flags(set_string_function_definition)
 #undef set_string_function_definition
 
-  BitMap& ideal_phase_mask() { return _ideal_phase_name_mask; };
-  bool should_print_phase(CompilerPhaseType cpt) { return _ideal_phase_name_mask.at(cpt); };
+  void set_ideal_phase_mask(const PhaseNameValidator& v) {
+    _ideal_phase_name_mask.set_from(v.mask());
+  };
+  bool should_print_phase(const CompilerPhaseType cpt) const {
+    return _ideal_phase_name_mask.at(cpt);
+  };
 
   void print_intx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" INTX_FORMAT " ", n, v); } }
   void print_uintx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" UINTX_FORMAT " ", n, v); } }

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -31,6 +31,7 @@
 #include "compiler/compiler_globals.hpp"
 #include "compiler/methodMatcher.hpp"
 #include "compiler/compilerOracle.hpp"
+#include "opto/phasetype.hpp"
 #include "utilities/bitMap.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/tribool.hpp"
@@ -199,6 +200,7 @@ void set_##name(void* value) {                                      \
 #undef set_string_function_definition
 
   BitMap& ideal_phase_mask() { return _ideal_phase_name_mask; };
+  bool should_print_phase(CompilerPhaseType cpt) { return _ideal_phase_name_mask.at(cpt); };
 
   void print_intx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" INTX_FORMAT " ", n, v); } }
   void print_uintx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" UINTX_FORMAT " ", n, v); } }

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -31,6 +31,7 @@
 #include "compiler/compiler_globals.hpp"
 #include "compiler/methodMatcher.hpp"
 #include "compiler/compilerOracle.hpp"
+#include "opto/phasetype.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/tribool.hpp"
 
@@ -128,7 +129,7 @@ private:
   InlineMatcher* _inlinematchers;
   CompilerDirectives* _directive;
   TriBoolArray<(size_t)vmIntrinsics::number_of_intrinsics(), int> _intrinsic_control_words;
-  uint64_t _ideal_phase_name_mask;
+  bool _ideal_phase_name_mask[PHASE_NUM_TYPES];
 
 public:
   DirectiveSet(CompilerDirectives* directive);
@@ -197,8 +198,7 @@ void set_##name(void* value) {                                      \
   compilerdirectives_c1_string_flags(set_string_function_definition)
 #undef set_string_function_definition
 
-  void set_ideal_phase_mask(uint64_t mask) { _ideal_phase_name_mask = mask; };
-  uint64_t ideal_phase_mask() { return _ideal_phase_name_mask; };
+  bool (&ideal_phase_mask())[PHASE_NUM_TYPES] { return _ideal_phase_name_mask; };
 
   void print_intx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" INTX_FORMAT " ", n, v); } }
   void print_uintx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" UINTX_FORMAT " ", n, v); } }

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -31,7 +31,7 @@
 #include "compiler/compiler_globals.hpp"
 #include "compiler/methodMatcher.hpp"
 #include "compiler/compilerOracle.hpp"
-#include "opto/phasetype.hpp"
+#include "utilities/bitMap.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/tribool.hpp"
 
@@ -129,7 +129,7 @@ private:
   InlineMatcher* _inlinematchers;
   CompilerDirectives* _directive;
   TriBoolArray<(size_t)vmIntrinsics::number_of_intrinsics(), int> _intrinsic_control_words;
-  phase_mask _ideal_phase_name_mask;
+  ResourceBitMap _ideal_phase_name_mask;
 
 public:
   DirectiveSet(CompilerDirectives* directive);
@@ -198,7 +198,7 @@ void set_##name(void* value) {                                      \
   compilerdirectives_c1_string_flags(set_string_function_definition)
 #undef set_string_function_definition
 
-  phase_mask& ideal_phase_mask() { return _ideal_phase_name_mask; };
+  BitMap& ideal_phase_mask() { return _ideal_phase_name_mask; };
 
   void print_intx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" INTX_FORMAT " ", n, v); } }
   void print_uintx(outputStream* st, ccstr n, intx v, bool mod) { if (mod) { st->print("%s:" UINTX_FORMAT " ", n, v); } }

--- a/src/hotspot/share/compiler/compilerDirectives.hpp
+++ b/src/hotspot/share/compiler/compilerDirectives.hpp
@@ -199,8 +199,8 @@ void set_##name(void* value) {                                      \
   compilerdirectives_c1_string_flags(set_string_function_definition)
 #undef set_string_function_definition
 
-  void set_ideal_phase_name_set(const PhaseNameValidator& v) {
-    _ideal_phase_name_set.set_from(v.phase_name_set());
+  void set_ideal_phase_name_set(const BitMap& set) {
+    _ideal_phase_name_set.set_from(set);
   };
   bool should_print_phase(const CompilerPhaseType cpt) const {
     return _ideal_phase_name_set.at(cpt);

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -777,7 +777,7 @@ static void scan_value(enum OptionType type, char* line, int& total_bytes_read,
       }
 #ifndef PRODUCT
       else if (option == CompileCommand::PrintIdealPhase) {
-        ResourceBitMap mask(PHASE_NUM_TYPES);
+        CHeapBitMap mask(PHASE_NUM_TYPES, mtCompiler);
         PhaseNameValidator validator(value, mask);
 
         if (!validator.is_valid()) {

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -777,8 +777,7 @@ static void scan_value(enum OptionType type, char* line, int& total_bytes_read,
       }
 #ifndef PRODUCT
       else if (option == CompileCommand::PrintIdealPhase) {
-        phase_mask mask;
-        memset(mask, false, sizeof(mask));
+        ResourceBitMap mask(PHASE_NUM_TYPES);
         PhaseNameValidator validator(value, mask);
 
         if (!validator.is_valid()) {

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -777,7 +777,7 @@ static void scan_value(enum OptionType type, char* line, int& total_bytes_read,
       }
 #ifndef PRODUCT
       else if (option == CompileCommand::PrintIdealPhase) {
-        bool mask[PHASE_NUM_TYPES];
+        phase_mask mask;
         memset(mask, false, sizeof(mask));
         PhaseNameValidator validator(value, mask);
 

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -777,8 +777,7 @@ static void scan_value(enum OptionType type, char* line, int& total_bytes_read,
       }
 #ifndef PRODUCT
       else if (option == CompileCommand::PrintIdealPhase) {
-        CHeapBitMap mask(PHASE_NUM_TYPES, mtCompiler);
-        PhaseNameValidator validator(value, mask);
+        PhaseNameValidator validator(value);
 
         if (!validator.is_valid()) {
           jio_snprintf(errorbuf, buf_size, "Unrecognized phase name in %s: %s", option2name(option), validator.what());

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -777,7 +777,8 @@ static void scan_value(enum OptionType type, char* line, int& total_bytes_read,
       }
 #ifndef PRODUCT
       else if (option == CompileCommand::PrintIdealPhase) {
-        uint64_t mask = 0;
+        bool mask[PHASE_NUM_TYPES];
+        memset(mask, false, sizeof(mask));
         PhaseNameValidator validator(value, mask);
 
         if (!validator.is_valid()) {

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -340,7 +340,7 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
 
           valid = validator.is_valid();
           if (valid) {
-            set->set_ideal_phase_mask(validator);
+            set->set_ideal_phase_name_set(validator);
           } else {
             error(VALUE_ERROR, "Unrecognized phase name detected in PrintIdealPhase: %s", validator.what());
           }

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -336,11 +336,12 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
             error(VALUE_ERROR, "Unrecognized intrinsic detected in DisableIntrinsic: %s", validator.what());
           }
         } else if (strncmp(option_key->name, "PrintIdealPhase", 15) == 0) {
-          BitMap& mask = set->ideal_phase_mask();
-          PhaseNameValidator validator(s, mask);
+          PhaseNameValidator validator(s);
 
           valid = validator.is_valid();
-          if (!valid) {
+          if (valid) {
+            set->set_ideal_phase_mask(validator);
+          } else {
             error(VALUE_ERROR, "Unrecognized phase name detected in PrintIdealPhase: %s", validator.what());
           }
         }

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -336,13 +336,11 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
             error(VALUE_ERROR, "Unrecognized intrinsic detected in DisableIntrinsic: %s", validator.what());
           }
         } else if (strncmp(option_key->name, "PrintIdealPhase", 15) == 0) {
-          uint64_t mask = 0;
+          bool (&mask)[PHASE_NUM_TYPES] = set->ideal_phase_mask();
           PhaseNameValidator validator(s, mask);
 
           valid = validator.is_valid();
-          if (valid) {
-            set->set_ideal_phase_mask(mask);
-          } else {
+          if (!valid) {
             error(VALUE_ERROR, "Unrecognized phase name detected in PrintIdealPhase: %s", validator.what());
           }
         }

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -336,7 +336,7 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
             error(VALUE_ERROR, "Unrecognized intrinsic detected in DisableIntrinsic: %s", validator.what());
           }
         } else if (strncmp(option_key->name, "PrintIdealPhase", 15) == 0) {
-          bool (&mask)[PHASE_NUM_TYPES] = set->ideal_phase_mask();
+          phase_mask& mask = set->ideal_phase_mask();
           PhaseNameValidator validator(s, mask);
 
           valid = validator.is_valid();

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -336,7 +336,7 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
             error(VALUE_ERROR, "Unrecognized intrinsic detected in DisableIntrinsic: %s", validator.what());
           }
         } else if (strncmp(option_key->name, "PrintIdealPhase", 15) == 0) {
-          phase_mask& mask = set->ideal_phase_mask();
+          BitMap& mask = set->ideal_phase_mask();
           PhaseNameValidator validator(s, mask);
 
           valid = validator.is_valid();

--- a/src/hotspot/share/compiler/directivesParser.cpp
+++ b/src/hotspot/share/compiler/directivesParser.cpp
@@ -340,7 +340,7 @@ bool DirectivesParser::set_option_flag(JSON_TYPE t, JSON_VAL* v, const key* opti
 
           valid = validator.is_valid();
           if (valid) {
-            set->set_ideal_phase_name_set(validator);
+            set->set_ideal_phase_name_set(validator.phase_name_set());
           } else {
             error(VALUE_ERROR, "Unrecognized phase name detected in PrintIdealPhase: %s", validator.what());
           }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -5141,7 +5141,7 @@ void Compile::end_method() {
 
 bool Compile::should_print_phase(CompilerPhaseType cpt) {
 #ifndef PRODUCT
-  if (_directive->ideal_phase_mask().at(cpt)) {
+  if (_directive->should_print_phase(cpt)) {
     return true;
   }
 #endif

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -5141,7 +5141,7 @@ void Compile::end_method() {
 
 bool Compile::should_print_phase(CompilerPhaseType cpt) {
 #ifndef PRODUCT
-  if ((_directive->ideal_phase_mask() & CompilerPhaseTypeHelper::to_bitmask(cpt)) != 0) {
+  if (_directive->ideal_phase_mask()[cpt]) {
     return true;
   }
 #endif

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -5141,7 +5141,7 @@ void Compile::end_method() {
 
 bool Compile::should_print_phase(CompilerPhaseType cpt) {
 #ifndef PRODUCT
-  if (_directive->ideal_phase_mask()[cpt]) {
+  if (_directive->ideal_phase_mask().at(cpt)) {
     return true;
   }
 #endif

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -102,9 +102,6 @@ class CompilerPhaseTypeHelper {
   static const char* to_description(CompilerPhaseType cpt) {
     return phase_descriptions[cpt];
   }
-  static uint64_t to_bitmask(CompilerPhaseType cpt) {
-    return (UINT64_C(1) << cpt);
-  }
 };
 
 static CompilerPhaseType find_phase(const char* str) {

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -197,7 +197,7 @@ class PhaseNameValidator {
 
   const BitMap& mask() const { return _mask; }
   bool is_valid() const { return _valid; }
-  bool is_set() const { return _set; }
+  bool is_mask_set() const { return _set; }
   const char* what() const { return _bad; }
 };
 

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -158,10 +158,11 @@ class PhaseNameIter {
 class PhaseNameValidator {
  private:
   bool _valid;
+  bool _set;
   char* _bad;
 
  public:
-  PhaseNameValidator(ccstrlist option, uint64_t& mask) : _valid(true), _bad(nullptr) {
+  PhaseNameValidator(ccstrlist option, bool (&mask)[PHASE_NUM_TYPES]) : _valid(true), _set(false), _bad(nullptr) {
     for (PhaseNameIter iter(option); *iter != nullptr && _valid; ++iter) {
 
       CompilerPhaseType cpt = find_phase(*iter);
@@ -172,10 +173,13 @@ class PhaseNameValidator {
         strncpy(_bad, *iter, len);
         _valid = false;
       } else if (PHASE_ALL == cpt) {
-        mask = ~(UINT64_C(0));
+        /* mask = ~(UINT64_C(0)); */
+        memset(mask, true, sizeof(mask));
+        _set = true;
       } else {
-        assert(cpt < 64, "out of bounds");
-        mask |= CompilerPhaseTypeHelper::to_bitmask(cpt);
+        /* assert(cpt < 64, "out of bounds"); */
+        mask[cpt] = true;
+        _set = true;
       }
     }
   }
@@ -188,6 +192,10 @@ class PhaseNameValidator {
 
   bool is_valid() const {
     return _valid;
+  }
+
+  bool is_set() const {
+    return _set;
   }
 
   const char* what() const {

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -156,12 +156,19 @@ class PhaseNameIter {
 
 class PhaseNameValidator {
  private:
+  CHeapBitMap _mask;
   bool _valid;
   bool _set;
   char* _bad;
 
+
  public:
-  PhaseNameValidator(ccstrlist option, BitMap& mask) : _valid(true), _set(false), _bad(nullptr) {
+  PhaseNameValidator(ccstrlist option)
+                    : _mask(PHASE_NUM_TYPES, mtCompiler),
+                      _valid(true),
+                      _set(false),
+                      _bad(nullptr)
+  {
     for (PhaseNameIter iter(option); *iter != nullptr && _valid; ++iter) {
 
       CompilerPhaseType cpt = find_phase(*iter);
@@ -172,11 +179,11 @@ class PhaseNameValidator {
         strncpy(_bad, *iter, len);
         _valid = false;
       } else if (PHASE_ALL == cpt) {
-        mask.set_range(0,PHASE_NUM_TYPES);
+        _mask.set_range(0,PHASE_NUM_TYPES);
         _set = true;
       } else {
         assert(cpt < PHASE_NUM_TYPES, "out of bounds");
-        mask.set_bit(cpt);
+        _mask.set_bit(cpt);
         _set = true;
       }
     }
@@ -188,17 +195,10 @@ class PhaseNameValidator {
     }
   }
 
-  bool is_valid() const {
-    return _valid;
-  }
-
-  bool is_set() const {
-    return _set;
-  }
-
-  const char* what() const {
-    return _bad;
-  }
+  const BitMap& mask() const { return _mask; }
+  bool is_valid() const { return _valid; }
+  bool is_set() const { return _set; }
+  const char* what() const { return _bad; }
 };
 
 #endif // SHARE_OPTO_PHASETYPE_HPP

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -92,6 +92,8 @@ static const char* phase_names[] = {
 #undef array_of_labels
 };
 
+typedef bool phase_mask[PHASE_NUM_TYPES];
+
 class CompilerPhaseTypeHelper {
   public:
   static const char* to_name(CompilerPhaseType cpt) {
@@ -162,7 +164,7 @@ class PhaseNameValidator {
   char* _bad;
 
  public:
-  PhaseNameValidator(ccstrlist option, bool (&mask)[PHASE_NUM_TYPES]) : _valid(true), _set(false), _bad(nullptr) {
+  PhaseNameValidator(ccstrlist option, phase_mask& mask) : _valid(true), _set(false), _bad(nullptr) {
     for (PhaseNameIter iter(option); *iter != nullptr && _valid; ++iter) {
 
       CompilerPhaseType cpt = find_phase(*iter);
@@ -173,11 +175,9 @@ class PhaseNameValidator {
         strncpy(_bad, *iter, len);
         _valid = false;
       } else if (PHASE_ALL == cpt) {
-        /* mask = ~(UINT64_C(0)); */
         memset(mask, true, sizeof(mask));
         _set = true;
       } else {
-        /* assert(cpt < 64, "out of bounds"); */
         mask[cpt] = true;
         _set = true;
       }

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -194,8 +194,14 @@ class PhaseNameValidator {
     assert(is_valid(), "Use of invalid phase name set");
     return _phase_name_set;
   }
-  bool is_valid() const { return _valid; }
-  const char* what() const { return _bad; }
+
+  bool is_valid() const {
+    return _valid;
+  }
+
+  const char* what() const {
+    return _bad;
+  }
 };
 
 #endif // SHARE_OPTO_PHASETYPE_HPP

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -160,7 +160,6 @@ class PhaseNameValidator {
   bool _valid;
   char* _bad;
 
-
  public:
   PhaseNameValidator(ccstrlist option) :
     _phase_name_set(PHASE_NUM_TYPES, mtCompiler),

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -196,7 +196,6 @@ class PhaseNameValidator {
     return _phase_name_set;
   }
   bool is_valid() const { return _valid; }
-  bool is_phase_name_set_empty() const { return _phase_name_set.is_empty(); }
   const char* what() const { return _bad; }
 };
 

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -156,18 +156,16 @@ class PhaseNameIter {
 
 class PhaseNameValidator {
  private:
-  CHeapBitMap _mask;
+  CHeapBitMap _phase_name_set;
   bool _valid;
-  bool _set;
   char* _bad;
 
 
  public:
-  PhaseNameValidator(ccstrlist option)
-                    : _mask(PHASE_NUM_TYPES, mtCompiler),
-                      _valid(true),
-                      _set(false),
-                      _bad(nullptr)
+  PhaseNameValidator(ccstrlist option) :
+    _phase_name_set(PHASE_NUM_TYPES, mtCompiler),
+    _valid(true),
+    _bad(nullptr)
   {
     for (PhaseNameIter iter(option); *iter != nullptr && _valid; ++iter) {
 
@@ -179,12 +177,10 @@ class PhaseNameValidator {
         strncpy(_bad, *iter, len);
         _valid = false;
       } else if (PHASE_ALL == cpt) {
-        _mask.set_range(0,PHASE_NUM_TYPES);
-        _set = true;
+        _phase_name_set.set_range(0, PHASE_NUM_TYPES);
       } else {
         assert(cpt < PHASE_NUM_TYPES, "out of bounds");
-        _mask.set_bit(cpt);
-        _set = true;
+        _phase_name_set.set_bit(cpt);
       }
     }
   }
@@ -195,9 +191,12 @@ class PhaseNameValidator {
     }
   }
 
-  const BitMap& mask() const { return _mask; }
+  const BitMap& phase_name_set() const {
+    assert(is_valid(), "Use of invalid phase name set");
+    return _phase_name_set;
+  }
   bool is_valid() const { return _valid; }
-  bool is_mask_set() const { return _set; }
+  bool is_phase_name_set_empty() const { return _phase_name_set.is_empty(); }
   const char* what() const { return _bad; }
 };
 

--- a/src/hotspot/share/opto/phasetype.hpp
+++ b/src/hotspot/share/opto/phasetype.hpp
@@ -25,6 +25,8 @@
 #ifndef SHARE_OPTO_PHASETYPE_HPP
 #define SHARE_OPTO_PHASETYPE_HPP
 
+#include "utilities/bitMap.inline.hpp"
+
 #define COMPILER_PHASES(flags) \
   flags(BEFORE_STRINGOPTS,            "Before StringOpts") \
   flags(AFTER_STRINGOPTS,             "After StringOpts") \
@@ -91,8 +93,6 @@ static const char* phase_names[] = {
        COMPILER_PHASES(array_of_labels)
 #undef array_of_labels
 };
-
-typedef bool phase_mask[PHASE_NUM_TYPES];
 
 class CompilerPhaseTypeHelper {
   public:
@@ -164,7 +164,7 @@ class PhaseNameValidator {
   char* _bad;
 
  public:
-  PhaseNameValidator(ccstrlist option, phase_mask& mask) : _valid(true), _set(false), _bad(nullptr) {
+  PhaseNameValidator(ccstrlist option, BitMap& mask) : _valid(true), _set(false), _bad(nullptr) {
     for (PhaseNameIter iter(option); *iter != nullptr && _valid; ++iter) {
 
       CompilerPhaseType cpt = find_phase(*iter);
@@ -175,10 +175,11 @@ class PhaseNameValidator {
         strncpy(_bad, *iter, len);
         _valid = false;
       } else if (PHASE_ALL == cpt) {
-        memset(mask, true, sizeof(mask));
+        mask.set_range(0,PHASE_NUM_TYPES);
         _set = true;
       } else {
-        mask[cpt] = true;
+        assert(cpt < PHASE_NUM_TYPES, "out of bounds");
+        mask.set_bit(cpt);
         _set = true;
       }
     }


### PR DESCRIPTION
This changeset removes the implicit upper limit on the number of compiler phases in `phasetype.hpp`. The limit was due to the 64-bit mask used in `Compile::should_print_phase`, causing the `assert(cpt < 64, "out of bounds");` in `phasetype.hpp` to trigger when increasing the number of phases to more than 64.

Changes:
- Replace the 64-bit mask with a bit map (`utilities/bitMap.hpp`).
- Clean up the `PhaseNameValidator` interface by allocating the mask internally.
- Move the check for whether a mask is non-zero ("is set") into `PhaseNameValidator`.
- Add a method `should_print_phase` to `DirectiveSet`, simplifying the `if`-condition in `Compile::should_print_phase`.

### Testing
Platforms: windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64.
- `tier1`
- HotSpot parts of `tier2` and `tier3`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319813](https://bugs.openjdk.org/browse/JDK-8319813): Remove upper limit on number of compiler phases in phasetype.hpp (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16729/head:pull/16729` \
`$ git checkout pull/16729`

Update a local copy of the PR: \
`$ git checkout pull/16729` \
`$ git pull https://git.openjdk.org/jdk.git pull/16729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16729`

View PR using the GUI difftool: \
`$ git pr show -t 16729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16729.diff">https://git.openjdk.org/jdk/pull/16729.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16729#issuecomment-1818509072)