### PR TITLE
8321183: Incorrect warning from cds about the modules file

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -412,7 +412,8 @@ bool SharedClassPathEntry::validate(bool is_class_path) const {
         }
         if (time_differs) {
           log_warning(cds)("%s timestamp has changed.", name);
-        } else {
+        }
+        if (size_differs) {
           log_warning(cds)("%s size has changed.", name);
         }
       }

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -397,23 +397,24 @@ bool SharedClassPathEntry::validate(bool is_class_path) const {
       log_warning(cds)("directory is not empty: %s", name);
       ok = false;
     }
-  } else if ((has_timestamp() && _timestamp != st.st_mtime) ||
-             _filesize != st.st_size) {
-    ok = false;
-    if (PrintSharedArchiveAndExit) {
-      log_warning(cds)(_timestamp != st.st_mtime ?
-                                 "Timestamp mismatch" :
-                                 "File size mismatch");
-    } else {
-      const char* bad_jar_msg = "A jar file is not the one used while building the shared archive file:";
-      log_warning(cds)("%s %s", bad_jar_msg, name);
-      if (!log_is_enabled(Info, cds)) {
-        log_warning(cds)("%s %s", bad_jar_msg, name);
-      }
-      if (_timestamp != st.st_mtime) {
-        log_warning(cds)("%s timestamp has changed.", name);
+  } else {
+    bool size_differs = _filesize != st.st_size;
+    bool time_differs = has_timestamp() && _timestamp != st.st_mtime;
+    if (time_differs || size_differs) {
+      ok = false;
+      if (PrintSharedArchiveAndExit) {
+        log_warning(cds)(time_differs ? "Timestamp mismatch" : "File size mismatch");
       } else {
-        log_warning(cds)("%s size has changed.", name);
+        const char* bad_file_msg = "This file is not the one used while building the shared archive file:";
+        log_warning(cds)("%s %s", bad_file_msg, name);
+        if (!log_is_enabled(Info, cds)) {
+          log_warning(cds)("%s %s", bad_file_msg, name);
+        }
+        if (time_differs) {
+          log_warning(cds)("%s timestamp has changed.", name);
+        } else {
+          log_warning(cds)("%s size has changed.", name);
+        }
       }
     }
   }

--- a/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/WrongClasspath.java
@@ -108,7 +108,7 @@ public class WrongClasspath {
     // message should be there.
     output = TestCommon.execAuto(
         "-cp", jars, "Hello");
-    output.shouldMatch("A jar file is not the one used while building the shared archive file:.*jar2.jar")
+    output.shouldMatch("This file is not the one used while building the shared archive file:.*jar2.jar")
           .shouldMatch(".warning..cds.*jar2.jar timestamp has changed.");
   }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/MainModuleOnly.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/MainModuleOnly.java
@@ -204,7 +204,7 @@ public class MainModuleOnly extends DynamicArchiveTestBase {
             "--module-path", moduleDir.toString(),
             "-m", TEST_MODULE1)
             .assertAbnormalExit(
-                "A jar file is not the one used while building the shared archive file:");
+                "This file is not the one used while building the shared archive file:");
         // create an archive with a non-empty directory in the --module-path.
         // The dumping process will exit with an error due to non-empty directory
         // in the --module-path.

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/WrongTopClasspath.java
@@ -111,7 +111,7 @@ public class WrongTopClasspath extends DynamicArchiveTestBase {
                 "assertNotShared:GenericTestApp") // but top archive is not useable
           .assertNormalExit(output -> {
               output.shouldContain(topArchiveMsg);
-              output.shouldMatch("A jar file is not the one used while building the shared archive file:.*GenericTestApp.jar");
+              output.shouldMatch("This file is not the one used while building the shared archive file:.*GenericTestApp.jar");
               output.shouldMatch(".warning..cds.*GenericTestApp.jar timestamp has changed.");});
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/MainModuleOnly.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/MainModuleOnly.java
@@ -65,7 +65,7 @@ public class MainModuleOnly {
     private static Path moduleDir2 = null;
     private static Path destJar = null;
 
-    private static final String jarFileError = "A jar file is not the one used while building the shared archive file:";
+    private static final String jarFileError = "This file is not the one used while building the shared archive file:";
 
     public static void buildTestModule() throws Exception {
 


### PR DESCRIPTION
When the `modules`  file used at run time differs in size from the one used at build time, the warning is confusing:

```
$ .../bin/java -jar .../demo/jfc/Notepad/Notepad.jar
[0.033s][warning][cds] A jar file is not the one used while building the shared archive file: /.../lib/modules
[0.033s][warning][cds] A jar file is not the one used while building the shared archive file: /.../lib/modules
[0.033s][warning][cds] /.../lib/modules timestamp has changed. 
```
Notice that it is referred to as `jar file` and that `timestamp has changed` rather than size.

The suggested patch is pretty self-explanatory. With this patch, the warnings look like this:
```
./build/linux-x86_64-server-release/images/jdk/bin/java -jar ./build/linux-x86_64-server-release/images/jdk/demo/jfc/Notepad/Notepad.jar
[0.014s][warning][cds] This file is not the one used while building the shared archive file: /home/maxim/openjdk/jdk/build/linux-x86_64-server-release/images/jdk/lib/modules
[0.014s][warning][cds] This file is not the one used while building the shared archive file: /home/maxim/openjdk/jdk/build/linux-x86_64-server-release/images/jdk/lib/modules
[0.014s][warning][cds] /home/maxim/openjdk/jdk/build/linux-x86_64-server-release/images/jdk/lib/modules size has changed.

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321183](https://bugs.openjdk.org/browse/JDK-8321183): Incorrect warning from cds about the modules file (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16926/head:pull/16926` \
`$ git checkout pull/16926`

Update a local copy of the PR: \
`$ git checkout pull/16926` \
`$ git pull https://git.openjdk.org/jdk.git pull/16926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16926`

View PR using the GUI difftool: \
`$ git pr show -t 16926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16926.diff">https://git.openjdk.org/jdk/pull/16926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16926#issuecomment-1836352862)