### PR TITLE
8321130: Microbenchmarks do not build any more after 8254693 on 32 bit platforms

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CLayouts.java
@@ -56,7 +56,7 @@ public class CLayouts {
     /**
      * The layout for the {@code long long} C type.
      */
-    public static final ValueLayout.OfLong C_LONG_LONG = (ValueLayout.OfLong) LINKER.canonicalLayouts().get("long");
+    public static final ValueLayout.OfLong C_LONG_LONG = (ValueLayout.OfLong) LINKER.canonicalLayouts().get("long long");
     /**
      * The layout for the {@code float} C type
      */

--- a/test/micro/org/openjdk/bench/java/lang/foreign/xor/libjnitest.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/xor/libjnitest.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 #include <jni.h>
 
+#include "jlong.h"
+
 JNIEXPORT void xor_op(jbyte *restrict src, jbyte *restrict dst, jint len) {
     for (int i = 0; i < len; ++i) {
         dst[i] ^= src[i];
@@ -69,7 +71,7 @@ JNIEXPORT void JNICALL Java_org_openjdk_bench_java_lang_foreign_xor_GetArrayRegi
 
 JNIEXPORT void JNICALL Java_org_openjdk_bench_java_lang_foreign_xor_GetArrayUnsafeXorOpImpl_xorOp
   (JNIEnv *env, jobject obj, jlong src, jlong dst, jint len) {
-    jbyte *sbuf = (jbyte*)(void*)src;
-    jbyte *dbuf = (jbyte*)(void*)dst;
+    jbyte *sbuf = (jbyte*)jlong_to_ptr(src);
+    jbyte *dbuf = (jbyte*)jlong_to_ptr(dst);
     xor_op(sbuf, dbuf, len);
 }


### PR DESCRIPTION
Need to use `jlong_to_ptr` instead of raw cast.

I've also fixed another latent issue in `CLayouts` where we were initializing `C_LONG_LONG` with the `long` layout. This was resulting in a class cast exception when running the XorTest benchmark. The size of `long` on Linux x86 32-bits is 4 bytes, so the returned layout has type `ValueLayout.OfInt` which we then try to cast to `ValueLayout.OfLong`, resulting in a CCE. This would also be an issue on Windows.

Testing: running XorTest benchmark on linux-x86 and windows-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321130](https://bugs.openjdk.org/browse/JDK-8321130): Microbenchmarks do not build any more after 8254693 on 32 bit platforms (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16913/head:pull/16913` \
`$ git checkout pull/16913`

Update a local copy of the PR: \
`$ git checkout pull/16913` \
`$ git pull https://git.openjdk.org/jdk.git pull/16913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16913`

View PR using the GUI difftool: \
`$ git pr show -t 16913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16913.diff">https://git.openjdk.org/jdk/pull/16913.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16913#issuecomment-1834585714)