### PR TITLE
8318468: compiler/tiered/LevelTransitionTest.java fails with -XX:CompileThreshold=100 -XX:TieredStopAtLevel=1

### DIFF
--- a/test/hotspot/jtreg/compiler/tiered/LevelTransitionTest.java
+++ b/test/hotspot/jtreg/compiler/tiered/LevelTransitionTest.java
@@ -204,7 +204,8 @@ public class LevelTransitionTest extends TieredLevelsTest {
         }
 
         private static class CompileMethodHolder {
-            private final int iter = 10;
+            // Make sure that loop backedge is never taken to prevent unexpected OSR compilations.
+            private final int iter = 1;
             private int field = 42;
 
             /**


### PR DESCRIPTION
The test fails with `-XX:CompileThreshold=100 -XX:TieredStopAtLevel=1` because `CompileMethodHolder::nonTrivialMethod` is unexpectedly OSR compiled but the test case has `isOSR() == false` (see line 197). The test is indeed not supposed to trigger an OSR compilation, and usually won't, but the loop is required to test tiered level transitions of a non-trivial method containing a loop. I simply changed the iterations to 1 to make sure that the backedge is never taken and thus prevent unexpected OSR compilations. The method will still be detected to have a loop and serve its purpose.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318468](https://bugs.openjdk.org/browse/JDK-8318468): compiler/tiered/LevelTransitionTest.java fails with -XX:CompileThreshold=100 -XX:TieredStopAtLevel=1 (**Bug** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16964/head:pull/16964` \
`$ git checkout pull/16964`

Update a local copy of the PR: \
`$ git checkout pull/16964` \
`$ git pull https://git.openjdk.org/jdk.git pull/16964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16964`

View PR using the GUI difftool: \
`$ git pr show -t 16964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16964.diff">https://git.openjdk.org/jdk/pull/16964.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16964#issuecomment-1840229883)