### PR TITLE
8321053: Use ByteArrayInputStream.buf directly when parameter of transferTo() is trusted

### DIFF
--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -208,7 +208,8 @@ public class ByteArrayInputStream extends InputStream {
         int len = count - pos;
         if (len > 0) {
             byte[] tmp;
-            if ("java.io".equals(out.getClass().getPackageName()))
+            if (out.getClass().getPackageName().startsWith("java.") &&
+                !(out instanceof FilterOutputStream))
                 tmp = null;
             else
                 tmp = new byte[Integer.min(len, MAX_TRANSFER_SIZE)];

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -207,10 +207,20 @@ public class ByteArrayInputStream extends InputStream {
     public synchronized long transferTo(OutputStream out) throws IOException {
         int len = count - pos;
         if (len > 0) {
+            byte[] tmp;
+            if ("java.io".equals(out.getClass().getPackageName()))
+                tmp = null;
+            else
+                tmp = new byte[Integer.min(len, MAX_TRANSFER_SIZE)];
+
             int nwritten = 0;
             while (nwritten < len) {
                 int nbyte = Integer.min(len - nwritten, MAX_TRANSFER_SIZE);
-                out.write(buf, pos, nbyte);
+                if (tmp != null) {
+                    System.arraycopy(buf, pos, tmp, 0, nbyte);
+                    out.write(tmp, 0, nbyte);
+                } else
+                    out.write(buf, pos, nbyte);
                 pos += nbyte;
                 nwritten += nbyte;
             }

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -208,22 +208,22 @@ public class ByteArrayInputStream extends InputStream {
         int len = count - pos;
         if (len > 0) {
             // 'tmp' is null if and only if 'out' is trusted
-            byte[] tmp;
+            byte[] tmpbuf;
             Class<?> outClass = out.getClass();
             if (outClass == ByteArrayOutputStream.class ||
                 outClass == FileOutputStream.class ||
                 outClass == PipedOutputStream.class)
-                tmp = null;
+                tmpbuf = null;
             else
-                tmp = new byte[Integer.min(len, MAX_TRANSFER_SIZE)];
+                tmpbuf = new byte[Integer.min(len, MAX_TRANSFER_SIZE)];
 
             int nwritten = 0;
             while (nwritten < len) {
                 int nbyte = Integer.min(len - nwritten, MAX_TRANSFER_SIZE);
                 // if 'out' is not trusted, transfer via a temporary buffer
-                if (tmp != null) {
-                    System.arraycopy(buf, pos, tmp, 0, nbyte);
-                    out.write(tmp, 0, nbyte);
+                if (tmpbuf != null) {
+                    System.arraycopy(buf, pos, tmpbuf, 0, nbyte);
+                    out.write(tmpbuf, 0, nbyte);
                 } else
                     out.write(buf, pos, nbyte);
                 pos += nbyte;

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -207,7 +207,7 @@ public class ByteArrayInputStream extends InputStream {
     public synchronized long transferTo(OutputStream out) throws IOException {
         int len = count - pos;
         if (len > 0) {
-            // 'tmp' is null if and only if 'out' is trusted
+            // 'tmpbuf' is null if and only if 'out' is trusted
             byte[] tmpbuf;
             Class<?> outClass = out.getClass();
             if (outClass == ByteArrayOutputStream.class ||

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -210,10 +210,9 @@ public class ByteArrayInputStream extends InputStream {
             // 'tmp' is null if and only if 'out' is trusted
             byte[] tmp;
             Class<?> outClass = out.getClass();
-            if (outClass.getPackageName().equals("java.io") &&
-                (outClass == ByteArrayOutputStream.class ||
-                 outClass == FileOutputStream.class ||
-                 outClass == PipedOutputStream.class))
+            if (outClass == ByteArrayOutputStream.class ||
+                outClass == FileOutputStream.class ||
+                outClass == PipedOutputStream.class)
                 tmp = null;
             else
                 tmp = new byte[Integer.min(len, MAX_TRANSFER_SIZE)];

--- a/src/java.base/share/classes/java/io/ByteArrayInputStream.java
+++ b/src/java.base/share/classes/java/io/ByteArrayInputStream.java
@@ -209,10 +209,11 @@ public class ByteArrayInputStream extends InputStream {
         if (len > 0) {
             // 'tmp' is null if and only if 'out' is trusted
             byte[] tmp;
-            if (out.getClass().getPackageName().equals("java.io") &&
-                (out instanceof ByteArrayOutputStream ||
-                 out instanceof FileOutputStream ||
-                 out instanceof PipedOutputStream))
+            Class<?> outClass = out.getClass();
+            if (outClass.getPackageName().equals("java.io") &&
+                (outClass == ByteArrayOutputStream.class ||
+                 outClass == FileOutputStream.class ||
+                 outClass == PipedOutputStream.class))
                 tmp = null;
             else
                 tmp = new byte[Integer.min(len, MAX_TRANSFER_SIZE)];

--- a/test/jdk/java/io/ByteArrayInputStream/TransferToTrusted.java
+++ b/test/jdk/java/io/ByteArrayInputStream/TransferToTrusted.java
@@ -72,8 +72,7 @@ public class TransferToTrusted {
 
         OutputStream[] outputStreams = new OutputStream[] {
             new ByteArrayOutputStream(),
-            new UntrustedOutputStream(),
-            new DataOutputStream(new UntrustedOutputStream())
+            new UntrustedOutputStream()
         };
 
         for (OutputStream out : outputStreams) {

--- a/test/jdk/java/io/ByteArrayInputStream/TransferToTrusted.java
+++ b/test/jdk/java/io/ByteArrayInputStream/TransferToTrusted.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8321053
+ * @summary Verify ByteArrayInputStream.buf is used directly by
+ *          ByteArrayInputStream.transferTo only when its OutputStream
+ *          parameter is trusted
+ * @key randomness
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Random;
+
+public class TransferToTrusted {
+    private static final Random RND = new Random(System.nanoTime());
+
+    private static class UntrustedOutputStream extends OutputStream {
+        UntrustedOutputStream() {
+            super();
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            Objects.checkFromIndexSize(off, len, b.length);
+            byte[] tmp = new byte[len];
+            RND.nextBytes(tmp);
+            System.arraycopy(tmp, 0, b, off, len);
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            write(new byte[] {(byte)b});
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        byte[] buf = new byte[128];
+        RND.nextBytes(buf);
+        byte[] dup = Arrays.copyOf(buf, buf.length);
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(dup);
+        bais.mark(dup.length);
+
+        OutputStream baos = new ByteArrayOutputStream();
+        bais.transferTo(baos);
+        bais.reset();
+        if (!Arrays.equals(buf, bais.readAllBytes()))
+            throw new RuntimeException("Internal buffer has been modified");
+
+        bais.reset();
+        OutputStream out = new UntrustedOutputStream();
+        bais.transferTo(out);
+        bais.reset();
+        if (!Arrays.equals(buf, bais.readAllBytes()))
+            throw new RuntimeException("Internal buffer has been modified");
+    }
+}


### PR DESCRIPTION
Pass `ByteArrayInputStream.buf ` directly to the `OutputStream` parameter of `BAIS.transferTo` only if the target stream is in the `java.io` package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321053](https://bugs.openjdk.org/browse/JDK-8321053): Use ByteArrayInputStream.buf directly when parameter of transferTo() is trusted (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [8a13b553](https://git.openjdk.org/jdk/pull/16893/files/8a13b553d98dacf2ffb73b6902a7d14dc0f0878b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16893/head:pull/16893` \
`$ git checkout pull/16893`

Update a local copy of the PR: \
`$ git checkout pull/16893` \
`$ git pull https://git.openjdk.org/jdk.git pull/16893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16893`

View PR using the GUI difftool: \
`$ git pr show -t 16893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16893.diff">https://git.openjdk.org/jdk/pull/16893.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16893#issuecomment-1832894405)