### PR TITLE
8321216: SerialGC attempts to access the card table beyond the end of the heap during card table scan

### DIFF
--- a/src/hotspot/share/gc/serial/cardTableRS.cpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.cpp
@@ -390,9 +390,12 @@ CardTable::CardValue* CardTableRS::find_first_dirty_card(CardValue* const start_
 template<typename Func>
 CardTable::CardValue* CardTableRS::find_first_clean_card(CardValue* const start_card,
                                                          CardValue* const end_card,
-                                                         HeapWord* end_address,
                                                          CardTableRS* ct,
                                                          Func& object_start) {
+
+  // end_card might be just beyond the heap, so need to use the _raw variant.
+  HeapWord* end_address = ct->addr_for_raw(end_card);
+
   for (CardValue* current_card = start_card; current_card < end_card; /* empty */) {
     if (is_dirty(current_card)) {
       current_card++;
@@ -500,7 +503,6 @@ void CardTableRS::non_clean_card_iterate(TenuredSpace* sp,
 
     CardValue* const dirty_r = find_first_clean_card(dirty_l + 1,
                                                      end_card,
-                                                     mr.end(),
                                                      ct,
                                                      object_start);
     assert(dirty_l < dirty_r, "inv");

--- a/src/hotspot/share/gc/serial/cardTableRS.hpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.hpp
@@ -56,13 +56,9 @@ class CardTableRS : public CardTable {
   static CardValue* find_first_dirty_card(CardValue* start_card,
                                           CardValue* end_card);
 
-  // Need to provide both end_card and end_address (address of the start of the
-  // card in the heap) because end_card might be the card beyond the heap which
-  // address we can not recover without an assertion triggering.
   template<typename Func>
   CardValue* find_first_clean_card(CardValue* start_card,
                                    CardValue* end_card,
-                                   HeapWord* end_address,
                                    CardTableRS* ct,
                                    Func& object_start);
 

--- a/src/hotspot/share/gc/serial/cardTableRS.hpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.hpp
@@ -56,9 +56,13 @@ class CardTableRS : public CardTable {
   static CardValue* find_first_dirty_card(CardValue* start_card,
                                           CardValue* end_card);
 
+  // Need to provide both end_card and end_address (address of the start of the
+  // card in the heap) because end_card might be the card beyond the heap which
+  // address we can not recover without an assertion triggering.
   template<typename Func>
   CardValue* find_first_clean_card(CardValue* start_card,
                                    CardValue* end_card,
+                                   HeapWord* end_address,
                                    CardTableRS* ct,
                                    Func& object_start);
 

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -149,7 +149,7 @@ public:
     // As _byte_map_base may be "negative" (the card table has been allocated before
     // the heap in memory), do not use pointer_delta() to avoid the assertion failure.
     size_t delta = p - _byte_map_base;
-    return (HeapWord*) (delta << _card_shift);    
+    return (HeapWord*) (delta << _card_shift);
   }
 
   // Mapping from card marking array entry to address of first word.

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -144,16 +144,21 @@ public:
     return byte_after(p);
   }
 
-  // Mapping from card marking array entry to address of first word
+  // Mapping from card marking array entry to address of first word without checks.
+  HeapWord* addr_for_raw(const CardValue* p) const {
+    // As _byte_map_base may be "negative" (the card table has been allocated before
+    // the heap in memory), do not use pointer_delta() to avoid the assertion failure.
+    size_t delta = p - _byte_map_base;
+    return (HeapWord*) (delta << _card_shift);    
+  }
+
+  // Mapping from card marking array entry to address of first word.
   HeapWord* addr_for(const CardValue* p) const {
     assert(p >= _byte_map && p < _byte_map + _byte_map_size,
            "out of bounds access to card marking array. p: " PTR_FORMAT
            " _byte_map: " PTR_FORMAT " _byte_map + _byte_map_size: " PTR_FORMAT,
            p2i(p), p2i(_byte_map), p2i(_byte_map + _byte_map_size));
-    // As _byte_map_base may be "negative" (the card table has been allocated before
-    // the heap in memory), do not use pointer_delta() to avoid the assertion failure.
-    size_t delta = p - _byte_map_base;
-    HeapWord* result = (HeapWord*) (delta << _card_shift);
+    HeapWord* result = addr_for_raw(p);
     assert(_whole_heap.contains(result),
            "Returning result = " PTR_FORMAT " out of bounds of "
            " card marking array's _whole_heap = [" PTR_FORMAT "," PTR_FORMAT ")",

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -83,6 +83,14 @@ protected:
     return cards_required(_whole_heap.word_size()) - 1;
   }
 
+  // Mapping from card marking array entry to address of first word without checks.
+  HeapWord* addr_for_raw(const CardValue* p) const {
+    // As _byte_map_base may be "negative" (the card table has been allocated before
+    // the heap in memory), do not use pointer_delta() to avoid the assertion failure.
+    size_t delta = p - _byte_map_base;
+    return (HeapWord*) (delta << _card_shift);
+  }
+
 private:
   void initialize_covered_region(void* region0_start, void* region1_start);
 
@@ -142,14 +150,6 @@ public:
   }
   const CardValue* byte_after_const(const void* p) const {
     return byte_after(p);
-  }
-
-  // Mapping from card marking array entry to address of first word without checks.
-  HeapWord* addr_for_raw(const CardValue* p) const {
-    // As _byte_map_base may be "negative" (the card table has been allocated before
-    // the heap in memory), do not use pointer_delta() to avoid the assertion failure.
-    size_t delta = p - _byte_map_base;
-    return (HeapWord*) (delta << _card_shift);
   }
 
   // Mapping from card marking array entry to address of first word.


### PR DESCRIPTION
Hi all,

  please review this fix to ` CardTableRS::find_first_clean_card` where when iterating through the object at the very end of the heap Serial GC accesses the card table beyond the allocated memory, which fails with an assert.

The fix is to allow retrieving addresses for cards beyond the card table using a special `addr_for_raw` method. 

In discussions with @albertnetymk , the initial version to add a check whether the current scan cursor is already at or beyond the end of the area to find clean cards for using an extra, somewhat superfluous parameter has been rejected as a bit confusing (the first commit).

Testing: failing test case, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321216](https://bugs.openjdk.org/browse/JDK-8321216): SerialGC attempts to access the card table beyond the end of the heap during card table scan (**Bug** - P1)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Contributors
 * Albert Mingkun Yang `<ayang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16968/head:pull/16968` \
`$ git checkout pull/16968`

Update a local copy of the PR: \
`$ git checkout pull/16968` \
`$ git pull https://git.openjdk.org/jdk.git pull/16968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16968`

View PR using the GUI difftool: \
`$ git pr show -t 16968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16968.diff">https://git.openjdk.org/jdk/pull/16968.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16968#issuecomment-1840560179)