### PR TITLE
8312150: Remove -Xnoagent option

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2591,9 +2591,6 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
     // -Xdebug
     } else if (match_option(option, "-Xdebug")) {
       warning("Option -Xdebug was deprecated in JDK 22 and will likely be removed in a future release.");
-    // -Xnoagent
-    } else if (match_option(option, "-Xnoagent")) {
-      warning("Option -Xnoagent was deprecated in JDK 22 and will likely be removed in a future release.");
     } else if (match_option(option, "-Xloggc:", &tail)) {
       // Deprecated flag to redirect GC output to a file. -Xloggc:<filename>
       log_warning(gc)("-Xloggc is deprecated. Will use -Xlog:gc:%s instead.", tail);

--- a/test/hotspot/jtreg/runtime/CommandLine/TestNullTerminatedFlags.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/TestNullTerminatedFlags.java
@@ -50,8 +50,7 @@ public class TestNullTerminatedFlags {
             "-Xshare:on",
             "-Xshare:auto",
             "-Xshare:off",
-            "-Xdebug",
-            "-Xnoagent"
+            "-Xdebug"
         };
 
     public static void main(String args[]) throws Exception{


### PR DESCRIPTION
Can I please get a review of this change which proposes to remove the `-Xnoagent` option of the `java` command? This addresses https://bugs.openjdk.org/browse/JDK-8312150.

In Java 22, we already deprecated this option for removal through https://bugs.openjdk.org/browse/JDK-8312073. As noted in that CSR, this option has been a no-op for several releases now and has been ignored by the `java` command. The option isn't part of any documented options either. In Java 22, the usage of this option will print a warning.

In Java 23 and above, with the current proposed change in this PR, the usage of this option will no longer be supported and it will start throwing an error just like any other unsupported option:

```
java -Xnoagent -version
Unrecognized option: -Xnoagent
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```
Having looked at some available data at hand, there are projects/builds which have been using this option (mostly due to copy/paste) and they will be impacted by this. So it will be good to do this change early during the 23 release cycle to allow the impacted projects to notice this change and update their launch scripts accordingly.

tier1, tier2 and tier3 tests continue to pass with this change. I'll create a CSR shortly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312150](https://bugs.openjdk.org/browse/JDK-8312150): Remove -Xnoagent option (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17032/head:pull/17032` \
`$ git checkout pull/17032`

Update a local copy of the PR: \
`$ git checkout pull/17032` \
`$ git pull https://git.openjdk.org/jdk.git pull/17032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17032`

View PR using the GUI difftool: \
`$ git pr show -t 17032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17032.diff">https://git.openjdk.org/jdk/pull/17032.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17032#issuecomment-1846773259)