### PR TITLE
8321025: Enable Neoverse N1 optimizations for Neoverse V2

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -204,8 +204,9 @@ void VM_Version::initialize() {
     }
   }
 
-  // Neoverse N1, N2 and V1
-  if (_cpu == CPU_ARM && (model_is(0xd0c) || model_is(0xd49) || model_is(0xd40))) {
+  // Neoverse N1, N2, V1, V2
+  if (_cpu == CPU_ARM && (model_is(0xd0c) || model_is(0xd49) ||
+                          model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }


### PR DESCRIPTION
As Arm Neoverse V2 will benefit from the same optimizations as Neoverse N1 does, it should have OnSpinWaitInst/OnSpinWaitInstCount defaults set to "isb"/1 and UseSIMDForMemoryOps default set to true.
This patch sets these flags accordingly for the V2 architecture.