### PR TITLE
8316234: AArch64: fastdebug build failure with GCC 12 and 13 due to -Wnonnull warning in vm_version_linux_aarch64.cpp

### DIFF
--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -181,7 +181,9 @@ void VM_Version::get_os_cpu_info() {
 }
 
 static bool read_fully(const char *fname, char *buf, size_t buflen) {
-  assert(buf != nullptr && buflen >= 1, "invalid arguments");
+  assert(buf != nullptr && buflen >= 1,
+         "invalid arguments: buf = " INTPTR_FORMAT ", buflen = " SIZE_FORMAT,
+         p2i(buf), buflen);
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
     ssize_t read_sz = ::read(fd, buf, buflen);

--- a/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
+++ b/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
@@ -181,8 +181,7 @@ void VM_Version::get_os_cpu_info() {
 }
 
 static bool read_fully(const char *fname, char *buf, size_t buflen) {
-  assert(buf != nullptr, "invalid argument");
-  assert(buflen >= 1, "invalid argument");
+  assert(buf != nullptr && buflen >= 1, "invalid arguments");
   int fd = os::open(fname, O_RDONLY, 0);
   if (fd != -1) {
     ssize_t read_sz = ::read(fd, buf, buflen);


### PR DESCRIPTION
I tested {release, fastdebug, slowdebug} JDK builds with GCC 11/12/13 on AArch64, and fastdebug build with GCC 12 and 13 failed due to -Wnonnull warning.

The warning is raised because GCC 12 and 13 still think that `buf` can be null even if we have the assertion `assert(buf != nullptr, ...);`. Note that GCC 12 and 13 correctly determine the value range of `buflen`, i.e. `1 <= buflen <= 0xffff ffff ffff ffff`.

Note-1: Since it involves the analysis of `assert` statements, that's why release build can pass.

Note-2: I suppose that the incorrect optimization result of `nonnull/nullability` for variable `buf` only occurs at high GCC optimization levels. That's why slowdebug build can pass.

Note-3: To be honest, I didn't fully understand why this warning is raised by GCC 12 and 13. Recently we struggled with GCC 12 false positive warnings many times. See [1][2].

To suppress this warning, we try to fool GCC compiler via minor code change in this patch.

[1] https://bugs.openjdk.org/browse/JDK-8299580
[2] https://bugs.openjdk.org/browse/JDK-8294031

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316234](https://bugs.openjdk.org/browse/JDK-8316234): AArch64: fastdebug build failure with GCC 12 and 13 due to -Wnonnull warning in vm_version_linux_aarch64.cpp (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16819/head:pull/16819` \
`$ git checkout pull/16819`

Update a local copy of the PR: \
`$ git checkout pull/16819` \
`$ git pull https://git.openjdk.org/jdk.git pull/16819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16819`

View PR using the GUI difftool: \
`$ git pr show -t 16819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16819.diff">https://git.openjdk.org/jdk/pull/16819.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16819#issuecomment-1827079497)