### PR TITLE
8320564: RISC-V: Minimal build failed after JDK-8316592

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2048,23 +2048,6 @@ void MacroAssembler::cmp_klass(Register oop, Register trial_klass, Register tmp1
   beq(trial_klass, tmp1, L);
 }
 
-// Multiply and multiply-accumulate unsigned 64-bit registers.
-void MacroAssembler::wide_mul(Register prod_lo, Register prod_hi, Register n, Register m) {
-  assert_different_registers(prod_lo, prod_hi);
-
-  mul(prod_lo, n, m);
-  mulhu(prod_hi, n, m);
-}
-void MacroAssembler::wide_madd(Register sum_lo, Register sum_hi, Register n,
-                Register m, Register tmp1, Register tmp2) {
-  assert_different_registers(sum_lo, sum_hi);
-  assert_different_registers(sum_hi, tmp2);
-
-  wide_mul(tmp1, tmp2, n, m);
-  cad(sum_lo, sum_lo, tmp1, tmp1);  // Add tmp1 to sum_lo with carry output to tmp1
-  adc(sum_hi, sum_hi, tmp2, tmp1);  // Add tmp2 with carry to sum_hi
-}
-
 // Move an oop into a register.
 void MacroAssembler::movoop(Register dst, jobject obj) {
   int oop_index;
@@ -3574,6 +3557,24 @@ void MacroAssembler::mul_add(Register out, Register in, Register offset,
   j(L_tail_loop);
 
   bind(L_end);
+}
+
+// Multiply and multiply-accumulate unsigned 64-bit registers.
+void MacroAssembler::wide_mul(Register prod_lo, Register prod_hi, Register n, Register m) {
+  assert_different_registers(prod_lo, prod_hi);
+
+  mul(prod_lo, n, m);
+  mulhu(prod_hi, n, m);
+}
+
+void MacroAssembler::wide_madd(Register sum_lo, Register sum_hi, Register n,
+                               Register m, Register tmp1, Register tmp2) {
+  assert_different_registers(sum_lo, sum_hi);
+  assert_different_registers(sum_hi, tmp2);
+
+  wide_mul(tmp1, tmp2, n, m);
+  cad(sum_lo, sum_lo, tmp1, tmp1);  // Add tmp1 to sum_lo with carry output to tmp1
+  adc(sum_hi, sum_hi, tmp2, tmp1);  // Add tmp2 with carry to sum_hi
 }
 
 // add two unsigned input and output carry

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -198,10 +198,6 @@ class MacroAssembler: public Assembler {
   void store_klass(Register dst, Register src, Register tmp = t0);
   void cmp_klass(Register oop, Register trial_klass, Register tmp1, Register tmp2, Label &L);
 
-  void wide_mul(Register prod_lo, Register prod_hi, Register n, Register m);
-  void wide_madd(Register sum_lo, Register sum_hi, Register n,
-                Register m, Register tmp1, Register tmp2);
-
   void encode_klass_not_null(Register r, Register tmp = t0);
   void decode_klass_not_null(Register r, Register tmp = t0);
   void encode_klass_not_null(Register dst, Register src, Register tmp);
@@ -1204,6 +1200,9 @@ public:
 #ifdef COMPILER2
   void mul_add(Register out, Register in, Register offset,
                Register len, Register k, Register tmp);
+  void wide_mul(Register prod_lo, Register prod_hi, Register n, Register m);
+  void wide_madd(Register sum_lo, Register sum_hi, Register n,
+                 Register m, Register tmp1, Register tmp2);
   void cad(Register dst, Register src1, Register src2, Register carry);
   void cadc(Register dst, Register src1, Register src2, Register carry);
   void adc(Register dst, Register src1, Register src2, Register carry);


### PR DESCRIPTION
Hi, please review this patch that fix the minimal build failed for riscv.

Error log for minimal build:

```
ERROR: Build failed for target 'all' in configuration 'linux-riscv64-minimal-fastdebug' (exit code 2)
Stopping javac server

=== Output from failing command(s) repeated here ===
* For target hotspot_variant-minimal_libjvm_objs_macroAssembler_riscv.o:
/home/jiangfeilong/workspace/jdk/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp: In member function 'void MacroAssembler::wide_madd(Register, Register, Register, Register, Register, Register)':
/home/jiangfeilong/workspace/jdk/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp:2064:3: error: 'cad' was not declared in this scope
 2064 | cad(sum_lo, sum_lo, tmp1, tmp1); // Add tmp1 to sum_lo with carry output to tmp1
      | ^~~
/home/jiangfeilong/workspace/jdk/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp:2065:3: error: 'adc' was not declared in this scope; did you mean 'add'?
 2065 | adc(sum_hi, sum_hi, tmp2, tmp1); // Add tmp2 with carry to sum_hi
      | ^~~
      | add

* All command lines available in /home/jiangfeilong/workspace/jdk/build/linux-riscv64-minimal-fastdebug/make-support/failure-logs.
=== End of repeated output ===
```

The root cause is that `cad` and `adc` are defined under `COMPILER2` macro but new methods `wide_mul` and `wide_madd` are not.

Testing:

- [x] linux-riscv minimal  fastdebug cross-compile

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320564](https://bugs.openjdk.org/browse/JDK-8320564): RISC-V: Minimal build failed after JDK-8316592 (**Bug** - P3)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16781/head:pull/16781` \
`$ git checkout pull/16781`

Update a local copy of the PR: \
`$ git checkout pull/16781` \
`$ git pull https://git.openjdk.org/jdk.git pull/16781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16781`

View PR using the GUI difftool: \
`$ git pr show -t 16781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16781.diff">https://git.openjdk.org/jdk/pull/16781.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16781#issuecomment-1822554444)