### PR TITLE
8321369: Unproblemlist gc/cslocker/TestCSLocker.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -48,4 +48,3 @@ vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003/TestDescription.ja
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64
 
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
-gc/cslocker/TestCSLocker.java 8310480 linux-x64


### PR DESCRIPTION
Hi all,

  please review this fix to unproblemlist gc/cs/TestCSLocker.java; the CR to fix this [JDK-8310480](https://bugs.openjdk.org/browse/JDK-8310480) has already been closed as duplicate of [JDK-8318706](https://bugs.openjdk.org/browse/JDK-8318706) that removed the GCLocker for G1 which is the cause for the issue.

Note that the test has only been problemlisted for linux-x64 previously, so it has already been run for a long time for other platforms and other collectors, so my testing did not extensively try all the other platforms/gc combinations (I did try with Serial and Parallel a few times with no issues; ZGC is excluded anyway in the test, and Shenandoah also does not use the GCLocker).

Testing: test case with g1, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321369](https://bugs.openjdk.org/browse/JDK-8321369): Unproblemlist gc/cslocker/TestCSLocker.java (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16970/head:pull/16970` \
`$ git checkout pull/16970`

Update a local copy of the PR: \
`$ git checkout pull/16970` \
`$ git pull https://git.openjdk.org/jdk.git pull/16970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16970`

View PR using the GUI difftool: \
`$ git pr show -t 16970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16970.diff">https://git.openjdk.org/jdk/pull/16970.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16970#issuecomment-1840647846)