### PR TITLE
8320663: Fix C syntax in LIB_SETUP_HSDIS_BINUTILS

### DIFF
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -278,7 +278,7 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
   fi
 
   AC_MSG_CHECKING([Checking binutils API])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include $disasm_header],[[void foo() {init_disassemble_info(0, 0, 0, 0);}]])],
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include $disasm_header],[[init_disassemble_info(0, 0, 0, 0);]])],
     [
       AC_MSG_RESULT([New API])
       HSDIS_CFLAGS="$HSDIS_CFLAGS -DBINUTILS_NEW_API"


### PR DESCRIPTION
The C snippet in AC_COMPILE_IFELSE is incorrect. 

As noted by @galderz: https://github.com/openjdk/jdk/pull/15138#discussion_r1402918327

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320663](https://bugs.openjdk.org/browse/JDK-8320663): Fix C syntax in LIB_SETUP_HSDIS_BINUTILS (**Bug** - P3)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Contributors
 * Galder Zamarreño `<galder@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16795/head:pull/16795` \
`$ git checkout pull/16795`

Update a local copy of the PR: \
`$ git checkout pull/16795` \
`$ git pull https://git.openjdk.org/jdk.git pull/16795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16795`

View PR using the GUI difftool: \
`$ git pr show -t 16795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16795.diff">https://git.openjdk.org/jdk/pull/16795.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16795#issuecomment-1824533866)