### PR TITLE
8320655: awt screencast robot spin and sync issues with native libpipewire api

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -43,6 +43,7 @@ int DEBUG_SCREENCAST_ENABLED = FALSE;
                                       (*env)->ExceptionDescribe(env); \
                                    }
 
+static volatile gboolean hasPipewireFailed = FALSE;
 static volatile gboolean sessionClosed = TRUE;
 static GString *activeSessionToken;
 
@@ -171,6 +172,7 @@ static gboolean initScreencast(const gchar *token,
     }
 
     gtk->g_string_printf(activeSessionToken, "%s", token);
+    hasPipewireFailed = FALSE;
     sessionClosed = FALSE;
     return TRUE;
 }
@@ -338,6 +340,8 @@ static void onStreamProcess(void *userdata) {
 
     DEBUG_SCREEN_PREFIX(screen, "data ready\n", NULL);
     fp_pw_stream_queue_buffer(data->stream, pwBuffer);
+
+    fp_pw_thread_loop_signal(pw.loop, FALSE);
 }
 
 static void onStreamStateChanged(
@@ -351,6 +355,12 @@ static void onStreamStateChanged(
                      old, fp_pw_stream_state_as_string(old),
                      state, fp_pw_stream_state_as_string(state),
                      error);
+    if (state == PW_STREAM_STATE_ERROR
+        || state == PW_STREAM_STATE_UNCONNECTED) {
+
+        hasPipewireFailed = TRUE;
+        fp_pw_thread_loop_signal(pw.loop, FALSE);
+    }
 }
 
 static const struct pw_stream_events streamEvents = {
@@ -473,14 +483,17 @@ static gboolean connectStream(int index) {
 
     while (!data->hasFormat) {
         fp_pw_thread_loop_wait(pw.loop);
+        fp_pw_thread_loop_accept(pw.loop);
+        if (hasPipewireFailed) {
+            fp_pw_thread_loop_unlock(pw.loop);
+            return FALSE;
+        }
     }
 
     DEBUG_SCREEN_PREFIX(data->screenProps,
             "frame size: %dx%d\n",
             data->rawFormat.size.width, data->rawFormat.size.height
     );
-
-    fp_pw_thread_loop_accept(pw.loop);
 
     return TRUE;
 }
@@ -539,7 +552,12 @@ static void onCoreError(
             "!!! pipewire error: id %u, seq: %d, res: %d (%s): %s\n",
             id, seq, res, strerror(res), message
     );
-    fp_pw_thread_loop_unlock(pw.loop);
+    if (id == PW_ID_CORE) {
+        fp_pw_thread_loop_lock(pw.loop);
+        hasPipewireFailed = TRUE;
+        fp_pw_thread_loop_signal(pw.loop, FALSE);
+        fp_pw_thread_loop_unlock(pw.loop);
+    }
 }
 
 static const struct pw_core_events coreEvents = {
@@ -904,7 +922,14 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl
     }
 
     while (!isAllDataReady()) {
+        fp_pw_thread_loop_lock(pw.loop);
         fp_pw_thread_loop_wait(pw.loop);
+        if (hasPipewireFailed) {
+            fp_pw_thread_loop_unlock(pw.loop);
+            releaseToken(env, jtoken, token);
+            return RESULT_ERROR;
+        }
+        fp_pw_thread_loop_unlock(pw.loop);
     }
 
     DEBUG_SCREENCAST("\nall data ready\n", NULL);


### PR DESCRIPTION
This patch addresses the issues described in the https://bugs.openjdk.org/browse/JDK-8320655 by fixing the proper locking and signalling around libpipewire thread loop condition variables and also fixing libpipewire error detection and signalling and propagation to the screencast API. This makes the screencast robot stable enough to consistently make it thru the entire javax/swing jtreg suite without hanging and also significantly reduces CPU consumption as there is no longer any burning spinners since they are now waiting on related conditions proper.
