### PR TITLE
make ThreadLocal.nextHashCode final

### DIFF
--- a/src/java.base/share/classes/java/lang/ThreadLocal.java
+++ b/src/java.base/share/classes/java/lang/ThreadLocal.java
@@ -93,7 +93,7 @@ public class ThreadLocal<T> {
      * The next hash code to be given out. Updated atomically. Starts at
      * zero.
      */
-    private static AtomicInteger nextHashCode =
+    private static final AtomicInteger nextHashCode =
         new AtomicInteger();
 
     /**


### PR DESCRIPTION
The static AtomicInteger used for the nextHashCode should be final.