### PR TITLE
8321180: Condition for non-latin1 string size too large exception is off by one

### DIFF
--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -42,15 +42,10 @@ import static java.lang.String.LATIN1;
 
 final class StringUTF16 {
 
+    // Return a new byte array for a UTF16-coded string for len chars
+    // Throw an exception if out of range
     public static byte[] newBytesFor(int len) {
-        if (len < 0) {
-            throw new NegativeArraySizeException();
-        }
-        if (len > MAX_LENGTH) {
-            throw new OutOfMemoryError("UTF16 String size is " + len +
-                                       ", should be less than " + MAX_LENGTH);
-        }
-        return new byte[len << 1];
+        return new byte[newBytesLength(len)];
     }
 
     // Check the size of a UTF16-coded string
@@ -59,9 +54,9 @@ final class StringUTF16 {
         if (len < 0) {
             throw new NegativeArraySizeException();
         }
-        if (len > MAX_LENGTH) {
+        if (len >= MAX_LENGTH) {
             throw new OutOfMemoryError("UTF16 String size is " + len +
-                                       ", should be less than " + MAX_LENGTH);
+                                       ", should be less than or equal to " + MAX_LENGTH);
         }
         return len << 1;
     }

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -56,7 +56,7 @@ final class StringUTF16 {
         }
         if (len >= MAX_LENGTH) {
             throw new OutOfMemoryError("UTF16 String size is " + len +
-                                       ", should be less than or equal to " + MAX_LENGTH);
+                                       ", should be less than " + MAX_LENGTH);
         }
         return len << 1;
     }

--- a/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
+++ b/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 /*
  * @test
@@ -44,23 +43,17 @@ public class MaxSizeUTF16String {
 
     // Create a large UTF-8 byte array with a single non-latin1 character
     private static byte[] generateUTF8Data(int byteSize) {
-        byte[] nonAscii = "\u0100".getBytes();
-        int nonAsciiSize = nonAscii.length;
-        int asciisize = byteSize - nonAsciiSize;
-        byte[] arr = new byte[asciisize + nonAsciiSize];
-        Arrays.fill(arr, (byte)'x');      // fill with latin1
-        System.arraycopy(nonAscii, 0, arr, 0, nonAsciiSize); // non-latin1 at start
+        byte[] nonAscii = "\u0100".getBytes(StandardCharsets.UTF_8);
+        byte[] arr = new byte[byteSize];
+        System.arraycopy(nonAscii, 0, arr, 0, nonAscii.length); // non-latin1 at start
         return arr;
     }
 
     // Create a large char array with a single non-latin1 character
     private static char[] generateCharData(int size) {
         char[] nonAscii = "\u0100".toCharArray();
-        int nonAsciiSize = nonAscii.length;
-        int asciisize = size - nonAsciiSize;
-        char[] arr = new char[asciisize + nonAsciiSize];
-        Arrays.fill(arr, 'x');      // fill with latin1
-        System.arraycopy(nonAscii, 0, arr, 0, nonAsciiSize); // non-latin1 at start
+        char[] arr = new char[size];
+        System.arraycopy(nonAscii, 0, arr, 0, nonAscii.length); // non-latin1 at start
         return arr;
     }
 

--- a/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
+++ b/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/*
+ * @test
+ * @bug 8077559 8321180
+ * @summary Tests Compact String for maximum size strings
+ * @requires os.maxMemory >= 7g & vm.bits == 64
+ * @run junit/othervm -XX:+CompactStrings -Xmx7g MaxSizeUTF16String
+ * @run junit/othervm -XX:-CompactStrings -Xmx7g MaxSizeUTF16String
+ */
+
+public class MaxSizeUTF16String {
+
+    private final static int MAX_UTF16_STRING_LENGTH = Integer.MAX_VALUE / 2;
+
+    private final static String EXPECTED_OOME_MESSAGE = "UTF16 String size is";
+
+    // Create a large UTF-8 byte array with a single non-latin1 character
+    private static byte[] generateUTF8Data(int byteSize) {
+        byte[] nonAscii = "\u0100".getBytes();
+        int nonAsciiSize = nonAscii.length;
+        int asciisize = byteSize - nonAsciiSize;
+        byte[] arr = new byte[asciisize + nonAsciiSize];
+        Arrays.fill(arr, (byte)'x');      // fill with latin1
+        System.arraycopy(nonAscii, 0, arr, 0, nonAsciiSize); // non-latin1 at start
+        return arr;
+    }
+
+    // Create a large char array with a single non-latin1 character
+    private static char[] generateCharData(int size) {
+        char[] nonAscii = "\u0100".toCharArray();
+        int nonAsciiSize = nonAscii.length;
+        int asciisize = size - nonAsciiSize;
+        char[] arr = new char[asciisize + nonAsciiSize];
+        Arrays.fill(arr, 'x');      // fill with latin1
+        System.arraycopy(nonAscii, 0, arr, 0, nonAsciiSize); // non-latin1 at start
+        return arr;
+    }
+
+    @Test
+    public void testMaxUTF8() {
+        // Overly large UTF-8 data with 1 non-latin1 char
+        final byte[] large_utf8_bytes = generateUTF8Data(MAX_UTF16_STRING_LENGTH + 1);
+        int[] sizes = new int[] {
+                MAX_UTF16_STRING_LENGTH + 1,
+                MAX_UTF16_STRING_LENGTH,
+                MAX_UTF16_STRING_LENGTH - 1};
+        for (int size : sizes) {
+            System.err.println("Checking max UTF16 string len: " + size);
+            try {
+                // Use only part of the UTF-8 byte array
+                new String(large_utf8_bytes, 0, size, StandardCharsets.UTF_8);
+                if (size >= MAX_UTF16_STRING_LENGTH) {
+                    fail("Expected OutOfMemoryError with message prefix: " + EXPECTED_OOME_MESSAGE);
+                }
+            } catch (OutOfMemoryError ex) {
+                if (!ex.getMessage().startsWith(EXPECTED_OOME_MESSAGE)) {
+                    fail("Failed: Not the OutOfMemoryError expected", ex);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMaxCharArray() {
+        // Overly large UTF-8 data with 1 non-latin1 char
+        final char[] large_char_array = generateCharData(MAX_UTF16_STRING_LENGTH + 1);
+        int[] sizes = new int[]{
+                MAX_UTF16_STRING_LENGTH + 1,
+                MAX_UTF16_STRING_LENGTH,
+                MAX_UTF16_STRING_LENGTH - 1};
+        for (int size : sizes) {
+            System.err.println("Checking max UTF16 string len: " + size);
+            try {
+                // Large char array with 1 non-latin1 char
+                new String(large_char_array, 0, size);
+                if (size >= MAX_UTF16_STRING_LENGTH) {
+                    fail("Expected OutOfMemoryError with message prefix: " + EXPECTED_OOME_MESSAGE);
+                }
+            } catch (OutOfMemoryError ex) {
+                if (!ex.getMessage().startsWith(EXPECTED_OOME_MESSAGE)) {
+                    throw new RuntimeException("Wrong exception message: " + ex.getMessage(), ex);
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
+++ b/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
@@ -22,9 +22,6 @@
  */
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.Arguments;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
In the compact string implementation of non-latin1 (UTF16) strings the length is constrained by VM implementation limit on the size a byte array that can be allocated. To produce a useful exception the implementation checks the string size against the maximum byte array size. The exception message is correct
```
"UTF16 String size is " + len + ", should be less than or equal to " + MAX_LENGTH
```
The code should match the message, otherwise the exception thrown is: 
```
java.lang.OutOfMemoryError: Requested array size exceeds VM limit 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321180](https://bugs.openjdk.org/browse/JDK-8321180): Condition for non-latin1 string size too large exception is off by one (**Bug** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17008/head:pull/17008` \
`$ git checkout pull/17008`

Update a local copy of the PR: \
`$ git checkout pull/17008` \
`$ git pull https://git.openjdk.org/jdk.git pull/17008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17008`

View PR using the GUI difftool: \
`$ git pr show -t 17008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17008.diff">https://git.openjdk.org/jdk/pull/17008.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17008#issuecomment-1843861134)