### PR TITLE
8320916: jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java failed with "OutOfMemoryError: GC overhead limit exceeded"

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/stacktrace/AllocationStackTrace.java
+++ b/test/jdk/jdk/jfr/event/gc/stacktrace/AllocationStackTrace.java
@@ -79,7 +79,7 @@ class HumongousMemoryAllocator extends MemoryAllocator {
 class OldGenMemoryAllocator extends MemoryAllocator {
 
     private List<byte[]> list = new ArrayList<byte[]>();
-    private int counter = 6000;
+    private int counter = 5000;
 
     @Override
     public void allocate() {
@@ -87,7 +87,7 @@ class OldGenMemoryAllocator extends MemoryAllocator {
             list.add(new byte[10 * KB]);
         } else {
             list = new ArrayList<byte[]>();
-            counter = 6000;
+            counter = 5000;
         }
 
         garbage = list;


### PR DESCRIPTION
Simple fix to reduce live set so that after the triggered full-gc, there is still some memory left.

Test: ~2/10 failure before the fix and no failure observed for 100 iterations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320916](https://bugs.openjdk.org/browse/JDK-8320916): jdk/jfr/event/gc/stacktrace/TestParallelMarkSweepAllocationPendingStackTrace.java failed with "OutOfMemoryError: GC overhead limit exceeded" (**Bug** - P4)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16870/head:pull/16870` \
`$ git checkout pull/16870`

Update a local copy of the PR: \
`$ git checkout pull/16870` \
`$ git pull https://git.openjdk.org/jdk.git pull/16870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16870`

View PR using the GUI difftool: \
`$ git pr show -t 16870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16870.diff">https://git.openjdk.org/jdk/pull/16870.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16870#issuecomment-1831008387)