### PR TITLE
8320681: [macos] Test tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java timed out on macOS

### DIFF
--- a/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
+++ b/test/jdk/tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import jdk.jpackage.test.Annotations.Test;
  * @build MacAppStoreJLinkOptionsTest
  * @modules jdk.jpackage/jdk.jpackage.internal
  * @requires (os.family == "mac")
- * @run main/othervm -Xmx512m jdk.jpackage.test.Main
+ * @run main/othervm/timeout=540 -Xmx512m jdk.jpackage.test.Main
  *  --jpt-run=MacAppStoreJLinkOptionsTest
  */
 public class MacAppStoreJLinkOptionsTest {


### PR DESCRIPTION
Looks like the test timed out due to slow/loaded host. Failure log similar to [JDK-8296489](https://bugs.openjdk.org/browse/JDK-8296489) and [JDK-8298735](https://bugs.openjdk.org/browse/JDK-8298735). Fixed by increasing test timeout.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320681](https://bugs.openjdk.org/browse/JDK-8320681): [macos] Test tools/jpackage/macosx/MacAppStoreJlinkOptionsTest.java timed out on macOS (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16838/head:pull/16838` \
`$ git checkout pull/16838`

Update a local copy of the PR: \
`$ git checkout pull/16838` \
`$ git pull https://git.openjdk.org/jdk.git pull/16838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16838`

View PR using the GUI difftool: \
`$ git pr show -t 16838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16838.diff">https://git.openjdk.org/jdk/pull/16838.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16838#issuecomment-1828962419)