### PR TITLE
8307246 : Printing: banded raster path doesn't account for device offset values

### DIFF
--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/print/PrinterJob/ImagePrinting/AlphaPrintingOffsets.java
+++ b/test/jdk/java/awt/print/PrinterJob/ImagePrinting/AlphaPrintingOffsets.java
@@ -55,7 +55,7 @@ import static java.awt.print.PageFormat.REVERSE_LANDSCAPE;
 
 public class AlphaPrintingOffsets {
     private static final String INSTRUCTIONS =
-            "Tested bug occurs only on-paper printing " +
+                    "Tested bug occurs only on-paper printing " +
                     "so you mustn't use PDF printer\n\n" +
                     "1. Java print dialog should appear.\n" +
                     "2. Press the Print button on the Java Print dialog.\n" +
@@ -82,14 +82,15 @@ public class AlphaPrintingOffsets {
                 instructionsHeader = "This test prints 2 pages with page " +
                         "margin rectangle and a text message. \n";
             }
-            PassFailJFrame.builder().instructions(instructionsHeader + INSTRUCTIONS)
-                    .rows(15).testUI(() -> createTestUI()).build().awaitAndCheck();
+            PassFailJFrame.builder()
+                    .instructions(instructionsHeader + INSTRUCTIONS)
+                    .rows(15)
+                    .testUI(() -> createTestUI())
+                    .build()
+                    .awaitAndCheck();
 
         } else {
-            System.out.println("Test failed : " +
-                    "Printer not configured or available.");
-            throw new RuntimeException("Test failed : " +
-                    "Printer not configured or available.");
+            throw new RuntimeException("Test failed : Printer not configured or available.");
         }
 
     }
@@ -134,8 +135,7 @@ public class AlphaPrintingOffsets {
             bookPageSavingTest.append(printableTransparent, pageFormatL);
             bookPageSavingTest.append(printableTransparent, pageFormatRL);
             printerJob.setPageable(bookPageSavingTest);
-        }
-        else {
+        } else {
             Printable printableOpaque = new CustomPrintable(255);
             Book bookDefaultTest = new Book();
             bookDefaultTest.append(printableOpaque, pageFormatP);


### PR DESCRIPTION
More correct way to take in consideration nonzero PHYSICALOFFSETX, PHYSICALOFFSETY of device for banded-raster printing loop. Only on Windows platform under certain conditions real device prints shifted image on paper.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307246](https://bugs.openjdk.org/browse/JDK-8307246): Printing: banded raster path doesn't account for device offset values (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17030/head:pull/17030` \
`$ git checkout pull/17030`

Update a local copy of the PR: \
`$ git checkout pull/17030` \
`$ git pull https://git.openjdk.org/jdk.git pull/17030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17030`

View PR using the GUI difftool: \
`$ git pr show -t 17030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17030.diff">https://git.openjdk.org/jdk/pull/17030.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17030#issuecomment-1846784314)