### PR TITLE
8317831: compiler/codecache/CheckLargePages.java fails on OL 8.8 with unexpected memory string

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4004,7 +4004,7 @@ bool os::can_commit_large_page_memory() {
 }
 
 bool os::can_execute_large_page_memory() {
-  return UseTransparentHugePages || UseLargePages;
+  return UseLargePages;
 }
 
 char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4004,7 +4004,7 @@ bool os::can_commit_large_page_memory() {
 }
 
 bool os::can_execute_large_page_memory() {
-  return UseTransparentHugePages;
+  return UseTransparentHugePages || UseLargePages;
 }
 
 char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4004,7 +4004,7 @@ bool os::can_commit_large_page_memory() {
 }
 
 bool os::can_execute_large_page_memory() {
-  return UseLargePages;
+  return UseTransparentHugePages;
 }
 
 char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc) {

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -73,8 +73,6 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
-compiler/codecache/CheckLargePages.java 8317831 linux-x64
-
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -73,6 +73,8 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
+compiler/codecache/CheckLargePages.java 8317831 linux-x64
+
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -73,7 +73,7 @@ compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x6
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 
-compiler/codecache/CheckLargePages.java 8317831 linux-x64
+compiler/codecache/CheckLargePages.java 8319795 linux-x64
 
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -30,7 +30,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseLargePages -XX:+UseTransparentHugePages compiler.codecache.CheckLargePages
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:+UseLargePages -XX:LargePageSizeInBytes=1g compiler.codecache.CheckLargePages
  */
 
 package compiler.codecache;
@@ -48,14 +48,14 @@ public class CheckLargePages {
 
     public static void main(String[] args) throws Exception {
         final boolean largePages = WHITE_BOX.getBooleanVMFlag("UseLargePages");
-        if (largePages) {
-            final long largePageSize = WHITE_BOX.getVMLargePageSize();
+        final long largePageSize = WHITE_BOX.getVMLargePageSize();
+        if (largePages && (largePageSize == 1024 * 1024 * 1024)) {
             ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
                     "-XX:+UseLargePages",
-                    "-XX:+UseTransparentHugePages",
                     "-XX:+SegmentedCodeCache",
-                    "-XX:InitialCodeCacheSize=15m",
-                    "-XX:ReservedCodeCacheSize=15m",
+                    "-XX:InitialCodeCacheSize=2g",
+                    "-XX:ReservedCodeCacheSize=2g",
+                    "-XX:LargePageSizeInBytes=1g",
                     "-Xlog:pagesize=info",
                     "-version");
             OutputAnalyzer out = new OutputAnalyzer(pb.start());
@@ -71,7 +71,8 @@ public class CheckLargePages {
             String revertedSizeString = out.firstMatch("Code cache size too small for (\\S*) pages. Reverting to smaller page size \\((\\S*)\\)\\.", 2);
             Asserts.assertEquals(parseMemoryString(revertedSizeString), smallerPageSize);
         } else {
-            System.out.println("UseLargePages is disabled. Skipping");
+            System.out.println("1GB large pages not supported: UseLargePages=" + largePages +
+                    (largePages ? ", largePageSize=" + largePageSize : "") + ". Skipping");
         }
     }
 


### PR DESCRIPTION
Test CheckLargePages was broken by the previous changes:

[JDK-8310233](https://bugs.openjdk.org/browse/JDK-8310233) changes the pagesize logs from
```
Usable page sizes: 4k, 1G
```
to
```
Large page support enabled. Usable page sizes: 4k, 1G. Default large page size: 1G.
```

[JDK-8261894](https://bugs.openjdk.org/browse/JDK-8261894) removes `UseHugeTLBFS`. It was also removed from `os::can_execute_large_page_memory`, and `CodeCache::page_size` cannot  use huge pages anymore.

This change includes:
- The regular expression in CheckLargePages is updated to capture only the page sizes.
- The static huge page will be fixed by  [JDK-8319795](https://bugs.openjdk.org/browse/JDK-8319795).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317831](https://bugs.openjdk.org/browse/JDK-8317831): compiler/codecache/CheckLargePages.java fails on OL 8.8 with unexpected memory string (**Bug** - P4)


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16962/head:pull/16962` \
`$ git checkout pull/16962`

Update a local copy of the PR: \
`$ git checkout pull/16962` \
`$ git pull https://git.openjdk.org/jdk.git pull/16962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16962`

View PR using the GUI difftool: \
`$ git pr show -t 16962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16962.diff">https://git.openjdk.org/jdk/pull/16962.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16962#issuecomment-1839833285)