### PR TITLE
8316649: JMX connection timeout cannot be changed and uses the default of 0 (infinite)

### DIFF
--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/ConnectorBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -785,7 +785,7 @@ public final class ConnectorBootstrap {
             env.put(RMIConnectorServer.SERIAL_FILTER_PATTERN, jmxRmiFilter);
         }
 
-        boolean useSocketFactory = bindAddress != null && !useSsl;
+        boolean useServerSocketFactory = bindAddress != null && !useSsl;
 
         if (useAuthentication) {
             if (loginConfigName != null) {
@@ -815,6 +815,10 @@ public final class ConnectorBootstrap {
             ssf = createSslRMIServerSocketFactory(
                     sslConfigFileName, enabledCipherSuites,
                     enabledProtocols, sslNeedClientAuth, bindAddress);
+        } else {
+            csf = new JMXPlainRMIClientSocketFactory();
+            env.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE,
+                    csf);
         }
 
         if (useSsl) {
@@ -824,7 +828,7 @@ public final class ConnectorBootstrap {
                     ssf);
         }
 
-        if (useSocketFactory) {
+        if (useServerSocketFactory) {
             ssf = new HostAwareSocketFactory(bindAddress);
             env.put(RMIConnectorServer.RMI_SERVER_SOCKET_FACTORY_ATTRIBUTE,
                     ssf);
@@ -849,7 +853,7 @@ public final class ConnectorBootstrap {
             registry =
                     new SingleEntryRegistry(port, csf, ssf,
                     "jmxrmi", exporter.firstExported);
-        } else if (useSocketFactory) {
+        } else if (useServerSocketFactory) {
             registry =
                     new SingleEntryRegistry(port, csf, ssf,
                     "jmxrmi", exporter.firstExported);

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/JMXPlainRMIClientSocketFactory.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/JMXPlainRMIClientSocketFactory.java
@@ -61,8 +61,4 @@ public class JMXPlainRMIClientSocketFactory implements RMIClientSocketFactory, S
             return s;
         }
     }
-
-//    public ServerSocket createServerSocket(int port) throws IOException {
-//        return new ServerSocket(port);
-//    }
 }

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/JMXPlainRMIClientSocketFactory.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/JMXPlainRMIClientSocketFactory.java
@@ -41,7 +41,7 @@ import java.security.PrivilegedAction;
  */
 public class JMXPlainRMIClientSocketFactory implements RMIClientSocketFactory, Serializable {
 
-    private static final long serialVersionUID = 1L; 
+    private static final long serialVersionUID = 1L;
 
     @SuppressWarnings("removal")
     private static final int connectTimeout =    // default 1 minute

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/JMXPlainRMIClientSocketFactory.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/JMXPlainRMIClientSocketFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package sun.management.jmxremote;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.ServerSocket;
+import java.rmi.server.RMISocketFactory;
+import java.rmi.server.RMIClientSocketFactory;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * Implement RMIClientSocketFactory to enable JMX-specific properties.
+ */
+public class JMXRMIStandardClientSocketFactory implements RMIClientSocketFactory, Serializable {
+
+    private static final long serialVersionUID = 1L; 
+
+    @SuppressWarnings("removal")
+    private static final int connectTimeout =    // default 1 minute
+        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+            Integer.getInteger("com.sun.management.jmxremote.rmi.tcpConnectTimeout", 60 * 1000).intValue());
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        // Guard against passing a negative value, Socket would always throw IllegalArgumentException.
+        if (connectTimeout <= 0) {
+            return new Socket(host, port);
+        } else {
+            SocketAddress address = host != null ? new InetSocketAddress(host, port) :
+                                                   new InetSocketAddress(InetAddress.getByName(null), port);
+            Socket s = new Socket();
+            s.connect(address, connectTimeout);
+            return s;
+        }
+    }
+
+//    public ServerSocket createServerSocket(int port) throws IOException {
+//        return new ServerSocket(port);
+//    }
+}

--- a/src/jdk.management.agent/share/classes/sun/management/jmxremote/JMXPlainRMIClientSocketFactory.java
+++ b/src/jdk.management.agent/share/classes/sun/management/jmxremote/JMXPlainRMIClientSocketFactory.java
@@ -39,7 +39,7 @@ import java.security.PrivilegedAction;
 /**
  * Implement RMIClientSocketFactory to enable JMX-specific properties.
  */
-public class JMXRMIStandardClientSocketFactory implements RMIClientSocketFactory, Serializable {
+public class JMXPlainRMIClientSocketFactory implements RMIClientSocketFactory, Serializable {
 
     private static final long serialVersionUID = 1L; 
 


### PR DESCRIPTION
JMX RMI Connections should use a timeout on the Socket connect call by default.

JMX Connections use RMI and some connection failures never terminate. The hang described in 8316649 is hard to reproduce manually: the description says it can be caused by a firewall that never returns a response.

Changing the base RMI implementation may not be desirable at this time.

JMX can use a new ClientSocketFactory for RMI which implements the connect timeout, which can recognise a new JMX-specific property `com.sun.management.jmxremote.rmi.tcpConnectTimeout`
(named like the existing com.sun.management.jmxremote... properties)

Defaulting to a 1 minute timeout on connect has no effect on existing tests, and should go unnoticed unless there really is a significant connection delay. Specifying zero for the new System Property will use the old technique of a connect with no timeout.

This can be tested, but it is not realistically usable: although specifying a 1 millisecond timeout will often fail (as expected/desired for the test), it will very often pass as the connection happens immediately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Change requires CSR request [JDK-8320580](https://bugs.openjdk.org/browse/JDK-8320580) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8316649](https://bugs.openjdk.org/browse/JDK-8316649): JMX connection timeout cannot be changed and uses the default of 0 (infinite) (**Enhancement** - P4)
 * [JDK-8320580](https://bugs.openjdk.org/browse/JDK-8320580): JMX RMI Connections should have a connect timeout property (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16856/head:pull/16856` \
`$ git checkout pull/16856`

Update a local copy of the PR: \
`$ git checkout pull/16856` \
`$ git pull https://git.openjdk.org/jdk.git pull/16856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16856`

View PR using the GUI difftool: \
`$ git pr show -t 16856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16856.diff">https://git.openjdk.org/jdk/pull/16856.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16856#issuecomment-1830347492)