### PR TITLE
8321519: Typo in exception message

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp
@@ -321,7 +321,7 @@ JVMFlag::Error JVMFlagAccess::set_ccstr(JVMFlag* flag, ccstr* value, JVMFlagOrig
     // Old value is heap allocated so free it.
     FREE_C_HEAP_ARRAY(char, old_value);
   }
-  // Unlike the other APIs, the old vale is NOT returned, so the caller won't need to free it.
+  // Unlike the other APIs, the old value is NOT returned, so the caller won't need to free it.
   // The callers typically don't care what the old value is.
   // If the caller really wants to know the old value, read it (and make a copy if necessary)
   // before calling this API.

--- a/src/java.base/share/classes/sun/nio/ch/Poller.java
+++ b/src/java.base/share/classes/sun/nio/ch/Poller.java
@@ -368,7 +368,7 @@ abstract class Poller {
 
             // check power of 2
             if (count != Integer.highestOneBit(count)) {
-                String msg = propName + " is set to a vale that is not a power of 2";
+                String msg = propName + " is set to a value that is not a power of 2";
                 throw new IllegalArgumentException(msg);
             }
             return count;

--- a/src/java.desktop/share/classes/com/sun/media/sound/ModelIdentifier.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/ModelIdentifier.java
@@ -39,7 +39,7 @@ public final class ModelIdentifier {
      *
      *  // INPUT parameters
      *  noteon    keynumber                7 bit midi value
-     *            velocity                 7 bit midi vale
+     *            velocity                 7 bit midi value
      *            on                       1 or 0
      *
      *  midi      pitch                    14 bit midi value


### PR DESCRIPTION
This PR fixes a typo in exception message printed when `jdk.readPollers` or `jdk.writePollers` is not a power of two.

While at it, I searched the code for other instances of `vale`, and corrected them as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321519](https://bugs.openjdk.org/browse/JDK-8321519): Typo in exception message (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17016/head:pull/17016` \
`$ git checkout pull/17016`

Update a local copy of the PR: \
`$ git checkout pull/17016` \
`$ git pull https://git.openjdk.org/jdk.git pull/17016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17016`

View PR using the GUI difftool: \
`$ git pr show -t 17016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17016.diff">https://git.openjdk.org/jdk/pull/17016.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17016#issuecomment-1845066876)