### PR TITLE
8321225: [JVMCI] HotSpotResolvedObjectTypeImpl.isLeafClass shouldn't create strong references

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedObjectTypeImpl.java
@@ -265,7 +265,12 @@ final class HotSpotResolvedObjectTypeImpl extends HotSpotResolvedJavaType implem
      * @return true if the type is a leaf class
      */
     private boolean isLeafClass() {
-        return compilerToVM().getResolvedJavaType(this, config().subklassOffset, false) == null;
+        // In general, compilerToVM().getResolvedJavaType should always be used to read a Klass*
+        // from HotSpot data structures but that has the side effect of creating a strong reference
+        // to the Class which we do not want since it can cause class unloading problems.  Since
+        // this code is only checking for null vs non-null so it should be safe to perform this
+        // check directly.
+        return UNSAFE.getLong(this.getKlassPointer() + config().subklassOffset) == 0;
     }
 
     /**


### PR DESCRIPTION
Checking for leaf Klasses requires seeing if the subklass field is null.  As part of the fix for JVMCI support for ZGC, JDK-8299229, it was changed to call into the runtime which had the side effect of creating a strong reference to an the class.  Since it's only checking for non-null it's ok to just perform thread directly as was done prior to JDK-8299229.  This avoids causing class unloading problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321225](https://bugs.openjdk.org/browse/JDK-8321225): [JVMCI] HotSpotResolvedObjectTypeImpl.isLeafClass shouldn't create strong references (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16943/head:pull/16943` \
`$ git checkout pull/16943`

Update a local copy of the PR: \
`$ git checkout pull/16943` \
`$ git pull https://git.openjdk.org/jdk.git pull/16943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16943`

View PR using the GUI difftool: \
`$ git pr show -t 16943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16943.diff">https://git.openjdk.org/jdk/pull/16943.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16943#issuecomment-1837879847)