### PR TITLE
8312098: Update man page for javadoc

### DIFF
--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -84,9 +84,9 @@ options, package names, and source file names in any order.
 The \f[V]javadoc\f[R] tool parses the declarations and documentation
 comments in a set of Java source files and produces corresponding HTML
 pages that describe (by default) the public and protected classes,
-nested classes (but not anonymous inner classes), interfaces,
-constructors, methods, and fields.
-You can use the \f[V]javadoc\f[R] tool to generate the API documentation
+nested and unnamed classes (but not anonymous inner classes),
+interfaces, constructors, methods, and fields.
+You can use the\f[V]javadoc\f[R] tool to generate the API documentation
 or the implementation documentation for a set of source files.
 .PP
 You can run the \f[V]javadoc\f[R] tool on entire packages, individual


### PR DESCRIPTION
Please review this **forwardport**.

The original issue should've been committed to mainline first and then backported to jdk21, but instead it was [committed in jdk21 first](https://github.com/openjdk/jdk21/pull/130) and almost forgotten to be brought to mainline.

This PR brings the change to mainline just in time: RDP 1 is next week.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312098](https://bugs.openjdk.org/browse/JDK-8312098): Update man page for javadoc (**Task** - P3)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16929/head:pull/16929` \
`$ git checkout pull/16929`

Update a local copy of the PR: \
`$ git checkout pull/16929` \
`$ git pull https://git.openjdk.org/jdk.git pull/16929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16929`

View PR using the GUI difftool: \
`$ git pr show -t 16929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16929.diff">https://git.openjdk.org/jdk/pull/16929.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16929#issuecomment-1836483195)