### PR TITLE
8321114: Rename "Unnamed Classes" to "Implicitly Declared Classes" better

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -190,21 +190,21 @@ import sun.reflect.misc.ReflectUtil;
  * a class or interface is hidden has no bearing on the characteristics
  * exposed by the methods of class {@code Class}.
  *
- * <h2><a id=implicitClasses>Implicit Classes</a></h2>
+ * <h2><a id=implicitClasses>Implicitly Declared Classes</a></h2>
  *
  * Conventionally, a Java compiler, starting from a source file for an
- * implicit class, say {@code HelloWorld.java}, creates a
+ * implicitly declared class, say {@code HelloWorld.java}, creates a
  * similarly-named {@code class} file, {@code HelloWorld.class}, where
  * the class stored in that {@code class} file is named {@code
  * "HelloWorld"}, matching the base names of the source and {@code
  * class} files.
  *
- * For the {@code Class} object of an implicit class {@code
+ * For the {@code Class} object of an implicitly declared class {@code
  * HelloWorld}, the methods to get the {@linkplain #getName name} and
  * {@linkplain #getTypeName type name} return results
  * equal to {@code "HelloWorld"}. The {@linkplain #getSimpleName
- * simple name} of such an implicit class is {@code "HelloWorld"} and the
- * {@linkplain #getCanonicalName canonical name} is {@code "HelloWorld"}.
+ * simple name} of such an implicitly declared class is {@code "HelloWorld"} and
+ * the {@linkplain #getCanonicalName canonical name} is {@code "HelloWorld"}.
  *
  * @param <T> the type of the class modeled by this {@code Class}
  * object.  For example, the type of {@code String.class} is {@code

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -71,7 +71,7 @@ public @interface PreviewFeature {
         STRING_TEMPLATES,
         @JEP(number=445, title="Unnamed Classes and Instance Main Methods", status="Deprecated")
         UNNAMED_CLASSES,
-        @JEP(number=463, title="Implicit Classes and Instance Main Methods", status="Preview")
+        @JEP(number=463, title="Implicitly Declared Classes and Instance Main Methods", status="Preview")
         IMPLICIT_CLASSES,
         @JEP(number=446, title="Scoped Values", status="Preview")
         SCOPED_VALUES,

--- a/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
@@ -181,7 +181,7 @@ public interface Filer {
      * classes, the name argument is used to provide the leading component of the
      * name used for the output file. For example {@code filer.createSourceFile("Foo")}
      * to create an implicitly declared class hosted in {@code Foo.java}. All
-     * implicit classes must be in an unnamed package.
+     * implicitly declared classes must be in an unnamed package.
      *
      * @apiNote To use a particular {@linkplain
      * java.nio.charset.Charset charset} to encode the contents of the
@@ -266,7 +266,7 @@ public interface Filer {
      * classes, the name argument is used to provide the leading component of the
      * name used for the output file. For example {@code filer.createSourceFile("Foo")}
      * to create an implicitly declared class hosted in {@code Foo.java}. All
-     * implicit classes must be in an unnamed package.
+     * implicitly declared classes must be in an unnamed package.
      *
      * @apiNote To avoid subsequent errors, the contents of the class
      * file should be compatible with the {@linkplain

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -123,7 +123,7 @@ public class Flags {
      */
     public static final int HASINIT          = 1<<18;
 
-    /** Class is a implicit top level class.
+    /** Class is an implicitly declared top level class.
      */
     public static final int IMPLICIT_CLASS    = 1<<19;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1554,7 +1554,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         @DefinedBy(Api.LANGUAGE_MODEL)
         public NestingKind getNestingKind() {
             apiComplete();
-            if (owner.kind == PCK) // Handles implicit classes as well
+            if (owner.kind == PCK) // Handles implicitly declared classes as well
                 return NestingKind.TOP_LEVEL;
             else if (name.isEmpty())
                 return NestingKind.ANONYMOUS;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3984,7 +3984,7 @@ public class JavacParser implements Parser {
                 // this code speculatively tests to see if a top level method
                 // or field can parse. If the method or field can parse then
                 // it is parsed. Otherwise, parsing continues as though
-                // implicit classes did not exist and error reporting
+                // implicitly declared classes did not exist and error reporting
                 // is the same as in the past.
                 if (Feature.IMPLICIT_CLASSES.allowedInSource(source) && !isDeclaration()) {
                     final JCModifiers finalMods = mods;
@@ -4012,7 +4012,7 @@ public class JavacParser implements Parser {
                 firstTypeDecl = false;
             }
         }
-        List<JCTree> topLevelDefs = isImplicitClass ?  constructImplictClass(defs.toList()) : defs.toList();
+        List<JCTree> topLevelDefs = isImplicitClass ?  constructImplicitClass(defs.toList()) : defs.toList();
         JCTree.JCCompilationUnit toplevel = F.at(firstToken.pos).TopLevel(topLevelDefs);
         if (!consumedToplevelDoc)
             attach(toplevel, firstToken.docComment());
@@ -4027,8 +4027,8 @@ public class JavacParser implements Parser {
         return toplevel;
     }
 
-    // Restructure top level to be an implicit class.
-    private List<JCTree> constructImplictClass(List<JCTree> origDefs) {
+    // Restructure top level to be an implicitly declared class.
+    private List<JCTree> constructImplicitClass(List<JCTree> origDefs) {
         ListBuffer<JCTree> topDefs = new ListBuffer<>();
         ListBuffer<JCTree> defs = new ListBuffer<>();
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3980,7 +3980,7 @@ public class JavacParser implements Parser {
                 defs.appendList(semiList.toList());
                 boolean isTopLevelMethodOrField = false;
 
-                // Do to a significant number of existing negative tests
+                // Due to a significant number of existing negative tests
                 // this code speculatively tests to see if a top level method
                 // or field can parse. If the method or field can parse then
                 // it is parsed. Otherwise, parsing continues as though

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -525,10 +525,10 @@ compiler.err.bad.file.name=\
     bad file name: {0}
 
 compiler.err.implicit.class.should.not.have.package.declaration=\
-    implicit class should not have package declaration
+    implicitly declared class should not have package declaration
 
 compiler.err.implicit.class.does.not.have.main.method=\
-    implicit class does not have main method in the form of void main() or void main(String[] args)
+    implicitly declared class does not have main method in the form of void main() or void main(String[] args)
 
 # 0: name, 1: name
 compiler.err.same.binary.name=\
@@ -3219,7 +3219,7 @@ compiler.misc.feature.unconditional.patterns.in.instanceof=\
     unconditional patterns in instanceof
 
 compiler.misc.feature.implicit.classes=\
-    implicit classes
+    implicitly declared classes
 
 compiler.misc.feature.super.init=\
     statements before super()

--- a/test/langtools/tools/javac/processing/model/element/TestImplicitClass.java
+++ b/test/langtools/tools/javac/processing/model/element/TestImplicitClass.java
@@ -52,7 +52,7 @@ import static javax.lang.model.util.ElementFilter.*;
 import javax.tools.JavaFileObject;
 
 /**
- * Test annotation processing representation of implicitly classes
+ * Test annotation processing representation of implicitly declared classes
  * constructed from either a source file or a class file.
  */
 @SuppressWarnings("preview")


### PR DESCRIPTION
Please review this PR to correctly rename "Unnamed Class" to "Implicitly Declared Class", not "Implicit Class".

Renaming is fixed where it affects documentation or the end-user. Renaming is not fixed where it only affects code: it's perfectly okay to derive an internal element name from "Implicit Class" rather than "Implicitly Declared Class", for brevity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321114](https://bugs.openjdk.org/browse/JDK-8321114): Rename "Unnamed Classes" to "Implicitly Declared Classes" better (**Bug** - P4)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16904/head:pull/16904` \
`$ git checkout pull/16904`

Update a local copy of the PR: \
`$ git checkout pull/16904` \
`$ git pull https://git.openjdk.org/jdk.git pull/16904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16904`

View PR using the GUI difftool: \
`$ git pr show -t 16904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16904.diff">https://git.openjdk.org/jdk/pull/16904.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16904#issuecomment-1833960791)