### PR TITLE
8320418: PPC64: invokevfinal_helper duplicates code to handle ResolvedMethodEntry

### DIFF
--- a/src/hotspot/cpu/ppc/templateTable_ppc.hpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc.hpp
@@ -27,7 +27,7 @@
 #define CPU_PPC_TEMPLATETABLE_PPC_HPP
 
   static void prepare_invoke(Register Rcache, Register Rret_addr, Register Rrecv, Register Rscratch);
-  static void invokevfinal_helper(Register Rcache, Register Rscratch1, Register Rscratch2, Register Rscratch3);
+  static void invokevfinal_helper(Register Rcache, Register Rscratch1, Register Rscratch2, Register Rscratch3, Register Rscratch4);
   static void generate_vtable_call(Register Rrecv_klass, Register Rindex, Register Rret, Register Rtemp);
   static void invokeinterface_object_method(Register Rrecv_klass, Register Rret, Register Rflags, Register Rcache, Register Rtemp, Register Rtemp2);
 

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3486,7 +3486,7 @@ void TemplateTable::invokevirtual(int byte_no) {
   if (RewriteBytecodes && !UseSharedSpaces && !DumpSharedSpaces) {
     patch_bytecode(Bytecodes::_fast_invokevfinal, Rnew_bc, R12_scratch2);
   }
-  invokevfinal_helper(Rcache, R11_scratch1, R12_scratch2, Rflags /* tmp */);
+  invokevfinal_helper(Rcache, R11_scratch1, R12_scratch2, Rflags /* tmp */, Rrecv /* tmp */);
 
   __ align(32, 12);
   __ bind(LnotFinal);
@@ -3509,35 +3509,23 @@ void TemplateTable::fast_invokevfinal(int byte_no) {
   assert(byte_no == f2_byte, "use this argument");
   Register Rcache  = R31;
   __ load_method_entry(Rcache, R11_scratch1);
-  invokevfinal_helper(Rcache, R11_scratch1, R12_scratch2, R22_tmp2);
+  invokevfinal_helper(Rcache, R11_scratch1, R12_scratch2, R22_tmp2, R23_tmp3);
 }
 
-void TemplateTable::invokevfinal_helper(Register Rcache, Register Rscratch1, Register Rscratch2, Register Rscratch3) {
+void TemplateTable::invokevfinal_helper(Register Rcache,
+                                        Register Rscratch1, Register Rscratch2, Register Rscratch3, Register Rscratch4) {
 
-  assert_different_registers(Rcache, Rscratch1, Rscratch2, Rscratch3);
+  assert_different_registers(Rcache, Rscratch1, Rscratch2, Rscratch3, Rscratch4);
 
-  // Load receiver from stack slot.
-  Register Rmethod = Rscratch3;
-  __ ld(Rmethod, in_bytes(ResolvedMethodEntry::method_offset()), Rcache);
+  Register Rrecv     = Rscratch2,
+           Rmethod   = Rscratch3,
+           Rret_addr = Rscratch4;
+  prepare_invoke(Rcache, Rret_addr, Rrecv, Rscratch1);
 
-  // Get return address.
-  Register Rtable_addr = Rscratch2,
-           Rret_addr   = Rcache,
-           Rret_type   = Rscratch1;
-  // Get return type. It's coded into the upper 4 bits of the lower half of the 64 bit value.
-  __ lbz(Rret_type, in_bytes(ResolvedMethodEntry::type_offset()), Rcache);
-  __ load_dispatch_table(Rtable_addr, Interpreter::invoke_return_entry_table());
-  __ sldi(Rret_type, Rret_type, LogBytesPerWord);
-  __ ldx(Rret_addr, Rret_type, Rtable_addr); // kills Rcache
-
-  Register Rnum_params = Rscratch2,
-           Rrecv       = Rscratch2;
-  __ ld(Rnum_params, in_bytes(Method::const_offset()), Rmethod);
-  __ lhz(Rnum_params /* number of params */, in_bytes(ConstMethod::size_of_parameters_offset()), Rnum_params);
-
-  // Load receiver and receiver null check.
-  __ load_receiver(Rnum_params, Rrecv);
+  // Receiver null check.
   __ null_check_throw(Rrecv, -1, Rscratch1);
+
+  __ ld(Rmethod, in_bytes(ResolvedMethodEntry::method_offset()), Rcache);
 
   __ profile_final_call(Rrecv, Rscratch1);
   // Argument and return type profiling.
@@ -3557,9 +3545,9 @@ void TemplateTable::invokespecial(int byte_no) {
            Rmethod     = R31;
 
   load_resolved_method_entry_special_or_static(Rcache,  // ResolvedMethodEntry*
-                                               Rmethod, // Method* or itable index
+                                               Rmethod, // Method*
                                                noreg);  // flags
-  prepare_invoke(Rcache, Rret_addr, Rreceiver, R11_scratch1); // recv
+  prepare_invoke(Rcache, Rret_addr, Rreceiver, R11_scratch1);
 
   // Receiver null check.
   __ null_check_throw(Rreceiver, -1, R11_scratch1);
@@ -3577,10 +3565,10 @@ void TemplateTable::invokestatic(int byte_no) {
   Register Rcache    = R3_ARG1,
            Rret_addr = R4_ARG2;
 
-  load_resolved_method_entry_special_or_static(Rcache,  // ResolvedMethodEntry*
-                                               R19_method, // Method* or itable index
-                                               noreg); // flags
-  prepare_invoke(Rcache, Rret_addr, noreg, R11_scratch1); // recv
+  load_resolved_method_entry_special_or_static(Rcache,     // ResolvedMethodEntry*
+                                               R19_method, // Method*
+                                               noreg);     // flags
+  prepare_invoke(Rcache, Rret_addr, noreg, R11_scratch1);
 
   __ profile_call(R11_scratch1, R12_scratch2);
   // Argument and return type profiling.
@@ -3638,7 +3626,7 @@ void TemplateTable::invokeinterface(int byte_no) {
                  Rcache           = R31;
 
   load_resolved_method_entry_interface(Rcache, noreg, noreg, Rflags);
-  prepare_invoke(Rcache, Rret_addr, Rreceiver, Rscratch1); // recv
+  prepare_invoke(Rcache, Rret_addr, Rreceiver, Rscratch1);
 
   // First check for Object case, then private interface method,
   // then regular interface method.
@@ -3756,7 +3744,7 @@ void TemplateTable::invokehandle(int byte_no) {
                  Rcache    = R31;
 
   load_resolved_method_entry_handle(Rcache,  // ResolvedMethodEntry*
-                                    Rmethod, // Method* or itable index
+                                    Rmethod, // Method*
                                     Rscratch1,
                                     Rflags);
   prepare_invoke(Rcache, Rret_addr, Rrecv, Rscratch1);

--- a/src/hotspot/share/interpreter/templateInterpreter.cpp
+++ b/src/hotspot/share/interpreter/templateInterpreter.cpp
@@ -244,6 +244,7 @@ address* TemplateInterpreter::invoke_return_entry_table_for(Bytecodes::Code code
   case Bytecodes::_invokespecial:
   case Bytecodes::_invokevirtual:
   case Bytecodes::_invokehandle:
+  case Bytecodes::_fast_invokevfinal:
     return Interpreter::invoke_return_entry_table();
   case Bytecodes::_invokeinterface:
     return Interpreter::invokeinterface_return_entry_table();


### PR DESCRIPTION
`TemplateTable::invokevfinal_helper` should use `TemplateTable::prepare_invoke`. `TemplateInterpreter::invoke_return_entry_table_for` needs to support `_fast_invokevfinal` bytecode for that which is only used by PPC64. (It is probably still beneficial for AIX which doesn't support CDS.)
In addition, I've cleaned up some inaccurate comments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320418](https://bugs.openjdk.org/browse/JDK-8320418): PPC64: invokevfinal_helper duplicates code to handle ResolvedMethodEntry (**Enhancement** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16741/head:pull/16741` \
`$ git checkout pull/16741`

Update a local copy of the PR: \
`$ git checkout pull/16741` \
`$ git pull https://git.openjdk.org/jdk.git pull/16741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16741`

View PR using the GUI difftool: \
`$ git pr show -t 16741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16741.diff">https://git.openjdk.org/jdk/pull/16741.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16741#issuecomment-1819320985)