### PR TITLE
8320330: Improve implementation of RShift Value

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1408,7 +1408,7 @@ const Type* RShiftLNode::Value(PhaseGVN* phase) const {
     return TypeLong::LONG;
   }
 
-  return TypeLong::make((jlong)r1->get_con() >> (r2->get_con() & 63));
+  return TypeLong::make(r1->get_con() >> (r2->get_con() & 63));
 }
 
 //=============================================================================

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -1297,15 +1297,12 @@ const Type* RShiftINode::Value(PhaseGVN* phase) const {
   if (t1 == Type::BOTTOM || t2 == Type::BOTTOM)
     return TypeInt::INT;
 
-  if (t2 == TypeInt::INT)
-    return TypeInt::INT;
-
   const TypeInt *r1 = t1->is_int(); // Handy access
   const TypeInt *r2 = t2->is_int(); // Handy access
 
   // If the shift is a constant, just shift the bounds of the type.
   // For example, if the shift is 31, we just propagate sign bits.
-  if (r2->is_con()) {
+  if (!r1->is_con() && r2->is_con()) {
     uint shift = r2->get_con();
     shift &= BitsPerJavaInteger-1;  // semantics of Java shifts
     // Shift by a multiple of 32 does nothing:
@@ -1327,11 +1324,22 @@ const Type* RShiftINode::Value(PhaseGVN* phase) const {
     return ti;
   }
 
-  if( !r1->is_con() || !r2->is_con() )
+  if (!r1->is_con() || !r2->is_con()) {
+    // If the left input is non-negative the result must also be non-negative, regardless of what the right input is.
+    if (r1->_lo >= 0) {
+      return TypeInt::make(0, r1->_hi, MAX2(r1->_widen, r2->_widen));
+    }
+
+    // Conversely, if the left input is negative then the result must be negative.
+    if (r1->_hi <= -1) {
+      return TypeInt::make(r1->_lo, -1, MAX2(r1->_widen, r2->_widen));
+    }
+
     return TypeInt::INT;
+  }
 
   // Signed shift right
-  return TypeInt::make( r1->get_con() >> (r2->get_con()&31) );
+  return TypeInt::make(r1->get_con() >> (r2->get_con() & 31));
 }
 
 //=============================================================================
@@ -1359,15 +1367,12 @@ const Type* RShiftLNode::Value(PhaseGVN* phase) const {
   if (t1 == Type::BOTTOM || t2 == Type::BOTTOM)
     return TypeLong::LONG;
 
-  if (t2 == TypeInt::INT)
-    return TypeLong::LONG;
-
   const TypeLong *r1 = t1->is_long(); // Handy access
   const TypeInt  *r2 = t2->is_int (); // Handy access
 
   // If the shift is a constant, just shift the bounds of the type.
   // For example, if the shift is 63, we just propagate sign bits.
-  if (r2->is_con()) {
+  if (!r1->is_con() && r2->is_con()) {
     uint shift = r2->get_con();
     shift &= (2*BitsPerJavaInteger)-1;  // semantics of Java shifts
     // Shift by a multiple of 64 does nothing:
@@ -1389,7 +1394,21 @@ const Type* RShiftLNode::Value(PhaseGVN* phase) const {
     return tl;
   }
 
-  return TypeLong::LONG;                // Give up
+  if (!r1->is_con() || !r2->is_con()) {
+    // If the left input is non-negative the result must also be non-negative, regardless of what the right input is.
+    if (r1->_lo >= 0) {
+      return TypeLong::make(0, r1->_hi, MAX2(r1->_widen, r2->_widen));
+    }
+
+    // Conversely, if the left input is negative then the result must be negative.
+    if (r1->_hi <= -1) {
+      return TypeLong::make(r1->_lo, -1, MAX2(r1->_widen, r2->_widen));
+    }
+
+    return TypeLong::LONG;
+  }
+
+  return TypeLong::make((jlong)r1->get_con() >> (r2->get_con() & 63));
 }
 
 //=============================================================================

--- a/test/hotspot/jtreg/compiler/c2/irTests/RShiftINodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/RShiftINodeIdealizationTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8320330
+ * @summary Test that RShiftINode optimizations are being performed as expected.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.RShiftINodeIdealizationTests
+ */
+public class RShiftINodeIdealizationTests {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Run(test = { "test1", "test2", "test3", "test4" })
+    public void runMethod() {
+        int a = RunInfo.getRandom().nextInt();
+        int b = RunInfo.getRandom().nextInt();
+        int c = RunInfo.getRandom().nextInt();
+        int d = RunInfo.getRandom().nextInt();
+
+        int min = Integer.MIN_VALUE;
+        int max = Integer.MAX_VALUE;
+
+        assertResult(a, 0);
+        assertResult(a, b);
+        assertResult(b, a);
+        assertResult(c, d);
+        assertResult(d, c);
+        assertResult(min, max);
+        assertResult(max, min);
+        assertResult(min, min);
+        assertResult(max, max);
+    }
+
+    @DontCompile
+    public void assertResult(int x, int y) {
+        Asserts.assertEQ((x >> y) >= 0 ? 0 : 1, test1(x, y));
+        Asserts.assertEQ(((x & 127) >> y) >= 0 ? 0 : 1, test2(x, y));
+        Asserts.assertEQ(((-(x & 127) - 1) >> y) >= 0 ? 0 : 1, test3(x, y));
+        Asserts.assertEQ((x >> 30) > 4 ? 0 : 1, test4(x, y));
+    }
+
+    @Test
+    @IR(counts = { IRNode.RSHIFT, "1" })
+    public int test1(int x, int y) {
+        return (x >> y) >= 0 ? 0 : 1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.RSHIFT })
+    public int test2(int x, int y) {
+        return ((x & 127) >> y) >= 0 ? 0 : 1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.RSHIFT })
+    public int test3(int x, int y) {
+        return ((-(x & 127) - 1) >> y) >= 0 ? 0 : 1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.RSHIFT })
+    public int test4(int x, int y) {
+        return (x >> 30) > 4 ? 0 : 1;
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/RShiftLNodeIdealizationTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/RShiftLNodeIdealizationTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8320330
+ * @summary Test that RShiftLNode optimizations are being performed as expected.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.RShiftLNodeIdealizationTests
+ */
+public class RShiftLNodeIdealizationTests {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Run(test = { "test1", "test2", "test3", "test4" })
+    public void runMethod() {
+        long a = RunInfo.getRandom().nextLong();
+        long b = RunInfo.getRandom().nextLong();
+        long c = RunInfo.getRandom().nextLong();
+        long d = RunInfo.getRandom().nextLong();
+
+        long min = Long.MIN_VALUE;
+        long max = Long.MAX_VALUE;
+
+        assertResult(a, 0);
+        assertResult(a, b);
+        assertResult(b, a);
+        assertResult(c, d);
+        assertResult(d, c);
+        assertResult(min, max);
+        assertResult(max, min);
+        assertResult(min, min);
+        assertResult(max, max);
+    }
+
+    @DontCompile
+    public void assertResult(long x, long y) {
+        Asserts.assertEQ((x >> y) >= 0 ? 0L : 1L, test1(x, y));
+        Asserts.assertEQ(((x & 127) >> y) >= 0 ? 0L : 1L, test2(x, y));
+        Asserts.assertEQ(((-(x & 127) - 1) >> y) >= 0 ? 0L : 1L, test3(x, y));
+        Asserts.assertEQ((x >> 62) > 4 ? 0L : 1L, test4(x, y));
+    }
+
+    @Test
+    @IR(counts = { IRNode.RSHIFT, "1" })
+    public long test1(long x, long y) {
+        return (x >> y) >= 0 ? 0 : 1;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.RSHIFT })
+    public long test2(long x, long y) {
+        return ((x & 127) >> y) >= 0 ? 0L : 1L;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.RSHIFT })
+    public long test3(long x, long y) {
+        return ((-(x & 127) - 1) >> y) >= 0 ? 0L : 1L;
+    }
+
+    @Test
+    @IR(failOn = { IRNode.RSHIFT })
+    public long test4(long x, long y) {
+        return (x >> 62) > 4 ? 0L : 1L;
+    }
+}


### PR DESCRIPTION
Hi, I've created this patch to improve the Value() implementation for right shift nodes. The primary change is preserving sign information when calculating the value, even if we can't come to a precise conclusion-- when looking at the right shift `X >> Y`, if `type(X)` is `>=0` then we can know that `type(X >> Y)` can be at most `>=0`, regardless of what `type(Y)` is. The inverse is also true for the `<0` case. Previously, these cases would have returned the entire int/long range as the set of possible values. I tried to find a more general way to approach this transform but the wrapping behavior of shifts made it hard to reason about and I didn't find many cases that would benefit from it, so I've decided to keep it simple.

I also slightly changed the logic that shifts the hi and lo ranges of the type to only operate on non-constant left-hand values, as the case where both are constant can be better handled by the end case that simply shifts the constant. The long variant has also been changed to better match the int version as well.

A common place to find this pattern is String#length:
https://github.com/openjdk/jdk/blob/db1d82347bb18e21c4c6a18076ffdaf17724c733/src/java.base/share/classes/java/lang/String.java#L1520-L1522

As it's shifting an array length, we should now be able to statically prove that the result will also be `>=0`. I ran some of the existing benchmarks and saw some nice improvements in the realm of string concatenation, due to the sharpened type allowing a branch to become dead:
```
                                                          Baseline                     Patch            Improvement
Benchmark                           (intValue) Mode   Cnt  Score   Error  Units    Score    Error  Units
StringConcat.concatConst4String        4711    avgt   15  23.471 ± 0.916  ns/op   21.630 ±  0.093  ns/op  (+ 8.16%)
StringConcat.concatConst6String        4711    avgt   15  29.386 ± 0.454  ns/op   28.292 ±  0.127  ns/op  (+ 3.79%)
StringConcat.concatConstString         4711    avgt   15   6.880 ± 0.051  ns/op    6.606 ±  0.021  ns/op  (+ 4.06%)
StringConcat.concatMethodConstString   4711    avgt   15   6.881 ± 0.029  ns/op    6.665 ±  0.069  ns/op  (+ 3.18%)
```

I've also attached an IR test, and tier1-3 testing passes on my linux x64 machine. Reviews would be appreciated!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320330](https://bugs.openjdk.org/browse/JDK-8320330): Improve implementation of RShift Value (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [43a9cf3c](https://git.openjdk.org/jdk/pull/16736/files/43a9cf3c33fe5dacd7d66e13dd46a3bd1465d03e)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16736/head:pull/16736` \
`$ git checkout pull/16736`

Update a local copy of the PR: \
`$ git checkout pull/16736` \
`$ git pull https://git.openjdk.org/jdk.git pull/16736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16736`

View PR using the GUI difftool: \
`$ git pr show -t 16736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16736.diff">https://git.openjdk.org/jdk/pull/16736.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16736#issuecomment-1819238906)