### PR TITLE
8319449: compiler/print/CompileCommandPrintMemStat.java fails on Graal

### DIFF
--- a/test/hotspot/jtreg/compiler/print/CompileCommandPrintMemStat.java
+++ b/test/hotspot/jtreg/compiler/print/CompileCommandPrintMemStat.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Checks that -XX:CompileCommand=PrintMemStat,... works
+ * @requires vm.compiler1.enabled | vm.compiler2.enabled
  * @library /test/lib
  * @run driver compiler.print.CompileCommandPrintMemStat
  */


### PR DESCRIPTION
The compiler memory statistics added in [8317683](https://bugs.openjdk.org/browse/JDK-8317683) only work for C1 and C2. 

This PR excludes the test for Graal.

Testing: verified test is excluded with Graal, tier 1 passes except failure related to https://github.com/openjdk/jdk/pull/16749.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319449](https://bugs.openjdk.org/browse/JDK-8319449): compiler/print/CompileCommandPrintMemStat.java fails on Graal (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16764/head:pull/16764` \
`$ git checkout pull/16764`

Update a local copy of the PR: \
`$ git checkout pull/16764` \
`$ git pull https://git.openjdk.org/jdk.git pull/16764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16764`

View PR using the GUI difftool: \
`$ git pr show -t 16764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16764.diff">https://git.openjdk.org/jdk/pull/16764.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16764#issuecomment-1821346808)