### PR TITLE
8320582: Zero: Misplaced CX8 enablement flag

### DIFF
--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -137,6 +137,12 @@ void VM_Version::initialize() {
 #ifdef ASSERT
   UNSUPPORTED_OPTION(CountCompiledCalls);
 #endif
+
+  // Supports 8-byte cmpxchg with compiler built-ins.
+  // These built-ins are supposed to be implemented on
+  // all platforms (even if not natively), so we claim
+  // the support unconditionally.
+  _supports_cx8 = true;
 }
 
 void VM_Version::initialize_cpu_information(void) {
@@ -144,12 +150,6 @@ void VM_Version::initialize_cpu_information(void) {
   if (_initialized) {
     return;
   }
-
-  // Supports 8-byte cmpxchg with compiler built-ins.
-  // These built-ins are supposed to be implemented on
-  // all platforms (even if not natively), so we claim
-  // the support unconditionally.
-  _supports_cx8 = true;
 
   _no_of_cores  = os::processor_count();
   _no_of_threads = _no_of_cores;


### PR DESCRIPTION
When doing [JDK-8319777](https://bugs.openjdk.org/browse/JDK-8319777), I misplaced the `_supports_cx8 = true` flag setting in the method that is only called when CPU features are polled from perf counter code. We need to move the check to a proper place. [JDK-8318776](https://github.com/openjdk/jdk/pull/16625/files) would catch fire without this.

Additional testing (redoing JDK-8319777 testing):
 - [x] Linux arm Zero fastdebug now builds fine with JDK-8318776 fix
 - [x] Linux x86_32 Zero release; jcstress
 - [x] Linux x86_32 Zero fastdebug, `compiler/unsafe java/lang/invoke/VarHandles`
 - [x] Linux x86_32 Zero fastdebug, bootcycle-images

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320582](https://bugs.openjdk.org/browse/JDK-8320582): Zero: Misplaced CX8 enablement flag (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16779/head:pull/16779` \
`$ git checkout pull/16779`

Update a local copy of the PR: \
`$ git checkout pull/16779` \
`$ git pull https://git.openjdk.org/jdk.git pull/16779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16779`

View PR using the GUI difftool: \
`$ git pr show -t 16779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16779.diff">https://git.openjdk.org/jdk/pull/16779.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16779#issuecomment-1822521946)