### PR TITLE
8320379: C2: Sort spilling/unspilling sequence for better ld/st merging into ldp/stp on AArch64

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -169,11 +169,10 @@ public:
   // Add a node to the current bundle
   void AddNodeToBundle(Node *n, const Block *bb);
 
-  // Return true only when the stack offset of the first spill node is
-  // greater than the stack offset of the second one. Otherwise, return false.
-  // When compare_two_spill_nodes(first, second) returns true, we think that
-  // "second" should be scheduled before "first" in the final basic block.
-  bool compare_two_spill_nodes(Node* first, Node* second);
+  // Return an integer less than, equal to, or greater than zero
+  // if the stack offset of the first argument is respectively
+  // less than, equal to, or greater than the second.
+  int compare_two_spill_nodes(Node* first, Node* second);
 
   // Add a node to the list of available nodes
   void AddNodeToAvailableList(Node *n);
@@ -2277,7 +2276,7 @@ Node * Scheduling::ChooseNodeToBundle() {
   return _available[0];
 }
 
-bool Scheduling::compare_two_spill_nodes(Node* first, Node* second) {
+int Scheduling::compare_two_spill_nodes(Node* first, Node* second) {
   assert(first->is_MachSpillCopy() && second->is_MachSpillCopy(), "");
 
   OptoReg::Name first_src_lo = _regalloc->get_reg_first(first->in(1));
@@ -2288,16 +2287,16 @@ bool Scheduling::compare_two_spill_nodes(Node* first, Node* second) {
   // Comparison between stack -> reg and stack -> reg
   if (OptoReg::is_stack(first_src_lo) && OptoReg::is_stack(second_src_lo) &&
       OptoReg::is_reg(first_dst_lo) && OptoReg::is_reg(second_dst_lo)) {
-    return _regalloc->reg2offset(first_src_lo) > _regalloc->reg2offset(second_src_lo);
+    return _regalloc->reg2offset(first_src_lo) - _regalloc->reg2offset(second_src_lo);
   }
 
   // Comparison between reg -> stack and reg -> stack
   if (OptoReg::is_stack(first_dst_lo) && OptoReg::is_stack(second_dst_lo) &&
       OptoReg::is_reg(first_src_lo) && OptoReg::is_reg(second_src_lo)) {
-    return _regalloc->reg2offset(first_dst_lo) > _regalloc->reg2offset(second_dst_lo);
+    return _regalloc->reg2offset(first_dst_lo) - _regalloc->reg2offset(second_dst_lo);
   }
 
-  return false;
+  return 0; // Not comparable
 }
 
 void Scheduling::AddNodeToAvailableList(Node *n) {
@@ -2313,7 +2312,7 @@ void Scheduling::AddNodeToAvailableList(Node *n) {
 
   // Insert in latency order (insertion sort). If two MachSpillCopyNodes
   // for stack spilling or unspilling have the same latency, we sort
-  // them in the order of stack offset. Some backends (aarch64) may also
+  // them in the order of stack offset. Some ports (e.g. aarch64) may also
   // have more opportunities to do ld/st merging
   uint i;
   for (i = 0; i < _available.size(); i++) {
@@ -2321,7 +2320,7 @@ void Scheduling::AddNodeToAvailableList(Node *n) {
       break;
     } else if (_current_latency[_available[i]->_idx] == latency &&
                n->is_MachSpillCopy() && _available[i]->is_MachSpillCopy() &&
-               compare_two_spill_nodes(n, _available[i])) {
+               compare_two_spill_nodes(n, _available[i]) > 0) {
       break;
     }
   }


### PR DESCRIPTION
Macro-assembler on aarch64 can merge adjacent loads or stores into ldp/stp.[[1]](https://github.com/openjdk/jdk/blob/a95062b39a431b4937ab6e9e73de4d2b8ea1ac49/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp#L2079)

For example, it can merge:
```
str     w20, [sp, #16]
str     w10, [sp, #20]
```
into
```
stp     w20, w10, [sp, #16]
```

But C2 may generate a sequence like:
```
str     x21, [sp, #8]
str     w20, [sp, #16]
str     x19, [sp, #24] <---
str     w10, [sp, #20] <--- Before sorting
str     x11, [sp, #40]
str     w13, [sp, #48]
str     x16, [sp, #56]
```
We can't do any merging for non-adjacent loads or stores.

The patch is to sort the spilling or unspilling sequence in the order of offset during instruction scheduling and bundling phase. After that, we can get a new sequence:
```
str     x21, [sp, #8]
str     w20, [sp, #16]
str     w10, [sp, #20] <---
str     x19, [sp, #24] <--- After sorting
str     x11, [sp, #40]
str     w13, [sp, #48]
str     x16, [sp, #56]
```

Then macro-assembler can do ld/st merging:
```
str     x21, [sp, #8]
stp     w20, w10, [sp, #16] <--- Merged
str     x19, [sp, #24]
str     x11, [sp, #40]
str     w13, [sp, #48]
str     x16, [sp, #56]
```

To justify the patch, we run `HelloWorld.java`
```
public class HelloWorld {
    public static void main(String [] args) {
        System.out.println("Hello World!");
    }
}
```
with `java -Xcomp -XX:-TieredCompilation HelloWorld`.

Before the patch, macro-assembler can do ld/st merging for 3688 times. After the patch, the number of ld/st merging increases to 3871 times, by ~5 %.

Tested tier1~3 on x86 and AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320379](https://bugs.openjdk.org/browse/JDK-8320379): C2: Sort spilling/unspilling sequence for better ld/st merging into ldp/stp on AArch64 (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16754/head:pull/16754` \
`$ git checkout pull/16754`

Update a local copy of the PR: \
`$ git checkout pull/16754` \
`$ git pull https://git.openjdk.org/jdk.git pull/16754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16754`

View PR using the GUI difftool: \
`$ git pr show -t 16754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16754.diff">https://git.openjdk.org/jdk/pull/16754.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16754#issuecomment-1820365898)