### PR TITLE
Improved the JavaDocs of the equals method

### DIFF
--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -121,9 +121,9 @@ public class Object {
      * override the default implementation, together with a compatible 
      * {@link #hashCode() hashCode} method.
      * <p>
-     * Note, that as overriding this method affects the behaviour in commonly
-     * used collection classes and for a correct behaviour requires you to 
-     * also override also the {@link #hashCode() hashCode} method, it can be
+     * Note, that as overriding this method affects how objects behave in the
+     * commonly used collection classes and correct behavior requires you to 
+     * override also the {@link #hashCode() hashCode} method, it can be
      * easier to define logical equality checks to some other way in your 
      * application. 
      * <p>

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -108,9 +108,9 @@ public class Object {
 
     /**
      * Indicates whether another object instance should be considered "equal
-     * to" this one, by libraries such as the 
-     * {@link java.util Java Collections Framework}. This method is used for 
-     * example by most implementations of 
+     * to" this one. Several libraries libraries like the 
+     * {@link java.util Java Collections Framework}, depend on this method. 
+     * This method is used for example by most implementations of 
      * {@link java.util.Collection#contains(Object)} and 
      * {@link java.util.Map#containsKey(Object)}. Overriding this method does
      * not affect the '==' operator.
@@ -124,8 +124,8 @@ public class Object {
      * Note, that as overriding this method affects how objects behave in the
      * commonly used collection classes and correct behavior requires you to 
      * override also the {@link #hashCode() hashCode} method, it can be
-     * easier to define logical equality checks to some other way in your 
-     * application. 
+     * easier to define logical equality checks in some other way in your 
+     * application code.
      * <p>
      * The {@code equals} method implements an equivalence relation
      * on non-null object references:

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -107,7 +107,25 @@ public class Object {
     public native int hashCode();
 
     /**
-     * Indicates whether some other object is "equal to" this one.
+     * Indicates whether another object instance should be considered "equal
+     * to" this one, by libraries such as the 
+     * {@link java.util Java Collections Framework}. This method is used for 
+     * example by most implementations of 
+     * {@link java.util.Collection#contains(Object)} and 
+     * {@link java.util.Map#containsKey(Object)}. Overriding this method does
+     * not affect the '==' operator.
+     * <p>
+     * The default implementation only makes a reference comparison. If you
+     * want for example two instances representing the same logical entity 
+     * to be considered equal in a {@link java.util.HashSet}, you must
+     * override the default implementation, together with a compatible 
+     * {@link #hashCode() hashCode} method.
+     * <p>
+     * Note, that as overriding this method affects the behaviour in commonly
+     * used collection classes and for a correct behaviour requires you to 
+     * also override also the {@link #hashCode() hashCode} method, it can be
+     * easier to define logical equality checks to some other way in your 
+     * application. 
      * <p>
      * The {@code equals} method implements an equivalence relation
      * on non-null object references:


### PR DESCRIPTION
During my almost two decades working with Vaadin, I have seen dozens of Java developers failing with our product because they don't understand how the collections framework is connected to the Object.equals/hashCode method. The JavaDoc of especially the equals mehtod is very concise. I believe making JavaDocs bit more verbose for Object.equals(Object) method would help some new (and even some more experienced) developers to succeed with Java.

Opening as draft PR to start discussion as I didn't yet create an issue or didn't check if I have contributor agreement signed or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16822/head:pull/16822` \
`$ git checkout pull/16822`

Update a local copy of the PR: \
`$ git checkout pull/16822` \
`$ git pull https://git.openjdk.org/jdk.git pull/16822/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16822`

View PR using the GUI difftool: \
`$ git pr show -t 16822`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16822.diff">https://git.openjdk.org/jdk/pull/16822.diff</a>

</details>
