### PR TITLE
8312307: Obsoleted code in hb-jdk-font.cc

### DIFF
--- a/src/java.desktop/share/native/libfontmanager/hb-jdk-font.cc
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk-font.cc
@@ -413,19 +413,6 @@ static hb_font_t* _hb_jdk_font_create(hb_face_t* face,
   return font;
 }
 
-#ifdef MACOSX
-static hb_font_t* _hb_jdk_ct_font_create(hb_face_t* face,
-                   JDKFontInfo *jdkFontInfo) {
-
-    hb_font_t *font = NULL;
-    font = hb_font_create(face);
-    hb_font_set_scale(font,
-                     HBFloatToFixed(jdkFontInfo->ptSize),
-                     HBFloatToFixed(jdkFontInfo->ptSize));
-    return font;
-}
-#endif
-
 hb_font_t* hb_jdk_font_create(hb_face_t* hbFace,
                              JDKFontInfo *jdkFontInfo,
                              hb_destroy_func_t destroy) {

--- a/src/java.desktop/share/native/libfontmanager/hb-jdk.h
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk.h
@@ -57,9 +57,6 @@ typedef struct JDKFontInfo_Struct {
  * Otherwise hb-ft would NOT pick up the font size correctly.
  */
 
-hb_face_t *
-hb_jdk_face_create(JDKFontInfo*   jdkFontInfo,
-                   hb_destroy_func_t destroy);
 hb_font_t *
 hb_jdk_font_create(hb_face_t* hbFace,
                    JDKFontInfo*   jdkFontInfo,


### PR DESCRIPTION
Clean up some un-used code in the 2D native font code that interfaces to libharfbuzz

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312307](https://bugs.openjdk.org/browse/JDK-8312307): Obsoleted code in hb-jdk-font.cc (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17022/head:pull/17022` \
`$ git checkout pull/17022`

Update a local copy of the PR: \
`$ git checkout pull/17022` \
`$ git pull https://git.openjdk.org/jdk.git pull/17022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17022`

View PR using the GUI difftool: \
`$ git pr show -t 17022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17022.diff">https://git.openjdk.org/jdk/pull/17022.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17022#issuecomment-1845921845)