### PR TITLE
8321215: Incorrect x86 instruction encoding for VSIB addressing mode

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -316,7 +316,7 @@ class Address {
   }
 
   bool xmmindex_needs_rex() const {
-    return _xmmindex->is_valid() && _xmmindex->encoding() >= 8;
+    return _xmmindex->is_valid() && ((_xmmindex->encoding() & 8) == 8);
   }
 
   relocInfo::relocType reloc() const { return _rspec.type(); }


### PR DESCRIPTION
For instructions that use VSIB addressing mode (gather/scatter), the assembler incorrectly sets EVEX.X bit when the VSIB vector register is in the range XMM16 - XMM23. The EVEX.X bit should only be set when bit 3 of the register encoding is 1,  i.e. if the register encoding is 8 - 15 or 24 - 31.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321215](https://bugs.openjdk.org/browse/JDK-8321215): Incorrect x86 instruction encoding for VSIB addressing mode (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16957/head:pull/16957` \
`$ git checkout pull/16957`

Update a local copy of the PR: \
`$ git checkout pull/16957` \
`$ git pull https://git.openjdk.org/jdk.git pull/16957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16957`

View PR using the GUI difftool: \
`$ git pr show -t 16957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16957.diff">https://git.openjdk.org/jdk/pull/16957.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16957#issuecomment-1839332628)