### PR TITLE
8321422: Test gc/g1/pinnedobjs/TestPinnedObjectTypes.java times out after completion

### DIFF
--- a/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectTypes.java
+++ b/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectTypes.java
@@ -52,7 +52,7 @@ public class TestPinnedObjectTypes {
                                                                              "-XX:+UnlockDiagnosticVMOptions",
                                                                              "-XX:+WhiteBoxAPI",
                                                                              "-Xbootclasspath/a:.",
-                                                                             "-XX:-CreateCoreDumpOnCrash",
+                                                                             "-XX:-CreateCoredumpOnCrash",
                                                                              "-Xmx32M",
                                                                              "-Xmn16M",
                                                                              "-Xlog:gc",

--- a/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectTypes.java
+++ b/test/hotspot/jtreg/gc/g1/pinnedobjs/TestPinnedObjectTypes.java
@@ -52,6 +52,7 @@ public class TestPinnedObjectTypes {
                                                                              "-XX:+UnlockDiagnosticVMOptions",
                                                                              "-XX:+WhiteBoxAPI",
                                                                              "-Xbootclasspath/a:.",
+                                                                             "-XX:-CreateCoreDumpOnCrash",
                                                                              "-Xmx32M",
                                                                              "-Xmn16M",
                                                                              "-Xlog:gc",


### PR DESCRIPTION
Hi all,

  please review this change that disables core file creation for the subtests of this test that check for assertion failure. Core dump creation can make the whole test time out.

```
----------System.out:(54/8466)----------
Command line:... -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. -Xmx32M -Xmn16M -Xlog:gc gc.g1.pinnedobjs.TestObjectPin Object ]
[2023-12-05T23:30:37.930237Z] Gathering output for process 98165
[0.066s][info][gc] Using G1
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/open/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp:268), pid=98165, tid=6403
#  assert(obj->is_typeArray()) failed: must be typeArray
#[...]
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

[2023-12-05T23:35:20.308715Z] Waiting for completion for process 98165
[2023-12-05T23:35:20.632162Z] Waiting for completion finished for process 98165
```
Notice the 5 min delay from the `Gathering output for process` to the `Waiting for completion finished` message. This repeats for the second test, triggering the timeout.

Testing: failing test

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321422](https://bugs.openjdk.org/browse/JDK-8321422): Test gc/g1/pinnedobjs/TestPinnedObjectTypes.java times out after completion (**Bug** - P2)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17013/head:pull/17013` \
`$ git checkout pull/17013`

Update a local copy of the PR: \
`$ git checkout pull/17013` \
`$ git pull https://git.openjdk.org/jdk.git pull/17013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17013`

View PR using the GUI difftool: \
`$ git pr show -t 17013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17013.diff">https://git.openjdk.org/jdk/pull/17013.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17013#issuecomment-1844979572)