### PR TITLE
8318227: RISC-V: C2 ConvHF2F

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -813,6 +813,8 @@ enum operand_size { int8, int16, int32, uint32, int64 };
 
   INSN(fsqrt_s,  0b1010011, 0b00000, 0b0101100);
   INSN(fsqrt_d,  0b1010011, 0b00000, 0b0101101);
+  INSN(fcvt_s_h, 0b1010011, 0b00010, 0b0100000);
+  INSN(fcvt_h_s, 0b1010011, 0b00000, 0b0100010);
   INSN(fcvt_s_d, 0b1010011, 0b00001, 0b0100000);
   INSN(fcvt_d_s, 0b1010011, 0b00000, 0b0100001);
 #undef INSN
@@ -1069,6 +1071,7 @@ enum operand_size { int8, int16, int32, uint32, int64 };
     emit(insn);                                      \
   }
 
+  INSN(fmv_h_x,  0b1010011, 0b000, 0b00000, 0b1111010);
   INSN(fmv_w_x,  0b1010011, 0b000, 0b00000, 0b1111000);
   INSN(fmv_d_x,  0b1010011, 0b000, 0b00000, 0b1111001);
 
@@ -1106,8 +1109,10 @@ enum fclass_mask {
     emit(insn);                                           \
   }
 
+  INSN(fclass_h, 0b1010011, 0b001, 0b00000, 0b1110010);
   INSN(fclass_s, 0b1010011, 0b001, 0b00000, 0b1110000);
   INSN(fclass_d, 0b1010011, 0b001, 0b00000, 0b1110001);
+  INSN(fmv_x_h,  0b1010011, 0b000, 0b00000, 0b1110010);
   INSN(fmv_x_w,  0b1010011, 0b000, 0b00000, 0b1110000);
   INSN(fmv_x_d,  0b1010011, 0b000, 0b00000, 0b1110001);
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -163,6 +163,8 @@
 
   void signum_fp(FloatRegister dst, FloatRegister one, bool is_double);
 
+  void float16_to_float(FloatRegister dst, Register src, Register tmp);
+
   // intrinsic methods implemented by rvv instructions
 
   // compress bits, i.e. j.l.Integer/Long::compress.

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -105,6 +105,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZba, false, "Use Zba instructions")                           \
   product(bool, UseZbb, false, "Use Zbb instructions")                           \
   product(bool, UseZbs, false, "Use Zbs instructions")                           \
+  product(bool, UseZfh, false, "Use Zfh instructions")                           \
   product(bool, UseZic64b, false, EXPERIMENTAL, "Use Zic64b instructions")       \
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1933,6 +1933,9 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_FmaVF:
     case Op_FmaVD:
       return UseFMA;
+
+    case Op_ConvHF2F:
+      return UseZfh;
   }
 
   return true; // Per default match rules are supported.
@@ -8269,6 +8272,20 @@ instruct convD2F_reg(fRegF dst, fRegD src) %{
   %}
 
   ins_pipe(fp_d2f);
+%}
+
+// single <-> half precision
+
+instruct convHF2F_reg_reg(fRegF dst, iRegINoSp src, iRegINoSp tmp) %{
+  match(Set dst (ConvHF2F src));
+  effect(TEMP tmp);
+  format %{ "fmv.h.x $dst, $src\t# move source from $src to $dst\n\t"
+            "fcvt.s.h $dst, $dst\t# convert half to single precision"
+  %}
+  ins_encode %{
+    __ float16_to_float($dst$$FloatRegister, $src$$Register, $tmp$$Register);
+  %}
+  ins_pipe(fp_f2i);
 %}
 
 // float <-> int

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -82,6 +82,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseZbs)) {
       FLAG_SET_DEFAULT(UseZbs, true);
     }
+    if (FLAG_IS_DEFAULT(UseZfh)) {
+      FLAG_SET_DEFAULT(UseZfh, true);
+    }
     if (FLAG_IS_DEFAULT(UseZic64b)) {
       FLAG_SET_DEFAULT(UseZic64b, true);
     }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -105,6 +105,8 @@ class VM_Version : public Abstract_VM_Version {
   // Zbc Carry-less multiplication
   // Zbs Single-bit instructions
   //
+  // Zfh Half-Precision Floating-Point instructions
+  //
   // Zicsr Control and Status Register (CSR) Instructions
   // Zifencei Instruction-Fetch Fence
   // Zic64b Cache blocks must be 64 bytes in size, naturally aligned in the address space.
@@ -137,6 +139,7 @@ class VM_Version : public Abstract_VM_Version {
   decl(ext_Zbb         , "Zbb"         , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZbb))         \
   decl(ext_Zbc         , "Zbc"         , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \
   decl(ext_Zbs         , "Zbs"         , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZbs))         \
+  decl(ext_Zfh         , "Zfh"         , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZfh))         \
   decl(ext_Zicsr       , "Zicsr"       , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \
   decl(ext_Zifencei    , "Zifencei"    , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \
   decl(ext_Zic64b      , "Zic64b"      , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZic64b))      \

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -49,6 +49,7 @@
 #define   RISCV_HWPROBE_EXT_ZBA                 (1 << 3)
 #define   RISCV_HWPROBE_EXT_ZBB                 (1 << 4)
 #define   RISCV_HWPROBE_EXT_ZBS                 (1 << 5)
+#define   RISCV_HWPROBE_EXT_ZFH                 (1 << 26)
 
 #define RISCV_HWPROBE_KEY_CPUPERF_0     5
 #define   RISCV_HWPROBE_MISALIGNED_UNKNOWN      (0 << 0)
@@ -144,6 +145,9 @@ void RiscvHwprobe::add_features_from_query_result() {
   }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBS)) {
     VM_Version::ext_Zbs.enable_feature();
+  }
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZFH)) {
+    VM_Version::ext_Zfh.enable_feature();
   }
   if (is_valid(RISCV_HWPROBE_KEY_CPUPERF_0)) {
     VM_Version::unaligned_access.enable_feature(

--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -49,7 +49,7 @@
 #define   RISCV_HWPROBE_EXT_ZBA                 (1 << 3)
 #define   RISCV_HWPROBE_EXT_ZBB                 (1 << 4)
 #define   RISCV_HWPROBE_EXT_ZBS                 (1 << 5)
-#define   RISCV_HWPROBE_EXT_ZFH                 (1 << 26)
+#define   RISCV_HWPROBE_EXT_ZFH                 (1 << 27)
 
 #define RISCV_HWPROBE_KEY_CPUPERF_0     5
 #define   RISCV_HWPROBE_MISALIGNED_UNKNOWN      (0 << 0)

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -240,6 +240,8 @@ void VM_Version::rivos_features() {
   ext_Zbb.enable_feature();
   ext_Zbs.enable_feature();
 
+  ext_Zfh.enable_feature();
+
   ext_Zicsr.enable_feature();
   ext_Zifencei.enable_feature();
   ext_Zic64b.enable_feature();

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16Conversion.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16Conversion.java
@@ -26,6 +26,7 @@
  * @bug 8289551 8302976
  * @summary Verify conversion between float and the binary16 format
  * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch=="aarch64"
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh,.*")
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @requires vm.compMode != "Xcomp"
  * @comment default run

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN.java
@@ -26,6 +26,7 @@
  * @bug 8289551 8302976
  * @summary Verify NaN sign and significand bits are preserved across conversions
  * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch=="aarch64"
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh,.*")
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @requires vm.compMode != "Xcomp"
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestAllFloat16ToFloat.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestAllFloat16ToFloat.java
@@ -26,6 +26,7 @@
  * @bug 8302976
  * @summary Verify conversion between float and the binary16 format
  * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch == "aarch64"
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh,.*")
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @requires vm.compMode != "Xcomp"
  * @comment default run:

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestConstFloat16ToFloat.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestConstFloat16ToFloat.java
@@ -26,6 +26,7 @@
  * @bug 8302976
  * @summary Verify conversion cons between float and the binary16 format
  * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch=="aarch64"
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh,.*")
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @requires vm.compMode != "Xcomp"
  * @comment default run:


### PR DESCRIPTION
Hi,
Can you review the patch to add ConvHF2F intrinsic to JDK for riscv？
Thanks!

(By latest kernel patch, `#define		RISCV_HWPROBE_EXT_ZFH		(1 << 27)`
https://lore.kernel.org/lkml/20231114141256.126749-11-cleger@rivosinc.com/)

## Test
### Functionality
#### hotspot tests
test/hotspot/jtreg/compiler/intrinsics/ 
test/hotspot/jtreg/compiler/c2/irTests

#### jdk tests
test/jdk/java/lang/Float/Binary16Conversion*.java

### Performance
tested on licheepi.

#### with UseZfh enabled
(i.e. enable the intrinsic)
```
Benchmark                                     (size)  Mode  Cnt      Score     Error  Units
Fp16ConversionBenchmark.float16ToFloat          2048  avgt   10   4659.796 ?  13.262  ns/op
Fp16ConversionBenchmark.float16ToFloatMemory    2048  avgt   10     22.957 ?   0.098  ns/op
```

#### with UseZfh disabled
(i.e. disable the intrinsic)
```
Benchmark                                     (size)  Mode  Cnt      Score    Error  Units
Fp16ConversionBenchmark.float16ToFloat          2048  avgt   10  22930.591 ? 72.595  ns/op
Fp16ConversionBenchmark.float16ToFloatMemory    2048  avgt   10     25.970 ?  0.063  ns/op
```