### PR TITLE
8320001: javac crashes while adding type annotations to constructor's return type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -2332,7 +2332,12 @@ public class ClassReader {
                 thrown.add(addTypeAnnotations(thrownType, thrownType(i++)));
             }
             mt.thrown = thrown.toList();
-            mt.restype = addTypeAnnotations(mt.restype, TargetType.METHOD_RETURN);
+            /* possible information loss if the type of the method is void then we can't add type
+             * annotations to it
+             */
+            if (!mt.restype.hasTag(TypeTag.VOID)) {
+                mt.restype = addTypeAnnotations(mt.restype, TargetType.METHOD_RETURN);
+            }
 
             Type recvtype = mt.recvtype != null ? mt.recvtype : s.implicitReceiverType();
             if (recvtype != null) {

--- a/test/langtools/tools/javac/annotations/typeAnnotations/TypeAnnosOnConstructorsTest.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/TypeAnnosOnConstructorsTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8320001
+ * @summary compiler crash while adding type annotations to constructor's return type
+ * @library /tools/lib /tools/javac/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main TypeAnnosOnConstructorsTest
+ */
+
+import java.io.IOException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.Task.Mode;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class TypeAnnosOnConstructorsTest extends TestRunner {
+    protected ToolBox tb;
+
+    TypeAnnosOnConstructorsTest() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public static void main(String... args) throws Exception {
+        new TypeAnnosOnConstructorsTest().runTests();
+    }
+
+    protected void runTests() throws Exception {
+        runTests(m -> new Object[]{Paths.get(m.getName())});
+    }
+
+    Path[] findJavaFiles(Path... paths) throws IOException {
+        return tb.findJavaFiles(paths);
+    }
+
+    @Test
+    public void testAnnoOnConstructors(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path y = src.resolve("Y.java");
+        Path yWrapper = src.resolve("YWrapper.java");
+
+        Path classes = base.resolve("classes");
+
+        Files.createDirectories(classes);
+
+        tb.writeJavaFiles(src,
+                """
+                import java.lang.annotation.Target;
+                import java.lang.annotation.ElementType;
+                import java.lang.annotation.Retention;
+                import java.lang.annotation.RetentionPolicy;
+
+                class Y {
+                    @TA public Y() {}
+                }
+
+                @Target(ElementType.TYPE_USE)
+                @Retention(RetentionPolicy.RUNTIME)
+                @interface TA {}
+                """,
+                """
+                class YWrapper {
+                    // just to make the compiler load the class file for class Y above
+                    Y y;
+                }
+                """);
+
+        // we need to compile Y first
+        new JavacTask(tb)
+                .files(y)
+                .outdir(classes)
+                .run();
+
+        Path classDir = getClassDir();
+        new JavacTask(tb)
+                .classpath(classes, classDir)
+                .options("-processor", SimpleProcessor.class.getName())
+                .files(yWrapper)
+                .outdir(classes)
+                .run(Task.Expect.SUCCESS);
+    }
+
+    public Path getClassDir() {
+        String classes = ToolBox.testClasses;
+        if (classes == null) {
+            return Paths.get("build");
+        } else {
+            return Paths.get(classes);
+        }
+    }
+
+    @SupportedAnnotationTypes("*")
+    public static final class SimpleProcessor extends AbstractProcessor {
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
+
+        @Override
+        public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Fix for [1] introduced a regression that is making some internal tests fail. Basically fix for [1] is trying to add annotations read from the class file to the corresponding symbol. Constructors are a bit special given that its return type is `void` thus type annotations can't be added to them. This fix is proposing just dropping the type annotation if it applies to the return type of a constructor.

TIA
[1] https://bugs.openjdk.org/browse/JDK-8225377