### PR TITLE
8316738: java/net/httpclient/HttpClientLocalAddrTest.java failed in timeout

### DIFF
--- a/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientLocalAddrTest.java
@@ -64,6 +64,7 @@ import static java.net.http.HttpClient.Version.HTTP_2;
  *      -Djdk.httpclient.HttpClient.log=frames,ssl,requests,responses,errors
  *      -Djdk.internal.httpclient.debug=true
  *      -Dsun.net.httpserver.idleInterval=50000
+ *      -Djdk.tracePinnedThreads=full
  *      HttpClientLocalAddrTest
  *
  * @run testng/othervm/java.security.policy=httpclient-localaddr-security.policy


### PR DESCRIPTION
Can I please get a review of this trivial test only change which adds the `-Djdk.tracePinnedThreads=full` system property when launching the `HttpClientLocalAddrTest` test?

This test has failed with timeout (on a rare occasion). The test uses virtual threads for the HttpClient instances it uses and has 2 `@run` test definitions. One of it already uses `-Djdk.tracePinnedThreads=full` to help debug any pinned thread issues. The commit in this PR updates the other `@run` definition to use this same system property for the same reason.

The test continues to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316738](https://bugs.openjdk.org/browse/JDK-8316738): java/net/httpclient/HttpClientLocalAddrTest.java failed in timeout (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17031/head:pull/17031` \
`$ git checkout pull/17031`

Update a local copy of the PR: \
`$ git checkout pull/17031` \
`$ git pull https://git.openjdk.org/jdk.git pull/17031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17031`

View PR using the GUI difftool: \
`$ git pr show -t 17031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17031.diff">https://git.openjdk.org/jdk/pull/17031.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17031#issuecomment-1846658133)