### PR TITLE
JDK-8320714: java/util/Locale/LocaleProvidersRun.java and java/util/ResourceBundle/modules/visibility/VisibilityTest.java timeout after passing

### DIFF
--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -28,6 +28,7 @@
  *      8150432 8215913 8220227 8228465 8232871 8232860 8236495 8245241
  *      8246721 8248695 8257964 8261919
  * @summary tests for "java.locale.providers" system property
+ * @requires vm.flagless
  * @library /test/lib
  * @build LocaleProviders
  *        providersrc.spi.src.tznp
@@ -180,7 +181,7 @@ public class LocaleProvidersRun {
             String param1, String param2, String param3) throws Throwable {
 
         // Build process (with VM flags)
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-ea", "-esa",
                 "-cp", Utils.TEST_CLASS_PATH,
                 "-Djava.util.logging.config.class=LocaleProviders$LogConfig",

--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -180,7 +180,7 @@ public class LocaleProvidersRun {
     private static void testRun(String prefList, String methodName,
             String param1, String param2, String param3) throws Throwable {
 
-        // Build process (with VM flags)
+        // Build process (without VM flags)
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 "-ea", "-esa",
                 "-cp", Utils.TEST_CLASS_PATH,

--- a/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
@@ -26,6 +26,7 @@
  * @bug 8137317 8139238 8210408
  * @summary Visibility tests for ResourceBundle.getBundle with and without
  *          an unnamed module argument.
+ * @requires vm.flagless
  * @library /test/lib
  *          ..
  * @build jdk.test.lib.JDKToolLauncher
@@ -331,7 +332,7 @@ public class VisibilityTest {
 
     private int runCmd(List<String> argsList) throws Throwable {
         // Build process (with VM flags)
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 Stream.concat(Stream.of("-ea", "-esa"), argsList.stream()).toList());
         // Evaluate process status
         return ProcessTools.executeCommand(pb).getExitValue();

--- a/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
+++ b/test/jdk/java/util/ResourceBundle/modules/visibility/VisibilityTest.java
@@ -331,7 +331,7 @@ public class VisibilityTest {
     }
 
     private int runCmd(List<String> argsList) throws Throwable {
-        // Build process (with VM flags)
+        // Build process (without VM flags)
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                 Stream.concat(Stream.of("-ea", "-esa"), argsList.stream()).toList());
         // Evaluate process status


### PR DESCRIPTION
Please review this PR which fixes timeouts for the two tests: _java/util/Locale/LocaleProvidersRun.java_ and _java/util/ResourceBundle/modules/visibility/VisibilityTest.java_.

These tests were updated to accept VM flags in [JDK-8319569](https://bugs.openjdk.org/browse/JDK-8319569), which is now causing timeouts in tiers 6 and 8. One set of VM flags causes _VisibilityTest.java_ to timeout with a duration of over 2 hours in tier6.

Both have been updated to run without VM flags and marked as `vm.flagless`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320714](https://bugs.openjdk.org/browse/JDK-8320714): java/util/Locale/LocaleProvidersRun.java and java/util/ResourceBundle/modules/visibility/VisibilityTest.java timeout after passing (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [f58cb4b5](https://git.openjdk.org/jdk/pull/16831/files/f58cb4b54d394fe13bb35b87d4e5fb0c60ae79e4)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [f58cb4b5](https://git.openjdk.org/jdk/pull/16831/files/f58cb4b54d394fe13bb35b87d4e5fb0c60ae79e4)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16831/head:pull/16831` \
`$ git checkout pull/16831`

Update a local copy of the PR: \
`$ git checkout pull/16831` \
`$ git pull https://git.openjdk.org/jdk.git pull/16831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16831`

View PR using the GUI difftool: \
`$ git pr show -t 16831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16831.diff">https://git.openjdk.org/jdk/pull/16831.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16831#issuecomment-1828493016)