### PR TITLE
8313355: javax/management/remote/mandatory/notif/ListenerScaleTest.java failed with "Exception: Failed: ratio=792.2791601423487"

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/notif/ListenerScaleTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/ListenerScaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,6 +77,7 @@ public class ListenerScaleTest {
     private static final int WARMUP_WITH_ONE_MBEAN = 1000;
     private static final int NOTIFS_TO_TIME = 100;
     private static final int EXTRA_MBEANS = 20000;
+    private static final double RATIO_FAIL_VALUE = 2500.0;
 
     private static final ObjectName testObjectName;
     static {
@@ -187,8 +188,9 @@ public class ListenerScaleTest {
         long manyMBeansTime = timeNotif(mbs);
         System.out.println("Time with many MBeans: " + manyMBeansTime + "ns");
         double ratio = (double) manyMBeansTime / singleMBeanTime;
-        if (ratio > 500.0)
+        if (ratio > RATIO_FAIL_VALUE) {
             throw new Exception("Failed: ratio=" + ratio);
+        }
         System.out.println("Test passed: ratio=" + ratio);
     }
 }


### PR DESCRIPTION
This test fails occasionally, and can be tuned to avoid most of the failures ever seen.

It exists to check that notification work does not scale linearly with number of MBeans, so it calculates a ratio of the time taken with one, and with 20,000 MBeans.

We should increase point at which that calculated ratio is considered a failure.  I chose 2500 here as it solves most of the failures that I think have ever been reported with the test, without being too forgiving that we ignore a serious slowdown in future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313355](https://bugs.openjdk.org/browse/JDK-8313355): javax/management/remote/mandatory/notif/ListenerScaleTest.java failed with "Exception: Failed: ratio=792.2791601423487" (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16761/head:pull/16761` \
`$ git checkout pull/16761`

Update a local copy of the PR: \
`$ git checkout pull/16761` \
`$ git pull https://git.openjdk.org/jdk.git pull/16761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16761`

View PR using the GUI difftool: \
`$ git pr show -t 16761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16761.diff">https://git.openjdk.org/jdk/pull/16761.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16761#issuecomment-1820895992)