### PR TITLE
8321066: Multiple JFR tests have started failing

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -83,7 +83,7 @@
 // to unsafe functions, if we have such async exception conditions,
 // and return immediately if that is the case.
 //
-// We also use NoSafepointVerifier to block potential safepoints.
+// We can't have safepoints in this code.
 // It would be problematic if an async exception handshake were installed later on
 // during another safepoint in the function, but before the memory access happens,
 // as the memory will be freed after the handshake is installed. We must notice
@@ -97,8 +97,7 @@
 // that is about to be freed. (i.e. there can be no UNSAFE_LEAF_SCOPED)
 #define UNSAFE_ENTRY_SCOPED(result_type, header) \
   JVM_ENTRY(static result_type, header) \
-  if (thread->has_async_exception_condition()) {return (result_type)0;} \
-  NoSafepointVerifier nsv;
+  if (thread->has_async_exception_condition()) {return (result_type)0;}
 
 #define UNSAFE_END JVM_END
 


### PR DESCRIPTION
Before integrating https://bugs.openjdk.org/browse/JDK-8310644 we added a seemingly innocent NoSafepointVerifier in some code that really shouldn't safepoint and reran tier1 only.

What nobody anticipated is that the JFR dumping during crash reporting code probably introduced by https://bugs.openjdk.org/browse/JDK-8233706 performs safepoint polls from inside the crash reporter. These JFR tests try to provoke a crash and check that the JFR recording gets dumped. But we crash during crash reporting in debug builds, because the NSV doesn't like the safepoint polls inside the crash reporter.

Now while this crash reporting code can seemingly make any NSV in the JVM fail if you get a crash there, and even worse, accept safepoints and do GC while crash reporting from totally safepoint unsafe code and what not, this change merely removes the new NSV from the fix that introduced the test failures. But maybe going forward we shouldn't poll for safepoints in the crash reporter.

I tested that the reported test failures fail deterministically without this patch and do not fail with this patch. I also re-ran tier1 just to be safe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321066](https://bugs.openjdk.org/browse/JDK-8321066): Multiple JFR tests have started failing (**Bug** - P2)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16900/head:pull/16900` \
`$ git checkout pull/16900`

Update a local copy of the PR: \
`$ git checkout pull/16900` \
`$ git pull https://git.openjdk.org/jdk.git pull/16900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16900`

View PR using the GUI difftool: \
`$ git pr show -t 16900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16900.diff">https://git.openjdk.org/jdk/pull/16900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16900#issuecomment-1833783409)