### PR TITLE
8321505 JFR: Update views

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -85,6 +85,15 @@ table = "COLUMN 'Method', 'Allocation Pressure'
          GROUP BY S
          ORDER BY W DESC LIMIT 25"
 
+[jvm.blocked-by-system-gc]
+label = "Blocked by System.gc()"
+table = "FORMAT none, none, cell-height:10
+         SELECT startTime, duration, stackTrace
+         FROM SystemGC
+         WHERE invokedConcurrent = 'false'
+         ORDER BY duration DESC
+         LIMIT 25"
+
 [application.class-loaders]
 label = "Class Loaders"
 table = "FORMAT missing:null-bootstrap, none, none
@@ -293,6 +302,15 @@ table = "COLUMN 'Name', 'Average', 'P95',
          FROM   GCPhaseConcurrent, GCPhaseConcurrentLevel1
          GROUP BY name ORDER BY S"
 
+[jvm.gc-parallel-phases]
+label = "Parallel GC Phases"
+table = "COLUMN 'Name', 'Average', 'P95',
+                'Longest', 'Count', 'Total'
+         SELECT name,  AVG(duration),  P95(duration),
+                MAX(duration), COUNT(*), SUM(duration) AS S
+         FROM   GCPhaseParallel
+         GROUP BY name ORDER BY S"
+
 [jvm.gc-configuration]
 label = 'GC Configuration'
 form = "COLUMN 'Young GC', 'Old GC',
@@ -372,6 +390,14 @@ table = "COLUMN 'Method', 'Samples', 'Percent'
          SELECT stackTrace.topFrame AS T, COUNT(*), COUNT(*)
          FROM ExecutionSample GROUP BY T LIMIT 25"
 
+[jvm.jdk-agents]
+label = "JDK Agents"
+table = "COLUMN 'Time', 'Initialization', 'Name', 'Options'
+         FORMAT none, none, truncate-beginning;cell-height:10, cell-height:10
+         SELECT LAST(initializationTime) AS t, LAST(initializationDuration), LAST(name), LAST(JavaAgent.options)
+         FROM JavaAgent, NativeAgent
+         ORDER BY t"
+
 [environment.jvm-flags]
 label = "Command Line Flags"
 table = "SELECT name AS N, LAST(value)
@@ -423,6 +449,14 @@ table = "SELECT stackTrace, monitorClass, COUNT(*), SUM(duration) AS S
 label = "Native Libraries"
 table = "FORMAT cell-height:2, none, none
          SELECT name AS N, baseAddress, topAddress FROM NativeLibrary GROUP BY name ORDER BY N"
+
+[environment.native-library-failures]
+label = "Native Library Load/Unload Failures"
+table = "COLUMN 'Operation', 'Library', 'Error Message'
+         FORMAT none, truncate-beginning, cell-height:10
+         SELECT eventType.label, name, errorMessage
+         FROM NativeLibraryUnload, NativeLibraryLoad
+         WHERE success = 'false'"
 
 [jvm.native-memory-committed]
 label = "Native Memory Committed"
@@ -522,17 +556,18 @@ table = "COLUMN 'Host', 'Reads', 'Total Read'
 
 [environment.system-information]
 label = "System Information"
-form = "COLUMN 'Total Physical Memory Size', 'OS Version', 'CPU Type',
+form = "COLUMN 'Total Physical Memory Size', 'OS Version', 'Virtualization', 'CPU Type',
                  'Number of Cores', 'Number of Hardware Threads',
                  'Number of Sockets', 'CPU Description'
-        SELECT LAST(totalSize), LAST(osVersion), LAST(cpu),
+        SELECT LAST(totalSize), LAST(osVersion), LAST(name), LAST(cpu),
                LAST(cores), LAST(hwThreads),
                LAST(sockets), LAST(description)
-        FROM CPUInformation, PhysicalMemory, OSInformation"
+        FROM CPUInformation, PhysicalMemory, OSInformation, VirtualizationInformation"
 
 [environment.system-processes]
 label = "System Processes"
 table = "COLUMN 'First Observed', 'Last Observed', 'PID', 'Command Line'
+         FORMAT none, none, none, truncate-beginning
          SELECT FIRST(startTime), LAST(startTime),
                 FIRST(pid), FIRST(commandLine)
          FROM SystemProcess GROUP BY pid"


### PR DESCRIPTION
Could I have a review of a change that updates the views for the jfr command.

- Include virtualisation support in System Information
- New view for native library load/unload failures
- New view for blocked by System.gc()
- New view for GC parallel phases
- New view for agents
- Improved file paths truncation for System Processes

Testing: jdk/jfr/tool

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321505](https://bugs.openjdk.org/browse/JDK-8321505): JFR: Update views (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17012/head:pull/17012` \
`$ git checkout pull/17012`

Update a local copy of the PR: \
`$ git checkout pull/17012` \
`$ git pull https://git.openjdk.org/jdk.git pull/17012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17012`

View PR using the GUI difftool: \
`$ git pr show -t 17012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17012.diff">https://git.openjdk.org/jdk/pull/17012.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17012#issuecomment-1844965583)