### PR TITLE
8305825: getBounds API returns wrong value resulting in multiple Regression Test Failures on Ubuntu 23.04

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java
@@ -341,7 +341,8 @@ abstract class XDecoratedPeer extends XWindowPeer {
             || ev.get_atom() == XWM.XA_NET_FRAME_EXTENTS.getAtom())
         {
             if (XWM.getWMID() != XWM.UNITY_COMPIZ_WM) {
-                if (getMWMDecorTitleProperty().isPresent()) {
+                if ((XWM.getWMID() == XWM.MUTTER_WM && !isTargetUndecorated() && isVisible())
+                    || getMWMDecorTitleProperty().isPresent()) {
                     // Insets might have changed "in-flight" if that property
                     // is present, so we need to get the actual values of
                     // insets from the WM and propagate them through all the

--- a/src/java.desktop/unix/classes/sun/awt/X11/XWM.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWM.java
@@ -1369,6 +1369,9 @@ final class XWM
               case UNITY_COMPIZ_WM:
                   res = new Insets(28, 1, 1, 1);
                   break;
+              case MUTTER_WM:
+                  res = new Insets(37, 0, 0, 0);
+                  break;
               case MOTIF_WM:
               case OPENLOOK_WM:
               default:
@@ -1380,6 +1383,7 @@ final class XWM
         }
         return res;
     }
+
     /*
      * Some buggy WMs ignore window gravity when processing
      * ConfigureRequest and position window as if the gravity is Static.

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -458,6 +458,7 @@ java/awt/Graphics2D/DrawString/RotTransText.java 8316878 linux-all
 java/awt/KeyboardFocusmanager/TypeAhead/ButtonActionKeyTest/ButtonActionKeyTest.java 8257529 windows-x64
 java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeForModalDialogTest/ConsumeForModalDialogTest.java 8302787 windows-all
 java/awt/KeyboardFocusmanager/TypeAhead/MenuItemActivatedTest/MenuItemActivatedTest.java 8302787 windows-all
+java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemonicKeyTypedTest.java 8321303 linux-all
 
 java/awt/Window/GetScreenLocation/GetScreenLocationTest.java 8225787 linux-x64
 java/awt/Dialog/MakeWindowAlwaysOnTop/MakeWindowAlwaysOnTop.java 8266243 macosx-aarch64
@@ -651,6 +652,7 @@ javax/sound/sampled/Clip/ClipIsRunningAfterStop.java 8307574 linux-x64
 
 javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,windows-all
 
+javax/swing/JFrame/MaximizeWindowTest.java 8321289 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedPerPixelTranslucentGradient.java 8233582 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/PerPixelTranslucentSwing.java 8194128 macosx-all
@@ -683,9 +685,6 @@ sanity/client/SwingSet/src/EditorPaneDemoTest.java 8212240 linux-x64
 
 # jdk_swing Ubuntu 23.04 specific
 
-javax/swing/JTree/8003400/Test8003400.java 8309734 linux-all
-javax/swing/JTable/7124218/SelectEditTableCell.java 8309734 linux-all
-javax/swing/JFileChooser/JFileChooserSetLocationTest.java 8309734 linux-all
 javax/swing/JComboBox/TestComboBoxComponentRendering.java 8309734 linux-all
 
 ############################################################################

--- a/test/jdk/java/awt/Dialog/NestedDialogs/Modal/NestedModalDialogTest.java
+++ b/test/jdk/java/awt/Dialog/NestedDialogs/Modal/NestedModalDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Dialog/NestedDialogs/Modal/NestedModalDialogTest.java
+++ b/test/jdk/java/awt/Dialog/NestedDialogs/Modal/NestedModalDialogTest.java
@@ -54,12 +54,11 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 
 public class NestedModalDialogTest {
-    private static Frame frame;
+    private static StartFrame frame;
     private static IntermediateDialog interDiag;
     private static TextDialog txtDiag;
 
     // Global variables so the robot thread can locate things.
-    private static Button[] robot_button = new Button[2];
     private static TextField robot_text = null;
     private static Robot robot = null;
 
@@ -78,6 +77,9 @@ public class NestedModalDialogTest {
     }
 
     private static void clickOnComp(Component comp) {
+        robot.waitForIdle();
+        robot.delay(1000);
+
         Rectangle bounds = new Rectangle(comp.getLocationOnScreen(), comp.getSize());
         robot.mouseMove(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
         robot.waitForIdle();
@@ -94,11 +96,11 @@ public class NestedModalDialogTest {
             // launch first frame with firstButton
             frame = new StartFrame();
             blockTillDisplayed(frame);
-            clickOnComp(robot_button[0]);
+            clickOnComp(frame.button);
 
             // Dialog must be created and onscreen before we proceed.
             blockTillDisplayed(interDiag);
-            clickOnComp(robot_button[1]);
+            clickOnComp(interDiag.button);
 
             // Again, the Dialog must be created and onscreen before we proceed.
             blockTillDisplayed(robot_text);
@@ -144,6 +146,8 @@ public class NestedModalDialogTest {
      */
     class StartFrame extends Frame {
 
+        public volatile Button button;
+
         /**
          * Constructs a new instance.
          */
@@ -168,7 +172,7 @@ public class NestedModalDialogTest {
             pan.add(but);
             add(pan);
             setVisible(true);
-            robot_button[0] = but;
+            button = but;
         }
     }
 
@@ -177,6 +181,7 @@ public class NestedModalDialogTest {
     class IntermediateDialog extends Dialog {
 
         Dialog m_parent;
+        public volatile Button button;
 
         public IntermediateDialog(Frame parent) {
             super(parent, "Intermediate Modal", true /*Modal*/);
@@ -193,9 +198,7 @@ public class NestedModalDialogTest {
             pan.add(but);
             add(pan);
             pack();
-
-            // The robot needs to know about us, so set global
-            robot_button[1] = but;
+            button = but;
         }
     }
 
@@ -215,12 +218,12 @@ public class NestedModalDialogTest {
         }
     }
 
-    public static void main(String[] args) throws RuntimeException, Exception {
+    public static void main(String[] args) throws Exception {
         try {
             new NestedModalDialogTest().testModalDialogs();
         } catch (Exception e) {
             throw new RuntimeException("NestedModalDialogTest object creation "
-                    + "failed");
+                    + "failed", e);
         }
     }
 }

--- a/test/jdk/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
+++ b/test/jdk/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
@@ -64,6 +64,7 @@ public class OwnedWindowFocusIMECrashTest {
         window.setVisible(true);
 
         Util.waitForIdle(robot);
+        robot.delay(1000);
 
         test();
 

--- a/test/jdk/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
+++ b/test/jdk/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
+++ b/test/jdk/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
+++ b/test/jdk/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
@@ -120,6 +120,7 @@ public class MultiResolutionSplashTest {
     static void testFocus() throws Exception {
 
         Robot robot = new Robot();
+        robot.setAutoWaitForIdle(true);
         robot.setAutoDelay(50);
 
         Frame frame = new Frame();
@@ -130,6 +131,7 @@ public class MultiResolutionSplashTest {
         frame.add(textField);
         frame.setVisible(true);
         robot.waitForIdle();
+        robot.delay(1000);
 
         robot.keyPress(KeyEvent.VK_A);
         robot.keyRelease(KeyEvent.VK_A);

--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
+++ b/test/jdk/javax/swing/JRootPane/DefaultButtonTest.java
@@ -83,6 +83,7 @@ public class DefaultButtonTest {
 
     public void runTest() throws Exception {
         Robot robot = new Robot();
+        robot.setAutoWaitForIdle(true);
         robot.setAutoDelay(100);
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             try {
@@ -100,6 +101,8 @@ public class DefaultButtonTest {
                     createUI();
                 });
                 robot.waitForIdle();
+                robot.delay(1000);
+
                 robot.keyPress(KeyEvent.VK_ENTER);
                 robot.keyRelease(KeyEvent.VK_ENTER);
                 robot.waitForIdle();

--- a/test/jdk/javax/swing/JTree/8003400/Test8003400.java
+++ b/test/jdk/javax/swing/JTree/8003400/Test8003400.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JTree/8003400/Test8003400.java
+++ b/test/jdk/javax/swing/JTree/8003400/Test8003400.java
@@ -109,6 +109,10 @@ public class Test8003400 {
 
                 Robot robot = new Robot();
                 robot.setAutoDelay(100);
+                robot.setAutoWaitForIdle(true);
+                robot.waitForIdle();
+                robot.delay(500);
+
                 SwingUtilities.invokeAndWait(() -> {
                     point = tree.getLocationOnScreen();
                     rect = tree.getBounds();


### PR DESCRIPTION
The root of this issue is the incorrect calculation of window decoration insets.

Previously we got non-zero window insets in the first PropertyNotify with [_NET_FRAME_EXTENTS](https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html#idm45771211302000) atom, save them and never change them again.

This changed starting with Ubuntu 23.04:
Now we can get several such notifications with zero window insets, and only then the correct value.

Our code is not ready for this. It affects all our JDK. As a result, many tests fail on Ubuntu 23.04 and 23.10.

The solution is to change these insets on the fly, for now only for Mutter window manager. 
The guessInsets for it have also been updated.


This also means that some tests need some stabilization as they are not ready for such late arrival of window insets.

Testing looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305825](https://bugs.openjdk.org/browse/JDK-8305825): getBounds API returns wrong value resulting in multiple Regression Test Failures on Ubuntu 23.04 (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [2ed7c837](https://git.openjdk.org/jdk/pull/16960/files/2ed7c83782a9d8b999d6c666e8ab026275cef986)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer) ⚠️ Review applies to [2ed7c837](https://git.openjdk.org/jdk/pull/16960/files/2ed7c83782a9d8b999d6c666e8ab026275cef986)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [2ed7c837](https://git.openjdk.org/jdk/pull/16960/files/2ed7c83782a9d8b999d6c666e8ab026275cef986)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [2ed7c837](https://git.openjdk.org/jdk/pull/16960/files/2ed7c83782a9d8b999d6c666e8ab026275cef986)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16960/head:pull/16960` \
`$ git checkout pull/16960`

Update a local copy of the PR: \
`$ git checkout pull/16960` \
`$ git pull https://git.openjdk.org/jdk.git pull/16960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16960`

View PR using the GUI difftool: \
`$ git pr show -t 16960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16960.diff">https://git.openjdk.org/jdk/pull/16960.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16960#issuecomment-1839726053)