### PR TITLE
8270269: Desktop.browse method fails if earlier CoInitialize call as COINIT_MULTITHREADED

### DIFF
--- a/src/java.desktop/windows/classes/sun/awt/windows/WDesktopPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WDesktopPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,8 @@ import java.io.IOException;
 import java.net.URI;
 
 import javax.swing.event.EventListenerList;
+
+import sun.awt.shell.ShellFolder;
 
 /**
  * Concrete implementation of the interface {@code DesktopPeer} for
@@ -102,18 +104,20 @@ final class WDesktopPeer implements DesktopPeer {
     }
 
     private void ShellExecute(File file, String verb) throws IOException {
-        String errMsg = ShellExecute(file.getAbsolutePath(), verb);
+        String errMsg = ShellFolder.invoke(
+                () -> ShellExecute(file.getAbsolutePath(), verb));
         if (errMsg != null) {
-            throw new IOException("Failed to " + verb + " " + file + ". Error message: " + errMsg);
+            throw new IOException("Failed to " + verb + " " + file +
+                                  ". Error message: " + errMsg);
         }
     }
 
     private void ShellExecute(URI uri, String verb) throws IOException {
-        String errmsg = ShellExecute(uri.toString(), verb);
-
+        String errmsg = ShellFolder.invoke(
+                () -> ShellExecute(uri.toString(), verb));
         if (errmsg != null) {
-            throw new IOException("Failed to " + verb + " " + uri
-                    + ". Error message: " + errmsg);
+            throw new IOException("Failed to " + verb + " " + uri +
+                                  ". Error message: " + errmsg);
         }
     }
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,20 +89,18 @@ JNIEXPORT jstring JNICALL Java_sun_awt_windows_WDesktopPeer_ShellExecute
                                         COINIT_DISABLE_OLE1DDE);
     HINSTANCE retval;
     DWORD error;
-    if (SUCCEEDED(hr) || hr == RPC_E_CHANGED_MODE) {
+    if (SUCCEEDED(hr)) {
         retval = ::ShellExecute(NULL, verb_c, fileOrUri_c, NULL, NULL,
                                 SW_SHOWNORMAL);
         error = ::GetLastError();
-        if (SUCCEEDED(hr)) {
-            ::CoUninitialize();
-        }
+        ::CoUninitialize();
     }
     _control87(oldcontrol87, 0xffffffff);
 
     JNU_ReleaseStringPlatformChars(env, fileOrUri_j, fileOrUri_c);
     JNU_ReleaseStringPlatformChars(env, verb_j, verb_c);
 
-    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+    if (FAILED(hr)) {
         return JNU_NewStringPlatform(env, L"CoInitializeEx() failed.");
     }
     if ((int)((intptr_t)retval) <= 32) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
@@ -85,7 +85,8 @@ JNIEXPORT jstring JNICALL Java_sun_awt_windows_WDesktopPeer_ShellExecute
 
     // 6457572: ShellExecute possibly changes FPU control word - saving it here
     unsigned oldcontrol87 = _control87(0, 0);
-    HINSTANCE retval = ::ShellExecute(NULL, verb_c, fileOrUri_c, NULL, NULL, SW_SHOWNORMAL);
+    HINSTANCE retval = ::ShellExecute(NULL, verb_c, fileOrUri_c, NULL, NULL,
+                                      SW_SHOWNORMAL);
     DWORD error = ::GetLastError();
     _control87(oldcontrol87, 0xffffffff);
 

--- a/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,18 +89,20 @@ JNIEXPORT jstring JNICALL Java_sun_awt_windows_WDesktopPeer_ShellExecute
                                         COINIT_DISABLE_OLE1DDE);
     HINSTANCE retval;
     DWORD error;
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) || hr == RPC_E_CHANGED_MODE) {
         retval = ::ShellExecute(NULL, verb_c, fileOrUri_c, NULL, NULL,
                                 SW_SHOWNORMAL);
         error = ::GetLastError();
-        ::CoUninitialize();
+        if (SUCCEEDED(hr)) {
+            ::CoUninitialize();
+        }
     }
     _control87(oldcontrol87, 0xffffffff);
 
     JNU_ReleaseStringPlatformChars(env, fileOrUri_j, fileOrUri_c);
     JNU_ReleaseStringPlatformChars(env, verb_j, verb_c);
 
-    if (FAILED(hr)) {
+    if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
         return JNU_NewStringPlatform(env, L"CoInitializeEx() failed.");
     }
     if ((int)((intptr_t)retval) <= 32) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Desktop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,24 +85,13 @@ JNIEXPORT jstring JNICALL Java_sun_awt_windows_WDesktopPeer_ShellExecute
 
     // 6457572: ShellExecute possibly changes FPU control word - saving it here
     unsigned oldcontrol87 = _control87(0, 0);
-    HRESULT hr = ::CoInitializeEx(NULL, COINIT_APARTMENTTHREADED |
-                                        COINIT_DISABLE_OLE1DDE);
-    HINSTANCE retval;
-    DWORD error;
-    if (SUCCEEDED(hr)) {
-        retval = ::ShellExecute(NULL, verb_c, fileOrUri_c, NULL, NULL,
-                                SW_SHOWNORMAL);
-        error = ::GetLastError();
-        ::CoUninitialize();
-    }
+    HINSTANCE retval = ::ShellExecute(NULL, verb_c, fileOrUri_c, NULL, NULL, SW_SHOWNORMAL);
+    DWORD error = ::GetLastError();
     _control87(oldcontrol87, 0xffffffff);
 
     JNU_ReleaseStringPlatformChars(env, fileOrUri_j, fileOrUri_c);
     JNU_ReleaseStringPlatformChars(env, verb_j, verb_c);
 
-    if (FAILED(hr)) {
-        return JNU_NewStringPlatform(env, L"CoInitializeEx() failed.");
-    }
     if ((int)((intptr_t)retval) <= 32) {
         // ShellExecute failed.
         LPTSTR buffer = NULL;


### PR DESCRIPTION
The fix for a regression caused by the https://bugs.openjdk.org/browse/JDK-6508941. it does not take into account RPC_E_CHANGED_MODE when COM was already initialized using COINIT_MULTITHREADED mode.

@aivanov-jdk please take a look.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8270269](https://bugs.openjdk.org/browse/JDK-8270269): Desktop.browse method fails if earlier CoInitialize call as COINIT_MULTITHREADED (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17010/head:pull/17010` \
`$ git checkout pull/17010`

Update a local copy of the PR: \
`$ git checkout pull/17010` \
`$ git pull https://git.openjdk.org/jdk.git pull/17010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17010`

View PR using the GUI difftool: \
`$ git pr show -t 17010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17010.diff">https://git.openjdk.org/jdk/pull/17010.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17010#issuecomment-1845066728)