### PR TITLE
JDK-8320806: Augment test/langtools/tools/javac/versions/Versions.java for JDK 22 language changes

### DIFF
--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 4981566 5028634 5094412 6304984 7025786 7025789 8001112 8028545
  * 8000961 8030610 8028546 8188870 8173382 8173382 8193290 8205619 8028563
- * 8245147 8245586 8257453 8286035 8306586
+ * 8245147 8245586 8257453 8286035 8306586 8320806
  * @summary Check interpretation of -target and -source options
  * @modules java.compiler
  *          jdk.compiler
@@ -272,8 +272,8 @@ public class Versions {
      * the uncommon program that is accepted in one version of the
      * language and rejected in a later version.)
      *
-     * When version of the language get a new, non-preview feature, a
-     * new source example enum constant should be added.
+     * When a version of the language gets a new, non-preview feature,
+     * a new source example enum constant should be added.
      */
     enum SourceExample {
         BASE(7, "Base.java", "public class Base { }\n"),
@@ -375,6 +375,20 @@ public class Versions {
              }
              """),
 
+         SOURCE_22(22, "New22.java",
+             // New feature in 22: Unnamed Variables & Patterns
+             """
+             public class New22 {
+                 public static void main(String... args) {
+                     Object o = new Object(){};
+
+                     System.out.println(switch (o) {
+                                        case Integer _ -> "Hello world.";
+                                        default        -> o.toString();
+                                        });
+                 }
+             }
+             """),
             ; // Reduce code churn when appending new constants
 
         private int sourceLevel;


### PR DESCRIPTION
Straightforward test update for a new language feature.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320806](https://bugs.openjdk.org/browse/JDK-8320806): Augment test/langtools/tools/javac/versions/Versions.java for JDK 22 language changes (**Enhancement** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16833/head:pull/16833` \
`$ git checkout pull/16833`

Update a local copy of the PR: \
`$ git checkout pull/16833` \
`$ git pull https://git.openjdk.org/jdk.git pull/16833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16833`

View PR using the GUI difftool: \
`$ git pr show -t 16833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16833.diff">https://git.openjdk.org/jdk/pull/16833.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16833#issuecomment-1828597801)