### PR TITLE
Simplify x86 char_array_compress intrinsic

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5651,7 +5651,7 @@ void MacroAssembler::fill_words(Register base, Register cnt, Register value)
 // - sun/nio/cs/ISO_8859_1$Encoder.implEncodeISOArray
 //     return the number of characters copied.
 // - java/lang/StringUTF16.compress
-//     return zero (0) if copy fails, otherwise 'len'.
+//     return index of non-latin1 character if copy fails, otherwise 'len'.
 //
 // This version always returns the number of characters copied, and does not
 // clobber the 'len' register. A successful copy will complete with the post-
@@ -5868,6 +5868,9 @@ address MacroAssembler::byte_array_inflate(Register src, Register dst, Register 
 }
 
 // Compress char[] array to byte[].
+// Intrinsic for java.lang.StringUTF16.compress(char[] src, int srcOff, byte[] dst, int dstOff, int len)
+// Return the array length if every element in array can be encoded,
+// otherwise, the index of first non-latin1 (> 0xff) character.
 void MacroAssembler::char_array_compress(Register src, Register dst, Register len,
                                          Register res,
                                          FloatRegister tmp0, FloatRegister tmp1,

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5874,9 +5874,6 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
                                          FloatRegister tmp2, FloatRegister tmp3,
                                          FloatRegister tmp4, FloatRegister tmp5) {
   encode_iso_array(src, dst, len, res, false, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5);
-  // Adjust result: res == len ? len : 0
-  cmp(len, res);
-  csel(res, res, zr, EQ);
 }
 
 // java.math.round(double a)

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -12727,16 +12727,8 @@ instruct string_compress(rarg1RegP src, rarg2RegP dst, iRegIsrc len, iRegIdst re
   ins_cost(300);
   format %{ "String Compress $src,$dst,$len -> $result \t// KILL $tmp1, $tmp2, $tmp3, $tmp4, $tmp5" %}
   ins_encode %{
-    Label Lskip, Ldone;
-    __ li($result$$Register, 0);
-    __ string_compress_16($src$$Register, $dst$$Register, $len$$Register, $tmp1$$Register,
-                          $tmp2$$Register, $tmp3$$Register, $tmp4$$Register, $tmp5$$Register, Ldone);
-    __ rldicl_($tmp1$$Register, $len$$Register, 0, 64-3); // Remaining characters.
-    __ beq(CCR0, Lskip);
-    __ string_compress($src$$Register, $dst$$Register, $tmp1$$Register, $tmp2$$Register, Ldone);
-    __ bind(Lskip);
-    __ mr($result$$Register, $len$$Register);
-    __ bind(Ldone);
+    __ encode_iso_array($src$$Register, $dst$$Register, $len$$Register, $tmp1$$Register, $tmp2$$Register,
+                        $tmp3$$Register, $tmp4$$Register, $tmp5$$Register, $result$$Register, false);
   %}
   ins_pipe(pipe_class_default);
 %}

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1860,14 +1860,12 @@ void C2_MacroAssembler::byte_array_inflate_v(Register src, Register dst, Registe
 }
 
 // Compress char[] array to byte[].
-// result: the array length if every element in array can be encoded; 0, otherwise.
+// Intrinsic for java.lang.StringUTF16.compress(char[] src, int srcOff, byte[] dst, int dstOff, int len)
+// result: the array length if every element in array can be encoded,
+// otherwise, the index of first non-latin1 (> 0xff) character.
 void C2_MacroAssembler::char_array_compress_v(Register src, Register dst, Register len,
                                               Register result, Register tmp) {
-  Label done;
   encode_iso_array_v(src, dst, len, result, tmp, false);
-  beqz(len, done);
-  mv(result, zr);
-  bind(done);
 }
 
 // Intrinsic for
@@ -1875,7 +1873,7 @@ void C2_MacroAssembler::char_array_compress_v(Register src, Register dst, Regist
 // - sun/nio/cs/ISO_8859_1$Encoder.implEncodeISOArray
 //     return the number of characters copied.
 // - java/lang/StringUTF16.compress
-//     return zero (0) if copy fails, otherwise 'len'.
+//     return index of non-latin1 character if copy fails, otherwise 'len'.
 //
 // This version always returns the number of characters copied. A successful
 // copy will complete with the post-condition: 'res' == 'len', while an

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10190,7 +10190,7 @@ instruct string_compress(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tm
   format %{ "String Compress $src->$dst($len) -> $result" %}
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
-                       $tmp$$Register, false, false);
+                       $tmp$$Register, true, false);
   %}
   ins_pipe(pipe_class_dummy);
 %}

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -8499,7 +8499,7 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
   XMMRegister tmp1Reg, XMMRegister tmp2Reg,
   XMMRegister tmp3Reg, XMMRegister tmp4Reg,
   Register tmp5, Register result, KRegister mask1, KRegister mask2) {
-  Label copy_chars_loop, return_length, done, reset_sp, copy_tail;
+  Label copy_chars_loop, done, reset_sp, copy_tail;
 
   // rsi: src
   // rdi: dst
@@ -8514,7 +8514,7 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
   assert(len != result, "");
 
   // save length for return
-  push(len);
+  movl(result, len);
 
   if ((AVX3Threshold == 0) && (UseAVX > 2) && // AVX512
     VM_Version::supports_avx512vlbw() &&
@@ -8531,8 +8531,8 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
 
     // First check whether a character is compressible ( <= 0xFF).
     // Create mask to test for Unicode chars inside zmm vector
-    movl(result, 0x00FF);
-    evpbroadcastw(tmp2Reg, result, Assembler::AVX_512bit);
+    movl(tmp5, 0x00FF);
+    evpbroadcastw(tmp2Reg, tmp5, Assembler::AVX_512bit);
 
     testl(len, -64);
     jcc(Assembler::zero, post_alignment);
@@ -8547,10 +8547,11 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     jcc(Assembler::zero, post_alignment);
 
     // ~(~0 << len), where len is the # of remaining elements to process
-    movl(result, 0xFFFFFFFF);
-    shlxl(result, result, tmp5);
-    notl(result);
-    kmovdl(mask2, result);
+    movl(len, 0xFFFFFFFF);
+    shlxl(len, len, tmp5);
+    notl(len);
+    kmovdl(mask2, len);
+    movl(len, result);
 
     evmovdquw(tmp1Reg, mask2, Address(src, 0), /*merge*/ false, Assembler::AVX_512bit);
     evpcmpw(mask1, mask2, tmp1Reg, tmp2Reg, Assembler::le, /*signed*/ false, Assembler::AVX_512bit);
@@ -8591,16 +8592,16 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     bind(copy_loop_tail);
     // bail out when there is nothing to be done
     testl(tmp5, 0xFFFFFFFF);
-    jcc(Assembler::zero, return_length);
+    jcc(Assembler::zero, done);
 
     movl(len, tmp5);
 
     // ~(~0 << len), where len is the # of remaining elements to process
-    movl(result, 0xFFFFFFFF);
-    shlxl(result, result, len);
-    notl(result);
+    movl(tmp5, 0xFFFFFFFF);
+    shlxl(tmp5, tmp5, len);
+    notl(tmp5);
 
-    kmovdl(mask2, result);
+    kmovdl(mask2, tmp5);
 
     evmovdquw(tmp1Reg, mask2, Address(src, 0), /*merge*/ false, Assembler::AVX_512bit);
     evpcmpw(mask1, mask2, tmp1Reg, tmp2Reg, Assembler::le, /*signed*/ false, Assembler::AVX_512bit);
@@ -8608,7 +8609,7 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     jcc(Assembler::carryClear, copy_tail);
 
     evpmovwb(Address(dst, 0), mask2, tmp1Reg, Assembler::AVX_512bit);
-    jmp(return_length);
+    jmp(done);
 
     bind(reset_for_copy_tail);
     lea(src, Address(src, tmp5, Address::times_2));
@@ -8620,21 +8621,20 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
   }
 
   if (UseSSE42Intrinsics) {
-    Label copy_32_loop, copy_16, copy_tail_sse, reset_for_copy_tail, reset_for_copy_tail_16;
-
-    movl(result, len);
-
-    movl(tmp5, 0xff00ff00);   // create mask to test for Unicode chars in vectors
+    Label copy_32_loop, copy_16, copy_tail_sse, reset_for_copy_tail;
 
     // vectored compression
-    andl(len, 0xfffffff0);    // vector count (in chars)
-    andl(result, 0x0000000f);    // tail count (in chars)
-    testl(len, len);
+    testl(len, 0xfffffff8);
+    jcc(Assembler::zero, copy_tail);
+
+    movl(tmp5, 0xff00ff00);   // create mask to test for Unicode chars in vectors
+    movdl(tmp1Reg, tmp5);
+    pshufd(tmp1Reg, tmp1Reg, 0);   // store Unicode mask in tmp1Reg
+
+    andl(len, 0xfffffff0);
     jcc(Assembler::zero, copy_16);
 
     // compress 16 chars per iter
-    movdl(tmp1Reg, tmp5);
-    pshufd(tmp1Reg, tmp1Reg, 0);   // store Unicode mask in tmp1Reg
     pxor(tmp4Reg, tmp4Reg);
 
     lea(src, Address(src, len, Address::times_2));
@@ -8655,64 +8655,53 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
 
     // compress next vector of 8 chars (if any)
     bind(copy_16);
-    movl(len, result);
-    andl(len, 0xfffffff8);    // vector count (in chars)
-    andl(result, 0x00000007);    // tail count (in chars)
-    testl(len, len);
+    // len = 0
+    testl(result, 0x00000008);     // check if there's a block of 8 chars to compress
     jccb(Assembler::zero, copy_tail_sse);
 
-    movdl(tmp1Reg, tmp5);
-    pshufd(tmp1Reg, tmp1Reg, 0);   // store Unicode mask in tmp1Reg
     pxor(tmp3Reg, tmp3Reg);
 
     movdqu(tmp2Reg, Address(src, 0));
     ptest(tmp2Reg, tmp1Reg);       // check for Unicode chars in vector
-    jccb(Assembler::notZero, reset_for_copy_tail_16);
+    jccb(Assembler::notZero, reset_for_copy_tail);
     packuswb(tmp2Reg, tmp3Reg);    // only LATIN1 chars; compress each to 1 byte
     movq(Address(dst, 0), tmp2Reg);
     addptr(src, 16);
     addptr(dst, 8);
-    jmp(copy_tail_sse);
+    jmpb(copy_tail_sse);
 
     bind(reset_for_copy_tail);
-    lea(src, Address(src, result, Address::times_2));
-    lea(dst, Address(dst, result, Address::times_1));
-    subptr(len, result);
-    jmpb(copy_chars_loop);
-
-    bind(reset_for_copy_tail_16);
-    addl(len, result);
-    lea(src, Address(src, len, Address::times_2));
-    lea(dst, Address(dst, len, Address::times_1));
-    negptr(len);
+    movl(tmp5, result);
+    andl(tmp5, 0x0000000f);
+    lea(src, Address(src, tmp5, Address::times_2));
+    lea(dst, Address(dst, tmp5, Address::times_1));
+    subptr(len, tmp5);
     jmpb(copy_chars_loop);
 
     bind(copy_tail_sse);
     movl(len, result);
+    andl(len, 0x00000007);    // tail count (in chars)
   }
   // compress 1 char per iter
   bind(copy_tail);
   testl(len, len);
-  jccb(Assembler::zero, return_length);
+  jccb(Assembler::zero, done);
   lea(src, Address(src, len, Address::times_2));
   lea(dst, Address(dst, len, Address::times_1));
   negptr(len);
 
   bind(copy_chars_loop);
-  load_unsigned_short(result, Address(src, len, Address::times_2));
-  testl(result, 0xff00);      // check if Unicode char
+  load_unsigned_short(tmp5, Address(src, len, Address::times_2));
+  testl(tmp5, 0xff00);      // check if Unicode char
   jccb(Assembler::notZero, reset_sp);
-  movb(Address(dst, len, Address::times_1), result);  // ASCII char; compress to 1 byte
+  movb(Address(dst, len, Address::times_1), tmp5);  // ASCII char; compress to 1 byte
   increment(len);
   jcc(Assembler::notZero, copy_chars_loop);
 
   // if compression succeeded, return length
-  bind(return_length);
-  pop(result);
   jmpb(done);
 
   bind(reset_sp);
-  pop(result);
   addl(result, len);
 
   bind(done);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -8632,7 +8632,7 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     pshufd(tmp1Reg, tmp1Reg, 0);   // store Unicode mask in tmp1Reg
 
     andl(len, 0xfffffff0);
-    jcc(Assembler::zero, copy_16);
+    jccb(Assembler::zero, copy_16);
 
     // compress 16 chars per iter
     pxor(tmp4Reg, tmp4Reg);
@@ -8651,7 +8651,7 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
     packuswb(tmp2Reg, tmp3Reg);    // only ASCII chars; compress each to 1 byte
     movdqu(Address(dst, len, Address::times_1), tmp2Reg);
     addptr(len, 16);
-    jcc(Assembler::notZero, copy_32_loop);
+    jccb(Assembler::notZero, copy_32_loop);
 
     // compress next vector of 8 chars (if any)
     bind(copy_16);
@@ -8696,11 +8696,9 @@ void MacroAssembler::char_array_compress(Register src, Register dst, Register le
   jccb(Assembler::notZero, reset_sp);
   movb(Address(dst, len, Address::times_1), tmp5);  // ASCII char; compress to 1 byte
   increment(len);
-  jcc(Assembler::notZero, copy_chars_loop);
+  jccb(Assembler::notZero, copy_chars_loop);
 
-  // if compression succeeded, return length
-  jmpb(done);
-
+  // add len then return (len will be zero if compress succeeded, otherwise negative)
   bind(reset_sp);
   addl(result, len);
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -8479,15 +8479,19 @@ void MacroAssembler::crc32c_ipl_alg2_alt2(Register in_out, Register in1, Registe
 #undef BLOCK_COMMENT
 
 // Compress char[] array to byte[].
-//   ..\jdk\src\java.base\share\classes\java\lang\StringUTF16.java
+// Intrinsic for java.lang.StringUTF16.compress(char[] src, int srcOff, byte[] dst, int dstOff, int len)
+// Return the array length if every element in array can be encoded,
+// otherwise, the index of first non-latin1 (> 0xff) character.
 //   @IntrinsicCandidate
-//   private static int compress(char[] src, int srcOff, byte[] dst, int dstOff, int len) {
+//   public static int compress(char[] src, int srcOff, byte[] dst, int dstOff, int len) {
 //     for (int i = 0; i < len; i++) {
-//       int c = src[srcOff++];
-//       if (c >>> 8 != 0) {
-//         return 0;
+//       char c = src[srcOff];
+//       if (c > 0xff) {
+//           return i;  // return index of non-latin1 char
 //       }
-//       dst[dstOff++] = (byte)c;
+//       dst[dstOff] = (byte)c;
+//       srcOff++;
+//       dstOff++;
 //     }
 //     return len;
 //   }

--- a/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
+++ b/src/java.base/share/classes/java/lang/AbstractStringBuilder.java
@@ -130,6 +130,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * as the specified {@code CharSequence}. The initial capacity of
      * the string builder is {@code 16} plus the length of the
      * {@code CharSequence} argument.
+     * <p>
+     * The contents are indeterminate if the {@code CharSequence}
+     * is modified before the constructor returns.
      *
      * @param      seq   the sequence to copy.
      */
@@ -666,6 +669,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * If {@code s} is {@code null}, then this method appends
      * characters as if the s parameter was a sequence containing the four
      * characters {@code "null"}.
+     * <p>
+     * The contents are indeterminate if the {@code CharSequence}
+     * is modified before the method returns.
      *
      * @param   s the sequence to append.
      * @param   start   the starting index of the subsequence to be appended.
@@ -1241,6 +1247,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * invocation of this object's
      * {@link #insert(int,CharSequence,int,int) insert}(dstOffset, s, 0, s.length())
      * method.
+     * <p>
+     * The contents are indeterminate if the {@code CharSequence}
+     * is modified before the method returns.
      *
      * <p>If {@code s} is {@code null}, then the four characters
      * {@code "null"} are inserted into this sequence.
@@ -1289,6 +1298,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * <p>If {@code s} is {@code null}, then this method inserts
      * characters as if the s parameter was a sequence containing the four
      * characters {@code "null"}.
+     * <p>
+     * The contents are indeterminate if the {@code CharSequence}
+     * is modified before the method returns.
      *
      * @param      dstOffset   the offset in this sequence.
      * @param      s       the sequence to be inserted.
@@ -1676,10 +1688,8 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
     void initBytes(char[] value, int off, int len) {
         if (String.COMPACT_STRINGS) {
             this.value = StringUTF16.compress(value, off, len);
-            if (this.value != null) {
-                this.coder = LATIN1;
-                return;
-            }
+            this.coder = (this.value.length == len) ? LATIN1 : UTF16;
+            return;
         }
         this.coder = UTF16;
         this.value = StringUTF16.toBytes(value, off, len);
@@ -1720,6 +1730,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
                     val[j++] = (byte)c;
                 } else {
                     inflate();
+                    // store c to make sure it has a UTF16 char
+                    StringUTF16.putChar(this.value, j++, c);
+                    i++;
                     StringUTF16.putCharsSB(this.value, j, s, i, end);
                     return;
                 }
@@ -1812,6 +1825,10 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
                 } else {
                     count = j;
                     inflate();
+                    // Store c to make sure sb has a UTF16 char
+                    StringUTF16.putChar(this.value, j++, c);
+                    count = j;
+                    i++;
                     StringUTF16.putCharsSB(this.value, j, s, i, end);
                     count += end - i;
                     return;
@@ -1923,6 +1940,9 @@ abstract sealed class AbstractStringBuilder implements Appendable, CharSequence
      * <p>
      * If {@code cs} is {@code null}, then the four characters
      * {@code "null"} are repeated into this sequence.
+     * <p>
+     * The contents are indeterminate if the {@code CharSequence}
+     * is modified before the method returns.
      *
      * @param cs     a {@code CharSequence}
      * @param count  number of times to copy

--- a/src/java.base/share/classes/java/lang/Appendable.java
+++ b/src/java.base/share/classes/java/lang/Appendable.java
@@ -57,6 +57,10 @@ public interface Appendable {
      * {@code csq}, the entire sequence may not be appended.  For
      * instance, if {@code csq} is a {@link java.nio.CharBuffer} then
      * the subsequence to append is defined by the buffer's position and limit.
+     * <p>
+     * The contents of this {@code Appendable} are indeterminate if the argument
+     * is modified before the {@code append} method returns or an exception is thrown
+     * when accessing the {@code CharSequence}.
      *
      * @param  csq
      *         The character sequence to append.  If {@code csq} is
@@ -81,6 +85,10 @@ public interface Appendable {
      * <pre>
      *     out.append(csq.subSequence(start, end)) </pre>
      *
+     * <p>
+     * The contents of this {@code Appendable} are indeterminate if the argument
+     * is modified before the {@code append} method returns or an exception is thrown
+     * when accessing the {@code CharSequence}.
      * @param  csq
      *         The character sequence from which a subsequence will be
      *         appended.  If {@code csq} is {@code null}, then characters

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -599,7 +599,7 @@ public final class String
                     utf16 = Arrays.copyOf(utf16, dp << 1);
                 }
                 this.value = utf16;
-                this.coder = (utf16.length == dp) ? LATIN1 : UTF16;
+                this.coder = UTF16;
             } else { // !COMPACT_STRINGS
                 byte[] dst = new byte[length << 1];
                 int dp = decodeUTF8_UTF16(bytes, offset, offset + length, dst, 0, true);

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -272,7 +272,8 @@ public final class String
      * characters currently contained in the character array argument. The
      * contents of the character array are copied; subsequent modification of
      * the character array does not affect the newly created string.
-     * The contents of the string are indeterminate if the character array
+     *
+     * <p> The contents of the string are indeterminate if the character array
      * is modified before the constructor returns.
      *
      * @param  value
@@ -289,7 +290,8 @@ public final class String
      * argument specifies the length of the subarray. The contents of the
      * subarray are copied; subsequent modification of the character array does
      * not affect the newly created string.
-     * The contents of the string are indeterminate if the character array
+     *
+     * <p> The contents of the string are indeterminate if the character array
      * is modified before the constructor returns.
      *
      * @param  value
@@ -322,7 +324,8 @@ public final class String
      * length of the subarray.  The contents of the subarray are converted to
      * {@code char}s; subsequent modification of the {@code int} array does not
      * affect the newly created string.
-     * The contents of the string are indeterminate if the array of codepoints
+     *
+     * <p> The contents of the string are indeterminate if the array of codepoints
      * is modified before the constructor returns.
      *
      * @param  codePoints
@@ -1390,7 +1393,8 @@ public final class String
      * in the given charset is unspecified.  The {@link
      * java.nio.charset.CharsetDecoder} class should be used when more control
      * over the decoding process is required.
-     * The contents of the string are indeterminate if the byte array
+     *
+     * <p> The contents of the string are indeterminate if the byte array
      * is modified before the constructor returns.
      *
      * @param  bytes
@@ -1420,7 +1424,8 @@ public final class String
      * sequences with this charset's default replacement string.  The {@link
      * java.nio.charset.CharsetDecoder} class should be used when more control
      * over the decoding process is required.
-     * The contents of the string are indeterminate if the byte array
+     *
+     * <p> The contents of the string are indeterminate if the byte array
      * is modified before the constructor returns.
      *
      * @param  bytes
@@ -1446,7 +1451,8 @@ public final class String
      * in the default charset is unspecified.  The {@link
      * java.nio.charset.CharsetDecoder} class should be used when more control
      * over the decoding process is required.
-     * The contents of the string are indeterminate if the byte array
+     *
+     * <p> The contents of the string are indeterminate if the byte array
      * is modified before the constructor returns.
      *
      * @param  bytes
@@ -1478,7 +1484,8 @@ public final class String
      * in the default charset is unspecified.  The {@link
      * java.nio.charset.CharsetDecoder} class should be used when more control
      * over the decoding process is required.
-     * The contents of the string are indeterminate if the byte array
+     *
+     * <p> The contents of the string are indeterminate if the byte array
      * is modified before the constructor returns.
      *
      * @param  bytes
@@ -1508,7 +1515,8 @@ public final class String
      * currently contained in the string builder argument. The contents of the
      * string builder are copied; subsequent modification of the string builder
      * does not affect the newly created string.
-     * The contents of the string are indeterminate if the {@code StringBuilder}
+     *
+     * <p> The contents of the string are indeterminate if the {@code StringBuilder}
      * is modified before the constructor returns.
      *
      * <p> This constructor is provided to ease migration to {@code
@@ -4502,7 +4510,8 @@ public final class String
      * argument. The contents of the character array are copied; subsequent
      * modification of the character array does not affect the returned
      * string.
-     * The contents of the string are indeterminate if the character array
+     *
+     * <p> The contents of the string are indeterminate if the character array
      * is modified before the constructor returns.
      *
      * @param   data     the character array.
@@ -4522,7 +4531,8 @@ public final class String
      * specifies the length of the subarray. The contents of the subarray
      * are copied; subsequent modification of the character array does not
      * affect the returned string.
-     * The contents of the string are indeterminate if the character array
+     *
+     * <p> The contents of the string are indeterminate if the character array
      * is modified before the constructor returns.
      *
      * @param   data     the character array.
@@ -4793,8 +4803,8 @@ public final class String
      * the8 low-order bits of the corresponding character, if the char[]
      * contains only latin1 character. Or a byte[] that stores all
      * characters in their byte sequences defined by the {@code StringUTF16}.
-     * <p>
-     * The contents of the string are indeterminate if the character array
+     *
+     * <p> The contents of the string are indeterminate if the character array
      * is modified before the constructor returns.
      */
     private String(char[] value, int off, int len, Void sig) {

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -34,7 +34,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.util.DecimalDigits;
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import static java.lang.String.LATIN1;

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.util.DecimalDigits;
+import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import static java.lang.String.LATIN1;
@@ -47,8 +48,12 @@ final class StringLatin1 {
         return (char)(value[index] & 0xff);
     }
 
+    public static boolean canEncode(char cp) {
+        return cp <= 0xff;
+    }
+
     public static boolean canEncode(int cp) {
-        return cp >>> 8 == 0;
+        return cp >=0 && cp <= 0xff;
     }
 
     public static int length(byte[] value) {

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -84,11 +84,6 @@ final class StringUTF16 {
                       ((val[index]   & 0xff) << LO_BYTE_SHIFT));
     }
 
-    // Like StringLatin1.isLatin1At, determine if a compact string UTF16-encoded bytes are latin1
-    private static boolean isLatin1At(byte[] val, int index) {
-        return val[index * 2 + HI_BYTE_OFFSET] == 0;
-    }
-
     public static int length(byte[] value) {
         return value.length >> 1;
     }
@@ -218,7 +213,7 @@ final class StringUTF16 {
             byte[] utf16 = toBytes(val, off, count);
             // If the original character that was found to be non-latin1 is latin1 in the copy
             // try to make a latin1 string from the copy
-            if (!isLatin1At(utf16, ndx)
+            if (getChar(utf16, ndx) > 0xff
                     || compress(utf16, 0, latin1, 0, count) != count) {
                 return utf16;
             }
@@ -244,7 +239,7 @@ final class StringUTF16 {
             byte[] utf16 = Arrays.copyOfRange(val, off << 1, newBytesLength(off + count));
             // If the original character that was found to be non-latin1 is latin1 in the copy
             // try to make a latin1 string from the copy
-            if (!isLatin1At(utf16, ndx)
+            if (getChar(utf16, ndx) > 0xff
                     || compress(utf16, 0, latin1, 0, count) != count) {
                 return utf16;
             }
@@ -304,7 +299,7 @@ final class StringUTF16 {
 
                     // The original character that was found to be UTF16 is not UTF16 in the copy
                     // Try to make a latin1 string from the copy
-                    if (isLatin1At(utf16, ndx) &&
+                    if (getChar(utf16, ndx) <= 0xff &&
                             compress(utf16, 0, latin1, 0, count) == count) {
                         return latin1;     // latin1 success
                     }
@@ -1690,16 +1685,13 @@ final class StringUTF16 {
 
     private static final int HI_BYTE_SHIFT;
     private static final int LO_BYTE_SHIFT;
-    private static final int HI_BYTE_OFFSET;
     static {
         if (isBigEndian()) {
             HI_BYTE_SHIFT = 8;
             LO_BYTE_SHIFT = 0;
-            HI_BYTE_OFFSET = 0;
         } else {
             HI_BYTE_SHIFT = 0;
             LO_BYTE_SHIFT = 8;
-            HI_BYTE_OFFSET = 1;
         }
     }
 

--- a/test/hotspot/jtreg/compiler/intrinsics/string/TestStringConstructionIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/string/TestStringConstructionIntrinsics.java
@@ -149,7 +149,7 @@ public class TestStringConstructionIntrinsics {
         assert (len + off < bytes.length);
         initializeBytes(off, len, ng, ngOffset);
         byte[] dst = new byte[bytes.length];
-        
+
         int calculated = Helper.compress(bytes, off, dst, 0, len);
         int expected = compress(bytes, off, dst, 0, len);
         if (calculated != expected) {
@@ -209,7 +209,7 @@ public class TestStringConstructionIntrinsics {
     private static void testConstructChars(int off, int len, int nonLatin1, int nlOffset) throws Exception {
         assert (len + off < bytes.length);
         initializeChars(off, len, nonLatin1, nlOffset);
-        
+
         int calculated = Helper.compress(chars, off, dst, 0, len);
         int expected = compress(chars, off, dst, 0, len);
         if (calculated != expected) {

--- a/test/jdk/java/lang/String/Chars.java
+++ b/test/jdk/java/lang/String/Chars.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,10 @@
  */
 
 /*
-    @test
-    @bug 8054307
-    @summary test chars() and codePoints()
-*/
+ * @test
+ * @bug 8054307 8311906
+ * @summary test String chars() and codePoints()
+ */
 
 import java.util.Arrays;
 import java.util.Random;
@@ -44,6 +44,7 @@ public class Chars {
                 cc[j] = (char)(ccExp[j] = cpExp[j] = r.nextInt(0x80));
             }
             testChars(cc, ccExp);
+            testCharsSubrange(cc, ccExp);
             testCPs(cc, cpExp);
 
             // bmp without surrogates
@@ -51,6 +52,7 @@ public class Chars {
                 cc[j] = (char)(ccExp[j] = cpExp[j] = r.nextInt(0x8000));
             }
             testChars(cc, ccExp);
+            testCharsSubrange(cc, ccExp);
             testCPs(cc, cpExp);
 
             // bmp with surrogates
@@ -69,6 +71,7 @@ public class Chars {
             }
             cpExp = Arrays.copyOf(cpExp, k);
             testChars(cc, ccExp);
+            testCharsSubrange(cc, ccExp);
             testCPs(cc, cpExp);
         }
     }
@@ -76,14 +79,35 @@ public class Chars {
     static void testChars(char[] cc, int[] expected) {
         String str = new String(cc);
         if (!Arrays.equals(expected, str.chars().toArray())) {
-            throw new RuntimeException("chars/codePoints() failed!");
+            throw new RuntimeException("testChars failed!");
+        }
+    }
+
+    static void testCharsSubrange(char[] cc, int[] expected) {
+        int[] offsets = { 7, 31 };   // offsets to test
+        int LENGTH = 13;
+        for (int i = 0; i < offsets.length; i++) {
+            int offset = Math.max(0, offsets[i]);       // confine to the input array
+            int count = Math.min(LENGTH, cc.length - offset);
+            String str = new String(cc, offset, count);
+            int[] actual = str.chars().toArray();
+            int errOffset = Arrays.mismatch(actual, 0, actual.length,
+                    expected, offset, offset + count);
+            if (errOffset >= 0) {
+                System.err.printf("expected[%d] (%d) != actual[%d] (%d)%n",
+                        offset + errOffset, expected[offset + errOffset],
+                        errOffset, actual[errOffset]);
+                System.err.println("expected: " + Arrays.toString(expected));
+                System.err.println("actual: " + Arrays.toString(actual));
+                throw new RuntimeException("testCharsSubrange failed!");
+            }
         }
     }
 
     static void testCPs(char[] cc, int[] expected) {
         String str = new String(cc);
         if (!Arrays.equals(expected, str.codePoints().toArray())) {
-            throw new RuntimeException("chars/codePoints() failed!");
+            throw new RuntimeException("testCPs failed!");
         }
     }
 }

--- a/test/jdk/java/lang/String/StringRacyConstructor.java
+++ b/test/jdk/java/lang/String/StringRacyConstructor.java
@@ -216,7 +216,7 @@ public class StringRacyConstructor {
 
         // Exhaustively check compress returning the correct index of the non-latin1 char.
         final int SIZE = 48;
-        final byte FILL_BYTE = 0x52;
+        final byte FILL_BYTE = 'R';
         chars = new char[SIZE];
         bytes = new byte[chars.length];
         for (int i = 0; i < SIZE; i++) { // Every starting index
@@ -278,7 +278,7 @@ public class StringRacyConstructor {
      * incorrectly encoded as UTF-16.
      */
     public static String racyStringConstruction(String original) throws ConcurrentModificationException {
-        if (original.chars().max().orElseThrow() > 256) {
+        if (original.chars().max().getAsInt() >= 256) {
             throw new IllegalArgumentException(
                     "Only work with latin-1 Strings");
         }
@@ -308,7 +308,7 @@ public class StringRacyConstructor {
                     // ignore interrupt
                 }
                 if (i >= 1_000_000) {
-                    System.err.printf("Unable to produce a UTF16 string in %d iterations: %s%n", i, original);
+                    System.out.printf("Unable to produce a UTF16 string in %d iterations: %s%n", i, original);
                 }
                 return s;
             }
@@ -354,7 +354,7 @@ public class StringRacyConstructor {
                     // ignore interrupt
                 }
                 if (i >= 1_000_000) {
-                    System.err.printf("Unable to produce a UTF16 string in %d iterations: %s%n", i, original);
+                    System.out.printf("Unable to produce a UTF16 string in %d iterations: %s%n", i, original);
                 }
                 return s;
             }
@@ -401,7 +401,7 @@ public class StringRacyConstructor {
                     // ignore interrupt
                 }
                 if (i >= 1_000_000) {
-                    System.err.printf("Unable to create a string in %d iterations: %s%n", i, original);
+                    System.out.printf("Unable to create a string in %d iterations: %s%n", i, original);
                 }
                 return s;
             }
@@ -420,7 +420,7 @@ public class StringRacyConstructor {
 
         @Override
         public int length() {
-            return aString.length() + 1;
+            return aString.length();
         }
 
         @Override

--- a/test/jdk/java/lang/String/StringRacyConstructor.java
+++ b/test/jdk/java/lang/String/StringRacyConstructor.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -150,7 +149,7 @@ public class StringRacyConstructor {
     public void racyCodePoint(String orig) {
         String iffyString = racyStringConstructionCodepoints(orig);
         // The contents are indeterminate due to the race
-        assertTrue(validCoder(iffyString), "invalid coder in non-determinstic string"
+        assertTrue(validCoder(iffyString), "invalid coder in non-deterministic string"
                 + ", orig:" + inspectString(orig)
                 + ", iffyString: " + inspectString(iffyString));
     }
@@ -162,7 +161,7 @@ public class StringRacyConstructor {
         // The contents are indeterminate due to the race
         if (!orig.equals(iffyString))
             System.err.println("orig: " + orig + ", iffy: " + iffyString + Arrays.toString(iffyString.codePoints().toArray()));
-        assertTrue(validCoder(iffyString), "invalid coder in non-determinstic string"
+        assertTrue(validCoder(iffyString), "invalid coder in non-deterministic string"
                 + ", orig:" + inspectString(orig)
                 + ", iffyString: " + inspectString(iffyString));
     }
@@ -264,7 +263,7 @@ public class StringRacyConstructor {
         char[] chars = original.toCharArray();
 
         // In another thread, flip the first character back
-        // and forth between being encodable as latin-1 or not
+        // and forth between being latin-1 or not
         Thread thread = new Thread(() -> {
             while (!Thread.interrupted()) {
                 chars[0] ^= 256;
@@ -280,7 +279,7 @@ public class StringRacyConstructor {
             String s = new String(chars);
             if ((s.charAt(0) < 256 && !original.equals(s)) || i > 1_000_000) {
                 thread.interrupt();
-                try  {
+                try {
                     thread.join();
                 } catch (InterruptedException ie) {
                     // ignore interrupt
@@ -310,7 +309,7 @@ public class StringRacyConstructor {
         }
 
         // In another thread, flip the first character back
-        // and forth between being encodable as latin-1 or not
+        // and forth between being latin-1 or not
         Thread thread = new Thread(() -> {
             while (!Thread.interrupted()) {
                 codePoints[0] ^= 256;
@@ -326,7 +325,7 @@ public class StringRacyConstructor {
             String s = new String(codePoints, 0, len);
             if ((s.charAt(0) < 256 && !original.equals(s)) || i > 1_000_000) {
                 thread.interrupt();
-                try  {
+                try {
                     thread.join();
                 } catch (InterruptedException ie) {
                     // ignore interrupt
@@ -357,7 +356,7 @@ public class StringRacyConstructor {
         }
 
         // In another thread, flip the first character back
-        // and forth between being encodable as latin-1 or as a surrogate pair.
+        // and forth between being latin-1 or as a surrogate pair.
         Thread thread = new Thread(() -> {
             while (!Thread.interrupted()) {
                 codePoints[0] ^= 0x10000;
@@ -373,7 +372,7 @@ public class StringRacyConstructor {
             String s = new String(codePoints, 0, len);
             if ((s.length() != original.length()) || i > 1_000_000) {
                 thread.interrupt();
-                try  {
+                try {
                     thread.join();
                 } catch (InterruptedException ie) {
                     // ignore interrupt
@@ -389,7 +388,7 @@ public class StringRacyConstructor {
     // A CharSequence that returns characters from a string and throws IllegalArgumentException
     // when the character requested is 0xFFFD (the replacement character)
     // The string contents determine when the exception is thrown.
-    class ThrowingCharSequence implements CharSequence {
+    static class ThrowingCharSequence implements CharSequence {
         private final String aString;
 
         ThrowingCharSequence(String aString) {

--- a/test/jdk/java/lang/String/StringRacyConstructor.java
+++ b/test/jdk/java/lang/String/StringRacyConstructor.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.java.lang.String;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/*
+ * @test
+ * @bug 8311906
+ * @modules java.base/java.lang:open
+ * @summary check String's racy constructors
+ * @run junit/othervm test.java.lang.String.StringRacyConstructor
+ */
+
+public class StringRacyConstructor {
+    private static final byte LATIN1 = 0;
+    private static final byte UTF16  = 1;
+
+    private static final Field STRING_CODER_FIELD;
+    private static final Field SB_CODER_FIELD;
+
+    static {
+        try {
+            STRING_CODER_FIELD = String.class.getDeclaredField("coder");
+            STRING_CODER_FIELD.setAccessible(true);
+            SB_CODER_FIELD = Class.forName("java.lang.AbstractStringBuilder").getDeclaredField("coder");
+            SB_CODER_FIELD.setAccessible(true);
+        } catch (NoSuchFieldException ex ) {
+            throw new ExceptionInInitializerError(ex);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Return the coder for the String
+    private static int coder(String s) {
+        try {
+            return STRING_CODER_FIELD.getByte(s);
+        } catch (IllegalAccessException iae) {
+            throw new AssertionError(iae);
+        }
+    }
+
+    // Return the coder for the StringBuilder
+    private static int sbCoder(StringBuilder sb) {
+        try {
+            return SB_CODER_FIELD.getByte(sb);
+        } catch (IllegalAccessException iae) {
+            throw new AssertionError(iae);
+        }
+    }
+
+    // Return a summary of the internals of the String
+    // The coder and indicate if the coder matches the string contents
+    private static String inspectString(String s) {
+        try {
+            char[] chars = s.toCharArray();
+            String r = new String(chars);
+
+            boolean invalidCoder = coder(s) != coder(r);
+            String coder = STRING_CODER_FIELD.getByte(s) == 0 ? "isLatin1" : "utf16";
+            return (invalidCoder ? "INVALID CODER" : "" ) + " \"" + s + "\", coder: " + coder;
+        } catch (IllegalAccessException ex ) {
+            return "EXCEPTION: " + ex.getMessage();
+        }
+    }
+
+    /**
+     * {@return true if the coder matches the presence/lack of UTF16 characters}
+     * If it returns false, the coder and the contents have failed the precondition for string.
+     * @param orig a string
+     */
+    private static boolean validCoder(String orig) {
+        int accum = 0;
+        for (int i = 0; i < orig.length(); i++)
+            accum |= orig.charAt(i);
+        byte expectedCoder = (accum < 256) ? LATIN1 : UTF16;
+        return expectedCoder == coder(orig);
+    }
+
+    // Check a StringBuilder for consistency of coder and latin1 vs UTF16
+    private static boolean validCoder(StringBuilder orig) {
+        int accum = 0;
+        for (int i = 0; i < orig.length(); i++)
+            accum |= orig.charAt(i);
+        byte expectedCoder = (accum < 256) ? LATIN1 : UTF16;
+        return expectedCoder == sbCoder(orig);
+    }
+
+    @Test
+    public void checkStringRange() {
+        char[] chars = {'a', 'b', 'c', 0xff21, 0xff22, 0xff23};
+        String orig = new String(chars);
+        char[] xx = orig.toCharArray();
+        String stringFromChars = new String(xx);
+        assertEquals(orig, stringFromChars, "mixed chars");
+        assertTrue(validCoder(stringFromChars), "invalid coder"
+                + ", invalid coder: " + inspectString(stringFromChars));
+    }
+
+    private static List<String> strings() {
+        return List.of("01234", " ");
+    }
+
+    @ParameterizedTest
+    @MethodSource("strings")
+    public void racyString(String orig) {
+        String racyString = racyStringConstruction(orig);
+        // The contents are indeterminate due to the race
+        assertTrue(validCoder(racyString), orig + " string invalid"
+                + ", racyString: " + inspectString(racyString));
+    }
+
+    @ParameterizedTest
+    @MethodSource("strings")
+    public void racyCodePoint(String orig) {
+        String iffyString = racyStringConstructionCodepoints(orig);
+        // The contents are indeterminate due to the race
+        assertTrue(validCoder(iffyString), "invalid coder in non-determinstic string"
+                + ", orig:" + inspectString(orig)
+                + ", iffyString: " + inspectString(iffyString));
+    }
+
+    @ParameterizedTest
+    @MethodSource("strings")
+    public void racyCodePointSurrogates(String orig) {
+        String iffyString = racyStringConstructionCodepointsSurrogates(orig);
+        // The contents are indeterminate due to the race
+        if (!orig.equals(iffyString))
+            System.err.println("orig: " + orig + ", iffy: " + iffyString + Arrays.toString(iffyString.codePoints().toArray()));
+        assertTrue(validCoder(iffyString), "invalid coder in non-determinstic string"
+                + ", orig:" + inspectString(orig)
+                + ", iffyString: " + inspectString(iffyString));
+    }
+
+    // Test the private methods of StringUTF16 that compress and copy COMPRESSED_STRING
+    // encoded byte arrays.
+    @Test
+    public void verifyUTF16CopyBytes()
+            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Class<?> stringUTF16 = Class.forName("java.lang.StringUTF16");
+        Method mCompressChars = stringUTF16.getDeclaredMethod("compress",
+                char[].class, int.class, byte[].class, int.class, int.class);
+        mCompressChars.setAccessible(true);
+
+        // First warmup the intrinsic and check 1 case
+        char[] chars = {'a', 'b', 'c', 0xff21, 0xff22, 0xff23};
+        byte[] bytes = new byte[chars.length];
+        int printWarningCount = 0;
+
+        for (int i = 0; i < 1_000_000; i++) {   // repeat to get C2 to kick in
+            // Copy only latin1 chars from UTF-16 converted prefix (3 chars -> 3 bytes)
+            int intResult = (int) mCompressChars.invoke(null, chars, 0, bytes, 0, chars.length);
+            if (intResult == 0) {
+                if (printWarningCount == 0) {
+                    printWarningCount = 1;
+                    System.out.println("StringUTF16.compress returned 0, may not be intrinsic");
+                }
+            } else {
+                assertEquals(3, intResult, "return length not-equal, iteration: " + i);
+            }
+        }
+
+        // Exhaustively check compress returning the correct index of the non-latin1 char.
+        final int SIZE = 48;
+        final byte FILL_BYTE = 0x52;
+        chars = new char[SIZE];
+        bytes = new byte[chars.length];
+        for (int i = 0; i < SIZE; i++) { // Every starting index
+            for (int j = i; j < SIZE; j++) {  // Every location of non-latin1
+                Arrays.fill(chars, 'A');
+                Arrays.fill(bytes, FILL_BYTE);
+                chars[j] = 0xFF21;
+                int intResult = (int) mCompressChars.invoke(null, chars, i, bytes, 0, chars.length - i);
+                assertEquals(j - i, intResult, "compress found wrong index");
+                assertEquals(FILL_BYTE, bytes[j], "extra character stored");
+            }
+        }
+
+    }
+
+    // Check that a concatenated "hello" has a valid coder
+    @Test
+    public void checkConcatAndIntern() {
+        var helloWorld = "hello world";
+        String helloToo = racyStringConstruction("hell".concat("o"));
+        String o = helloToo.intern();
+        var hello = "hello";
+        assertTrue(validCoder(helloToo), "startsWith: "
+                + ", hell: " + inspectString(helloToo)
+                + ", o: " + inspectString(o)
+                + ", hello: " + inspectString(hello)
+                + ", hello world: " + inspectString(helloWorld));
+    }
+
+    // Check that an empty string with racy construction has a valid coder
+    @Test
+    public void racyEmptyString() {
+        var space = racyStringConstruction(" ");
+        var trimmed = space.trim();
+        assertTrue(validCoder(trimmed), "empty string invalid coder"
+                + ", trimmed: " + inspectString(trimmed));
+    }
+
+    // Check that an exception in a user implemented CharSequence doesn't result in
+    // an invalid coder when appended to a StringBuilder
+    @Test
+    void charSequenceException() {
+        ThrowingCharSequence bs = new ThrowingCharSequence("A\u2030\uFFFD");
+        var sb = new StringBuilder();
+        try {
+            sb.append(bs);
+            fail("An IllegalArgumentException should have been thrown");
+        } catch (IllegalArgumentException ex) {
+            // ignore expected
+        }
+        assertTrue(validCoder(sb), "invalid coder in StringBuilder");
+    }
+
+    /**
+     * Given a latin-1 String, attempt to create a copy that is
+     * incorrectly encoded as UTF-16.
+     */
+    public static String racyStringConstruction(String original) throws ConcurrentModificationException {
+        if (original.chars().max().orElseThrow() > 256) {
+            throw new IllegalArgumentException(
+                    "Only work with latin-1 Strings");
+        }
+
+        char[] chars = original.toCharArray();
+
+        // In another thread, flip the first character back
+        // and forth between being encodable as latin-1 or not
+        Thread thread = new Thread(() -> {
+            while (!Thread.interrupted()) {
+                chars[0] ^= 256;
+            }
+        });
+        thread.start();
+
+        // at the same time call the String constructor,
+        // until we hit the race condition
+        int i = 0;
+        while (true) {
+            i++;
+            String s = new String(chars);
+            if ((s.charAt(0) < 256 && !original.equals(s)) || i > 1_000_000) {
+                thread.interrupt();
+                try  {
+                    thread.join();
+                } catch (InterruptedException ie) {
+                    // ignore interrupt
+                }
+                if (i >= 1_000_000) {
+                    System.err.printf("Unable to produce a UTF16 string in %d iterations: %s%n", i, original);
+                }
+                return s;
+            }
+        }
+    }
+
+    /**
+     * Given a latin-1 String, creates a copy that is
+     * incorrectly encoded as UTF-16 using the APIs for Codepoints.
+     */
+    public static String racyStringConstructionCodepoints(String original) throws ConcurrentModificationException {
+        if (original.chars().max().orElseThrow() > 256) {
+            throw new IllegalArgumentException(
+                    "Can only work with latin-1 Strings");
+        }
+
+        int len = original.length();
+        int[] codePoints = new int[len];
+        for (int i = 0; i < len; i++) {
+            codePoints[i] = original.charAt(i);
+        }
+
+        // In another thread, flip the first character back
+        // and forth between being encodable as latin-1 or not
+        Thread thread = new Thread(() -> {
+            while (!Thread.interrupted()) {
+                codePoints[0] ^= 256;
+            }
+        });
+        thread.start();
+
+        // at the same time call the String constructor,
+        // until we hit the race condition
+        int i = 0;
+        while (true) {
+            i++;
+            String s = new String(codePoints, 0, len);
+            if ((s.charAt(0) < 256 && !original.equals(s)) || i > 1_000_000) {
+                thread.interrupt();
+                try  {
+                    thread.join();
+                } catch (InterruptedException ie) {
+                    // ignore interrupt
+                }
+                if (i >= 1_000_000) {
+                    System.err.printf("Unable to produce a UTF16 string in %d iterations: %s%n", i, original);
+                }
+                return s;
+            }
+        }
+    }
+
+    /**
+     * Returns a string created from a codepoint array that has been racily
+     * modified to contain high and low surrogates. The string is a different length
+     * than the original due to the surrogate encoding.
+     */
+    public static String racyStringConstructionCodepointsSurrogates(String original) throws ConcurrentModificationException {
+        if (original.chars().max().orElseThrow() > 256) {
+            throw new IllegalArgumentException(
+                    "Can only work with latin-1 Strings");
+        }
+
+        int len = original.length();
+        int[] codePoints = new int[len];
+        for (int i = 0; i < len; i++) {
+            codePoints[i] = original.charAt(i);
+        }
+
+        // In another thread, flip the first character back
+        // and forth between being encodable as latin-1 or as a surrogate pair.
+        Thread thread = new Thread(() -> {
+            while (!Thread.interrupted()) {
+                codePoints[0] ^= 0x10000;
+            }
+        });
+        thread.start();
+
+        // at the same time call the String constructor,
+        // until we hit the race condition
+        int i = 0;
+        while (true) {
+            i++;
+            String s = new String(codePoints, 0, len);
+            if ((s.length() != original.length()) || i > 1_000_000) {
+                thread.interrupt();
+                try  {
+                    thread.join();
+                } catch (InterruptedException ie) {
+                    // ignore interrupt
+                }
+                if (i >= 1_000_000) {
+                    System.err.printf("Unable to create a string in %d iterations: %s%n", i, original);
+                }
+                return s;
+            }
+        }
+    }
+
+    // A CharSequence that returns characters from a string and throws IllegalArgumentException
+    // when the character requested is 0xFFFD (the replacement character)
+    // The string contents determine when the exception is thrown.
+    class ThrowingCharSequence implements CharSequence {
+        private final String aString;
+
+        ThrowingCharSequence(String aString) {
+            this.aString = aString;
+        }
+
+        @Override
+        public int length() {
+            return aString.length() + 1;
+        }
+
+        @Override
+        public char charAt(int index) {
+            char ch = aString.charAt(index);
+            if (ch == 0xFFFD) {
+                throw new IllegalArgumentException("Replacement character at index " + index);
+            }
+            return ch;
+        }
+
+        @Override
+        // Not used; returns the entire string
+        public CharSequence subSequence(int start, int end) {
+            return this;
+        }
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/StringConstructor.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringConstructor.java
@@ -38,121 +38,115 @@ import java.util.concurrent.TimeUnit;
 @Fork(3)
 public class StringConstructor {
 
-    private static char INTEROBANG = 0x2030;
+    private static final char INTEROBANG = 0x2030;
+
+    // Fixed offset to use for ranged newStrings
     public final int offset = 1;
-  @Param({"7", "64"})
-  public int size;
 
-  // Fixed offset to use for ranged newStrings
-  private byte[] array;
+    @Param({"7", "64"})
+    public int size;
 
-  private char[] chars;
-  private char[] charsMixedBegin;
-  private char[] charsMixedSmall;
-  private char[] charsMixedEnd;
-  private int[] codePointsLatin1;
-  private int[] codePointsMixedBegin;
-  private int[] codePointsMixedSmall;
+    private byte[] array;
+    private char[] chars;
+    private char[] charsMixedBegin;
+    private char[] charsMixedSmall;
+    private char[] charsMixedEnd;
+    private int[] codePointsLatin1;
+    private int[] codePointsMixedBegin;
+    private int[] codePointsMixedSmall;
 
     private static int[] intCopyOfChars(char[] chars, int newLength) {
         int[] res = new int[newLength];
         for (int i = 0; i < Math.min(chars.length, newLength); i++)
-            res[i] = (int) chars[i];
+            res[i] = chars[i];
         return res;
     }
 
-  @Setup
-  public void setup() {
-      String s = "a".repeat(size);
-      array = s.getBytes(StandardCharsets.UTF_8);
-      chars = s.toCharArray();
-      charsMixedBegin = Arrays.copyOf(chars, array.length);
-      charsMixedBegin[0] = INTEROBANG;
-      charsMixedSmall = Arrays.copyOf(chars, array.length);
-      charsMixedSmall[Math.min(charsMixedSmall.length - 1, 7)] = INTEROBANG;
-      charsMixedEnd = new char[size + 7];
-      Arrays.fill(charsMixedEnd, 'a');
-      charsMixedEnd[charsMixedEnd.length - 1] = INTEROBANG;
+    @Setup
+    public void setup() {
+        String s = "a".repeat(size);
+        array = s.getBytes(StandardCharsets.UTF_8);
+        chars = s.toCharArray();
+        charsMixedBegin = Arrays.copyOf(chars, array.length);
+        charsMixedBegin[0] = INTEROBANG;
+        charsMixedSmall = Arrays.copyOf(chars, array.length);
+        charsMixedSmall[Math.min(charsMixedSmall.length - 1, 7)] = INTEROBANG;
+        charsMixedEnd = new char[size + 7];
+        Arrays.fill(charsMixedEnd, 'a');
+        charsMixedEnd[charsMixedEnd.length - 1] = INTEROBANG;
 
-      codePointsLatin1 = intCopyOfChars(chars, array.length);
-      codePointsMixedBegin = intCopyOfChars(chars, array.length);
-      codePointsMixedBegin[0] = INTEROBANG;
-      codePointsMixedSmall = intCopyOfChars(chars, array.length);
-      codePointsMixedSmall[Math.min(codePointsMixedSmall.length - 1, 7)] = INTEROBANG;
-  }
+        codePointsLatin1 = intCopyOfChars(chars, array.length);
+        codePointsMixedBegin = intCopyOfChars(chars, array.length);
+        codePointsMixedBegin[0] = INTEROBANG;
+        codePointsMixedSmall = intCopyOfChars(chars, array.length);
+        codePointsMixedSmall[Math.min(codePointsMixedSmall.length - 1, 7)] = INTEROBANG;
+    }
 
+    @Benchmark
+    public String newStringFromBytes() {
+        return new String(array);
+    }
 
-  @Benchmark
-  public String newStringFromBytes() {
-      return new String(array);
-  }
+    @Benchmark
+    public String newStringFromBytesRanged() {
+        return new String(array, offset, array.length - offset);
+    }
 
-  @Benchmark
-  public String newStringFromBytesRanged() {
-      return new String(array, offset, array.length - offset);
-  }
-  
-  @Benchmark
-  public String newStringFromBytesRangedWithCharsetUTF8() {
-      return new String(array, offset, array.length - offset, StandardCharsets.UTF_8);
-  }
-  
-  @Benchmark
-  public String newStringFromBytesWithCharsetUTF8() {
-      return new String(array, StandardCharsets.UTF_8);
-  }
+    @Benchmark
+    public String newStringFromBytesRangedWithCharsetUTF8() {
+        return new String(array, offset, array.length - offset, StandardCharsets.UTF_8);
+    }
 
-  @Benchmark
-  public String newStringFromBytesWithCharsetNameUTF8() throws Exception {
-      return new String(array, StandardCharsets.UTF_8.name());
-  }
-  
-  @Benchmark
-  public String newStringFromCharsLatin1() {
-      return new String(chars);
-  }
+    @Benchmark
+    public String newStringFromBytesWithCharsetUTF8() {
+        return new String(array, StandardCharsets.UTF_8);
+    }
 
-//  @Benchmark
-//  public String newStringFromCharsLatin1Ranged () {
-//      return new String(chars, 0, chars.length);
-//  }
+    @Benchmark
+    public String newStringFromBytesWithCharsetNameUTF8() throws Exception {
+        return new String(array, StandardCharsets.UTF_8.name());
+    }
 
-  @Benchmark
-  public String newStringFromCharsMixedBegin() {
-      return new String(charsMixedBegin);
-  }
+    @Benchmark
+    public String newStringFromCharsLatin1() {
+        return new String(chars);
+    }
 
-  @Benchmark
-  public String newStringFromCharsMixedSmall() {
-      return new String(charsMixedSmall);
-  }
+    @Benchmark
+    public String newStringFromCharsMixedBegin() {
+        return new String(charsMixedBegin);
+    }
 
-  @Benchmark
-  public String newStringFromCharsMixedEnd() {
-      return new String(charsMixedEnd);
-  }
+    @Benchmark
+    public String newStringFromCharsMixedSmall() {
+        return new String(charsMixedSmall);
+    }
 
-  @Benchmark
+    @Benchmark
+    public String newStringFromCharsMixedEnd() {
+        return new String(charsMixedEnd);
+    }
+
+    @Benchmark
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     public void newStringFromCharsMixedAll(Blackhole bh) {
         bh.consume(new String(charsMixedBegin));
         bh.consume(new String(charsMixedSmall));
         bh.consume(new String(chars));
     }
+
     @Benchmark
-  public String newStringFromCodePointRangedLatin1() {
-      return new String(codePointsLatin1, 0, codePointsLatin1.length);
-  }
+    public String newStringFromCodePointRangedLatin1() {
+        return new String(codePointsLatin1, 0, codePointsLatin1.length);
+    }
 
-  @Benchmark
-  public String newStringFromCodePointRangedMixedBegin() {
-      return new String(codePointsMixedBegin, 0, codePointsMixedBegin.length);
-  }
+    @Benchmark
+    public String newStringFromCodePointRangedMixedBegin() {
+        return new String(codePointsMixedBegin, 0, codePointsMixedBegin.length);
+    }
 
-  @Benchmark
-  public String newStringFromCodePointRangedMixedSmall() {
-      return new String(codePointsMixedSmall, 0, codePointsMixedSmall.length);
-  }
-
-
+    @Benchmark
+    public String newStringFromCodePointRangedMixedSmall() {
+        return new String(codePointsMixedSmall, 0, codePointsMixedSmall.length);
+    }
 }

--- a/test/micro/org/openjdk/bench/java/lang/StringConstructor.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringConstructor.java
@@ -21,11 +21,13 @@
  * questions.
  */
 
-package micro.org.openjdk.bench.java.lang;
+package org.openjdk.bench.java.lang;
 
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Thread)
@@ -36,45 +38,121 @@ import java.util.concurrent.TimeUnit;
 @Fork(3)
 public class StringConstructor {
 
+    private static char INTEROBANG = 0x2030;
+    public final int offset = 1;
   @Param({"7", "64"})
   public int size;
 
-  // Offset to use for ranged newStrings
-  @Param("1")
-  public int offset;
+  // Fixed offset to use for ranged newStrings
   private byte[] array;
+
+  private char[] chars;
+  private char[] charsMixedBegin;
+  private char[] charsMixedSmall;
+  private char[] charsMixedEnd;
+  private int[] codePointsLatin1;
+  private int[] codePointsMixedBegin;
+  private int[] codePointsMixedSmall;
+
+    private static int[] intCopyOfChars(char[] chars, int newLength) {
+        int[] res = new int[newLength];
+        for (int i = 0; i < Math.min(chars.length, newLength); i++)
+            res[i] = (int) chars[i];
+        return res;
+    }
 
   @Setup
   public void setup() {
-      if (offset > size) {
-        offset = size;
-      }
-      array = "a".repeat(size).getBytes(StandardCharsets.UTF_8);
+      String s = "a".repeat(size);
+      array = s.getBytes(StandardCharsets.UTF_8);
+      chars = s.toCharArray();
+      charsMixedBegin = Arrays.copyOf(chars, array.length);
+      charsMixedBegin[0] = INTEROBANG;
+      charsMixedSmall = Arrays.copyOf(chars, array.length);
+      charsMixedSmall[Math.min(charsMixedSmall.length - 1, 7)] = INTEROBANG;
+      charsMixedEnd = new char[size + 7];
+      Arrays.fill(charsMixedEnd, 'a');
+      charsMixedEnd[charsMixedEnd.length - 1] = INTEROBANG;
+
+      codePointsLatin1 = intCopyOfChars(chars, array.length);
+      codePointsMixedBegin = intCopyOfChars(chars, array.length);
+      codePointsMixedBegin[0] = INTEROBANG;
+      codePointsMixedSmall = intCopyOfChars(chars, array.length);
+      codePointsMixedSmall[Math.min(codePointsMixedSmall.length - 1, 7)] = INTEROBANG;
   }
 
+
   @Benchmark
-  public String newStringFromArray() {
+  public String newStringFromBytes() {
       return new String(array);
   }
 
   @Benchmark
-  public String newStringFromArrayWithCharset() {
+  public String newStringFromBytesRanged() {
+      return new String(array, offset, array.length - offset);
+  }
+  
+  @Benchmark
+  public String newStringFromBytesRangedWithCharsetUTF8() {
+      return new String(array, offset, array.length - offset, StandardCharsets.UTF_8);
+  }
+  
+  @Benchmark
+  public String newStringFromBytesWithCharsetUTF8() {
       return new String(array, StandardCharsets.UTF_8);
   }
 
   @Benchmark
-  public String newStringFromArrayWithCharsetName() throws Exception {
+  public String newStringFromBytesWithCharsetNameUTF8() throws Exception {
       return new String(array, StandardCharsets.UTF_8.name());
   }
+  
+  @Benchmark
+  public String newStringFromCharsLatin1() {
+      return new String(chars);
+  }
+
+//  @Benchmark
+//  public String newStringFromCharsLatin1Ranged () {
+//      return new String(chars, 0, chars.length);
+//  }
 
   @Benchmark
-  public String newStringFromRangedArray() {
-    return new String(array, offset, array.length - offset);
+  public String newStringFromCharsMixedBegin() {
+      return new String(charsMixedBegin);
   }
 
   @Benchmark
-  public String newStringFromRangedArrayWithCharset() {
-      return new String(array, offset, array.length - offset, StandardCharsets.UTF_8);
+  public String newStringFromCharsMixedSmall() {
+      return new String(charsMixedSmall);
   }
+
+  @Benchmark
+  public String newStringFromCharsMixedEnd() {
+      return new String(charsMixedEnd);
+  }
+
+  @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void newStringFromCharsMixedAll(Blackhole bh) {
+        bh.consume(new String(charsMixedBegin));
+        bh.consume(new String(charsMixedSmall));
+        bh.consume(new String(chars));
+    }
+    @Benchmark
+  public String newStringFromCodePointRangedLatin1() {
+      return new String(codePointsLatin1, 0, codePointsLatin1.length);
+  }
+
+  @Benchmark
+  public String newStringFromCodePointRangedMixedBegin() {
+      return new String(codePointsMixedBegin, 0, codePointsMixedBegin.length);
+  }
+
+  @Benchmark
+  public String newStringFromCodePointRangedMixedSmall() {
+      return new String(codePointsMixedSmall, 0, codePointsMixedSmall.length);
+  }
+
 
 }


### PR DESCRIPTION
When investigating x86 intrinsic overheads as part of 8311906 performance work it seemed we could simplify the char_array_compress intrinsic somewhat:

- avoid pushing len to stack by rearranging code
- consolidate reset_for_copy_tail and reset_for_copy_tail_16
- fewer and shorter jumps
- skip short jump past `addl(result, len)` on success (`len` will hold 0 so effect-neutral)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16735/head:pull/16735` \
`$ git checkout pull/16735`

Update a local copy of the PR: \
`$ git checkout pull/16735` \
`$ git pull https://git.openjdk.org/jdk.git pull/16735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16735`

View PR using the GUI difftool: \
`$ git pr show -t 16735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16735.diff">https://git.openjdk.org/jdk/pull/16735.diff</a>

</details>
