### PR TITLE
JDK-8320940: Fix typo in java.lang.Double

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -234,7 +234,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * equivalent of 15 to 17 digits of decimal precision. (The
  * equivalent precision varies according to the different relative
  * densities of binary and decimal values at different points along the
- * real number line).
+ * real number line.)
  *
  * <p>This representation hazard of decimal fractions is one reason to
  * use caution when storing monetary values as {@code float} or {@code


### PR DESCRIPTION
Typo fix to to the new text added in JDK-8295391.