### PR TITLE
8315827: Kitchensink.java and RenaissanceStressTest.java time out with jvmti module errors

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/javaThreadStatus.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "jfr/recorder/jfrRecorder.hpp"
 #include "jfr/periodic/sampling/jfrCallTrace.hpp"
@@ -200,7 +201,7 @@ void OSThreadSampler::protected_task(const SuspendedThreadTaskContext& context) 
       ev->set_starttime(_suspend_time);
       ev->set_endtime(_suspend_time); // fake to not take an end time
       ev->set_sampledThread(JfrThreadLocal::thread_id(jt));
-      ev->set_state(static_cast<u8>(java_lang_Thread::get_thread_status(_thread_oop)));
+      ev->set_state(static_cast<u8>(JavaThreadStatus::RUNNABLE));
     }
   }
 }
@@ -230,7 +231,7 @@ static void write_native_event(JfrThreadSampleClosure& closure, JavaThread* jt, 
   EventNativeMethodSample *ev = closure.next_event_native();
   ev->set_starttime(JfrTicks::now());
   ev->set_sampledThread(JfrThreadLocal::thread_id(jt));
-  ev->set_state(static_cast<u8>(java_lang_Thread::get_thread_status(thread_oop)));
+  ev->set_state(static_cast<u8>(JavaThreadStatus::RUNNABLE));
 }
 
 void JfrNativeSamplerCallback::call() {


### PR DESCRIPTION
Greetings,

A deadlock interaction pattern has surfaced where the JFR sampler thread has suspended a thread, reportedly in state thread_in_java. That thread is currently running barrier code and is holding a semaphore as part of logging inside of LogFileOutput::write( ).

When the JFR thread sampler attempts to read the thread status from the thread object, it triggers the same barrier code, eventually waiting for the semaphore inside LogFileOutput::write( ). Since the owner is suspended, a deadlock ensues.

To avoid triggering barriers as part of the sampler code, we can avoid reading the thread status from the thread object as part of sampling. This is especially so because we know what the thread state is at this point, especially for _thread_in_java but also for _thread_in_native. It is most likely JavaThreadStatus::RUNNABLE (5). Write it as a constant.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315827](https://bugs.openjdk.org/browse/JDK-8315827): Kitchensink.java and RenaissanceStressTest.java  time out with jvmti module errors (**Bug** - P2)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16982/head:pull/16982` \
`$ git checkout pull/16982`

Update a local copy of the PR: \
`$ git checkout pull/16982` \
`$ git pull https://git.openjdk.org/jdk.git pull/16982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16982`

View PR using the GUI difftool: \
`$ git pr show -t 16982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16982.diff">https://git.openjdk.org/jdk/pull/16982.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16982#issuecomment-1841464016)