### PR TITLE
8316454: JFR break locale settings

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
@@ -68,10 +68,10 @@ public final class ValueFormatter {
     private static final int DISPLAY_NANO_DIGIT = 3;
     private static final int BASE = 10;
 
-    // -XX:FlightRecorderOptions:repository=<path> triggers an up call
+    // -XX:FlightRecorderOptions:repository=<path> triggers an upcall
     // which will load this class. If NumberFormat.getNumberInstance()
     // is called during startup, locale settings will not take effect.
-    // Workaround is to create an instance lazily. See numberFormatInstance()
+    // Workaround is to create an instance lazily. See numberFormatInstance().
     private static NumberFormat NUMBER_FORMAT;
 
     public static String formatTimespan(Duration dValue, String separation) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
@@ -57,7 +57,6 @@ public final class ValueFormatter {
         }
     }
 
-    private static final NumberFormat NUMBER_FORMAT = NumberFormat.getNumberInstance();
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
     private static final Duration MICRO_SECOND = Duration.ofNanos(1_000);
     private static final Duration SECOND = Duration.ofSeconds(1);
@@ -68,6 +67,12 @@ public final class ValueFormatter {
     private static final int MILL_SIGNIFICANT_FIGURES = 3;
     private static final int DISPLAY_NANO_DIGIT = 3;
     private static final int BASE = 10;
+
+    // -XX:FlightRecorderOptions:repository=<path> triggers an up call
+    // which will load this class. If NumberFormat.getNumberInstance()
+    // is called during startup, locale settings will not take effect.
+    // Workaround is to create an instance lazily. See numberFormatInstance()
+    private static NumberFormat NUMBER_FORMAT;
 
     public static String formatTimespan(Duration dValue, String separation) {
         if (dValue == null) {
@@ -110,8 +115,15 @@ public final class ValueFormatter {
         }
     }
 
+    private static NumberFormat numberFormatInstance() {
+        if (NUMBER_FORMAT == null) {
+            NUMBER_FORMAT = NumberFormat.getNumberInstance();
+        }
+        return NUMBER_FORMAT;
+    }
+
     public static String formatNumber(Number n) {
-        return NUMBER_FORMAT.format(n);
+        return numberFormatInstance().format(n);
     }
 
     public static String formatDuration(Duration d) {


### PR DESCRIPTION
Could I have a review of PR that prevents locale settings from not working.

Testing: jdk/jdk/jfr/* + jdk/java/util/Local/ with -XX:FlightRecorderOptions=repository=jfrrep

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316454](https://bugs.openjdk.org/browse/JDK-8316454): JFR break locale settings (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17018/head:pull/17018` \
`$ git checkout pull/17018`

Update a local copy of the PR: \
`$ git checkout pull/17018` \
`$ git pull https://git.openjdk.org/jdk.git pull/17018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17018`

View PR using the GUI difftool: \
`$ git pr show -t 17018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17018.diff">https://git.openjdk.org/jdk/pull/17018.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17018#issuecomment-1845223978)