### PR TITLE
8320798: Console read line with zero out should zero out underlying buffer

### DIFF
--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -196,7 +196,7 @@ public final class JdkConsoleImpl implements JdkConsole {
             if (zeroOut) {
                 Arrays.fill(rcb, 0, len, ' ');
                 if (reader instanceof LineReader lr) {
-                    lr.spaceOut(len);
+                    lr.zeroOut();
                 }
             }
         }
@@ -231,9 +231,9 @@ public final class JdkConsoleImpl implements JdkConsole {
             nextChar = nChars = 0;
             leftoverLF = false;
         }
-        public void spaceOut(int charCount) throws IOException {
+        public void zeroOut() throws IOException {
             if (in instanceof StreamDecoder sd) {
-                sd.spaceOut(charCount);
+                sd.fillZeroToPosition();
             }
         }
         public void close () {}

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -195,6 +195,9 @@ public final class JdkConsoleImpl implements JdkConsole {
             System.arraycopy(rcb, 0, b, 0, len);
             if (zeroOut) {
                 Arrays.fill(rcb, 0, len, ' ');
+                if (reader instanceof LineReader lr) {
+                    lr.spaceOut(len);
+                }
             }
         }
         return b;
@@ -227,6 +230,11 @@ public final class JdkConsoleImpl implements JdkConsole {
             cb = new char[1024];
             nextChar = nChars = 0;
             leftoverLF = false;
+        }
+        public void spaceOut(int charCount) throws IOException {
+            if (in instanceof StreamDecoder sd) {
+                sd.spaceOut(charCount);
+            }
         }
         public void close () {}
         public boolean ready() throws IOException {

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -273,28 +273,25 @@ public class StreamDecoder extends Reader {
         return !closed;
     }
 
-    public void spaceOut(int charCount) throws IOException {
+    public void fillZeroToPosition() throws IOException {
         Object lock = this.lock;
         if (lock instanceof InternalLock locker) {
             locker.lock();
             try {
-                lockedSpaceOut(charCount);
+                lockedFillZeroToPosition();
             } finally {
                 locker.unlock();
             }
         } else {
             synchronized (lock) {
-                lockedSpaceOut(charCount);
+                lockedFillZeroToPosition();
             }
         }
     }
 
-    private void lockedSpaceOut(int charCount) throws IOException {
+    private void lockedFillZeroToPosition() throws IOException {
         ensureOpen();
-        var byteCount = charCount * 4; // worst case for all supplementary chars
-        var fromIndex = bb.arrayOffset() + Math.max(bb.position() - byteCount, 0);
-        var toIndex = bb.arrayOffset() + bb.position();
-        Arrays.fill(bb.array(), fromIndex, toIndex, (byte)' ');
+        Arrays.fill(bb.array(), 0, bb.arrayOffset() + bb.position(), (byte)0);
     }
 
     // -- Charset-based stream decoder impl --

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -291,7 +291,7 @@ public class StreamDecoder extends Reader {
 
     private void lockedFillZeroToPosition() throws IOException {
         ensureOpen();
-        Arrays.fill(bb.array(), 0, bb.arrayOffset() + bb.position(), (byte)0);
+        Arrays.fill(bb.array(), bb.arrayOffset(), bb.arrayOffset() + bb.position(), (byte)0);
     }
 
     // -- Charset-based stream decoder impl --

--- a/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
+++ b/src/java.base/share/classes/sun/nio/cs/StreamDecoder.java
@@ -289,8 +289,7 @@ public class StreamDecoder extends Reader {
         }
     }
 
-    private void lockedFillZeroToPosition() throws IOException {
-        ensureOpen();
+    private void lockedFillZeroToPosition() {
         Arrays.fill(bb.array(), bb.arrayOffset(), bb.arrayOffset() + bb.position(), (byte)0);
     }
 


### PR DESCRIPTION
It is best practice to zero out the underlying buffer after use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320798](https://bugs.openjdk.org/browse/JDK-8320798): Console read line with zero out should zero out underlying buffer (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [90c4dece](https://git.openjdk.org/jdk/pull/16861/files/90c4dece613ae5d154da09dfbbeb8475c743a79b)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [90c4dece](https://git.openjdk.org/jdk/pull/16861/files/90c4dece613ae5d154da09dfbbeb8475c743a79b)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [90c4dece](https://git.openjdk.org/jdk/pull/16861/files/90c4dece613ae5d154da09dfbbeb8475c743a79b)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [90c4dece](https://git.openjdk.org/jdk/pull/16861/files/90c4dece613ae5d154da09dfbbeb8475c743a79b)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16861/head:pull/16861` \
`$ git checkout pull/16861`

Update a local copy of the PR: \
`$ git checkout pull/16861` \
`$ git pull https://git.openjdk.org/jdk.git pull/16861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16861`

View PR using the GUI difftool: \
`$ git pr show -t 16861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16861.diff">https://git.openjdk.org/jdk/pull/16861.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16861#issuecomment-1830522005)