### PR TITLE
JDK-8320932: [BACKOUT] dsymutil command leaves around temporary directories

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -1105,7 +1105,7 @@ define SetupNativeCompilationBody
               $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Info.plist \
               $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Resources/DWARF/$$($1_BASENAME)
           $1_CREATE_DEBUGINFO_CMDS := \
-              $(DSYMUTIL) --reproducer Off --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
+              $(DSYMUTIL) --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
         endif
 
         # Since the link rule creates more than one file that we want to track,


### PR DESCRIPTION
This is a backout of [JDK-8320863](https://bugs.openjdk.org/browse/JDK-8320863). That fix only works on a very limited selection of Xcode versions, and is causing the build to fail on other versions, including at least 12, 13 and 15.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320932](https://bugs.openjdk.org/browse/JDK-8320932): [BACKOUT] dsymutil command leaves around temporary directories (**Sub-task** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16864/head:pull/16864` \
`$ git checkout pull/16864`

Update a local copy of the PR: \
`$ git checkout pull/16864` \
`$ git pull https://git.openjdk.org/jdk.git pull/16864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16864`

View PR using the GUI difftool: \
`$ git pr show -t 16864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16864.diff">https://git.openjdk.org/jdk/pull/16864.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16864#issuecomment-1830817005)