### PR TITLE
Reuse StringLatin1::equals in regionMatches

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2182,7 +2182,7 @@ public final class String
         byte[] tv = value;
         byte[] ov = other.value;
         if (coder == otherCoder) {
-            if (ooffset == 0 && toffset == 0 && len == (tv.length >> coder) && ov.length == tv.length) {
+            if ((ooffset | toffset) == 0 && len == (tv.length >> coder) && ov.length == tv.length) {
                 return StringLatin1.equals(tv, ov);
             }
             if (coder == UTF16) {

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2177,10 +2177,14 @@ public final class String
         if (len <= 0) {
            return true;
         }
+        byte coder = coder();
+        byte otherCoder = other.coder();
         byte[] tv = value;
         byte[] ov = other.value;
-        byte coder = coder();
-        if (coder == other.coder()) {
+        if (coder == otherCoder) {
+            if (ooffset == 0 && toffset == 0 && len == (tv.length >> coder) && ov.length == tv.length) {
+                return StringLatin1.equals(tv, ov);
+            }
             if (coder == UTF16) {
                 toffset <<= UTF16;
                 ooffset <<= UTF16;


### PR DESCRIPTION
This improvement has been found on https://github.com/vert-x3/vertx-web/pull/2526.

It can potentially affect the existing ArraysSupport.mismatch caller code-path performance ie requires investigation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16933/head:pull/16933` \
`$ git checkout pull/16933`

Update a local copy of the PR: \
`$ git checkout pull/16933` \
`$ git pull https://git.openjdk.org/jdk.git pull/16933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16933`

View PR using the GUI difftool: \
`$ git pr show -t 16933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16933.diff">https://git.openjdk.org/jdk/pull/16933.diff</a>

</details>
