### PR TITLE
8320911: RISC-V: Enable hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
@@ -108,7 +108,7 @@ public class TestChaCha20 {
             // Riscv64 intrinsics require the vector instructions
             if (containsFuzzy(cpuFeatures, "v", true)) {
                 System.out.println("Setting up vector worker");
-                configs.add(new ArrayList());
+                configs.add(List.of("-XX:+UseRVV"));
             }
         } else {
             // We only have ChaCha20 intrinsics on x64, aarch64 and riscv64

--- a/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
@@ -105,7 +105,7 @@ public class TestChaCha20 {
                 configs.add(new ArrayList());
             }
         } else if (Platform.isRISCV64()) {
-            // AArch64 intrinsics require the advanced simd instructions
+            // Riscv64 intrinsics require the vector instructions
             if (containsFuzzy(cpuFeatures, "v", true)) {
                 System.out.println("Setting up vector worker");
                 configs.add(new ArrayList());

--- a/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
@@ -36,6 +36,9 @@ import jdk.test.whitebox.cpuinfo.CPUInfo;
  * @bug 8247645
  * @summary ChaCha20 Intrinsics
  * @library /test/lib
+ * @requires (vm.cpu.features ~= ".*avx512.*" | vm.cpu.features ~= ".*avx2.*" | vm.cpu.features ~= ".*avx.*") |
+ *           (os.arch=="aarch64" & vm.cpu.features ~= ".*simd.*") |
+ *           (os.arch == "riscv64" & vm.cpu.features ~= ".*v,.*")
  * @build   compiler.intrinsics.chacha.ExerciseChaCha20
  *          jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -57,9 +60,13 @@ public class TestChaCha20 {
         return n;
     }
 
-    private static boolean containsFuzzy(List<String> list, String sub) {
+    private static boolean containsFuzzy(List<String> list, String sub, Boolean matchExactly) {
         for (String s : list) {
-            if (s.contains(sub)) return true;
+            if (matchExactly) {
+                if (s.equals(sub)) return true;
+            } else {
+                if (s.contains(sub)) return true;
+            }
         }
         return false;
     }
@@ -79,32 +86,32 @@ public class TestChaCha20 {
             }
 
             // Otherwise, select the tests that make sense on current platform.
-            if (containsFuzzy(cpuFeatures, "avx512")) {
+            if (containsFuzzy(cpuFeatures, "avx512", false)) {
                 System.out.println("Setting up AVX512 worker");
                 configs.add(List.of("-XX:UseAVX=3"));
             }
-            if (containsFuzzy(cpuFeatures, "avx2")) {
+            if (containsFuzzy(cpuFeatures, "avx2", false)) {
                 System.out.println("Setting up AVX2 worker");
                 configs.add(List.of("-XX:UseAVX=2"));
             }
-            if (containsFuzzy(cpuFeatures, "avx")) {
+            if (containsFuzzy(cpuFeatures, "avx", false)) {
                 System.out.println("Setting up AVX worker");
                 configs.add(List.of("-XX:UseAVX=1"));
             }
         } else if (Platform.isAArch64()) {
             // AArch64 intrinsics require the advanced simd instructions
-            if (containsFuzzy(cpuFeatures, "simd")) {
+            if (containsFuzzy(cpuFeatures, "simd", false)) {
                 System.out.println("Setting up ASIMD worker");
                 configs.add(new ArrayList());
             }
         } else if (Platform.isRISCV64()) {
             // AArch64 intrinsics require the advanced simd instructions
-            if (containsFuzzy(cpuFeatures, "v")) {
+            if (containsFuzzy(cpuFeatures, "v", true)) {
                 System.out.println("Setting up vector worker");
-                configs.add(List.of("-XX:+UseRVV"));
+                configs.add(new ArrayList());
             }
         } else {
-            // We only have ChaCha20 intrinsics on x64 and aarch64
+            // We only have ChaCha20 intrinsics on x64, aarch64 and riscv64
             // currently.  If the platform is neither of these then
             // the ChaCha20 known answer tests in
             // com/sun/crypto/provider/Cipher are sufficient.

--- a/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
@@ -97,6 +97,12 @@ public class TestChaCha20 {
                 System.out.println("Setting up ASIMD worker");
                 configs.add(new ArrayList());
             }
+        } else if (Platform.isRISCV64()) {
+            // AArch64 intrinsics require the advanced simd instructions
+            if (containsFuzzy(cpuFeatures, "v")) {
+                System.out.println("Setting up vector worker");
+                configs.add(List.of("-XX:+UseRVV"));
+            }
         } else {
             // We only have ChaCha20 intrinsics on x64 and aarch64
             // currently.  If the platform is neither of these then


### PR DESCRIPTION
Hi,
Can you review this simple patch to enable TestChaCha20.java on riscv?
Thanks!

It's missed when working on JDK-8315716, so in this patch also add  `@requires` jtreg tag to make it obvious to spot which arch is supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320911](https://bugs.openjdk.org/browse/JDK-8320911): RISC-V: Enable hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16857/head:pull/16857` \
`$ git checkout pull/16857`

Update a local copy of the PR: \
`$ git checkout pull/16857` \
`$ git pull https://git.openjdk.org/jdk.git pull/16857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16857`

View PR using the GUI difftool: \
`$ git pr show -t 16857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16857.diff">https://git.openjdk.org/jdk/pull/16857.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16857#issuecomment-1830267904)