### PR TITLE
8321001: RISC-V: C2 SignumVF

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1586,11 +1586,6 @@ enum VectorMask {
   INSN(vfadd_vf,  0b1010111, 0b101, 0b000000);
   INSN(vfrsub_vf, 0b1010111, 0b101, 0b100111);
 
-  // Vector Floating-Point Sign-Injection Instructions
-  INSN(vfsgnj_vf, 0b1010111, 0b101, 0b001000);
-  INSN(vfsgnjx_vf, 0b1010111, 0b101, 0b001010);
-  INSN(vfsgnjn_vf, 0b1010111, 0b101, 0b001001);
-
 #undef INSN
 
 #define INSN(NAME, op, funct3, funct6)                                                             \

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1417,6 +1417,7 @@ enum VectorMask {
   INSN(vmfeq_vv, 0b1010111, 0b001, 0b011000);
 
   // Vector Floating-Point Sign-Injection Instructions
+  INSN(vfsgnj_vv, 0b1010111, 0b001, 0b001000);
   INSN(vfsgnjx_vv, 0b1010111, 0b001, 0b001010);
   INSN(vfsgnjn_vv, 0b1010111, 0b001, 0b001001);
 
@@ -1584,6 +1585,11 @@ enum VectorMask {
   INSN(vfsub_vf,  0b1010111, 0b101, 0b000010);
   INSN(vfadd_vf,  0b1010111, 0b101, 0b000000);
   INSN(vfrsub_vf, 0b1010111, 0b101, 0b100111);
+
+  // Vector Floating-Point Sign-Injection Instructions
+  INSN(vfsgnj_vf, 0b1010111, 0b101, 0b001000);
+  INSN(vfsgnjx_vf, 0b1010111, 0b101, 0b001010);
+  INSN(vfsgnjn_vf, 0b1010111, 0b101, 0b001001);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1676,15 +1676,14 @@ void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister one, bool is_
   bind(done);
 }
 
-void C2_MacroAssembler::signum_fp_v(VectorRegister dst, BasicType bt, int vlen,
-                                    VectorRegister zero, VectorRegister one) {
+void C2_MacroAssembler::signum_fp_v(VectorRegister dst, VectorRegister one, BasicType bt, int vlen) {
   vsetvli_helper(bt, vlen);
 
   // check if input is -0, +0, signaling NaN or quiet NaN
   vfclass_v(v0, dst);
   mv(t0, fclass_mask::zero | fclass_mask::nan);
   vand_vx(v0, v0, t0);
-  vmseq_vv(v0, v0, zero);
+  vmseq_vi(v0, v0, 0);
 
   // use floating-point 1.0 with a sign of input
   vfsgnj_vv(dst, one, dst, v0_t);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1676,6 +1676,20 @@ void C2_MacroAssembler::signum_fp(FloatRegister dst, FloatRegister one, bool is_
   bind(done);
 }
 
+void C2_MacroAssembler::signum_fp_v(VectorRegister dst, BasicType bt, int vlen,
+                                    VectorRegister zero, VectorRegister one) {
+  vsetvli_helper(bt, vlen);
+
+  // check if input is -0, +0, signaling NaN or quiet NaN
+  vfclass_v(v0, dst);
+  mv(t0, fclass_mask::zero | fclass_mask::nan);
+  vand_vx(v0, v0, t0);
+  vmseq_vv(v0, v0, zero);
+
+  // use floating-point 1.0 with a sign of input
+  vfsgnj_vv(dst, one, dst, v0_t);
+}
+
 void C2_MacroAssembler::compress_bits_v(Register dst, Register src, Register mask, bool is_long) {
   Assembler::SEW sew = is_long ? Assembler::e64 : Assembler::e32;
   // intrinsic is enabled when MaxVectorSize >= 16

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -163,6 +163,8 @@
 
   void signum_fp(FloatRegister dst, FloatRegister one, bool is_double);
 
+  void signum_fp_v(VectorRegister dst, BasicType bt, int vlen, VectorRegister zero, VectorRegister one);
+
   // intrinsic methods implemented by rvv instructions
 
   // compress bits, i.e. j.l.Integer/Long::compress.

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -163,7 +163,7 @@
 
   void signum_fp(FloatRegister dst, FloatRegister one, bool is_double);
 
-  void signum_fp_v(VectorRegister dst, BasicType bt, int vlen, VectorRegister zero, VectorRegister one);
+  void signum_fp_v(VectorRegister dst, VectorRegister one, BasicType bt, int vlen);
 
   // intrinsic methods implemented by rvv instructions
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3660,6 +3660,23 @@ instruct vexpand(vReg dst, vReg src, vRegMask_V0 v0, vReg tmp) %{
   ins_pipe(pipe_slow);
 %}
 
+// ------------------------------ Vector signum --------------------------------
+
+// Vector Math.signum
+
+instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
+  match(Set dst (SignumVF dst (Binary zero one)));
+  match(Set dst (SignumVD dst (Binary zero one)));
+  effect(TEMP_DEF dst);
+  format %{ "vsignum $dst, $dst\t" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ signum_fp_v(as_VectorRegister($dst$$reg), bt, Matcher::vector_length(this),
+                  as_VectorRegister($zero$$reg), as_VectorRegister($one$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // ------------------------------ Vector Load Gather ---------------------------
 
 instruct gather_load(vReg dst, indirect mem, vReg idx) %{

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3667,7 +3667,7 @@ instruct vexpand(vReg dst, vReg src, vRegMask_V0 v0, vReg tmp) %{
 instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
   match(Set dst (SignumVF dst (Binary zero one)));
   match(Set dst (SignumVD dst (Binary zero one)));
-  effect(TEMP_DEF dst);
+  effect(TEMP_DEF dst, TEMP v0);
   format %{ "vsignum $dst, $dst\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3671,8 +3671,8 @@ instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
   format %{ "vsignum $dst, $dst\t" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ signum_fp_v(as_VectorRegister($dst$$reg), bt, Matcher::vector_length(this),
-                   as_VectorRegister($zero$$reg), as_VectorRegister($one$$reg));
+    __ signum_fp_v(as_VectorRegister($dst$$reg), as_VectorRegister($one$$reg),
+                   bt, Matcher::vector_length(this));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3672,7 +3672,7 @@ instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ signum_fp_v(as_VectorRegister($dst$$reg), bt, Matcher::vector_length(this),
-                  as_VectorRegister($zero$$reg), as_VectorRegister($one$$reg));
+                   as_VectorRegister($zero$$reg), as_VectorRegister($one$$reg));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/test/hotspot/jtreg/compiler/vectorization/TestSignumVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSignumVector.java
@@ -24,9 +24,11 @@
 /**
  * @test
  * @bug 8282711 8290249
- * @summary Accelerate Math.signum function for AVX, AVX512 and aarch64 (Neon and SVE)
+ * @summary Accelerate Math.signum function for AVX, AVX512, aarch64 (Neon and SVE)
+ *          and riscv64 (vector)
  * @requires vm.compiler2.enabled
- * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*") | os.arch == "aarch64"
+ * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*") | os.arch == "aarch64" |
+ *           (os.arch == "riscv64" & vm.cpu.features ~= ".*v,.*")
  * @library /test/lib /
  * @run driver compiler.vectorization.TestSignumVector
  */


### PR DESCRIPTION
Hi,
Can you review the patch to add intrinisc SignumVF/SignumVD on riscv?
Thanks

## Test
test/hotspot/jtreg/compiler/intrinsics/
test/hotspot/jtreg/compiler/vectorapi/
and tests found via:
grep -nr test/hotspot/jtreg/ -we Math.signum
and test found via:
grep -nr test/jdk/ -we Math.signum

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8321001](https://bugs.openjdk.org/browse/JDK-8321001): RISC-V: C2 SignumVF (**Sub-task** - P4)
 * [JDK-8321002](https://bugs.openjdk.org/browse/JDK-8321002): RISC-V: C2 SignumVD (**Sub-task** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16925/head:pull/16925` \
`$ git checkout pull/16925`

Update a local copy of the PR: \
`$ git checkout pull/16925` \
`$ git pull https://git.openjdk.org/jdk.git pull/16925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16925`

View PR using the GUI difftool: \
`$ git pr show -t 16925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16925.diff">https://git.openjdk.org/jdk/pull/16925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16925#issuecomment-1836311946)