### PR TITLE
JDK-8320383: refresh libraries cache on AIX in VMError::report

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1017,6 +1017,10 @@ int os::current_process_id() {
 // directory not the java application's temp directory, ala java.io.tmpdir.
 const char* os::get_temp_directory() { return "/tmp"; }
 
+void os::prepare_native_symbols() {
+  LoadedLibraries::reload();
+}
+
 // Check if addr is inside libjvm.so.
 bool os::address_is_in_vm(address addr) {
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -895,6 +895,9 @@ bool os::address_is_in_vm(address addr) {
   return false;
 }
 
+void os::prepare_native_symbols() {
+}
+
 bool os::dll_address_to_function_name(address addr, char *buf,
                                       int buflen, int *offset,
                                       bool demangle) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1470,6 +1470,9 @@ bool os::address_is_in_vm(address addr) {
   return false;
 }
 
+void os::prepare_native_symbols() {
+}
+
 bool os::dll_address_to_function_name(address addr, char *buf,
                                       int buflen, int *offset,
                                       bool demangle) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1398,6 +1398,9 @@ const char* os::get_current_directory(char *buf, size_t buflen) {
   return _getcwd(buf, n);
 }
 
+void os::prepare_native_symbols() {
+}
+
 //-----------------------------------------------------------
 // Helper functions for fatal error handler
 #ifdef _WIN64

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -673,6 +673,8 @@ class os: AllStatic {
   static const char*    get_temp_directory();
   static const char*    get_current_directory(char *buf, size_t buflen);
 
+  static void           prepare_native_symbols();
+
   // Builds the platform-specific name of a library.
   // Returns false if the buffer is too small.
   static bool           dll_build_name(char* buffer, size_t size,

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -725,6 +725,14 @@ void VMError::report(outputStream* st, bool _verbose) {
                    "Runtime Environment to continue.");
     }
 
+#ifdef AIX
+  // avoid the cache update for malloc/mmap errors
+  if (should_report_bug(_id)) {
+    printf("update loaded lib cache !!!!!\n");
+    LoadedLibraries::reload();
+  }
+#endif
+
 #ifdef ASSERT
   // Error handler self tests
   // Meaning of codes passed through in the tests.

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -725,12 +725,10 @@ void VMError::report(outputStream* st, bool _verbose) {
                    "Runtime Environment to continue.");
     }
 
-#ifdef AIX
   // avoid the cache update for malloc/mmap errors
   if (should_report_bug(_id)) {
-    LoadedLibraries::reload();
+    os::prepare_native_symbols();
   }
-#endif
 
 #ifdef ASSERT
   // Error handler self tests

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -728,7 +728,6 @@ void VMError::report(outputStream* st, bool _verbose) {
 #ifdef AIX
   // avoid the cache update for malloc/mmap errors
   if (should_report_bug(_id)) {
-    printf("update loaded lib cache !!!!!\n");
     LoadedLibraries::reload();
   }
 #endif

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -74,10 +74,6 @@
 #include "jvmci/jvmci.hpp"
 #endif
 
-#ifdef AIX
-#include "loadlib_aix.hpp"
-#endif
-
 #ifndef PRODUCT
 #include <signal.h>
 #endif // PRODUCT
@@ -1352,7 +1348,7 @@ void VMError::report(outputStream* st, bool _verbose) {
 void VMError::print_vm_info(outputStream* st) {
 
   char buf[O_BUFLEN];
-  AIX_ONLY(LoadedLibraries::reload());
+  os::prepare_native_symbols();
 
   report_vm_version(st, buf, sizeof(buf));
 


### PR DESCRIPTION
VMError::report outputs information about loaded shared libraries; but this info could be outdated on AIX because the libraries cache is currently not refreshed before printing.
This is similar to [JDK-8318587](https://bugs.openjdk.org/browse/JDK-8318587) .
The refresh in VMError::report could be omitted in some situations where the refresh call is considered problematic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320383](https://bugs.openjdk.org/browse/JDK-8320383): refresh libraries cache on AIX in VMError::report (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16730/head:pull/16730` \
`$ git checkout pull/16730`

Update a local copy of the PR: \
`$ git checkout pull/16730` \
`$ git pull https://git.openjdk.org/jdk.git pull/16730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16730`

View PR using the GUI difftool: \
`$ git pr show -t 16730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16730.diff">https://git.openjdk.org/jdk/pull/16730.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16730#issuecomment-1818522837)