### PR TITLE
8320525: G1: G1UpdateRemSetTrackingBeforeRebuild::distribute_marked_bytes accesses partially unloaded klass

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1131,13 +1131,12 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
     // Distribute the given marked bytes across the humongous object starting
     // with hr and note end of marking for these regions.
     void distribute_marked_bytes(HeapRegion* hr, size_t marked_bytes) {
-      size_t const obj_size_in_words = cast_to_oop(hr->bottom())->size();
-
       // "Distributing" zero words means that we only note end of marking for these
-      // regions.
-      assert(marked_bytes == 0 || obj_size_in_words * HeapWordSize == marked_bytes,
+      // regions; also, we should not access their header any more them as their
+      // klass may have been unloaded.
+      assert(marked_bytes == 0 || cast_to_oop(hr->bottom())->size() * HeapWordSize == marked_bytes,
              "Marked bytes should either be 0 or the same as humongous object (%zu) but is %zu",
-             obj_size_in_words * HeapWordSize, marked_bytes);
+             cast_to_oop(hr->bottom())->size() * HeapWordSize, marked_bytes);
 
       auto distribute_bytes = [&] (HeapRegion* r) {
         size_t const bytes_to_add = MIN2(HeapRegion::GrainBytes, marked_bytes);
@@ -1149,9 +1148,7 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
       };
       _g1h->humongous_obj_regions_iterate(hr, distribute_bytes);
 
-      assert(marked_bytes == 0,
-             "%zu bytes left after distributing space across %zu regions",
-             marked_bytes, G1CollectedHeap::humongous_obj_size_in_regions(obj_size_in_words));
+      assert(marked_bytes == 0, "%zu bytes left after distributing space ", marked_bytes);
     }
 
     void update_marked_bytes(HeapRegion* hr) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1131,9 +1131,7 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
     // Distribute the given marked bytes across the humongous object starting
     // with hr and note end of marking for these regions.
     void distribute_marked_bytes(HeapRegion* hr, size_t marked_bytes) {
-      // "Distributing" zero words means that we only note end of marking for these
-      // regions; also, we should not access their header any more them as their
-      // klass may have been unloaded.
+      // Dead humongous objects (marked_bytes == 0) may have already been unloaded.
       assert(marked_bytes == 0 || cast_to_oop(hr->bottom())->size() * HeapWordSize == marked_bytes,
              "Marked bytes should either be 0 or the same as humongous object (%zu) but is %zu",
              cast_to_oop(hr->bottom())->size() * HeapWordSize, marked_bytes);
@@ -1147,8 +1145,6 @@ class G1UpdateRemSetTrackingBeforeRebuildTask : public WorkerTask {
         marked_bytes -= bytes_to_add;
       };
       _g1h->humongous_obj_regions_iterate(hr, distribute_bytes);
-
-      assert(marked_bytes == 0, "%zu bytes left after distributing space ", marked_bytes);
     }
 
     void update_marked_bytes(HeapRegion* hr) {


### PR DESCRIPTION
Hi all,

  please review this fix that removes the access to a partially unloaded (i.e. unlinked only) `Klass` used for debug code in `G1UpdateRemSetTrackingBeforeRebuild::distribute_marked_bytes`.

This starts to fail if metadata purging happens before the call to this methods (as https://bugs.openjdk.org/browse/JDK-8317809 suggests). The test gc/g1/humongousObjects/TestHumongousClassLoader.java starts to crash on linux-x86 with 100% reproduction because it more aggressively uncommits memory when purging metaspace.

The fix fixes the asserts to only access the klass when it should not be unloaded yet.

Testing: failing test case not failing any more, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320525](https://bugs.openjdk.org/browse/JDK-8320525): G1: G1UpdateRemSetTrackingBeforeRebuild::distribute_marked_bytes accesses partially unloaded klass (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16766/head:pull/16766` \
`$ git checkout pull/16766`

Update a local copy of the PR: \
`$ git checkout pull/16766` \
`$ git pull https://git.openjdk.org/jdk.git pull/16766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16766`

View PR using the GUI difftool: \
`$ git pr show -t 16766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16766.diff">https://git.openjdk.org/jdk/pull/16766.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16766#issuecomment-1821221390)