### PR TITLE
8280087: G1: Handle out-of-mark stack situations during reference processing more gracefully

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -126,7 +126,6 @@ void G1Arguments::initialize_mark_stack_size() {
     FLAG_SET_ERGO(MarkStackSize, mark_stack_size);
   }
 
-  log_trace(gc)("MarkStackSize: %uk  MarkStackSizeMax: %uk", (uint)(MarkStackSize / K), (uint)(MarkStackSizeMax / K));
 }
 
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -142,7 +142,7 @@ private:
     size_t _capacity;
     size_t _num_buckets;
     bool _growable;
-    TaskQueueEntryChunk* volatile* _data;
+    TaskQueueEntryChunk* volatile* _buckets;
     char _pad0[DEFAULT_CACHE_LINE_SIZE];
     volatile size_t _size;
     char _pad4[DEFAULT_CACHE_LINE_SIZE - sizeof(size_t)];

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -210,6 +210,15 @@ private:
       _should_grow = false;
     }
 
+    // During G1CMConcurrentMarkingTask or finalize_marking phases, we prefer to restart the marking when
+    // the G1CMMarkStack overflows. Attempts to expand the G1CMMarkStack should be followed with a restart
+    // of the marking. On failure to allocate a new chuck, the caller just returns and forces a restart.
+    // This approach offers better memory utilization for the G1CMMarkStack, as each iteration of the
+    // marking potentially involves traversing fewer unmarked nodes in the graph.
+
+    // However, during the reference processing phase, instead of restarting the marking process, the
+    // G1CMMarkStack is expanded upon failure to allocate a new chunk. The decision between these two
+    // modes of expansion is determined by the _should_grow parameter.
     void set_should_grow() {
       _should_grow = true;
     }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -230,8 +230,8 @@ private:
   // Alignment and minimum capacity of this mark stack in number of oops.
   static size_t capacity_alignment();
 
-  // Allocate and initialize the mark stack with the given number of oops.
-  bool initialize(size_t initial_capacity, size_t max_capacity);
+  // Allocate and initialize the mark stack.
+  bool initialize();
 
   // Pushes the given buffer containing at most EntriesPerChunk elements on the mark
   // stack. If less than EntriesPerChunk elements are to be pushed, the array must

--- a/test/hotspot/jtreg/gc/g1/TestMarkStackOverflow.java
+++ b/test/hotspot/jtreg/gc/g1/TestMarkStackOverflow.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.g1;
+
+import java.util.LinkedHashMap;
+
+/* @test
+ * @bug 8313212
+ * @summary Finalizing objects may create new concurrent marking work during reference processing.
+ * If the marking work overflows the global mark stack, we should resize the global mark stack
+ * until MarkStackSizeMax if possible.
+ * @requires vm.gc.G1
+ * @run main/othervm -XX:ActiveProcessorCount=2 -XX:MarkStackSize=1 -Xmx250m gc.g1.TestMarkStackOverflow
+ */
+
+public class TestMarkStackOverflow {
+    public static void main(String[] args) throws Exception {
+        for (int i = 0; i < 10; i++) {
+            Finalizable holder1 = new Finalizable();
+            System.out.printf("Used mem %.2f MB\n", getUsedMem());
+        }
+    }
+
+    private static double getUsedMem() {
+        return (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (double) (1024 * 1024);
+    }
+
+    private static class Finalizable {
+        public static final int NUM_OBJECTS = 200_000;
+        private final LinkedHashMap<Object, Object> list = new LinkedHashMap<>();
+
+        public Finalizable() {
+            for (int i = 0; i < NUM_OBJECTS; i++) {
+                Object entry = new Object();
+                list.put(entry, entry);
+            }
+        }
+
+        @SuppressWarnings("removal")
+        protected void finalize() {
+            System.out.print("");
+        }
+    }
+}

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -66,8 +66,6 @@ tools/javac/annotations/typeAnnotations/referenceinfos/Lambda.java              
 tools/javac/annotations/typeAnnotations/referenceinfos/NestedTypes.java         8057687    generic-all    emit correct byte code an attributes for type annotations
 tools/javac/warnings/suppress/TypeAnnotations.java                              8057683    generic-all    improve ordering of errors with type annotations
 tools/javac/modules/SourceInSymlinkTest.java                                    8180263    windows-all    fails when run on a subst drive
-tools/javac/lambda/bytecode/TestLambdaBytecodeTargetRelease14.java              8312534    linux-i586     fails with assert "g1ConcurrentMark.cpp: Overflow during reference processing"
-tools/javac/varargs/warning/Warn5.java                                          8312534    linux-i586     fails with assert "g1ConcurrentMark.cpp: Overflow during reference processing"
 
 ###########################################################################
 #


### PR DESCRIPTION
Hi all,

Please review this change to modify how we grow the global marking stack used by Concurrent Marking. This patch allows for growing the marking stack without the need to copy over elements. Consequently, we can grow the marking stack even during the reference processing phase without the need to restart the marking cycle.

This mainly addresses the issue where object marking work created during reference processing may overflow the global marking stack. Currently G1 just bails out with a fatal error  as expanding the marking stack would require a restart which is not valid during the reference processing phase.

We have decided to maintain the restart concurrent marking when the global mark stack overflows during the marking phase of the concurrent cycle as this offers better memory utilisation.

Testing: Tier 1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280087](https://bugs.openjdk.org/browse/JDK-8280087): G1: Handle out-of-mark stack situations during reference processing more gracefully (**Enhancement** - P3)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [cf8a87aa](https://git.openjdk.org/jdk/pull/16979/files/cf8a87aa4e5789240a510b223aa7fb14298d3135)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [6ad04b0f](https://git.openjdk.org/jdk/pull/16979/files/6ad04b0f03b279a016810d55d5094b0b39bcd2c4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16979/head:pull/16979` \
`$ git checkout pull/16979`

Update a local copy of the PR: \
`$ git checkout pull/16979` \
`$ git pull https://git.openjdk.org/jdk.git pull/16979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16979`

View PR using the GUI difftool: \
`$ git pr show -t 16979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16979.diff">https://git.openjdk.org/jdk/pull/16979.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16979#issuecomment-1841315548)