### PR TITLE
8321474: TestAutoCreateSharedArchiveUpgrade.java should be updated with JDK 21

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java
@@ -90,7 +90,7 @@ public class TestAutoCreateSharedArchiveUpgrade {
             try {
                 setupJVMs(Integer.parseInt(versions[i]));
                 doTest();
-            } catch (RuntimeException e) {
+            } catch (NumberFormatException  e) {
                 throw new RuntimeException("Invalid AutoCreateSharedArchive JDK version: " + versions[i]);
             }
         }
@@ -103,21 +103,8 @@ public class TestAutoCreateSharedArchiveUpgrade {
 
         newJVM = TEST_JDK + FS + "bin" + FS + "java";
 
-        //
-        if (fetchVersion < 19 && fetchVersion > 0) {
-            throw new RuntimeException("Unsupported JDK version " + fetchVersion);
-        } else if (fetchVersion >= 19) {
-            oldJVM = fetchJDK(fetchVersion) + FS + "bin" + FS + "java";
-        } else if (PREV_JDK != null) {
-            oldJVM = PREV_JDK + FS + "bin" + FS + "java";
-        } else if (BOOT_JDK != null) {
-            oldJVM = BOOT_JDK + FS + "bin" + FS + "java";
-        } else {
-            throw new SkippedException("Use -Dtest.previous.jdk or -Dtest.boot.jdk to specify a " +
-                                       "previous version of the JDK that supports " +
-                                       "-XX:+AutoCreateSharedArchive");
-        }
-
+        // Version 0 is used here to indicate that no version is supplied so that
+        // PREV_JDK or BOOT_JDK are used
         if (fetchVersion >= 19) {
             oldJVM = fetchJDK(fetchVersion) + FS + "bin" + FS + "java";
         } else if (fetchVersion > 0) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java
@@ -103,7 +103,8 @@ public class TestAutoCreateSharedArchiveUpgrade {
 
         newJVM = TEST_JDK + FS + "bin" + FS + "java";
 
-        if (fetchVersion < 19) {
+        //
+        if (fetchVersion < 19 && fetchVersion > 0) {
             throw new RuntimeException("Unsupported JDK version " + fetchVersion);
         } else if (fetchVersion >= 19) {
             oldJVM = fetchJDK(fetchVersion) + FS + "bin" + FS + "java";
@@ -115,6 +116,20 @@ public class TestAutoCreateSharedArchiveUpgrade {
             throw new SkippedException("Use -Dtest.previous.jdk or -Dtest.boot.jdk to specify a " +
                                        "previous version of the JDK that supports " +
                                        "-XX:+AutoCreateSharedArchive");
+        }
+
+        if (fetchVersion >= 19) {
+            oldJVM = fetchJDK(fetchVersion) + FS + "bin" + FS + "java";
+        } else if (fetchVersion > 0) {
+            throw new RuntimeException("Unsupported JDK version " + fetchVersion);
+        } else if (PREV_JDK != null) {
+            oldJVM = PREV_JDK + FS + "bin" + FS + "java";
+        } else if (BOOT_JDK != null) {
+            oldJVM = BOOT_JDK + FS + "bin" + FS + "java";
+        } else {
+            throw new SkippedException("Use -Dtest.previous.jdk or -Dtest.boot.jdk to specify a " +
+                                      "previous version of the JDK that supports " +
+                                      "-XX:+AutoCreateSharedArchive");
         }
 
         System.out.println("Using newJVM = " + newJVM);

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java
@@ -30,7 +30,7 @@
  * @library /test/lib
  * @compile -source 1.8 -target 1.8 ../test-classes/HelloJDK8.java
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar Hello.jar HelloJDK8
- * @run driver TestAutoCreateSharedArchiveUpgrade
+ * @run driver/timeout=600 TestAutoCreateSharedArchiveUpgrade
  */
 
 import java.io.File;
@@ -52,7 +52,7 @@ public class TestAutoCreateSharedArchiveUpgrade {
     // the JDK using "jtreg -vmoption:-Dtest.previous.jdk=${JDK19_HOME} ..."
     private static final String PREV_JDK = System.getProperty("test.previous.jdk", null);
 
-    // If you're unning this test using something like
+    // If you're running this test using something like
     // "make test TEST=test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java",
     // the test.boot.jdk property is normally passed by make/RunTests.gmk
     private static String BOOT_JDK = System.getProperty("test.boot.jdk", null);
@@ -90,7 +90,7 @@ public class TestAutoCreateSharedArchiveUpgrade {
             try {
                 setupJVMs(Integer.parseInt(versions[i]));
                 doTest();
-            } catch (NumberFormatException e) {
+            } catch (RuntimeException e) {
                 throw new RuntimeException("Invalid AutoCreateSharedArchive JDK version: " + versions[i]);
             }
         }
@@ -103,7 +103,9 @@ public class TestAutoCreateSharedArchiveUpgrade {
 
         newJVM = TEST_JDK + FS + "bin" + FS + "java";
 
-        if (fetchVersion >= 19) {
+        if (fetchVersion < 19) {
+            throw new RuntimeException("Unsupported JDK version " + fetchVersion);
+        } else if (fetchVersion >= 19) {
             oldJVM = fetchJDK(fetchVersion) + FS + "bin" + FS + "java";
         } else if (PREV_JDK != null) {
             oldJVM = PREV_JDK + FS + "bin" + FS + "java";
@@ -186,6 +188,9 @@ public class TestAutoCreateSharedArchiveUpgrade {
                 break;
             case 20:
                 build = 29;
+                break;
+            case 21:
+                build = 35;
                 break;
             default:
                 throw new RuntimeException("Unsupported JDK version " + version);

--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchiveUpgrade.java
@@ -90,7 +90,7 @@ public class TestAutoCreateSharedArchiveUpgrade {
             try {
                 setupJVMs(Integer.parseInt(versions[i]));
                 doTest();
-            } catch (NumberFormatException  e) {
+            } catch (NumberFormatException e) {
                 throw new RuntimeException("Invalid AutoCreateSharedArchive JDK version: " + versions[i]);
             }
         }
@@ -115,8 +115,8 @@ public class TestAutoCreateSharedArchiveUpgrade {
             oldJVM = BOOT_JDK + FS + "bin" + FS + "java";
         } else {
             throw new SkippedException("Use -Dtest.previous.jdk or -Dtest.boot.jdk to specify a " +
-                                      "previous version of the JDK that supports " +
-                                      "-XX:+AutoCreateSharedArchive");
+                                       "previous version of the JDK that supports " +
+                                       "-XX:+AutoCreateSharedArchive");
         }
 
         System.out.println("Using newJVM = " + newJVM);


### PR DESCRIPTION
This test needs to be updated with each release since the release build number is hard coded. Now that the test has to download and install more JDKs, it will take longer to run and may timeout. A longer timeout is added as well as a minor correction where an exception was not being thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321474](https://bugs.openjdk.org/browse/JDK-8321474): TestAutoCreateSharedArchiveUpgrade.java should be updated with JDK 21 (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [9637b473](https://git.openjdk.org/jdk/pull/17005/files/9637b473cc0ae943529ee4a1b1a2d53066e641c5)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17005/head:pull/17005` \
`$ git checkout pull/17005`

Update a local copy of the PR: \
`$ git checkout pull/17005` \
`$ git pull https://git.openjdk.org/jdk.git pull/17005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17005`

View PR using the GUI difftool: \
`$ git pr show -t 17005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17005.diff">https://git.openjdk.org/jdk/pull/17005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17005#issuecomment-1845873606)