### PR TITLE
8321409: Console read line with zero out should zero out underlying buffer in JLine (redux)

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -114,7 +114,7 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
             } catch (EndOfFileException eofe) {
                 return null;
             } finally {
-                jline.getBuffer().zeroOut();
+                jline.zeroOut();
             }
         }
 

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/LineReader.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/LineReader.java
@@ -750,4 +750,9 @@ public interface LineReader {
     void setAutosuggestion(SuggestionType type);
 
     SuggestionType getAutosuggestion();
+
+    // JDK specific modification
+    default void zeroOut() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/LineReaderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/reader/impl/LineReaderImpl.java
@@ -6250,4 +6250,10 @@ public class LineReaderImpl implements LineReader, Flushable
         }
     }
 
+    // JDK specific modification
+    @Override
+    public void zeroOut() {
+        buf.zeroOut();
+        parsedLine = null;
+    }
 }


### PR DESCRIPTION
This is an additional fix to JDK-8321131, where more clearing is required in JLine.