### PR TITLE
8316197: Make tracing of inline cache available in unified logging

### DIFF
--- a/src/hotspot/cpu/aarch64/compiledIC_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compiledIC_aarch64.cpp
@@ -28,6 +28,7 @@
 #include "code/compiledIC.hpp"
 #include "code/icBuffer.hpp"
 #include "code/nmethod.hpp"
+#include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"

--- a/src/hotspot/cpu/aarch64/compiledIC_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compiledIC_aarch64.cpp
@@ -90,9 +90,9 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   address stub = find_stub();
   guarantee(stub != nullptr, "stub not found");
 
-  if (TraceICs) {
+  {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    log_trace(inlinecache)("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }

--- a/src/hotspot/cpu/arm/compiledIC_arm.cpp
+++ b/src/hotspot/cpu/arm/compiledIC_arm.cpp
@@ -28,6 +28,7 @@
 #include "code/icBuffer.hpp"
 #include "code/nativeInst.hpp"
 #include "code/nmethod.hpp"
+#include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"

--- a/src/hotspot/cpu/arm/compiledIC_arm.cpp
+++ b/src/hotspot/cpu/arm/compiledIC_arm.cpp
@@ -105,9 +105,9 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   address stub = find_stub();
   guarantee(stub != nullptr, "stub not found");
 
-  if (TraceICs) {
+  {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    log_trace(inlinecache)("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }

--- a/src/hotspot/cpu/ppc/compiledIC_ppc.cpp
+++ b/src/hotspot/cpu/ppc/compiledIC_ppc.cpp
@@ -167,9 +167,9 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   address stub = find_stub();
   guarantee(stub != nullptr, "stub not found");
 
-  if (TraceICs) {
+  {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    log_trace(inlinecache)("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }

--- a/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
@@ -88,9 +88,9 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   address stub = find_stub();
   guarantee(stub != nullptr, "stub not found");
 
-  if (TraceICs) {
+  {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    log_trace(inlinecache)("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }

--- a/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
@@ -29,6 +29,7 @@
 #include "code/compiledIC.hpp"
 #include "code/icBuffer.hpp"
 #include "code/nmethod.hpp"
+#include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"

--- a/src/hotspot/cpu/s390/compiledIC_s390.cpp
+++ b/src/hotspot/cpu/s390/compiledIC_s390.cpp
@@ -95,9 +95,9 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   address stub = find_stub();
   guarantee(stub != nullptr, "stub not found");
 
-  if (TraceICs) {
+  {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    log_trace(inlinecache)("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }

--- a/src/hotspot/cpu/x86/compiledIC_x86.cpp
+++ b/src/hotspot/cpu/x86/compiledIC_x86.cpp
@@ -28,6 +28,7 @@
 #include "code/compiledIC.hpp"
 #include "code/icBuffer.hpp"
 #include "code/nmethod.hpp"
+#include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"

--- a/src/hotspot/cpu/x86/compiledIC_x86.cpp
+++ b/src/hotspot/cpu/x86/compiledIC_x86.cpp
@@ -84,9 +84,9 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   address stub = find_stub();
   guarantee(stub != nullptr, "stub not found");
 
-  if (TraceICs) {
+  {
     ResourceMark rm;
-    tty->print_cr("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
+    log_trace(inlinecache)("CompiledDirectStaticCall@" INTPTR_FORMAT ": set_to_interpreted %s",
                   p2i(instruction_address()),
                   callee->name_and_sig_as_C_string());
   }

--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -364,6 +364,10 @@ bool CompiledIC::is_call_to_interpreted() const {
 
 bool CompiledIC::set_to_clean(bool in_use) {
   assert(CompiledICLocker::is_safe(_method), "mt unsafe call");
+  if (TraceInlineCacheClearing) {
+    tty->print_cr("IC@" INTPTR_FORMAT ": set to clean", p2i(instruction_address()));
+    print();
+  }
   log_trace(inlinecache)("IC@" INTPTR_FORMAT ": set to clean", p2i(instruction_address()));
 
   address entry = _call->get_resolve_call_stub(is_optimized());

--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -291,10 +291,10 @@ bool CompiledIC::set_to_megamorphic(CallInfo* call_info, Bytecodes::Code bytecod
     }
   }
 
-  if (TraceICs) {
+  {
     ResourceMark rm;
     assert(call_info->selected_method() != nullptr, "Unexpected null selected method");
-    tty->print_cr ("IC@" INTPTR_FORMAT ": to megamorphic %s entry: " INTPTR_FORMAT,
+    log_trace(inlinecache)("IC@" INTPTR_FORMAT ": to megamorphic %s entry: " INTPTR_FORMAT,
                    p2i(instruction_address()), call_info->selected_method()->print_value_string(), p2i(entry));
   }
 
@@ -364,10 +364,7 @@ bool CompiledIC::is_call_to_interpreted() const {
 
 bool CompiledIC::set_to_clean(bool in_use) {
   assert(CompiledICLocker::is_safe(_method), "mt unsafe call");
-  if (TraceInlineCacheClearing || TraceICs) {
-    tty->print_cr("IC@" INTPTR_FORMAT ": set to clean", p2i(instruction_address()));
-    print();
-  }
+  log_trace(inlinecache)("IC@" INTPTR_FORMAT ": set to clean", p2i(instruction_address()));
 
   address entry = _call->get_resolve_call_stub(is_optimized());
 
@@ -433,9 +430,9 @@ bool CompiledIC::set_to_monomorphic(CompiledICInfo& info) {
       methodHandle method (thread, (Method*)info.cached_metadata());
       _call->set_to_interpreted(method, info);
 
-      if (TraceICs) {
-         ResourceMark rm(thread);
-         tty->print_cr ("IC@" INTPTR_FORMAT ": monomorphic to interpreter: %s",
+      {
+        ResourceMark rm(thread);
+        log_trace(inlinecache)("IC@" INTPTR_FORMAT ": monomorphic to interpreter: %s",
            p2i(instruction_address()),
            method->print_value_string());
       }
@@ -449,9 +446,9 @@ bool CompiledIC::set_to_monomorphic(CompiledICInfo& info) {
       // LSan appears unable to follow malloc-based memory consistently when embedded as an
       // immediate in generated machine code. So we have to ignore it.
       LSAN_IGNORE_OBJECT(holder);
-      if (TraceICs) {
+      {
          ResourceMark rm(thread);
-         tty->print_cr ("IC@" INTPTR_FORMAT ": monomorphic to interpreter via icholder ", p2i(instruction_address()));
+         log_trace(inlinecache)("IC@" INTPTR_FORMAT ": monomorphic to interpreter via icholder ", p2i(instruction_address()));
       }
     }
   } else {
@@ -479,10 +476,10 @@ bool CompiledIC::set_to_monomorphic(CompiledICInfo& info) {
       }
     }
 
-    if (TraceICs) {
+    {
       ResourceMark rm(thread);
       assert(info.cached_metadata() == nullptr || info.cached_metadata()->is_klass(), "must be");
-      tty->print_cr ("IC@" INTPTR_FORMAT ": monomorphic to compiled (rcvr klass = %s) %s",
+      log_trace(inlinecache)("IC@" INTPTR_FORMAT ": monomorphic to compiled (rcvr klass = %s) %s",
         p2i(instruction_address()),
         (info.cached_metadata() != nullptr) ? ((Klass*)info.cached_metadata())->print_value_string() : "nullptr",
         (safe) ? "" : " via stub");
@@ -606,9 +603,9 @@ bool CompiledDirectStaticCall::is_call_to_interpreted() const {
 }
 
 void CompiledStaticCall::set_to_compiled(address entry) {
-  if (TraceICs) {
+  {
     ResourceMark rm;
-    tty->print_cr("%s@" INTPTR_FORMAT ": set_to_compiled " INTPTR_FORMAT,
+    log_trace(inlinecache)("%s@" INTPTR_FORMAT ": set_to_compiled " INTPTR_FORMAT,
         name(),
         p2i(instruction_address()),
         p2i(entry));

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -97,6 +97,7 @@ class outputStream;
   LOG_TAG(iklass) \
   LOG_TAG(indy) \
   LOG_TAG(init) \
+  LOG_TAG(inlinecache)\
   LOG_TAG(inlining) \
   LOG_TAG(install) \
   LOG_TAG(interpreter) \
@@ -213,8 +214,7 @@ class outputStream;
   LOG_TAG(vmoperation) \
   LOG_TAG(vmthread) \
   LOG_TAG(vtables) \
-  LOG_TAG(vtablestubs) \
-  LOG_TAG(inlinecache)
+  LOG_TAG(vtablestubs)
 
 #define PREFIX_LOG_TAG(T) (LogTag::_##T)
 

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -213,7 +213,8 @@ class outputStream;
   LOG_TAG(vmoperation) \
   LOG_TAG(vmthread) \
   LOG_TAG(vtables) \
-  LOG_TAG(vtablestubs)
+  LOG_TAG(vtablestubs) \
+  LOG_TAG(inlinecache)
 
 #define PREFIX_LOG_TAG(T) (LogTag::_##T)
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -870,14 +870,8 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, TraceBytecodes, false,                                      \
           "Trace bytecode execution")                                       \
                                                                             \
-  develop(bool, TraceICs, false,                                            \
-          "Trace inline cache changes")                                     \
-                                                                            \
   notproduct(bool, TraceInvocationCounterOverflow, false,                   \
           "Trace method invocation counter overflow")                       \
-                                                                            \
-  develop(bool, TraceInlineCacheClearing, false,                            \
-          "Trace clearing of inline caches in nmethods")                    \
                                                                             \
   develop(bool, VerifyDependencies, trueInDebug,                            \
           "Exercise and verify the compilation dependency mechanism")       \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -873,6 +873,9 @@ const int ObjectAlignmentInBytes = 8;
   notproduct(bool, TraceInvocationCounterOverflow, false,                   \
           "Trace method invocation counter overflow")                       \
                                                                             \
+  develop(bool, TraceInlineCacheClearing, false,                            \
+          "Trace clearing of inline caches in nmethods")                    \
+                                                                            \
   develop(bool, VerifyDependencies, trueInDebug,                            \
           "Exercise and verify the compilation dependency mechanism")       \
                                                                             \

--- a/test/hotspot/jtreg/compiler/arguments/TestTraceICs.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestTraceICs.java
@@ -25,7 +25,8 @@
  * @test
  * @bug 8217447
  * @summary Test running TraceICs enabled.
- * @run main/othervm compiler.arguments.TestTraceICs
+ * @run main/othervm -Xlog:inlinecache=trace
+ *                   compiler.arguments.TestTraceICs
  */
 
 package compiler.arguments;

--- a/test/hotspot/jtreg/compiler/arguments/TestTraceICs.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestTraceICs.java
@@ -25,8 +25,7 @@
  * @test
  * @bug 8217447
  * @summary Test running TraceICs enabled.
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+TraceICs
- *                   compiler.arguments.TestTraceICs
+ * @run main/othervm compiler.arguments.TestTraceICs
  */
 
 package compiler.arguments;

--- a/test/hotspot/jtreg/compiler/arguments/TestTraceICs.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestTraceICs.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8217447
- * @summary Test running TraceICs enabled.
+ * @summary Test running with log:inlinecache=trace enabled.
  * @run main/othervm -Xlog:inlinecache=trace
  *                   compiler.arguments.TestTraceICs
  */


### PR DESCRIPTION
This removes develop flag `TraceICs` and makes the logs available via `-Xlog`.

Example:
```
% java -Xlog:inlinecache=trace -version
[0.061s][trace][inlinecache] CompiledDirectStaticCall@0x00007f3739001d17: set_to_interpreted java.lang.StringLatin1.hashCode([B)I
[0.078s][trace][inlinecache] IC@0x00007f3739004a87: monomorphic to compiled (rcvr klass = nullptr)
[0.079s][trace][inlinecache] CompiledDirectStaticCall@0x00007f3739005dff: set_to_interpreted jdk.internal.util.ArraysSupport.vectorizedHashCode(Ljava/lang/Object;IIII)I
[0.079s][trace][inlinecache] CompiledDirectStaticCall@0x00007f373900502f: set_to_interpreted jdk.internal.org.objectweb.asm.ByteVector.enlarge(I)V
[0.079s][trace][inlinecache] IC@0x00007f373900502f: monomorphic to interpreter: {method} {0x00007f36f03e6318} 'enlarge' '(I)V' in 'jdk/internal/org/objectweb/asm/ByteVector'
[0.079s][trace][inlinecache] CompiledDirectStaticCall@0x00007f3739006b0f: set_to_compiled 0x00007f3739002120
[0.083s][trace][inlinecache] CompiledDirectStaticCall@0x00007f373900928f: set_to_interpreted java.lang.AbstractStringBuilder.newCapacity(I)I
[0.083s][trace][inlinecache] IC@0x00007f373900928f: monomorphic to interpreter: {method} {0x00007f36f00cd170} 'newCapacity' '(I)I' in 'java/lang/AbstractStringBuilder'
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316197](https://bugs.openjdk.org/browse/JDK-8316197): Make tracing of inline cache available in unified logging (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [5d782f75](https://git.openjdk.org/jdk/pull/17026/files/5d782f759d357dc3d49bfd0c11806ae0c096ec8b)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17026/head:pull/17026` \
`$ git checkout pull/17026`

Update a local copy of the PR: \
`$ git checkout pull/17026` \
`$ git pull https://git.openjdk.org/jdk.git pull/17026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17026`

View PR using the GUI difftool: \
`$ git pr show -t 17026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17026.diff">https://git.openjdk.org/jdk/pull/17026.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17026#issuecomment-1846249050)