### PR TITLE
8319137: release _object in ObjectMonitor dtor to avoid races

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -281,16 +281,10 @@ ObjectMonitor::~ObjectMonitor() {
 
 oop ObjectMonitor::object() const {
   check_object_context();
-  if (_object.is_null()) {
-    return nullptr;
-  }
   return _object.resolve();
 }
 
 oop ObjectMonitor::object_peek() const {
-  if (_object.is_null()) {
-    return nullptr;
-  }
   return _object.peek();
 }
 

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -276,7 +276,7 @@ ObjectMonitor::ObjectMonitor(oop object) :
 { }
 
 ObjectMonitor::~ObjectMonitor() {
-  release_object();
+  _object.release(_oop_storage);
 }
 
 oop ObjectMonitor::object() const {

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -276,10 +276,7 @@ ObjectMonitor::ObjectMonitor(oop object) :
 { }
 
 ObjectMonitor::~ObjectMonitor() {
-  if (!_object.is_null()) {
-    // Release object's oop storage if it hasn't already been done.
-    release_object();
-  }
+  release_object();
 }
 
 oop ObjectMonitor::object() const {
@@ -587,9 +584,6 @@ bool ObjectMonitor::deflate_monitor() {
     // Install the old mark word if nobody else has already done it.
     install_displaced_markword_in_object(obj);
   }
-
-  // Release object's oop storage since the ObjectMonitor has been deflated:
-  release_object();
 
   // We leave owner == DEFLATER_MARKER and contentions < 0
   // to force any racing threads to retry.

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -364,7 +364,6 @@ private:
   // Deflation support
   bool      deflate_monitor();
   void      install_displaced_markword_in_object(const oop obj);
-  void      release_object() { _object.release(_oop_storage); }
 };
 
 #endif // SHARE_RUNTIME_OBJECTMONITOR_HPP

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1581,14 +1581,18 @@ public:
   };
 };
 
-static size_t delete_monitors(GrowableArray<ObjectMonitor*>* delete_list) {
+static size_t delete_monitors(JavaThread* current, GrowableArray<ObjectMonitor*>* delete_list,
+                              LogStream* ls, elapsedTimer* timer_p) {
   NativeHeapTrimmer::SuspendMark sm("monitor deletion");
-  size_t count = 0;
+  size_t deleted_count = 0;
   for (ObjectMonitor* monitor: *delete_list) {
     delete monitor;
-    count++;
+    deleted_count++;
+    // A JavaThread must check for a safepoint/handshake and honor it.
+    ObjectSynchronizer::chk_for_block_req(current, "deletion", "deleted_count",
+                                          deleted_count, ls, timer_p);
   }
-  return count;
+  return deleted_count;
 }
 
 // This function is called by the MonitorDeflationThread to deflate
@@ -1662,30 +1666,7 @@ size_t ObjectSynchronizer::deflate_idle_monitors() {
 
     // After the handshake, safely free the ObjectMonitors that were
     // deflated and unlinked in this cycle.
-    if (current->is_Java_thread()) {
-      if (ls != NULL) {
-        timer.stop();
-        ls->print_cr("before setting blocked: unlinked_count=" SIZE_FORMAT
-                     ", in_use_list stats: ceiling=" SIZE_FORMAT ", count="
-                     SIZE_FORMAT ", max=" SIZE_FORMAT,
-                     unlinked_count, in_use_list_ceiling(),
-                     _in_use_list.count(), _in_use_list.max());
-      }
-      // Mark the calling JavaThread blocked (safepoint safe) while we free
-      // the ObjectMonitors so we don't delay safepoints whilst doing that.
-      ThreadBlockInVM tbivm(JavaThread::cast(current));
-      if (ls != NULL) {
-        ls->print_cr("after setting blocked: in_use_list stats: ceiling="
-                     SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
-                     in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
-        timer.start();
-      }
-      deleted_count = delete_monitors(&delete_list);
-      // ThreadBlockInVM is destroyed here
-    } else {
-      // A non-JavaThread can just free the ObjectMonitors:
-      deleted_count = delete_monitors(&delete_list);
-    }
+    deleted_count = delete_monitors(JavaThread::cast(current), &delete_list, ls, &timer);
     assert(unlinked_count == deleted_count, "must be");
   }
 


### PR DESCRIPTION
Please review the following fix which moves the release of the _object WeakHandle back to the ObjectMonitor dtor. Releasing it earlier as we do today introduces a race which can lead to crashes. Tested running tiers123 in mach5.

This fix is an effective backout of [JDK-8256302](https://bugs.openjdk.org/browse/JDK-8256302).

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319137](https://bugs.openjdk.org/browse/JDK-8319137): release _object in ObjectMonitor dtor to avoid races (**Bug** - P2)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**) ⚠️ Review applies to [3cfea97d](https://git.openjdk.org/jdk/pull/16738/files/3cfea97d74d19c7e06bc2e801fcd0b896b5d0186)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [3cfea97d](https://git.openjdk.org/jdk/pull/16738/files/3cfea97d74d19c7e06bc2e801fcd0b896b5d0186)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16738/head:pull/16738` \
`$ git checkout pull/16738`

Update a local copy of the PR: \
`$ git checkout pull/16738` \
`$ git pull https://git.openjdk.org/jdk.git pull/16738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16738`

View PR using the GUI difftool: \
`$ git pr show -t 16738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16738.diff">https://git.openjdk.org/jdk/pull/16738.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16738#issuecomment-1819247076)