### PR TITLE
JDK-8320859: gtest high malloc footprint caused by BufferNodeAllocator stress test

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
+++ b/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
@@ -234,7 +234,7 @@ static void run_test(BufferNode::Allocator* allocator, CompletedList* cbl) {
 }
 
 TEST_VM(BufferNodeAllocatorTest, stress_free_list_allocator) {
-  const size_t buffer_capacity = 1024;
+  const size_t buffer_capacity = DEFAULT_CACHE_LINE_SIZE / sizeof(void*);
   BufferNode::Allocator allocator("Test Allocator", buffer_capacity);
   CompletedList completed;
   run_test(&allocator, &completed);

--- a/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
+++ b/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
@@ -193,8 +193,8 @@ static void run_test(BufferNode::Allocator* allocator, CompletedList* cbl) {
   volatile bool allocator_running = true;
   volatile bool processor_running = true;
 
-  ProcessorThread* proc_threads[nthreads] = {};
-  for (uint i = 0; i < nthreads; ++i) {
+  ProcessorThread* proc_threads[nthreads * 2] = {};
+  for (uint i = 0; i < nthreads * 2; ++i) {
     proc_threads[i] = new ProcessorThread(&post,
                                           allocator,
                                           cbl,

--- a/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
+++ b/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
@@ -189,17 +189,17 @@ static void run_test(BufferNode::Allocator* allocator, CompletedList* cbl) {
   // deallocation is slower than allocation, so lets create
   // more deallocation threads to prevent too large buildup of
   // free nodes (footprint)
-  const uint nthreads_mut = 4;
-  const uint nthreads_proc = 6;
-  const uint milliseconds_to_run = 1000;
+  constexpr uint num_allocator_threads = 4;
+  constexpr uint num_processor_threads = 6;
+  constexpr uint milliseconds_to_run = 1000;
 
   Semaphore post;
   volatile size_t total_allocations = 0;
   volatile bool allocator_running = true;
   volatile bool processor_running = true;
 
-  ProcessorThread* proc_threads[nthreads_proc] = {};
-  for (uint i = 0; i < nthreads_proc; ++i) {
+  ProcessorThread* proc_threads[num_processor_threads] = {};
+  for (uint i = 0; i < num_processor_threads; ++i) {
     proc_threads[i] = new ProcessorThread(&post,
                                           allocator,
                                           cbl,
@@ -207,8 +207,8 @@ static void run_test(BufferNode::Allocator* allocator, CompletedList* cbl) {
     proc_threads[i]->doit();
   }
 
-  AllocatorThread* alloc_threads[nthreads_mut] = {};
-  for (uint i = 0; i < nthreads_mut; ++i) {
+  AllocatorThread* alloc_threads[num_allocator_threads] = {};
+  for (uint i = 0; i < num_allocator_threads; ++i) {
     alloc_threads[i] = new AllocatorThread(&post,
                                            allocator,
                                            cbl,
@@ -224,12 +224,12 @@ static void run_test(BufferNode::Allocator* allocator, CompletedList* cbl) {
     this_thread->sleep(milliseconds_to_run);
   }
   Atomic::release_store(&allocator_running, false);
-  for (uint i = 0; i < nthreads_mut; ++i) {
+  for (uint i = 0; i < num_allocator_threads; ++i) {
     ThreadInVMfromNative invm(this_thread);
     post.wait_with_safepoint_check(this_thread);
   }
   Atomic::release_store(&processor_running, false);
-  for (uint i = 0; i < nthreads_proc; ++i) {
+  for (uint i = 0; i < num_processor_threads; ++i) {
     ThreadInVMfromNative invm(this_thread);
     post.wait_with_safepoint_check(this_thread);
   }


### PR DESCRIPTION
`BufferNodeAllocatorTest.stress_free_list_allocator_vm` is too expensive. On my box, this test accumulates ~1.5 GB of malloc footprint and raises the libc memory retention from 50m to 800m.

It is quite alone in its hunger. The rest of the tests together accumulate just ~50mb of libc retention.

The buffer does a stress test of the BufferNodeAllocator. Four "mutator threads" race four "gc threads". Mutator threads allocate buffers, GC threads release them. No processing is done on the buffers; this seems to be purely a test of the allocator and its freelist mechanism. The memory footprint of this test depends on the number of retained free buffers in the allocator. The allocator bulk-releases free buffers triggered by a free-count threshold. On my box, the number of free items in the unmodified stock VM is 100k..200k.

It is not clear whether the fact that so many free list items exist indicates a problem with the allocator itself. It looks like the free list should be drained if there are more than 10 items in this list.

In any case, each buffer's capacity is 1024 * sizeof(void*)+header, so 8KB+x, and with 100..200k of those things it explains the NMT-reported malloc footprint of ~1..2GB. An easy fix is to reduce the size of this buffer; since they are not processed, their size should not matter.

---------

The patch decreases the size per buffer node to cache line size. I chose cache line size out of the vague feeling that I don't want to cause false sharing and thereby degrade the test. 

Interestingly enough, reducing the buffer size greatly increases the number of free items since it makes allocation cheaper. This also happens in release builds, so this is not us zapping stuff; my unproven assumption is that this is the libc just being slower when allocating 8K vs 64-byte blocks. But with smaller buffers, we spend more time in freelist management and less time in the libc, which is good for a stress test.

This patch also increases the number of "processor" threads vs "mutator" threads. Since allocation seems to have a speed edge over deallocation, this reduces the number of free items somewhat.

This reduces the malloc spike seen from this thread from 1.5-2GB to ~160MB (release) 3xxMB (debug). We could reduce it a lot more if we reduced the buffer size to its minimum (1 slot); that would risk false sharing and may degrade test performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320859](https://bugs.openjdk.org/browse/JDK-8320859): gtest high malloc footprint caused by BufferNodeAllocator stress test (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [7a8a694f](https://git.openjdk.org/jdk/pull/16845/files/7a8a694faf48c02c8c08b674b61d08674652c69a)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [7a8a694f](https://git.openjdk.org/jdk/pull/16845/files/7a8a694faf48c02c8c08b674b61d08674652c69a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16845/head:pull/16845` \
`$ git checkout pull/16845`

Update a local copy of the PR: \
`$ git checkout pull/16845` \
`$ git pull https://git.openjdk.org/jdk.git pull/16845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16845`

View PR using the GUI difftool: \
`$ git pr show -t 16845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16845.diff">https://git.openjdk.org/jdk/pull/16845.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16845#issuecomment-1829627754)