### PR TITLE
8315969: compiler/rangechecks/TestRangeCheckHoistingScaledIV.java: make flagless

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -51,8 +51,6 @@ compiler/cpuflags/TestAESIntrinsicsOnSupportedConfig.java 8190680 generic-all
 compiler/runtime/Test8168712.java 8211769,8211771 generic-ppc64,generic-ppc64le,linux-s390x
 compiler/loopopts/TestUnreachableInnerLoop.java 8288981 linux-s390x
 
-compiler/rangechecks/TestRangeCheckHoistingScaledIV.java 8315969 generic-all
-
 compiler/rtm/locking/TestRTMAbortRatio.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestRTMAbortThreshold.java 8183263 generic-x64,generic-i586
 compiler/rtm/locking/TestRTMAfterNonRTMDeopt.java 8183263 generic-x64,generic-i586

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 8289996
  * @summary Test range check hoisting for some scaled iv at array index
  * @library /test/lib /
+ * @requires vm.flagless
  * @requires vm.debug & vm.compiler2.enabled & (os.simpleArch == "x64" | os.arch == "aarch64")
  * @modules jdk.incubator.vector
  * @run main/othervm compiler.rangechecks.TestRangeCheckHoistingScaledIV


### PR DESCRIPTION
A recent improvement ([JDK-8314838](https://bugs.openjdk.org/browse/JDK-8314838)) changed dependant VM creation in that test - we now forward given arguments via 'ProcessTools.createTestJvm()'. It has been revealed, however, that the test doesn't work well with '-Xcomp'. A bug ([JDK-8316124](https://bugs.openjdk.org/browse/JDK-8316124)) has been filed.

I suggest to temporarily make test 'vm.flagless' to allow for running the test in CI. As soon as [JDK-8316124](https://bugs.openjdk.org/browse/JDK-8316124) is fixed, we'll remove that limitation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315969](https://bugs.openjdk.org/browse/JDK-8315969): compiler/rangechecks/TestRangeCheckHoistingScaledIV.java: make flagless (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16746/head:pull/16746` \
`$ git checkout pull/16746`

Update a local copy of the PR: \
`$ git checkout pull/16746` \
`$ git pull https://git.openjdk.org/jdk.git pull/16746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16746`

View PR using the GUI difftool: \
`$ git pr show -t 16746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16746.diff">https://git.openjdk.org/jdk/pull/16746.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16746#issuecomment-1819655770)