### PR TITLE
8320679: [JVMCI] invalid code in PushLocalFrame event message

### DIFF
--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -189,7 +189,7 @@ void JVMCIEnv::init_env_mode_runtime(JavaThread* thread, JNIEnv* parent_env) {
   JNIAccessMark jni(this, thread);
   jint result = _env->PushLocalFrame(32);
   if (result != JNI_OK) {
-    JVMCI_event_1("[%s:%d] Error pushing local JNI frame (err: %d)", _file, _line, _init_error);
+    JVMCI_event_1("[%s:%d] Error pushing local JNI frame (err: %d)", _file, _line, result);
     return;
   }
   _pop_frame_on_close = true;


### PR DESCRIPTION
This is a trivial fix to the JVMCI event logged when PushLocalFrame fails in a new libjvmci env. It must report the value of `result`, not `_init_error`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320679](https://bugs.openjdk.org/browse/JDK-8320679): [JVMCI] invalid code in PushLocalFrame event message (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16803/head:pull/16803` \
`$ git checkout pull/16803`

Update a local copy of the PR: \
`$ git checkout pull/16803` \
`$ git pull https://git.openjdk.org/jdk.git pull/16803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16803`

View PR using the GUI difftool: \
`$ git pr show -t 16803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16803.diff">https://git.openjdk.org/jdk/pull/16803.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16803#issuecomment-1824991535)