### PR TITLE
Fixed typo in x86_64 sharedRuntime

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -197,7 +197,7 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
   // Save registers, fpu state, and flags.
   // We assume caller has already pushed the return address onto the
   // stack, so rsp is 8-byte aligned here.
-  // We push rpb twice in this sequence because we want the real rbp
+  // We push rbp twice in this sequence because we want the real rbp
   // to be under the return like a normal enter.
 
   __ enter();          // rsp becomes 16-byte aligned here


### PR DESCRIPTION
This just fixes a typo in the `sharedRuntime_x86_64.cpp` file, where the `RBP` register is refered to as `RPB`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16892/head:pull/16892` \
`$ git checkout pull/16892`

Update a local copy of the PR: \
`$ git checkout pull/16892` \
`$ git pull https://git.openjdk.org/jdk.git pull/16892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16892`

View PR using the GUI difftool: \
`$ git pr show -t 16892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16892.diff">https://git.openjdk.org/jdk/pull/16892.diff</a>

</details>
