### PR TITLE
8321637: Simplify if statement in ArraysSupport::hugeLength

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -751,10 +751,8 @@ public class ArraysSupport {
         if (minLength < 0) { // overflow
             throw new OutOfMemoryError(
                 "Required array length " + oldLength + " + " + minGrowth + " is too large");
-        } else if (minLength <= SOFT_MAX_ARRAY_LENGTH) {
-            return SOFT_MAX_ARRAY_LENGTH;
-        } else {
-            return minLength;
+        }  else {
+            return Math.max(minLength, SOFT_MAX_ARRAY_LENGTH);
         }
     }
 


### PR DESCRIPTION
It looks the `else-if` and `else` clauses in method `ArraysSupport::hugeLength` could be simplified by `Math::max`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321637](https://bugs.openjdk.org/browse/JDK-8321637): Simplify if statement in ArraysSupport::hugeLength (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17043/head:pull/17043` \
`$ git checkout pull/17043`

Update a local copy of the PR: \
`$ git checkout pull/17043` \
`$ git pull https://git.openjdk.org/jdk.git pull/17043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17043`

View PR using the GUI difftool: \
`$ git pr show -t 17043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17043.diff">https://git.openjdk.org/jdk/pull/17043.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17043#issuecomment-1848779233)