### PR TITLE
8321105: Enable UseCryptoPmullForCRC32 for Neoverse V2

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -204,7 +204,11 @@ void VM_Version::initialize() {
     }
   }
 
-  // Neoverse N1, N2, V1, V2
+  // Neoverse
+  //   N1: 0xd0c
+  //   N2: 0xd49
+  //   V1: 0xd40
+  //   V2: 0xd4f
   if (_cpu == CPU_ARM && (model_is(0xd0c) || model_is(0xd49) ||
                           model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
@@ -235,8 +239,10 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseCRC32, false);
   }
 
-  // Neoverse V1
-  if (_cpu == CPU_ARM && model_is(0xd40)) {
+  // Neoverse
+  //   V1: 0xd40
+  //   V2: 0xd4f
+  if (_cpu == CPU_ARM && (model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseCryptoPmullForCRC32)) {
       FLAG_SET_DEFAULT(UseCryptoPmullForCRC32, true);
     }


### PR DESCRIPTION
UseCryptoPmullForCRC32 enables to use crypto pmull instructions in CRC32 implementation. It is set to true for Neoverse V1. As the performance of the instructions is the same on Neoverse V2, UseCryptoPmullForCRC32 should be set to true for V2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321105](https://bugs.openjdk.org/browse/JDK-8321105): Enable UseCryptoPmullForCRC32 for Neoverse V2 (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16949/head:pull/16949` \
`$ git checkout pull/16949`

Update a local copy of the PR: \
`$ git checkout pull/16949` \
`$ git pull https://git.openjdk.org/jdk.git pull/16949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16949`

View PR using the GUI difftool: \
`$ git pr show -t 16949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16949.diff">https://git.openjdk.org/jdk/pull/16949.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16949#issuecomment-1838665945)