### PR TITLE
JDK-8321017: Record in JFR that IEEE rounding mode was corrupted by loading a library

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1008,22 +1008,22 @@ void *os::Bsd::dlopen_helper(const char *filename, int mode) {
   void * result= ::dlopen(filename, RTLD_LAZY);
 
 #ifndef IA32
-  if (result  != nullptr && ! IEEE_subnormal_handling_OK()) {
+  if (result != nullptr && ! IEEE_subnormal_handling_OK()) {
     // We just dlopen()ed a library that mangled the floating-point
     // flags. Silently fix things now.
+    JFR_ONLY(load_event.set_fp_env_correction_attempt(true);)
     int rtn = fesetenv(&default_fenv);
     assert(rtn == 0, "fesetenv must succeed");
-    bool ieee_handling_after_issue = IEEE_subnormal_handling_OK();
 
-    if (ieee_handling_after_issue) {
+    if (IEEE_subnormal_handling_OK()) {
       Events::log_dll_message(nullptr, "IEEE subnormal handling had to be corrected after loading %s", filename);
       log_info(os)("IEEE subnormal handling had to be corrected after loading %s", filename);
+      JFR_ONLY(load_event.set_fp_env_correction_success(true);)
     } else {
       Events::log_dll_message(nullptr, "IEEE subnormal handling could not be corrected after loading %s", filename);
       log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
+      assert(false, "fesetenv didn't work");
     }
-
-    assert(ieee_handling_after_issue, "fesetenv didn't work");
   }
 #endif // IA32
 

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -979,7 +979,7 @@ bool os::dll_address_to_library_name(address addr, char* buf,
 // in case of error it checks if .dll/.so was built for the
 // same architecture as Hotspot is running on
 
-void *os::Bsd::dlopen_helper(const char *filename, int mode) {
+void *os::Bsd::dlopen_helper(const char *filename, int mode, char *ebuf, int ebuflen) {
 #ifndef IA32
   bool ieee_handling = IEEE_subnormal_handling_OK();
   if (!ieee_handling) {
@@ -1005,27 +1005,44 @@ void *os::Bsd::dlopen_helper(const char *filename, int mode) {
   assert(rtn == 0, "fegetenv must succeed");
 #endif // IA32
 
-  void * result= ::dlopen(filename, RTLD_LAZY);
-
-#ifndef IA32
-  if (result != nullptr && ! IEEE_subnormal_handling_OK()) {
-    // We just dlopen()ed a library that mangled the floating-point
-    // flags. Silently fix things now.
-    JFR_ONLY(load_event.set_fp_env_correction_attempt(true);)
-    int rtn = fesetenv(&default_fenv);
-    assert(rtn == 0, "fesetenv must succeed");
-
-    if (IEEE_subnormal_handling_OK()) {
-      Events::log_dll_message(nullptr, "IEEE subnormal handling had to be corrected after loading %s", filename);
-      log_info(os)("IEEE subnormal handling had to be corrected after loading %s", filename);
-      JFR_ONLY(load_event.set_fp_env_correction_success(true);)
-    } else {
-      Events::log_dll_message(nullptr, "IEEE subnormal handling could not be corrected after loading %s", filename);
-      log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
-      assert(false, "fesetenv didn't work");
+  void* result;
+  JFR_ONLY(NativeLibraryLoadEvent load_event(filename, &result);)
+  result = ::dlopen(filename, RTLD_LAZY);
+  if (result == nullptr) {
+    const char* error_report = ::dlerror();
+    if (error_report == nullptr) {
+      error_report = "dlerror returned no error description";
     }
-  }
+    if (ebuf != nullptr && ebuflen > 0) {
+      ::strncpy(ebuf, error_report, ebuflen-1);
+      ebuf[ebuflen-1]='\0';
+    }
+    Events::log_dll_message(nullptr, "Loading shared library %s failed, %s", filename, error_report);
+    log_info(os)("shared library load of %s failed, %s", filename, error_report);
+    JFR_ONLY(load_event.set_error_msg(error_report);)
+  } else {
+    Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
+    log_info(os)("shared library load of %s was successful", filename);
+#ifndef IA32
+    if (! IEEE_subnormal_handling_OK()) {
+      // We just dlopen()ed a library that mangled the floating-point
+      // flags. Silently fix things now.
+      JFR_ONLY(load_event.set_fp_env_correction_attempt(true);)
+      int rtn = fesetenv(&default_fenv);
+      assert(rtn == 0, "fesetenv must succeed");
+
+      if (IEEE_subnormal_handling_OK()) {
+        Events::log_dll_message(nullptr, "IEEE subnormal handling had to be corrected after loading %s", filename);
+        log_info(os)("IEEE subnormal handling had to be corrected after loading %s", filename);
+        JFR_ONLY(load_event.set_fp_env_correction_success(true);)
+      } else {
+        Events::log_dll_message(nullptr, "IEEE subnormal handling could not be corrected after loading %s", filename);
+        log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
+        assert(false, "fesetenv didn't work");
+      }
+    }
 #endif // IA32
+  }
 
   return result;
 }
@@ -1037,30 +1054,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
 #else
   log_info(os)("attempting shared library load of %s", filename);
 
-  void* result;
-  JFR_ONLY(NativeLibraryLoadEvent load_event(filename, &result);)
-  result = os::Bsd::dlopen_helper(filename, RTLD_LAZY);
-  if (result != nullptr) {
-    Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
-    // Successful loading
-    log_info(os)("shared library load of %s was successful", filename);
-    return result;
-  }
-
-  const char* error_report = ::dlerror();
-  if (error_report == nullptr) {
-    error_report = "dlerror returned no error description";
-  }
-  if (ebuf != nullptr && ebuflen > 0) {
-    // Read system error message into ebuf
-    ::strncpy(ebuf, error_report, ebuflen-1);
-    ebuf[ebuflen-1]='\0';
-  }
-  Events::log_dll_message(nullptr, "Loading shared library %s failed, %s", filename, error_report);
-  log_info(os)("shared library load of %s failed, %s", filename, error_report);
-  JFR_ONLY(load_event.set_error_msg(error_report);)
-
-  return nullptr;
+  return os::Bsd::dlopen_helper(filename, RTLD_LAZY, ebuf, ebuflen);
 #endif // STATIC_BUILD
 }
 #else
@@ -1071,29 +1065,13 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   log_info(os)("attempting shared library load of %s", filename);
 
   void* result;
-  JFR_ONLY(NativeLibraryLoadEvent load_event(filename, &result);)
-  result = os::Bsd::dlopen_helper(filename, RTLD_LAZY);
+  result = os::Bsd::dlopen_helper(filename, RTLD_LAZY, ebuf, ebuflen);
   if (result != nullptr) {
-    Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
-    // Successful loading
-    log_info(os)("shared library load of %s was successful", filename);
     return result;
   }
 
-  Elf32_Ehdr elf_head;
-
-  const char* const error_report = ::dlerror();
-  if (error_report == nullptr) {
-    error_report = "dlerror returned no error description";
-  }
-  if (ebuf != nullptr && ebuflen > 0) {
-    // Read system error message into ebuf
-    ::strncpy(ebuf, error_report, ebuflen-1);
-    ebuf[ebuflen-1]='\0';
-  }
   Events::log_dll_message(nullptr, "Loading shared library %s failed, %s", filename, error_report);
   log_info(os)("shared library load of %s failed, %s", filename, error_report);
-  JFR_ONLY(load_event.set_error_msg(error_report);)
   int diag_msg_max_length=ebuflen-strlen(ebuf);
   char* diag_msg_buf=ebuf+strlen(ebuf);
 
@@ -1102,7 +1080,6 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     return nullptr;
   }
 
-
   int file_descriptor= ::open(filename, O_RDONLY | O_NONBLOCK);
 
   if (file_descriptor < 0) {
@@ -1110,6 +1087,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     return nullptr;
   }
 
+  Elf32_Ehdr elf_head;
   bool failed_to_read_elf_head=
     (sizeof(elf_head)!=
      (::read(file_descriptor, &elf_head,sizeof(elf_head))));

--- a/src/hotspot/os/bsd/os_bsd.hpp
+++ b/src/hotspot/os/bsd/os_bsd.hpp
@@ -70,7 +70,7 @@ class os::Bsd {
   // Real-time clock functions
   static void clock_init(void);
 
-  static void *dlopen_helper(const char *path, int mode);
+  static void *dlopen_helper(const char *path, int mode, char *ebuf, int ebuflen);
 
   // Stack repair handling
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1854,18 +1854,19 @@ void * os::Linux::dlopen_helper(const char *filename, char *ebuf, int ebuflen) {
     if (! IEEE_subnormal_handling_OK()) {
       // We just dlopen()ed a library that mangled the floating-point flags.
       // Attempt to fix things now.
+      JFR_ONLY(load_event.set_fp_env_correction_attempt(true);)
       int rtn = fesetenv(&default_fenv);
       assert(rtn == 0, "fesetenv must succeed");
-      bool ieee_handling_after_issue = IEEE_subnormal_handling_OK();
 
-      if (ieee_handling_after_issue) {
+      if (IEEE_subnormal_handling_OK()) {
         Events::log_dll_message(nullptr, "IEEE subnormal handling had to be corrected after loading %s", filename);
         log_info(os)("IEEE subnormal handling had to be corrected after loading %s", filename);
+        JFR_ONLY(load_event.set_fp_env_correction_success(true);)
       } else {
         Events::log_dll_message(nullptr, "IEEE subnormal handling could not be corrected after loading %s", filename);
         log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
+        assert(false, "fesetenv didn't work");
       }
-      assert(ieee_handling_after_issue, "fesetenv didn't work");
     }
 #endif // IA32
   }

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -957,6 +957,8 @@
     <Field type="string" name="name" label="Name" />
     <Field type="boolean" name="success" label="Success" description="Success or failure of the load operation" />
     <Field type="string" name="errorMessage" label="Error Message" description="In case of a load error, error description" />
+    <Field type="boolean" name="fpEnvCorrectionAttempt" label="FPU Environment correction" description="In case of IEEE conformance issues we might reset the FP environment" />
+    <Field type="boolean" name="fpEnvCorrectionSuccess" label="FPU Environment correction result" description="Stores result in case FP environment correction" />
   </Event>
 
   <Event name="NativeLibraryUnload" category="Java Virtual Machine, Runtime" label="Native Library Unload" thread="true" stackTrace="true" startTime="true"

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -958,7 +958,7 @@
     <Field type="boolean" name="success" label="Success" description="Success or failure of the load operation" />
     <Field type="string" name="errorMessage" label="Error Message" description="In case of a load error, error description" />
     <Field type="boolean" name="fpEnvCorrectionAttempt" label="FPU Environment correction" description="In case of IEEE conformance issues we might reset the FP environment" />
-    <Field type="boolean" name="fpEnvCorrectionSuccess" label="FPU Environment correction result" description="Stores result in case FP environment correction" />
+    <Field type="boolean" name="fpEnvCorrectionSuccess" label="FPU Environment correction result" description="Stores the result in the case of an FP environment correction" />
   </Event>
 
   <Event name="NativeLibraryUnload" category="Java Virtual Machine, Runtime" label="Native Library Unload" thread="true" stackTrace="true" startTime="true"

--- a/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
@@ -67,7 +67,7 @@ static inline JfrTicksWrapper* allocate_start_time() {
   return EventType::is_enabled() ? new JfrTicksWrapper() : nullptr;
 }
 
-NativeLibraryLoadEvent::NativeLibraryLoadEvent(const char* name, void** result) : JfrNativeLibraryEventBase(name), _result(result) {
+NativeLibraryLoadEvent::NativeLibraryLoadEvent(const char* name, void** result) : JfrNativeLibraryEventBase(name), _result(result), _fp_env_correction_attempt(false), _fp_env_correction_success(false) {
   assert(_result != nullptr, "invariant");
   _start_time = allocate_start_time<EventNativeLibraryLoad>();
 }
@@ -88,8 +88,17 @@ void NativeLibraryUnloadEvent::set_result(bool result) {
   _result = result;
 }
 
+static void set_additional_data(EventNativeLibraryLoad& event, const NativeLibraryLoadEvent& helper) {
+  event.set_fpEnvCorrectionAttempt(helper.get_fp_env_correction_attempt());
+  event.set_fpEnvCorrectionSuccess(helper.get_fp_env_correction_success());
+}
+
+static void set_additional_data(EventNativeLibraryUnload& event, const NativeLibraryUnloadEvent& helper) {
+  // no additional entries atm. for the unload event
+}
+
 template <typename EventType, typename HelperType>
-static void commit(HelperType& helper) {
+static void commit(const HelperType& helper) {
   if (!helper.has_start_time()) {
     return;
   }
@@ -99,6 +108,7 @@ static void commit(HelperType& helper) {
   event.set_name(helper.name());
   event.set_errorMessage(helper.error_msg());
   event.set_success(helper.success());
+  set_additional_data(event, helper);
   Thread* thread = Thread::current();
   assert(thread != nullptr, "invariant");
   if (thread->is_Java_thread()) {

--- a/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.hpp
+++ b/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.hpp
@@ -52,10 +52,16 @@ class JfrNativeLibraryEventBase : public StackObj {
 class NativeLibraryLoadEvent : public JfrNativeLibraryEventBase {
  private:
   void** _result;
+  bool _fp_env_correction_attempt;
+  bool _fp_env_correction_success;
  public:
   NativeLibraryLoadEvent(const char* name, void** result);
   ~NativeLibraryLoadEvent();
   bool success() const;
+  bool get_fp_env_correction_attempt() const { return _fp_env_correction_attempt; }
+  bool get_fp_env_correction_success() const { return _fp_env_correction_success; }
+  void set_fp_env_correction_attempt(bool v) { _fp_env_correction_attempt = v; }
+  void set_fp_env_correction_success(bool v) { _fp_env_correction_success = v; }
 };
 
 class NativeLibraryUnloadEvent : public JfrNativeLibraryEventBase {


### PR DESCRIPTION
[JDK-8295159](https://bugs.openjdk.org/browse/JDK-8295159) added some IEEE conformance checks and corrections of the floating point environment on Linux and macOS/BSD, and later some UL logging was added too.
However the information is not added to the JFR events, and this should be enhanced.
The already existing NativeLibraryLoad event can be used for storing the additional information, because the IEEE conformance check and fenv  get/set  is placed in the HS dlopen_helper , where already the NativeLibraryLoad  event objects are created/commited .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321017](https://bugs.openjdk.org/browse/JDK-8321017): Record in JFR that IEEE rounding mode was corrupted by loading a library (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [c7e63a27](https://git.openjdk.org/jdk/pull/16903/files/c7e63a27035ce0d62ad98f1989dca309b4485791)
 * [Johannes Bechberger](https://openjdk.org/census#jbechberger) (@parttimenerd - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16903/head:pull/16903` \
`$ git checkout pull/16903`

Update a local copy of the PR: \
`$ git checkout pull/16903` \
`$ git pull https://git.openjdk.org/jdk.git pull/16903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16903`

View PR using the GUI difftool: \
`$ git pr show -t 16903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16903.diff">https://git.openjdk.org/jdk/pull/16903.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16903#issuecomment-1833934026)