### PR TITLE
add test-libgraal

### DIFF
--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -32,6 +32,10 @@ inputs:
   debug-suffix:
     description: 'File name suffix denoting debug level, possibly empty'
     required: false
+  include-static-libs:
+    description: 'Should static-libs be part of installed JDK bundle?'
+    default: false
+    required: false
 outputs:
   jdk-path:
     description: 'Path to the installed JDK bundle'
@@ -73,6 +77,13 @@ runs:
           echo 'Unpacking jdk bundle...'
           mkdir -p bundles/jdk
           tar -xf bundles/jdk-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz -C bundles/jdk
+        fi
+
+        if [[ '${{ inputs.include-static-libs }}' == 'true' ]]; then
+          if [[ -d bundles/jdk && -e bundles/static-libs-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz ]]; then
+            echo 'Unpacking static-libs bundle...'
+            tar -xf bundles/static-libs-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz -C bundles/jdk
+          fi
         fi
 
         if [[ -e bundles/symbols-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz ]]; then

--- a/.github/actions/get-graal/action.yml
+++ b/.github/actions/get-graal/action.yml
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+name: 'Get Graal'
+description: 'Clone Graal from GitHub'
+outputs:
+  path:
+    description: 'Path to cloned Graal repo'
+    value: ${{ steps.path-name.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: 'Checkout graal repo'
+      uses: actions/checkout@v4
+      with:
+        repository: graalvm/graal
+        ref: refs/heads/master
+        path: graal
+        fetch-depth: 1
+
+    - name: 'Export path to where graal is cloned'
+      id: path-name
+      run: |
+        # Export the path
+        echo 'path=graal' >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -45,6 +45,7 @@ runs:
         jdk_bundle_tar_gz="$(ls build/*/bundles/jdk-*_bin${{ inputs.debug-suffix }}.tar.gz 2> /dev/null || true)"
         symbols_bundle="$(ls build/*/bundles/jdk-*_bin${{ inputs.debug-suffix }}-symbols.tar.gz 2> /dev/null || true)"
         tests_bundle="$(ls build/*/bundles/jdk-*_bin-tests${{ inputs.debug-suffix }}.tar.gz 2> /dev/null || true)"
+        static_libs_bundle="$(ls build/*/bundles/jdk-*_bin-static-libs${{ inputs.debug-suffix }}.tar.gz 2> /dev/null || true)"
 
         mkdir bundles
 
@@ -60,8 +61,11 @@ runs:
         if [[ "$tests_bundle" != "" ]]; then
           mv "$tests_bundle" "bundles/tests-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz"
         fi
+        if [[ "$static_libs_bundle" != "" ]]; then
+          mv "$static_libs_bundle" "bundles/static-libs-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz"
+        fi
 
-        if [[ "$jdk_bundle_zip$jdk_bundle_tar_gz$symbols_bundle$tests_bundle" != "" ]]; then
+        if [[ "$jdk_bundle_zip$jdk_bundle_tar_gz$symbols_bundle$tests_bundle$static_libs_bundle" != "" ]]; then
           echo 'bundles-found=true' >> $GITHUB_OUTPUT
         else
           echo 'bundles-found=false' >> $GITHUB_OUTPUT

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -76,6 +76,11 @@ jobs:
             flags: --with-debug-level=fastdebug
             suffix: -debug
 
+          # Only build static-libs-bundles for release builds.
+          # For debug builds, building static-libs often exceeds disk space.
+          - debug-level: release
+            static-libs: static-libs-bundles
+
     steps:
       - name: 'Checkout the JDK source'
         uses: actions/checkout@v4
@@ -134,7 +139,7 @@ jobs:
         id: build
         uses: ./.github/actions/do-build
         with:
-          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
+          make-target: '${{ inputs.make-target }} ${{ matrix.static-libs }} ${{ inputs.make-arguments }}'
           platform: ${{ inputs.platform }}
           debug-suffix: '${{ matrix.suffix }}'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -330,6 +330,15 @@ jobs:
       bootjdk-platform: windows-x64
       runs-on: windows-2019
 
+  test-libgraal-linux-x64:
+    name: linux-x64
+    needs:
+      - build-linux-x64
+    uses: ./.github/workflows/test-libgraal.yml
+    with:
+      runs-on: ubuntu-22.04
+      platform: linux-x64
+
   # Remove bundles so they are not misconstrued as binary distributions from the JDK project
   remove-bundles:
     name: 'Remove bundle artifacts'

--- a/.github/workflows/test-libgraal.yml
+++ b/.github/workflows/test-libgraal.yml
@@ -1,0 +1,106 @@
+#
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+name: 'Build and test libgraal'
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: test-libgraal
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - 'libgraal/release'
+          #- 'libgraal/fastdebug'
+
+        include:
+          - test-name: 'libgraal/release'
+
+          # - test-name: 'libgraal/fastdebug'
+          #   debug-suffix: -debug
+    env:
+      JAVA_HOME: ${{ github.workspace }}/jdk
+      MX_PATH: ${{ github.workspace }}/mx
+      MX_PYTHON: python3.8
+
+    steps:
+      - name: 'Checkout the JDK source'
+        uses: actions/checkout@v4
+
+      - name: 'Clone Graal'
+        id: graal
+        uses: ./.github/actions/get-graal
+
+      - name: 'Get bundles'
+        id: bundles
+        uses: ./.github/actions/get-bundles
+        with:
+          platform: ${{ inputs.platform }}
+          debug-suffix: ${{ matrix.debug-suffix }}
+          include-static-libs: true
+
+      - name: Determine mx version
+        run: echo "MX_VERSION=$(jq -r '.mx_version' ${{ steps.graal.outputs.path }}/common.json)" >> ${GITHUB_ENV}
+
+      - name: Checkout graalvm/mx
+        uses: actions/checkout@v4
+        with:
+          repository: graalvm/mx.git
+          ref: ${{ env.MX_VERSION }}
+          fetch-depth: 1
+          path: ${{ env.MX_PATH }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Update mx cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.mx
+          key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+          restore-keys: ${{ runner.os }}-mx-
+
+      - name: Build libgraal
+        id: build-libgraal
+        run: ${MX_PATH}/mx --primary-suite-path ${{ steps.graal.outputs.path }}/vm --java-home=${{ steps.bundles.outputs.jdk-path }} --env libgraal build
+
+      - name: Test libgraal
+        id: libgraal-gate
+        run: ${MX_PATH}/mx --primary-suite-path ${{ steps.graal.outputs.path }}/vm --java-home=${{ steps.bundles.outputs.jdk-path }} --env libgraal gate --task 'LibGraal Compiler'


### PR DESCRIPTION
This PR adds a GitHub Action that will fetch the Graal sources and use them to build and test libgraal on OpenJDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16756/head:pull/16756` \
`$ git checkout pull/16756`

Update a local copy of the PR: \
`$ git checkout pull/16756` \
`$ git pull https://git.openjdk.org/jdk.git pull/16756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16756`

View PR using the GUI difftool: \
`$ git pr show -t 16756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16756.diff">https://git.openjdk.org/jdk/pull/16756.diff</a>

</details>
