### PR TITLE
8321207: javac is not accepting correct code

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -490,7 +490,12 @@ public class Flow {
             try {
                 for (List<JCTree> defs = classDef.defs; defs.nonEmpty(); defs = defs.tail) {
                     JCTree def = defs.head;
-                    if (!def.hasTag(METHODDEF) && ((TreeInfo.flags(def) & STATIC) != 0) == isStatic)
+                    /* we need to check for flags in the symbol too as there could be cases for which implicit flags are
+                     * represented in the symbol but not in the tree modifiers as they were not originally in the source
+                     * code
+                     */
+                    boolean isDefStatic = ((TreeInfo.flags(def) | (TreeInfo.symbolFor(def) == null ? 0 : TreeInfo.symbolFor(def).flags_field)) & STATIC) != 0;
+                    if (!def.hasTag(METHODDEF) && (isDefStatic == isStatic))
                         handler.accept(def);
                 }
             } finally {

--- a/test/langtools/tools/javac/lambda/LambdaCapture08.java
+++ b/test/langtools/tools/javac/lambda/LambdaCapture08.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8321207
+ * @summary javac is not accepting correct code
+ * @compile LambdaCapture08.java
+ */
+
+import java.util.function.*;
+
+interface LambdaCapture08 {
+    Object O = new Object() {
+        IntSupplier x(int m) {
+            return () -> m;
+        }
+    };
+}


### PR DESCRIPTION
Common code like:

```
import java.util.*;
import java.util.function.*;

interface Test {
    Object O = new Object() { // but if the implicit static initializer is added here the code is accepted
        IntSupplier x(int m) {
            return () -> m;
        }
    };
}
```
is failing after fix for [JDK-8194743](https://bugs.openjdk.org/browse/JDK-8194743). The issue here is that method Flow.BaseAnalyzer::forEachInitializer is invoked twice once for static and another once for non-static initializers. The static-ness of the initializer is determined at this method by checking the modifiers in the corresponding AST. The problem with this is that implicit flags are added to symbols at Check::checkFlags but they don't make their way up to the AST's modifiers. The proposed fix is checking for static-ness at both the modifiers and the corresponding symbol

TIA