### PR TITLE
8286827: BogusColorSpace methods return wrong array

### DIFF
--- a/src/java.desktop/share/classes/com/sun/imageio/plugins/common/BogusColorSpace.java
+++ b/src/java.desktop/share/classes/com/sun/imageio/plugins/common/BogusColorSpace.java
@@ -90,7 +90,7 @@ public class BogusColorSpace extends ColorSpace {
         System.arraycopy(colorvalue, 0, rgbvalue, 0,
                          Math.min(3, getNumComponents()));
 
-        return colorvalue;
+        return rgbvalue;
     }
 
     public float[] fromRGB(float[] rgbvalue) {
@@ -104,7 +104,7 @@ public class BogusColorSpace extends ColorSpace {
         System.arraycopy(rgbvalue, 0, colorvalue, 0,
                          Math.min(3, colorvalue.length));
 
-        return rgbvalue;
+        return colorvalue;
     }
 
     public float[] toCIEXYZ(float[] colorvalue) {
@@ -118,7 +118,7 @@ public class BogusColorSpace extends ColorSpace {
         System.arraycopy(colorvalue, 0, xyzvalue, 0,
                          Math.min(3, getNumComponents()));
 
-        return colorvalue;
+        return xyzvalue;
     }
 
     public float[] fromCIEXYZ(float[] xyzvalue) {
@@ -132,6 +132,6 @@ public class BogusColorSpace extends ColorSpace {
         System.arraycopy(xyzvalue, 0, colorvalue, 0,
                          Math.min(3, colorvalue.length));
 
-        return xyzvalue;
+        return colorvalue;
     }
 }


### PR DESCRIPTION
The conversion methods in this class return the wrong array.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286827](https://bugs.openjdk.org/browse/JDK-8286827): BogusColorSpace methods return wrong array (**Bug** - P5)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17024/head:pull/17024` \
`$ git checkout pull/17024`

Update a local copy of the PR: \
`$ git checkout pull/17024` \
`$ git pull https://git.openjdk.org/jdk.git pull/17024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17024`

View PR using the GUI difftool: \
`$ git pr show -t 17024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17024.diff">https://git.openjdk.org/jdk/pull/17024.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17024#issuecomment-1846013131)