### PR TITLE
8320750: Allow a testcase to run with multiple -Xlog

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -726,7 +726,7 @@ public class VMProps implements Callable<Map<String, String>> {
        and a value part ("true" if no value was given)
      */
     public static Flag parseXFlag(String xflag) {
-        Matcher m = Pattern.compile("-([a-zA-Z]+)(.*)").matcher(xflag);
+        Matcher m = Pattern.compile("-([a-zA-Z/]+)(.*)").matcher(xflag);
         if (!m.matches()) {
             throw new RuntimeException("Could not parse flag: " + xflag);
         }

--- a/test/lib-test/jtreg-ext/requires/VMPropsTest.java
+++ b/test/lib-test/jtreg-ext/requires/VMPropsTest.java
@@ -35,9 +35,10 @@
  * @summary testing parsing of -Xflags
  */
 
-import static jdk.test.lib.Asserts.assertTrue;
-import static jdk.test.lib.Asserts.assertEQ;
+import java.util.Map;
 import requires.VMProps;
+import static jdk.test.lib.Asserts.assertEQ;
+import static jdk.test.lib.Asserts.assertTrue;
 
 /**
  * This tests parsing of -Xflags.
@@ -52,9 +53,14 @@ public class VMPropsTest {
         assertEQ(VMProps.parseXFlag("-name4g").value(), "4g");
         assertEQ(VMProps.parseXFlag("-name43g").name(), "name");
         assertEQ(VMProps.parseXFlag("-name43g").value(), "43g");
+        assertEQ(VMProps.parseXFlag("-Xbootclasspath/a:path").name(), "Xbootclasspath/a");
+        assertEQ(VMProps.parseXFlag("-Xbootclasspath/a:path").value(), "path");
 
         // Make sure that we handle several flags that are equal
         System.setProperty("test.java.opts", "-Xlog:gc* -Xlog:gc*");
-        VMProps.xFlags();
+        Map<String, String> xFlagsMap = VMProps.xFlags();
+
+        // check special handling of -Xlog
+        assertEQ(xFlagsMap.get("vm.opt.x.Xlog"), "NONEMPTY_TEST_SENTINEL");
     }
 }

--- a/test/lib-test/jtreg-ext/requires/VMPropsTest.java
+++ b/test/lib-test/jtreg-ext/requires/VMPropsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test VMPropsTest
+ * @bug 8320750
+ * @library /test/lib
+ * @library /test/jtreg-ext
+ * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.foreign
+ *          java.management/sun.management
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI VMPropsTest
+ * @summary testing parsing of -Xflags
+ */
+
+import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.Asserts.assertEQ;
+import requires.VMProps;
+
+/**
+ * This tests parsing of -Xflags.
+ */
+public class VMPropsTest {
+    public static void main(String[] args) {
+        assertEQ(VMProps.parseXFlag("-name").name(), "name");
+        assertEQ(VMProps.parseXFlag("-name").value(), "true");
+        assertEQ(VMProps.parseXFlag("-name:value").name(), "name");
+        assertEQ(VMProps.parseXFlag("-name:value").value(), "value");
+        assertEQ(VMProps.parseXFlag("-name4g").name(), "name");
+        assertEQ(VMProps.parseXFlag("-name4g").value(), "4g");
+        assertEQ(VMProps.parseXFlag("-name43g").name(), "name");
+        assertEQ(VMProps.parseXFlag("-name43g").value(), "43g");
+
+        // Make sure that we handle several flags that are equal
+        System.setProperty("test.java.opts", "-Xlog:gc* -Xlog:gc*");
+        VMProps.xFlags();
+    }
+}


### PR DESCRIPTION
Running a testcase with muliple -Xlog crashes JTREG test cases. This is because `Collector.toMap` is not given a merge strategy.

When the same argument is passed multiple times, I have added a merge strategy to use the latter value. This is similar to how it is implemented for `vm.opt.*` in JTREG.

If the flag tested is `-Xlog`, replace the value part with a dummy value "NONEMPTY_TEST_SENTINEL". This is because in the case of multiple `-Xlog` all values are used, and JTREG does not give a satisfactory way to represent them. This dummy value should make it hard to try to `@require` on specific values by mistake.

Tested with:
```
 @requires vm.opt.x.Xlog == "NONEMPTY_TEST_SENTINEL"
 @requires vm.opt.x.Xlog == "NONEMPTY_TEST_SENTINELXXX"
 @requires vm.opt.x.Xms == "3g"

and

JAVA_OPTIONS=-Xms3g -Xms4g
JAVA_OPTIONS=-Xms4g -Xms3g
JAVA_OPTIONS=-Xlog:gc* -Xlog:gc*
``` 

Running tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with updated jcheck configuration in pull request)

### Issue
 * [JDK-8320750](https://bugs.openjdk.org/browse/JDK-8320750): Allow a testcase to run with multiple -Xlog (**Bug** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [d129a0fb](https://git.openjdk.org/jdk/pull/16824/files/d129a0fbd79ad6dce97607cfd6d977baa1e2a934)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16824/head:pull/16824` \
`$ git checkout pull/16824`

Update a local copy of the PR: \
`$ git checkout pull/16824` \
`$ git pull https://git.openjdk.org/jdk.git pull/16824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16824`

View PR using the GUI difftool: \
`$ git pr show -t 16824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16824.diff">https://git.openjdk.org/jdk/pull/16824.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16824#issuecomment-1829927334)