### PR TITLE
8320057: [macos14] javax/swing/JToolTip/4846413/bug4846413.java: Tooltip has not been found!

### DIFF
--- a/test/jdk/javax/swing/JToolTip/4846413/bug4846413.java
+++ b/test/jdk/javax/swing/JToolTip/4846413/bug4846413.java
@@ -69,11 +69,11 @@ public class bug4846413 {
             SwingUtilities.invokeAndWait(() -> createAndShowGUI());
 
             robot.waitForIdle();
-	    robot.delay(1000);
+            robot.delay(1000);
 
             Point movePoint = getButtonPoint();
             robot.mouseMove(movePoint.x, movePoint.y);
-	    if (System.getProperty("os.name").contains("OS X")) {
+            if (System.getProperty("os.name").contains("OS X")) {
                 String version = System.getProperty("os.version", "");
                 if (version.startsWith("14.")) {
                     robot.mouseMove(movePoint.x, movePoint.y);
@@ -87,7 +87,7 @@ public class bug4846413 {
             }
 
             SwingUtilities.invokeAndWait(() -> checkToolTip());
-	} finally {
+        } finally {
             SwingUtilities.invokeAndWait(() -> {
                 if (frame != null) {
                     frame.dispose();
@@ -106,7 +106,7 @@ public class bug4846413 {
                             new Rectangle(0, 0, (int)screenSize.getWidth(),
                                                 (int)screenSize.getHeight()));
                 ImageIO.write(img, "png", new File("screen.png"));
-	    } catch (Exception e) {}
+            } catch (Exception e) {}
             throw new RuntimeException("Tooltip has not been found!");
         }
 

--- a/test/jdk/javax/swing/JToolTip/4846413/bug4846413.java
+++ b/test/jdk/javax/swing/JToolTip/4846413/bug4846413.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,71 +28,94 @@
  * @summary Checks if No tooltip modification when no KeyStroke modifier
  * @library ../../regtesthelpers
  * @build Util
- * @author Konstantin Eremin
  * @run main bug4846413
  */
+
+import java.io.File;
 import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.Toolkit;
-import javax.swing.*;
-import java.awt.event.*;
+import java.awt.event.ContainerAdapter;
+import java.awt.event.ContainerEvent;
+import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLayeredPane;
+import javax.swing.JToolTip;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.imageio.ImageIO;
 import javax.swing.plaf.metal.MetalToolTipUI;
 
 public class bug4846413 {
 
     private static volatile boolean isTooltipAdded;
     private static JButton button;
+    private static JFrame frame;
+    private static Robot robot;
 
     public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoDelay(100);
 
-        Robot robot = new Robot();
-        robot.setAutoDelay(50);
+            UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
 
-        UIManager.setLookAndFeel("javax.swing.plaf.metal.MetalLookAndFeel");
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
 
-        javax.swing.SwingUtilities.invokeAndWait(new Runnable() {
+            robot.waitForIdle();
+	    robot.delay(1000);
 
-            public void run() {
-                createAndShowGUI();
+            Point movePoint = getButtonPoint();
+            robot.mouseMove(movePoint.x, movePoint.y);
+	    if (System.getProperty("os.name").contains("OS X")) {
+                String version = System.getProperty("os.version", "");
+                if (version.startsWith("14.")) {
+                    robot.mouseMove(movePoint.x, movePoint.y);
+                }
             }
-        });
+            robot.waitForIdle();
 
-        robot.waitForIdle();
+            long timeout = System.currentTimeMillis() + 9000;
+            while (!isTooltipAdded && (System.currentTimeMillis() < timeout)) {
+                try {Thread.sleep(500);} catch (Exception e) {}
+            }
 
-        Point movePoint = getButtonPoint();
-        robot.mouseMove(movePoint.x, movePoint.y);
-        robot.waitForIdle();
-
-        long timeout = System.currentTimeMillis() + 9000;
-        while (!isTooltipAdded && (System.currentTimeMillis() < timeout)) {
-            try {Thread.sleep(500);} catch (Exception e) {}
+            SwingUtilities.invokeAndWait(() -> checkToolTip());
+	} finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
-
-        checkToolTip();
     }
 
-    private static void checkToolTip() throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
+    private static void checkToolTip() {
+        JToolTip tooltip = (JToolTip) Util.findSubComponent(JFrame.getFrames()[0], "JToolTip");
 
-            @Override
-            public void run() {
-                JToolTip tooltip = (JToolTip) Util.findSubComponent(
-                        JFrame.getFrames()[0], "JToolTip");
+        if (tooltip == null) {
+            try {
+                Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+                BufferedImage img = robot.createScreenCapture(
+                            new Rectangle(0, 0, (int)screenSize.getWidth(),
+                                                (int)screenSize.getHeight()));
+                ImageIO.write(img, "png", new File("screen.png"));
+	    } catch (Exception e) {}
+            throw new RuntimeException("Tooltip has not been found!");
+        }
 
-                if (tooltip == null) {
-                    throw new RuntimeException("Tooltip has not been found!");
-                }
+        MetalToolTipUI tooltipUI = (MetalToolTipUI) MetalToolTipUI.createUI(tooltip);
+        tooltipUI.installUI(tooltip);
 
-                MetalToolTipUI tooltipUI = (MetalToolTipUI) MetalToolTipUI.createUI(tooltip);
-                tooltipUI.installUI(tooltip);
-
-                if (!"-Insert".equals(tooltipUI.getAcceleratorString())) {
-                    throw new RuntimeException("Tooltip acceleration is not properly set!");
-                }
-
-            }
-        });
+        if (!"-Insert".equals(tooltipUI.getAcceleratorString())) {
+            throw new RuntimeException("Tooltip acceleration is not properly set!");
+        }
     }
 
     private static Point getButtonPoint() throws Exception {
@@ -111,7 +134,7 @@ public class bug4846413 {
     }
 
     private static void createAndShowGUI() {
-        JFrame frame = new JFrame("Test");
+        frame = new JFrame("Test");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setSize(200, 200);
         frame.setLocationRelativeTo(null);


### PR DESCRIPTION
Test failing on macos14 citing "ToolTip not found"...Investigation shows that the mouse is not moved when invoked 1st time to desired location on screen causing tooltip to not show...However, subsequent runs of the same test without any change causes it to pass every time.
Workaround is proposed to check if running on 14.x, then invoke a dummy mouse movement to same location which causes the test to pass for several iterations in macos14 environment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320057](https://bugs.openjdk.org/browse/JDK-8320057): [macos14] javax/swing/JToolTip/4846413/bug4846413.java: Tooltip has not been found! (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16776/head:pull/16776` \
`$ git checkout pull/16776`

Update a local copy of the PR: \
`$ git checkout pull/16776` \
`$ git pull https://git.openjdk.org/jdk.git pull/16776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16776`

View PR using the GUI difftool: \
`$ git pr show -t 16776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16776.diff">https://git.openjdk.org/jdk/pull/16776.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16776#issuecomment-1822359892)