### PR TITLE
8320399: RISC-V: Some format clean-up in opto assembly code

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1036,12 +1036,13 @@ void C2_MacroAssembler::string_indexof_linearscan(Register haystack, Register ne
 
 // Compare strings.
 void C2_MacroAssembler::string_compare(Register str1, Register str2,
-                                    Register cnt1, Register cnt2, Register result, Register tmp1, Register tmp2,
-                                    Register tmp3, int ae)
+                                       Register cnt1, Register cnt2, Register result,
+                                       Register tmp1, Register tmp2, Register tmp3,
+                                       int ae)
 {
   Label DONE, SHORT_LOOP, SHORT_STRING, SHORT_LAST, TAIL, STUB,
-      DIFFERENCE, NEXT_WORD, SHORT_LOOP_TAIL, SHORT_LAST2, SHORT_LAST_INIT,
-      SHORT_LOOP_START, TAIL_CHECK, L;
+        DIFFERENCE, NEXT_WORD, SHORT_LOOP_TAIL, SHORT_LAST2, SHORT_LAST_INIT,
+        SHORT_LOOP_START, TAIL_CHECK, L;
 
   const int STUB_THRESHOLD = 64 + 8;
   bool isLL = ae == StrIntrinsicNode::LL;

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8645,7 +8645,7 @@ instruct MoveF2I_reg_reg(iRegINoSp dst, fRegF src) %{
 
   ins_cost(XFER_COST);
 
-  format %{ "fmv.x.w  $dst, $src\t#@MoveL2D_reg_stack" %}
+  format %{ "fmv.x.w  $dst, $src\t#@MoveF2I_reg_reg" %}
 
   ins_encode %{
     __ fmv_x_w(as_Register($dst$$reg), as_FloatRegister($src$$reg));
@@ -8699,7 +8699,7 @@ instruct MoveL2D_reg_reg(fRegD dst, iRegL src) %{
 
   ins_cost(XFER_COST);
 
-  format %{ "fmv.d.x  $dst, $src\t#@MoveD2L_reg_reg" %}
+  format %{ "fmv.d.x  $dst, $src\t#@MoveL2D_reg_reg" %}
 
   ins_encode %{
     __ fmv_d_x(as_FloatRegister($dst$$reg), as_Register($src$$reg));
@@ -8720,7 +8720,8 @@ instruct cmpF3_reg_reg(iRegINoSp dst, fRegF op1, fRegF op2)
   format %{ "flt.s  $dst, $op2, $op1\t#@cmpF3_reg_reg\n\t"
             "bgtz   $dst, done\n\t"
             "feq.s  $dst, $op1, $op2\n\t"
-            "addi   $dst, $dst, -1\t#@cmpF3_reg_reg"
+            "addi   $dst, $dst, -1\n\t"
+            "done:"
   %}
 
   ins_encode %{
@@ -8740,7 +8741,8 @@ instruct cmpD3_reg_reg(iRegINoSp dst, fRegD op1, fRegD op2)
   format %{ "flt.d  $dst, $op2, $op1\t#@cmpD3_reg_reg\n\t"
             "bgtz   $dst, done\n\t"
             "feq.d  $dst, $op1, $op2\n\t"
-            "addi   $dst, $dst, -1\t#@cmpD3_reg_reg"
+            "addi   $dst, $dst, -1\n\t"
+            "done:"
   %}
 
   ins_encode %{
@@ -8758,8 +8760,9 @@ instruct cmpL3_reg_reg(iRegINoSp dst, iRegL op1, iRegL op2)
   ins_cost(ALU_COST * 3 + BRANCH_COST);
   format %{ "slt   $dst, $op2, $op1\t#@cmpL3_reg_reg\n\t"
             "bnez  $dst, done\n\t"
-            "slt  $dst, $op1, $op2\n\t"
-            "neg   $dst, $dst\t#@cmpL3_reg_reg"
+            "slt   $dst, $op1, $op2\n\t"
+            "neg   $dst, $dst\n\t"
+            "done:"
   %}
   ins_encode %{
     __ cmp_l2i(t0, as_Register($op1$$reg), as_Register($op2$$reg));
@@ -8777,7 +8780,8 @@ instruct cmpUL3_reg_reg(iRegINoSp dst, iRegL op1, iRegL op2)
   format %{ "sltu  $dst, $op2, $op1\t#@cmpUL3_reg_reg\n\t"
             "bnez  $dst, done\n\t"
             "sltu  $dst, $op1, $op2\n\t"
-            "neg   $dst, $dst\t#@cmpUL3_reg_reg"
+            "neg   $dst, $dst\n\t"
+            "done:"
   %}
   ins_encode %{
     __ cmp_ul2i(t0, as_Register($op1$$reg), as_Register($op2$$reg));
@@ -8795,7 +8799,8 @@ instruct cmpU3_reg_reg(iRegINoSp dst, iRegI op1, iRegI op2)
   format %{ "sltu  $dst, $op2, $op1\t#@cmpU3_reg_reg\n\t"
             "bnez  $dst, done\n\t"
             "sltu  $dst, $op1, $op2\n\t"
-            "neg   $dst, $dst\t#@cmpU3_reg_reg"
+            "neg   $dst, $dst\n\t"
+            "done:"
   %}
   ins_encode %{
     __ cmp_uw2i(t0, as_Register($op1$$reg), as_Register($op2$$reg));
@@ -8940,12 +8945,12 @@ instruct minI_rReg(iRegINoSp dst, iRegI src1, iRegI src2)
 
   ins_cost(BRANCH_COST + ALU_COST * 2);
   format %{
-    "ble $src1, $src2, Lsrc1.\t#@minI_rReg\n\t"
+    "ble $src1, $src2, Lsrc1\t#@minI_rReg\n\t"
     "mv $dst, $src2\n\t"
     "j Ldone\n\t"
-    "bind Lsrc1\n\t"
+    "Lsrc1:\n\t"
     "mv $dst, $src1\n\t"
-    "bind\t#@minI_rReg"
+    "Ldone:"
   %}
 
   ins_encode %{
@@ -8972,9 +8977,9 @@ instruct maxI_rReg(iRegINoSp dst, iRegI src1, iRegI src2)
     "bge $src1, $src2, Lsrc1\t#@maxI_rReg\n\t"
     "mv $dst, $src2\n\t"
     "j Ldone\n\t"
-    "bind Lsrc1\n\t"
+    "Lsrc1:\n\t"
     "mv $dst, $src1\n\t"
-    "bind\t#@maxI_rReg"
+    "Ldone:"
   %}
 
   ins_encode %{


### PR DESCRIPTION
Hi, please review this trivial clean-up in riscv.ad and c2_macroAssembler_riscv.cpp:
- Some C2 instructions are missing the `done` label at the end of the format string. 
- Fix format naming error in `MoveF2I_reg_reg` and `MoveL2D_reg_reg`.
- Small code adjustments to `C2_MacroAssembler::string_compare`.

Testing:
- [x] GHA linux-riscv cross-compiling

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320399](https://bugs.openjdk.org/browse/JDK-8320399): RISC-V: Some format clean-up in opto assembly code (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16734/head:pull/16734` \
`$ git checkout pull/16734`

Update a local copy of the PR: \
`$ git checkout pull/16734` \
`$ git pull https://git.openjdk.org/jdk.git pull/16734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16734`

View PR using the GUI difftool: \
`$ git pr show -t 16734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16734.diff">https://git.openjdk.org/jdk/pull/16734.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16734#issuecomment-1818895834)