### PR TITLE
8321467: MemorySegment.setString(long, String, Charset) throws IAE(Misaligned access)

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/StringSupport.java
@@ -82,7 +82,7 @@ public final class StringSupport {
 
     private static void writeShort(MemorySegment segment, long offset, Charset charset, String string) {
         int bytes = copyBytes(string, segment, charset, offset);
-        segment.set(JAVA_SHORT, offset + bytes, (short)0);
+        segment.set(JAVA_SHORT_UNALIGNED, offset + bytes, (short)0);
     }
 
     private static String readInt(MemorySegment segment, long offset, Charset charset) {
@@ -94,7 +94,7 @@ public final class StringSupport {
 
     private static void writeInt(MemorySegment segment, long offset, Charset charset, String string) {
         int bytes = copyBytes(string, segment, charset, offset);
-        segment.set(JAVA_INT, offset + bytes, 0);
+        segment.set(JAVA_INT_UNALIGNED, offset + bytes, 0);
     }
 
     /**
@@ -222,7 +222,7 @@ public final class StringSupport {
 
         int offset = 0;
         for (; offset < headCount; offset += Short.BYTES) {
-            short curr = segment.get(JAVA_SHORT, start + offset);
+            short curr = segment.get(JAVA_SHORT_UNALIGNED, start + offset);
             if (curr == 0) {
                 return offset;
             }

--- a/test/jdk/java/foreign/TestStringEncoding.java
+++ b/test/jdk/java/foreign/TestStringEncoding.java
@@ -22,8 +22,6 @@
  *
  */
 
-import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
@@ -33,16 +31,12 @@ import java.lang.foreign.SegmentAllocator;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
-import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import jdk.internal.foreign.StringSupport;
@@ -333,6 +327,27 @@ public class TestStringEncoding {
         }
     }
 
+    @Test(dataProvider = "charsetsAndSegments")
+    public void testStringGetWithCharset(SupportedCharset charset, HeapSegment segment) {
+        for (int offset = 0 ; offset <= charset.align ; offset++) {
+            segment.segment.getString(offset, charset.charset);
+        }
+    }
+
+    @Test(dataProvider = "charsetsAndSegments")
+    public void testStringSetWithCharset(SupportedCharset charset, HeapSegment segment) {
+        for (int offset = 0 ; offset <= charset.align ; offset++) {
+            segment.segment.setString(offset, "H", charset.charset);
+        }
+    }
+
+    @Test(dataProvider = "charsetsAndSegments")
+    public void testStringAllocateFromWithCharset(SupportedCharset charset, HeapSegment segment) {
+        for (int offset = 0 ; offset <= charset.align ; offset++) {
+            SegmentAllocator.prefixAllocator(segment.segment.asSlice(offset)).allocateFrom("H", charset.charset);
+        }
+    }
+
     @DataProvider
     public static Object[][] strings() {
         return new Object[][]{
@@ -456,4 +471,52 @@ public class TestStringEncoding {
         }
     }
 
+    enum SupportedCharset {
+        ISO_8859_1(StandardCharsets.ISO_8859_1, 1),
+        US_ASCII(StandardCharsets.US_ASCII, 1),
+        UTF_8(StandardCharsets.UTF_8, 1),
+        UTF_16(StandardCharsets.UTF_16, 2),
+        UTF_16BE(StandardCharsets.UTF_16BE, 2),
+        UTF_16LE(StandardCharsets.UTF_16LE, 2),
+        UTF_32(StandardCharsets.UTF_32, 4),
+        UTF_32BE(StandardCharsets.UTF_32BE, 4),
+        UTF_32LE(StandardCharsets.UTF_32LE, 4);
+
+        final Charset charset;
+        final long align;
+
+        SupportedCharset(Charset charset, long align) {
+            this.charset = charset;
+            this.align = align;
+        }
+    }
+
+    enum HeapSegment {
+        BYTE(MemorySegment.ofArray(new byte[80]), 1),
+        CHAR(MemorySegment.ofArray(new char[40]), 2),
+        SHORT(MemorySegment.ofArray(new short[40]), 2),
+        INT(MemorySegment.ofArray(new int[20]), 4),
+        FLOAT(MemorySegment.ofArray(new float[20]), 4),
+        LONG(MemorySegment.ofArray(new long[10]), 8),
+        DOUBLE(MemorySegment.ofArray(new double[10]), 8);
+
+        final MemorySegment segment;
+        final long maxAlign;
+
+        HeapSegment(MemorySegment segment, long maxAlign) {
+            this.segment = segment;
+            this.maxAlign = maxAlign;
+        }
+    }
+
+    @DataProvider
+    public static Object[][] charsetsAndSegments() {
+        List<Object[]> values = new ArrayList<>();
+        for (SupportedCharset charset : SupportedCharset.values()) {
+            for (HeapSegment heapSegments : HeapSegment.values()) {
+                values.add(new Object[] { charset, heapSegments });
+            }
+        }
+        return values.toArray(Object[][]::new);
+    }
 }

--- a/test/jdk/java/foreign/TestStringEncoding.java
+++ b/test/jdk/java/foreign/TestStringEncoding.java
@@ -329,21 +329,21 @@ public class TestStringEncoding {
 
     @Test(dataProvider = "charsetsAndSegments")
     public void testStringGetWithCharset(Charset charset, MemorySegment segment) {
-        for (int offset = 0 ; offset < 5 ; offset++) {
+        for (int offset = 0 ; offset < Long.BYTES ; offset++) {
             segment.getString(offset, charset);
         }
     }
 
     @Test(dataProvider = "charsetsAndSegments")
     public void testStringSetWithCharset(Charset charset, MemorySegment segment) {
-        for (int offset = 0 ; offset < 5 ; offset++) {
+        for (int offset = 0 ; offset < Long.BYTES ; offset++) {
             segment.setString(offset, "H", charset);
         }
     }
 
     @Test(dataProvider = "charsetsAndSegments")
     public void testStringAllocateFromWithCharset(Charset charset, MemorySegment segment) {
-        for (int offset = 0 ; offset < 5 ; offset++) {
+        for (int offset = 0 ; offset < Long.BYTES ; offset++) {
             SegmentAllocator.prefixAllocator(segment.asSlice(offset)).allocateFrom("H", charset);
         }
     }


### PR DESCRIPTION
This PR fixes a couple of aligned accesses when reading/writing strings. Such aligned accesses crept in when we optimized string read/write operations to work in bulk. As a result, depending on the maximum alignment constraints supported by the heap segment, some string operations might fail.

I've added some tests to make sure that all operations work as expected with unaligned semantics.

Note: I've considered inferring an alignment constraint from the provided charset, and then use aligned operations (and document that behavior), but I found that to be unsatisfactory: memory operations typically accept a layout, which allow clients to opt out from alignment checks if needed. But if we always infer an alignment constraint from the provided charset, clients would find themselves w/o an escape hatch. For this reason, I think the best way to fix this is to use unaligned operations when reading/writing the string.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321467](https://bugs.openjdk.org/browse/JDK-8321467): MemorySegment.setString(long, String, Charset) throws IAE(Misaligned access) (**Bug** - P3)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/16999/head:pull/16999` \
`$ git checkout pull/16999`

Update a local copy of the PR: \
`$ git checkout pull/16999` \
`$ git pull https://git.openjdk.org/jdk.git pull/16999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16999`

View PR using the GUI difftool: \
`$ git pr show -t 16999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/16999.diff">https://git.openjdk.org/jdk/pull/16999.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/16999#issuecomment-1843290413)