### PR TITLE
8320645: DocLint should use javax.lang.model to detect default constructors

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -1248,14 +1248,8 @@ public class Checker extends DocTreePathScanner<Void, Void> {
     }
 
     private boolean isDefaultConstructor() {
-        if (env.currElement.getKind() == ElementKind.CONSTRUCTOR) {
-            // A synthetic default constructor has the same pos as the
-            // enclosing class
-            TreePath p = env.currPath;
-            return env.getPos(p) == env.getPos(p.getParentPath());
-        } else {
-            return false;
-        }
+        return env.currElement.getKind() == ElementKind.CONSTRUCTOR
+                && env.elements.getOrigin(env.currElement) == Elements.Origin.MANDATED;
     }
 
     private boolean isDeclaredType() {


### PR DESCRIPTION
jdk.javadoc.internal.doclint.Checker should favour the official javax.lang.model.util.Elements.getOrigin API over implementation-specific source tree positioning, to detect the default constructor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320645](https://bugs.openjdk.org/browse/JDK-8320645): DocLint should use javax.lang.model to detect default constructors (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16790/head:pull/16790` \
`$ git checkout pull/16790`

Update a local copy of the PR: \
`$ git checkout pull/16790` \
`$ git pull https://git.openjdk.org/jdk.git pull/16790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16790`

View PR using the GUI difftool: \
`$ git pr show -t 16790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16790.diff">https://git.openjdk.org/jdk/pull/16790.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16790#issuecomment-1824137128)