### PR TITLE
8319700: [AArch64] C2 compilation fails with "Field too big for insn"

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -1290,6 +1290,9 @@ static bool aarch64_test_and_branch_reachable(int branch_offset, int target_offs
   return test_and_branch_to_trampoline_delta < test_and_branch_delta_limit;
 }
 
+ZLoadBarrierStubC2Aarch64::ZLoadBarrierStubC2Aarch64(const MachNode* node, Address ref_addr, Register ref)
+  : ZLoadBarrierStubC2(node, ref_addr, ref), _test_and_branch_reachable_entry(), _offset(), _deferred_emit(false), _test_and_branch_reachable(false) {}
+
 ZLoadBarrierStubC2Aarch64::ZLoadBarrierStubC2Aarch64(const MachNode* node, Address ref_addr, Register ref, int offset)
   : ZLoadBarrierStubC2(node, ref_addr, ref), _test_and_branch_reachable_entry(), _offset(offset), _deferred_emit(false), _test_and_branch_reachable(false) {
   PhaseOutput* const output = Compile::current()->output();
@@ -1317,6 +1320,12 @@ int ZLoadBarrierStubC2Aarch64::get_stub_size() {
   ZLoadBarrierStubC2::emit_code(masm);
   output->set_in_scratch_emit_size(false);
   return cb.insts_size();
+}
+
+ZLoadBarrierStubC2Aarch64* ZLoadBarrierStubC2Aarch64::create(const MachNode* node, Address ref_addr, Register ref) {
+  ZLoadBarrierStubC2Aarch64* const stub = new (Compile::current()->comp_arena()) ZLoadBarrierStubC2Aarch64(node, ref_addr, ref);
+  register_stub(stub);
+  return stub;
 }
 
 ZLoadBarrierStubC2Aarch64* ZLoadBarrierStubC2Aarch64::create(const MachNode* node, Address ref_addr, Register ref, int offset) {

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
@@ -265,10 +265,12 @@ private:
   bool _deferred_emit;
   bool _test_and_branch_reachable;
 
+  ZLoadBarrierStubC2Aarch64(const MachNode* node, Address ref_addr, Register ref);
   ZLoadBarrierStubC2Aarch64(const MachNode* node, Address ref_addr, Register ref, int offset);
 
   int get_stub_size();
 public:
+  static ZLoadBarrierStubC2Aarch64* create(const MachNode* node, Address ref_addr, Register ref);
   static ZLoadBarrierStubC2Aarch64* create(const MachNode* node, Address ref_addr, Register ref, int offset);
 
   virtual void emit_code(MacroAssembler& masm);

--- a/src/hotspot/cpu/aarch64/gc/z/z_aarch64.ad
+++ b/src/hotspot/cpu/aarch64/gc/z/z_aarch64.ad
@@ -48,7 +48,7 @@ static void z_keep_alive_load_barrier(MacroAssembler& _masm, const MachNode* nod
   __ relocate(barrier_Relocation::spec(), ZBarrierRelocationFormatMarkBadBeforeMov);
   __ movzw(tmp, barrier_Relocation::unpatched);
   __ tst(ref, tmp);
-  ZLoadBarrierStubC2* const stub = ZLoadBarrierStubC2::create(node, ref_addr, ref);
+  ZLoadBarrierStubC2Aarch64* const stub = ZLoadBarrierStubC2Aarch64::create(node, ref_addr, ref);
   __ br(Assembler::NE, *stub->entry());
   z_uncolor(_masm, node, ref);
   __ bind(*stub->continuation());

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -42,6 +42,7 @@
 #include "opto/rootnode.hpp"
 #include "opto/runtime.hpp"
 #include "opto/type.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 
@@ -226,6 +227,7 @@ Label* ZBarrierStubC2::continuation() {
 }
 
 ZLoadBarrierStubC2* ZLoadBarrierStubC2::create(const MachNode* node, Address ref_addr, Register ref) {
+  AARCH64_ONLY(fatal("Should use ZLoadBarrierStubC2Aarch64::create"));
   ZLoadBarrierStubC2* const stub = new (Compile::current()->comp_arena()) ZLoadBarrierStubC2(node, ref_addr, ref);
   register_stub(stub);
 
@@ -275,6 +277,7 @@ void ZLoadBarrierStubC2::emit_code(MacroAssembler& masm) {
 }
 
 ZStoreBarrierStubC2* ZStoreBarrierStubC2::create(const MachNode* node, Address ref_addr, Register new_zaddress, Register new_zpointer, bool is_native, bool is_atomic) {
+  AARCH64_ONLY(fatal("Should use ZStoreBarrierStubC2Aarch64::create"));
   ZStoreBarrierStubC2* const stub = new (Compile::current()->comp_arena()) ZStoreBarrierStubC2(node, ref_addr, new_zaddress, new_zpointer, is_native, is_atomic);
   register_stub(stub);
 

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -52,9 +52,9 @@ static void inc_trampoline_stubs_count();
 static int trampoline_stubs_count();
 static int stubs_start_offset();
 
-public:
   ZBarrierStubC2(const MachNode* node);
 
+public:
   RegMask& live() const;
   Label* entry();
   Label* continuation();


### PR DESCRIPTION
Not all ZGC C2 BarrierStubs used on aarch64 participates in the laying out of trampoline stubs. (Used enable as many `tbX` instructions as possible.) This leads to to incorrect calculations which may cause the target offset for the `tbX` branch to become to large. 

This fix changes all the BarriesStubs to stubs which participates in the trampoline logic. 

Until more platforms requires specialised barrier stub layouts it is not worth adding better support for this pattern. Without a redesign it does make it harder to ensure that this is used correctly. For now the shared code asserts when building for aarch64 that the general shared stubs are not used directly. But care would still have to be taken if any new barrier stubs are introduced. 

The behaviour was more easily reproducible when large inlining heuristics. This flag combination was used to get somewhat reliable reproducibility `-esa -ea -XX:MaxInlineLevel=300 -XX:MaxInlineSize=1100 -XX:MaxTrivialSize=1000 -XX:LiveNodeCountInliningCutoff=1000000 -XX:MaxNodeLimit=3000000 -XX:NodeLimitFudgeFactor=600000 -XX:+UnlockExperimentalVMOptions -XX:+UseVectorStubs`

There was also an observation inside the JBS comments that there where no `tbX` instructions branching to the emitted trampolines. However I was unable to reproduce this. Ran all tests with the following guarantee, this could not observe it either. 

```diff
diff --git a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
index ebaf1829972..b6c40163a6b 100644
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -36,6 +36,7 @@
 #include "runtime/icache.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/macros.hpp"
 #ifdef COMPILER1
 #include "c1/c1_LIRAssembler.hpp"
@@ -1358,6 +1359,7 @@ void ZLoadBarrierStubC2Aarch64::emit_code(MacroAssembler& masm) {
   // Current assumption is that the barrier stubs are the first stubs emitted after the actual code
   assert(stubs_start_offset() <= output->buffer_sizing_data()->_code, "stubs are assumed to be emitted directly after code and code_size is a hard limit on where it can start");
 
+  guarantee(!_test_and_branch_reachable_entry.is_unused(), "Should be used");
   __ bind(_test_and_branch_reachable_entry);
 
   // Next branch's offset is unknown, but is > branch_offset
```

- Testing
  - `linux-aarch64`, `linux-aarch64-debug`,`macosx-aarch64`, `macosx-aarch64-debug`
    - [x] ZGC tier1-tier7 Test Groups
    - [x] ZGC tier1-tier7 Test Groups with large C2 inlining heuristics
      - (With test failures due to incompatible flags filtered out)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319700](https://bugs.openjdk.org/browse/JDK-8319700): [AArch64] C2 compilation fails with "Field too big for insn" (**Bug** - P2)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16780/head:pull/16780` \
`$ git checkout pull/16780`

Update a local copy of the PR: \
`$ git checkout pull/16780` \
`$ git pull https://git.openjdk.org/jdk.git pull/16780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16780`

View PR using the GUI difftool: \
`$ git pr show -t 16780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16780.diff">https://git.openjdk.org/jdk/pull/16780.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16780#issuecomment-1822535007)