### PR TITLE
JDK-8275889: Search dialog has redundant scrollbars

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/markup/Head.java
@@ -319,6 +319,11 @@ public class Head extends Content {
     }
 
     private void addStylesheets(HtmlTree head) {
+        if (index) {
+            // Add JQuery-UI stylesheet first so its rules can be overridden.
+            addStylesheet(head, DocPaths.RESOURCE_FILES.resolve(DocPaths.JQUERY_UI_CSS));
+        }
+
         if (mainStylesheet == null) {
             mainStylesheet = DocPaths.STYLESHEET;
         }
@@ -331,10 +336,6 @@ public class Head extends Content {
         for (DocPath path : localStylesheets) {
             // Local stylesheets are contained in doc-files, so omit resource-files prefix
             addStylesheet(head, path);
-        }
-
-        if (index) {
-            addStylesheet(head, DocPaths.RESOURCE_FILES.resolve(DocPaths.JQUERY_UI_CSS));
         }
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -692,11 +692,14 @@ nav {
 /*
  * Styles for javadoc search.
  */
-.ui-state-active {
+.ui-menu .ui-state-active {
     /* Overrides the color of selection used in jQuery UI */
     background: var(--selected-background-color);
-    border: 1px solid var(--selected-background-color);
     color: var(--selected-text-color);
+    /* Workaround for browser bug, see JDK-8275889 */
+    margin: -1px 0;
+    border-top: 1px solid var(--selected-background-color);
+    border-bottom: 1px solid var(--selected-background-color);
 }
 .ui-autocomplete-category {
     font-weight:bold;
@@ -704,15 +707,16 @@ nav {
     padding:7px 0 7px 3px;
     background-color:var(--navbar-background-color);
     color:var(--navbar-text-color);
+    box-sizing: border-box;
 }
 .ui-autocomplete {
     max-height:85%;
     max-width:65%;
     overflow-y:auto;
     overflow-x:auto;
-    scrollbar-width: thin;
     white-space:nowrap;
     box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+    overscroll-behavior: contain;
 }
 ul.ui-autocomplete {
     position:fixed;
@@ -723,6 +727,7 @@ ul.ui-autocomplete li {
     float:left;
     clear:both;
     min-width:100%;
+    box-sizing: border-box;
 }
 ul.ui-autocomplete li.ui-static-link {
     position:sticky;
@@ -746,6 +751,10 @@ li.ui-static-link a, li.ui-static-link a:visited {
 }
 .ui-autocomplete .result-highlight {
     font-weight:bold;
+}
+.ui-menu .ui-menu-item-wrapper {
+    padding-top: 0.4em;
+    padding-bottom: 0.4em;
 }
 #search-input, #page-search-input {
     background-image:url('glass.png');


### PR DESCRIPTION
Please review a change to fix multiple issues that caused a horizontal scrollbar to appear on the list of search results in JavaDoc-generated documentation even when not required by the list content. The problems are described in more detail in the JBS issue, but to summarize:

 - Our category headers contained horizontal padding which was added to the width of 100%. This is solved by adding `box-sizing: border-box` where necessary.
 - The selected item is shown with a negative margin and positive border to work around a browser bug, which also caused horizontal overflow. This is solved by only applying the margin and border to the vertical axis.

For the second fix it was also necessary to change the order in which stylesheets are loaded in HTML files in order to be able to override declarations in the JQuery-UI stylesheet.

I also added a little bit of vertical padding to result list items as the list looked very crammed to me. Generated documentation (top-level files only) can be viewed at the URL below. Search results should not display a horizontal scrollbar unless required by the contents of the list.

https://cr.openjdk.org/~hannesw/8275889/api.00/