### PR TITLE
8321182: SourceExample.SOURCE_14 comment should refer to 'switch expressions' instead of 'text blocks'

### DIFF
--- a/test/langtools/tools/javac/versions/Versions.java
+++ b/test/langtools/tools/javac/versions/Versions.java
@@ -42,9 +42,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /*
@@ -240,16 +238,8 @@ public class Versions {
 
     protected void check(String major, List<String> args) {
         printargs("check", args);
-        List<String> jcargs = new ArrayList<>();
-        jcargs.add("-Xlint:-options");
 
-        // add in args conforming to List requrements of JavaCompiler
-        for (String onearg : args) {
-            String[] fields = onearg.split(" ");
-            for (String onefield : fields) {
-                jcargs.add(onefield);
-            }
-        }
+        List<String> jcargs = javaCompilerOptions(args);
 
         boolean creturn = compile("Base.java", jcargs);
         if (!creturn) {
@@ -262,6 +252,25 @@ public class Versions {
         } else if (!checkClassFileVersion("Base.class", major)) {
             failedCases++;
         }
+    }
+
+    /**
+     * Create a list of options suitable for use with {@link JavaCompiler}
+     * @param args a list of space-delimited options, such as "-source 11"
+     * @return a list of arguments suitable for use with {@link JavaCompiler}
+     */
+    private static List<String> javaCompilerOptions(List<String> args) {
+        List<String> jcargs = new ArrayList<>();
+        jcargs.add("-Xlint:-options");
+
+        // add in args conforming to List requirements of JavaCompiler
+        for (String onearg : args) {
+            String[] fields = onearg.split(" ");
+            for (String onefield : fields) {
+                jcargs.add(onefield);
+            }
+        }
+        return jcargs;
     }
 
     /**
@@ -311,7 +320,7 @@ public class Versions {
             """),
 
          SOURCE_14(14, "New14.java",
-             // New feature in 14: text blocks
+             // New feature in 14: switch expressions
              """
              public class New14 {
                  static {
@@ -427,16 +436,7 @@ public class Versions {
     protected void pass(List<String> args) {
         printargs("pass", args);
 
-        List<String> jcargs = new ArrayList<>();
-        jcargs.add("-Xlint:-options");
-
-        // add in args conforming to List requrements of JavaCompiler
-        for (String onearg : args) {
-            String[] fields = onearg.split(" ");
-            for (String onefield : fields) {
-                jcargs.add(onefield);
-            }
-        }
+        List<String> jcargs = javaCompilerOptions(args);
 
         // empty list is error
         if (jcargs.isEmpty()) {
@@ -464,16 +464,7 @@ public class Versions {
     protected void fail(List<String> args) {
         printargs("fail", args);
 
-        List<String> jcargs = new ArrayList<>();
-        jcargs.add("-Xlint:-options");
-
-        // add in args conforming to List requrements of JavaCompiler
-        for (String onearg : args) {
-            String[] fields = onearg.split(" ");
-            for (String onefield : fields) {
-                jcargs.add(onefield);
-            }
-        }
+        List<String> jcargs = javaCompilerOptions(args);
 
         // empty list is error
         if (jcargs.isEmpty()) {


### PR DESCRIPTION
The `Versions` test has a comment referring to 'text blocks' when the feature introduced in Java 14 was actually 'switch expressions'. This looks like a simple copy/paste mistake.

This PR fixes the comment. While touching the code, I also took the liberty to do the following improvements:

- Fixed a typo in `requirements' in a code comment
- Removed some unused imports
- Reduced duplication of `JavaCompiler` option conversion by introducing a separate method `javaCompilerOptions`. (Used the 'extract method' refactoring in IntelliJ IDEA which replaced 3 duplicates)

If the last fix is considered gratuitous, let me know and I can simplify the PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321182](https://bugs.openjdk.org/browse/JDK-8321182): SourceExample.SOURCE_14 comment should refer to 'switch expressions' instead of 'text blocks' (**Enhancement** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16924/head:pull/16924` \
`$ git checkout pull/16924`

Update a local copy of the PR: \
`$ git checkout pull/16924` \
`$ git pull https://git.openjdk.org/jdk.git pull/16924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16924`

View PR using the GUI difftool: \
`$ git pr show -t 16924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16924.diff">https://git.openjdk.org/jdk/pull/16924.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16924#issuecomment-1836323890)