### PR TITLE
8320687: sun.jvmstat.monitor.MonitoredHost.getMonitoredHost() throws unexpected exceptions when invoked concurrently

### DIFF
--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredHost.java
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/monitor/MonitoredHost.java
@@ -135,10 +135,10 @@ public abstract class MonitoredHost {
 
 
     /*
-     * Load the MonitoredHostServices
+     * Load the MonitoredHostServices.
+     * Access to this field MUST be guarded through synchronization on "monitoredHosts"
+     * field
      */
-    // not thread safe, access MUST be guarded through synchronization on "monitoredHosts"
-    // field
     private static final ServiceLoader<MonitoredHostService> monitoredHostServiceLoader =
         ServiceLoader.load(MonitoredHostService.class, MonitoredHostService.class.getClassLoader());
 

--- a/test/jdk/sun/jvmstat/monitor/MonitoredVm/ConcurrentGetMonitoredHost.java
+++ b/test/jdk/sun/jvmstat/monitor/MonitoredVm/ConcurrentGetMonitoredHost.java
@@ -38,9 +38,9 @@ import sun.jvmstat.monitor.VmIdentifier;
  * @summary verify that sun.jvmstat.monitor.MonitoredHost.getMonitoredHost() doesn't
  *          unexpectedly throw an exception when invoked by concurrent threads
  *
- * @run main/othervm GetMonitoredHost
+ * @run main/othervm ConcurrentGetMonitoredHost
  */
-public class GetMonitoredHost {
+public class ConcurrentGetMonitoredHost {
 
     /*
      * Launches multiple concurrent threads and invokes MonitoredHost.getMonitoredHost()

--- a/test/jdk/sun/jvmstat/monitor/MonitoredVm/GetMonitoredHost.java
+++ b/test/jdk/sun/jvmstat/monitor/MonitoredVm/GetMonitoredHost.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import sun.jvmstat.monitor.MonitoredHost;
+import sun.jvmstat.monitor.VmIdentifier;
+
+/*
+ * @test
+ * @bug 8320687
+ * @summary verify that sun.jvmstat.monitor.MonitoredHost.getMonitoredHost() doesn't
+ *          unexpectedly throw an exception when invoked by concurrent threads
+ *
+ * @run main/othervm GetMonitoredHost
+ */
+public class GetMonitoredHost {
+
+    /*
+     * Launches multiple concurrent threads and invokes MonitoredHost.getMonitoredHost()
+     * in each of these threads and expects the call to return successfully without any
+     * exceptions.
+     */
+    public static void main(final String[] args) throws Exception {
+        final String pidStr = "12345";
+        final VmIdentifier vmid = new VmIdentifier(pidStr);
+        final int numTasks = 100;
+        final List<Task> tasks = new ArrayList<>();
+        for (int i = 0; i < numTasks; i++) {
+            tasks.add(new Task(vmid));
+        }
+        System.out.println("Submitting " + numTasks + " concurrent tasks to" +
+                " get MonitoredHost for " + vmid);
+        try (ExecutorService executor = Executors.newCachedThreadPool()) {
+            // wait for all tasks to complete
+            final List<Future<MonitoredHost>> results = executor.invokeAll(tasks);
+            // verify each one successfully completed and each of
+            // the returned MonitoredHost is not null
+            for (final Future<MonitoredHost> result : results) {
+                final MonitoredHost mh = result.get();
+                if (mh == null) {
+                    throw new AssertionError("MonitoredHost.getMonitoredHost() returned" +
+                            " null for vmid " + vmid);
+                }
+            }
+        }
+        System.out.println("All " + numTasks + " completed successfully");
+    }
+
+    // a task which just calls MonitoredHost.getMonitoredHost(VmIdentifier) and
+    // returns the resultant MonitoredHost
+    private static final class Task implements Callable<MonitoredHost> {
+        private final VmIdentifier vmid;
+
+        private Task(final VmIdentifier vmid) {
+            this.vmid = Objects.requireNonNull(vmid);
+        }
+
+        @Override
+        public MonitoredHost call() throws Exception {
+            return MonitoredHost.getMonitoredHost(this.vmid);
+        }
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/JDK-8320687?

As noted in the issue, the `sun.jvmstat.monitor.MonitoredHost.getMonitoredHost()` uses a shared instance of `java.util.ServiceLoader` to load `MonitoredHostService` services. The `ServiceLoader` class javadoc explicitly notes that it isn't thread safe. The issue at hand is caused to due using an instance of `ServiceLoader` concurrently by multiple threads.

The fix proposes to guard the usage of the shared `ServiceLoader` instance through the `monitoredHosts` object monitor. We already use that monitor when dealing with the internal cache which is populated after loading the relevant `MonitoredHostService`(s).

A new jtreg test has been introduced which always reproduces the issue without the source changes and passes with this fix.

tier1, tier2, tier3 and svc_tools tests have been run with this change and all passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320687](https://bugs.openjdk.org/browse/JDK-8320687): sun.jvmstat.monitor.MonitoredHost.getMonitoredHost() throws unexpected exceptions when invoked concurrently (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [669e5e5e](https://git.openjdk.org/jdk/pull/16805/files/669e5e5e0e747aac72f63d87987433d6e79d137e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16805/head:pull/16805` \
`$ git checkout pull/16805`

Update a local copy of the PR: \
`$ git checkout pull/16805` \
`$ git pull https://git.openjdk.org/jdk.git pull/16805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16805`

View PR using the GUI difftool: \
`$ git pr show -t 16805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16805.diff">https://git.openjdk.org/jdk/pull/16805.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16805#issuecomment-1825191983)