### PR TITLE
8321069: JvmtiThreadState::state_for_while_locked() returns nullptr for an attached JNI thread with a java.lang.Thread object after JDK-8319935

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
@@ -85,9 +85,8 @@ inline JvmtiThreadState* JvmtiThreadState::state_for_while_locked(JavaThread *th
       (thread->is_exiting() ||
        (thread->threadObj() == nullptr && thread->is_attaching_via_jni())
       )) {
-    // Don't add a JvmtiThreadState to a thread that is exiting or is attaching.
-    // When a thread is attaching, it may not have a Java level thread object
-    // created yet.
+    // Don't add a JvmtiThreadState to a thread that is exiting, or is attaching
+    // and does not yet have a Java level thread object allocated.
     return nullptr;
   }
 

--- a/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.inline.hpp
@@ -82,7 +82,9 @@ inline JvmtiThreadState* JvmtiThreadState::state_for_while_locked(JavaThread *th
   JvmtiThreadState *state = thread == nullptr ? nullptr : thread->jvmti_thread_state();
 
   if (state == nullptr && thread != nullptr &&
-      (thread->is_exiting() || thread->is_attaching_via_jni())) {
+      (thread->is_exiting() ||
+       (thread->threadObj() == nullptr && thread->is_attaching_via_jni())
+      )) {
     // Don't add a JvmtiThreadState to a thread that is exiting or is attaching.
     // When a thread is attaching, it may not have a Java level thread object
     // created yet.


### PR DESCRIPTION
In the fix for the following bug:

[JDK-8319935](https://bugs.openjdk.org/browse/JDK-8319935) Ensure only one JvmtiThreadState is created for one JavaThread associated with attached native thread

JvmtiThreadState::state_for_while_locked() was changed to
return nullptr for attaching JNI threads regardless of whether
that JNI thread/JavaThread had a java.lang.Thread object.

We should only filter out a JavaThread that's attaching via JNI
if it has no java.lang.Thread object.

This fix has been tested with Mach5 Tier[1-7] and there are no related test failures.
Mach5 Tier8 is in process.

I'm going to need @jianglizhou to rerun her testing for:

[JDK-8319935](https://bugs.openjdk.org/browse/JDK-8319935) Ensure only one JvmtiThreadState is created for one JavaThread associated with attached native thread

since the test(s) for that fix are not yet integrated in the jdk/jdk repo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321069](https://bugs.openjdk.org/browse/JDK-8321069): JvmtiThreadState::state_for_while_locked() returns nullptr for an attached JNI thread with a java.lang.Thread object after JDK-8319935 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [5c9eb2ec](https://git.openjdk.org/jdk/pull/16934/files/5c9eb2ec3a2425971f1f35e31655ce6c04a473ba)
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16934/head:pull/16934` \
`$ git checkout pull/16934`

Update a local copy of the PR: \
`$ git checkout pull/16934` \
`$ git pull https://git.openjdk.org/jdk.git pull/16934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16934`

View PR using the GUI difftool: \
`$ git pr show -t 16934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16934.diff">https://git.openjdk.org/jdk/pull/16934.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16934#issuecomment-1837212349)