### PR TITLE
8319111: Mismatched MemorySegment heap access is not consistently intrinsified

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -997,10 +997,10 @@ class methodHandle;
                                      "I"                                                                                                       \
                                      "Ljava/lang/Object;"                                                                                      \
                                      "J"                                                                                                       \
+                                     "Z"                                                                                                       \
                                      "Ljava/lang/Object;"                                                                                      \
                                      "J"                                                                                                       \
                                      "Ljdk/internal/vm/vector/VectorSupport$VectorSpecies;"                                                    \
-                                     "Z"                                                                                                       \
                                      "Ljdk/internal/vm/vector/VectorSupport$LoadOperation;)"                                                   \
                                      "Ljdk/internal/vm/vector/VectorSupport$VectorPayload;")                                                   \
    do_name(vector_load_op_name,     "load")                                                                                                    \
@@ -1012,12 +1012,12 @@ class methodHandle;
                                             "I"                                                                                                \
                                             "Ljava/lang/Object;"                                                                               \
                                             "J"                                                                                                \
+                                            "Z"                                                                                                \
                                             "Ljdk/internal/vm/vector/VectorSupport$VectorMask;"                                                \
                                             "I"                                                                                                \
                                             "Ljava/lang/Object;"                                                                               \
                                             "J"                                                                                                \
                                             "Ljdk/internal/vm/vector/VectorSupport$VectorSpecies;"                                             \
-                                            "Z"                                                                                                \
                                             "Ljdk/internal/vm/vector/VectorSupport$LoadVectorMaskedOperation;)"                                \
                                             "Ljdk/internal/vm/vector/VectorSupport$Vector;")                                                   \
    do_name(vector_load_masked_op_name,     "loadMasked")                                                                                       \
@@ -1028,10 +1028,10 @@ class methodHandle;
                                       "I"                                                                                                      \
                                       "Ljava/lang/Object;"                                                                                     \
                                       "J"                                                                                                      \
+                                      "Z"                                                                                                      \
                                       "Ljdk/internal/vm/vector/VectorSupport$VectorPayload;"                                                   \
                                       "Ljava/lang/Object;"                                                                                     \
                                       "J"                                                                                                      \
-                                      "Z"                                                                                                      \
                                       "Ljdk/internal/vm/vector/VectorSupport$StoreVectorOperation;)"                                           \
                                       "V")                                                                                                     \
    do_name(vector_store_op_name,     "store")                                                                                                  \
@@ -1043,11 +1043,11 @@ class methodHandle;
                                              "I"                                                                                               \
                                              "Ljava/lang/Object;"                                                                              \
                                              "J"                                                                                               \
+                                             "Z"                                                                                               \
                                              "Ljdk/internal/vm/vector/VectorSupport$Vector;"                                                   \
                                              "Ljdk/internal/vm/vector/VectorSupport$VectorMask;"                                               \
                                              "Ljava/lang/Object;"                                                                              \
                                              "J"                                                                                               \
-                                             "Z"                                                                                               \
                                              "Ljdk/internal/vm/vector/VectorSupport$StoreVectorMaskedOperation;)"                              \
                                              "V")                                                                                              \
    do_name(vector_store_masked_op_name,     "storeMasked")                                                                                     \

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -1000,6 +1000,7 @@ class methodHandle;
                                      "Ljava/lang/Object;"                                                                                      \
                                      "J"                                                                                                       \
                                      "Ljdk/internal/vm/vector/VectorSupport$VectorSpecies;"                                                    \
+                                     "Z"                                                                                                       \
                                      "Ljdk/internal/vm/vector/VectorSupport$LoadOperation;)"                                                   \
                                      "Ljdk/internal/vm/vector/VectorSupport$VectorPayload;")                                                   \
    do_name(vector_load_op_name,     "load")                                                                                                    \
@@ -1016,6 +1017,7 @@ class methodHandle;
                                             "Ljava/lang/Object;"                                                                               \
                                             "J"                                                                                                \
                                             "Ljdk/internal/vm/vector/VectorSupport$VectorSpecies;"                                             \
+                                            "Z"                                                                                                \
                                             "Ljdk/internal/vm/vector/VectorSupport$LoadVectorMaskedOperation;)"                                \
                                             "Ljdk/internal/vm/vector/VectorSupport$Vector;")                                                   \
    do_name(vector_load_masked_op_name,     "loadMasked")                                                                                       \
@@ -1029,6 +1031,7 @@ class methodHandle;
                                       "Ljdk/internal/vm/vector/VectorSupport$VectorPayload;"                                                   \
                                       "Ljava/lang/Object;"                                                                                     \
                                       "J"                                                                                                      \
+                                      "Z"                                                                                                      \
                                       "Ljdk/internal/vm/vector/VectorSupport$StoreVectorOperation;)"                                           \
                                       "V")                                                                                                     \
    do_name(vector_store_op_name,     "store")                                                                                                  \
@@ -1044,6 +1047,7 @@ class methodHandle;
                                              "Ljdk/internal/vm/vector/VectorSupport$VectorMask;"                                               \
                                              "Ljava/lang/Object;"                                                                              \
                                              "J"                                                                                               \
+                                             "Z"                                                                                               \
                                              "Ljdk/internal/vm/vector/VectorSupport$StoreVectorMaskedOperation;)"                              \
                                              "V")                                                                                              \
    do_name(vector_store_masked_op_name,     "storeMasked")                                                                                     \

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -928,7 +928,7 @@ bool LibraryCallKit::inline_vector_frombits_coerced() {
   return true;
 }
 
-static bool elem_consistent_with_arr(BasicType elem_bt, const TypeAryPtr* arr_type) {
+static bool elem_consistent_with_arr(BasicType elem_bt, const TypeAryPtr* arr_type, bool mismatched_ms) {
   assert(arr_type != nullptr, "unexpected");
   BasicType arr_elem_bt = arr_type->elem()->array_element_basic_type();
   if (elem_bt == arr_elem_bt) {
@@ -940,7 +940,7 @@ static bool elem_consistent_with_arr(BasicType elem_bt, const TypeAryPtr* arr_ty
     // Load/store of byte vector from/to boolean[] is supported
     return true;
   } else {
-    return false;
+    return mismatched_ms;
   }
 }
 
@@ -951,7 +951,7 @@ static bool elem_consistent_with_arr(BasicType elem_bt, const TypeAryPtr* arr_ty
 //  S extends VectorSpecies<E>>
 // VM load(Class<? extends VM> vmClass, Class<E> elementType, int length,
 //         Object base, long offset,    // Unsafe addressing
-//         C container, long index, S s,     // Arguments for default implementation
+//         C container, long index, S s,  boolean from_ms,    // Arguments for default implementation
 //         LoadOperation<C, VM, E, S> defaultImpl)
 //
 // public static
@@ -960,21 +960,23 @@ static bool elem_consistent_with_arr(BasicType elem_bt, const TypeAryPtr* arr_ty
 // void store(Class<?> vectorClass, Class<?> elementType, int length,
 //            Object base, long offset,    // Unsafe addressing
 //            V v,
-//            C container, long index,      // Arguments for default implementation
+//            C container, long index, boolean from_ms, // Arguments for default implementation
 //            StoreVectorOperation<C, V> defaultImpl)
 
 bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
   const TypeInstPtr* vector_klass = gvn().type(argument(0))->isa_instptr();
   const TypeInstPtr* elem_klass   = gvn().type(argument(1))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(2))->isa_int();
+  const TypeInt*     from_ms      = gvn().type(argument(10))->isa_int();
 
-  if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
+  if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr || !from_ms->is_con() ||
       vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
     if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s",
+      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s from_ms=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
-                    NodeClassNames[argument(2)->Opcode()]);
+                    NodeClassNames[argument(2)->Opcode()],
+                    NodeClassNames[argument(10)->Opcode()]);
     }
     return false; // not enough info for intrinsification
   }
@@ -1033,11 +1035,10 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
   const bool needs_cpu_membar = is_mixed_access || is_mismatched_access;
 
-  // Now handle special case where load/store happens from/to byte array but element type is not byte.
-  bool using_byte_array = arr_type != nullptr && arr_type->elem()->array_element_basic_type() == T_BYTE && elem_bt != T_BYTE;
-  // Handle loading masks.
-  // If there is no consistency between array and vector element types, it must be special byte array case or loading masks
-  if (arr_type != nullptr && !using_byte_array && !is_mask && !elem_consistent_with_arr(elem_bt, arr_type)) {
+  bool mismatched_ms = from_ms->get_con() && !is_mask && arr_type != nullptr && arr_type->elem()->array_element_basic_type() != elem_bt;
+  BasicType mem_elem_bt = mismatched_ms ? arr_type->elem()->array_element_basic_type() : elem_bt;
+  int mem_num_elem = mismatched_ms ? (num_elem * type2aelembytes(elem_bt)) / type2aelembytes(mem_elem_bt) : num_elem;
+  if (arr_type != nullptr && !is_mask && !elem_consistent_with_arr(elem_bt, arr_type, mismatched_ms)) {
     if (C->print_intrinsics()) {
       tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s ismask=no",
                     is_store, is_store ? "store" : "load",
@@ -1047,19 +1048,33 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
     set_sp(old_sp);
     return false;
   }
-  // Since we are using byte array, we need to double check that the byte operations are supported by backend.
-  if (using_byte_array) {
-    int byte_num_elem = num_elem * type2aelembytes(elem_bt);
-    if (!arch_supports_vector(is_store ? Op_StoreVector : Op_LoadVector, byte_num_elem, T_BYTE, VecMaskNotUsed)
-        || !arch_supports_vector(Op_VectorReinterpret, byte_num_elem, T_BYTE, VecMaskNotUsed)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d*8 etype=%s/8 ismask=no",
-                      is_store, is_store ? "store" : "load",
-                      byte_num_elem, type2name(elem_bt));
+
+  // In case of mismatched memory segment accesses, we need to double check that the source type memory operations are supported by backend.
+  if (mismatched_ms) {
+    if (is_store) {
+      if (!arch_supports_vector(Op_StoreVector, num_elem, elem_bt, VecMaskNotUsed)
+          || !arch_supports_vector(Op_VectorReinterpret, mem_num_elem, mem_elem_bt, VecMaskNotUsed)) {
+        if (C->print_intrinsics()) {
+          tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d*8 etype=%s/8 ismask=no",
+                        is_store, "store",
+                        num_elem, type2name(elem_bt));
+        }
+        set_map(old_map);
+        set_sp(old_sp);
+        return false; // not supported
       }
-      set_map(old_map);
-      set_sp(old_sp);
-      return false; // not supported
+    } else {
+      if (!arch_supports_vector(Op_LoadVector, mem_num_elem, mem_elem_bt, VecMaskNotUsed)
+          || !arch_supports_vector(Op_VectorReinterpret, num_elem, elem_bt, VecMaskNotUsed)) {
+        if (C->print_intrinsics()) {
+          tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d*8 etype=%s/8 ismask=no",
+                        is_store, "load",
+                        mem_num_elem, type2name(mem_elem_bt));
+        }
+        set_map(old_map);
+        set_sp(old_sp);
+        return false; // not supported
+      }
     }
   }
   if (is_mask) {
@@ -1095,9 +1110,9 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
     // In case the store needs to happen to byte array, reinterpret the incoming vector to byte vector.
     int store_num_elem = num_elem;
-    if (using_byte_array) {
-      store_num_elem = num_elem * type2aelembytes(elem_bt);
-      const TypeVect* to_vect_type = TypeVect::make(T_BYTE, store_num_elem);
+    if (mismatched_ms) {
+      store_num_elem = mem_num_elem;
+      const TypeVect* to_vect_type = TypeVect::make(mem_elem_bt, store_num_elem);
       val = gvn().transform(new VectorReinterpretNode(val, val->bottom_type()->is_vect(), to_vect_type));
     }
     if (is_mask) {
@@ -1108,9 +1123,8 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
   } else {
     // When using byte array, we need to load as byte then reinterpret the value. Otherwise, do a simple vector load.
     Node* vload = nullptr;
-    if (using_byte_array) {
-      int load_num_elem = num_elem * type2aelembytes(elem_bt);
-      vload = gvn().transform(LoadVectorNode::make(0, control(), memory(addr), addr, addr_type, load_num_elem, T_BYTE));
+    if (mismatched_ms) {
+      vload = gvn().transform(LoadVectorNode::make(0, control(), memory(addr), addr, addr_type, mem_num_elem, mem_elem_bt));
       const TypeVect* to_vect_type = TypeVect::make(elem_bt, num_elem);
       vload = gvn().transform(new VectorReinterpretNode(vload, vload->bottom_type()->is_vect(), to_vect_type));
     } else {
@@ -1142,37 +1156,38 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 //  E,
 //  S extends VectorSpecies<E>,
 //  M extends VectorMask<E>>
-// V loadMasked(Class<? extends V> vectorClass, Class<M> maskClass, Class<E> elementType,
-//              int length, Object base, long offset, M m, int offsetInRange,
-//              C container, long index, S s,  // Arguments for default implementation
+// V loadMasked(Class<? extends V> vClass, Class<M> mClass, Class<E> eClass,
+//              int length, Object base, long offset,
+//              M m, int offsetInRange,
+//              C container, long index, S s, boolean from_m, // Arguments for default implementation
 //              LoadVectorMaskedOperation<C, V, S, M> defaultImpl) {
-//
 // public static
 // <C,
 //  V extends Vector<E>,
 //  M extends VectorMask<E>,
 //  E>
-// void storeMasked(Class<? extends V> vectorClass, Class<M> maskClass, Class<E> elementType,
-//                  int length, Object base, long offset,
-//                  V v, M m,
-//                  C container, long index,  // Arguments for default implementation
-//                  StoreVectorMaskedOperation<C, V, M, E> defaultImpl) {
-//
+// void storeMasked(Class<? extends V> vClass, Class<M> mClass, Class<E> eClass,
+//                  int length,
+//                  Object base, long offset,
+//                  V v, M m, C container, long index, boolean from_ms, // Arguments for default implementation
+//                  StoreVectorMaskedOperation<C, V, M> defaultImpl) {
 bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   const TypeInstPtr* vector_klass = gvn().type(argument(0))->isa_instptr();
   const TypeInstPtr* mask_klass   = gvn().type(argument(1))->isa_instptr();
   const TypeInstPtr* elem_klass   = gvn().type(argument(2))->isa_instptr();
   const TypeInt*     vlen         = gvn().type(argument(3))->isa_int();
+  const TypeInt*     from_ms      = gvn().type(argument(is_store ? 12 : 13))->isa_int();
 
   if (vector_klass == nullptr || mask_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
-      vector_klass->const_oop() == nullptr || mask_klass->const_oop() == nullptr ||
-      elem_klass->const_oop() == nullptr || !vlen->is_con()) {
+      vector_klass->const_oop() == nullptr || mask_klass->const_oop() == nullptr || from_ms == nullptr ||
+      elem_klass->const_oop() == nullptr || !vlen->is_con() || !from_ms->is_con()) {
     if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s mclass=%s etype=%s vlen=%s",
+      tty->print_cr("  ** missing constant: vclass=%s mclass=%s etype=%s vlen=%s from_ms=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
-                    NodeClassNames[argument(3)->Opcode()]);
+                    NodeClassNames[argument(3)->Opcode()],
+                    NodeClassNames[argument(is_store ? 12 : 13)->Opcode()]);
     }
     return false; // not enough info for intrinsification
   }
@@ -1212,10 +1227,9 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   const TypePtr *addr_type = gvn().type(addr)->isa_ptr();
   const TypeAryPtr* arr_type = addr_type->isa_aryptr();
 
-  // Now handle special case where load/store happens from/to byte array but element type is not byte.
-  bool using_byte_array = arr_type != nullptr && arr_type->elem()->array_element_basic_type() == T_BYTE && elem_bt != T_BYTE;
+  bool mismatched_ms = from_ms->get_con() && arr_type != nullptr && arr_type->elem()->array_element_basic_type() != elem_bt;
   // If there is no consistency between array and vector element types, it must be special byte array case
-  if (arr_type != nullptr && !using_byte_array && !elem_consistent_with_arr(elem_bt, arr_type)) {
+  if (arr_type != nullptr && !elem_consistent_with_arr(elem_bt, arr_type, mismatched_ms)) {
     if (C->print_intrinsics()) {
       tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s",
                     is_store, is_store ? "storeMasked" : "loadMasked",
@@ -1226,8 +1240,8 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
     return false;
   }
 
-  int mem_num_elem = using_byte_array ? num_elem * type2aelembytes(elem_bt) : num_elem;
-  BasicType mem_elem_bt = using_byte_array ? T_BYTE : elem_bt;
+  int mem_num_elem = mismatched_ms ? num_elem * type2aelembytes(elem_bt) : num_elem;
+  BasicType mem_elem_bt = mismatched_ms ? T_BYTE : elem_bt;
   bool supports_predicate = arch_supports_vector(is_store ? Op_StoreVectorMasked : Op_LoadVectorMasked,
                                                 mem_num_elem, mem_elem_bt, VecMaskUseLoad);
 
@@ -1255,9 +1269,9 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
 
     if (needs_predicate) {
       if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: op=%s vlen=%d etype=%s using_byte_array=%d",
+        tty->print_cr("  ** not supported: op=%s vlen=%d etype=%s mismatched_ms=%d",
                       is_store ? "storeMasked" : "loadMasked",
-                      num_elem, type2name(elem_bt), using_byte_array ? 1 : 0);
+                      num_elem, type2name(elem_bt), mismatched_ms ? 1 : 0);
       }
       set_map(old_map);
       set_sp(old_sp);
@@ -1270,8 +1284,8 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   if (!supports_predicate && (!arch_supports_vector(Op_LoadVector, mem_num_elem, mem_elem_bt, VecMaskNotUsed) ||
       !arch_supports_vector(Op_VectorBlend, mem_num_elem, mem_elem_bt, VecMaskUseLoad))) {
     if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: op=loadMasked vlen=%d etype=%s using_byte_array=%d",
-                    num_elem, type2name(elem_bt), using_byte_array ? 1 : 0);
+      tty->print_cr("  ** not supported: op=loadMasked vlen=%d etype=%s mismatched_ms=%d",
+                    num_elem, type2name(elem_bt), mismatched_ms ? 1 : 0);
     }
     set_map(old_map);
     set_sp(old_sp);
@@ -1280,10 +1294,10 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
 
   // Since we are using byte array, we need to double check that the vector reinterpret operation
   // with byte type is supported by backend.
-  if (using_byte_array) {
+  if (mismatched_ms) {
     if (!arch_supports_vector(Op_VectorReinterpret, mem_num_elem, T_BYTE, VecMaskNotUsed)) {
       if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s using_byte_array=1",
+        tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s mismatched_ms=1",
                       is_store, is_store ? "storeMasked" : "loadMasked",
                       num_elem, type2name(elem_bt));
       }
@@ -1343,7 +1357,7 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
     }
     set_all_memory(reset_memory());
 
-    if (using_byte_array) {
+    if (mismatched_ms) {
       // Reinterpret the incoming vector to byte vector.
       const TypeVect* to_vect_type = TypeVect::make(mem_elem_bt, mem_num_elem);
       val = gvn().transform(new VectorReinterpretNode(val, val->bottom_type()->is_vect(), to_vect_type));
@@ -1357,7 +1371,7 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   } else {
     Node* vload = nullptr;
 
-    if (using_byte_array) {
+    if (mismatched_ms) {
       // Reinterpret the vector mask to byte type.
       const TypeVect* from_mask_type = TypeVect::makemask(elem_bt, num_elem);
       const TypeVect* to_mask_type = TypeVect::makemask(mem_elem_bt, mem_num_elem);
@@ -1376,7 +1390,7 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
       vload = gvn().transform(new VectorBlendNode(zero, vload, mask));
     }
 
-    if (using_byte_array) {
+    if (mismatched_ms) {
       const TypeVect* to_vect_type = TypeVect::make(elem_bt, num_elem);
       vload = gvn().transform(new VectorReinterpretNode(vload, vload->bottom_type()->is_vect(), to_vect_type));
     }
@@ -1525,7 +1539,7 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
   const TypeAryPtr* arr_type = addr_type->isa_aryptr();
 
   // The array must be consistent with vector type
-  if (arr_type == nullptr || (arr_type != nullptr && !elem_consistent_with_arr(elem_bt, arr_type))) {
+  if (arr_type == nullptr || (arr_type != nullptr && !elem_consistent_with_arr(elem_bt, arr_type, false))) {
     if (C->print_intrinsics()) {
       tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s ismask=no",
                     is_scatter, is_scatter ? "scatter" : "gather",

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1232,6 +1232,9 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   const TypeAryPtr* arr_type = addr_type->isa_aryptr();
 
   bool mismatched_ms = from_ms->get_con() && arr_type != nullptr && arr_type->elem()->array_element_basic_type() != elem_bt;
+  if (mismatched_ms BIG_ENDIAN_ONLY(&& true)) {
+    return false;
+  }
   // If there is no consistency between array and vector element types, it must be special byte array case
   if (arr_type != nullptr && !elem_consistent_with_arr(elem_bt, arr_type, mismatched_ms)) {
     if (C->print_intrinsics()) {

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1232,9 +1232,7 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   const TypeAryPtr* arr_type = addr_type->isa_aryptr();
 
   bool mismatched_ms = from_ms->get_con() && arr_type != nullptr && arr_type->elem()->array_element_basic_type() != elem_bt;
-  if (mismatched_ms BIG_ENDIAN_ONLY(&& true)) {
-    return false;
-  }
+  BIG_ENDIAN_ONLY(if (mismatched_ms) return false;)
   // If there is no consistency between array and vector element types, it must be special byte array case
   if (arr_type != nullptr && !elem_consistent_with_arr(elem_bt, arr_type, mismatched_ms)) {
     if (C->print_intrinsics()) {

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -356,7 +356,7 @@ public class ScopedMemoryAccess {
 
             return VectorSupport.load(vmClass, e, length,
                     msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
-                    msp, offset, s,
+                    msp, offset, s, true,
                     defaultImpl);
         } finally {
             Reference.reachabilityFence(session);
@@ -398,7 +398,7 @@ public class ScopedMemoryAccess {
 
             return VectorSupport.loadMasked(vmClass, maskClass, e, length,
                     msp.unsafeGetBase(), msp.unsafeGetOffset() + offset, m, offsetInRange,
-                    msp, offset, s,
+                    msp, offset, s, true,
                     defaultImpl);
         } finally {
             Reference.reachabilityFence(session);
@@ -440,7 +440,7 @@ public class ScopedMemoryAccess {
             VectorSupport.store(vmClass, e, length,
                     msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
                     v,
-                    msp, offset,
+                    msp, offset, true,
                     defaultImpl);
         } finally {
             Reference.reachabilityFence(session);
@@ -482,7 +482,7 @@ public class ScopedMemoryAccess {
             VectorSupport.storeMasked(vmClass, maskClass, e, length,
                     msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
                     v, m,
-                    msp, offset,
+                    msp, offset, true,
                     defaultImpl);
         } finally {
             Reference.reachabilityFence(session);

--- a/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
+++ b/src/java.base/share/classes/jdk/internal/misc/X-ScopedMemoryAccess.java.template
@@ -355,8 +355,8 @@ public class ScopedMemoryAccess {
             session.checkValidStateRaw();
 
             return VectorSupport.load(vmClass, e, length,
-                    msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
-                    msp, offset, s, true,
+                    msp.unsafeGetBase(), msp.unsafeGetOffset() + offset, true,
+                    msp, offset, s,
                     defaultImpl);
         } finally {
             Reference.reachabilityFence(session);
@@ -397,8 +397,8 @@ public class ScopedMemoryAccess {
             session.checkValidStateRaw();
 
             return VectorSupport.loadMasked(vmClass, maskClass, e, length,
-                    msp.unsafeGetBase(), msp.unsafeGetOffset() + offset, m, offsetInRange,
-                    msp, offset, s, true,
+                    msp.unsafeGetBase(), msp.unsafeGetOffset() + offset, true, m, offsetInRange,
+                    msp, offset, s,
                     defaultImpl);
         } finally {
             Reference.reachabilityFence(session);
@@ -438,9 +438,9 @@ public class ScopedMemoryAccess {
             session.checkValidStateRaw();
 
             VectorSupport.store(vmClass, e, length,
-                    msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
+                    msp.unsafeGetBase(), msp.unsafeGetOffset() + offset, true,
                     v,
-                    msp, offset, true,
+                    msp, offset,
                     defaultImpl);
         } finally {
             Reference.reachabilityFence(session);
@@ -480,9 +480,9 @@ public class ScopedMemoryAccess {
             session.checkValidStateRaw();
 
             VectorSupport.storeMasked(vmClass, maskClass, e, length,
-                    msp.unsafeGetBase(), msp.unsafeGetOffset() + offset,
+                    msp.unsafeGetBase(), msp.unsafeGetOffset() + offset, true,
                     v, m,
-                    msp, offset, true,
+                    msp, offset,
                     defaultImpl);
         } finally {
             Reference.reachabilityFence(session);

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -422,7 +422,7 @@ public class VectorSupport {
     VM load(Class<? extends VM> vmClass, Class<E> eClass,
             int length,
             Object base, long offset,
-            C container, long index, S s,
+            C container, long index, S s, boolean from_ms,
             LoadOperation<C, VM, S> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         return defaultImpl.load(container, index, s);
@@ -447,7 +447,7 @@ public class VectorSupport {
     V loadMasked(Class<? extends V> vClass, Class<M> mClass, Class<E> eClass,
                  int length, Object base, long offset,
                  M m, int offsetInRange,
-                 C container, long index, S s,
+                 C container, long index, S s, boolean from_ms,
                  LoadVectorMaskedOperation<C, V, S, M> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         return defaultImpl.load(container, index, s, m);
@@ -495,7 +495,7 @@ public class VectorSupport {
     void store(Class<?> vClass, Class<?> eClass,
                int length,
                Object base, long offset,
-               V v, C container, long index,
+               V v, C container, long index, boolean from_ms,
                StoreVectorOperation<C, V> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         defaultImpl.store(container, index, v);
@@ -516,7 +516,7 @@ public class VectorSupport {
     void storeMasked(Class<? extends V> vClass, Class<M> mClass, Class<E> eClass,
                      int length,
                      Object base, long offset,
-                     V v, M m, C container, long index,
+                     V v, M m, C container, long index, boolean from_ms,
                      StoreVectorMaskedOperation<C, V, M> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         defaultImpl.store(container, index, v, m);

--- a/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/vector/VectorSupport.java
@@ -421,8 +421,8 @@ public class VectorSupport {
      S extends VectorSpecies<E>>
     VM load(Class<? extends VM> vmClass, Class<E> eClass,
             int length,
-            Object base, long offset,
-            C container, long index, S s, boolean from_ms,
+            Object base, long offset, boolean fromSegment,
+            C container, long index, S s,
             LoadOperation<C, VM, S> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         return defaultImpl.load(container, index, s);
@@ -445,9 +445,9 @@ public class VectorSupport {
      S extends VectorSpecies<E>,
      M extends VectorMask<E>>
     V loadMasked(Class<? extends V> vClass, Class<M> mClass, Class<E> eClass,
-                 int length, Object base, long offset,
+                 int length, Object base, long offset, boolean fromSegment,
                  M m, int offsetInRange,
-                 C container, long index, S s, boolean from_ms,
+                 C container, long index, S s,
                  LoadVectorMaskedOperation<C, V, S, M> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         return defaultImpl.load(container, index, s, m);
@@ -494,8 +494,8 @@ public class VectorSupport {
      V extends VectorPayload>
     void store(Class<?> vClass, Class<?> eClass,
                int length,
-               Object base, long offset,
-               V v, C container, long index, boolean from_ms,
+               Object base, long offset, boolean fromSegment,
+               V v, C container, long index,
                StoreVectorOperation<C, V> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         defaultImpl.store(container, index, v);
@@ -515,8 +515,8 @@ public class VectorSupport {
      E>
     void storeMasked(Class<? extends V> vClass, Class<M> mClass, Class<E> eClass,
                      int length,
-                     Object base, long offset,
-                     V v, M m, C container, long index, boolean from_ms,
+                     Object base, long offset, boolean fromSegment,
+                     V v, M m, C container, long index,
                      StoreVectorMaskedOperation<C, V, M> defaultImpl) {
         assert isNonCapturingLambda(defaultImpl) : defaultImpl;
         defaultImpl.store(container, index, v, m);

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -75,7 +75,7 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         VectorSupport.store(
             vsp.maskType(), vsp.elementType(), laneCount,
             bits, (long) i + Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
-            this, bits, i,
+            this, bits, i, false,
             (c, idx, s) -> System.arraycopy(s.getBits(), 0, c, (int) idx, s.length()));
 
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractMask.java
@@ -74,8 +74,8 @@ abstract class AbstractMask<E> extends VectorMask<E> {
         i = VectorIntrinsics.checkFromIndexSize(i, laneCount, bits.length);
         VectorSupport.store(
             vsp.maskType(), vsp.elementType(), laneCount,
-            bits, (long) i + Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
-            this, bits, i, false,
+            bits, (long) i + Unsafe.ARRAY_BOOLEAN_BASE_OFFSET, false,
+            this, bits, i,
             (c, idx, s) -> System.arraycopy(s.getBits(), 0, c, (int) idx, s.length()));
 
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3375,7 +3375,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3528,7 +3528,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, booleanArrayAddress(a, offset),
             normalized,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
@@ -3738,7 +3738,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3755,7 +3755,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3772,7 +3772,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, booleanArrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> (byte) (arr_[off_ + i] ? 1 : 0)));
     }
@@ -3789,7 +3789,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, booleanArrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> (byte) (arr_[off_ + i] ? 1 : 0)));
     }
@@ -3837,7 +3837,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, a, offset,
+            this, a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3854,7 +3854,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3873,7 +3873,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, booleanArrayAddress(a, offset),
-            normalized, m, a, offset,
+            normalized, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3373,9 +3373,9 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
+            a, arrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3526,9 +3526,9 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteVector normalized = this.and((byte) 1);
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset),
+            a, booleanArrayAddress(a, offset), false,
             normalized,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
@@ -3737,8 +3737,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3754,8 +3754,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3771,8 +3771,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, booleanArrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> (byte) (arr_[off_ + i] ? 1 : 0)));
     }
@@ -3788,8 +3788,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, booleanArrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> (byte) (arr_[off_ + i] ? 1 : 0)));
     }
@@ -3836,8 +3836,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3853,8 +3853,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteSpecies vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3872,8 +3872,8 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         ByteVector normalized = this.and((byte) 1);
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset),
-            normalized, m, a, offset, false,
+            a, booleanArrayAddress(a, offset), false,
+            normalized, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3063,7 +3063,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3295,7 +3295,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3312,7 +3312,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3414,7 +3414,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, a, offset,
+            this, a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3431,7 +3431,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3061,9 +3061,9 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         DoubleSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
+            a, arrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3294,8 +3294,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         DoubleSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3311,8 +3311,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         DoubleSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3413,8 +3413,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         DoubleSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3430,8 +3430,8 @@ public abstract class DoubleVector extends AbstractVector<Double> {
         DoubleSpecies vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3067,9 +3067,9 @@ public abstract class FloatVector extends AbstractVector<Float> {
         FloatSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
+            a, arrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3281,8 +3281,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         FloatSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3298,8 +3298,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         FloatSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3382,8 +3382,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         FloatSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3399,8 +3399,8 @@ public abstract class FloatVector extends AbstractVector<Float> {
         FloatSpecies vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3069,7 +3069,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3282,7 +3282,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3299,7 +3299,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3383,7 +3383,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, a, offset,
+            this, a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3400,7 +3400,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3223,9 +3223,9 @@ public abstract class IntVector extends AbstractVector<Integer> {
         IntSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
+            a, arrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3437,8 +3437,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
         IntSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3454,8 +3454,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
         IntSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3538,8 +3538,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
         IntSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3555,8 +3555,8 @@ public abstract class IntVector extends AbstractVector<Integer> {
         IntSpecies vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3225,7 +3225,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3438,7 +3438,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3455,7 +3455,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3539,7 +3539,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, a, offset,
+            this, a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3556,7 +3556,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3102,9 +3102,9 @@ public abstract class LongVector extends AbstractVector<Long> {
         LongSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
+            a, arrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3335,8 +3335,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         LongSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3352,8 +3352,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         LongSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3454,8 +3454,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         LongSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3471,8 +3471,8 @@ public abstract class LongVector extends AbstractVector<Long> {
         LongSpecies vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3104,7 +3104,7 @@ public abstract class LongVector extends AbstractVector<Long> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3336,7 +3336,7 @@ public abstract class LongVector extends AbstractVector<Long> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3353,7 +3353,7 @@ public abstract class LongVector extends AbstractVector<Long> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3455,7 +3455,7 @@ public abstract class LongVector extends AbstractVector<Long> {
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, a, offset,
+            this, a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3472,7 +3472,7 @@ public abstract class LongVector extends AbstractVector<Long> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3372,9 +3372,9 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
+            a, arrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3520,9 +3520,9 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, charArrayAddress(a, offset),
+            a, charArrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));
@@ -3723,8 +3723,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3740,8 +3740,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3756,8 +3756,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, charArrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, charArrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> (short) arr_[off_ + i]));
     }
@@ -3773,8 +3773,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         return VectorSupport.loadMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-                a, charArrayAddress(a, offset), m, offsetInRange,
-                a, offset, vsp, false,
+                a, charArrayAddress(a, offset), false, m, offsetInRange,
+                a, offset, vsp,
                 (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                             (arr_, off_, i) -> (short) arr_[off_ + i]));
     }
@@ -3822,8 +3822,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3839,8 +3839,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3889,8 +3889,8 @@ public abstract class ShortVector extends AbstractVector<Short> {
         ShortSpecies vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, charArrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, charArrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3374,7 +3374,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3522,7 +3522,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, charArrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));
@@ -3724,7 +3724,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3741,7 +3741,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -3757,7 +3757,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, charArrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> (short) arr_[off_ + i]));
     }
@@ -3774,7 +3774,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         return VectorSupport.loadMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
                 a, charArrayAddress(a, offset), m, offsetInRange,
-                a, offset, vsp,
+                a, offset, vsp, false,
                 (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                             (arr_, off_, i) -> (short) arr_[off_ + i]));
     }
@@ -3823,7 +3823,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, a, offset,
+            this, a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -3840,7 +3840,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -3890,7 +3890,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, charArrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -208,7 +208,7 @@ public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport
         return VectorSupport.load(
                 vsp.maskType(), vsp.elementType(), laneCount,
                 bits, (long) offset + Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
-                bits, offset, vsp,
+                bits, offset, vsp, false,
                 (c, idx, s)
                   -> s.opm(n -> c[((int )idx) + n]));
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/VectorMask.java
@@ -207,8 +207,8 @@ public abstract class VectorMask<E> extends jdk.internal.vm.vector.VectorSupport
         offset = VectorIntrinsics.checkFromIndexSize(offset, laneCount, bits.length);
         return VectorSupport.load(
                 vsp.maskType(), vsp.elementType(), laneCount,
-                bits, (long) offset + Unsafe.ARRAY_BOOLEAN_BASE_OFFSET,
-                bits, offset, vsp, false,
+                bits, (long) offset + Unsafe.ARRAY_BOOLEAN_BASE_OFFSET, false,
+                bits, offset, vsp,
                 (c, idx, s)
                   -> s.opm(n -> c[((int )idx) + n]));
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -4178,9 +4178,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
+            a, arrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -4397,9 +4397,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, charArrayAddress(a, offset),
+            a, charArrayAddress(a, offset), false,
             this,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));
@@ -4558,9 +4558,9 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         ByteVector normalized = this.and((byte) 1);
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset),
+            a, booleanArrayAddress(a, offset), false,
             normalized,
-            a, offset, false,
+            a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
@@ -4770,8 +4770,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -4787,8 +4787,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, arrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -4864,8 +4864,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, charArrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, charArrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> (short) arr_[off_ + i]));
     }
@@ -4881,8 +4881,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         return VectorSupport.loadMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-                a, charArrayAddress(a, offset), m, offsetInRange,
-                a, offset, vsp, false,
+                a, charArrayAddress(a, offset), false, m, offsetInRange,
+                a, offset, vsp,
                 (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                             (arr_, off_, i) -> (short) arr_[off_ + i]));
     }
@@ -4898,8 +4898,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset),
-            a, offset, vsp, false,
+            a, booleanArrayAddress(a, offset), false,
+            a, offset, vsp,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> (byte) (arr_[off_ + i] ? 1 : 0)));
     }
@@ -4915,8 +4915,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp, false,
+            a, booleanArrayAddress(a, offset), false, m, offsetInRange,
+            a, offset, vsp,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> (byte) (arr_[off_ + i] ? 1 : 0)));
     }
@@ -4964,8 +4964,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, a, offset,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -4981,8 +4981,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, arrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, arrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -5062,8 +5062,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         ByteVector normalized = this.and((byte) 1);
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, booleanArrayAddress(a, offset),
-            normalized, m, a, offset, false,
+            a, booleanArrayAddress(a, offset), false,
+            normalized, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
@@ -5112,8 +5112,8 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         $Type$Species vsp = vspecies();
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
-            a, charArrayAddress(a, offset),
-            this, m, a, offset, false,
+            a, charArrayAddress(a, offset), false,
+            this, m, a, offset,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -4180,7 +4180,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -4399,7 +4399,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, charArrayAddress(a, offset),
             this,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));
@@ -4560,7 +4560,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, booleanArrayAddress(a, offset),
             normalized,
-            a, offset,
+            a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
@@ -4771,7 +4771,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -4788,7 +4788,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> arr_[off_ + i]));
     }
@@ -4865,7 +4865,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, charArrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> (short) arr_[off_ + i]));
     }
@@ -4882,7 +4882,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         return VectorSupport.loadMasked(
                 vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
                 a, charArrayAddress(a, offset), m, offsetInRange,
-                a, offset, vsp,
+                a, offset, vsp, false,
                 (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                             (arr_, off_, i) -> (short) arr_[off_ + i]));
     }
@@ -4899,7 +4899,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         return VectorSupport.load(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, booleanArrayAddress(a, offset),
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s) -> s.ldOp(arr, (int) off,
                                     (arr_, off_, i) -> (byte) (arr_[off_ + i] ? 1 : 0)));
     }
@@ -4916,7 +4916,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         return VectorSupport.loadMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, booleanArrayAddress(a, offset), m, offsetInRange,
-            a, offset, vsp,
+            a, offset, vsp, false,
             (arr, off, s, vm) -> s.ldOp(arr, (int) off, vm,
                                         (arr_, off_, i) -> (byte) (arr_[off_ + i] ? 1 : 0)));
     }
@@ -4965,7 +4965,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         VectorSupport.store(
             vsp.vectorType(), vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, a, offset,
+            this, a, offset, false,
             (arr, off, v)
             -> v.stOp(arr, (int) off,
                       (arr_, off_, i, e) -> arr_[off_+i] = e));
@@ -4982,7 +4982,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, arrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = e));
@@ -5063,7 +5063,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, booleanArrayAddress(a, offset),
-            normalized, m, a, offset,
+            normalized, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (e & 1) != 0));
@@ -5113,7 +5113,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         VectorSupport.storeMasked(
             vsp.vectorType(), maskClass, vsp.elementType(), vsp.laneCount(),
             a, charArrayAddress(a, offset),
-            this, m, a, offset,
+            this, m, a, offset, false,
             (arr, off, v, vm)
             -> v.stOp(arr, (int) off, vm,
                       (arr_, off_, i, e) -> arr_[off_ + i] = (char) e));

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadSegmentVarious.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadSegmentVarious.java
@@ -55,6 +55,9 @@ public class TestLoadSegmentVarious {
     private static final VectorSpecies<Integer> INTEGER_SPECIES = VectorSpecies.ofLargestShape(int.class);
     private static final VectorSpecies<Double> DOUBLE_SPECIES = VectorSpecies.ofLargestShape(double.class);
 
+    private static final VectorMask<Integer> INTEGER_MASK = VectorMask.fromLong(INTEGER_SPECIES, (1 << (INTEGER_SPECIES.length() / 2)) - 1);
+    private static final VectorMask<Double> DOUBLE_MASK = VectorMask.fromLong(DOUBLE_SPECIES, (1 << (DOUBLE_SPECIES.length() / 2)) - 1);
+
     // Must be evenly dividable by Double.BYTES
     @Param("1024")
     private int size;
@@ -253,4 +256,27 @@ public class TestLoadSegmentVarious {
         }
     }
 
+    @Benchmark
+    public void intVectorFromIntBackedSegmentMasked(Blackhole bh) {
+        for (int i = 0; i < INTEGER_SPECIES.loopBound(intSrcArray.length); i += INTEGER_SPECIES.vectorByteSize()) {
+            var v = IntVector.fromMemorySegment(INTEGER_SPECIES, doubleSegment, i, ByteOrder.nativeOrder(), INTEGER_MASK);
+            bh.consume(v);
+        }
+    }
+
+    @Benchmark
+    public void intVectorFromDoubleBackedSegmentMasked(Blackhole bh) {
+        for (int i = 0; i < INTEGER_SPECIES.loopBound(intSrcArray.length); i += INTEGER_SPECIES.vectorByteSize()) {
+            var v = IntVector.fromMemorySegment(INTEGER_SPECIES, doubleSegment, i, ByteOrder.nativeOrder(), INTEGER_MASK);
+            bh.consume(v);
+        }
+    }
+
+    @Benchmark
+    public void doubleVectorFromIntBackedSegmentMasked(Blackhole bh) {
+        for (int i = 0; i < DOUBLE_SPECIES.loopBound(doubleSrcArray.length); i += DOUBLE_SPECIES.vectorByteSize()) {
+            var v = DoubleVector.fromMemorySegment(DOUBLE_SPECIES, intSegment, i, ByteOrder.nativeOrder(), DOUBLE_MASK);
+            bh.consume(v);
+        }
+    }
 }


### PR DESCRIPTION
Patch enables intrinsification of fromMemorySegment, intoMemorySegment APIs and their masked variants for mismatched memory segments i.e. heap based memory segments whose backing storage type differs from the vector type in which they are loaded to or stored from.

A load from a mismatched segment first moves the contents into type compatible vector followed by reinterpretation to desired vector type. This facilitates value forwarding from a preceding vector store as alias indices are computed using backing storage type.

Mismatched masked vector loads and stores are performed at byte granularity, this handles both narrowing and widening scenarios where vector lane size is smaller than backing storage element type and vice versa.

Following are the performance numbers of and existing JMH micro.

![image](https://github.com/openjdk/jdk/assets/59989778/a0b177af-78ca-4ac8-b6b0-bfe3655b16a6)

Please review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319111](https://bugs.openjdk.org/browse/JDK-8319111): Mismatched MemorySegment heap access is not consistently intrinsified (**Enhancement** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16888/head:pull/16888` \
`$ git checkout pull/16888`

Update a local copy of the PR: \
`$ git checkout pull/16888` \
`$ git pull https://git.openjdk.org/jdk.git pull/16888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16888`

View PR using the GUI difftool: \
`$ git pr show -t 16888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16888.diff">https://git.openjdk.org/jdk/pull/16888.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16888#issuecomment-1832433732)