### PR TITLE
8316497 : ColorConvertOp - typo for non-ICC conversions needs one-line fix

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
@@ -835,7 +835,7 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
                                       dstDiffMinMax[i] + dstMinVal[i];
                     }
                     if (nonICCDst) {
-                        color = srcColorSpace.fromCIEXYZ(dstColor);
+                        color = dstColorSpace.fromCIEXYZ(dstColor);
                         for (int i = 0; i < dstNumComp; i++) {
                             dstColor[i] = color[i];
                         }

--- a/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
@@ -768,7 +768,7 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
             }
             float[] srcMinVal = new float[iccSrcNumComp];
             float[] srcInvDiffMinMax = new float[iccSrcNumComp];
-            for (int i = 0; i < srcNumComp; i++) {
+            for (int i = 0; i < iccSrcNumComp; i++) {
                 srcMinVal[i] = cs.getMinValue(i);
                 srcInvDiffMinMax[i] = maxNum / (cs.getMaxValue(i) - srcMinVal[i]);
             }
@@ -782,7 +782,7 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
             }
             float[] dstMinVal = new float[iccDstNumComp];
             float[] dstDiffMinMax = new float[iccDstNumComp];
-            for (int i = 0; i < dstNumComp; i++) {
+            for (int i = 0; i < iccDstNumComp; i++) {
                 dstMinVal[i] = cs.getMinValue(i);
                 dstDiffMinMax[i] = (cs.getMaxValue(i) - dstMinVal[i]) / maxNum;
             }

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -35,7 +35,7 @@ import java.awt.image.WritableRaster;
 /*
  * @test
  * @bug 8316497
- * @summary Verifies Color filter on Non ICC profile
+ * @summary Verifies Color filter on non-ICC profile
  */
 public class NonICCFilterTest {
 
@@ -43,32 +43,40 @@ public class NonICCFilterTest {
 
         private final ColorSpace csRGB;
 
-        protected TestColorSpace(boolean bSrc) {
-            super(ColorSpace.getInstance(ColorSpace.CS_sRGB).getType(),
-                    ColorSpace.getInstance(ColorSpace.CS_sRGB).getNumComponents());
-            csRGB = ColorSpace.getInstance(bSrc ? ColorSpace.CS_LINEAR_RGB :
-                    ColorSpace.CS_sRGB);
+        protected TestColorSpace(ColorSpace csRGB) {
+            super(csRGB.getType(), csRGB.getNumComponents());
+            this.csRGB = csRGB;
         }
 
+        private static ColorSpace createColorSpace(boolean isSrc) {
+            return new TestColorSpace(ColorSpace.getInstance(isSrc
+                    ? ColorSpace.CS_LINEAR_RGB
+                    : ColorSpace.CS_sRGB));
+        }
+
+        @Override
         public float[] toRGB(float[] colorvalue) {
-            return colorvalue;
+            return csRGB.toRGB(colorvalue);
         }
 
+        @Override
         public float[] fromRGB(float[] rgbvalue) {
-            return rgbvalue;
+            return csRGB.fromRGB(rgbvalue);
         }
 
+        @Override
         public float[] toCIEXYZ(float[] colorvalue) {
             return csRGB.toCIEXYZ(csRGB.toRGB(colorvalue));
         }
 
+        @Override
         public float[] fromCIEXYZ(float[] xyzvalue) {
             return csRGB.fromRGB(csRGB.fromCIEXYZ(xyzvalue));
         }
     }
 
     private static BufferedImage createTestImage(boolean isSrc) {
-        ColorSpace cs = new TestColorSpace(isSrc);
+        ColorSpace cs = TestColorSpace.createColorSpace(isSrc);
         ComponentColorModel cm = new ComponentColorModel(cs, false, false,
                 Transparency.OPAQUE, DataBuffer.TYPE_FLOAT);
         WritableRaster raster = cm.createCompatibleWritableRaster(50, 50);
@@ -96,15 +104,15 @@ public class NonICCFilterTest {
     }
 
     public static void main(String[] args) {
-        BufferedImage src, dest;
-        src = createTestImage(true);
-        dest = createTestImage(false);
+
+        BufferedImage src = createTestImage(true);
+        BufferedImage dst = createTestImage(false);
 
         ColorConvertOp ccop =
                 new ColorConvertOp(ColorSpace.getInstance(ColorSpace.CS_sRGB), null);
-        ccop.filter(src, dest);
+        ccop.filter(src, dst);
 
-        if (compareImages(src, dest)) {
+        if (compareImages(src, dst)) {
             throw new RuntimeException("Test failed: Source equal to Destination");
         }
     }

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -21,7 +21,10 @@
  * questions.
  */
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.GradientPaint;
+import java.awt.Graphics2D;
+import java.awt.Transparency;
 import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorConvertOp;
@@ -29,12 +32,11 @@ import java.awt.image.ComponentColorModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.WritableRaster;
 
-/**
+/*
  * @test
  * @bug 8316497
  * @summary Verifies Color filter on Non ICC profile
  */
-
 public class NonICCFilterTest {
 
     private static class TestColorSpace extends ColorSpace {
@@ -65,10 +67,9 @@ public class NonICCFilterTest {
     }
 
     private static BufferedImage createTestImage(boolean isSrc) {
-
         ColorSpace cs = new TestColorSpace(isSrc);
         ComponentColorModel cm = new ComponentColorModel(cs, false, false,
-                        Transparency.OPAQUE, DataBuffer.TYPE_FLOAT);
+                Transparency.OPAQUE, DataBuffer.TYPE_FLOAT);
         WritableRaster raster = cm.createCompatibleWritableRaster(50, 50);
         BufferedImage img = new BufferedImage(cm, raster, false, null);
 
@@ -76,7 +77,7 @@ public class NonICCFilterTest {
         GradientPaint gp = new GradientPaint(0, 0, Color.GREEN,
                 raster.getWidth(), raster.getHeight(), Color.BLUE);
         g.setPaint(gp);
-        g.fillRect(0,0,raster.getWidth(), raster.getHeight());
+        g.fillRect(0, 0, raster.getWidth(), raster.getHeight());
         g.dispose();
 
         return img;

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -103,12 +103,7 @@ public class NonICCFilterTest {
                 new ColorConvertOp(ColorSpace.getInstance(ColorSpace.CS_sRGB), null);
         ccop.filter(src, dest);
 
-        try {
-            if (compareImages(src, dest)) {
-                throw new RuntimeException("Source equal to Destination");
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Test failed: " + e);
-        }
+        if (compareImages(src, dest)) {
+            throw new RuntimeException("\"Test failed: \" Source equal to Destination");
     }
 }

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -66,12 +66,12 @@ public class NonICCFilterTest {
 
         @Override
         public float[] toCIEXYZ(float[] colorvalue) {
-            return csRGB.toCIEXYZ(csRGB.toRGB(colorvalue));
+            return csRGB.toCIEXYZ(colorvalue);
         }
 
         @Override
         public float[] fromCIEXYZ(float[] xyzvalue) {
-            return csRGB.fromRGB(csRGB.fromCIEXYZ(xyzvalue));
+            return csRGB.fromCIEXYZ(xyzvalue);
         }
     }
 

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -56,12 +56,12 @@ public class NonICCFilterTest {
 
         @Override
         public float[] toRGB(float[] colorvalue) {
-            return csRGB.toRGB(colorvalue);
+            return colorvalue;
         }
 
         @Override
         public float[] fromRGB(float[] rgbvalue) {
-            return csRGB.fromRGB(rgbvalue);
+            return rgbvalue;
         }
 
         @Override

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -104,7 +104,7 @@ public final class NonICCFilterTest {
         };
     }
 
-    private static boolean compareImages(BufferedImage destTest, BufferedImage destGold) {
+    private static boolean areImagesEqual(BufferedImage destTest, BufferedImage destGold) {
         for (int x = 0; x < destTest.getWidth(); x++) {
             for (int y = 0; y < destTest.getHeight(); y++) {
                 int rgb1 = destTest.getRGB(x, y);
@@ -113,11 +113,11 @@ public final class NonICCFilterTest {
                     System.err.println("x = " + x + ", y = " + y);
                     System.err.println("rgb1 = " + Integer.toHexString(rgb1));
                     System.err.println("rgb2 = " + Integer.toHexString(rgb2));
-                    return true;
+                    return false;
                 }
             }
         }
-        return false;
+        return true;
     }
 
     public static void main(String[] args) {
@@ -134,7 +134,7 @@ public final class NonICCFilterTest {
         ColorConvertOp gold = new ColorConvertOp(mid, null);
         gold.filter(srcGold, destGold);
 
-        if (compareImages(destTest, destGold)) {
+        if (!areImagesEqual(destTest, destGold)) {
             throw new RuntimeException("Test failed");
         }
     }

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -104,6 +104,6 @@ public class NonICCFilterTest {
         ccop.filter(src, dest);
 
         if (compareImages(src, dest)) {
-            throw new RuntimeException("\"Test failed: \" Source equal to Destination");
+            throw new RuntimeException("Test failed: Source equal to Destination");
     }
 }

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -41,10 +41,11 @@ public class NonICCFilterTest {
 
     private static class TestColorSpace extends ColorSpace {
 
-        private ColorSpace csRGB;
+        private final ColorSpace csRGB;
 
         protected TestColorSpace(boolean bSrc) {
-            super(CS_sRGB, 3);
+            super(ColorSpace.getInstance(ColorSpace.CS_sRGB).getType(),
+                    ColorSpace.getInstance(ColorSpace.CS_sRGB).getNumComponents());
             csRGB = ColorSpace.getInstance(bSrc ? ColorSpace.CS_LINEAR_RGB :
                     ColorSpace.CS_sRGB);
         }
@@ -58,11 +59,11 @@ public class NonICCFilterTest {
         }
 
         public float[] toCIEXYZ(float[] colorvalue) {
-            return csRGB.toCIEXYZ(toRGB(colorvalue));
+            return csRGB.toCIEXYZ(csRGB.toRGB(colorvalue));
         }
 
         public float[] fromCIEXYZ(float[] xyzvalue) {
-            return fromRGB(csRGB.fromCIEXYZ(xyzvalue));
+            return csRGB.fromRGB(csRGB.fromCIEXYZ(xyzvalue));
         }
     }
 
@@ -105,5 +106,6 @@ public class NonICCFilterTest {
 
         if (compareImages(src, dest)) {
             throw new RuntimeException("Test failed: Source equal to Destination");
+        }
     }
 }

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -83,9 +83,7 @@ public class NonICCFilterTest {
         return img;
     }
 
-    private static boolean compareImages(BufferedImage src,
-                                         BufferedImage dest) {
-
+    private static boolean compareImages(BufferedImage src, BufferedImage dest) {
         for (int x = 0; x < src.getWidth(); x++) {
             for (int y = 0; y < src.getHeight(); y++) {
                 if (src.getRGB(x, y) != dest.getRGB(x, y)) {

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.*;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorConvertOp;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.WritableRaster;
+
+/**
+ * @test
+ * @bug 8316497
+ * @summary Verifies Color filter on Non ICC profile
+ */
+
+public class NonICCFilterTest {
+
+    private static class TestColorSpace extends ColorSpace {
+
+        private ColorSpace csRGB;
+
+        protected TestColorSpace(boolean bSrc) {
+            super(CS_sRGB, 3);
+            csRGB = ColorSpace.getInstance(bSrc ? ColorSpace.CS_LINEAR_RGB :
+                    ColorSpace.CS_sRGB);
+        }
+
+        public float[] toRGB(float[] colorvalue) {
+            return colorvalue;
+        }
+
+        public float[] fromRGB(float[] rgbvalue) {
+            return rgbvalue;
+        }
+
+        public float[] toCIEXYZ(float[] colorvalue) {
+            return csRGB.toCIEXYZ(toRGB(colorvalue));
+        }
+
+        public float[] fromCIEXYZ(float[] xyzvalue) {
+            return fromRGB(csRGB.fromCIEXYZ(xyzvalue));
+        }
+    }
+
+    private static BufferedImage createTestImage(boolean isSrc) {
+
+        ColorSpace cs = new TestColorSpace(isSrc);
+        ComponentColorModel cm = new ComponentColorModel(cs, false, false,
+                        Transparency.OPAQUE, DataBuffer.TYPE_FLOAT);
+        WritableRaster raster = cm.createCompatibleWritableRaster(50, 50);
+        BufferedImage img = new BufferedImage(cm, raster, false, null);
+
+        Graphics2D g = img.createGraphics();
+        GradientPaint gp = new GradientPaint(0, 0, Color.GREEN,
+                raster.getWidth(), raster.getHeight(), Color.BLUE);
+        g.setPaint(gp);
+        g.fillRect(0,0,raster.getWidth(), raster.getHeight());
+        g.dispose();
+
+        return img;
+    }
+
+    private static boolean compareImages(BufferedImage src,
+                                         BufferedImage dest) {
+
+        for (int x = 0; x < src.getWidth(); x++) {
+            for (int y = 0; y < src.getHeight(); y++) {
+                if (src.getRGB(x, y) != dest.getRGB(x, y)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public static void main(String[] args) {
+        BufferedImage src, dest;
+        src = createTestImage(true);
+        dest = createTestImage(false);
+
+        ColorConvertOp ccop =
+                new ColorConvertOp(ColorSpace.getInstance(ColorSpace.CS_sRGB), null);
+        ccop.filter(src, dest);
+
+        try {
+            if (compareImages(src, dest)) {
+                throw new RuntimeException("Source equal to Destination");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Test failed: " + e);
+        }
+    }
+}

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -35,7 +35,7 @@ import java.awt.image.WritableRaster;
 /*
  * @test
  * @bug 8316497
- * @summary Verifies Color filter on Non ICC profile
+ * @summary Verifies Color filter on non-ICC profile
  */
 public final class NonICCFilterTest {
     private static final int WIDTH = 100;

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -44,8 +44,10 @@ public final class NonICCFilterTest {
     private enum ColorSpaceSelector {
         GRAY,
         RGB,
+        PYCC,
         WRAPPED_GRAY,
-        WRAPPED_RGB
+        WRAPPED_RGB,
+        WRAPPED_PYCC
     }
 
     private static final class TestColorSpace extends ColorSpace {
@@ -101,6 +103,9 @@ public final class NonICCFilterTest {
 
             case RGB -> ColorSpace.getInstance(ColorSpace.CS_sRGB);
             case WRAPPED_RGB -> new TestColorSpace(ColorSpace.getInstance(ColorSpace.CS_sRGB));
+
+            case PYCC -> ColorSpace.getInstance(ColorSpace.CS_PYCC);
+            case WRAPPED_PYCC -> new TestColorSpace(ColorSpace.getInstance(ColorSpace.CS_PYCC));
         };
     }
 
@@ -127,7 +132,7 @@ public final class NonICCFilterTest {
         BufferedImage srcGold = createTestImage(createCS(ColorSpaceSelector.GRAY));
         BufferedImage destGold = createTestImage(createCS(ColorSpaceSelector.RGB));
 
-        ColorSpace mid = ColorSpace.getInstance(ColorSpace.CS_PYCC);
+        ColorSpace mid = createCS(ColorSpaceSelector.PYCC);
         ColorConvertOp test = new ColorConvertOp(mid, null);
         test.filter(srcTest, destTest);
 
@@ -135,7 +140,18 @@ public final class NonICCFilterTest {
         gold.filter(srcGold, destGold);
 
         if (!areImagesEqual(destTest, destGold)) {
-            throw new RuntimeException("Test failed");
+            throw new RuntimeException("ICC test failed");
+        }
+
+        mid = createCS(ColorSpaceSelector.WRAPPED_PYCC);
+        test = new ColorConvertOp(mid, null);
+        test.filter(srcTest, destTest);
+
+        gold = new ColorConvertOp(mid, null);
+        gold.filter(srcGold, destGold);
+
+        if (!areImagesEqual(destTest, destGold)) {
+            throw new RuntimeException("Wrapper test failed");
         }
     }
 }

--- a/test/jdk/java/awt/color/NonICCFilterTest.java
+++ b/test/jdk/java/awt/color/NonICCFilterTest.java
@@ -132,23 +132,17 @@ public final class NonICCFilterTest {
         BufferedImage srcGold = createTestImage(createCS(ColorSpaceSelector.GRAY));
         BufferedImage destGold = createTestImage(createCS(ColorSpaceSelector.RGB));
 
-        ColorSpace mid = createCS(ColorSpaceSelector.PYCC);
-        ColorConvertOp test = new ColorConvertOp(mid, null);
-        test.filter(srcTest, destTest);
-
-        ColorConvertOp gold = new ColorConvertOp(mid, null);
+        ColorConvertOp gold = new ColorConvertOp(createCS(ColorSpaceSelector.PYCC), null);
+        gold.filter(srcTest, destTest);
         gold.filter(srcGold, destGold);
 
         if (!areImagesEqual(destTest, destGold)) {
             throw new RuntimeException("ICC test failed");
         }
 
-        mid = createCS(ColorSpaceSelector.WRAPPED_PYCC);
-        test = new ColorConvertOp(mid, null);
+        ColorConvertOp test = new ColorConvertOp(createCS(ColorSpaceSelector.WRAPPED_PYCC), null);
         test.filter(srcTest, destTest);
-
-        gold = new ColorConvertOp(mid, null);
-        gold.filter(srcGold, destGold);
+        test.filter(srcGold, destGold);
 
         if (!areImagesEqual(destTest, destGold)) {
             throw new RuntimeException("Wrapper test failed");


### PR DESCRIPTION
Hi Reviewers, 
There was a typo for color conversion instead of dstColorSpace function srcColorSpace was used. Please review and let me know your suggestions if any. 

Renjith.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8316497](https://bugs.openjdk.org/browse/JDK-8316497): ColorConvertOp - typo for non-ICC conversions needs one-line fix (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [bec09a31](https://git.openjdk.org/jdk/pull/16895/files/bec09a31a0b6a7b60fa1aee5b6f8edb7d314cf2d)


### Contributors
 * Sergey Bylokhov `<serb@openjdk.org>`
 * Alexey Ivanov `<aivanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16895/head:pull/16895` \
`$ git checkout pull/16895`

Update a local copy of the PR: \
`$ git checkout pull/16895` \
`$ git pull https://git.openjdk.org/jdk.git pull/16895/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16895`

View PR using the GUI difftool: \
`$ git pr show -t 16895`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16895.diff">https://git.openjdk.org/jdk/pull/16895.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16895#issuecomment-1833057877)