### PR TITLE
8320858: Move jpackage tests to tier3

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -75,11 +75,12 @@ tier2_part3 = \
 tier3 = \
     :build \
     :jdk_vector \
+    -:jdk_vector_sanity \
     :jdk_rmi \
     :jdk_svc \
-   -:jdk_svc_sanity \
-   -:jdk_vector_sanity \
-   -:svc_tools
+    -:jdk_svc_sanity \
+    -:svc_tools \
+    :jdk_jpackage
 
 # Everything not in other tiers
 tier4 = \
@@ -284,10 +285,11 @@ jdk_loom = \
     jdk/jfr/threading
 
 #
-# Tool (and tool API) tests are split into core and svc groups
+# Tool (and tool API) tests are mostly split into core and svc groups
 #
 core_tools = \
     tools \
+    -tools/jpackage \
     jdk/internal/jrtfs \
     sun/tools/jrunscript
 
@@ -299,10 +301,14 @@ svc_tools = \
 
 jdk_tools = \
     :core_tools \
-    :svc_tools
+    :svc_tools \
+    :jdk_jpackage
 
 jdk_jfr = \
     jdk/jfr
+
+jdk_jpackage = \
+    tools/jpackage
 
 #
 # Catch-all for other areas with a small number of tests


### PR DESCRIPTION
Update the jtreg test group configuration in the jdk test tree so that the jpackage tests run in tier3 rather than tier2.

At this time, the jpackage tests run in jdk:tier2, more specifically jdk:tier2_part2 as part of the core_tools test group. The  jpackage tests take a significant amount of time on some platforms (on macOS and Windows in particular). The changes here remove tools/jpackage from core_tools (it's not a core tool anyway) and adds the tests to tier3. In the future then maybe tier3 can be split up if needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320858](https://bugs.openjdk.org/browse/JDK-8320858): Move jpackage tests to tier3 (**Enhancement** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16841/head:pull/16841` \
`$ git checkout pull/16841`

Update a local copy of the PR: \
`$ git checkout pull/16841` \
`$ git pull https://git.openjdk.org/jdk.git pull/16841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16841`

View PR using the GUI difftool: \
`$ git pr show -t 16841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16841.diff">https://git.openjdk.org/jdk/pull/16841.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16841#issuecomment-1829897386)