### PR TITLE
8310644: Make panama memory segment close use async handshakes

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -67,22 +67,72 @@ public:
   }
 };
 
-class CloseScopedMemoryClosure : public HandshakeClosure {
-  jobject _deopt;
+static bool is_in_scoped_access(JavaThread* jt, oop session) {
+  const int max_critical_stack_depth = 10;
+  int depth = 0;
+  for (vframeStream stream(jt); !stream.at_end(); stream.next()) {
+    Method* m = stream.method();
+    if (m->is_scoped()) {
+      StackValueCollection* locals = stream.asJavaVFrame()->locals();
+      for (int i = 0; i < locals->size(); i++) {
+        StackValue* var = locals->at(i);
+        if (var->type() == T_OBJECT) {
+          if (var->get_obj() == session) {
+            assert(depth < max_critical_stack_depth, "can't have more than %d critical frames", max_critical_stack_depth);
+            return true;
+          }
+        }
+      }
+      break;
+    }
+    depth++;
+#ifndef ASSERT
+    if (depth >= max_critical_stack_depth) {
+      break;
+    }
+#endif
+  }
+
+  return false;
+}
+
+class ScopedAsyncExceptionHandshake : public AsyncExceptionHandshake {
+  OopHandle _session;
 
 public:
-  jboolean _found;
+  ScopedAsyncExceptionHandshake(OopHandle& session, OopHandle& error)
+    : AsyncExceptionHandshake(error),
+      _session(session) {}
 
-  CloseScopedMemoryClosure(jobject deopt, jobject exception)
+  ~ScopedAsyncExceptionHandshake() {
+    _session.release(Universe::vm_global());
+  }
+
+  virtual void do_thread(Thread* thread) {
+    JavaThread* jt = JavaThread::cast(thread);
+    ResourceMark rm;
+    if (is_in_scoped_access(jt, _session.resolve())) {
+      // Throw exception to unwind out from the scoped access
+      AsyncExceptionHandshake::do_thread(thread);
+    }
+  }
+};
+
+class CloseScopedMemoryClosure : public HandshakeClosure {
+  jobject _session;
+  jobject _error;
+
+public:
+  CloseScopedMemoryClosure(jobject session, jobject error)
     : HandshakeClosure("CloseScopedMemory")
-    , _deopt(deopt)
-    , _found(false) {}
+    , _session(session)
+    , _error(error) {}
 
   void do_thread(Thread* thread) {
-
     JavaThread* jt = JavaThread::cast(thread);
 
     if (!jt->has_last_Java_frame()) {
+      // No frames; not in a scoped memory access
       return;
     }
 
@@ -97,8 +147,8 @@ public:
     }
 
     ResourceMark rm;
-    if (_deopt != nullptr && last_frame.is_compiled_frame() && last_frame.can_be_deoptimized()) {
-      CloseScopedMemoryFindOopClosure cl(_deopt);
+    if (_session != nullptr && last_frame.is_compiled_frame() && last_frame.can_be_deoptimized()) {
+      CloseScopedMemoryFindOopClosure cl(_session);
       CompiledMethod* cm = last_frame.cb()->as_compiled_method();
 
       /* FIXME: this doesn't work if reachability fences are violated by C2
@@ -111,30 +161,20 @@ public:
       Deoptimization::deoptimize(jt, last_frame);
     }
 
-    const int max_critical_stack_depth = 10;
-    int depth = 0;
-    for (vframeStream stream(jt); !stream.at_end(); stream.next()) {
-      Method* m = stream.method();
-      if (m->is_scoped()) {
-        StackValueCollection* locals = stream.asJavaVFrame()->locals();
-        for (int i = 0; i < locals->size(); i++) {
-          StackValue* var = locals->at(i);
-          if (var->type() == T_OBJECT) {
-            if (var->get_obj() == JNIHandles::resolve(_deopt)) {
-              assert(depth < max_critical_stack_depth, "can't have more than %d critical frames", max_critical_stack_depth);
-              _found = true;
-              return;
-            }
-          }
-        }
-        break;
-      }
-      depth++;
-#ifndef ASSERT
-      if (depth >= max_critical_stack_depth) {
-        break;
-      }
-#endif
+    if (jt->has_async_exception_condition()) {
+      // Target thread just about to throw an async exception using async handshakes,
+      // we will then unwind out from the scoped memory access.
+      return;
+    }
+
+    if (is_in_scoped_access(jt, JNIHandles::resolve(_session))) {
+      // We have found that the target thread is inside of a scoped access.
+      // An asynchronous handshake is sent to the target thread, telling it
+      // to throw an exception, which will unwind the target thread out from
+      // the scoped access.
+      OopHandle session(Universe::vm_global(), JNIHandles::resolve(_session));
+      OopHandle error(Universe::vm_global(), JNIHandles::resolve(_error));
+      jt->install_async_exception(new ScopedAsyncExceptionHandshake(session, error));
     }
   }
 };
@@ -146,10 +186,9 @@ public:
  * class annotated with the '@Scoped' annotation), and whose local variables mention the session being
  * closed (deopt), this method returns false, signalling that the session cannot be closed safely.
  */
-JVM_ENTRY(jboolean, ScopedMemoryAccess_closeScope(JNIEnv *env, jobject receiver, jobject deopt, jobject exception))
-  CloseScopedMemoryClosure cl(deopt, exception);
+JVM_ENTRY(void, ScopedMemoryAccess_closeScope(JNIEnv *env, jobject receiver, jobject session, jobject error))
+  CloseScopedMemoryClosure cl(session, error);
   Handshake::execute(&cl);
-  return !cl._found;
 JVM_END
 
 /// JVM_RegisterUnsafeMethods
@@ -157,14 +196,14 @@ JVM_END
 #define PKG_MISC "Ljdk/internal/misc/"
 #define PKG_FOREIGN "Ljdk/internal/foreign/"
 
-#define MEMACCESS "ScopedMemoryAccess"
-#define SCOPE PKG_FOREIGN "MemorySessionImpl;"
+#define SCOPED_SESSION PKG_FOREIGN "MemorySessionImpl;"
+#define SCOPED_ERROR PKG_MISC "ScopedMemoryAccess$ScopedAccessError;"
 
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
 
 static JNINativeMethod jdk_internal_misc_ScopedMemoryAccess_methods[] = {
-    {CC "closeScope0",   CC "(" SCOPE ")Z",           FN_PTR(ScopedMemoryAccess_closeScope)},
+  {CC "closeScope0", CC "(" SCOPED_SESSION SCOPED_ERROR ")V", FN_PTR(ScopedMemoryAccess_closeScope)},
 };
 
 #undef CC
@@ -172,8 +211,8 @@ static JNINativeMethod jdk_internal_misc_ScopedMemoryAccess_methods[] = {
 
 #undef PKG_MISC
 #undef PKG_FOREIGN
-#undef MEMACCESS
-#undef SCOPE
+#undef SCOPED_SESSION
+#undef SCOPED_ERROR
 
 // This function is exported, used by NativeLookup.
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -225,9 +225,9 @@ class JavaThread: public Thread {
   friend class AsyncExceptionHandshake;
   friend class HandshakeState;
 
-  void install_async_exception(AsyncExceptionHandshake* aec = nullptr);
   void handle_async_exception(oop java_throwable);
  public:
+  void install_async_exception(AsyncExceptionHandshake* aec = nullptr);
   bool has_async_exception_condition();
   inline void set_pending_unsafe_access_error();
   static void send_async_exception(JavaThread* jt, oop java_throwable);

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -55,13 +55,12 @@ public abstract sealed class MemorySessionImpl
         implements Scope
         permits ConfinedSession, GlobalSession, SharedSession {
     static final int OPEN = 0;
-    static final int CLOSING = -1;
-    static final int CLOSED = -2;
+    static final int CLOSED = -1;
 
     static final VarHandle STATE;
     static final int MAX_FORKS = Integer.MAX_VALUE;
 
-    static final ScopedMemoryAccess.ScopedAccessError ALREADY_CLOSED = new ScopedMemoryAccess.ScopedAccessError(MemorySessionImpl::alreadyClosed);
+    public static final ScopedMemoryAccess.ScopedAccessError ALREADY_CLOSED = new ScopedMemoryAccess.ScopedAccessError(MemorySessionImpl::alreadyClosed);
     static final ScopedMemoryAccess.ScopedAccessError WRONG_THREAD = new ScopedMemoryAccess.ScopedAccessError(MemorySessionImpl::wrongThread);
     // This is the session of all zero-length memory segments
     public static final MemorySessionImpl GLOBAL_SESSION = new GlobalSession();

--- a/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
@@ -77,17 +77,13 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
     }
 
     void justClose() {
-        int prevState = (int) STATE.compareAndExchange(this, OPEN, CLOSING);
+        int prevState = (int) STATE.compareAndExchange(this, OPEN, CLOSED);
         if (prevState < 0) {
             throw alreadyClosed();
         } else if (prevState != OPEN) {
             throw alreadyAcquired(prevState);
         }
-        boolean success = SCOPED_MEMORY_ACCESS.closeScope(this);
-        STATE.setVolatile(this, success ? CLOSED : OPEN);
-        if (!success) {
-            throw alreadyAcquired(1);
-        }
+        SCOPED_MEMORY_ACCESS.closeScope(this);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -83,11 +83,11 @@ public class ScopedMemoryAccess {
         registerNatives();
     }
 
-    public boolean closeScope(MemorySessionImpl session) {
-        return closeScope0(session);
+    public void closeScope(MemorySessionImpl session) {
+        closeScope0(session, MemorySessionImpl.ALREADY_CLOSED);
     }
 
-    native boolean closeScope0(MemorySessionImpl session);
+    native void closeScope0(MemorySessionImpl session, ScopedAccessError error);
 
     private ScopedMemoryAccess() {}
 

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -98,16 +98,18 @@ public class TestHandshake {
         @Override
         public final void run() {
             start("\"Accessor #\" + id");
-            outer: while (segment.scope().isAlive()) {
+            while (segment.scope().isAlive()) {
                 try {
                     doAccess();
                 } catch (IllegalStateException ex) {
-                    long delay = System.currentTimeMillis() - start.get();
-                    System.out.println("Accessor #" + id + " suspending - elapsed (ms): " + delay);
-                    backoff();
-                    delay = System.currentTimeMillis() - start.get();
-                    System.out.println("Accessor #" + id + " resuming - elapsed (ms): " + delay);
-                    continue outer;
+                    if (!failed.get()) {
+                        // ignore - this means segment was alive, but was closed while we were accessing it
+                        // next isAlive test should fail
+                        failed.set(true);
+                    } else {
+                        // rethrow!
+                        throw ex;
+                    }
                 }
             }
             long delay = System.currentTimeMillis() - start.get();
@@ -246,14 +248,7 @@ public class TestHandshake {
         @Override
         public void run() {
             start("Handshaker");
-            while (true) {
-                try {
-                    arena.close();
-                    break;
-                } catch (IllegalStateException ex) {
-                    Thread.onSpinWait();
-                }
-            }
+            arena.close(); // This should NOT throw
             long delay = System.currentTimeMillis() - start.get();
             System.out.println("Segment closed - elapsed (ms): " + delay);
         }


### PR DESCRIPTION
The current logic for closing memory in panama today is susceptible to live lock if we have a closing thread that wants to close the memory in a loop that keeps failing, and a bunch of accessing threads that want to perform accesses as long as the memory is alive. They can both create impediments for the other.

By using asynchronous handshakes to install an exception onto threads that are in @Scoped memory accesses, we can have close always succeed, and the accessing threads bail out. The idea is that we perform a synchronous handshake first to find threads that are in scoped methods. They might however be in the middle of throwing an exception or something wild like there, where an exception can't be delivered. We install an async handshake that will roll us forward to the first place where we can indeed install exceptions, then we reevaluate if we still need to do that, or if we have unwound out from the scoped method. If we are still inside of it, we ensure an exception is installed so we don't continue executing bytecodes that might access the memory that we have freed.

Tested tier 1-5 as well as running test/jdk/java/foreign/TestHandshake.java hundreds of times, which tests this API pretty well.