### PR TITLE
8320921: GHA: Parallelize hotspot_compiler test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,9 @@ jobs:
           - 'jdk/tier1 part 3'
           - 'langtools/tier1'
           - 'hs/tier1 common'
-          - 'hs/tier1 compiler'
+          - 'hs/tier1 compiler part 1'
+          - 'hs/tier1 compiler part 2'
+          - 'hs/tier1 compiler part 3'
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'
@@ -83,8 +85,16 @@ jobs:
             test-suite: 'test/hotspot/jtreg/:tier1_common'
             debug-suffix: -debug
 
-          - test-name: 'hs/tier1 compiler'
-            test-suite: 'test/hotspot/jtreg/:tier1_compiler'
+          - test-name: 'hs/tier1 compiler part 1'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_1'
+            debug-suffix: -debug
+
+          - test-name: 'hs/tier1 compiler part 2'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_2'
+            debug-suffix: -debug
+
+          - test-name: 'hs/tier1 compiler part 3'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_3 test/hotspot/jtreg/:tier1_compiler_not_xcomp'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 gc'


### PR DESCRIPTION
In current GHA, `hotspot_compiler` testing takes a long time, and often takes the longest. On MacOS and Windows it routinely takes 60..80 minutes, while other test runs in 30..40 minutes. This often drags the total wall clock time to run the GHA up. Fortunately, there are already three parts in `hotspot_compiler` test group, which we might just run separately:
https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/TEST.groups#L142-L146

There is a bit of awkwardness about `not_xcomp` subgroup, which does not have lots of tests. Instead of doing another short job, I think we can just meld it into "part 3".

Additional testing:
 - [ ] GHA