### PR TITLE
JDK-8320538: Obsolete CSS styles in collection framework doc-file

### DIFF
--- a/src/java.base/share/classes/java/util/doc-files/coll-index.html
+++ b/src/java.base/share/classes/java/util/doc-files/coll-index.html
@@ -29,16 +29,7 @@
 <head>
 <meta name="generator" content="HTML Tidy, see www.w3.org" />
 <title>The Collections Framework</title>
-
-<style type="text/css">
-/*<![CDATA[*/
-
-ul li, ul ul li {font-weight: normal;}
-pre             {margin-left: 42pt;}
-a               {font-weight: bold;}
-
-/*]]>*/
-</style>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 </head>
 <body>
 <h1>The Collections Framework</h1>


### PR DESCRIPTION
Please review a simple change to remove a stray inline CSS element from the Collection Framework index doc file. The only thing the `a {font-weight: bold;}` rule did was to make all links in the header and footer bold as [can be seen here][1]; the three content links to the other doc files are still displayed in bold font because they are contained in `<b>` tags. The other CSS rules had no effect in the page. 

[1]: https://download.java.net/java/early_access/jdk22/docs/api/java.base/java/util/doc-files/coll-index.html

Screenshot of the fixed page:
<img width="1082" alt="coll-framework-index" src="https://github.com/openjdk/jdk/assets/15975/0bd3b613-e535-438c-bd4d-7c8817df5702">

I also added the `<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">` meta tag which is present in all other pages (both doc-files and generated by JavaDoc).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320538](https://bugs.openjdk.org/browse/JDK-8320538): Obsolete CSS styles in collection framework doc-file (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16997/head:pull/16997` \
`$ git checkout pull/16997`

Update a local copy of the PR: \
`$ git checkout pull/16997` \
`$ git pull https://git.openjdk.org/jdk.git pull/16997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16997`

View PR using the GUI difftool: \
`$ git pr show -t 16997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16997.diff">https://git.openjdk.org/jdk/pull/16997.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16997#issuecomment-1843245641)