### PR TITLE
JDK-8320830: [AIX] Dont mix os::dll_load() with direct dlclose() calls

### DIFF
--- a/src/hotspot/os/aix/libodm_aix.cpp
+++ b/src/hotspot/os/aix/libodm_aix.cpp
@@ -35,7 +35,7 @@
 dynamicOdm::dynamicOdm() {
   const char* libodmname = "/usr/lib/libodm.a(shr_64.o)";
   char ebuf[512];
-  void* _libhandle = os::dll_load(libodmname, ebuf, sizeof(ebuf));
+  _libhandle = os::dll_load(libodmname, ebuf, sizeof(ebuf));
 
   if (!_libhandle) {
     trcVerbose("Cannot load %s (error %s)", libodmname, ebuf);

--- a/src/hotspot/os/aix/libodm_aix.cpp
+++ b/src/hotspot/os/aix/libodm_aix.cpp
@@ -48,14 +48,14 @@ dynamicOdm::dynamicOdm() {
   _odm_terminate   = (fun_odm_terminate  )dlsym(_libhandle, "odm_terminate"  );
   if (!_odm_initialize || !_odm_set_path || !_odm_mount_class || !_odm_get_obj || !_odm_terminate) {
     trcVerbose("Couldn't find all required odm symbols from %s", libodmname);
-    dlclose(_libhandle);
+    os::dll_unload(_libhandle);
     _libhandle = nullptr;
     return;
   }
 }
 
 dynamicOdm::~dynamicOdm() {
-  if (_libhandle) { dlclose(_libhandle); }
+  if (_libhandle) { os::dll_unload(_libhandle); }
 }
 
 

--- a/src/hotspot/os/aix/libperfstat_aix.cpp
+++ b/src/hotspot/os/aix/libperfstat_aix.cpp
@@ -114,7 +114,7 @@ bool libperfstat::init() {
 void libperfstat::cleanup() {
 
   if (g_libhandle) {
-    dlclose(g_libhandle);
+    os::dll_unload(g_libhandle);
     g_libhandle = nullptr;
   }
 


### PR DESCRIPTION
We should not mix os::dll_load() with dlclose(), but should call os::dll_unload(). At the moment this is benign, but this prevents certain type of platforms specific workarounds inside os::dll_load() and is a prerequisite for these upcoming changes. 

There are two places I see where this happens, both are AIX specific:

```
os/aix/libodm_aix.cpp
51: dlclose(_libhandle);
58: if (_libhandle) { dlclose(_libhandle); }

os/aix/libperfstat_aix.cpp
117: dlclose(g_libhandle);
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320830](https://bugs.openjdk.org/browse/JDK-8320830): [AIX] Dont mix os::dll_load() with direct dlclose() calls (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [cb3df4fb](https://git.openjdk.org/jdk/pull/16846/files/cb3df4fb7131d0c21e1920a1da3dc70211fff50b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16846/head:pull/16846` \
`$ git checkout pull/16846`

Update a local copy of the PR: \
`$ git checkout pull/16846` \
`$ git pull https://git.openjdk.org/jdk.git pull/16846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16846`

View PR using the GUI difftool: \
`$ git pr show -t 16846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16846.diff">https://git.openjdk.org/jdk/pull/16846.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16846#issuecomment-1829660256)