### PR TITLE
8316658: serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java	fails intermittently

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -48,7 +48,7 @@
  * @modules java.instrument
  *          java.compiler
  * @run main RedefineClassHelper
- * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=20m -XX:MaxMetaspaceSize=20m RedefineLeakThrowable
+ * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=28m -XX:MaxMetaspaceSize=28m RedefineLeakThrowable
  */
 
 class Tester {
@@ -76,7 +76,7 @@ public class RedefineLeakThrowable {
 
 
     public static void main(String argv[]) throws Exception {
-        for (int i = 0; i < 800; i++) {
+        for (int i = 0; i < 1000; i++) {
             RedefineClassHelper.redefineClass(Tester.class, NEW_TESTER);
         }
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -26,22 +26,6 @@
  * @bug 8308762
  * @library /test/lib
  * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
- * @requires os.family == "aix"
- * @requires vm.jvmti
- * @requires vm.flagless
- * @modules java.base/jdk.internal.misc
- * @modules java.instrument
- *          java.compiler
- * @run main RedefineClassHelper
- * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=23m -XX:MaxMetaspaceSize=23m RedefineLeakThrowable
- */
-
-/*
- * @test
- * @bug 8308762
- * @library /test/lib
- * @summary Test that redefinition of class containing Throwable refs does not leak constant pool
- * @requires os.family != "aix"
  * @requires vm.jvmti
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java
@@ -48,7 +48,7 @@
  * @modules java.instrument
  *          java.compiler
  * @run main RedefineClassHelper
- * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=17m -XX:MaxMetaspaceSize=17m RedefineLeakThrowable
+ * @run main/othervm/timeout=6000 -javaagent:redefineagent.jar -XX:MetaspaceSize=20m -XX:MaxMetaspaceSize=20m RedefineLeakThrowable
  */
 
 class Tester {
@@ -76,7 +76,7 @@ public class RedefineLeakThrowable {
 
 
     public static void main(String argv[]) throws Exception {
-        for (int i = 0; i < 700; i++) {
+        for (int i = 0; i < 800; i++) {
             RedefineClassHelper.redefineClass(Tester.class, NEW_TESTER);
         }
     }


### PR DESCRIPTION
…ava fails intermittently

Adjust metaspace to 20MB and iterations to 800
Metaspace usage after those adjustments on linux x64:
 - without leak: 13MB
 - with leak: 26MB

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ The commit message contains a tab on line 1

### Issue
 * [JDK-8316658](https://bugs.openjdk.org/browse/JDK-8316658): serviceability/jvmti/RedefineClasses/RedefineLeakThrowable.java	fails intermittently (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16777/head:pull/16777` \
`$ git checkout pull/16777`

Update a local copy of the PR: \
`$ git checkout pull/16777` \
`$ git pull https://git.openjdk.org/jdk.git pull/16777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16777`

View PR using the GUI difftool: \
`$ git pr show -t 16777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16777.diff">https://git.openjdk.org/jdk/pull/16777.diff</a>

</details>
