### PR TITLE
8321018: Parallel: Make some methods in ParCompactionManager private

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.hpp
@@ -105,7 +105,8 @@ class ParCompactionManager : public CHeapObj<mtGC> {
   // Returns true and a valid task if there has not been enough space in the shared
   // objArray stack, otherwise returns false and the task is invalid.
   bool publish_or_pop_objarray_tasks(ObjArrayTask& task);
- protected:
+
+  ParCompactionManager();
   // Array of task queues.  Needed by the task terminator.
   static RegionTaskQueueSet* region_task_queues()      { return _region_task_queues; }
   OopTaskQueue*  oop_stack()       { return &_oop_stack; }
@@ -155,7 +156,6 @@ class ParCompactionManager : public CHeapObj<mtGC> {
   // Simply use the first compaction manager here.
   static ParCompactionManager* get_vmthread_cm() { return _manager_array[0]; }
 
-  ParCompactionManager();
 
   ParMarkBitMap* mark_bitmap() { return _mark_bitmap; }
 


### PR DESCRIPTION
Trivial reducing visibility of some methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321018](https://bugs.openjdk.org/browse/JDK-8321018): Parallel: Make some methods in ParCompactionManager private (**Enhancement** - P4)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16885/head:pull/16885` \
`$ git checkout pull/16885`

Update a local copy of the PR: \
`$ git checkout pull/16885` \
`$ git pull https://git.openjdk.org/jdk.git pull/16885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16885`

View PR using the GUI difftool: \
`$ git pr show -t 16885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16885.diff">https://git.openjdk.org/jdk/pull/16885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16885#issuecomment-1832073236)