### PR TITLE
8282726: java/net/vthread/BlockingSocketOps.java timeout/hang intermittently on Windows

### DIFF
--- a/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
+++ b/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
@@ -66,7 +66,7 @@ class PollsetPoller extends Poller {
     }
 
     @Override
-    void implDeregister(int fd) {
+    void implDeregister(int fdVal, boolean polled) {
         int ret = Pollset.pollsetCtl(setid, Pollset.PS_DELETE, fd, 0);
         assert ret == 0;
     }

--- a/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
+++ b/src/java.base/aix/classes/sun/nio/ch/PollsetPoller.java
@@ -66,7 +66,7 @@ class PollsetPoller extends Poller {
     }
 
     @Override
-    void implDeregister(int fdVal, boolean polled) {
+    void implDeregister(int fd, boolean polled) {
         int ret = Pollset.pollsetCtl(setid, Pollset.PS_DELETE, fd, 0);
         assert ret == 0;
     }

--- a/src/java.base/linux/classes/sun/nio/ch/EPollPoller.java
+++ b/src/java.base/linux/classes/sun/nio/ch/EPollPoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,8 +62,11 @@ class EPollPoller extends Poller {
     }
 
     @Override
-    void implDeregister(int fdVal) {
-        EPoll.ctl(epfd, EPOLL_CTL_DEL, fdVal, 0);
+    void implDeregister(int fdVal, boolean polled) {
+        // event is disabled if already polled
+        if (!polled) {
+            EPoll.ctl(epfd, EPOLL_CTL_DEL, fdVal, 0);
+        }
     }
 
     @Override

--- a/src/java.base/macosx/classes/sun/nio/ch/KQueuePoller.java
+++ b/src/java.base/macosx/classes/sun/nio/ch/KQueuePoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,8 +56,11 @@ class KQueuePoller extends Poller {
     }
 
     @Override
-    void implDeregister(int fdVal) {
-        KQueue.register(kqfd, fdVal, filter, EV_DELETE);
+    void implDeregister(int fdVal, boolean polled) {
+        // event was deleted if already polled
+        if (!polled) {
+            KQueue.register(kqfd, fdVal, filter, EV_DELETE);
+        }
     }
 
     @Override

--- a/src/java.base/share/classes/sun/nio/ch/Poller.java
+++ b/src/java.base/share/classes/sun/nio/ch/Poller.java
@@ -94,14 +94,16 @@ abstract class Poller {
     }
 
     /**
-     * Register the file descriptor.
+     * Register the file descriptor. The registration is "one shot", meaning it should
+     * be polled at most once.
      */
     abstract void implRegister(int fdVal) throws IOException;
 
     /**
      * Deregister the file descriptor.
+     * @param polled true if the file descriptor has already been polled
      */
-    abstract void implDeregister(int fdVal);
+    abstract void implDeregister(int fdVal, boolean polled);
 
     /**
      * Poll for events. The {@link #polled(int)} method is invoked for each
@@ -182,23 +184,23 @@ abstract class Poller {
     }
 
     /**
-     * Registers the file descriptor.
+     * Registers the file descriptor to be polled at most once when the file descriptor
+     * is ready for I/O.
      */
     private void register(int fdVal) throws IOException {
-        Thread previous = map.putIfAbsent(fdVal, Thread.currentThread());
+        Thread previous = map.put(fdVal, Thread.currentThread());
         assert previous == null;
         implRegister(fdVal);
     }
 
     /**
-     * Deregister the file descriptor, a no-op if already polled.
+     * Deregister the file descriptor so that the file descriptor is not polled.
      */
     private void deregister(int fdVal) {
         Thread previous = map.remove(fdVal);
-        assert previous == null || previous == Thread.currentThread();
-        if (previous != null) {
-            implDeregister(fdVal);
-        }
+        boolean polled = (previous == null);
+        assert polled || previous == Thread.currentThread();
+        implDeregister(fdVal, polled);
     }
 
     /**

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,14 +129,7 @@ class PipeImpl
                         }
 
                         // Establish connection (assume connection is eagerly accepted)
-                        if (sa instanceof InetSocketAddress
-                                && Thread.currentThread().isVirtual()) {
-                            // workaround "lost event" issue on older releases of Windows
-                            sc1 = SocketChannel.open();
-                            sc1.socket().connect(sa, 10_000);
-                        } else {
-                            sc1 = SocketChannel.open(sa);
-                        }
+                        sc1 = SocketChannel.open(sa);
                         RANDOM_NUMBER_GENERATOR.nextBytes(secret.array());
                         do {
                             sc1.write(secret);

--- a/src/java.base/windows/classes/sun/nio/ch/WEPollPoller.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WEPollPoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,16 +46,13 @@ class WEPollPoller extends Poller {
 
     @Override
     void implRegister(int fdVal) throws IOException {
-        // re-arm
-        int err = WEPoll.ctl(handle, EPOLL_CTL_MOD, fdVal, (event | EPOLLONESHOT));
-        if (err == ENOENT)
-            err = WEPoll.ctl(handle, EPOLL_CTL_ADD, fdVal, (event | EPOLLONESHOT));
+        int err = WEPoll.ctl(handle, EPOLL_CTL_ADD, fdVal, (event | EPOLLONESHOT));
         if (err != 0)
             throw new IOException("epoll_ctl failed: " + err);
     }
 
     @Override
-    void implDeregister(int fdVal) {
+    void implDeregister(int fdVal, boolean polled) {
         WEPoll.ctl(handle, EPOLL_CTL_DEL, fdVal, 0);
     }
 

--- a/test/jdk/java/net/vthread/BlockingSocketOps.java
+++ b/test/jdk/java/net/vthread/BlockingSocketOps.java
@@ -685,7 +685,7 @@ class BlockingSocketOps {
                 Socket s1 = new Socket();
                 Socket s2;
                 try {
-                    s1.connect(listener.getLocalSocketAddress(), 10_000);
+                    s1.connect(listener.getLocalSocketAddress());
                     s2 = listener.accept();
                 } catch (IOException ioe) {
                     s1.close();

--- a/test/jdk/java/nio/channels/vthread/BlockingChannelOps.java
+++ b/test/jdk/java/nio/channels/vthread/BlockingChannelOps.java
@@ -808,7 +808,7 @@ class BlockingChannelOps {
                 SocketChannel sc1 = SocketChannel.open();
                 SocketChannel sc2 = null;
                 try {
-                    sc1.socket().connect(listener.getLocalAddress(), 10_000);
+                    sc1.socket().connect(listener.getLocalAddress());
                     sc2 = listener.accept();
                 } catch (IOException ioe) {
                     sc1.close();


### PR DESCRIPTION
This is a Windows specific issue where a virtual thread attempting to establish a connection appears to hang, and the test eventually times out. It initially looked like an issue on older releases of Windows but it turns out to be an issue that arises when a SOCKET handle is recycled quickly. Thanks to Daniel Jeliński for spending time to find a way to reproduce this quickly, up to now it was too intermittent and needed tens of thousands of runs to have some chance of reproducing.

When a SOCKET has been polled, the event is disabled rather than removed from wepoll / AFD poll. When the SOCKET is closed and immediately recycled then there is a race with the close event and registration of the "new" socket for events. The change that we've tested is to remove the event after polling. This is done virtual thread "client" rather than the poller to avoid racing with an async close.

As part of this change I've removed a temporary change to the Windows Pipe implementation and also remove the connect timeout that went into a few tests to workaround the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282726](https://bugs.openjdk.org/browse/JDK-8282726): java/net/vthread/BlockingSocketOps.java timeout/hang intermittently on Windows (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16742/head:pull/16742` \
`$ git checkout pull/16742`

Update a local copy of the PR: \
`$ git checkout pull/16742` \
`$ git pull https://git.openjdk.org/jdk.git pull/16742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16742`

View PR using the GUI difftool: \
`$ git pr show -t 16742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16742.diff">https://git.openjdk.org/jdk/pull/16742.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16742#issuecomment-1820328259)