### PR TITLE
8320710: Adjust heap size when close to compressed oops limit

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1479,12 +1479,14 @@ void Arguments::set_use_compressed_oops() {
   // the only value that can override MaxHeapSize if we are
   // to use UseCompressedOops are InitialHeapSize and MinHeapSize.
   size_t max_heap_size = MAX3(MaxHeapSize, InitialHeapSize, MinHeapSize);
+  bool isExplicitlyDisabled = !FLAG_IS_DEFAULT(UseCompressedOops) && !UseCompressedOops;
 
   double ratio = max_heap_size / (double) max_heap_for_compressed_oops();
-  if (ratio > 1 && ratio < 1.02) {
+  if (!isExplicitlyDisabled && ratio > 1 && ratio < 1.02) {
     // User set max heap within 2% of the compressed oops limit. Assume they intended or at least
     // would benefit from a small reduction to allow enabling compressed oops. This is easily done by
     // accident, for example setting -Xmx32G is a tiny amount over the limit.
+    // TODO: print human readable size
     warning("Heap size lowered from %lu to %lu to accommodate Compressed Oops", max_heap_size, max_heap_for_compressed_oops());
     max_heap_size = max_heap_for_compressed_oops();
     if (!FLAG_IS_DEFAULT(MaxHeapSize) && MaxHeapSize > max_heap_size) {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1488,7 +1488,7 @@ void Arguments::set_use_compressed_oops() {
     // would benefit from a small reduction to allow enabling compressed oops. This is easily done by
     // accident, for example setting -Xmx32G is a tiny amount over the limit.
     // TODO: print human readable size
-    warning("Heap size lowered from " SIZE_FORMAT "%s to " SIZE_FORMAT "%s to accommodate Compressed Oops", 
+    warning("Heap size lowered from " SIZE_FORMAT "%s to " SIZE_FORMAT "%s to accommodate Compressed Oops",
             byte_size_in_exact_unit(max_heap_size), exact_unit_for_byte_size (max_heap_size),
             byte_size_in_exact_unit(max_for_compressed_oops), exact_unit_for_byte_size (max_for_compressed_oops));
     max_heap_size = max_for_compressed_oops;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1479,16 +1479,19 @@ void Arguments::set_use_compressed_oops() {
   // the only value that can override MaxHeapSize if we are
   // to use UseCompressedOops are InitialHeapSize and MinHeapSize.
   size_t max_heap_size = MAX3(MaxHeapSize, InitialHeapSize, MinHeapSize);
+  size_t max_for_compressed_oops = max_heap_for_compressed_oops();
   bool isExplicitlyDisabled = !FLAG_IS_DEFAULT(UseCompressedOops) && !UseCompressedOops;
 
-  double ratio = max_heap_size / (double) max_heap_for_compressed_oops();
+  double ratio = max_heap_size / (double) max_for_compressed_oops;
   if (!isExplicitlyDisabled && ratio > 1 && ratio < 1.02) {
     // User set max heap within 2% of the compressed oops limit. Assume they intended or at least
     // would benefit from a small reduction to allow enabling compressed oops. This is easily done by
     // accident, for example setting -Xmx32G is a tiny amount over the limit.
     // TODO: print human readable size
-    warning("Heap size lowered from %lu to %lu to accommodate Compressed Oops", max_heap_size, max_heap_for_compressed_oops());
-    max_heap_size = max_heap_for_compressed_oops();
+    warning("Heap size lowered from " SIZE_FORMAT "%s to " SIZE_FORMAT "%s to accommodate Compressed Oops", 
+            byte_size_in_exact_unit(max_heap_size), exact_unit_for_byte_size (max_heap_size),
+            byte_size_in_exact_unit(max_for_compressed_oops), exact_unit_for_byte_size (max_for_compressed_oops));
+    max_heap_size = max_for_compressed_oops;
     if (!FLAG_IS_DEFAULT(MaxHeapSize) && MaxHeapSize > max_heap_size) {
       FLAG_SET_ERGO(MaxHeapSize, max_heap_size);
     }
@@ -1500,7 +1503,7 @@ void Arguments::set_use_compressed_oops() {
     }
   }
 
-  if (max_heap_size <= max_heap_for_compressed_oops()) {
+  if (max_heap_size <= max_for_compressed_oops) {
     if (FLAG_IS_DEFAULT(UseCompressedOops)) {
       FLAG_SET_ERGO(UseCompressedOops, true);
     }

--- a/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestUseCompressedOopsErgoTools.java
@@ -111,19 +111,25 @@ class TestUseCompressedOopsErgoTools {
 
     checkUseCompressedOops(gcflags, maxHeapForCompressedOops, true);
     checkUseCompressedOops(gcflags, maxHeapForCompressedOops - 1, true);
-    checkUseCompressedOops(gcflags, maxHeapForCompressedOops + 1, false);
+    checkUseCompressedOops(gcflags, maxHeapForCompressedOops + 1, true);
+    checkUseCompressedOops(gcflags, (long) (maxHeapForCompressedOops * 1.02), true);
+    checkUseCompressedOops(gcflags, (long) (maxHeapForCompressedOops * 1.02) + 1, false);
 
     // the use of HeapBaseMinAddress should not change the outcome
     checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), maxHeapForCompressedOops, true);
     checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), maxHeapForCompressedOops - 1, true);
-    checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), maxHeapForCompressedOops + 1, false);
+    checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), maxHeapForCompressedOops + 1, true);
+    checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), (long) (maxHeapForCompressedOops * 1.02), true);
+    checkUseCompressedOops(join(gcflags, "-XX:HeapBaseMinAddress=32G"), (long) (maxHeapForCompressedOops * 1.02) + 1, false);
 
     // use a different object alignment
     maxHeapForCompressedOops = getMaxHeapForCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"));
 
     checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), maxHeapForCompressedOops, true);
     checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), maxHeapForCompressedOops - 1, true);
-    checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), maxHeapForCompressedOops + 1, false);
+    checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), maxHeapForCompressedOops + 1, true);
+    checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), (long) (maxHeapForCompressedOops * 1.02), true);
+    checkUseCompressedOops(join(gcflags, "-XX:ObjectAlignmentInBytes=16"), (long) (maxHeapForCompressedOops * 1.02) + 1, false);
 
     // use a different CompressedClassSpaceSize
     String compressedClassSpaceSizeArg = "-XX:CompressedClassSpaceSize=" + 2 * getCompressedClassSpaceSize();
@@ -131,7 +137,9 @@ class TestUseCompressedOopsErgoTools {
 
     checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), maxHeapForCompressedOops, true);
     checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), maxHeapForCompressedOops - 1, true);
-    checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), maxHeapForCompressedOops + 1, false);
+    checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), maxHeapForCompressedOops + 1, true);
+    checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), (long) (maxHeapForCompressedOops * 1.02), true);
+    checkUseCompressedOops(join(gcflags, compressedClassSpaceSizeArg), (long) (maxHeapForCompressedOops * 1.02) + 1, false);
   }
 
   private static void checkUseCompressedOops(String[] args, long heapsize, boolean expectUseCompressedOops) throws Exception {


### PR DESCRIPTION
When the heap is between 0 and 2% larger than the compressed oops limit, lower it enough to enable compressed oops. See [issue](https://bugs.openjdk.org/browse/JDK-8320710) for more details.

This is just one way of doing it to show the idea, any other ideas welcome.

Before:
```
java -Xmx32G -XX:+UseCompressedOops -version
OpenJDK 64-Bit Server VM warning: Max heap size too large for Compressed Oops
```
After:
```
java -Xmx32G -XX:+UseCompressedOops -version
OpenJDK 64-Bit Server VM warning: Heap size lowered from 32G to 32256M to accommodate Compressed Oops
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320710](https://bugs.openjdk.org/browse/JDK-8320710): Adjust heap size when close to compressed oops limit (**Enhancement** - P4)


### Reviewers
 * @huy164 (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16813/head:pull/16813` \
`$ git checkout pull/16813`

Update a local copy of the PR: \
`$ git checkout pull/16813` \
`$ git pull https://git.openjdk.org/jdk.git pull/16813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16813`

View PR using the GUI difftool: \
`$ git pr show -t 16813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16813.diff">https://git.openjdk.org/jdk/pull/16813.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16813#issuecomment-1825950282)