### PR TITLE
JDK-8320941: Discuss receiver type handling 

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -234,7 +234,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * equivalent of 15 to 17 digits of decimal precision. (The
  * equivalent precision varies according to the different relative
  * densities of binary and decimal values at different points along the
- * real number line).
+ * real number line.)
  *
  * <p>This representation hazard of decimal fractions is one reason to
  * use caution when storing monetary values as {@code float} or {@code

--- a/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
@@ -89,6 +89,17 @@ public interface ExecutableElement extends Element, Parameterizable {
      * non-inner class, or an initializer (static or instance), has no
      * receiver type.
      *
+     * <p>The receiver <em>parameter</em> is a syntactic device added
+     * to the language for the purpose of hosting annotations. Even
+     * when source code is used as the basis for creating an
+     * executable, if a receiver parameter is not present in the
+     * source code, an implementation may elect to return a {@code
+     * NoType} object even in cases where a receiver <em>type</em> is
+     * nominally defined on the executable in question, such as an
+     * instance method.  When a receiver parameter is present and
+     * hosting annotations, a suitably annotated receiver type is
+     * returned.
+     *
      * @return the receiver type of this executable
      * @since 1.8
      *


### PR DESCRIPTION
Please review this note to discuss when ExecutableElement returns a non-sentinel object for the receiver type.

(The PR was accidentally created from the wrong branch; the change to java.lang.Double can be ignored.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8321061](https://bugs.openjdk.org/browse/JDK-8321061) to be approved

### Issues
 * [JDK-8320941](https://bugs.openjdk.org/browse/JDK-8320941): Discuss receiver type handling (**Enhancement** - P4)
 * [JDK-8321061](https://bugs.openjdk.org/browse/JDK-8321061): Discuss receiver type handling (**CSR**)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16874/head:pull/16874` \
`$ git checkout pull/16874`

Update a local copy of the PR: \
`$ git checkout pull/16874` \
`$ git pull https://git.openjdk.org/jdk.git pull/16874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16874`

View PR using the GUI difftool: \
`$ git pr show -t 16874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16874.diff">https://git.openjdk.org/jdk/pull/16874.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16874#issuecomment-1831146824)