### PR TITLE
8320533: Adjust capstone integration for v6 changes

### DIFF
--- a/make/Hsdis.gmk
+++ b/make/Hsdis.gmk
@@ -47,7 +47,7 @@ ifeq ($(HSDIS_BACKEND), capstone)
     CAPSTONE_ARCH := CS_ARCH_X86
     CAPSTONE_MODE := CS_MODE_$(OPENJDK_TARGET_CPU_BITS)
   else ifeq ($(call isTargetCpuArch, aarch64), true)
-    CAPSTONE_ARCH := CS_ARCH_ARM64
+    CAPSTONE_ARCH := CS_ARCH_AARCH64
     CAPSTONE_MODE := CS_MODE_ARM
   else
     $(error No support for Capstone on this platform)

--- a/make/Hsdis.gmk
+++ b/make/Hsdis.gmk
@@ -47,7 +47,7 @@ ifeq ($(HSDIS_BACKEND), capstone)
     CAPSTONE_ARCH := CS_ARCH_X86
     CAPSTONE_MODE := CS_MODE_$(OPENJDK_TARGET_CPU_BITS)
   else ifeq ($(call isTargetCpuArch, aarch64), true)
-    CAPSTONE_ARCH := CS_ARCH_AARCH64
+    CAPSTONE_ARCH := CS_ARCH_$(CAPSTONE_ARCH_AARCH64_NAME)
     CAPSTONE_MODE := CS_MODE_ARM
   else
     $(error No support for Capstone on this platform)

--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -63,6 +63,19 @@ AC_DEFUN([LIB_SETUP_HSDIS_CAPSTONE],
       AC_MSG_ERROR([Cannot continue])
     fi
   fi
+
+  capstone_header="\"$CAPSTONE/include/capstone/capstone.h\""
+  AC_MSG_CHECKING([capstone aarch64 arch name])
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include $capstone_header],[[cs_arch test = CS_ARCH_AARCH64]])],
+    [
+      AC_MSG_RESULT([AARCH64])
+      CAPSTONE_ARCH_AARCH64_NAME="AARCH64"
+    ],
+    [
+      AC_MSG_RESULT([ARM64])
+      CAPSTONE_ARCH_AARCH64_NAME="ARM64"
+    ]
+  )
 ])
 
 ################################################################################
@@ -365,6 +378,7 @@ AC_DEFUN_ONCE([LIB_SETUP_HSDIS],
   AC_SUBST(HSDIS_CFLAGS)
   AC_SUBST(HSDIS_LDFLAGS)
   AC_SUBST(HSDIS_LIBS)
+  AC_SUBST(CAPSTONE_ARCH_AARCH64_NAME)
 
   AC_MSG_CHECKING([if hsdis should be bundled])
   if test "x$ENABLE_HSDIS_BUNDLING" = "xtrue"; then

--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -377,6 +377,7 @@ ENABLE_HSDIS_BUNDLING := @ENABLE_HSDIS_BUNDLING@
 HSDIS_CFLAGS := @HSDIS_CFLAGS@
 HSDIS_LDFLAGS := @HSDIS_LDFLAGS@
 HSDIS_LIBS := @HSDIS_LIBS@
+CAPSTONE_ARCH_AARCH64_NAME := @CAPSTONE_ARCH_AARCH64_NAME@
 
 # The boot jdk to use. This is overridden in bootcycle-spec.gmk. Make sure to keep
 # it in sync.

--- a/src/utils/hsdis/capstone/hsdis-capstone.c
+++ b/src/utils/hsdis/capstone/hsdis-capstone.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0

--- a/src/utils/hsdis/capstone/hsdis-capstone.c
+++ b/src/utils/hsdis/capstone/hsdis-capstone.c
@@ -52,6 +52,11 @@
 #include <inttypes.h>
 #include <string.h>
 
+/* Undefine macro to avoid generating invalid C code.
+   Capstone refactored cs_detail for AArch64 architecture
+   from `cs_arm64 arm64` to `cs_aarch64 aarch64`
+   and that causes invalid macro expansion.
+*/
 #undef aarch64
 #include <capstone.h>
 

--- a/src/utils/hsdis/capstone/hsdis-capstone.c
+++ b/src/utils/hsdis/capstone/hsdis-capstone.c
@@ -52,6 +52,7 @@
 #include <inttypes.h>
 #include <string.h>
 
+#undef aarch64
 #include <capstone.h>
 
 #include "hsdis.h"


### PR DESCRIPTION
FYI @theRealAph

It includes a couple of commits to integrate with Capstone v6 while still working with Capstone v5 and before:
* `CAPSTONE_ARCH` for aarch64 is now `CS_ARCH_AARCH64` instead of `CS_ARCH_ARM64`. See [this document](https://github.com/Rot127/capstone/blob/v6-release-guide/docs/cs_v6_release_guide.md) to understand motivation for this Capstone change.
* The `-Daarch64` macro was getting in the way and was causing invalid C to be produced. Undefined it before including `capstone.h`. Thx @rwestrel for suggesting the fix!
* Enhanced autoconf to select the right aarch64 arch name depending on the capstone library in use.

Here's some output to demonstrate autoconf:

1. If using capstone v6, you will see:
```
checking capstone aarch64 arch name... AARCH64
```

2. If using capstone v5, or earlier, you will see:
```
checking capstone aarch64 arch name... ARM64
```

With v5 or earlier, the compilation error in the config log file is the expected one:

```
configure:142906: checking capstone aarch64 arch name
configure:142919: /usr/bin/clang -c  -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -iframework /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks  -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -iframework /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks conftest.c >&5
conftest.c:27:16: error: use of undeclared identifier 'CS_ARCH_AARCH64'; did you mean 'CS_ARCH_ARM64'?
cs_arch test = CS_ARCH_AARCH64
               ^~~~~~~~~~~~~~~
               CS_ARCH_ARM64
/Users/galder/opt/capstone-5/include/capstone/capstone.h:76:2: note: 'CS_ARCH_ARM64' declared here
        CS_ARCH_ARM64,          ///< ARM-64, also called AArch64
        ^
1 error generated.
configure:142919: $? = 1
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "OpenJDK"
| #define PACKAGE_TARNAME "openjdk"
| #define PACKAGE_VERSION "openjdk"
| #define PACKAGE_STRING "OpenJDK openjdk"
| #define PACKAGE_BUGREPORT "build-dev@openjdk.org"
| #define PACKAGE_URL "https://openjdk.org"
| #define HAVE_STDIO_H 1
| #define HAVE_STDLIB_H 1
| #define HAVE_STRING_H 1
| #define HAVE_INTTYPES_H 1
| #define HAVE_STDINT_H 1
| #define HAVE_STRINGS_H 1
| #define HAVE_SYS_STAT_H 1
| #define HAVE_SYS_TYPES_H 1
| #define HAVE_UNISTD_H 1
| #define STDC_HEADERS 1
| #define HAVE_STDIO_H 1
| #define SIZEOF_INT_P 8
| #define HAVE_CUPS_CUPS_H 1
| #define HAVE_CUPS_PPD_H 1
| /* end confdefs.h.  */
| #include "/Users/galder/opt/capstone-5/include/capstone/capstone.h"
| int
| main (void)
| {
| cs_arch test = CS_ARCH_AARCH64
|   ;
|   return 0;
| }
```

Happy to squash both commits together if it makes sense.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320533](https://bugs.openjdk.org/browse/JDK-8320533): Adjust capstone integration for v6 changes (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [06aeba6b](https://git.openjdk.org/jdk/pull/16788/files/06aeba6b7f5c3f235e479da7e312a827e740528b)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16788/head:pull/16788` \
`$ git checkout pull/16788`

Update a local copy of the PR: \
`$ git checkout pull/16788` \
`$ git pull https://git.openjdk.org/jdk.git pull/16788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16788`

View PR using the GUI difftool: \
`$ git pr show -t 16788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16788.diff">https://git.openjdk.org/jdk/pull/16788.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16788#issuecomment-1823840519)