### PR TITLE
8321119: Disable java/foreign/TestHandshake.java on Zero VMs

### DIFF
--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @requires vm.flavor != "zero"
  * @modules java.base/jdk.internal.vm.annotation java.base/jdk.internal.misc
  * @key randomness
  * @run testng/othervm TestHandshake


### PR DESCRIPTION
This test is problematic on Zero due to https://bugs.openjdk.org/browse/JDK-8321064

Disable it for now on that platform, until a Zero maintainer has a chance to look into it.

Testing: running TestHandshake on zero to see that it is skipped.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321119](https://bugs.openjdk.org/browse/JDK-8321119): Disable java/foreign/TestHandshake.java on Zero VMs (**Bug** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16906/head:pull/16906` \
`$ git checkout pull/16906`

Update a local copy of the PR: \
`$ git checkout pull/16906` \
`$ git pull https://git.openjdk.org/jdk.git pull/16906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16906`

View PR using the GUI difftool: \
`$ git pr show -t 16906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16906.diff">https://git.openjdk.org/jdk/pull/16906.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16906#issuecomment-1834089697)