### PR TITLE
JDK-8317307: test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails with ConnectException: Connection timed out: no further information

### DIFF
--- a/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
+++ b/test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ public class LdapPoolTimeoutTest {
             // assertCompletion may wrap a CommunicationException in an RTE
             assertNotNull(msg);
             assertTrue(msg.contains("Network is unreachable")
-                        || msg.contains("No route to host"));
+                        || msg.contains("No route to host") || msg.contains("Connection timed out"));
         } catch (NamingException ex) {
             String msg = ex.getCause() == null ? ex.getMessage() : ex.getCause().getMessage();
             System.err.println("MSG: " + msg);


### PR DESCRIPTION
On Windows we recently run into this error rather often in the test LdapPoolTimeoutTest.java :

MSG RTE: javax.naming.CommunicationException: example.com:1234 [Root exception is java.net.ConnectException: Connection timed out: no further information]
MSG: Connect timed out
MSG: Timeout exceeded while waiting for a connection: 26984ms
MSG: Timed out waiting for lock
MSG: Timed out waiting for lock
MSG: Timed out waiting for lock
MSG: Timeout exceeded while waiting for a connection: 26984ms
MSG: Timeout exceeded while waiting for a connection: 26984ms
java.lang.Exception: failures: 1
at com.sun.javatest.regtest.agent.TestNGRunner.main(TestNGRunner.java:104)
at com.sun.javatest.regtest.agent.TestNGRunner.main(TestNGRunner.java:58)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1570)

We should extend the accepted exception message strings and also also  'Connection timed out' .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317307](https://bugs.openjdk.org/browse/JDK-8317307): test/jdk/com/sun/jndi/ldap/LdapPoolTimeoutTest.java fails with ConnectException: Connection timed out: no further information (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16922/head:pull/16922` \
`$ git checkout pull/16922`

Update a local copy of the PR: \
`$ git checkout pull/16922` \
`$ git pull https://git.openjdk.org/jdk.git pull/16922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16922`

View PR using the GUI difftool: \
`$ git pr show -t 16922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16922.diff">https://git.openjdk.org/jdk/pull/16922.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16922#issuecomment-1836152915)