### PR TITLE
6230751: [Fmt-Ch] Recursive MessageFormats in ChoiceFormats ignore indicated subformats

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -102,7 +102,7 @@ import java.util.Arrays;
  *
  * <p>
  * For more sophisticated patterns, {@code ChoiceFormat} can be used with
- * {@link MessageFormat} to produce accurate forms for singular and plural.
+ * {@link MessageFormat} to produce accurate forms for singular and plural:
  * {@snippet lang=java :
  * MessageFormat msgFmt = new MessageFormat("The disk \"{0}\" contains {1}.");
  * double[] fileLimits = {0,1,2};

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -118,6 +118,8 @@ import java.util.Arrays;
  * The disk "MyDisk" contains one file.
  * The disk "MyDisk" contains 1,273 files.
  * </pre></blockquote>
+ * See {@link MessageFormat##pattern_caveats MessageFormat} for caveats regarding
+ * {@code MessageFormat} patterns within a {@code ChoiceFormat} pattern.
  *
  * <h2><a id="patterns">Patterns</a></h2>
  * A {@code ChoiceFormat} pattern has the following syntax:

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -88,7 +88,6 @@ import java.util.Arrays;
  * <p>
  * Below is an example of constructing a ChoiceFormat with arrays to format
  * and parse values:
- * <blockquote>
  * {@snippet lang=java :
  * double[] limits = {1,2,3,4,5,6,7};
  * String[] dayOfWeekNames = {"Sun","Mon","Tue","Wed","Thur","Fri","Sat"};
@@ -100,34 +99,25 @@ import java.util.Arrays;
  *                              + form.parse(form.format(i),status));
  * }
  * }
- * </blockquote>
+ *
+ * <p>
  * For more sophisticated patterns, {@code ChoiceFormat} can be used with
- * {@link MessageFormat} to produce accurate forms for singular and plural:
- * <blockquote>
+ * {@link MessageFormat} to produce accurate forms for singular and plural.
  * {@snippet lang=java :
- * double[] filelimits = {0,1,2};
- * String[] filepart = {"are no files","is one file","are {2} files"};
- * ChoiceFormat fileform = new ChoiceFormat(filelimits, filepart);
- * Format[] testFormats = {fileform, null, NumberFormat.getInstance()};
- * MessageFormat pattform = new MessageFormat("There {0} on {1}");
- * pattform.setFormats(testFormats);
- * Object[] testArgs = {null, "ADisk", null};
- * for (int i = 0; i < 4; ++i) {
- *     testArgs[0] = Integer.valueOf(i);
- *     testArgs[2] = testArgs[0];
- *     System.out.println(pattform.format(testArgs));
+ * MessageFormat msgFmt = new MessageFormat("The disk \"{0}\" contains {1}.");
+ * double[] fileLimits = {0,1,2};
+ * String[] filePart = {"no files","one file","{1,number} files"};
+ * ChoiceFormat fileChoices = new ChoiceFormat(fileLimits, filePart);
+ * msgFmt.setFormatByArgumentIndex(1, fileChoices);
+ * Object[] args = {"MyDisk", 1273};
+ * System.out.println(msgFmt.format(args));
  * }
- * }
- * </blockquote>
- * Would output the following:
- * <blockquote>
- * <pre>{@code
- * There are no files on ADisk
- * There is one file on ADisk
- * There are 2 files on ADisk
- * There are 3 files on ADisk
- * }</pre>
- * </blockquote>
+ * The output with different values for {@code fileCount}:
+ * <blockquote><pre>
+ * The disk "MyDisk" contains no files.
+ * The disk "MyDisk" contains one file.
+ * The disk "MyDisk" contains 1,273 files.
+ * </pre></blockquote>
  *
  * <h2><a id="patterns">Patterns</a></h2>
  * A {@code ChoiceFormat} pattern has the following syntax:
@@ -194,7 +184,6 @@ import java.util.Arrays;
  * {@code new ChoiceFormat("1# ''one'' ").format(1)} returns {@code " 'one' "}.
  *
  * <p>Below is an example of constructing a ChoiceFormat with a pattern:
- * <blockquote>
  * {@snippet lang=java :
  * ChoiceFormat fmt = new ChoiceFormat(
  *      "-1#is negative| 0#is zero or fraction | 1#is one |1.0<is 1+ |2#is two |2<is more than 2.");
@@ -210,7 +199,6 @@ import java.util.Arrays;
  * System.out.println(fmt.format(Double.NaN)); // outputs "is negative"
  * System.out.println(fmt.format(Double.POSITIVE_INFINITY)); // outputs "is more than 2."
  * }
- * </blockquote>
  *
  * <h2><a id="synchronization">Synchronization</a></h2>
  *

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -266,7 +266,7 @@ import java.util.Objects;
  *
  * <p>
  * For more sophisticated patterns, {@link ChoiceFormat} can be used with
- * {@code MessageFormat} to produce accurate forms for singular and plural.
+ * {@code MessageFormat} to produce accurate forms for singular and plural:
  * {@snippet lang=java :
  * MessageFormat msgFmt = new MessageFormat("The disk \"{0}\" contains {1}.");
  * double[] fileLimits = {0,1,2};

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -288,7 +288,7 @@ import java.util.Objects;
  * above example, or by using a pattern. See {@link ChoiceFormat}
  * for more information.
  * {@snippet lang=java :
- * form.applyPattern(
+ * msgFmt.applyPattern(
  *    "There {0,choice,0#are no files|1#is one file|1<are {1,number,integer} files}.");
  * }
  *

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -293,9 +293,15 @@ import java.util.Objects;
  * }
  *
  * <p>
- * <strong>Note:</strong> As we see above, the string produced
- * by a {@code ChoiceFormat} in {@code MessageFormat} is treated as special;
- * occurrences of '{' are used to indicate subformats, and cause recursion.
+ * <strong id="pattern_caveats">Notes:</strong> As seen in the previous snippet,
+ * the string produced by a {@code ChoiceFormat} in {@code MessageFormat} is
+ * treated as special; occurrences of '{' are used to indicate subformats, and
+ * cause recursion. A limitation to this behavior is that, if a {@code MessageFormat}
+ * {@code FormatElement} is defined in the {@code ChoiceFormat} pattern, it will only
+ * be formatted according to the {@code FormatType} and {@code FormatStyle}
+ * pattern provided. The associated subformats of the {@code MessageFormat} will
+ * not be applied to the {@code FormatElement} defined in the {@code ChoiceFormat}
+ * pattern, even if the {@code ArgumentIndex} has an associated subformat.
  * If you create both a {@code MessageFormat} and {@code ChoiceFormat}
  * programmatically (instead of using the string patterns), then be careful not to
  * produce a format that recurses on itself, which will cause an infinite loop.

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -296,12 +296,12 @@ import java.util.Objects;
  * <strong id="pattern_caveats">Notes:</strong> As seen in the previous snippet,
  * the string produced by a {@code ChoiceFormat} in {@code MessageFormat} is
  * treated as special; occurrences of '{' are used to indicate subformats, and
- * cause recursion. A limitation to this behavior is that, if a {@code MessageFormat}
- * {@code FormatElement} is defined in the {@code ChoiceFormat} pattern, it will only
- * be formatted according to the {@code FormatType} and {@code FormatStyle}
- * pattern provided. The associated subformats of the {@code MessageFormat} will
- * not be applied to the {@code FormatElement} defined in the {@code ChoiceFormat}
- * pattern, even if the {@code ArgumentIndex} has an associated subformat.
+ * cause recursion. If a {@code FormatElement} is defined in the {@code ChoiceFormat}
+ * pattern, it will only be formatted according to the {@code FormatType} and
+ * {@code FormatStyle} pattern provided. The associated subformats of the
+ * {@code MessageFormat} will not be applied to the {@code FormatElement}
+ * defined in the {@code ChoiceFormat} pattern, even if the {@code ArgumentIndex}
+ * has an associated subformat.
  * If you create both a {@code MessageFormat} and {@code ChoiceFormat}
  * programmatically (instead of using the string patterns), then be careful not to
  * produce a format that recurses on itself, which will cause an infinite loop.

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -231,7 +231,6 @@ import java.util.Objects;
  * <p>
  * The first example uses the static method {@code MessageFormat.format},
  * which internally creates a {@code MessageFormat} for one-time use:
- * <blockquote>
  * {@snippet lang=java :
  * int planet = 7;
  * String event = "a disturbance in the Force";
@@ -240,7 +239,6 @@ import java.util.Objects;
  *     "At {1,time} on {1,date}, there was {2} on planet {0,number,integer}.",
  *     planet, new Date(), event);
  * }
- * </blockquote>
  * The output is:
  * <blockquote><pre>
  * At 12:30 PM on Jul 3, 2053, there was a disturbance in the Force on planet 7.
@@ -249,7 +247,6 @@ import java.util.Objects;
  * <p>
  * The following example creates a {@code MessageFormat} instance that
  * can be used repeatedly:
- * <blockquote>
  * {@snippet lang=java :
  * int fileCount = 1273;
  * String diskName = "MyDisk";
@@ -260,7 +257,6 @@ import java.util.Objects;
  *
  * System.out.println(form.format(testArgs));
  * }
- * </blockquote>
  * The output with different values for {@code fileCount}:
  * <blockquote><pre>
  * The disk "MyDisk" contains 0 file(s).
@@ -269,23 +265,17 @@ import java.util.Objects;
  * </pre></blockquote>
  *
  * <p>
- * For more sophisticated patterns, you can use a {@code ChoiceFormat}
- * to produce correct forms for singular and plural:
- * <blockquote>
+ * For more sophisticated patterns, {@link ChoiceFormat} can be used with
+ * {@code MessageFormat} to produce accurate forms for singular and plural.
  * {@snippet lang=java :
- * MessageFormat form = new MessageFormat("The disk \"{1}\" contains {0}.");
- * double[] filelimits = {0,1,2};
- * String[] filepart = {"no files","one file","{0,number} files"};
- * ChoiceFormat fileform = new ChoiceFormat(filelimits, filepart);
- * form.setFormatByArgumentIndex(0, fileform);
- *
- * int fileCount = 1273;
- * String diskName = "MyDisk";
- * Object[] testArgs = {Long.valueOf(fileCount), diskName};
- *
- * System.out.println(form.format(testArgs));
+ * MessageFormat msgFmt = new MessageFormat("The disk \"{0}\" contains {1}.");
+ * double[] fileLimits = {0,1,2};
+ * String[] filePart = {"no files","one file","{1,number} files"};
+ * ChoiceFormat fileChoices = new ChoiceFormat(fileLimits, filePart);
+ * msgFmt.setFormatByArgumentIndex(1, fileChoices);
+ * Object[] args = {"MyDisk", 1273};
+ * System.out.println(msgFmt.format(args));
  * }
- * </blockquote>
  * The output with different values for {@code fileCount}:
  * <blockquote><pre>
  * The disk "MyDisk" contains no files.
@@ -297,12 +287,10 @@ import java.util.Objects;
  * You can create the {@code ChoiceFormat} programmatically, as in the
  * above example, or by using a pattern. See {@link ChoiceFormat}
  * for more information.
- * <blockquote>
  * {@snippet lang=java :
  * form.applyPattern(
- *    "There {0,choice,0#are no files|1#is one file|1<are {0,number,integer} files}.");
+ *    "There {0,choice,0#are no files|1#is one file|1<are {1,number,integer} files}.");
  * }
- * </blockquote>
  *
  * <p>
  * <strong>Note:</strong> As we see above, the string produced
@@ -314,7 +302,6 @@ import java.util.Objects;
  * <p>
  * When a single argument is parsed more than once in the string, the last match
  * will be the final result of the parsing.  For example,
- * <blockquote>
  * {@snippet lang=java :
  * MessageFormat mf = new MessageFormat("{0,number,#.##}, {0,number,#.#}");
  * Object[] objs = {Double.valueOf(3.1415)};
@@ -323,20 +310,17 @@ import java.util.Objects;
  * objs = mf.parse(result, new ParsePosition(0));
  * // objs now equals {Double.valueOf(3.1)}
  * }
- * </blockquote>
  *
  * <p>
  * Likewise, parsing with a {@code MessageFormat} object using patterns containing
  * multiple occurrences of the same argument would return the last match.  For
  * example,
- * <blockquote>
  * {@snippet lang=java :
  * MessageFormat mf = new MessageFormat("{0}, {0}, {0}");
  * String forParsing = "x, y, z";
  * Object[] objs = mf.parse(forParsing, new ParsePosition(0));
  * // objs now equals {new String("z")}
  * }
- * </blockquote>
  *
  * <h3><a id="synchronization">Synchronization</a></h3>
  *

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -299,9 +299,8 @@ import java.util.Objects;
  * cause recursion. If a {@code FormatElement} is defined in the {@code ChoiceFormat}
  * pattern, it will only be formatted according to the {@code FormatType} and
  * {@code FormatStyle} pattern provided. The associated subformats of the
- * {@code MessageFormat} will not be applied to the {@code FormatElement}
- * defined in the {@code ChoiceFormat} pattern, even if the {@code ArgumentIndex}
- * has an associated subformat.
+ * top level {@code MessageFormat} will not be applied to the {@code FormatElement}
+ * defined in the {@code ChoiceFormat} pattern.
  * If you create both a {@code MessageFormat} and {@code ChoiceFormat}
  * programmatically (instead of using the string patterns), then be careful not to
  * produce a format that recurses on itself, which will cause an infinite loop.


### PR DESCRIPTION
Please review this PR which updates an incorrect code example in _java/text/ChoiceFormat_.

ChoiceFormat (and MessageFormat) provide an example of how to produce a pattern that supports singular and plural forms. The ChoiceFormat example is incorrect, as recursive MessageFormats produced by a ChoiceFormat subformat only recognize subformats defined through the MessageFormat pattern syntax, not through the subformats contained within the top level MessageFormat. 

In the original example,
`Format[] testFormats = {fileform, null, NumberFormat.getInstance()};` could have been replaced with 
`Format[] testFormats = {fileform, null, new ChoiceFormat("0#BROKEN")};` and the original output would have been the same.

This PR replaces the example with the one used in MessageFormat, which is correct. 

This PR also includes a drive-by fix to remove leftover `<blockquote>`s from a previous `@snippet` conversion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8321420](https://bugs.openjdk.org/browse/JDK-8321420) to be approved

### Issues
 * [JDK-6230751](https://bugs.openjdk.org/browse/JDK-6230751): [Fmt-Ch] Recursive MessageFormats in ChoiceFormats ignore indicated subformats (**Bug** - P4)
 * [JDK-8321420](https://bugs.openjdk.org/browse/JDK-8321420): [Fmt-Ch] Recursive MessageFormats in ChoiceFormats ignore indicated subformats (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16891/head:pull/16891` \
`$ git checkout pull/16891`

Update a local copy of the PR: \
`$ git checkout pull/16891` \
`$ git pull https://git.openjdk.org/jdk.git pull/16891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16891`

View PR using the GUI difftool: \
`$ git pr show -t 16891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16891.diff">https://git.openjdk.org/jdk/pull/16891.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16891#issuecomment-1832821303)