### PR TITLE
8288712: Typo in javadoc in javax.imageio.ImageReader.java

### DIFF
--- a/src/java.desktop/share/classes/javax/imageio/ImageReader.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageReader.java
@@ -2582,7 +2582,7 @@ public abstract class ImageReader {
      * width or height of 0, an {@code IllegalArgumentException}
      * is thrown.
      *
-     * <p> The {@link #getSourceRegion getSourceRegion>}
+     * <p> The {@link #getSourceRegion getSourceRegion}
      * method may be used if only source clipping is desired.
      *
      * @param param an {@code ImageReadParam}, or {@code null}.


### PR DESCRIPTION
As can be seen here
https://docs.oracle.com/en/java/javase/21/docs/api/java.desktop/javax/imageio/ImageReader.html#computeRegions(javax.imageio.ImageReadParam,int,int,java.awt.image.BufferedImage,java.awt.Rectangle,java.awt.Rectangle)

There's an extra '>' in the javadoc source with the result being
"The getSourceRegion> method may be used if only source clipping is desired."

fix is to remove it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288712](https://bugs.openjdk.org/browse/JDK-8288712): Typo in javadoc in javax.imageio.ImageReader.java (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17025/head:pull/17025` \
`$ git checkout pull/17025`

Update a local copy of the PR: \
`$ git checkout pull/17025` \
`$ git pull https://git.openjdk.org/jdk.git pull/17025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17025`

View PR using the GUI difftool: \
`$ git pr show -t 17025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17025.diff">https://git.openjdk.org/jdk/pull/17025.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17025#issuecomment-1846028854)