### PR TITLE
8321594: NativeThreadSet should use placeholder for virtual threads

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/NativeThreadSet.java
+++ b/src/java.base/share/classes/sun/nio/ch/NativeThreadSet.java
@@ -27,9 +27,8 @@ package sun.nio.ch;
 
 // Special-purpose data structure for sets of native threads
 
-
 class NativeThreadSet {
-    private final int OTHER_THREAD_INDEX = -99;
+    private static final int OTHER_THREAD_INDEX = -99;
 
     private final int initialCapacity;
     private long[] threads;             // array of thread handles, created lazily
@@ -80,7 +79,6 @@ class NativeThreadSet {
      * Removes the thread at the given index. A no-op if index is -1.
      */
     void remove(int i) {
-        assert i >= -1 || i == OTHER_THREAD_INDEX;
         synchronized (this) {
             if (i >= 0) {
                 assert threads[i] == NativeThread.current();
@@ -89,6 +87,7 @@ class NativeThreadSet {
             } else if (i == OTHER_THREAD_INDEX) {
                 otherThreads--;
             } else {
+                assert i == -1;
                 return;
             }
             if (used == 0 && otherThreads == 0 && waitingToEmpty) {

--- a/src/java.base/share/classes/sun/nio/ch/NativeThreadSet.java
+++ b/src/java.base/share/classes/sun/nio/ch/NativeThreadSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,75 +29,84 @@ package sun.nio.ch;
 
 
 class NativeThreadSet {
-
-    private long[] elts;
-    private int used = 0;
+    private final int initialCapacity;
+    private long[] threads;             // array of thread handles, created lazily
+    private int used;                   // number of thread handles in threads array
+    private int otherThreads;           // count of threads without a native thread handle
     private boolean waitingToEmpty;
 
     NativeThreadSet(int n) {
-        elts = new long[n];
+        initialCapacity = n;
     }
 
     /**
-     * Adds the current native thread to this set, returning its index so that
+     * Adds the current thread handle to this set, returning an index so that
      * it can efficiently be removed later.
      */
     int add() {
-        long th = NativeThread.currentNativeThread();
-        // 0 and -1 are treated as placeholders, not real thread handles
-        if (th == 0)
-            th = -1;
+        long th = NativeThread.current();
         synchronized (this) {
+            if (!NativeThread.isNativeThread(th)) {
+                otherThreads++;
+                return -1;
+            }
+
+            // add native thread handle to array, creating or growing array if needed
             int start = 0;
-            if (used >= elts.length) {
-                int on = elts.length;
+            if (threads == null) {
+                threads = new long[initialCapacity];
+            } else if (used >= threads.length) {
+                int on = threads.length;
                 int nn = on * 2;
-                long[] nelts = new long[nn];
-                System.arraycopy(elts, 0, nelts, 0, on);
-                elts = nelts;
+                long[] nthreads = new long[nn];
+                System.arraycopy(threads, 0, nthreads, 0, on);
+                threads = nthreads;
                 start = on;
             }
-            for (int i = start; i < elts.length; i++) {
-                if (elts[i] == 0) {
-                    elts[i] = th;
+            for (int i = start; i < threads.length; i++) {
+                if (threads[i] == 0) {
+                    threads[i] = th;
                     used++;
                     return i;
                 }
             }
-            assert false;
-            return -1;
+            throw new InternalError();
         }
-
     }
 
     /**
-     * Removes the thread at the give index.
+     * Removes the thread at the given index.
      */
     void remove(int i) {
         synchronized (this) {
-            assert (elts[i] == NativeThread.currentNativeThread()) || (elts[i] == -1);
-            elts[i] = 0;
-            used--;
-            if (used == 0 && waitingToEmpty)
+            if (i >= 0) {
+                assert threads[i] == NativeThread.current();
+                threads[i] = 0;
+                used--;
+            } else {
+                assert NativeThread.isNativeThread(NativeThread.current());
+                otherThreads--;
+            }
+            if (used == 0 && otherThreads == 0 && waitingToEmpty) {
                 notifyAll();
+            }
         }
     }
 
-    // Signals all threads in this set.
-    //
+    /**
+     * Signals all native threads in the thread set and wait for the thread set to empty.
+     */
     synchronized void signalAndWait() {
         boolean interrupted = false;
-        while (used > 0) {
-            int u = used;
-            int n = elts.length;
-            for (int i = 0; i < n; i++) {
-                long th = elts[i];
-                if (th == 0)
-                    continue;
-                if (th != -1)
+        while (used > 0 || otherThreads > 0) {
+            int u = used, i = 0;
+            while (u > 0 && i < threads.length) {
+                long th = threads[i];
+                if (th != 0) {
                     NativeThread.signal(th);
-                if (--u == 0)
-                    break;
+                    u--;
+                }
+                i++;
             }
             waitingToEmpty = true;
             try {

--- a/src/java.base/unix/classes/sun/nio/ch/NativeThread.java
+++ b/src/java.base/unix/classes/sun/nio/ch/NativeThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,14 +50,6 @@ public class NativeThread {
         } else {
             return current0();
         }
-    }
-
-    /**
-     * Returns the id of the current native thread if the platform can signal
-     * native threads, 0 if the platform can not signal native threads.
-     */
-    static long currentNativeThread() {
-        return current0();
     }
 
     /**

--- a/src/java.base/windows/classes/sun/nio/ch/NativeThread.java
+++ b/src/java.base/windows/classes/sun/nio/ch/NativeThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,14 +43,6 @@ public class NativeThread {
             // no support for signalling threads on Windows
             return 0;
         }
-    }
-
-    /**
-     * Returns the id of the current native thread if the platform can signal
-     * native threads, 0 if the platform can not signal native threads.
-     */
-    static long currentNativeThread() {
-        return 0;
     }
 
     /**


### PR DESCRIPTION
FileChannel has a supporting class named NativeThreadSet to track the threads doing I/O on the channel. It supports the signalling of native threads that are blocked in file I/O and also supports waiting for all threads to finish I/O operations. The signalling part is problematic as it's not feasible on all platforms. It's also problematic for virtual threads because the native thread handle may change, e.g. there is ongoing work on monitors where the native thread handle when blocking on monitorenter may be different to when the thread continues. There is a longer term work required to re-examine if FileChannel needs to continue to be interruptible. The change proposed here to not signal virtual threads so the behavior is similar to Windows and other ports where it's not feasible to preempt file I/O operations. This aligns the behavior with what we've had in the loom repo for some time.

The implementation change are straight forward, might be more than they initially seem as "elts" is renamed. The main change is that NativeThreadSet keeps count of non-native threads rather than putting a placeholder in the array. The array is also created lazily.

Testing: tier1-3, FileChannel tests with JTREG_TEST_THREAD_FACTORY=Virtual.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321594](https://bugs.openjdk.org/browse/JDK-8321594): NativeThreadSet should use placeholder for virtual threads (**Enhancement** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17034/head:pull/17034` \
`$ git checkout pull/17034`

Update a local copy of the PR: \
`$ git checkout pull/17034` \
`$ git pull https://git.openjdk.org/jdk.git pull/17034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17034`

View PR using the GUI difftool: \
`$ git pr show -t 17034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17034.diff">https://git.openjdk.org/jdk/pull/17034.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17034#issuecomment-1849705722)