### PR TITLE
8321164: javac with annotation processor throws AssertionError: Filling jrt:/... during JarFileObject[/...]

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -2407,20 +2407,27 @@ public class Types {
     }
     // where
         private TypeMapping<Boolean> erasure = new StructuralTypeMapping<Boolean>() {
+            @SuppressWarnings("fallthrough")
             private Type combineMetadata(final Type s,
                                          final Type t) {
                 if (t.getMetadata().nonEmpty()) {
-                    switch (s.getKind()) {
-                        case OTHER:
-                        case UNION:
-                        case INTERSECTION:
-                        case PACKAGE:
-                        case EXECUTABLE:
-                        case NONE:
-                        case VOID:
-                        case ERROR:
+                    switch (s.getTag()) {
+                        case CLASS:
+                            if (s instanceof UnionClassType ||
+                                s instanceof IntersectionClassType) {
+                                return s;
+                            }
+                            //fall-through
+                        case BYTE, CHAR, SHORT, LONG, FLOAT, INT, DOUBLE, BOOLEAN,
+                             ARRAY, MODULE, TYPEVAR, WILDCARD:
+                            return s.dropMetadata(Annotations.class);
+                        case VOID, METHOD, PACKAGE, FORALL, DEFERRED, BOT,
+                             NONE, ERROR, UNKNOWN, UNDETVAR, UNINITIALIZED_THIS,
+                             UNINITIALIZED_OBJECT:
                             return s;
-                        default: return s.dropMetadata(Annotations.class);
+                        default:
+                            throw new AssertionError(s.getTag().name());
+                        
                     }
                 } else {
                     return s;

--- a/test/langtools/tools/javac/annotations/ReadingMethodWithTypeAnno.java
+++ b/test/langtools/tools/javac/annotations/ReadingMethodWithTypeAnno.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8321164
+ * @summary Indirectly verify that types.erasure does not complete, called from
+ *          ClassReader.isSameBinaryType, which must not complete.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.JavacTask toolbox.TestRunner toolbox.ToolBox
+ * @run main ReadingMethodWithTypeAnno
+ */
+
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import toolbox.JavacTask;
+import toolbox.Task.Expect;
+import toolbox.Task.OutputKind;
+import toolbox.TestRunner;
+import toolbox.ToolBox;
+
+public class ReadingMethodWithTypeAnno extends TestRunner {
+    public static void main(String... args) throws Exception {
+        ReadingMethodWithTypeAnno r = new ReadingMethodWithTypeAnno();
+        r.runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    public ReadingMethodWithTypeAnno() throws IOException {
+        super(System.err);
+    }
+
+    @Test
+    public void test_DeclNone_UseNone(Path base) throws IOException {
+        Path libSrc = base.resolve("lib-src");
+        Path libClasses = Files.createDirectories(base.resolve("lib-classes"));
+
+        tb.writeJavaFiles(libSrc,
+                          """
+                          public class Lib {
+                              public void test(java.lang.@Ann String s) {
+                                  new Object() {};
+                              }
+                          }
+                          """,
+                          """
+                          import java.lang.annotation.ElementType;
+                          import java.lang.annotation.Target;
+                          @Target(ElementType.TYPE_USE)
+                          public @interface Ann {}
+                          """);
+
+        new JavacTask(tb)
+                .outdir(libClasses)
+                .files(tb.findJavaFiles(libSrc))
+                .run(Expect.SUCCESS)
+                .writeAll()
+                .getOutput(OutputKind.DIRECT);
+
+        Path src = base.resolve("src");
+        Path classes = Files.createDirectories(base.resolve("classes"));
+
+        tb.writeJavaFiles(src,
+                          """
+                          public class Test {
+                          }
+                          """);
+
+        new JavacTask(tb)
+                .outdir(classes)
+                .classpath(libClasses)
+                .files(tb.findJavaFiles(src))
+                .callback(task -> {
+                    task.addTaskListener(new TaskListener() {
+                        @Override
+                        public void finished(TaskEvent e) {
+                            if (e.getKind() == TaskEvent.Kind.ENTER) {
+                                task.getElements().getTypeElement("Lib");
+                                task.getElements().getTypeElement("Lib$1");
+                            }
+                        }
+                    });
+                })
+                .run(Expect.SUCCESS)
+                .writeAll()
+                .getOutput(OutputKind.DIRECT);
+    }
+
+}
+


### PR DESCRIPTION
This is a latent bug revealed by the recent JDK-8225377/https://git.openjdk.org/jdk/commit/de6667cf11aa59d1bab78ae5fb235ea0b901d5c4.

The problem (to my understanding) is as follows:
 - `ClassReader` cannot be used recursively, i.e. while completing one class from a classfile, we cannot complete another one. `ClassReader` carefully avoids situations like this.
 - when reading an anonymous class, the `EnclosingMethod` attribute is read, and the enclosing method must be found. `ClassReader` uses a special `ClassReader. isSameBinaryType` method, that is supposed to avoid completion:
https://github.com/openjdk/jdk/blob/3edc24a71d29632e0a2166a64fc25ce83f631b47/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java#L1401
 - the `isSameBinaryType` method uses erasure, and if the given type has type annotations, the erasure will try to remove the annotations:
https://github.com/openjdk/jdk/blob/3edc24a71d29632e0a2166a64fc25ce83f631b47/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java#L2423

The problem is that this method uses `Type.getKind()` which completes.

The proposal in this patch is to avoid the completion by not using `getKind`, but rather `getTag`. While I am not completely sure why the code avoids doing `dropMetadata` for some types, I tried to replicate the existing behavior. One caveat is that certain types may have `getTag() == CLASS`, but `getKind() == ERROR` (e.g. if the class is not found). The new code is not replicating this aspect, as we cannot reliably determine whether a `ClassType` is erroneous or not without completing it. But, it is not clear to me why dropping annotations from an erroneous `ClassType` should be problematic.
