### PR TITLE
8320358: GHA: ignore jdk* branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ on:
     branches-ignore:
       - master
       - pr/*
+      - jdk*
   workflow_dispatch:
     inputs:
       platforms:


### PR DESCRIPTION
At some point we are likely to use stabilization branches in the mainline jdk repo rather than a separate repo. In preparation, this PR excludes branches matching `jdk*`, like we currently do for `master` and `pr/*`.

A potential drawback of doing this is that it will exclude developer branches named `jdk-8888888` or similar, using a lower-case `jdk`. Developers who want a GHA run will need to use `JDK` (uppercase) or some other prefix.

This is unlikely to be a problem in practice. I checked the most recent 100 open pull requests in the `jdk` repo at the time I created this fix, and while many of them use "JDK" (upper case) as a prefix, I found none that use "jdk" (lower case).


#### Testing

I pushed the following branch that was even with `jdk:master` at the time I pushed it (thus without this fix). GHA was run as expected:

* [jdk-8000000](https://github.com/kevinrushforth/jdk/tree/jdk-8000000) : [GHA run](https://github.com/kevinrushforth/jdk/actions/runs/6910232226) (NOTE: once this fix is integrated, such a branch would not get a GHA run)


I pushed the following branches that all include this fix. GHA runs were skipped on the branches that start with `jdk` and run on the others:

* [JDK-8320358](https://github.com/kevinrushforth/jdk/tree/JDK-8320358) : [GHA run](https://github.com/kevinrushforth/jdk/actions/runs/6910192534), (you can also see this from this PR's test results)
* [gha-exclude-jdk](https://github.com/kevinrushforth/jdk/tree/gha-exclude-jdk) : [GHA run](https://github.com/kevinrushforth/jdk/actions/runs/6910204060)
* [jdk12345](https://github.com/kevinrushforth/jdk/tree/jdk12345) : No GHA run
* [jdk-8320358-gha](https://github.com/kevinrushforth/jdk/tree/jdk-8320358-gha) : No GHA run

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320358](https://bugs.openjdk.org/browse/JDK-8320358): GHA: ignore jdk* branches (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16763/head:pull/16763` \
`$ git checkout pull/16763`

Update a local copy of the PR: \
`$ git checkout pull/16763` \
`$ git pull https://git.openjdk.org/jdk.git pull/16763/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16763`

View PR using the GUI difftool: \
`$ git pr show -t 16763`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16763.diff">https://git.openjdk.org/jdk/pull/16763.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16763#issuecomment-1821072706)