### PR TITLE
8320691: Timeout handler on Windows takes 2 hours to complete

### DIFF
--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -57,8 +57,8 @@ native.stack.args=-c "~*kP n;qd" -p %p
 native.stack.params.repeat=6
 
 native.core.app=cdb
-native.core.args=-c ".dump /ma core.%p;qd" -p %p
-native.core.params.timeout=3600000
+native.core.args=-c ".dump /mA core.%p;qd" -p %p
+native.core.params.timeout=600000
 ################################################################################
 # environment info to gather
 ################################################################################

--- a/test/failure_handler/src/share/conf/windows.properties
+++ b/test/failure_handler/src/share/conf/windows.properties
@@ -57,7 +57,7 @@ native.stack.args=-c "~*kP n;qd" -p %p
 native.stack.params.repeat=6
 
 native.core.app=cdb
-native.core.args=-c ".dump /f core.%p;qd" -p %p
+native.core.args=-c ".dump /ma core.%p;qd" -p %p
 native.core.params.timeout=3600000
 ################################################################################
 # environment info to gather


### PR DESCRIPTION
The recent cdb versions do not support `.dump /f`:
```
*****************************************************************************
* .dump /f is not supported on a user mode process.                         *
*                                                                           *
* .dump /ma creates a complete memory dump of a user mode process.          *
*****************************************************************************
```
and after printing that message, cdb ignores the rest of the command line and never quits.

This PR updates the dump command to use the recommended `/ma` parameter. This allows the command to produce a dump and complete in a timely manner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320691](https://bugs.openjdk.org/browse/JDK-8320691): Timeout handler on Windows takes 2 hours to complete (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [7e6bd035](https://git.openjdk.org/jdk/pull/16806/files/7e6bd035376059f20e4a29a1977bbc30e274b4dd)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16806/head:pull/16806` \
`$ git checkout pull/16806`

Update a local copy of the PR: \
`$ git checkout pull/16806` \
`$ git pull https://git.openjdk.org/jdk.git pull/16806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16806`

View PR using the GUI difftool: \
`$ git pr show -t 16806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16806.diff">https://git.openjdk.org/jdk/pull/16806.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16806#issuecomment-1825333528)