### PR TITLE
8320447: Remove obsolete `LintCategory.hidden`

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Lint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -343,12 +343,7 @@ public class Lint
         RESTRICTED("restricted");
 
         LintCategory(String option) {
-            this(option, false);
-        }
-
-        LintCategory(String option, boolean hidden) {
             this.option = option;
-            this.hidden = hidden;
             map.put(option, this);
         }
 
@@ -357,7 +352,6 @@ public class Lint
         }
 
         public final String option;
-        public final boolean hidden;
     }
 
     /**


### PR DESCRIPTION
Please review this change that removes the `LintCategory.hidden` member.

`LintCategory.hidden` is an obsolete member with no uses. It was used for a custom "internal" category, "sunapi".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320447](https://bugs.openjdk.org/browse/JDK-8320447): Remove obsolete `LintCategory.hidden` (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16755/head:pull/16755` \
`$ git checkout pull/16755`

Update a local copy of the PR: \
`$ git checkout pull/16755` \
`$ git pull https://git.openjdk.org/jdk.git pull/16755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16755`

View PR using the GUI difftool: \
`$ git pr show -t 16755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16755.diff">https://git.openjdk.org/jdk/pull/16755.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16755#issuecomment-1820475592)