### PR TITLE
8321059: Unneeded array assignments in MergeCollation and CompactByteArray

### DIFF
--- a/src/java.base/share/classes/java/text/MergeCollation.java
+++ b/src/java.base/share/classes/java/text/MergeCollation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,8 +68,6 @@ final class MergeCollation {
      */
     public MergeCollation(String pattern) throws ParseException
     {
-        for (int i = 0; i < statusArray.length; i++)
-            statusArray[i] = 0;
         setPattern(pattern);
     }
 

--- a/src/java.base/share/classes/sun/text/CompactByteArray.java
+++ b/src/java.base/share/classes/sun/text/CompactByteArray.java
@@ -39,6 +39,8 @@
 package sun.text;
 
 
+import java.util.Arrays;
+
 /**
  * class CompactATypeArray : use only on primitive data types
  * Provides a compact way to store information that is indexed by Unicode
@@ -78,9 +80,7 @@ public final class CompactByteArray implements Cloneable {
         indices = new short[INDEXCOUNT];
         hashes = new int[INDEXCOUNT];
         if (defaultValue != (byte)0) {
-            for (i = 0; i < UNICODECOUNT; ++i) {
-                values[i] = defaultValue;
-            }
+            Arrays.fill(values, defaultValue);
         }
         for (i = 0; i < INDEXCOUNT; ++i) {
             indices[i] = (short)(i<<BLOCKSHIFT);

--- a/src/java.base/share/classes/sun/text/CompactByteArray.java
+++ b/src/java.base/share/classes/sun/text/CompactByteArray.java
@@ -77,12 +77,13 @@ public final class CompactByteArray implements Cloneable {
         values = new byte[UNICODECOUNT];
         indices = new short[INDEXCOUNT];
         hashes = new int[INDEXCOUNT];
-        for (i = 0; i < UNICODECOUNT; ++i) {
-            values[i] = defaultValue;
+        if (defaultValue != (byte)0) {
+            for (i = 0; i < UNICODECOUNT; ++i) {
+                values[i] = defaultValue;
+            }
         }
         for (i = 0; i < INDEXCOUNT; ++i) {
             indices[i] = (short)(i<<BLOCKSHIFT);
-            hashes[i] = 0;
         }
         isCompact = false;
     }


### PR DESCRIPTION
Removing the unnecessary array assignments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321059](https://bugs.openjdk.org/browse/JDK-8321059): Unneeded array assignments in MergeCollation and  CompactByteArray (**Enhancement** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [4fd6e61b](https://git.openjdk.org/jdk/pull/16912/files/4fd6e61be63d443787607fcd0d488efa3982de2a)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16912/head:pull/16912` \
`$ git checkout pull/16912`

Update a local copy of the PR: \
`$ git checkout pull/16912` \
`$ git pull https://git.openjdk.org/jdk.git pull/16912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16912`

View PR using the GUI difftool: \
`$ git pr show -t 16912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16912.diff">https://git.openjdk.org/jdk/pull/16912.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16912#issuecomment-1834543282)