### PR TITLE
8310524: C2: record parser-generated LoadN nodes for IGVN

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1563,6 +1563,10 @@ Node* GraphKit::make_load(Node* ctl, Node* adr, const Type* t, BasicType bt,
   if (((bt == T_OBJECT) && C->do_escape_analysis()) || C->eliminate_boxing()) {
     // Improve graph before escape analysis and boxing elimination.
     record_for_igvn(ld);
+    if (ld->is_DecodeN()) {
+      // Also record the actual load (LoadN) in case ld is DecodeN
+      record_for_igvn(ld->in(1));
+    }
   }
   return ld;
 }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1565,6 +1565,7 @@ Node* GraphKit::make_load(Node* ctl, Node* adr, const Type* t, BasicType bt,
     record_for_igvn(ld);
     if (ld->is_DecodeN()) {
       // Also record the actual load (LoadN) in case ld is DecodeN
+      assert(ld->in(1)->Opcode() == Op_LoadN, "Assumption invalid: input to DecodeN is not LoadN");
       record_for_igvn(ld->in(1));
     }
   }

--- a/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestLoadNIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestLoadNIdeal.java
@@ -36,7 +36,8 @@ import compiler.lib.ir_framework.*;
 public class TestLoadNIdeal {
 
     public static void main(String[] args) {
-        TestFramework.run();
+        // Ensure that we run with compressed oops
+        TestFramework.runWithFlags("-XX:+UseCompressedOops");
     }
 
     static class A { int x; }
@@ -45,7 +46,7 @@ public class TestLoadNIdeal {
     void dummy(A p[]) { }
 
     @Test
-    @IR(counts = {IRNode.LOAD_N, "1"})
+    @IR(applyIf = { "UseCompressedOops", "true" }, counts = { IRNode.LOAD_N, "1" })
     int test() {
         A p[] = new A[1];
         p[0] = new A();

--- a/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestLoadNIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestLoadNIdeal.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests.igvn;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8310524
+ * @summary Test that IGVN optimizes away one of two identical LoadNs.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.igvn.TestLoadNIdeal
+ */
+
+public class TestLoadNIdeal {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    static class A { int x; }
+
+    @DontCompile
+    void dummy(A p[]) { }
+
+    @Test
+    @IR(counts = {IRNode.LOAD_N, "1"})
+    int test() {
+        A p[] = new A[1];
+        p[0] = new A();
+
+        // Dummy is not compiled and hence not inlined => Escape analysis
+        // cannot ensure that p[0] is unmodified after the call.
+        dummy(p);
+
+        // We should only need to load p[0] once here. Storing A within an
+        // array adds range checks for the first load and ensures the second
+        // load is not optimized already at bytecode parsing.
+        return p[0].x + p[0].x;
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestLoadNIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestLoadNIdeal.java
@@ -42,7 +42,7 @@ public class TestLoadNIdeal {
 
     static class A { int x; }
 
-    @DontCompile
+    @DontInline
     void dummy(A p[]) { }
 
     @Test
@@ -51,7 +51,7 @@ public class TestLoadNIdeal {
         A p[] = new A[1];
         p[0] = new A();
 
-        // Dummy is not compiled and hence not inlined => Escape analysis
+        // The dummy method is not inlined => Escape analysis
         // cannot ensure that p[0] is unmodified after the call.
         dummy(p);
 


### PR DESCRIPTION
This changeset fixes an issue where LoadN nodes were not recorded during bytecode parsing for later revisit in IGVN, in some cases resulting in missed optimization opportunities (see, e.g., the included new regression test).

Changes:
- Make sure to record newly added LoadN-nodes for IGVN in `GraphKit::make_load`.
- Add a regression test.

### Testing
- tier1, tier2, tier3, tier4, tier5 (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310524](https://bugs.openjdk.org/browse/JDK-8310524): C2: record parser-generated LoadN nodes for IGVN (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16967/head:pull/16967` \
`$ git checkout pull/16967`

Update a local copy of the PR: \
`$ git checkout pull/16967` \
`$ git pull https://git.openjdk.org/jdk.git pull/16967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16967`

View PR using the GUI difftool: \
`$ git pr show -t 16967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16967.diff">https://git.openjdk.org/jdk/pull/16967.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16967#issuecomment-1840323346)