### PR TITLE
8316649: JMX connection timeout cannot be changed and uses the default of 0 (infinite)

### DIFF
--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPDirectSocketFactory.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPDirectSocketFactory.java
@@ -47,7 +47,8 @@ public class TCPDirectSocketFactory extends RMISocketFactory {
 
     public Socket createSocket(String host, int port) throws IOException
     {
-        if (connectTimeout == 0) {
+        // Guard against passing a negative value, Socket would always throw IllegalArgumentException.
+        if (connectTimeout <= 0) {
             return new Socket(host, port);
         } else {
             SocketAddress address = host != null ? new InetSocketAddress(host, port) :

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPDirectSocketFactory.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPDirectSocketFactory.java
@@ -40,21 +40,20 @@ import java.security.PrivilegedAction;
  */
 public class TCPDirectSocketFactory extends RMISocketFactory {
 
-    public static final int DEFAULT_CONNECT_TIMEOUT = 60 * 1000; // default 1 minute
+    @SuppressWarnings("removal")
+    private static final int connectTimeout =    // default 1 minute
+        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+            Integer.getInteger("sun.rmi.transport.tcp.initialConnectTimeout", 60 * 1000).intValue());
 
     public Socket createSocket(String host, int port) throws IOException
     {
-        @SuppressWarnings("removal")
-        int timeout =
-            AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
-                Integer.getInteger("sun.rmi.transport.tcp.initialConnectTimeout", DEFAULT_CONNECT_TIMEOUT).intValue());
-        if (timeout == 0) {
+        if (connectTimeout == 0) {
             return new Socket(host, port);
         } else {
             SocketAddress address = host != null ? new InetSocketAddress(host, port) :
                                                    new InetSocketAddress(InetAddress.getByName(null), port);
             Socket s = new Socket();
-            s.connect(address, timeout);
+            s.connect(address, connectTimeout);
             return s;
         }
     }


### PR DESCRIPTION
RMI Connections (in general) should use a timeout on the Socket connect call by default.

JMX connections use RMI and some connection failures never terminate.  The hang described in 8316649 is hard to reproduce manually: the description says it can be caused by a firewall that never returns a response.

src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPChannel.java
has other timeouts but nothing to control the initial Socket connect.

Defaulting to a 1 minute timeout on connect has no effect on existing tests for RMI and JMX, and should go unnoticed in applications unless there really is a significant connection delay.  Specifying zero for the new System Property sun.rmi.transport.tcp.initialConnectTimeout uses the old code path of a connect with no timeout.

I have a test, but it is not realistically usable: although specifying a 1 millisecond timeout will often fail (as expected/desired for the test), it will often pass as the connection happens immediately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Change requires CSR request [JDK-8320580](https://bugs.openjdk.org/browse/JDK-8320580) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8316649](https://bugs.openjdk.org/browse/JDK-8316649): JMX connection timeout cannot be changed and uses the default of 0 (infinite) (**Enhancement** - P4)
 * [JDK-8320580](https://bugs.openjdk.org/browse/JDK-8320580): JMX RMI Connections should have a connect timeout property (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16771/head:pull/16771` \
`$ git checkout pull/16771`

Update a local copy of the PR: \
`$ git checkout pull/16771` \
`$ git pull https://git.openjdk.org/jdk.git pull/16771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16771`

View PR using the GUI difftool: \
`$ git pr show -t 16771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16771.diff">https://git.openjdk.org/jdk/pull/16771.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16771#issuecomment-1824072869)