### PR TITLE
8320139: [JVMCI] VmObjectAlloc is not generated by intrinsics methods which allocate objects

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -115,6 +115,11 @@ class CompilerToVM {
     // Minimum alignment of an offset into CodeBuffer::SECT_CONSTS
     static int data_section_item_alignment;
 
+    /*
+     * Pointer to JvmtiExport::_should_notify_object_alloc.
+     * Exposed as an int* instead of an address so the
+     * underlying type is part of the JVMCIVMStructs definition.
+     */
     static int* _should_notify_object_alloc;
 
    public:

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -115,6 +115,8 @@ class CompilerToVM {
     // Minimum alignment of an offset into CodeBuffer::SECT_CONSTS
     static int data_section_item_alignment;
 
+    static int* _should_notify_object_alloc;
+
    public:
      static void initialize(JVMCI_TRAPS);
 

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -130,6 +130,8 @@ address CompilerToVM::Data::symbol_clinit;
 
 int CompilerToVM::Data::data_section_item_alignment;
 
+int* CompilerToVM::Data::_should_notify_object_alloc;
+
 void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   Klass_vtable_start_offset = in_bytes(Klass::vtable_start_offset());
   Klass_vtable_length_offset = in_bytes(Klass::vtable_length_offset());
@@ -195,6 +197,8 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   _fields_annotations_base_offset = Array<AnnotationArray*>::base_offset_in_bytes();
 
   data_section_item_alignment = relocInfo::addr_unit();
+
+  _should_notify_object_alloc = &JvmtiExport::_should_notify_object_alloc;
 
   BarrierSet* bs = BarrierSet::barrier_set();
   if (bs->is_a(BarrierSet::CardTableBarrierSet)) {

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -122,6 +122,8 @@
                                                                                                                                      \
   static_field(CompilerToVM::Data,             data_section_item_alignment,            int)                                          \
                                                                                                                                      \
+  static_field(CompilerToVM::Data,             _should_notify_object_alloc,            int*)                                         \
+                                                                                                                                     \
   static_field(Abstract_VM_Version,            _features,                              uint64_t)                                     \
                                                                                                                                      \
   nonstatic_field(Annotations,                 _class_annotations,                     AnnotationArray*)                             \


### PR DESCRIPTION
This PR exports a pointer to `JvmtiExport::_should_notify_object_alloc` via JVMCI to enable intrinsification of unsafe allocations in accordance to C2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320139](https://bugs.openjdk.org/browse/JDK-8320139): [JVMCI] VmObjectAlloc is not generated by intrinsics methods which allocate objects (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**) ⚠️ Review applies to [0b430d8b](https://git.openjdk.org/jdk/pull/16980/files/0b430d8b2d6b6006dee083627b261155423d43a4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16980/head:pull/16980` \
`$ git checkout pull/16980`

Update a local copy of the PR: \
`$ git checkout pull/16980` \
`$ git pull https://git.openjdk.org/jdk.git pull/16980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16980`

View PR using the GUI difftool: \
`$ git pr show -t 16980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16980.diff">https://git.openjdk.org/jdk/pull/16980.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16980#issuecomment-1843352897)