### PR TITLE
8319072: JFR: Turn off events for JFR.view

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdQuery.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdQuery.java
@@ -71,6 +71,11 @@ public final class DCmdQuery extends AbstractDCmd {
         }
     }
 
+    @Override
+    protected final boolean isInteractive() {
+        return true;
+    }
+
     private String stripQuotes(String text) {
         if (text.startsWith("\"")) {
             text = text.substring(1);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdView.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdView.java
@@ -84,6 +84,11 @@ public class DCmdView extends AbstractDCmd {
     }
 
     @Override
+    protected final boolean isInteractive() {
+        return true;
+    }
+
+    @Override
     public String[] printHelp() {
         List<String> lines = new ArrayList<>();
         lines.addAll(getOptions().lines().toList());


### PR DESCRIPTION
Could I have a review of a change that disables events for the Attach thread when executing the diagnostic command JFR.view. The rationale is to avoid exception events etc. that create noise in the output making troubleshooting the application harder. I also removed an incorrect comment.

I'm not a fan of overrides that return boolean values, but it was hard to come up with something better without a large refactoring, or adding boilerplate code to the other diagnostic commands.

Testing: idk/jdk/jfr




Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319072](https://bugs.openjdk.org/browse/JDK-8319072): JFR: Turn off events for JFR.view (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16936/head:pull/16936` \
`$ git checkout pull/16936`

Update a local copy of the PR: \
`$ git checkout pull/16936` \
`$ git pull https://git.openjdk.org/jdk.git pull/16936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16936`

View PR using the GUI difftool: \
`$ git pr show -t 16936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16936.diff">https://git.openjdk.org/jdk/pull/16936.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16936#issuecomment-1837239744)