### PR TITLE
8312023: Parallel pretouch should shortcut when only 1 thread is needed

### DIFF
--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -84,7 +84,7 @@ void PretouchTask::pretouch(const char* task_name, char* start_address, char* en
   size_t num_chunks = ((total_bytes - 1) / chunk_size) + 1;
   uint num_workers = 1;
   if (pretouch_workers != nullptr) {
-    num_workers = MIN2<uint>(num_chunks, pretouch_workers->max_workers());
+    num_workers = (uint)MIN2(num_chunks, (size_t)pretouch_workers->max_workers());
   }
 
   bool use_workers = (num_workers > 1);

--- a/src/hotspot/share/gc/shared/pretouchTask.cpp
+++ b/src/hotspot/share/gc/shared/pretouchTask.cpp
@@ -81,17 +81,23 @@ void PretouchTask::pretouch(const char* task_name, char* start_address, char* en
     return;
   }
 
+  size_t num_chunks = ((total_bytes - 1) / chunk_size) + 1;
+  uint num_workers = 1;
   if (pretouch_workers != nullptr) {
-    size_t num_chunks = ((total_bytes - 1) / chunk_size) + 1;
+    num_workers = MIN2<uint>(num_chunks, pretouch_workers->max_workers());
+  }
 
-    uint num_workers = (uint)MIN2(num_chunks, (size_t)pretouch_workers->max_workers());
-    log_debug(gc, heap)("Running %s with %u workers for " SIZE_FORMAT " work units pre-touching " SIZE_FORMAT "B.",
-                        task.name(), num_workers, num_chunks, total_bytes);
+  bool use_workers = (num_workers > 1);
 
+  log_debug(gc, heap)("Running %s with %u %s for " SIZE_FORMAT " work units pre-touching " PROPERFMT,
+            task.name(), num_workers,
+            use_workers ? "parallel workers" : "worker",
+            num_chunks, PROPERFMTARGS(total_bytes));
+
+  if (use_workers) {
+    assert(pretouch_workers != nullptr, "Sanity");
     pretouch_workers->run_task(&task, num_workers);
   } else {
-    log_debug(gc, heap)("Running %s pre-touching " SIZE_FORMAT "B.",
-                        task.name(), total_bytes);
     task.work(0);
   }
 }


### PR DESCRIPTION
This is a follow-up for code introduced in JDK 16 by [JDK-8252221](https://bugs.openjdk.org/browse/JDK-8252221). 

Unfortunately, we do pre-touch not only at startup, but also during the application lifetime when space boundary moves, see [JDK-8312021](https://bugs.openjdk.org/browse/JDK-8312021). From that code, we start the pre-touch threads unconditionally, even when we only need one thread anyway. This is clearly visible with `-Xlog:gc+heap=debug`. The actual pretouch takes single-digit microseconds, but the round-trip through the worker pool incurs latency of about 100us (2x 50us) in my setups. This is significant for very short GC pauses.

Additional testing:
 - [x] Ad-hoc benchmarks
 - [x] Linux x86_64 server fastdebug, `tier{1,2,3}` with `-XX:+UseParallelGC -XX:+AlwaysPreTouch`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312023](https://bugs.openjdk.org/browse/JDK-8312023): Parallel pretouch should shortcut when only 1 thread is needed (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16882/head:pull/16882` \
`$ git checkout pull/16882`

Update a local copy of the PR: \
`$ git checkout pull/16882` \
`$ git pull https://git.openjdk.org/jdk.git pull/16882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16882`

View PR using the GUI difftool: \
`$ git pr show -t 16882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16882.diff">https://git.openjdk.org/jdk/pull/16882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16882#issuecomment-1831859264)