### PR TITLE
8320602: Lock contention in SchemaDVFactory.getInstance()

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/SchemaDVFactory.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/SchemaDVFactory.java
@@ -53,7 +53,7 @@ public abstract class SchemaDVFactory {
      * @exception DVFactoryException  cannot create an instance of the specified
      *                                class name or the default class name
      */
-    public static synchronized final SchemaDVFactory getInstance() throws DVFactoryException {
+    public static final SchemaDVFactory getInstance() throws DVFactoryException {
         return getInstance(DEFAULT_FACTORY_CLASS);
     } //getInstance():  SchemaDVFactory
 
@@ -66,7 +66,7 @@ public abstract class SchemaDVFactory {
      * @exception DVFactoryException  cannot create an instance of the specified
      *                                class name or the default class name
      */
-    public static synchronized final SchemaDVFactory getInstance(String factoryClass) throws DVFactoryException {
+    public static final SchemaDVFactory getInstance(String factoryClass) throws DVFactoryException {
 
         try {
             // if the class name is not specified, use the default one
@@ -78,7 +78,7 @@ public abstract class SchemaDVFactory {
     }
 
     // can't create a new object of this class
-    protected SchemaDVFactory(){}
+    protected SchemaDVFactory() {}
 
     /**
      * Get a built-in simple type of the given name


### PR DESCRIPTION
Applying an update from the upstream source, quote: "Removing synchronized from the getInstance() methods". As the reporter noted, this change was made 16 years ago.

Tests: SQE & unit tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320602](https://bugs.openjdk.org/browse/JDK-8320602): Lock contention in SchemaDVFactory.getInstance() (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16829/head:pull/16829` \
`$ git checkout pull/16829`

Update a local copy of the PR: \
`$ git checkout pull/16829` \
`$ git pull https://git.openjdk.org/jdk.git pull/16829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16829`

View PR using the GUI difftool: \
`$ git pr show -t 16829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16829.diff">https://git.openjdk.org/jdk/pull/16829.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16829#issuecomment-1828303801)