### PR TITLE
8321269: Require platforms to define DEFAULT_CACHE_LINE_SIZE

### DIFF
--- a/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globalDefinitions_aarch64.hpp
@@ -42,6 +42,8 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 // and Operational Models for ARMv8"
 #define CPU_MULTI_COPY_ATOMIC
 
+#define DEFAULT_CACHE_LINE_SIZE 64
+
 // According to the ARMv8 ARM, "Concurrent modification and execution
 // of instructions can lead to the resulting instruction performing
 // any behavior that can be achieved by executing any sequence of

--- a/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
+++ b/src/hotspot/cpu/arm/globalDefinitions_arm.hpp
@@ -49,6 +49,8 @@ const bool HaveVFP = true;
 // arm32 is not specified as multi-copy-atomic
 // So we must not #define CPU_MULTI_COPY_ATOMIC
 
+#define DEFAULT_CACHE_LINE_SIZE 64
+
 #define STUBROUTINES_MD_HPP    "stubRoutines_arm.hpp"
 #define INTERP_MASM_MD_HPP     "interp_masm_arm.hpp"
 #define TEMPLATETABLE_MD_HPP   "templateTable_arm.hpp"

--- a/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
+++ b/src/hotspot/cpu/zero/globalDefinitions_zero.hpp
@@ -30,6 +30,8 @@
 #define SUPPORTS_NATIVE_CX8
 #endif
 
+#define DEFAULT_CACHE_LINE_SIZE 64
+
 #define SUPPORT_MONITOR_COUNT
 
 #include <ffi.h>

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -604,7 +604,7 @@ const bool support_IRIW_for_not_multiple_copy_atomic_cpu = PPC64_ONLY(true) NOT_
 
 // The expected size in bytes of a cache line, used to pad data structures.
 #ifndef DEFAULT_CACHE_LINE_SIZE
-  #define DEFAULT_CACHE_LINE_SIZE 64
+#error "Platform should define DEFAULT_CACHE_LINE_SIZE"
 #endif
 
 


### PR DESCRIPTION
Found it while doing new code that wants to know the cache line size. Currently, there is a fallback in `globalDefinitions.hpp` that defaults `DEFAULT_CACHE_LINE_SIZE` to `64` if platform does not define it. Instead of relying on default, force platform definitions to tell what is the reasonable default for the platform. This would simplify porting to other architectures, with less surprises for them.

The actual sizes do not change. If any existing platform needs adjustments, those should be handled as separate issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321269](https://bugs.openjdk.org/browse/JDK-8321269): Require platforms to define DEFAULT_CACHE_LINE_SIZE (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16948/head:pull/16948` \
`$ git checkout pull/16948`

Update a local copy of the PR: \
`$ git checkout pull/16948` \
`$ git pull https://git.openjdk.org/jdk.git pull/16948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16948`

View PR using the GUI difftool: \
`$ git pr show -t 16948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16948.diff">https://git.openjdk.org/jdk/pull/16948.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16948#issuecomment-1838700911)