### PR TITLE
8321163: [test] OutputAnalyzer.getExitValue() unnecessarily logs even when process has already completed

### DIFF
--- a/test/lib/jdk/test/lib/process/OutputBuffer.java
+++ b/test/lib/jdk/test/lib/process/OutputBuffer.java
@@ -120,7 +120,7 @@ public interface OutputBuffer {
     private final StreamTask outTask;
     private final StreamTask errTask;
     private final Process p;
-    private volatile Integer processExitCode; // null implies we don't yet know
+    private volatile Integer processExitValue; // null implies we don't yet know
 
     private final void logProgress(String state) {
         System.out.println("[" + Instant.now().toString() + "] " + state
@@ -147,18 +147,18 @@ public interface OutputBuffer {
 
     @Override
     public int getExitValue() {
-      Integer exitCode = this.processExitCode;
-      if (exitCode != null) {
-        return exitCode;
+      Integer exitValue = this.processExitValue;
+      if (exitValue != null) {
+        return exitValue;
       }
       try {
           logProgress("Waiting for completion");
           boolean aborted = true;
           try {
-              this.processExitCode = exitCode = p.waitFor();
+              this.processExitValue = exitValue = p.waitFor();
               logProgress("Waiting for completion finished");
               aborted = false;
-              return exitCode;
+              return exitValue;
           } finally {
               if (aborted) {
                   logProgress("Waiting for completion FAILED");

--- a/test/lib/jdk/test/lib/process/OutputBuffer.java
+++ b/test/lib/jdk/test/lib/process/OutputBuffer.java
@@ -120,7 +120,7 @@ public interface OutputBuffer {
     private final StreamTask outTask;
     private final StreamTask errTask;
     private final Process p;
-    private volatile Integer processExitValue; // null implies we don't yet know
+    private volatile Integer exitValue; // null implies we don't yet know
 
     private final void logProgress(String state) {
         System.out.println("[" + Instant.now().toString() + "] " + state
@@ -147,7 +147,6 @@ public interface OutputBuffer {
 
     @Override
     public int getExitValue() {
-      Integer exitValue = this.processExitValue;
       if (exitValue != null) {
         return exitValue;
       }
@@ -155,7 +154,7 @@ public interface OutputBuffer {
           logProgress("Waiting for completion");
           boolean aborted = true;
           try {
-              this.processExitValue = exitValue = p.waitFor();
+              exitValue = p.waitFor();
               logProgress("Waiting for completion finished");
               aborted = false;
               return exitValue;


### PR DESCRIPTION
Can I please get a review for this change to the test library's `OutputAnalyzer` class, which proposes to remove some unnecessary logging from the `getExitValue()` call?

As noted in https://bugs.openjdk.org/browse/JDK-8321163, right now this method logs:

```
[2023-11-24T11:47:54.557561Z] Waiting for completion for process 24909
[2023-11-24T11:47:54.557873Z] Waiting for completion finished for process 24909

```
even when the process has already completed and the exit value already known. The change in this PR makes it such that if the exit value is available then we no longer log this (nor call `process.waitFor()`).

No new tests have been added given the nature of this change. tier1, tier2 and tier3 tests continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321163](https://bugs.openjdk.org/browse/JDK-8321163): [test] OutputAnalyzer.getExitValue() unnecessarily logs even when process has already completed (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16919/head:pull/16919` \
`$ git checkout pull/16919`

Update a local copy of the PR: \
`$ git checkout pull/16919` \
`$ git pull https://git.openjdk.org/jdk.git pull/16919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16919`

View PR using the GUI difftool: \
`$ git pr show -t 16919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16919.diff">https://git.openjdk.org/jdk/pull/16919.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16919#issuecomment-1835800964)