### PR TITLE
8318809: java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java shows intermittent failures on linux ppc64le and aarch64

### DIFF
--- a/test/jdk/java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java
+++ b/test/jdk/java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java
@@ -281,36 +281,6 @@ public class WhiteBox {
         assertInvariants(q);
     }
 
-    /**
-     * Actions that append an element, and are expected to
-     * leave at most one slack node at tail.
-     */
-    @DataProvider
-    public Object[][] addActions() {
-        return List.<Consumer<ConcurrentLinkedQueue>>of(
-            q -> q.add(1),
-            q -> q.offer(1))
-            .stream().map(x -> new Object[]{ x }).toArray(Object[][]::new);
-    }
-
-    @Test(dataProvider = "addActions")
-    public void addActionsOneNodeSlack(
-        Consumer<ConcurrentLinkedQueue> addAction) {
-        ConcurrentLinkedQueue q = new ConcurrentLinkedQueue();
-        int n = 1 + rnd.nextInt(5);
-        for (int i = 0; i < n; i++) {
-            boolean slack = next(tail(q)) != null;
-            addAction.accept(q);
-            if (slack)
-                assertNull(next(tail(q)));
-            else {
-                assertNotNull(next(tail(q)));
-                assertNull(next(next(tail(q))));
-            }
-            assertInvariants(q);
-        }
-    }
-
     byte[] serialBytes(Object o) {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
We've seen some rare failures of the CLQ Whitebox test on "less-strong" architectures, and the only thing which -- given my research -- could be the culprit is spuriously failing weakCAS (which is correct in terms of the implementation of CLQ).

After discussion with @DougLea, it was decided as the CLQ implementation does not guarantee what the failing test tests, and modifying the test would mean that it would generally not be able to enforce anything, the test is invalid and should be removed -- hence this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318809](https://bugs.openjdk.org/browse/JDK-8318809): java/util/concurrent/ConcurrentLinkedQueue/WhiteBox.java shows intermittent failures on linux ppc64le and aarch64 (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16786/head:pull/16786` \
`$ git checkout pull/16786`

Update a local copy of the PR: \
`$ git checkout pull/16786` \
`$ git pull https://git.openjdk.org/jdk.git pull/16786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16786`

View PR using the GUI difftool: \
`$ git pr show -t 16786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16786.diff">https://git.openjdk.org/jdk/pull/16786.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16786#issuecomment-1839500488)