### PR TITLE
8321141: VM build issue on MacOS after JDK-8267532

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -474,6 +474,7 @@ ciBitData ciMethodData::exception_handler_bci_to_data(int bci) {
   }
   // called with invalid bci or wrong Method/MethodData
   ShouldNotReachHere();
+  return ciBitData(nullptr);
 }
 
 // Conservatively decode the trap_state of a ciProfileData.


### PR DESCRIPTION
[JDK-8267532](https://bugs.openjdk.org/browse/JDK-8267532) added new method `ciMethodData::exception_handler_bci_to_data()` which has `ShouldNotReachHere()` call on one exit without returning any value.

Unfortunately `ATTRIBUTE_NORETURN` attribute  in `ShouldNotReachHere()` seems don't work with older versions of Xcode.

The fix is to add `return` statement.

Tested with old Xcode (12.4) I have. Also tested with tier1 which includes builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321141](https://bugs.openjdk.org/browse/JDK-8321141): VM build issue on MacOS after JDK-8267532 (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16914/head:pull/16914` \
`$ git checkout pull/16914`

Update a local copy of the PR: \
`$ git checkout pull/16914` \
`$ git pull https://git.openjdk.org/jdk.git pull/16914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16914`

View PR using the GUI difftool: \
`$ git pr show -t 16914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16914.diff">https://git.openjdk.org/jdk/pull/16914.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16914#issuecomment-1834766216)