### PR TITLE
8321373: Build should use LC_ALL=C.UTF-8

### DIFF
--- a/make/autoconf/spec.gmk.in
+++ b/make/autoconf/spec.gmk.in
@@ -57,7 +57,7 @@ COMMA := ,
 MAKE := @MAKE@
 
 # Make sure all shell commands are executed with the C locale
-export LC_ALL := C
+export LC_ALL := C.UTF-8
 
 # Make sure we override any local CLASSPATH variable
 export CLASSPATH := @CLASSPATH@


### PR DESCRIPTION
We're currently setting LC_ALL=C. Not all tools will default to utf-8 as their encoding of choice when they see this locale, but use an arbitrarily encoding, which might not properly handle all UTF-8 characters. Since in practice, all our encoding is utf8, we should tell our tools this as well.

This will at least have effect on how Java treats path names including unicode characters. 