### PR TITLE
8320403: C2: PrintIdeal is no longer dumped to tty when xtty is set

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -589,10 +589,12 @@ void Compile::print_ideal_ir(const char* phase_name) {
                compile_id(),
                is_osr_compilation() ? " compile_kind='osr'" : "",
                phase_name);
-    xtty->print("%s", ss.as_string()); // print to tty would use xml escape encoding
+  }
+
+  tty->print("%s", ss.as_string());
+
+  if (xtty != nullptr) {
     xtty->tail("ideal");
-  } else {
-    tty->print("%s", ss.as_string());
   }
 }
 #endif


### PR DESCRIPTION
During debugging, it was noticed that the output of `PrintIdeal` is not printed to tty anymore when `LogCompilation` is enabled (i.e. xtty is set). This was accidentally changed by [JDK-8306922](https://bugs.openjdk.org/browse/JDK-8306922). This fix reverts this part of the change to dump to tty instead of xtty which also gets dumped to the log file.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320403](https://bugs.openjdk.org/browse/JDK-8320403): C2: PrintIdeal is no longer dumped to tty when xtty is set (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16778/head:pull/16778` \
`$ git checkout pull/16778`

Update a local copy of the PR: \
`$ git checkout pull/16778` \
`$ git pull https://git.openjdk.org/jdk.git pull/16778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16778`

View PR using the GUI difftool: \
`$ git pr show -t 16778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16778.diff">https://git.openjdk.org/jdk/pull/16778.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16778#issuecomment-1822435848)