### PR TITLE
8318157: RISC-V: implement ensureMaterializedForStackWalk intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2357,6 +2357,11 @@ encode %{
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
+    } else if (_method->intrinsic_id() == vmIntrinsicID::_ensureMaterializedForStackWalk) {
+      // The NOP here is purely to ensure that eliding a call to
+      // JVM_EnsureMaterializedForStackWalk doesn't change the code size.
+      __ nop();
+      __ block_comment("call JVM_EnsureMaterializedForStackWalk (elided)");
     } else {
       int method_index = resolved_method_index(cbuf);
       RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)


### PR DESCRIPTION
Please, review addition of the ensureMaterializedForStackWalk C2 intrinsic for RISC-V. 
It's implemented by analogy to AArch64 and x86_64 [1].

The benchmark shows the following performance improvement on the T-Head RVB-ICE board:
**Before**
```
Benchmark                                             Mode  Cnt    Score    Error  Units
ScopedValues.CreateBindThenGetThenRemove_ScopedValue  avgt   10  873.072  12.051  ns/op
ScopedValues.bindThenGetNoRemove_ThreadLocal          avgt   10   55.507  18.006  ns/op
ScopedValues.bindThenGetThenRemove_ScopedValue        avgt   10  758.185  14.585  ns/op
ScopedValues.bindThenGetThenRemove_ThreadLocal        avgt   10  922.742   9.597  ns/op
ScopedValues.bindViaGet_ScopedValue                   avgt   10  603.164  13.694  ns/op
ScopedValues.bind_ScopedValue                         avgt   10  557.377   9.591  ns/op
ScopedValues.bind_ThreadLocal                         avgt   10  854.636  17.014  ns/op
ScopedValues.counter_ScopedValue                      avgt   10   35.367   0.421  ns/op
ScopedValues.counter_ThreadLocal                      avgt   10   45.345   0.283  ns/op
ScopedValues.setNoRemove_ScopedValue                  avgt   10   39.838   0.432  ns/op
ScopedValues.setNoRemove_ThreadLocal                  avgt   10   44.769   0.404  ns/op
ScopedValues.sixValues_ScopedValue                    avgt   10    2.566   0.006  us/op
ScopedValues.sixValues_ThreadLocal                    avgt   10    9.067   0.020  us/op
ScopedValues.thousandAdds_ScopedValue                 avgt   10    0.158   0.004  us/op
ScopedValues.thousandAdds_ThreadLocal                 avgt   10    9.662   0.019  us/op
ScopedValues.thousandIsBoundQueries                   avgt   10   31.203   0.451  ns/op
ScopedValues.thousandMaybeGets                        avgt   10  156.356   4.469  ns/op
```
**After**
```
Benchmark                                             Mode  Cnt    Score    Error  Units
ScopedValues.CreateBindThenGetThenRemove_ScopedValue  avgt   10  367.616   4.382  ns/op
ScopedValues.bindThenGetNoRemove_ThreadLocal          avgt   10   55.935  18.048  ns/op
ScopedValues.bindThenGetThenRemove_ScopedValue        avgt   10  371.733   2.835  ns/op
ScopedValues.bindThenGetThenRemove_ThreadLocal        avgt   10  902.112  12.709  ns/op
ScopedValues.bindViaGet_ScopedValue                   avgt   10  158.404   2.920  ns/op
ScopedValues.bind_ScopedValue                         avgt   10  158.365   2.328  ns/op
ScopedValues.bind_ThreadLocal                         avgt   10  908.319   9.238  ns/op
ScopedValues.counter_ScopedValue                      avgt   10   35.438   0.470  ns/op
ScopedValues.counter_ThreadLocal                      avgt   10   43.705   0.435  ns/op
ScopedValues.setNoRemove_ScopedValue                  avgt   10   39.848   0.638  ns/op
ScopedValues.setNoRemove_ThreadLocal                  avgt   10   47.336  11.987  ns/op
ScopedValues.sixValues_ScopedValue                    avgt   10    2.847   0.008  us/op
ScopedValues.sixValues_ThreadLocal                    avgt   10    9.066   0.017  us/op
ScopedValues.thousandAdds_ScopedValue                 avgt   10    0.160   0.005  us/op
ScopedValues.thousandAdds_ThreadLocal                 avgt   10    9.651   0.020  us/op
ScopedValues.thousandIsBoundQueries                   avgt   10   31.145   0.512  ns/op
ScopedValues.thousandMaybeGets                        avgt   10  160.829   6.699  ns/op
```

[1] [JDK-8286666](https://bugs.openjdk.org/browse/JDK-8286666), https://github.com/openjdk/jdk/commit/221e1a426070088b819ddc37b7ca77d9d8626eb4#diff-018aa61d1a7aafcf70a535fcd40a318a4bd6511fd40ac39ce4be90cc52216749R3635

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318157](https://bugs.openjdk.org/browse/JDK-8318157): RISC-V: implement ensureMaterializedForStackWalk intrinsic (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16808/head:pull/16808` \
`$ git checkout pull/16808`

Update a local copy of the PR: \
`$ git checkout pull/16808` \
`$ git pull https://git.openjdk.org/jdk.git pull/16808/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16808`

View PR using the GUI difftool: \
`$ git pr show -t 16808`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16808.diff">https://git.openjdk.org/jdk/pull/16808.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16808#issuecomment-1828083067)