### PR TITLE
8320365

### DIFF
--- a/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
+++ b/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
@@ -456,12 +456,14 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
                 // IPP currently does not support it but PPD does.
 
                 try {
-                    cps = new CUPSPrinter(printer);
-                    mediaSizeNames = cps.getMediaSizeNames();
-                    mediaTrays = cps.getMediaTrays();
-                    customMediaSizeNames = cps.getCustomMediaSizeNames();
-                    defaultMediaIndex = cps.getDefaultMediaIndex();
-                    rawResolutions = cps.getRawResolutions();
+                    if (cps == null) {
+                        cps = new CUPSPrinter(printer);
+                        mediaSizeNames = cps.getMediaSizeNames();
+                        mediaTrays = cps.getMediaTrays();
+                        customMediaSizeNames = cps.getCustomMediaSizeNames();
+                        defaultMediaIndex = cps.getDefaultMediaIndex();
+                        rawResolutions = cps.getRawResolutions();
+                    }
                     urlConnection.disconnect();
                     init = true;
                     return;
@@ -1225,9 +1227,17 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
 
 
     public synchronized PrintServiceAttributeSet getAttributes() {
-        // update getAttMap by sending again get-attributes IPP request
-        init = false;
-        initAttributes();
+        if (!init) {
+            // get all attributes for the first time.
+            initAttributes();
+        } else {
+            // only need service attributes updated.
+            // update getAttMap by sending again get-attributes IPP request
+            if ((urlConnection = getIPPConnection(myURL)) != null) {
+                opGetAttributes();
+                urlConnection.disconnect();
+            }
+        }
 
         HashPrintServiceAttributeSet attrs =
             new HashPrintServiceAttributeSet();


### PR DESCRIPTION
Whilst reviewing the fix for https://bugs.openjdk.org/browse/JDK-7001133 I realised that although the proposed
changes there may help, the problem would be inconsequential except that if anything causes an app to
call PrintService.getAttributes()  we will continually be re-initialising attributes, which causes IPPPrintService
to keep creating new instances of CUPSPrinter which are then discarded and over-written.
So update the implementation to only re-initialise the relevant attributes.