### PR TITLE
8320618: NPE: Cannot invoke "java.lang.constant.ClassDesc.isArray()" because "this.sym" is null

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -1394,7 +1394,7 @@ public final class StackMapGenerator {
         }
 
         Type getComponent() {
-            if (sym.isArray()) {
+            if (isArray()) {
                 var comp = sym.componentType();
                 if (comp.isPrimitive()) {
                     return switch (comp.descriptorString().charAt(0)) {


### PR DESCRIPTION
ClassFile API StackMapGenerator caused a NPE for a test case with invalid sequence of instructions.
This fix simply avoids the NPE and adds StackMapsTest::testInvalidAALOADStack

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320618](https://bugs.openjdk.org/browse/JDK-8320618): NPE: Cannot invoke "java.lang.constant.ClassDesc.isArray()" because "this.sym" is null (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16793/head:pull/16793` \
`$ git checkout pull/16793`

Update a local copy of the PR: \
`$ git checkout pull/16793` \
`$ git pull https://git.openjdk.org/jdk.git pull/16793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16793`

View PR using the GUI difftool: \
`$ git pr show -t 16793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16793.diff">https://git.openjdk.org/jdk/pull/16793.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16793#issuecomment-1824309050)