### PR TITLE
8320886: Unsafe_SetMemory0 is not guarded

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -969,7 +969,8 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
       assert(which == call32_operand, "jcc has no disp32 or imm");
       return ip;
     default:
-      ShouldNotReachHere();
+      fatal("Instruction not handled: %02X", 0xFF & *(ip-1));
+      //ShouldNotReachHere();
     }
     break;
 

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -920,6 +920,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     case 0x11: // movups
     case 0x12: // movlps
     case 0x28: // movaps
+    case 0x29: // movaps
     case 0x2E: // ucomiss
     case 0x2F: // comiss
     case 0x54: // andps
@@ -969,8 +970,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
       assert(which == call32_operand, "jcc has no disp32 or imm");
       return ip;
     default:
-      fatal("Instruction not handled: %02X", 0xFF & *(ip-1));
-      //ShouldNotReachHere();
+      fatal("not handled: 0x0F%2X", 0xFF & *(ip-1));
     }
     break;
 

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -368,7 +368,10 @@ UNSAFE_ENTRY(void, Unsafe_SetMemory0(JNIEnv *env, jobject unsafe, jobject obj, j
   oop base = JNIHandles::resolve(obj);
   void* p = index_oop_from_field_offset_long(base, offset);
 
-  Copy::fill_to_memory_atomic(p, sz, value);
+  {
+    GuardUnsafeAccess guard(thread);
+    Copy::fill_to_memory_atomic(p, sz, value);
+  }
 } UNSAFE_END
 
 UNSAFE_ENTRY(void, Unsafe_CopyMemory0(JNIEnv *env, jobject unsafe, jobject srcObj, jlong srcOffset, jobject dstObj, jlong dstOffset, jlong size)) {

--- a/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
+++ b/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
@@ -146,16 +146,16 @@ public class InternalErrorTest {
                 buffer.get(new byte[8]);
                 break;
             case 1:
-                // testing Unsafe.copySwapMemory, trying to access next  page after truncation.
+                // testing Unsafe.copySwapMemory, trying to access next page after truncation.
                 unsafe.copySwapMemory(null, mapAddr + pageSize, new byte[4000], 16, 2000, 2);
                 break;
             case 2:
-                // testing Unsafe.copySwapMemory, trying to access next  page after truncation.
+                // testing Unsafe.copySwapMemory, trying to access next page after truncation.
                 unsafe.copySwapMemory(null, mapAddr + pageSize, null, allocMem, 2000, 2);
                 break;
             case 3:
                 MemorySegment segment = MemorySegment.ofBuffer(buffer);
-                // testing Unsafe.setMemory, trying to access next  page after truncation.
+                // testing Unsafe.setMemory, trying to access next page after truncation.
                 segment.fill((byte) 0xF0);
                 break;
         }

--- a/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
+++ b/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
@@ -41,6 +41,7 @@
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.lang.foreign.MemorySegment;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.MappedByteBuffer;
@@ -60,6 +61,8 @@ public class InternalErrorTest {
     private static final String failureMsg1 = "InternalError not thrown";
     private static final String failureMsg2 = "Wrong InternalError: ";
 
+    private static final int NUM_TESTS = 4;
+
     public static void main(String[] args) throws Throwable {
         Unsafe unsafe = Unsafe.getUnsafe();
 
@@ -71,9 +74,9 @@ public class InternalErrorTest {
             s.append("1");
         }
         Files.write(file.toPath(), s.toString().getBytes());
-        FileChannel fileChannel = new RandomAccessFile(file, "r").getChannel();
+        FileChannel fileChannel = new RandomAccessFile(file, "rw").getChannel();
         MappedByteBuffer buffer =
-            fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, fileChannel.size());
+            fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, fileChannel.size());
 
         // Get address of mapped memory.
         long mapAddr = 0;
@@ -86,13 +89,13 @@ public class InternalErrorTest {
         }
         long allocMem = unsafe.allocateMemory(4000);
 
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < NUM_TESTS; i++) {
             test(buffer, unsafe, mapAddr, allocMem, i);
         }
 
         Files.write(file.toPath(), "2".getBytes());
         buffer.position(buffer.position() + pageSize);
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < NUM_TESTS; i++) {
             try {
                 test(buffer, unsafe, mapAddr, allocMem, i);
                 WhiteBox.getWhiteBox().forceSafepoint();
@@ -107,7 +110,7 @@ public class InternalErrorTest {
         Method m = InternalErrorTest.class.getMethod("test", MappedByteBuffer.class, Unsafe.class, long.class, long.class, int.class);
         WhiteBox.getWhiteBox().enqueueMethodForCompilation(m, 3);
 
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < NUM_TESTS; i++) {
             try {
                 test(buffer, unsafe, mapAddr, allocMem, i);
                 WhiteBox.getWhiteBox().forceSafepoint();
@@ -121,7 +124,7 @@ public class InternalErrorTest {
 
         WhiteBox.getWhiteBox().enqueueMethodForCompilation(m, 4);
 
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < NUM_TESTS; i++) {
             try {
                 test(buffer, unsafe, mapAddr, allocMem, i);
                 WhiteBox.getWhiteBox().forceSafepoint();
@@ -149,6 +152,11 @@ public class InternalErrorTest {
             case 2:
                 // testing Unsafe.copySwapMemory, trying to access next  page after truncation.
                 unsafe.copySwapMemory(null, mapAddr + pageSize, null, allocMem, 2000, 2);
+                break;
+            case 3:
+                MemorySegment segment = MemorySegment.ofBuffer(buffer);
+                // testing Unsafe.setMemory, trying to access next  page after truncation.
+                segment.fill((byte) 0xF0);
                 break;
         }
     }


### PR DESCRIPTION
See JBS issue.

Guard the memory access done in Unsafe_SetMemory0 to prevent a SIGBUS error from crashing the VM when a truncated memory mapped file is accessed.

Testing: local `InternalErrorTest`, Tier 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320886](https://bugs.openjdk.org/browse/JDK-8320886): Unsafe_SetMemory0 is not guarded (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [e9a5247e](https://git.openjdk.org/jdk/pull/16848/files/e9a5247ee00571b4adc4c5c7e627422abcacec42)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16848/head:pull/16848` \
`$ git checkout pull/16848`

Update a local copy of the PR: \
`$ git checkout pull/16848` \
`$ git pull https://git.openjdk.org/jdk.git pull/16848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16848`

View PR using the GUI difftool: \
`$ git pr show -t 16848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16848.diff">https://git.openjdk.org/jdk/pull/16848.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16848#issuecomment-1830496051)