### PR TITLE
8320781: Fix whitespace in j.l.Double and j.u.z.ZipInputStream @snippets

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -316,7 +316,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *
  * {@snippet lang="java" :
  * double d = 0.0;
- * while(d != 1.0) { // Surprising infinite loop
+ * while (d != 1.0) { // Surprising infinite loop
  *   d += 0.1; // Sum never _exactly_ equals 1.0
  * }
  * }
@@ -325,7 +325,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *
  * {@snippet lang="java" :
  * double d = 0.0;
- * for(int i = 0; i < 10; i++) {
+ * for (int i = 0; i < 10; i++) {
  *   d += 0.1;
  * } // Value of d is equal to Math.nextDown(1.0).
  * }
@@ -335,7 +335,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  *
  * {@snippet lang="java" :
  *  double d = 0.0;
- *  while(d <= 1.0) {
+ *  while (d <= 1.0) {
  *    d += 0.1;
  *  } // Value of d approximately 1.0999999999999999
  *  }

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -51,12 +51,12 @@ import static java.util.zip.ZipUtils.*;
  * {@code ZipInputStream} read methods such
  * as {@link #read(byte[], int, int) read} or {@link #readAllBytes() readAllBytes()}.
  * For example:
- *    {@snippet :
+ *    {@snippet lang="java" :
  *      Path jar = Path.of("foo.jar");
  *      try (InputStream is = Files.newInputStream(jar);
  *           ZipInputStream zis = new ZipInputStream(is)) {
  *          ZipEntry ze;
- *          while((ze= zis.getNextEntry()) != null) {
+ *          while ((ze = zis.getNextEntry()) != null) {
  *             var bytes = zis.readAllBytes();
  *             System.out.printf("Entry: %s, bytes read: %s%n", ze.getName(),
  *                     bytes.length);


### PR DESCRIPTION
Please review this trivial, formatting and documentation-only change which adds missing whitespace around a few `if` statements, `while` statements and assigments in `@snippet` code in `j.l.Double` and `j.u.z.ZipInputStream`.

While there are many similar issues in the OpenJDK code base, these were the only instances found in `@snippet` code in the API of `java.base`, so it could be worthwhile fixing. 

While updating the snippet in `ZipInputStream`, I took the liberty to also add `lang = "java"` since this seems more commonly included around the code base.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320781](https://bugs.openjdk.org/browse/JDK-8320781): Fix whitespace in j.l.Double and j.u.z.ZipInputStream @<!---->snippets (**Enhancement** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16827/head:pull/16827` \
`$ git checkout pull/16827`

Update a local copy of the PR: \
`$ git checkout pull/16827` \
`$ git pull https://git.openjdk.org/jdk.git pull/16827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16827`

View PR using the GUI difftool: \
`$ git pr show -t 16827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16827.diff">https://git.openjdk.org/jdk/pull/16827.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16827#issuecomment-1828169827)