### PR TITLE
JDK-8263256: Test java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java fails due to dynamic reconfigurations of network interface during test

### DIFF
--- a/test/jdk/java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java
+++ b/test/jdk/java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java
+++ b/test/jdk/java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java
@@ -38,10 +38,16 @@ import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 
+import jdk.test.lib.Platform;
+import jdk.test.lib.NetworkConfiguration;
+
 /**
  * @test
  * @bug 8007373
  * @summary jdk7 backward compatibility serialization problem
+ * @library /test/lib
+ * @build jdk.test.lib.NetworkConfiguration
+ * @run main/othervm Inet6AddressSerializationTest
  */
 
 public class Inet6AddressSerializationTest {
@@ -177,10 +183,17 @@ public class Inet6AddressSerializationTest {
                 .getNetworkInterfaces(); e.hasMoreElements();) {
             NetworkInterface netIF = e.nextElement();
             // Skip (Windows)Teredo Tunneling Pseudo-Interface
+            String dName = netIF.getDisplayName();
             if (isWindows) {
-                String dName = netIF.getDisplayName();
                 if (dName != null && dName.contains("Teredo")) {
                     continue;
+                }
+            }
+            // skipp awdl and llw interfaces on macosx
+            if (Platform.isOSX()) {
+                if((dName != null) &&
+                        ((dName.contains("awdl")) || (dName.contains("llw")))) {
+                        continue;
                 }
             }
             for (Enumeration<InetAddress> iadrs = netIF.getInetAddresses(); iadrs
@@ -622,8 +635,8 @@ public class Inet6AddressSerializationTest {
                         + deserializedNetworkInterface);
                 failed = true;
             }
-        } else if (!expectedNetworkInterface
-                .equals(deserializedNetworkInterface)) {
+        } else if (!NetworkConfiguration.isSameInterface(expectedNetworkInterface,
+                      deserializedNetworkInterface)) {
             System.err.println("Error checking "
                     + // versionStr +
                     " NetworkInterface, expected:" + expectedNetworkInterface

--- a/test/jdk/java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java
+++ b/test/jdk/java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java
@@ -189,7 +189,7 @@ public class Inet6AddressSerializationTest {
                     continue;
                 }
             }
-            // skipp awdl and llw interfaces on macosx
+            // skip awdl and llw interfaces on macosx
             if (Platform.isOSX()) {
                 if((dName != null) &&
                         ((dName.contains("awdl")) || (dName.contains("llw")))) {


### PR DESCRIPTION
Test java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java fails fails due to dynamic reconfigurations of network interface during test - this fix uses the utility method NetworkConfiguration::isSameInterface to replace NetworkInterface::equals method call. Additionally, for macosx the awdl and llw interfaces are excluded from the test

Please oblige and review this change to address issue https://bugs.openjdk.org/browse/JDK-8263256

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8263256](https://bugs.openjdk.org/browse/JDK-8263256): Test java/net/Inet6Address/serialize/Inet6AddressSerializationTest.java fails due to dynamic reconfigurations of network interface during test (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [04c31fe5](https://git.openjdk.org/jdk/pull/16998/files/04c31fe58eae401ac222e8167828c95683c41d4a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16998/head:pull/16998` \
`$ git checkout pull/16998`

Update a local copy of the PR: \
`$ git checkout pull/16998` \
`$ git pull https://git.openjdk.org/jdk.git pull/16998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16998`

View PR using the GUI difftool: \
`$ git pr show -t 16998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16998.diff">https://git.openjdk.org/jdk/pull/16998.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16998#issuecomment-1843266832)