### PR TITLE
8320386: Remove java/nio/channels/vthread/BlockingChannelOps.java#direct-register from ProblemList

### DIFF
--- a/test/jdk/ProblemList-generational-zgc.txt
+++ b/test/jdk/ProblemList-generational-zgc.txt
@@ -39,4 +39,3 @@ sun/tools/jhsdb/HeapDumpTestWithActiveProcess.java 8307393   generic-all
 
 com/sun/jdi/ThreadMemoryLeakTest.java          8307402 generic-all
 java/util/concurrent/locks/Lock/OOMEInAQS.java 8309218 generic-all
-java/nio/channels/vthread/BlockingChannelOps.java#direct-register 8315544 windows-x64


### PR DESCRIPTION
The direct-register test variant was removed in c099cf53f25496c99629dc578045aa5186e1109d. The failing test case was also modified - the socket timeout is much shorter now, so even if the receive operation gets stuck for the full duration, the test will still pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320386](https://bugs.openjdk.org/browse/JDK-8320386): Remove java/nio/channels/vthread/BlockingChannelOps.java#direct-register from ProblemList (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16732/head:pull/16732` \
`$ git checkout pull/16732`

Update a local copy of the PR: \
`$ git checkout pull/16732` \
`$ git pull https://git.openjdk.org/jdk.git pull/16732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16732`

View PR using the GUI difftool: \
`$ git pr show -t 16732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16732.diff">https://git.openjdk.org/jdk/pull/16732.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16732#issuecomment-1818762423)