### PR TITLE
8321631: Fix comments in access.hpp

### DIFF
--- a/src/hotspot/share/oops/access.hpp
+++ b/src/hotspot/share/oops/access.hpp
@@ -53,8 +53,8 @@
 // * store_at: Store a value in an internal pointer relative to a base object.
 // * atomic_cmpxchg: Atomically compare-and-swap a new value at an address if previous value matched the compared value.
 // * atomic_cmpxchg_at: Atomically compare-and-swap a new value at an internal pointer address if previous value matched the compared value.
-// * atomic_xchg: Atomically swap a new value at an address if previous value matched the compared value.
-// * atomic_xchg_at: Atomically swap a new value at an internal pointer address if previous value matched the compared value.
+// * atomic_xchg: Atomically swap a new value at an address without checking the previous value.
+// * atomic_xchg_at: Atomically swap a new value at an internal pointer address without checking the previous value.
 // * arraycopy: Copy data from one heap array to another heap array. The ArrayAccess class has convenience functions for this.
 // * clone: Clone the contents of an object to a newly allocated object.
 //
@@ -83,12 +83,11 @@
 //             and whether the access is performed on the heap or outside. Then the
 //             appropriate BarrierSet::AccessBarrier is called to perform the access.
 //
-// The implementation of step 1-4 resides in in accessBackend.hpp, to allow selected
+// The implementation of step 1-4 resides in accessBackend.hpp, to allow selected
 // accesses to be accessible from only access.hpp, as opposed to access.inline.hpp.
 // Steps 5.a and 5.b require knowledge about the GC backends, and therefore needs to
 // include the various GC backend .inline.hpp headers. Their implementation resides in
-// access.inline.hpp. The accesses that are allowed through the access.hpp file
-// must be instantiated in access.cpp using the INSTANTIATE_HPP_ACCESS macro.
+// access.inline.hpp.
 
 template <DecoratorSet decorators = DECORATORS_NONE>
 class Access: public AllStatic {


### PR DESCRIPTION
Hi all,

This trivial patch fixes the comments about `atomic_xchg` and `atomic_xchg_at` in `access.hpp`.
And it removes the unnecessary content about `INSTANTIATE_HPP_ACCESS` 
which has been aleready removed in [JDK-8230808](https://bugs.openjdk.org/browse/JDK-8230808).

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321631](https://bugs.openjdk.org/browse/JDK-8321631): Fix comments in access.hpp (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17042/head:pull/17042` \
`$ git checkout pull/17042`

Update a local copy of the PR: \
`$ git checkout pull/17042` \
`$ git pull https://git.openjdk.org/jdk.git pull/17042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17042`

View PR using the GUI difftool: \
`$ git pr show -t 17042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17042.diff">https://git.openjdk.org/jdk/pull/17042.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17042#issuecomment-1848318366)