### PR TITLE
8320918: Fix errors in the built-in Catalog implementation

### DIFF
--- a/src/java.xml/share/classes/jdk/xml/internal/JdkConstants.java
+++ b/src/java.xml/share/classes/jdk/xml/internal/JdkConstants.java
@@ -304,7 +304,7 @@ public final class JdkConstants {
      * System Property for the JDKCatalog' RESOLVE property
      * @since 22
      */
-    public static final String JDKCATALOG_RESOLVE = "jdk.xml.jdkCatalog.resolve";
+    public static final String JDKCATALOG_RESOLVE = "jdk.xml.jdkcatalog.resolve";
 
     // Catalog Resolve Integer mappings for String values
     public static final int CONTINUE = 0;

--- a/src/java.xml/share/conf/jaxp.properties
+++ b/src/java.xml/share/conf/jaxp.properties
@@ -51,7 +51,7 @@
 # property called javax.xml.catalog.files. An entry for the FILES property in the
 # configuration file would therefore use javax.xml.catalog.files as the key, that
 # is:
-#     javax.xml.catalog.files=strict
+#     javax.xml.catalog.resolve=strict
 #
 #
 # Extension Functions:
@@ -128,6 +128,24 @@ jdk.xml.overrideDefaultParser=false
 #
 # javax.xml.useCatalog=true
 #
+# Implementation Specific Properties - jdkcatalog.resolve
+#
+# This property instructs the JDK default CatalogResolver to act in accordance with
+# the setting when unable to resolve an external reference with the built-in Catalog.
+# The options are:
+#     continue -- indicates that the processing should continue
+#     ignore -- indicates that the reference is skipped
+#     strict -- indicates that the resolver should throw a CatalogException
+#
+# The following setting would cause the resolve to throw a CatalogException when
+# unable to resolve an external reference:
+# jdk.xml.jdkcatalog.resolve=strict
+#
+# Implementation Specific Properties - DTD
+#
+# This property instructs the parsers to: deny, ignore or allow DTD processing.
+# The following setting would cause the parser to reject DTD by throwing an exception.
+# jdk.xml.dtd.support=deny
 #
 # Implementation Specific Properties - Limits
 #

--- a/src/java.xml/share/conf/jaxp.properties
+++ b/src/java.xml/share/conf/jaxp.properties
@@ -47,8 +47,8 @@
 # the default property values. The format is:
 #     system-property-name=value
 #
-# For example, the FILES property in CatalogFeatures has an associated system
-# property called javax.xml.catalog.files. An entry for the FILES property in the
+# For example, the RESOLVE property in CatalogFeatures has an associated system
+# property called javax.xml.catalog.resolve. An entry for the RESOLVE property in the
 # configuration file would therefore use javax.xml.catalog.resolve as the key, that
 # is:
 #     javax.xml.catalog.resolve=strict

--- a/src/java.xml/share/conf/jaxp.properties
+++ b/src/java.xml/share/conf/jaxp.properties
@@ -49,7 +49,7 @@
 #
 # For example, the FILES property in CatalogFeatures has an associated system
 # property called javax.xml.catalog.files. An entry for the FILES property in the
-# configuration file would therefore use javax.xml.catalog.files as the key, that
+# configuration file would therefore use javax.xml.catalog.resolve as the key, that
 # is:
 #     javax.xml.catalog.resolve=strict
 #

--- a/test/jaxp/javax/xml/jaxp/unittest/common/catalog/CatalogTestBase.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/catalog/CatalogTestBase.java
@@ -57,7 +57,7 @@ public class CatalogTestBase extends TestBase {
 
         // error (not from catalog) is expect when CATALOG=continue
         boolean isErrExpected = true;
-        String expected1 = "invalid.site.com";
+        String expected1 = UNKNOWN_HOST;
 
         // expected when reference is resolved by Catalog
         String expected3 = "", expected4 = "";

--- a/test/jaxp/javax/xml/jaxp/unittest/common/config/files/catalog2.properties
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/config/files/catalog2.properties
@@ -13,7 +13,7 @@
 # ---- Config File: for testing the CATALOG property ----
 #
 # strict: report error if not resolved by the JDK Catalog
-jdk.xml.jdkCatalog.resolve=strict
+jdk.xml.jdkcatalog.resolve=strict
 # Enable Extension Functions
 jdk.xml.enableExtensionFunctions=true
 # Disallow overriding the default parser

--- a/test/jaxp/javax/xml/jaxp/unittest/common/config/files/jaxp.properties
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/config/files/jaxp.properties
@@ -51,7 +51,7 @@
 # property called javax.xml.catalog.files. An entry for the FILES property in the
 # configuration file would therefore use javax.xml.catalog.files as the key, that
 # is:
-#     javax.xml.catalog.files=strict
+#     javax.xml.catalog.resolve=strict
 #
 #
 # Extension Functions:
@@ -127,6 +127,19 @@ jdk.xml.overrideDefaultParser=false
 # references. The value is a boolean and the default value is true.
 #
 # javax.xml.useCatalog=true
+#
+# Implementation Specific Properties - jdkcatalog.resolve
+#
+# This property instructs the JDK default CatalogResolver to act in accordance with
+# the setting when unable to resolve an external reference with the built-in Catalog.
+# The options are:
+#     continue -- indicates that the processing should continue
+#     ignore -- indicates that the reference is skipped
+#     strict -- indicates that the resolver should throw a CatalogException
+#
+# The following setting would cause the resolve to throw a CatalogException when
+# unable to resolve an external reference:
+# jdk.xml.jdkcatalog.resolve=strict
 #
 # Implementation Specific Properties - DTD
 #

--- a/test/jaxp/javax/xml/jaxp/unittest/common/config/files/jaxp.properties
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/config/files/jaxp.properties
@@ -47,8 +47,8 @@
 # the default property values. The format is:
 #     system-property-name=value
 #
-# For example, the FILES property in CatalogFeatures has an associated system
-# property called javax.xml.catalog.files. An entry for the FILES property in the
+# For example, the RESOLVE property in CatalogFeatures has an associated system
+# property called javax.xml.catalog.resolve. An entry for the RESOLVE property in the
 # configuration file would therefore use javax.xml.catalog.resolve as the key, that
 # is:
 #     javax.xml.catalog.resolve=strict

--- a/test/jaxp/javax/xml/jaxp/unittest/common/config/files/jaxp.properties
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/config/files/jaxp.properties
@@ -49,7 +49,7 @@
 #
 # For example, the FILES property in CatalogFeatures has an associated system
 # property called javax.xml.catalog.files. An entry for the FILES property in the
-# configuration file would therefore use javax.xml.catalog.files as the key, that
+# configuration file would therefore use javax.xml.catalog.resolve as the key, that
 # is:
 #     javax.xml.catalog.resolve=strict
 #

--- a/test/jaxp/javax/xml/jaxp/unittest/common/util/TestBase.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/util/TestBase.java
@@ -102,7 +102,7 @@ public class TestBase {
 
     // Impl Specific Properties
     public static final String SP_DTD = "jdk.xml.dtd.support";
-    public static final String SP_CATALOG = "jdk.xml.jdkCatalog.resolve";
+    public static final String SP_CATALOG = "jdk.xml.jdkcatalog.resolve";
     public static final String OVERRIDE_PARSER = "jdk.xml.overrideDefaultParser";
 
     // DTD/CATALOG constants
@@ -121,6 +121,7 @@ public class TestBase {
     // CATALOG=strict
     public static final String CONFIG_CATALOG_STRICT = "catalog2.properties";
 
+    public static final String UNKNOWN_HOST = "invalid.site.com";
 
     String xmlExternalEntity, xmlExternalEntityId;
     String xmlGE_Expansion, xmlGE_ExpansionId;
@@ -334,15 +335,17 @@ public class TestBase {
 
     protected void processError(boolean expectError, String error, Exception e)
             throws Exception {
-        //e.printStackTrace();
         String str = e.getMessage();
-//        System.out.println("Exp Msg: " + str);
-        //e.printStackTrace();
         if (!expectError) {
-            Assert.assertTrue(false, "Expected pass, but Exception is thrown " +
-                    str);
+            Assert.assertTrue(false, "Expected pass, but Exception is thrown " + str);
         } else {
-            Assert.assertTrue((str != null) && str.contains(error));
+            // This check is necessary since errors other than UnknownHostException
+            // can contain the host name in the System ID
+            if (UNKNOWN_HOST.equals(error)) {
+                Assert.assertTrue((str != null) && str.equals(error));
+            } else {
+                Assert.assertTrue((str != null) && str.contains(error));
+            }
         }
     }
 


### PR DESCRIPTION
Fix errors in the built-in Catalog implementation, specifically:
    -- incorrect case in the property name as defined in the CSR (https://bugs.openjdk.org/browse/JDK-8306056)
    -- tests needed to be updated accordingly
    -- jaxp.properties updated with documentation for the new properties
    
Tests: passed after the update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320918](https://bugs.openjdk.org/browse/JDK-8320918): Fix errors in the built-in Catalog implementation (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [e3908863](https://git.openjdk.org/jdk/pull/16862/files/e390886367984a577cb0b5191b3c7d6c99f7267d)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16862/head:pull/16862` \
`$ git checkout pull/16862`

Update a local copy of the PR: \
`$ git checkout pull/16862` \
`$ git pull https://git.openjdk.org/jdk.git pull/16862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16862`

View PR using the GUI difftool: \
`$ git pr show -t 16862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16862.diff">https://git.openjdk.org/jdk/pull/16862.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16862#issuecomment-1830659148)