### PR TITLE
8319440: RISC-V: remove register keyword from read_csr

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -74,7 +74,7 @@
 
 #define read_csr(csr)                                           \
 ({                                                              \
-        register unsigned long __v;                             \
+        unsigned long __v;                                      \
         __asm__ __volatile__ ("csrr %0, %1"                     \
                               : "=r" (__v)                      \
                               : "i" (csr)                       \


### PR DESCRIPTION
Hello everyone! I removed the `register` keyword from `read_csr` function, which is used to check CPU vector length. Inside QEMU with RVV I see that the behavior is the same as with `register`. Furthermore, inside GDB I see that register used for `csrr vlenb` is `a0` with and without `register` keyword. With this fix `make hotspot` with latest clang used succeeded without any warnings.