### PR TITLE
8320959: jdk/jfr/event/runtime/TestShutdownEvent.java crash with CONF=fastdebug -Xcomp

### DIFF
--- a/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
@@ -103,17 +103,15 @@ static void commit(HelperType& helper) {
   assert(thread != nullptr, "invariant");
   if (thread->is_Java_thread()) {
     JavaThread* jt = JavaThread::cast(thread);
-    if (jt->thread_state() == _thread_in_Java) {
-      ThreadInVMfromJava transition(jt);
-      event.commit();
-      return;
-    } else if (jt->thread_state() != _thread_in_vm) {
-      assert(jt->thread_state() == _thread_in_native, "invariant");
+    if (jt->thread_state() == _thread_in_native) {
       // For a JavaThread to take a JFR stacktrace, it must be in _thread_in_vm. Can safepoint here.
       ThreadInVMfromNative transition(jt);
       event.commit();
       return;
     }
+    // If a thread comes here still _thread_in_Java, which can happen for example
+    // when loading the disassembler library in response to traps in JIT code - all is ok.
+    // Since there is no ljf, an event will be committed without a stacktrace.
   }
   event.commit();
 }

--- a/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
@@ -103,7 +103,11 @@ static void commit(HelperType& helper) {
   assert(thread != nullptr, "invariant");
   if (thread->is_Java_thread()) {
     JavaThread* jt = JavaThread::cast(thread);
-    if (jt->thread_state() != _thread_in_vm) {
+    if (jt->thread_state() == _thread_in_Java) {
+      ThreadInVMfromJava transition(jt);
+      event.commit();
+      return;
+    } else if (jt->thread_state() != _thread_in_vm) {
       assert(jt->thread_state() == _thread_in_native, "invariant");
       // For a JavaThread to take a JFR stacktrace, it must be in _thread_in_vm. Can safepoint here.
       ThreadInVMfromNative transition(jt);


### PR DESCRIPTION
Run `make test CONF=fastdebug TEST=jdk/jfr/event/runtime/TestShutdownEvent.java JTREG="VM_OPTIONS=-Xcomp"`, can occur SIGSEGV.

<pre>
# Internal Error (/home/sunguoyun/jdk-ls/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp:107), pid=13214, tid=13215
# assert(jt->thread_state() == _thread_in_native) failed: invariant
#
# JRE version: OpenJDK Runtime Environment (22.0) (fastdebug build 22-internal-adhoc.sunguoyun.jdk-ls)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 22-internal-adhoc.sunguoyun.jdk-ls, compiled mode, sharing, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V [libjvm.so+0xe9404a] NativeLibraryLoadEvent::~NativeLibraryLoadEvent()+0xd1a
#
# CreateCoredumpOnCrash turned off, no core file dumped
#
</pre>

Because current thread state is '_thread_in_Java'. I had make a fix, please review it , thanks.

Testing:
GHA testing
tier1-3 for loongarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320959](https://bugs.openjdk.org/browse/JDK-8320959): jdk/jfr/event/runtime/TestShutdownEvent.java crash with CONF=fastdebug -Xcomp (**Bug** - P3)(⚠️ The fixVersion in this issue is [22] but the fixVersion in .jcheck/conf is 23, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Contributors
 * Markus Grönlund `<mgronlun@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16894/head:pull/16894` \
`$ git checkout pull/16894`

Update a local copy of the PR: \
`$ git checkout pull/16894` \
`$ git pull https://git.openjdk.org/jdk.git pull/16894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16894`

View PR using the GUI difftool: \
`$ git pr show -t 16894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16894.diff">https://git.openjdk.org/jdk/pull/16894.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16894#issuecomment-1832973476)