### PR TITLE
8320443: [macos] Test java/awt/print/PrinterJob/PrinterDevice.java fails on macOS

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -823,6 +823,10 @@ public final class CPrinterJob extends RasterPrinterJob {
             public void run() {
                 synchronized (ret) {
                     try {
+                        Paper paper = pageFormat.getPaper();
+                        double width = Math.rint(paper.getWidth());
+                        double height = Math.rint(paper.getHeight());
+                        setGraphicsConfigInfo(((Graphics2D)graphics).getTransform(), width, height);
                         int pageResult = printable.print(
                             graphics, pageFormat, pageIndex);
                         if (pageResult != Printable.NO_SUCH_PAGE) {

--- a/src/java.desktop/share/classes/sun/print/PSPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/PSPrinterJob.java
@@ -264,7 +264,7 @@ public class PSPrinterJob extends RasterPrinterJob {
    private AffineTransform mLastTransform;
 
    private double xres = PS_XRES;
-   private double yres = PS_XRES;
+   private double yres = PS_YRES;
 
    /* non-null if printing EPS for Java Plugin */
    private EPSPrinter epsPrinter = null;

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -2093,7 +2093,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
     private PrinterGraphicsConfig pgConfig;
 
     protected synchronized void setGraphicsConfigInfo(AffineTransform at,
-                                            double pw, double ph) {
+                                                      double pw, double ph) {
         Point2D.Double pt = new Point2D.Double(pw, ph);
         at.transform(pt, pt);
 

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -2092,7 +2092,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
     private AffineTransform defaultDeviceTransform;
     private PrinterGraphicsConfig pgConfig;
 
-    synchronized protected void setGraphicsConfigInfo(AffineTransform at,
+    protected synchronized void setGraphicsConfigInfo(AffineTransform at,
                                             double pw, double ph) {
         Point2D.Double pt = new Point2D.Double(pw, ph);
         at.transform(pt, pt);

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -2092,7 +2092,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
     private AffineTransform defaultDeviceTransform;
     private PrinterGraphicsConfig pgConfig;
 
-    synchronized void setGraphicsConfigInfo(AffineTransform at,
+    synchronized protected void setGraphicsConfigInfo(AffineTransform at,
                                             double pw, double ph) {
         Point2D.Double pt = new Point2D.Double(pw, ph);
         at.transform(pt, pt);

--- a/test/jdk/java/awt/print/PrinterJob/PrinterDevice.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrinterDevice.java
@@ -106,7 +106,7 @@ public class PrinterDevice implements Printable {
         /* Make sure that device really is TYPE_PRINTER */
         GraphicsDevice gd = gConfig.getDevice();
         System.out.println("Printer Device ID = " + gd.getIDstring());
-        if (!(gd.getType() == GraphicsDevice.TYPE_PRINTER)) {
+        if (gd.getType() != GraphicsDevice.TYPE_PRINTER) {
             failed = true;
             throw new RuntimeException("Expected printer device");
         }

--- a/test/jdk/java/awt/print/PrinterJob/PrinterDevice.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrinterDevice.java
@@ -23,21 +23,32 @@
 
 /*
  *
- * @bug 4276227
+ * @bug 4276227 8320443
  * @summary Checks that the PrinterGraphics is for a Printer GraphicsDevice.
  * Test doesn't run unless there's a printer on the system.
- * @author prr
+ * @key printer
  * @run main/othervm PrinterDevice
  */
 
-import java.awt.*;
-import java.awt.geom.*;
-import java.awt.print.*;
-import java.io.*;
-import javax.print.attribute.*;
-import javax.print.attribute.standard.*;
+import java.io.File;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.Destination;
+import javax.print.attribute.standard.OrientationRequested;
 
 public class PrinterDevice implements Printable {
+
+    static volatile boolean failed = false;
 
     public static void main(String args[]) throws PrinterException {
         System.setProperty("java.awt.headless", "true");
@@ -54,39 +65,52 @@ public class PrinterDevice implements Printable {
         aset.add(OrientationRequested.LANDSCAPE);
         pj.setPrintable(new PrinterDevice());
         pj.print(aset);
+        if (failed) {
+            throw new RuntimeException("Test failed but no exception propagated.");
+        }
     }
 
     public int print(Graphics g, PageFormat pf, int pageIndex) {
-         if (pageIndex > 0 ) {
-             return Printable.NO_SUCH_PAGE;
-         }
+        if (pageIndex > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-         /* Make sure calls to get DeviceConfig, its transforms,
-          * etc all work without exceptions and as expected */
-         Graphics2D g2 = (Graphics2D)g;
-         GraphicsConfiguration gConfig = g2.getDeviceConfiguration();
-         AffineTransform dt = gConfig.getDefaultTransform();
-         AffineTransform nt = gConfig.getNormalizingTransform();
-         AffineTransform gt = g2.getTransform();
+        Graphics2D g2 = (Graphics2D)g;
+        GraphicsConfiguration gConfig = g2.getDeviceConfiguration();
+        AffineTransform nt = null;
+        try {
+            /* Make sure calls to get DeviceConfig, its transforms,
+             * etc all work without exceptions and as expected */
+            System.out.println("GraphicsConfig="+gConfig);
+            AffineTransform dt = gConfig.getDefaultTransform();
+            System.out.println("Default transform = " + dt);
+            nt = gConfig.getNormalizingTransform();
+            System.out.println("Normalizing transform = " + nt);
+            AffineTransform gt = g2.getTransform();
+            System.out.println("Graphics2D transform = " + gt);
+        } catch (Exception e) {
+            failed = true;
+            System.err.println("Unexpected exception getting transform.");
+            e.printStackTrace();
+            throw e;
+        }
 
-         System.out.println("Graphics2D transform = " + gt);
-         System.out.println("Default transform = " + dt);
-         System.out.println("Normalizing transform = " + nt);
+        Rectangle bounds = gConfig.getBounds();
+        System.out.println("Bounds = " + bounds);
+        if (!nt.isIdentity()) {
+            failed = true;
+            throw new RuntimeException("Expected Identity transform");
+        }
 
-         Rectangle bounds = gConfig.getBounds();
-         System.out.println("Bounds = " + bounds);
-         if (!nt.isIdentity()) {
-             throw new RuntimeException("Expected Identity transdform");
-         }
-
-         /* Make sure that device really is TYPE_PRINTER */
-         GraphicsDevice gd = gConfig.getDevice();
-         System.out.println("Printer Device ID = " + gd.getIDstring());
-         if (!(gd.getType() == GraphicsDevice.TYPE_PRINTER)) {
-             throw new RuntimeException("Expected printer device");
-         }
-         System.out.println(" *** ");
-         System.out.println("");
-         return Printable.PAGE_EXISTS;
+        /* Make sure that device really is TYPE_PRINTER */
+        GraphicsDevice gd = gConfig.getDevice();
+        System.out.println("Printer Device ID = " + gd.getIDstring());
+        if (!(gd.getType() == GraphicsDevice.TYPE_PRINTER)) {
+            failed = true;
+            throw new RuntimeException("Expected printer device");
+        }
+        System.out.println(" *** ");
+        System.out.println("");
+        return Printable.PAGE_EXISTS;
     }
 }

--- a/test/jdk/java/awt/print/PrinterJob/PrinterDevice.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrinterDevice.java
@@ -23,6 +23,7 @@
 
 /*
  *
+ * @test
  * @bug 4276227 8320443
  * @summary Checks that the PrinterGraphics is for a Printer GraphicsDevice.
  * Test doesn't run unless there's a printer on the system.

--- a/test/jdk/java/awt/print/PrinterJob/PrinterDevice.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrinterDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
  *
  * @test
  * @bug 4276227 8320443
+ * @key printer
  * @summary Checks that the PrinterGraphics is for a Printer GraphicsDevice.
  * Test doesn't run unless there's a printer on the system.
- * @key printer
  * @run main/othervm PrinterDevice
  */
 


### PR DESCRIPTION
For as long as we've had the macOS port, it seems that queries on the GraphicsConfiguration associated with
a printer would give you null for the defaultTransform.
Clearly this API isn't a popular one to call in such a context else we'd have had lots of reports.
We have a test that would have caught it except that until recently the macOS printing implementation
was swallowing exceptions it should not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320443](https://bugs.openjdk.org/browse/JDK-8320443): [macos] Test java/awt/print/PrinterJob/PrinterDevice.java fails on macOS (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to [5a463312](https://git.openjdk.org/jdk/pull/16773/files/5a463312b281db740c953c0a28eda04c990b2612)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16773/head:pull/16773` \
`$ git checkout pull/16773`

Update a local copy of the PR: \
`$ git checkout pull/16773` \
`$ git pull https://git.openjdk.org/jdk.git pull/16773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16773`

View PR using the GUI difftool: \
`$ git pr show -t 16773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16773.diff">https://git.openjdk.org/jdk/pull/16773.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16773#issuecomment-1821719062)