### PR TITLE
8320129: "top" command during jtreg failure handler does not display CPU usage on OSX

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -116,7 +116,7 @@ system.sysctl.args=-a
 process.ps.app=ps
 process.ps.args=-Meo pid,pcpu,cputime,start,pmem,vsz,rss,state,wchan,user,args
 process.top.app=top
-process.top.args=-l 1
+process.top.args=-l 2
 
 memory.vmstat.app=vm_stat
 memory.vmstat.args=-c 3 3


### PR DESCRIPTION
Description of problem and propsed fix from @plummercj 
'
In test/failure_handler/src/share/conf/mac.properties we have:

process.top.app=top
process.top.args=-l 1

So top is run with the "-l 1" args, causing it to do one iteration and then exit. Unfortunately the first iteration always shows all 0's for CPU usage. If you do at least 2 iterations, you do see the proper CPU usage on the 2nd iteration. The user just needs to know to scroll down to see it. I suggest we start using "-l 2" unless someone has a better idea.

BTW, for proper CPU usage you can instead look at the failure handler "ps" output, which seems to be correct. But it is nice to have "top" produce the correct output so all the CPU hogs are at the top of the list.
'

I verified that top report contains now 2 samples.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320129](https://bugs.openjdk.org/browse/JDK-8320129): "top" command during jtreg failure handler does not display CPU usage on OSX (**Bug** - P5)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16915/head:pull/16915` \
`$ git checkout pull/16915`

Update a local copy of the PR: \
`$ git checkout pull/16915` \
`$ git pull https://git.openjdk.org/jdk.git pull/16915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16915`

View PR using the GUI difftool: \
`$ git pr show -t 16915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16915.diff">https://git.openjdk.org/jdk/pull/16915.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16915#issuecomment-1835229878)