### PR TITLE
JDK-8319633: runtime/posixSig/TestPosixSig.java intermittent timeouts on UNIX

### DIFF
--- a/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
+++ b/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
@@ -45,12 +45,13 @@ public class TestPosixSig {
 
             // Create a new java process for the TestPsig Java/JNI test.
             // We run the VM in interpreted mode, because the JIT might mark
-            // a Java method as not-entrant, which means turning the first opcode
-            // of the compiled method to NULL. Calling such a method after establishing
+            // a Java method as not-entrant, which means turning the first instruction
+            // into an illegal one. Calling such a method after establishing
             // the new SIGILL signal handler with TestPosixSig.changeSigActionFor(4)
-            // below will result in an endless loop, where the invalid opcode will be
-            // continously executed, raising SIGILL, and the signal handler will return
-            // to the invalid opcode...
+            // below, but before the JNI checker noted and reacted on this signal handler
+            // modification, the JVM may crash or hang in an endless loop, where the
+            // illegal instruction will be continously executed, raising SIGILL, and
+            // the signal handler will return to the illegal insruction again...
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-XX:+CheckJNICalls",
                 "-Xint",

--- a/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
+++ b/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
@@ -51,7 +51,7 @@ public class TestPosixSig {
             // below, but before the JNI checker noted and reacted on this signal handler
             // modification, the JVM may crash or hang in an endless loop, where the
             // illegal instruction will be continously executed, raising SIGILL, and
-            // the signal handler will return to the illegal insruction again...
+            // the signal handler will return to the illegal instruction again...
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-XX:+CheckJNICalls",
                 "-Xint",

--- a/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
+++ b/test/hotspot/jtreg/runtime/posixSig/TestPosixSig.java
@@ -44,8 +44,16 @@ public class TestPosixSig {
         if (args.length == 0) {
 
             // Create a new java process for the TestPsig Java/JNI test.
+            // We run the VM in interpreted mode, because the JIT might mark
+            // a Java method as not-entrant, which means turning the first opcode
+            // of the compiled method to NULL. Calling such a method after establishing
+            // the new SIGILL signal handler with TestPosixSig.changeSigActionFor(4)
+            // below will result in an endless loop, where the invalid opcode will be
+            // continously executed, raising SIGILL, and the signal handler will return
+            // to the invalid opcode...
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-XX:+CheckJNICalls",
+                "-Xint",
                 "-Djava.library.path=" + libpath + ":.",
                 "TestPosixSig", "dummy");
 

--- a/test/hotspot/jtreg/runtime/posixSig/libTestPsig.c
+++ b/test/hotspot/jtreg/runtime/posixSig/libTestPsig.c
@@ -28,34 +28,17 @@
 #include <errno.h>
 #include <string.h>
 
-void(*psig_handler) (int, siginfo_t *, void *) = 0;
-
 static void sig_handler(int sig, siginfo_t *info, ucontext_t *context) {
     printf( " HANDLER (1) " );
-    /* call the previous signal handler in the chain to avoid unhandled
-     * illegal Opcode (SIGILL) event, which would result in endles recursion
-     */
-    if (psig_handler) {
-        psig_handler(sig, info, context);
-    }
 }
 
 JNIEXPORT void JNICALL Java_TestPosixSig_changeSigActionFor(JNIEnv *env, jclass klass, jint val) {
-    struct sigaction act, oact;
+    struct sigaction act;
     act.sa_handler = (void (*)())sig_handler;
     sigemptyset(&act.sa_mask);
-    act.sa_flags = SA_SIGINFO;
-    int retval = sigaction(val, &act, &oact);
+    act.sa_flags = 0;
+    int retval = sigaction(val, &act, 0);
     if (retval != 0) {
         printf("ERROR: failed to set %d signal handler error=%s\n", val, strerror(errno));
-    }
-    /* store the previous signal handler in the global psig_handler variable to be able
-     * to continue the signal chain
-     */
-    if (oact.sa_handler != SIG_DFL &&
-        oact.sa_handler != SIG_ERR &&
-        oact.sa_handler != SIG_IGN &&
-        oact.sa_handler != NULL) {
-        psig_handler = oact.sa_sigaction;
     }
 }

--- a/test/hotspot/jtreg/runtime/posixSig/libTestPsig.c
+++ b/test/hotspot/jtreg/runtime/posixSig/libTestPsig.c
@@ -28,7 +28,7 @@
 #include <errno.h>
 #include <string.h>
 
-void(*psig_handler) (int, siginfo_t *, ucontext_t *) = 0;
+void(*psig_handler) (int, siginfo_t *, void *) = 0;
 
 static void sig_handler(int sig, siginfo_t *info, ucontext_t *context) {
     printf( " HANDLER (1) " );
@@ -56,6 +56,6 @@ JNIEXPORT void JNICALL Java_TestPosixSig_changeSigActionFor(JNIEnv *env, jclass 
         oact.sa_handler != SIG_ERR &&
         oact.sa_handler != SIG_IGN &&
         oact.sa_handler != NULL) {
-        psig_handler = (void(*) (int, siginfo_t *, ucontext_t *))oact.sa_handler;
+        psig_handler = oact.sa_sigaction;
     }
 }


### PR DESCRIPTION
Every 1-2 weeks we run into timeouts when running jtreg test runtime/posixSig/TestPosixSig.java on UNIX.
The thread stack shows that we are in line 54 of TestPosixSig.java.

The reason is the following: The test registers a new dummy signal handler for SIGILL, without delegating the task to the previous handler in the chain. In case the VM then calls a Java method marked as not-entrant at least on PPC64 a SIGILL is raised. Because this is not handled by the registered handler the SIGILL will happen again and again in an endless recursion.
One solution would be to add a delegation to the hotspot signal handler, which is the previous handler in the chain.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319633](https://bugs.openjdk.org/browse/JDK-8319633): runtime/posixSig/TestPosixSig.java intermittent timeouts on UNIX (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [d6fe9c6c](https://git.openjdk.org/jdk/pull/16797/files/d6fe9c6c5fab36430f7b37c2c42f89b14f0d29e2)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16797/head:pull/16797` \
`$ git checkout pull/16797`

Update a local copy of the PR: \
`$ git checkout pull/16797` \
`$ git pull https://git.openjdk.org/jdk.git pull/16797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16797`

View PR using the GUI difftool: \
`$ git pr show -t 16797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16797.diff">https://git.openjdk.org/jdk/pull/16797.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16797#issuecomment-1824547408)