### PR TITLE
8257076: os::scan_pages is empty on all platforms

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1914,10 +1914,6 @@ bool os::numa_get_group_ids_for_range(const void** addresses, int* lgrp_ids, siz
   return false;
 }
 
-char *os::scan_pages(char *start, char* end, page_info* page_expected, page_info* page_found) {
-  return end;
-}
-
 // Reserves and attaches a shared memory segment.
 char* os::pd_reserve_memory(size_t bytes, bool exec) {
   // Always round to os::vm_page_size(), which may be larger than 4K.

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1674,11 +1674,6 @@ bool os::numa_get_group_ids_for_range(const void** addresses, int* lgrp_ids, siz
   return false;
 }
 
-char *os::scan_pages(char *start, char* end, page_info* page_expected, page_info* page_found) {
-  return end;
-}
-
-
 bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {
 #if defined(__OpenBSD__)
   // XXX: Work-around mmap/MAP_FIXED bug temporarily on OpenBSD

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3012,12 +3012,6 @@ size_t os::numa_get_leaf_groups(uint *ids, size_t size) {
   return i;
 }
 
-char *os::scan_pages(char *start, char* end, page_info* page_expected,
-                     page_info* page_found) {
-  return end;
-}
-
-
 int os::Linux::sched_getcpu_syscall(void) {
   unsigned int cpu = 0;
   long retval = -1;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3825,11 +3825,6 @@ bool os::numa_get_group_ids_for_range(const void** addresses, int* lgrp_ids, siz
   return false;
 }
 
-char *os::scan_pages(char *start, char* end, page_info* page_expected,
-                     page_info* page_found) {
-  return end;
-}
-
 char* os::non_memory_address_word() {
   // Must never look like an address returned by reserve_memory,
   // even in its subfields (as defined by the CPU immediate fields,

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -707,27 +707,5 @@ void MutableNUMASpace::LGRPSpace::scan_pages(size_t page_size, size_t page_count
   char *scan_start = last_page_scanned();
   char* scan_end = MIN2(scan_start + page_size * page_count, range_end);
 
-  os::page_info page_expected, page_found;
-  page_expected.size = page_size;
-  page_expected.lgrp_id = checked_cast<uint>(lgrp_id());
-
-  char *s = scan_start;
-  while (s < scan_end) {
-    char *e = (char*)scan_end;
-    if (e == nullptr) {
-      break;
-    }
-    if (e != scan_end) {
-      assert(e < scan_end, "e: " PTR_FORMAT " scan_end: " PTR_FORMAT, p2i(e), p2i(scan_end));
-
-      if ((page_expected.size != page_size || checked_cast<uint>(page_expected.lgrp_id) != lgrp_id())
-          && page_expected.size != 0) {
-        os::free_memory(s, pointer_delta(e, s, sizeof(char)), page_size);
-      }
-      page_expected = page_found;
-    }
-    s = e;
-  }
-
   set_last_page_scanned(scan_end);
 }

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -713,7 +713,7 @@ void MutableNUMASpace::LGRPSpace::scan_pages(size_t page_size, size_t page_count
 
   char *s = scan_start;
   while (s < scan_end) {
-    char *e = os::scan_pages(s, (char*)scan_end, &page_expected, &page_found);
+    char *e = (char*)scan_end;
     if (e == nullptr) {
       break;
     }

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -83,11 +83,8 @@ class MutableNUMASpace : public MutableSpace {
 
     SpaceStats _space_stats;
 
-    char* _last_page_scanned;
-    char* last_page_scanned()            { return _last_page_scanned; }
-    void set_last_page_scanned(char* p)  { _last_page_scanned = p;    }
    public:
-    LGRPSpace(uint l, size_t alignment) : _lgrp_id(l), _allocation_failed(false), _last_page_scanned(nullptr) {
+    LGRPSpace(uint l, size_t alignment) : _lgrp_id(l), _allocation_failed(false) {
       _space = new MutableSpace(alignment);
       _alloc_rate = new AdaptiveWeightedAverage(NUMAChunkResizeWeight);
     }
@@ -125,7 +122,6 @@ class MutableNUMASpace : public MutableSpace {
     void clear_space_stats()                        { _space_stats = SpaceStats(); }
 
     void accumulate_statistics(size_t page_size);
-    void scan_pages(size_t page_size, size_t page_count);
   };
 
   GrowableArray<LGRPSpace*>* _lgrp_spaces;
@@ -156,8 +152,6 @@ class MutableNUMASpace : public MutableSpace {
   size_t default_chunk_size();
   // Adapt the chunk size to follow the allocation rate.
   size_t adaptive_chunk_size(int i, size_t limit);
-  // Scan and free invalid pages.
-  void scan_pages(size_t page_count);
   // Return the bottom_region and the top_region. Align them to page_size() boundary.
   // |------------------new_region---------------------------------|
   // |----bottom_region--|---intersection---|------top_region------|

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -523,8 +523,6 @@ class os: AllStatic {
     size_t size;
     int lgrp_id;
   };
-  static char*  scan_pages(char *start, char* end, page_info* page_expected, page_info* page_found);
-
   static char*  non_memory_address_word();
   // reserve, commit and pin the entire memory region
   static char*  reserve_memory_special(size_t size, size_t alignment, size_t page_size,


### PR DESCRIPTION
The function os::scan_pages was only ever implemented in Solaris and then removed in [JDK-8244224](https://bugs.openjdk.org/browse/JDK-8244224)

All other platforms have empty implementations and the interface is not optimal as os::scan_pages expects the range to have just one page size, while in reality it can have multiple. 

This PR removes this interface, ensuing empty implementations and all dead code related to page scanning.

Testing: Tier 1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8257076](https://bugs.openjdk.org/browse/JDK-8257076): os::scan_pages is empty on all platforms (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16740/head:pull/16740` \
`$ git checkout pull/16740`

Update a local copy of the PR: \
`$ git checkout pull/16740` \
`$ git pull https://git.openjdk.org/jdk.git pull/16740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16740`

View PR using the GUI difftool: \
`$ git pr show -t 16740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16740.diff">https://git.openjdk.org/jdk/pull/16740.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16740#issuecomment-1821630910)