### PR TITLE
8227529: With malformed --app-image the error messages are awful

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -423,6 +423,14 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         return outputDir().resolve(bundleName);
     }
 
+    Optional<Path> nullableOutputBundle() {
+        try {
+            return Optional.ofNullable(outputBundle());
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
+    }
+
     /**
      * Returns application layout.
      *
@@ -749,11 +757,15 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         if (hasArgument("--dest")) {
             if (isImagePackageType()) {
                 TKit.deleteDirectoryContentsRecursive(outputDir());
-            } else if (ThrowingSupplier.toSupplier(() -> TKit.deleteIfExists(
-                    outputBundle())).get()) {
-                TKit.trace(
-                        String.format("Deleted [%s] file before running jpackage",
-                                outputBundle()));
+            } else {
+                nullableOutputBundle().ifPresent(path -> {
+                    if (ThrowingSupplier.toSupplier(() -> TKit.deleteIfExists(
+                            path)).get()) {
+                        TKit.trace(String.format(
+                                "Deleted [%s] file before running jpackage",
+                                path));
+                    }
+                });
             }
         }
 

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/PackageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -582,7 +582,9 @@ public final class PackageTest extends RunnablePackageTest {
                     if (expectedJPackageExitCode == 0) {
                         TKit.assertFileExists(cmd.outputBundle());
                     } else {
-                        TKit.assertPathExists(cmd.outputBundle(), false);
+                        cmd.nullableOutputBundle().ifPresent(outputBundle -> {
+                            TKit.assertPathExists(outputBundle, false);
+                        });
                     }
                     verifyPackageBundle(cmd, result);
                     break;

--- a/test/jdk/tools/jpackage/share/AppImagePackageTest.java
+++ b/test/jdk/tools/jpackage/share/AppImagePackageTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import java.io.IOException;
 import java.util.List;
+import jdk.jpackage.internal.AppImageFile;
 import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.JPackageCommand;
@@ -100,6 +101,55 @@ public class AppImagePackageTest {
         .setExpectedExitCode(TKit.isOSX() ? 1 : 0)
         .run(Action.CREATE, Action.UNPACK);
         // default: {CREATE, UNPACK, VERIFY}, but we can't verify foreign image
+    }
+
+    @Test
+    public static void testBadAppImage() throws IOException {
+        Path appImageDir = TKit.createTempDirectory("appimage");
+        Files.createFile(appImageDir.resolve("foo"));
+        configureAppImageWithoutJPackageXMLFile(appImageDir).addInitializer(
+                cmd -> {
+                    cmd.removeArgumentWithValue("--name");
+                }).run(Action.CREATE);
+    }
+
+    @Test
+    public static void testBadAppImage2() throws IOException {
+        Path appImageDir = TKit.createTempDirectory("appimage");
+        Files.createFile(appImageDir.resolve("foo"));
+        configureAppImageWithoutJPackageXMLFile(appImageDir).run(Action.CREATE);
+    }
+
+    @Test
+    public static void testBadAppImage3() throws IOException {
+        Path appImageDir = TKit.createTempDirectory("appimage");
+
+        JPackageCommand appImageCmd = JPackageCommand.helloAppImage().
+                setFakeRuntime().setArgumentValue("--dest", appImageDir);
+
+        configureAppImageWithoutJPackageXMLFile(appImageCmd.outputBundle()).
+                addRunOnceInitializer(() -> {
+                    appImageCmd.execute();
+                    Files.delete(AppImageFile.getPathInAppImage(appImageCmd.
+                            outputBundle()));
+                }).run(Action.CREATE);
+    }
+
+    private static PackageTest configureAppImageWithoutJPackageXMLFile(
+            Path appImageDir) {
+        return new PackageTest()
+                .addInitializer(cmd -> {
+                    cmd.saveConsoleOutput(true);
+                    cmd.addArguments("--app-image", appImageDir);
+                    cmd.removeArgumentWithValue("--input");
+                    cmd.ignoreDefaultVerbose(true); // no "--verbose" option
+                })
+                .addBundleVerifier((cmd, result) -> {
+                    TKit.assertTextStream(
+                    "Error: Missing .jpackage.xml file in app-image dir").apply(
+                            result.getOutput().stream());
+                })
+                .setExpectedExitCode(1);
     }
 
     private static Path iconPath(String name) {


### PR DESCRIPTION
Add tests to make sure jpackage emits meaningful error messages when used with invalid app images.

Added `JPackageCommand.nullableOutputBundle()` function that returns an empty `Optional` instance if it fails to deduce a path to the output bundle from jpackage command line. This is the case when jpackage command is used with `--app-image` cli option and referenced app image directory is missing `.jpackage.xml` file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8227529](https://bugs.openjdk.org/browse/JDK-8227529): With malformed --app-image the error messages are awful (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16901/head:pull/16901` \
`$ git checkout pull/16901`

Update a local copy of the PR: \
`$ git checkout pull/16901` \
`$ git pull https://git.openjdk.org/jdk.git pull/16901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16901`

View PR using the GUI difftool: \
`$ git pr show -t 16901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16901.diff">https://git.openjdk.org/jdk/pull/16901.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16901#issuecomment-1833870310)