### PR TITLE
JDK-8321063: AArch64: Zero build fails after JDK-8320368

### DIFF
--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -84,7 +84,7 @@ char* CompressedKlassPointers::reserve_address_space_for_16bit_move(size_t size,
   return reserve_address_space_X(nth_bit(32), nth_bit(48), size, nth_bit(32), aslr);
 }
 
-#ifndef AARCH64
+#if !defined(AARCH64) || defined(ZERO)
 // On aarch64 we have an own version; all other platforms use the default version
 void CompressedKlassPointers::initialize(address addr, size_t len) {
   // The default version of this code tries, in order of preference:


### PR DESCRIPTION
Trivial build fix for zero on aarch64