### PR TITLE
8320198: some reference processing tests don't wait long enough for reference processing to complete

### DIFF
--- a/test/jdk/java/lang/Object/FinalizationOption.java
+++ b/test/jdk/java/lang/Object/FinalizationOption.java
@@ -89,7 +89,7 @@ public class FinalizationOption {
         for (int i = 0; i < 100; i++) {
             System.gc();
             try {
-                Thread.sleep(10L);
+                Thread.sleep(30L);
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
             }

--- a/test/jdk/jdk/internal/util/ReferencedKeyTest.java
+++ b/test/jdk/jdk/internal/util/ReferencedKeyTest.java
@@ -137,7 +137,7 @@ public class ReferencedKeyTest {
         obj = null;
         Reference.reachabilityFence(obj);
         Reference.reachabilityFence(ref);
-        long timeout = 1000L;
+        long timeout = 3000L;
         long quanta = 200L;
         long retries = timeout / quanta;
 


### PR DESCRIPTION
This slightly increases the wait for reference processing to complete to accommodate long Xcomp compile times.  Testing is underway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320198](https://bugs.openjdk.org/browse/JDK-8320198): some reference processing tests don't wait long enough for reference processing to complete (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16956/head:pull/16956` \
`$ git checkout pull/16956`

Update a local copy of the PR: \
`$ git checkout pull/16956` \
`$ git pull https://git.openjdk.org/jdk.git pull/16956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16956`

View PR using the GUI difftool: \
`$ git pr show -t 16956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16956.diff">https://git.openjdk.org/jdk/pull/16956.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16956#issuecomment-1839170585)