### PR TITLE
8320863: dsymutil command leaves around temporary directories

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1105,7 +1105,7 @@ define SetupNativeCompilationBody
               $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Info.plist \
               $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Resources/DWARF/$$($1_BASENAME)
           $1_CREATE_DEBUGINFO_CMDS := \
-              $(DSYMUTIL) --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
+              $(DSYMUTIL) --reproducer Off --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
         endif
 
         # Since the link rule creates more than one file that we want to track,


### PR DESCRIPTION
Can I please get a review of this change which proposes to workaround a bug in `dsymutil` tool on macos?

As noted in https://bugs.openjdk.org/browse/JDK-8320863, the `dsymutil` tool shipped in Xcode 14.3.1 has a bug which causes it to create a temporary directories and leave them around, whenever that tool is used. JDK build uses that tool in the build process to generate debuginfo files on macos. When I run the JDK mainline build locally on my macos system, I see that every `make clean images` build ends up creating and leaving 72 new `dsymutil-*` temporary directories. 

The bug in dsymutil has been acknowledged and fixed in llvm upstream project https://github.com/llvm/llvm-project/issues/61920. Until that fix makes it into Xcode released versions, the JDK build would need a workaround. The commit in this PR proposes to pass `--reproducer Off` option to this command. Doing so prevents the tool from leaving around these temporary directories. As noted in the linked llvm project's issue, these temporary directories are used for generating any crash report reproducers so that they can then be submitted as bug reports. Using `--reproducer Off` disables the reproducer generation https://github.com/llvm/llvm-project/issues/61920#issuecomment-1495392157:

> The default is that if dsymutil crashes it will produce a reproducer for filing a bug report. So with this option you will not get that.

Not generating these reproducers should be OK for the JDK builds.

Before doing this change, I ran several `make clean images` build locally on my macos and verified that every single run generates these dsymutil temporary directories. After this proposed change, I reran the same command again several times and I have verified that these directories are no longer created. 

tier1,tier2, tier3 testing too has completed successfully with this change.
