### PR TITLE
8320805: JFR: Create view for deprecated methods

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Aggregator.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Aggregator.java
@@ -57,6 +57,10 @@ enum Aggregator {
      */
     LIST("LIST"),
     /**
+     * Aggregate unique values into a comma-separated list, including {@code null}.
+     */
+    SET("SET"),
+    /**
      * The highest numeric value.
      */
     MAXIMUM("MAX"),

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
@@ -28,7 +28,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -122,17 +121,14 @@ final class FieldBuilder {
             configureNotInitFrameField();
             return true;
         }
-
         if (fieldName.equals("stackTrace.topFrame.class")) {
             configureTopFrameClassField();
             return true;
         }
-
         if (fieldName.equals("stackTrace.topFrame")) {
             configureTopFrameField();
             return true;
         }
-
         if (fieldName.equals("id") && field.type.getName().equals("jdk.ActiveSetting")) {
             configureEventTypeIdField();
             return true;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
@@ -123,10 +123,16 @@ final class FieldBuilder {
             return true;
         }
 
+        if (fieldName.equals("stackTrace.topFrame.class")) {
+            configureTopFrameClassField();
+            return true;
+        }
+
         if (fieldName.equals("stackTrace.topFrame")) {
             configureTopFrameField();
             return true;
         }
+
         if (fieldName.equals("id") && field.type.getName().equals("jdk.ActiveSetting")) {
             configureEventTypeIdField();
             return true;
@@ -171,6 +177,20 @@ final class FieldBuilder {
         field.valueGetter = e -> {
             RecordedStackTrace t = e.getStackTrace();
             return t != null ? t.getFrames().getFirst() : null;
+        };
+        field.lexicalSort = true;
+    }
+
+    private void configureTopFrameClassField() {
+        field.alignLeft = true;
+        field.label = "Class";
+        field.dataType = "java.lang.Class";
+        field.valueGetter = e -> {
+            RecordedStackTrace t = e.getStackTrace();
+            if (t == null) {
+                return null;
+            }
+            return t.getFrames().getFirst().getMethod().getType();
         };
         field.lexicalSort = true;
     }
@@ -379,7 +399,7 @@ final class FieldBuilder {
             field.alignLeft = false;
             field.lexicalSort = false;
         }
-        if (aggregator == Aggregator.LIST) {
+        if (aggregator == Aggregator.LIST || aggregator == Aggregator.SET) {
             field.alignLeft = true;
             field.lexicalSort = true;
         }
@@ -392,6 +412,7 @@ final class FieldBuilder {
             case SUM -> "Total " + field.label;
             case UNIQUE -> "Unique Count " + field.label;
             case LIST -> field.label + "s";
+            case SET -> field.label + "s";
             case MISSING -> field.label;
             case DIFFERENCE -> "Difference " + field.label;
             case MEDIAN -> "Median " + field.label;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldFormatter.java
@@ -27,6 +27,8 @@ package jdk.jfr.internal.query;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.StringJoiner;
 
 import jdk.jfr.consumer.RecordedClass;
 import jdk.jfr.consumer.RecordedClassLoader;
@@ -51,6 +53,13 @@ public class FieldFormatter {
         if (object == null) {
             return field.missingText;
         }
+        if (object instanceof Collection<?> c) {
+            StringJoiner sj = new StringJoiner(", ");
+            for (Object o : c) {
+                sj.add(format(field, o, compact));
+            }
+            return sj.toString();
+        }
         if (object instanceof String s) {
             return stripFormatting(s);
         }
@@ -69,6 +78,10 @@ public class FieldFormatter {
         }
         if (object instanceof Integer i && i == Integer.MIN_VALUE) {
             return field.missingText;
+        }
+
+        if (object instanceof RecordedFrame f && f.isJavaFrame()) {
+            object = f.getMethod();
         }
 
         if (object instanceof RecordedThread t) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
@@ -28,10 +28,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.StringJoiner;
 
 abstract class Function {
 
@@ -46,7 +46,11 @@ abstract class Function {
             return new FirstNonNull();
         }
         if (aggregator == Aggregator.LIST) {
-            return new List();
+            return new Container(new ArrayList<>());
+        }
+
+        if (aggregator == Aggregator.SET) {
+            return new Container(new HashSet<>());
         }
 
         if (aggregator == Aggregator.DIFFERENCE) {
@@ -391,23 +395,22 @@ abstract class Function {
         }
     }
 
-    // **** LIST ****
+    // **** LIST and SET ****
 
-    private static final class List extends Function {
-        private final ArrayList<Object> list = new ArrayList<>();
+    private static final class Container extends Function {
+        private final Collection<Object> collection;
 
+        private Container(Collection<Object> collection) {
+            this.collection = collection;
+        }
         @Override
         public void add(Object value) {
-            list.add(value);
+            collection.add(value);
         }
 
         @Override
         public Object result() {
-            StringJoiner sj = new StringJoiner(", ");
-            for (Object object : list) {
-                sj.add(String.valueOf(object));
-            }
-            return sj.toString();
+            return collection;
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
@@ -30,7 +30,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 abstract class Function {
@@ -50,7 +50,7 @@ abstract class Function {
         }
 
         if (aggregator == Aggregator.SET) {
-            return new Container(new HashSet<>());
+            return new Container(new LinkedHashSet<>());
         }
 
         if (aggregator == Aggregator.DIFFERENCE) {
@@ -382,7 +382,7 @@ abstract class Function {
     // **** UNIQUE ****
 
     private static final class Unique extends Function {
-        private final Set<Object> unique = new HashSet<>();
+        private final Set<Object> unique = new LinkedHashSet<>();
 
         @Override
         public void add(Object value) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableCell.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableCell.java
@@ -25,6 +25,7 @@
 package jdk.jfr.internal.query;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import jdk.jfr.internal.query.Configuration.Truncate;
 
@@ -69,7 +70,7 @@ final class TableCell {
     }
     public void addLine(String text) {
         int contentWidth = getContentWidth();
-        if (text.length() >= contentWidth) {
+        if (text.length() > contentWidth) {
             add(truncate(text, contentWidth));
         } else {
             addAligned(text);
@@ -141,6 +142,10 @@ final class TableCell {
             }
             lines.add(text.substring(index, end));
         }
+    }
+
+    public void sort() {
+        Collections.sort(lines);
     }
 
     public void clear() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableRenderer.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableRenderer.java
@@ -32,10 +32,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
-import jdk.jfr.consumer.RecordedClass;
-import jdk.jfr.consumer.RecordedObject;
-import jdk.jfr.consumer.RecordedFrame;
-import jdk.jfr.consumer.RecordedMethod;
 import jdk.jfr.consumer.RecordedStackTrace;
 import jdk.jfr.internal.query.Configuration.Truncate;
 import jdk.jfr.internal.util.Output;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableRenderer.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableRenderer.java
@@ -28,9 +28,12 @@ import static jdk.jfr.internal.query.Configuration.MAX_PREFERRED_WIDTH;
 import static jdk.jfr.internal.query.Configuration.MIN_PREFERRED_WIDTH;
 import static jdk.jfr.internal.query.Configuration.PREFERRED_WIDTH;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedObject;
 import jdk.jfr.consumer.RecordedFrame;
 import jdk.jfr.consumer.RecordedMethod;
 import jdk.jfr.consumer.RecordedStackTrace;
@@ -293,36 +296,38 @@ final class TableRenderer {
         if (cell.cellHeight > 1) {
             Object o = row.getValue(columnIndex);
             if (o instanceof RecordedStackTrace s) {
-                setStackTrace(cell, s);
+                o = s.getFrames();
+            }
+            if (o instanceof Collection<?> c) {
+                setMultiline(cell, c);
                 return;
             }
         }
 
         if (text.length() > cell.getContentSize()) {
             Object o = row.getValue(columnIndex);
-
             cell.setContent(FieldFormatter.formatCompact(cell.field, o));
             return;
         }
         cell.setContent(text);
     }
 
-    private void setStackTrace(TableCell cell, RecordedStackTrace s) {
+    private void setMultiline(TableCell cell, Collection<?> objects) {
         int row = 0;
         cell.clear();
-        for(RecordedFrame f : s.getFrames()) {
+        for(Object object : objects) {
             if (row == cell.cellHeight) {
                 return;
             }
-            if (f.isJavaFrame()) {
-                RecordedMethod method = f.getMethod();
-                String text = FieldFormatter.format(cell.field, method);
-                if (text.length() > cell.getContentWidth()) {
-                    text = FieldFormatter.formatCompact(cell.field, method);
-                }
-                cell.addLine(text);
+            String text = FieldFormatter.format(cell.field, object);
+            if (text.length() > cell.getContentWidth()) {
+                text = FieldFormatter.formatCompact(cell.field, object);
             }
+            cell.addLine(text);
             row++;
+        }
+        if (cell.field.lexicalSort) {
+            cell.sort();
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -173,6 +173,16 @@ table = "COLUMN 'Monitor Address', 'Class', 'Threads', 'Max Duration'
          FROM JavaMonitorEnter
          GROUP BY monitorClass ORDER BY M"
 
+[application.deprecated-methods-for-removal]
+label = "Deprecated Methods for Removal"
+table = "COLUMN 'Deprecated Method', 'Called from Class'
+         FORMAT truncate-beginning, cell-height:10000;truncate-beginning
+         SELECT method AS m, SET(stackTrace.topFrame.class)
+         FROM DeprecatedInvocation
+         WHERE forRemoval = 'true'
+         GROUP BY m
+         ORDER BY m"
+
 [environment.cpu-information]
 label ="CPU Information"
 form = "SELECT cpu, sockets, cores, hwThreads, description FROM CPUInformation"


### PR DESCRIPTION
Could I have a review of a new view for the 'jfr' command to display deprecated methods for removal.

Usage:

`$ jfr view deprecated-methods-for-removal <recording-file>`

If the package name doesn't fit, the _--width size_ option can be specified.

A new aggregator function SET is introduced and if the cell-height is more than 1, items in the set, or list, are written on separate lines. I also added support for the synthetic field "stackTrace.topFrame.class". Long term plan is to allow ".class" suffix on any method/frame field, not just the topFrame. Elipsis is no longer used when contents exactly matches the column width. Switched to LinkedHashSet to make results deterministic and in the order items are found in the file.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320805](https://bugs.openjdk.org/browse/JDK-8320805): JFR: Create view for deprecated methods (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17000/head:pull/17000` \
`$ git checkout pull/17000`

Update a local copy of the PR: \
`$ git checkout pull/17000` \
`$ git pull https://git.openjdk.org/jdk.git pull/17000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17000`

View PR using the GUI difftool: \
`$ git pr show -t 17000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17000.diff">https://git.openjdk.org/jdk/pull/17000.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17000#issuecomment-1843418589)