### PR TITLE
JDK-8321484: Make TestImplicitlyDeclaredClasses release independent

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testImplicitlyDeclaredClasses/TestImplicitlyDeclaredClasses.java
+++ b/test/langtools/jdk/javadoc/doclet/testImplicitlyDeclaredClasses/TestImplicitlyDeclaredClasses.java
@@ -65,7 +65,7 @@ public class TestImplicitlyDeclaredClasses extends JavadocTester {
                         .collect(Collectors.joining("\n")));
                 // TODO: remove preview-related options once "Implicitly Declared
                 //  Classes and Instance Main Methods" has been standardized
-                javadoc("--enable-preview", "--source=22",
+                javadoc("--enable-preview", "--source=" + Runtime.version().feature(),
                         "-d", base.resolve("out-" + index).toString(),
                         src.toString());
 


### PR DESCRIPTION
Simple test fix ahead of the fork.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321484](https://bugs.openjdk.org/browse/JDK-8321484): Make TestImplicitlyDeclaredClasses release independent (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17003/head:pull/17003` \
`$ git checkout pull/17003`

Update a local copy of the PR: \
`$ git checkout pull/17003` \
`$ git pull https://git.openjdk.org/jdk.git pull/17003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17003`

View PR using the GUI difftool: \
`$ git pr show -t 17003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17003.diff">https://git.openjdk.org/jdk/pull/17003.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17003#issuecomment-1843704077)