### PR TITLE
8320707: Change virtual thread tests for pinning to use a native frame

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/JfrEvents.java
+++ b/test/jdk/java/lang/Thread/virtual/JfrEvents.java
@@ -26,12 +26,12 @@
  * @summary Basic test for JFR jdk.VirtualThreadXXX events
  * @requires vm.continuations
  * @modules jdk.jfr java.base/java.lang:+open
- * @run junit/othervm JfrEvents
+ * @library /test/lib
+ * @run junit/othervm --enable-native-access=ALL-UNNAMED JfrEvents
  */
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -39,20 +39,27 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jdk.jfr.EventType;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingFile;
 
+import jdk.test.lib.thread.VThreadPinner;
+import jdk.test.lib.thread.VThreadPinner.ThrowingAction;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.*;
 
 class JfrEvents {
-    private static final Object lock = new Object();
 
     /**
      * Test jdk.VirtualThreadStart and jdk.VirtualThreadEnd events.
@@ -86,44 +93,89 @@ class JfrEvents {
     }
 
     /**
+     * Arguments for testVirtualThreadPinned to test jdk.VirtualThreadPinned event.
+     *   [0] label/description
+     *   [1] the operation to park/wait
+     *   [2] the Thread.State when parked/waiting
+     *   [3] the action to unpark/notify the thread
+     */
+    static Stream<Arguments> pinnedCases() {
+        Object lock = new Object();
+
+        // park with native frame on stack
+        var finish1 = new AtomicBoolean();
+        var parkWhenPinned = Arguments.of(
+            "LockSupport.park when pinned",
+            (ThrowingAction) () -> {
+                VThreadPinner.runPinned(() -> {
+                    while (!finish1.get()) {
+                        LockSupport.park();
+                    }
+                });
+            },
+            Thread.State.WAITING,
+                (Consumer<Thread>) t -> {
+                    finish1.set(true);
+                    LockSupport.unpark(t);
+                }
+        );
+
+        // timed park with native frame on stack
+        var finish2 = new AtomicBoolean();
+        var timedParkWhenPinned = Arguments.of(
+            "LockSupport.parkNanos when pinned",
+            (ThrowingAction) () -> {
+                VThreadPinner.runPinned(() -> {
+                    while (!finish2.get()) {
+                        LockSupport.parkNanos(Long.MAX_VALUE);
+                    }
+                });
+            },
+            Thread.State.TIMED_WAITING,
+            (Consumer<Thread>) t -> {
+                finish2.set(true);
+                LockSupport.unpark(t);
+            }
+        );
+
+        return Stream.of(parkWhenPinned, timedParkWhenPinned);
+    }
+
+    /**
      * Test jdk.VirtualThreadPinned event.
      */
-    @Test
-    void testVirtualThreadPinned() throws Exception {
-        Runnable[] parkers = new Runnable[] {
-            () -> LockSupport.park(),
-            () -> LockSupport.parkNanos(Duration.ofDays(1).toNanos())
-        };
+    @ParameterizedTest
+    @MethodSource("pinnedCases")
+    void testVirtualThreadPinned(String label,
+                                 ThrowingAction<Exception> parker,
+                                 Thread.State expectedState,
+                                 Consumer<Thread> unparker) throws Exception {
 
         try (Recording recording = new Recording()) {
             recording.enable("jdk.VirtualThreadPinned");
 
             recording.start();
-            try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-                for (Runnable parker : parkers) {
-                    // execute parking task in virtual thread
-                    var threadRef = new AtomicReference<Thread>();
-                    executor.submit(() -> {
-                        threadRef.set(Thread.currentThread());
-                        synchronized (lock) {
-                            parker.run();   // should pin carrier
-                        }
-                    });
-
-                    // wait for the task to start and the virtual thread to park
-                    Thread thread;
-                    while ((thread = threadRef.get()) == null) {
-                        Thread.sleep(10);
-                    }
+            try {
+                var exception = new AtomicReference<Throwable>();
+                var thread = Thread.ofVirtual().start(() -> {
                     try {
-                        Thread.State state = thread.getState();
-                        while (state != Thread.State.WAITING && state != Thread.State.TIMED_WAITING) {
-                            Thread.sleep(10);
-                            state = thread.getState();
-                        }
-                    } finally {
-                        LockSupport.unpark(thread);
+                        parker.run();
+                    } catch (Throwable e) {
+                        exception.set(e);
                     }
+                });
+                try {
+                    // wait for thread to park/wait
+                    Thread.State state = thread.getState();
+                    while (state != expectedState) {
+                        assertTrue(state != Thread.State.TERMINATED, thread.toString());
+                        Thread.sleep(10);
+                        state = thread.getState();
+                    }
+                } finally {
+                    unparker.accept(thread);
+                    thread.join();
+                    assertNull(exception.get());
                 }
             } finally {
                 recording.stop();
@@ -132,9 +184,9 @@ class JfrEvents {
             Map<String, Integer> events = sumEvents(recording);
             System.err.println(events);
 
-            // should have a pinned event for each park
+            // should have at least one pinned event
             int pinnedCount = events.getOrDefault("jdk.VirtualThreadPinned", 0);
-            assertEquals(parkers.length, pinnedCount);
+            assertTrue(pinnedCount >= 1, "Expected one or more events");
         }
     }
 

--- a/test/jdk/java/lang/Thread/virtual/stress/PinALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/PinALot.java
@@ -25,13 +25,15 @@
  * @test
  * @summary Stress test timed park when pinned
  * @requires vm.debug != true
- * @run main PinALot 500000
+ * @library /test/lib
+ * @run main/othervm --enable-native-access=ALL-UNNAMED PinALot 500000
  */
 
 /*
  * @test
  * @requires vm.debug == true
- * @run main/othervm/timeout=300 PinALot 200000
+ * @library /test/lib
+ * @run main/othervm/timeout=300 --enable-native-access=ALL-UNNAMED PinALot 200000
  */
 
 import java.time.Duration;
@@ -39,9 +41,9 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
-public class PinALot {
+import jdk.test.lib.thread.VThreadPinner;
 
-    static final Object lock = new Object();
+public class PinALot {
 
     public static void main(String[] args) throws Exception {
         int iterations = 1_000_000;
@@ -53,11 +55,11 @@ public class PinALot {
         AtomicInteger count = new AtomicInteger();
 
         Thread thread = Thread.ofVirtual().start(() -> {
-            synchronized (lock) {
+            VThreadPinner.runPinned(() -> {
                 while (count.incrementAndGet() < ITERATIONS) {
                     LockSupport.parkNanos(1);
                 }
-            }
+            });
         });
 
         boolean terminated;

--- a/test/lib/jdk/test/lib/thread/VThreadPinner.java
+++ b/test/lib/jdk/test/lib/thread/VThreadPinner.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.thread;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+
+import java.lang.invoke.*;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Helper class to allow tests run an action in a virtual thread while pinning its carrier.
+ *
+ * It defines the {@code runPinned} method to run an action with a native frame on the stack.
+ */
+public class VThreadPinner {
+    private static final Path JAVA_LIBRARY_PATH = Path.of(System.getProperty("java.library.path"));
+    private static final Path LIB_PATH = JAVA_LIBRARY_PATH.resolve(System.mapLibraryName("VThreadPinner"));
+
+    // method handle to call the native function
+    private static final MethodHandle INVOKER = invoker();
+
+    // function pointer to call
+    private static final MemorySegment UPCALL_STUB = upcallStub();
+
+    /**
+     * Thread local with the action to run.
+     */
+    private static final ThreadLocal<ActionRunner> ACTION_RUNNER = new ThreadLocal<>();
+
+    /**
+     * Runs an action, capturing any exception or error thrown.
+     */
+    private static class ActionRunner implements Runnable {
+        private final ThrowingAction<?> action;
+        private Throwable throwable;
+
+        ActionRunner(ThrowingAction<?> action) {
+            this.action = action;
+        }
+
+        @Override
+        public void run() {
+            try {
+                action.run();
+            } catch (Throwable ex) {
+                throwable = ex;
+            }
+        }
+
+        Throwable exception() {
+            return throwable;
+        }
+    }
+
+    /**
+     * Called by the native function to run the action stashed in the thread local. The
+     * action runs with the native frame on the stack.
+     */
+    private static void callback() {
+        ACTION_RUNNER.get().run();
+    }
+
+    /**
+     * A function to run from a virtual thread pinned to its carrier.
+     */
+    @FunctionalInterface
+    public interface ThrowingAction<X extends Throwable> {
+        void run() throws X;
+    }
+
+    /**
+     * Runs the given action on virtual thread pinned to its carrier.
+     */
+    public static <X extends Throwable> void runPinned(ThrowingAction<X> action) throws X {
+        if (!Thread.currentThread().isVirtual()) {
+            throw new IllegalCallerException("Not a virtual thread");
+        }
+        var runner = new ActionRunner(action);
+        ACTION_RUNNER.set(runner);
+        try {
+            INVOKER.invoke(UPCALL_STUB);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        } finally {
+            ACTION_RUNNER.remove();
+        }
+        Throwable ex = runner.exception();
+        if (ex != null) {
+            if (ex instanceof RuntimeException e)
+                throw e;
+            if (ex instanceof Error e)
+                throw e;
+            throw (X) ex;
+        }
+    }
+
+    /**
+     * Returns a method handle to the native function void call(void *(*f)(void *)).
+     */
+    private static MethodHandle invoker() {
+        Linker abi = Linker.nativeLinker();
+        try {
+            SymbolLookup lib = SymbolLookup.libraryLookup(LIB_PATH, Arena.global());
+            MemorySegment symbol = lib.find("call").orElseThrow();
+            FunctionDescriptor desc = FunctionDescriptor.ofVoid(ValueLayout.ADDRESS);
+            return abi.downcallHandle(symbol, desc);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Returns an upcall stub to use as a function pointer to invoke the callback method.
+     */
+    private static MemorySegment upcallStub() {
+        Linker abi = Linker.nativeLinker();
+        try {
+            MethodHandle callback = MethodHandles.lookup()
+                    .findStatic(VThreadPinner.class, "callback", MethodType.methodType(void.class));
+            return abi.upcallStub(callback, FunctionDescriptor.ofVoid(), Arena.global());
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/thread/VThreadRunner.java
+++ b/test/lib/jdk/test/lib/thread/VThreadRunner.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Helper class to support tests running tasks a in virtual thread.
+ * Helper class to support tests running tasks in a virtual thread.
  */
 public class VThreadRunner {
     private VThreadRunner() { }

--- a/test/lib/jdk/test/lib/thread/libVThreadPinner.c
+++ b/test/lib/jdk/test/lib/thread/libVThreadPinner.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <stdio.h>
+
+#ifdef _WIN64
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+/*
+ * Call a function with the given function pointer.
+ */
+EXPORT void call(void *(*f)(void)) {
+    (*f)();
+}


### PR DESCRIPTION
TBD

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320707](https://bugs.openjdk.org/browse/JDK-8320707): Change virtual thread tests for pinning to use a native frame (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16811/head:pull/16811` \
`$ git checkout pull/16811`

Update a local copy of the PR: \
`$ git checkout pull/16811` \
`$ git pull https://git.openjdk.org/jdk.git pull/16811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16811`

View PR using the GUI difftool: \
`$ git pr show -t 16811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16811.diff">https://git.openjdk.org/jdk/pull/16811.diff</a>

</details>
