### PR TITLE
JDK-8320309: AIX: pthreads created by foreign test library don't work as expected

### DIFF
--- a/test/lib/native/testlib_threads.h
+++ b/test/lib/native/testlib_threads.h
@@ -89,6 +89,7 @@ void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
     if (result != 0) {
         fatal("failed to create thread", result);
     }
+    pthread_attr_destroy(&attr);
     result = pthread_join(thread, NULL);
     if (result != 0) {
         fatal("failed to join thread", result);

--- a/test/lib/native/testlib_threads.h
+++ b/test/lib/native/testlib_threads.h
@@ -81,7 +81,11 @@ void run_in_new_thread_and_join(PROCEDURE proc, void* context) {
     }
 #else
     pthread_t thread;
-    int result = pthread_create(&thread, NULL, procedure, &helper);
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    size_t stack_size = 0x100000;
+    pthread_attr_setstacksize(&attr, stack_size);
+    int result = pthread_create(&thread, &attr, procedure, &helper);
     if (result != 0) {
         fatal("failed to create thread", result);
     }


### PR DESCRIPTION
Following test fails due to missing pthread attributes on AIX :
java/foreign/TestUpcallAsync.java
java/foreign/stackwalk/TestAsyncStackWalk.java
java/foreign/loaderLookup/TestLoaderLookupJNI.java
java/foreign/enablenativeaccess/TestEnableNativeAccessJarManifest.java
java/foreign/enablenativeaccess/TestEnableNativeAccess.java

Note : Test needs the changes from [pull/16579](https://github.com/openjdk/jdk/pull/16579) and [pull/16414](https://github.com/openjdk/jdk/pull/16414 )

JBS Issue : [JDK-8320309](https://bugs.openjdk.org/browse/JDK-8320309)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320309](https://bugs.openjdk.org/browse/JDK-8320309): AIX: pthreads created by foreign test library don't work as expected (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16757/head:pull/16757` \
`$ git checkout pull/16757`

Update a local copy of the PR: \
`$ git checkout pull/16757` \
`$ git pull https://git.openjdk.org/jdk.git pull/16757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16757`

View PR using the GUI difftool: \
`$ git pr show -t 16757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16757.diff">https://git.openjdk.org/jdk/pull/16757.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16757#issuecomment-1822440227)