### PR TITLE
8319925: CSS.BackgroundImage incorrectly uses double-checked locking

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2933,7 +2933,8 @@ public class CSS implements Serializable {
      */
     @SuppressWarnings("serial") // Same-version serialization only
     static class BackgroundImage extends CssValue {
-        private volatile ImageIcon image;
+        private volatile boolean loadedImage;
+        private ImageIcon image;
 
         Object parseCssValue(String value) {
             BackgroundImage retValue = new BackgroundImage();
@@ -2947,9 +2948,9 @@ public class CSS implements Serializable {
 
         // PENDING: this base is wrong for linked style sheets.
         ImageIcon getImage(URL base) {
-            if (image == null) {
+            if (!loadedImage) {
                 synchronized(this) {
-                    if (image == null) {
+                    if (!loadedImage) {
                         URL url = CSS.getURL(base, svalue);
                         if (url != null) {
                             image = new ImageIcon();
@@ -2958,6 +2959,7 @@ public class CSS implements Serializable {
                                 image.setImage(tmpImg);
                             }
                         }
+                        loadedImage = true;
                     }
                 }
             }

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2933,8 +2933,7 @@ public class CSS implements Serializable {
      */
     @SuppressWarnings("serial") // Same-version serialization only
     static class BackgroundImage extends CssValue {
-        private volatile boolean loadedImage;
-        private ImageIcon image;
+        private volatile ImageIcon image;
 
         Object parseCssValue(String value) {
             BackgroundImage retValue = new BackgroundImage();
@@ -2948,11 +2947,10 @@ public class CSS implements Serializable {
 
         // PENDING: this base is wrong for linked style sheets.
         ImageIcon getImage(URL base) {
-            if (!loadedImage) {
+            if (image == null) {
                 synchronized(this) {
-                    if (!loadedImage) {
+                    if (image == null) {
                         URL url = CSS.getURL(base, svalue);
-                        loadedImage = true;
                         if (url != null) {
                             image = new ImageIcon();
                             Image tmpImg = Toolkit.getDefaultToolkit().createImage(url);

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2933,8 +2933,8 @@ public class CSS implements Serializable {
      */
     @SuppressWarnings("serial") // Same-version serialization only
     static class BackgroundImage extends CssValue {
-        private boolean    loadedImage;
-        private ImageIcon  image;
+        private volatile boolean loadedImage;
+        private ImageIcon image;
 
         Object parseCssValue(String value) {
             BackgroundImage retValue = new BackgroundImage();


### PR DESCRIPTION
CSS.BackgroundImage.getImage uses double-checked locking but the loadedImage field isn't declared as volatile. Without the volatile modifier, double-checked locking implementation is broken.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319925](https://bugs.openjdk.org/browse/JDK-8319925): CSS.BackgroundImage incorrectly uses double-checked locking (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16917/head:pull/16917` \
`$ git checkout pull/16917`

Update a local copy of the PR: \
`$ git checkout pull/16917` \
`$ git pull https://git.openjdk.org/jdk.git pull/16917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16917`

View PR using the GUI difftool: \
`$ git pr show -t 16917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16917.diff">https://git.openjdk.org/jdk/pull/16917.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16917#issuecomment-1835548544)