### PR TITLE
Deprecate runFinalization() in JavaLangRefAccess.java interface

### DIFF
--- a/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangRefAccess.java
@@ -48,7 +48,18 @@ public interface JavaLangRefAccess {
      * Runs the finalization methods of any objects pending finalization.
      *
      * Invoked by Runtime.runFinalization()
+     *
+     * @deprecated Finalization has been deprecated for removal.  See
+     * {@link java.lang.Object#finalize} for background information and details
+     * about migration options.
+     * <p>
+     * When running in a JVM in which finalization has been disabled or removed,
+     * no objects will be pending finalization, so this method does nothing.
+     *
+     * @see     java.lang.Object#finalize()
+     * @jls 12.6 Finalization of Class Instances
      */
+    @Deprecated(since="22", forRemoval=true)
     void runFinalization();
 
     /**


### PR DESCRIPTION
for consistency

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16836/head:pull/16836` \
`$ git checkout pull/16836`

Update a local copy of the PR: \
`$ git checkout pull/16836` \
`$ git pull https://git.openjdk.org/jdk.git pull/16836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16836`

View PR using the GUI difftool: \
`$ git pr show -t 16836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16836.diff">https://git.openjdk.org/jdk/pull/16836.diff</a>

</details>
