### PR TITLE
8320942: Only set openjdk-target when cross compiling linux-aarch64

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -407,6 +407,8 @@ var getJibProfilesCommon = function (input, data) {
  * @returns {{}} Profiles part of the configuration
  */
 var getJibProfilesProfiles = function (input, common, data) {
+    var cross_compiling = input.build_platform != input.target_platform;
+
     // Main SE profiles
     var profiles = {
 
@@ -484,14 +486,12 @@ var getJibProfilesProfiles = function (input, common, data) {
         "linux-aarch64": {
             target_os: "linux",
             target_cpu: "aarch64",
-            build_cpu: "x64",
             dependencies: ["devkit", "gtest", "build_devkit", "pandoc"],
             configure_args: [
-                "--openjdk-target=aarch64-linux-gnu",
                 "--with-zlib=system",
                 "--disable-dtrace",
 		"--enable-compatible-cds-alignment",
-            ],
+	    ].concat(cross_compiling ? ["--openjdk-target=aarch64-linux-gnu"] : []),
         },
 
         "linux-arm32": {


### PR DESCRIPTION
When building linux-aarch64 at Oracle using jib, --openjdk-target=aarch64-linux-gnu is always specified regardless of if building natively or cross compiling (on linux-x64). Among other things this has the (harmless) effect of tricking configure into thinking that it's cross compiling even for native builds:

checking whether we are cross compiling... yes

The reason is that the target value (aarch64-linux-gnu) doesn't match what config.guess returns (aarch64-unknown-linux-gnu). An explicit target is only needed when cross compiling and should not be specified for native builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320942](https://bugs.openjdk.org/browse/JDK-8320942): Only set openjdk-target when cross compiling linux-aarch64 (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16873/head:pull/16873` \
`$ git checkout pull/16873`

Update a local copy of the PR: \
`$ git checkout pull/16873` \
`$ git pull https://git.openjdk.org/jdk.git pull/16873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16873`

View PR using the GUI difftool: \
`$ git pr show -t 16873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16873.diff">https://git.openjdk.org/jdk/pull/16873.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16873#issuecomment-1831115070)