### PR TITLE
8321276: runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java failed with "'17 2: jdk/test/lib/apps ' missing from stdout/stderr"

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java
@@ -90,8 +90,8 @@ public class DynamicSharedSymbols extends DynamicArchiveTestBase {
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), Long.toString(pid), "VM.symboltable", "-verbose"});
         OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "jcmd-symboltable");
-        output.shouldContain("17 3: jdk/test/lib/apps\n");  // 3 because as a TempSymbol will be found in the TempSymbolCleanupDelayer queue
-                   // note we might want to drain the queue before CDS dumps but this is correct for now, unless the queue length changes.
+        output.shouldContain("17 3: jdk/test/lib/apps\n");  // 3 because a TempSymbol will be found in the TempSymbolCleanupDelayer queue.
+                   // Note: we might want to drain the queue before CDS dumps but this is correct for now, unless the queue length changes.
         output.shouldContain("Dynamic shared symbols:\n");
         output.shouldContain("5 65535: Hello\n");
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java
@@ -90,7 +90,8 @@ public class DynamicSharedSymbols extends DynamicArchiveTestBase {
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(new String[] {JDKToolFinder.getJDKTool("jcmd"), Long.toString(pid), "VM.symboltable", "-verbose"});
         OutputAnalyzer output = CDSTestUtils.executeAndLog(pb, "jcmd-symboltable");
-        output.shouldContain("17 2: jdk/test/lib/apps\n");
+        output.shouldContain("17 3: jdk/test/lib/apps\n");  // 3 because as a TempSymbol will be found in the TempSymbolCleanupDelayer queue
+                   // note we might want to drain the queue before CDS dumps but this is correct for now, unless the queue length changes.
         output.shouldContain("Dynamic shared symbols:\n");
         output.shouldContain("5 65535: Hello\n");
 


### PR DESCRIPTION
Please review this trivial change to fix the test to expect that the TempSymbol refcount is 1 more than expected.  The symbol is cached in [JDK-8315559](https://bugs.openjdk.org/browse/JDK-8315559) Delay TempSymbol cleanup to avoid symbol table churn.

A late change in the review removed draining the queue periodically, which caused this test failure.
Tested locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321276](https://bugs.openjdk.org/browse/JDK-8321276): runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java failed with "'17 2: jdk/test/lib/apps ' missing from stdout/stderr" (**Bug** - P2)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * @huy164 (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16954/head:pull/16954` \
`$ git checkout pull/16954`

Update a local copy of the PR: \
`$ git checkout pull/16954` \
`$ git pull https://git.openjdk.org/jdk.git pull/16954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16954`

View PR using the GUI difftool: \
`$ git pr show -t 16954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16954.diff">https://git.openjdk.org/jdk/pull/16954.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16954#issuecomment-1839053378)