### PR TITLE
8320682: [AArch64] C1 compilation fails with "Field too big for insn"

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -575,7 +575,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
       if (__ operand_valid_for_float_immediate(c->as_jfloat())) {
         __ fmovs(dest->as_float_reg(), (c->as_jfloat()));
       } else {
-        __ adr(rscratch1, InternalAddress(float_constant(c->as_jfloat())));
+        __ lea(rscratch1, InternalAddress(float_constant(c->as_jfloat())));
         __ ldrs(dest->as_float_reg(), Address(rscratch1));
       }
       break;
@@ -585,7 +585,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
       if (__ operand_valid_for_float_immediate(c->as_jdouble())) {
         __ fmovd(dest->as_double_reg(), (c->as_jdouble()));
       } else {
-        __ adr(rscratch1, InternalAddress(double_constant(c->as_jdouble())));
+        __ lea(rscratch1, InternalAddress(double_constant(c->as_jdouble())));
         __ ldrd(dest->as_double_reg(), Address(rscratch1));
       }
       break;

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -575,7 +575,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
       if (__ operand_valid_for_float_immediate(c->as_jfloat())) {
         __ fmovs(dest->as_float_reg(), (c->as_jfloat()));
       } else {
-        __ lea(rscratch1, InternalAddress(float_constant(c->as_jfloat())));
+        __ adr(rscratch1, InternalAddress(float_constant(c->as_jfloat())));
         __ ldrs(dest->as_float_reg(), Address(rscratch1));
       }
       break;
@@ -585,7 +585,7 @@ void LIR_Assembler::const2reg(LIR_Opr src, LIR_Opr dest, LIR_PatchCode patch_cod
       if (__ operand_valid_for_float_immediate(c->as_jdouble())) {
         __ fmovd(dest->as_double_reg(), (c->as_jdouble()));
       } else {
-        __ lea(rscratch1, InternalAddress(double_constant(c->as_jdouble())));
+        __ adr(rscratch1, InternalAddress(double_constant(c->as_jdouble())));
         __ ldrd(dest->as_double_reg(), Address(rscratch1));
       }
       break;

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -275,6 +275,8 @@
   develop(bool, InstallMethods, true,                                       \
           "Install methods at the end of successful compilations")          \
                                                                             \
+  /* The compiler assumes, in many places, that methods are at most 1MB. */ \
+  /* Therefore, we restrict this flag to at most 1MB.                    */ \
   develop(intx, NMethodSizeLimit, (64*K)*wordSize,                          \
           "Maximum size of a compiled method.")                             \
           range(0, 1*M)                                                     \

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -277,7 +277,7 @@
                                                                             \
   develop(intx, NMethodSizeLimit, (64*K)*wordSize,                          \
           "Maximum size of a compiled method.")                             \
-          range(0, max_jint)                                                \
+          range(0, 1*M)                                                     \
                                                                             \
   develop(bool, TraceFPUStack, false,                                       \
           "Trace emulation of the FPU stack (intel only)")                  \

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -79,6 +79,20 @@
  *
  */
 
+/**
+ * @test
+ * @bug 8320682
+ * @requires vm.debug
+ * @requires os.family == "linux"
+ * @summary Test flag with large value and specific compilation.
+ *
+ * @run main/othervm -XX:NMethodSizeLimit=224001703
+ *                   -XX:CompileOnly=java.util.HashMap::putMapEntries
+ *                   -Xcomp
+ *                   compiler.arguments.TestC1Globals
+ *
+ */
+
 package compiler.arguments;
 
 public class TestC1Globals {

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -83,7 +83,6 @@
  * @test
  * @bug 8320682
  * @requires vm.debug
- * @requires os.family == "linux"
  * @summary Test flag with large value and specific compilation.
  *
  * @run main/othervm -XX:NMethodSizeLimit=224001703

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -23,31 +23,11 @@
 
 /**
  * @test
- * @bug 8318817
- * @requires vm.debug
- * @summary Test flag with large value
- *
- * @run main/othervm -XX:NMethodSizeLimit=351658240
- *                   compiler.arguments.TestC1Globals
- */
-
-/**
- * @test
- * @bug 8318817
- * @requires vm.debug
- * @summary Test flag with large value
- *
- * @run main/othervm -XX:NMethodSizeLimit=224001703
- *                   compiler.arguments.TestC1Globals
- */
-
-/**
- * @test
  * @bug 8316653
  * @requires vm.debug
- * @summary Test flag with max value
+ * @summary Test flag with max value.
  *
- * @run main/othervm -XX:NMethodSizeLimit=2147483647
+ * @run main/othervm -XX:NMethodSizeLimit=1M
  *                   compiler.arguments.TestC1Globals
  */
 
@@ -56,36 +36,21 @@
  * @bug 8318817
  * @requires vm.debug
  * @requires os.family == "linux"
- * @summary Test flag with large value combined with transparent huge pages on
+ * @summary Test flag with max value combined with transparent huge pages on
  *          Linux.
  *
- * @run main/othervm -XX:NMethodSizeLimit=351658240
+ * @run main/othervm -XX:NMethodSizeLimit=1M
  *                   -XX:+UseTransparentHugePages
  *                   compiler.arguments.TestC1Globals
- *
- */
-
-/**
- * @test
- * @bug 8318817
- * @requires vm.debug
- * @requires os.family == "linux"
- * @summary Test flag with large value combined with transparent huge pages on
- *          Linux.
- *
- * @run main/othervm -XX:NMethodSizeLimit=224001703
- *                   -XX:+UseTransparentHugePages
- *                   compiler.arguments.TestC1Globals
- *
  */
 
 /**
  * @test
  * @bug 8320682
  * @requires vm.debug
- * @summary Test flag with large value and specific compilation.
+ * @summary Test flag with max value and specific compilation.
  *
- * @run main/othervm -XX:NMethodSizeLimit=224001703
+ * @run main/othervm -XX:NMethodSizeLimit=1M
  *                   -XX:CompileOnly=java.util.HashMap::putMapEntries
  *                   -Xcomp
  *                   compiler.arguments.TestC1Globals


### PR DESCRIPTION
This changeset fixes an issue where addresses for float and double constants on aarch64 were sometimes out of range for PC-relative offsets using `adr`.

Changes:
- Set an upper bound of `1M` for the flag `NMethodSizeLimit`, ensuring that float and double constants are in range for `adr`.
- Revise tests in `TestC1Globals.java` to use the new upper bound of `1M` for `NMethodSizeLimit`. Also, remove no longer applicable tests in `TestC1Globals.java`.

### Testing (in progress)
Platforms: windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64
- tier1, tier2, tier3, tier4, tier5
- Targeted and repeated tests for `TestC1Globals.java` in all tiers

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320682](https://bugs.openjdk.org/browse/JDK-8320682): [AArch64] C1 compilation fails with "Field too big for insn" (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [d19040e5](https://git.openjdk.org/jdk/pull/16951/files/d19040e5f0d6ecc92c39b03e5a52df104747da30)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [d19040e5](https://git.openjdk.org/jdk/pull/16951/files/d19040e5f0d6ecc92c39b03e5a52df104747da30)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [d19040e5](https://git.openjdk.org/jdk/pull/16951/files/d19040e5f0d6ecc92c39b03e5a52df104747da30)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16951/head:pull/16951` \
`$ git checkout pull/16951`

Update a local copy of the PR: \
`$ git checkout pull/16951` \
`$ git pull https://git.openjdk.org/jdk.git pull/16951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16951`

View PR using the GUI difftool: \
`$ git pr show -t 16951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16951.diff">https://git.openjdk.org/jdk/pull/16951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16951#issuecomment-1838746421)