### PR TITLE
8321219: runtime/jni/FastGetField: assert(is_interpreted_frame()) failed: interpreted frame expected

### DIFF
--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -558,7 +558,7 @@ JvmtiVTMSTransitionDisabler::VTMS_vthread_start(jobject vthread) {
   // objects for globally enabled virtual thread filtered events. Otherwise,
   // it is an important optimization to create JvmtiThreadState objects lazily.
   // This optimization is disabled when watchpoint capabilities are present. It is to
-  // work around a bug with virtual thread frames which can be not deoptimized in time. 
+  // work around a bug with virtual thread frames which can be not deoptimized in time.
   if (JvmtiThreadState::seen_interp_only_mode() ||
       JvmtiExport::should_post_field_access() ||
       JvmtiExport::should_post_field_modification()){

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -557,7 +557,9 @@ JvmtiVTMSTransitionDisabler::VTMS_vthread_start(jobject vthread) {
   // If interp_only_mode has been enabled then we must eagerly create JvmtiThreadState
   // objects for globally enabled virtual thread filtered events. Otherwise,
   // it is an important optimization to create JvmtiThreadState objects lazily.
-  if (JvmtiThreadState::seen_interp_only_mode()) {
+  if (JvmtiThreadState::seen_interp_only_mode() ||
+      JvmtiExport::should_post_field_access() ||
+      JvmtiExport::should_post_field_modification()){
     JvmtiEventController::thread_started(thread);
   }
   if (JvmtiExport::should_post_vthread_start()) {

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -557,6 +557,8 @@ JvmtiVTMSTransitionDisabler::VTMS_vthread_start(jobject vthread) {
   // If interp_only_mode has been enabled then we must eagerly create JvmtiThreadState
   // objects for globally enabled virtual thread filtered events. Otherwise,
   // it is an important optimization to create JvmtiThreadState objects lazily.
+  // This optimization is disabled when watchpoint capabilities are present. It is to
+  // work around a bug with virtual thread frames which can be not deoptimized in time. 
   if (JvmtiThreadState::seen_interp_only_mode() ||
       JvmtiExport::should_post_field_access() ||
       JvmtiExport::should_post_field_modification()){


### PR DESCRIPTION
This is a trivial fix for a regression caused by:
 [8308614](https://bugs.openjdk.org/browse/JDK-8308614) Enabling JVMTI ClassLoad event slows down vthread creation by factor 10

The fix of 8308614 just triggered a known issue:
  [8316283](https://bugs.openjdk.org/browse/JDK-8316283) field watch events are not always posted with -Xcomp option
  
The fix is just a work around with the extra checks with the `JvmtiExport::should_post_field_access()` and `JvmtiExport::should_post_field_modification()`.

Testing:
- The test `runtime/jni/FastGetField/FastGetField.java` does not fail anymore with this fix
- In progress: Test with tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321219](https://bugs.openjdk.org/browse/JDK-8321219): runtime/jni/FastGetField: assert(is_interpreted_frame()) failed: interpreted frame expected (**Bug** - P2)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [7d47fd12](https://git.openjdk.org/jdk/pull/16961/files/7d47fd12b5b39fe956fef718bff0d3bb78c9df8e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16961/head:pull/16961` \
`$ git checkout pull/16961`

Update a local copy of the PR: \
`$ git checkout pull/16961` \
`$ git pull https://git.openjdk.org/jdk.git pull/16961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16961`

View PR using the GUI difftool: \
`$ git pr show -t 16961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16961.diff">https://git.openjdk.org/jdk/pull/16961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16961#issuecomment-1839795986)