### PR TITLE
8321279: Implement hashCode() in Heap-X-Buffer.java.template

### DIFF
--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -707,7 +707,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(hb, position(), limit(), 1, ArraysSupport.T_BYTE);
+        return ArraysSupport.vectorizedHashCode(hb, position(), limit() - 1, 1, ArraysSupport.T_BYTE);
     }
 
 #end[byte]
@@ -738,7 +738,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(hb, position(), limit(), 1, ArraysSupport.T_CHAR);
+        return ArraysSupport.vectorizedHashCode(hb, position(), limit() - 1, 1, ArraysSupport.T_CHAR);
     }
 #end[char]
 

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -29,6 +29,7 @@ package java.nio;
 
 import java.lang.foreign.MemorySegment;
 import java.util.Objects;
+import java.util.Arrays;
 
 /**
 #if[rw]
@@ -174,6 +175,10 @@ class Heap$Type$Buffer$RW$
 
     public $type$ get(int i) {
         return hb[ix(checkIndex(i))];
+    }
+
+    public int hashCode() {
+        return Arrays.hashCode(hb);
     }
 
 #if[streamableType]

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -707,7 +707,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(a, position(), limit(), 1, ArraysSupport.T_BYTE)
+        return ArraysSupport.vectorizedHashCode(hb, position(), limit(), 1, ArraysSupport.T_BYTE);
     }
 
 #end[byte]
@@ -738,7 +738,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(a, position(), limit(), 1, ArraysSupport.T_CHAR)
+        return ArraysSupport.vectorizedHashCode(hb, position(), limit(), 1, ArraysSupport.T_CHAR);
     }
 #end[char]
 

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -707,7 +707,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(hb, position(), limit() - 1, 1, ArraysSupport.T_BYTE);
+        return ArraysSupport.vectorizedHashCode(hb, position(), limit() - position(), 1, ArraysSupport.T_BYTE);
     }
 
 #end[byte]
@@ -738,7 +738,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(hb, position(), limit() - 1, 1, ArraysSupport.T_CHAR);
+        return ArraysSupport.vectorizedHashCode(hb, position(), limit() - position(), 1, ArraysSupport.T_CHAR);
     }
 #end[char]
 

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -29,7 +29,7 @@ package java.nio;
 
 import java.lang.foreign.MemorySegment;
 import java.util.Objects;
-import java.util.Arrays;
+import jdk.internal.util.ArraysSupport;
 
 /**
 #if[rw]
@@ -175,10 +175,6 @@ class Heap$Type$Buffer$RW$
 
     public $type$ get(int i) {
         return hb[ix(checkIndex(i))];
-    }
-
-    public int hashCode() {
-        return Arrays.hashCode(hb);
     }
 
 #if[streamableType]
@@ -710,6 +706,9 @@ class Heap$Type$Buffer$RW$
                                                                    addr, segment)));
     }
 
+    public int hashCode() {
+        return ArraysSupport.vectorizedHashCode(a, position(), limit(), 1, ArraysSupport.T_BYTE)
+    }
 
 #end[byte]
 
@@ -738,6 +737,9 @@ class Heap$Type$Buffer$RW$
                                       offset, segment);
     }
 
+    public int hashCode() {
+        return ArraysSupport.vectorizedHashCode(a, position(), limit(), 1, ArraysSupport.T_CHAR)
+    }
 #end[char]
 
 


### PR DESCRIPTION
Currently in `Heap*Buffer.hashCode()` is inherited from `*Buffer`, implemented as 
```java
public int hashCode() {
    int h = 1;
    int p = position();
    for (int i = limit() - 1; i >= p; i--)
        h = 31 * h + (int)get(i);
    return h;
}
```
This can be improved using `ArraysSupport.vectorizedHashCode()`