### PR TITLE
8321387: SegmentAllocator:allocateFrom(AddressLayout, MemorySegment) does not throw stated UnsupportedOperationException

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -631,6 +631,9 @@ public sealed interface MemoryLayout
      *     <li>The accessed memory segment must be
      *     {@link MemorySegment#isAccessibleBy(Thread) accessible} from the thread
      *     performing the access operation, or a {@link WrongThreadException} is thrown.</li>
+     *     <li>For write operations, the accessed memory segment must not be
+     *     {@link MemorySegment#isReadOnly() read only}, or an
+     *     {@link IllegalArgumentException} is thrown.</li>
      *     <li>The {@linkplain MemorySegment#scope() scope} associated with the accessed
      *     segment must be {@linkplain MemorySegment.Scope#isAlive() alive}, or an
      *     {@link IllegalStateException} is thrown.</li>

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1493,7 +1493,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IndexOutOfBoundsException if {@code dstOffset > dstSegment.byteSize() - bytes}
      * @throws IndexOutOfBoundsException if either {@code srcOffset},
      *         {@code dstOffset} or {@code bytes} are {@code < 0}
-     * @throws UnsupportedOperationException if {@code dstSegment} is
+     * @throws IllegalArgumentException if {@code dstSegment} is
      *         {@linkplain #isReadOnly() read-only}
      */
     @ForceInline
@@ -1552,7 +1552,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         {@code dstSegment} is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
      *         such that {@code dstSegment.isAccessibleBy(T) == false}
-     * @throws UnsupportedOperationException if {@code dstSegment} is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if {@code dstSegment} is {@linkplain #isReadOnly() read-only}
      * @throws IndexOutOfBoundsException if {@code elementCount * srcLayout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code elementCount * dtsLayout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code srcOffset > srcSegment.byteSize() - (elementCount * srcLayout.byteSize())}
@@ -1921,7 +1921,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
      * @throws UnsupportedOperationException if this segment is
      *         {@linkplain #isReadOnly() read-only}
-     * @throws UnsupportedOperationException if {@code value} is not a
+     * @throws IllegalArgumentException if {@code value} is not a
      *         {@linkplain #isNative() native} segment
      */
     void set(AddressLayout layout, long offset, MemorySegment value);
@@ -2336,7 +2336,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
      * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
-     * @throws UnsupportedOperationException if {@code value} is not a {@linkplain #isNative() native} segment
+     * @throws IllegalArgumentException if {@code value} is not a {@linkplain #isNative() native} segment
      */
     void setAtIndex(AddressLayout layout, long index, MemorySegment value);
 
@@ -2460,7 +2460,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the source element layout
      * @throws IllegalArgumentException if {@code dstLayout.byteAlignment() > dstLayout.byteSize()}
-     * @throws UnsupportedOperationException if {@code dstSegment} is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if {@code dstSegment} is {@linkplain #isReadOnly() read-only}
      * @throws IndexOutOfBoundsException if {@code elementCount * dstLayout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code dstOffset > dstSegment.byteSize() - (elementCount * dstLayout.byteSize())}
      * @throws IndexOutOfBoundsException if {@code srcIndex > srcArray.length - elementCount}

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -869,7 +869,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
      *         such that {@code isAccessibleBy(T) == false}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     MemorySegment fill(byte value);
@@ -894,7 +894,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         {@code src} is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
      *         such that {@code src.isAccessibleBy(T) == false}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      * @return this segment
      */
@@ -1269,6 +1269,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         this segment is not {@linkplain Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
      *         such that {@code isAccessibleBy(T) == false}
+     * @throws IllegalArgumentException if this segment is
+     *         {@linkplain #isReadOnly() read-only}
      */
     void setString(long offset, String str);
 
@@ -1306,6 +1308,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         such that {@code isAccessibleBy(T) == false}
      * @throws IllegalArgumentException if {@code charset} is not a
      *         {@linkplain StandardCharsets standard charset}
+     * @throws IllegalArgumentException if this segment is
+     *         {@linkplain #isReadOnly() read-only}
      */
     void setString(long offset, String str, Charset charset);
 
@@ -1605,7 +1609,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the provided layout
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     void set(ValueLayout.OfByte layout, long offset, byte value);
@@ -1643,7 +1647,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the provided layout
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     void set(ValueLayout.OfBoolean layout, long offset, boolean value);
@@ -1681,7 +1685,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the provided layout
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     void set(ValueLayout.OfChar layout, long offset, char value);
@@ -1719,7 +1723,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the provided layout
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     void set(ValueLayout.OfShort layout, long offset, short value);
@@ -1757,7 +1761,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the provided layout
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     void set(ValueLayout.OfInt layout, long offset, int value);
@@ -1795,7 +1799,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the provided layout
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     void set(ValueLayout.OfFloat layout, long offset, float value);
@@ -1833,7 +1837,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the provided layout
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     void set(ValueLayout.OfLong layout, long offset, long value);
@@ -1871,7 +1875,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         <a href="MemorySegment.html#segment-alignment">incompatible with the alignment constraint</a>
      *         in the provided layout
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is
+     * @throws IllegalArgumentException if this segment is
      *         {@linkplain #isReadOnly() read-only}
      */
     void set(ValueLayout.OfDouble layout, long offset, double value);
@@ -1923,6 +1927,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *         {@linkplain #isReadOnly() read-only}
      * @throws IllegalArgumentException if {@code value} is not a
      *         {@linkplain #isNative() native} segment
+     * @throws IllegalArgumentException if this segment is
+     *         {@linkplain #isReadOnly() read-only}
      */
     void set(AddressLayout layout, long offset, MemorySegment value);
 
@@ -2055,7 +2061,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if {@code layout.byteAlignment() > layout.byteSize()}
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if this segment is {@linkplain #isReadOnly() read-only}
      */
     void setAtIndex(ValueLayout.OfByte layout, long index, byte value);
 
@@ -2078,7 +2084,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if {@code layout.byteAlignment() > layout.byteSize()}
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if this segment is {@linkplain #isReadOnly() read-only}
      */
     void setAtIndex(ValueLayout.OfBoolean layout, long index, boolean value);
 
@@ -2101,7 +2107,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if {@code layout.byteAlignment() > layout.byteSize()}
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if this segment is {@linkplain #isReadOnly() read-only}
      */
     void setAtIndex(ValueLayout.OfShort layout, long index, short value);
 
@@ -2146,7 +2152,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if {@code layout.byteAlignment() > layout.byteSize()}
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if this segment is {@linkplain #isReadOnly() read-only}
      */
     void setAtIndex(ValueLayout.OfInt layout, long index, int value);
 
@@ -2191,7 +2197,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if {@code layout.byteAlignment() > layout.byteSize()}
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if this segment is {@linkplain #isReadOnly() read-only}
      */
     void setAtIndex(ValueLayout.OfFloat layout, long index, float value);
 
@@ -2236,7 +2242,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if {@code layout.byteAlignment() > layout.byteSize()}
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if this segment is {@linkplain #isReadOnly() read-only}
      */
     void setAtIndex(ValueLayout.OfLong layout, long index, long value);
 
@@ -2281,7 +2287,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IllegalArgumentException if {@code layout.byteAlignment() > layout.byteSize()}
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize()} overflows
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
-     * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
+     * @throws IllegalArgumentException if this segment is {@linkplain #isReadOnly() read-only}
      */
     void setAtIndex(ValueLayout.OfDouble layout, long index, double value);
 
@@ -2337,6 +2343,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @throws IndexOutOfBoundsException if {@code index * layout.byteSize() > byteSize() - layout.byteSize()}
      * @throws UnsupportedOperationException if this segment is {@linkplain #isReadOnly() read-only}
      * @throws IllegalArgumentException if {@code value} is not a {@linkplain #isNative() native} segment
+     * @throws IllegalArgumentException if this segment is
+     *         {@linkplain #isReadOnly() read-only}
      */
     void setAtIndex(AddressLayout layout, long index, MemorySegment value);
 

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -350,7 +350,7 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
-     * @throws UnsupportedOperationException if {@code value} is not
+     * @throws IllegalArgumentException if {@code value} is not
      *         a {@linkplain MemorySegment#isNative() native} segment
      */
     default MemorySegment allocateFrom(AddressLayout layout, MemorySegment value) {

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -92,8 +92,6 @@ public interface SegmentAllocator {
      *
      * @param str the Java string to be converted into a C string
      * @return a new native segment containing the converted C string
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(String str) {
@@ -121,8 +119,6 @@ public interface SegmentAllocator {
      * @return a new native segment containing the converted C string
      * @throws IllegalArgumentException if {@code charset} is not a
      *         {@linkplain StandardCharsets standard charset}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      * @implSpec The default implementation for this method copies the contents of the
      *           provided Java string into a new memory segment obtained by calling
      *           {@code this.allocate(B + N)}, where:
@@ -174,8 +170,6 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfByte layout, byte value) {
         Objects.requireNonNull(layout);
@@ -201,8 +195,6 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfChar layout, char value) {
         Objects.requireNonNull(layout);
@@ -228,8 +220,6 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfShort layout, short value) {
         Objects.requireNonNull(layout);
@@ -255,8 +245,6 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfInt layout, int value) {
         Objects.requireNonNull(layout);
@@ -282,8 +270,6 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfFloat layout, float value) {
         Objects.requireNonNull(layout);
@@ -309,8 +295,6 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfLong layout, long value) {
         Objects.requireNonNull(layout);
@@ -336,8 +320,6 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfDouble layout, double value) {
         Objects.requireNonNull(layout);
@@ -370,8 +352,6 @@ public interface SegmentAllocator {
      * @param value  the value to be set in the newly allocated memory segment
      * @throws IllegalArgumentException if {@code value} is not
      *         a {@linkplain MemorySegment#isNative() native} segment
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(AddressLayout layout, MemorySegment value) {
         Objects.requireNonNull(value);
@@ -406,8 +386,6 @@ public interface SegmentAllocator {
      *         in the source element layout
      * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
      * @throws IllegalArgumentException if {@code sourceElementLayout.byteAlignment() > sourceElementLayout.byteSize()}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      * @throws IllegalStateException if the {@linkplain MemorySegment#scope() scope} associated
      *         with {@code source} is not {@linkplain MemorySegment.Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
@@ -450,8 +428,6 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfByte elementLayout, byte... elements) {
@@ -479,8 +455,6 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfShort elementLayout, short... elements) {
@@ -508,8 +482,6 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfChar elementLayout, char... elements) {
@@ -537,8 +509,6 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfInt elementLayout, int... elements) {
@@ -566,8 +536,6 @@ public interface SegmentAllocator {
      *                 memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfFloat elementLayout, float... elements) {
@@ -595,8 +563,6 @@ public interface SegmentAllocator {
      *                 memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfLong elementLayout, long... elements) {
@@ -624,8 +590,6 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
-     * @throws IllegalArgumentException if the allocated segment is
-     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfDouble elementLayout, double... elements) {
@@ -701,18 +665,16 @@ public interface SegmentAllocator {
      * <p>
      * The returned allocator throws {@link IndexOutOfBoundsException} when a slice of
      * the provided segment with the requested size and alignment cannot be found.
-     * <p>
-     * Providing a {@linkplain MemorySegment#isReadOnly() read only} segment is discouraged
-     * as the returned SegmentAllocator will not be able to support {@code allocateFrom()}
-     * operations.
      *
      * @implNote A slicing allocator is not <em>thread-safe</em>.
      *
      * @param segment the segment from which the returned allocator should slice from
      * @return a new slicing allocator
+     * @throws IllegalArgumentException if the {@code segment} is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     static SegmentAllocator slicingAllocator(MemorySegment segment) {
-        Objects.requireNonNull(segment);
+        assertWritable(segment);
         return new SlicingAllocator(segment);
     }
 
@@ -728,10 +690,6 @@ public interface SegmentAllocator {
      * }
      * The returned allocator throws {@link IndexOutOfBoundsException} when a slice of
      * the provided segment with the requested size and alignment cannot be found.
-     * <p>
-     * Providing a {@linkplain MemorySegment#isReadOnly() read only} segment is discouraged
-     * as the returned SegmentAllocator will not be able to support {@code allocateFrom()}
-     * operations.
      *
      * @apiNote A prefix allocator can be useful to limit allocation requests in case a
      *          client knows that they have fully processed the contents of the allocated
@@ -744,9 +702,19 @@ public interface SegmentAllocator {
      * @param segment the memory segment to be recycled by the returned allocator
      * @return an allocator that recycles an existing segment upon each new
      *         allocation request
+     * @throws IllegalArgumentException if the {@code segment} is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     static SegmentAllocator prefixAllocator(MemorySegment segment) {
-        return (AbstractMemorySegmentImpl)Objects.requireNonNull(segment);
+        assertWritable(segment);
+        return (AbstractMemorySegmentImpl)segment;
+    }
+
+    private static void assertWritable(MemorySegment segment) {
+        // Implicit null check
+        if (segment.isReadOnly()) {
+            throw new IllegalArgumentException("read-only segment");
+        }
     }
 
     @ForceInline

--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -92,6 +92,8 @@ public interface SegmentAllocator {
      *
      * @param str the Java string to be converted into a C string
      * @return a new native segment containing the converted C string
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(String str) {
@@ -119,6 +121,8 @@ public interface SegmentAllocator {
      * @return a new native segment containing the converted C string
      * @throws IllegalArgumentException if {@code charset} is not a
      *         {@linkplain StandardCharsets standard charset}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      * @implSpec The default implementation for this method copies the contents of the
      *           provided Java string into a new memory segment obtained by calling
      *           {@code this.allocate(B + N)}, where:
@@ -170,6 +174,8 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfByte layout, byte value) {
         Objects.requireNonNull(layout);
@@ -195,6 +201,8 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfChar layout, char value) {
         Objects.requireNonNull(layout);
@@ -220,6 +228,8 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfShort layout, short value) {
         Objects.requireNonNull(layout);
@@ -245,6 +255,8 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfInt layout, int value) {
         Objects.requireNonNull(layout);
@@ -270,6 +282,8 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfFloat layout, float value) {
         Objects.requireNonNull(layout);
@@ -295,6 +309,8 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfLong layout, long value) {
         Objects.requireNonNull(layout);
@@ -320,6 +336,8 @@ public interface SegmentAllocator {
      *
      * @param layout the layout of the block of memory to be allocated
      * @param value  the value to be set in the newly allocated memory segment
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(ValueLayout.OfDouble layout, double value) {
         Objects.requireNonNull(layout);
@@ -352,6 +370,8 @@ public interface SegmentAllocator {
      * @param value  the value to be set in the newly allocated memory segment
      * @throws IllegalArgumentException if {@code value} is not
      *         a {@linkplain MemorySegment#isNative() native} segment
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     default MemorySegment allocateFrom(AddressLayout layout, MemorySegment value) {
         Objects.requireNonNull(value);
@@ -386,6 +406,8 @@ public interface SegmentAllocator {
      *         in the source element layout
      * @throws IllegalArgumentException if {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
      * @throws IllegalArgumentException if {@code sourceElementLayout.byteAlignment() > sourceElementLayout.byteSize()}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      * @throws IllegalStateException if the {@linkplain MemorySegment#scope() scope} associated
      *         with {@code source} is not {@linkplain MemorySegment.Scope#isAlive() alive}
      * @throws WrongThreadException if this method is called from a thread {@code T},
@@ -428,6 +450,8 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfByte elementLayout, byte... elements) {
@@ -455,6 +479,8 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfShort elementLayout, short... elements) {
@@ -482,6 +508,8 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfChar elementLayout, char... elements) {
@@ -509,6 +537,8 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfInt elementLayout, int... elements) {
@@ -536,6 +566,8 @@ public interface SegmentAllocator {
      *                 memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfFloat elementLayout, float... elements) {
@@ -563,6 +595,8 @@ public interface SegmentAllocator {
      *                 memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfLong elementLayout, long... elements) {
@@ -590,6 +624,8 @@ public interface SegmentAllocator {
      *                      memory block
      * @throws IllegalArgumentException if
      *         {@code elementLayout.byteAlignment() > elementLayout.byteSize()}
+     * @throws IllegalArgumentException if the allocated segment is
+     *         {@linkplain MemorySegment#isReadOnly() read-only}
      */
     @ForceInline
     default MemorySegment allocateFrom(ValueLayout.OfDouble elementLayout, double... elements) {
@@ -665,6 +701,10 @@ public interface SegmentAllocator {
      * <p>
      * The returned allocator throws {@link IndexOutOfBoundsException} when a slice of
      * the provided segment with the requested size and alignment cannot be found.
+     * <p>
+     * Providing a {@linkplain MemorySegment#isReadOnly() read only} segment is discouraged
+     * as the returned SegmentAllocator will not be able to support {@code allocateFrom()}
+     * operations.
      *
      * @implNote A slicing allocator is not <em>thread-safe</em>.
      *
@@ -688,6 +728,10 @@ public interface SegmentAllocator {
      * }
      * The returned allocator throws {@link IndexOutOfBoundsException} when a slice of
      * the provided segment with the requested size and alignment cannot be found.
+     * <p>
+     * Providing a {@linkplain MemorySegment#isReadOnly() read only} segment is discouraged
+     * as the returned SegmentAllocator will not be able to support {@code allocateFrom()}
+     * operations.
      *
      * @apiNote A prefix allocator can be useful to limit allocation requests in case a
      *          client knows that they have fully processed the contents of the allocated

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -150,7 +150,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void set(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
 #if[floatingPoint]
         SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -186,7 +186,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setVolatile(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -206,7 +206,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -226,7 +226,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -237,7 +237,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean compareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -247,7 +247,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchange(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -258,7 +258,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -269,7 +269,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -280,7 +280,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -290,7 +290,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -300,7 +300,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -310,7 +310,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -320,7 +320,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSet(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -331,7 +331,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSetAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -342,7 +342,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSetRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -355,7 +355,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAdd(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -369,7 +369,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAddAcquire(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -383,7 +383,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAddRelease(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -411,7 +411,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOr(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -425,7 +425,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -439,7 +439,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -465,7 +465,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -479,7 +479,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -493,7 +493,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -520,7 +520,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXor(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -534,7 +534,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -548,7 +548,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -34,7 +34,6 @@ import java.lang.ref.Reference;
 import java.util.Objects;
 
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
-import static jdk.internal.foreign.AbstractMemorySegmentImpl.AccessConstraint.*;
 
 #warn
 
@@ -98,9 +97,9 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 #end[floatingPoint]
 
     @ForceInline
-    static AbstractMemorySegmentImpl checkAddress(Object obb, long offset, long length, AbstractMemorySegmentImpl.AccessConstraint constraint) {
+    static AbstractMemorySegmentImpl checkAddress(Object obb, long offset, long length, boolean ro) {
         AbstractMemorySegmentImpl oo = (AbstractMemorySegmentImpl)Objects.requireNonNull(obb);
-        oo.checkAccess(offset, length, constraint);
+        oo.checkAccess(offset, length, ro);
         return oo;
     }
 
@@ -126,7 +125,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ get(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, NONE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
 #if[floatingPoint]
         $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -150,7 +149,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void set(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
 #if[floatingPoint]
         SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -176,7 +175,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getVolatile(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, NONE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -186,7 +185,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setVolatile(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -196,7 +195,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAcquire(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, NONE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -206,7 +205,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -216,7 +215,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getOpaque(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, NONE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -226,7 +225,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -237,7 +236,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean compareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -247,7 +246,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchange(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -258,7 +257,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -269,7 +268,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -280,7 +279,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -290,7 +289,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -300,7 +299,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -310,7 +309,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -320,7 +319,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSet(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -331,7 +330,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSetAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -342,7 +341,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSetRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -355,7 +354,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAdd(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -369,7 +368,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAddAcquire(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -383,7 +382,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAddRelease(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -411,7 +410,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOr(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -425,7 +424,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -439,7 +438,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -465,7 +464,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -479,7 +478,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -493,7 +492,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -520,7 +519,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXor(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -534,7 +533,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -548,7 +547,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -126,7 +126,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ get(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, READ_ONLY);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, NONE);
 #if[floatingPoint]
         $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -150,7 +150,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void set(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
 #if[floatingPoint]
         SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -176,7 +176,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getVolatile(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, READ_ONLY);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, NONE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -186,7 +186,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setVolatile(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -196,7 +196,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAcquire(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, READ_ONLY);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, NONE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -206,7 +206,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -216,7 +216,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getOpaque(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, READ_ONLY);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, NONE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -226,7 +226,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -237,7 +237,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean compareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -247,7 +247,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchange(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -258,7 +258,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -269,7 +269,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -280,7 +280,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -290,7 +290,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -300,7 +300,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -310,7 +310,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -320,7 +320,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSet(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -331,7 +331,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSetAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -342,7 +342,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSetRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -355,7 +355,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAdd(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -369,7 +369,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAddAcquire(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -383,7 +383,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAddRelease(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -411,7 +411,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOr(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -425,7 +425,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -439,7 +439,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -465,7 +465,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -479,7 +479,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -493,7 +493,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -520,7 +520,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXor(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -534,7 +534,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -548,7 +548,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_UOE);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -34,6 +34,7 @@ import java.lang.ref.Reference;
 import java.util.Objects;
 
 import static java.lang.invoke.MethodHandleStatics.UNSAFE;
+import static jdk.internal.foreign.AbstractMemorySegmentImpl.AccessConstraint.*;
 
 #warn
 
@@ -97,9 +98,9 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 #end[floatingPoint]
 
     @ForceInline
-    static AbstractMemorySegmentImpl checkAddress(Object obb, long offset, long length, boolean ro) {
+    static AbstractMemorySegmentImpl checkAddress(Object obb, long offset, long length, AbstractMemorySegmentImpl.AccessConstraint constraint) {
         AbstractMemorySegmentImpl oo = (AbstractMemorySegmentImpl)Objects.requireNonNull(obb);
-        oo.checkAccess(offset, length, ro);
+        oo.checkAccess(offset, length, constraint);
         return oo;
     }
 
@@ -125,7 +126,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ get(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, READ_ONLY);
 #if[floatingPoint]
         $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -149,7 +150,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void set(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
 #if[floatingPoint]
         SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
@@ -175,7 +176,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getVolatile(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, READ_ONLY);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -185,7 +186,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setVolatile(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -195,7 +196,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAcquire(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, READ_ONLY);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -205,7 +206,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -215,7 +216,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getOpaque(VarHandle ob, Object obb, long base) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, true);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, READ_ONLY);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -225,7 +226,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -236,7 +237,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean compareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -246,7 +247,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchange(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -257,7 +258,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -268,7 +269,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -279,7 +280,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -289,7 +290,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -299,7 +300,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -309,7 +310,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
                 offsetNonPlain(bb, base, handle.alignmentMask),
@@ -319,7 +320,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSet(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -330,7 +331,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSetAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -341,7 +342,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndSetRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
@@ -354,7 +355,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAdd(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -368,7 +369,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAddAcquire(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -382,7 +383,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndAddRelease(VarHandle ob, Object obb, long base, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -410,7 +411,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOr(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -424,7 +425,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -438,7 +439,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -464,7 +465,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -478,7 +479,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -492,7 +493,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -519,7 +520,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXor(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -533,7 +534,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
@@ -547,7 +548,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, long base, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, false);
+        AbstractMemorySegmentImpl bb = checkAddress(obb, base, handle.length, ON_WRITE_IAE);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -193,7 +193,7 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     public final MemorySegment fill(byte value){
-        checkAccess(0, length, ON_WRITE_UOE);
+        checkAccess(0, length, ON_WRITE_IAE);
         SCOPED_MEMORY_ACCESS.setMemory(sessionImpl(), unsafeGetBase(), unsafeGetOffset(), length, value);
         return this;
     }
@@ -360,7 +360,7 @@ public abstract sealed class AbstractMemorySegmentImpl
     }
 
     public enum AccessConstraint {
-        READ_ONLY, ON_WRITE_UOE, ON_WRITE_IAE
+        NONE, ON_WRITE_UOE, ON_WRITE_IAE
     }
 
     @ForceInline
@@ -618,7 +618,7 @@ public abstract sealed class AbstractMemorySegmentImpl
             throw new IllegalArgumentException("Destination segment incompatible with alignment constraints");
         }
         long size = elementCount * srcElementLayout.byteSize();
-        srcImpl.checkAccess(srcOffset, size, READ_ONLY);
+        srcImpl.checkAccess(srcOffset, size, NONE);
         dstImpl.checkAccess(dstOffset, size, ON_WRITE_IAE);
         if (srcElementLayout.byteSize() == 1 || srcElementLayout.order() == dstElementLayout.order()) {
             ScopedMemoryAccess.getScopedMemoryAccess().copyMemory(srcImpl.sessionImpl(), dstImpl.sessionImpl(),
@@ -645,7 +645,7 @@ public abstract sealed class AbstractMemorySegmentImpl
         if (!srcImpl.isAlignedForElement(srcOffset, srcLayout)) {
             throw new IllegalArgumentException("Source segment incompatible with alignment constraints");
         }
-        srcImpl.checkAccess(srcOffset, elementCount * dstInfo.scale(), READ_ONLY);
+        srcImpl.checkAccess(srcOffset, elementCount * dstInfo.scale(), NONE);
         Objects.checkFromIndexSize(dstIndex, elementCount, Array.getLength(dstArray));
         if (dstInfo.scale() == 1 || srcLayout.order() == ByteOrder.nativeOrder()) {
             ScopedMemoryAccess.getScopedMemoryAccess().copyMemory(srcImpl.sessionImpl(), null,
@@ -691,8 +691,8 @@ public abstract sealed class AbstractMemorySegmentImpl
         AbstractMemorySegmentImpl dstImpl = (AbstractMemorySegmentImpl)Objects.requireNonNull(dstSegment);
         long srcBytes = srcToOffset - srcFromOffset;
         long dstBytes = dstToOffset - dstFromOffset;
-        srcImpl.checkAccess(srcFromOffset, srcBytes, READ_ONLY);
-        dstImpl.checkAccess(dstFromOffset, dstBytes, READ_ONLY);
+        srcImpl.checkAccess(srcFromOffset, srcBytes, NONE);
+        dstImpl.checkAccess(dstFromOffset, dstBytes, NONE);
         if (dstImpl == srcImpl) {
             srcImpl.checkValidState();
             return -1;

--- a/test/jdk/java/foreign/TestArrayCopy.java
+++ b/test/jdk/java/foreign/TestArrayCopy.java
@@ -26,12 +26,9 @@
  * @run testng TestArrayCopy
  */
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -240,7 +237,7 @@ public class TestArrayCopy {
         try {
             helper.copyFromArray(srcArr, 0, SEG_LENGTH_BYTES / bytesPerElement, dstSeg, 0, ByteOrder.nativeOrder());
             fail();
-        } catch (UnsupportedOperationException ex) {
+        } catch (IllegalArgumentException ex) {
             //ok
         }
     }

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -87,7 +87,7 @@ public class TestMemoryAccess {
                 if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
-            } catch (UnsupportedOperationException ex) {
+            } catch (IllegalArgumentException ex) {
                 if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }
@@ -121,7 +121,7 @@ public class TestMemoryAccess {
                 if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
-            } catch (UnsupportedOperationException ex) {
+            } catch (IllegalArgumentException ex) {
                 if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }
@@ -185,7 +185,7 @@ public class TestMemoryAccess {
                 if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
-            } catch (UnsupportedOperationException ex) {
+            } catch (IllegalArgumentException ex) {
                 if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }

--- a/test/jdk/java/foreign/TestMemoryAccess.java
+++ b/test/jdk/java/foreign/TestMemoryAccess.java
@@ -87,7 +87,7 @@ public class TestMemoryAccess {
                 if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
-            } catch (IllegalArgumentException ex) {
+            } catch (UnsupportedOperationException ex) {
                 if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }
@@ -121,7 +121,7 @@ public class TestMemoryAccess {
                 if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
-            } catch (IllegalArgumentException ex) {
+            } catch (UnsupportedOperationException ex) {
                 if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }
@@ -185,7 +185,7 @@ public class TestMemoryAccess {
                 if (isRO) {
                     throw new AssertionError(); //not ok, memory should be immutable
                 }
-            } catch (IllegalArgumentException ex) {
+            } catch (UnsupportedOperationException ex) {
                 if (!isRO) {
                     throw new AssertionError(); //we should not have failed!
                 }

--- a/test/jdk/java/foreign/TestMemoryAccessInstance.java
+++ b/test/jdk/java/foreign/TestMemoryAccessInstance.java
@@ -27,7 +27,6 @@
  * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_SEGMENT_FORCE_EXACT=true --enable-native-access=ALL-UNNAMED TestMemoryAccessInstance
  */
 
-import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.Arena;
 import java.lang.foreign.ValueLayout;

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -100,6 +100,16 @@ public class TestSegmentAllocators {
 
     static final int SIZE_256M = 1024 * 1024 * 256;
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testReadOnlySlicingAllocator() {
+        SegmentAllocator.slicingAllocator(MemorySegment.ofArray(new int[0]).asReadOnly());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testReadOnlyPrefixAllocator() {
+        SegmentAllocator.prefixAllocator(MemorySegment.ofArray(new int[0]).asReadOnly());
+    }
+
     @Test
     public void testBigAllocationInUnboundedSession() {
         try (Arena arena = Arena.ofConfined()) {

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -160,6 +160,25 @@ public class TestSegmentAllocators {
         }
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = ".*Heap segment not allowed.*")
+    public void testArenaAllocateFromHeapSegment() {
+        try (Arena arena = Arena.ofConfined()) {
+            var heapSegment = MemorySegment.ofArray(new int[]{1});
+            arena.allocateFrom(ValueLayout.ADDRESS, heapSegment);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = ".*Heap segment not allowed.*")
+    public void testAllocatorAllocateFromHeapSegment() {
+        try (Arena arena = Arena.ofConfined()) {
+            SegmentAllocator allocator = SegmentAllocator.prefixAllocator(arena.allocate(16));
+            var heapSegment = MemorySegment.ofArray(new int[]{1});
+            allocator.allocateFrom(ValueLayout.ADDRESS, heapSegment);
+        }
+    }
+
     @Test
     public void testArrayAllocateDelegation() {
         AtomicInteger calls = new AtomicInteger();

--- a/test/jdk/java/foreign/TestSegmentCopy.java
+++ b/test/jdk/java/foreign/TestSegmentCopy.java
@@ -76,12 +76,21 @@ public class TestSegmentCopy {
         }
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class, dataProvider = "segmentKinds")
+    @Test(expectedExceptions = IllegalArgumentException.class, dataProvider = "segmentKinds")
     public void testReadOnlyCopy(SegmentKind kind1, SegmentKind kind2) {
         MemorySegment s1 = kind1.makeSegment(TEST_BYTE_SIZE);
         MemorySegment s2 = kind2.makeSegment(TEST_BYTE_SIZE);
         // check failure with read-only dest
         MemorySegment.copy(s1, Type.BYTE.layout, 0, s2.asReadOnly(), Type.BYTE.layout, 0, 0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = ".*Attempt to write a read-only segment.*")
+    public void badCopy6Arg() {
+        try (Arena scope = Arena.ofConfined()) {
+            MemorySegment dest = scope.allocate(ValueLayout.JAVA_INT).asReadOnly();
+            MemorySegment.copy(new int[1],0, dest, ValueLayout.JAVA_INT, 0 ,1); // should throw
+        }
     }
 
     @Test(expectedExceptions = IndexOutOfBoundsException.class, dataProvider = "types")

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -325,10 +325,16 @@ public class TestSegments {
         assertEquals(segment.scope(), arena.scope());
     }
 
-    @Test(dataProvider = "segmentFactories", expectedExceptions = UnsupportedOperationException.class)
+    @Test(dataProvider = "segmentFactories", expectedExceptions = IllegalArgumentException.class)
     public void testFillIllegalAccessMode(Supplier<MemorySegment> segmentSupplier) {
         MemorySegment segment = segmentSupplier.get();
         segment.asReadOnly().fill((byte) 0xFF);
+    }
+
+    @Test(dataProvider = "segmentFactories", expectedExceptions = IllegalArgumentException.class)
+    public void testFromStringIllegalAccessMode(Supplier<MemorySegment> segmentSupplier) {
+        MemorySegment segment = segmentSupplier.get();
+        segment.asReadOnly().setString(0, "a");
     }
 
     @Test(dataProvider = "segmentFactories")


### PR DESCRIPTION
This PR proposes to change the exception type for exceptions thrown for certain methods with a parameter of type `MemorySegment` when it is `MemorySegment::isReadOnly`. Previously an `UnsupportedOperationException` was specified but in some cases, in reality, an `IllegalArgumentException` was thrown. 

The principle used in this PR is that operations acting on an MS where the MS is `this` should throw an `UnsupportedOperationException` whereas in cases where the MS is a *parameter* an `IllegalArgumentException` should be thrown.

It should be noted that this PR retains the previous behavior for MS VarHandle access (even though the MS is a parameter to the accessor methods, the first parameter can be said to represent `this`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8321513](https://bugs.openjdk.org/browse/JDK-8321513) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8321387](https://bugs.openjdk.org/browse/JDK-8321387): SegmentAllocator:allocateFrom(AddressLayout, MemorySegment) does not throw stated UnsupportedOperationException (**Bug** - P3)(⚠️ The fixVersion in this issue is [22] but the fixVersion in .jcheck/conf is 23, a new backport will be created when this pr is integrated.)
 * [JDK-8321513](https://bugs.openjdk.org/browse/JDK-8321513): SegmentAllocator:allocateFrom(AddressLayout, MemorySegment) does not throw stated UnsupportedOperationException (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16993/head:pull/16993` \
`$ git checkout pull/16993`

Update a local copy of the PR: \
`$ git checkout pull/16993` \
`$ git pull https://git.openjdk.org/jdk.git pull/16993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16993`

View PR using the GUI difftool: \
`$ git pr show -t 16993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16993.diff">https://git.openjdk.org/jdk/pull/16993.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16993#issuecomment-1842942975)