### PR TITLE
Update for sun.print.RasterPrinterJob in banded-raster printing loop

### DIFF
--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -2396,6 +2396,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
                      * the page on the next iteration of the loop.
                      */
                     bandGraphics.setTransform(uniformTransform);
+                    bandGraphics.translate(-deviceAddressableX,deviceAddressableY);
                     bandGraphics.transform(deviceTransform);
                     deviceTransform.translate(0, -bandHeight);
 
@@ -2418,12 +2419,12 @@ public abstract class RasterPrinterJob extends PrinterJob {
                          * We also need to translate by the adjusted amount
                          * so that printing appears in the correct place.
                          */
-                        int bandX = deviceLeft - deviceAddressableX;
+                        int bandX = deviceLeft;
                         if (bandX < 0) {
                             bandGraphics.translate(bandX/xScale,0);
                             bandX = 0;
                         }
-                        int bandY = deviceTop + bandTop - deviceAddressableY;
+                        int bandY = deviceTop;
                         if (bandY < 0) {
                             bandGraphics.translate(0,bandY/yScale);
                             bandY = 0;
@@ -2434,7 +2435,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
                         painterGraphics.setDelegate((Graphics2D) bandGraphics.create());
                         painter.print(painterGraphics, origPage, pageIndex);
                         painterGraphics.dispose();
-                        printBand(data, bandX, bandY, bandWidth, bandHeight);
+                        printBand(data, bandX, bandTop+bandY, bandWidth, bandHeight);
                     }
                 }
 


### PR DESCRIPTION
More correct way to take in consideration nonzero PHYSICALOFFSETX, PHYSICALOFFSETY of device for banded-raster printing loop. Only on Windows platform under certain conditions real device prints shifted image on paper.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17015/head:pull/17015` \
`$ git checkout pull/17015`

Update a local copy of the PR: \
`$ git checkout pull/17015` \
`$ git pull https://git.openjdk.org/jdk.git pull/17015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17015`

View PR using the GUI difftool: \
`$ git pr show -t 17015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17015.diff">https://git.openjdk.org/jdk/pull/17015.diff</a>

</details>
