### PR TITLE
8321640: Move the method barrier_stubs_init from BarrierSetAssembler to BarrierSet

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.hpp
@@ -111,8 +111,6 @@ public:
     Label&   slow_case                 // continuation point if fast allocation fails
   );
 
-  virtual void barrier_stubs_init() {}
-
   virtual NMethodPatchingType nmethod_patching_type() { return NMethodPatchingType::stw_instruction_and_data_patch; }
 
   virtual void nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation, Label* guard);

--- a/src/hotspot/cpu/arm/gc/shared/barrierSetAssembler_arm.hpp
+++ b/src/hotspot/cpu/arm/gc/shared/barrierSetAssembler_arm.hpp
@@ -59,7 +59,6 @@ public:
     Label&             slow_case         // continuation point if fast allocation fails
   );
 
-  virtual void barrier_stubs_init() {}
   virtual NMethodPatchingType nmethod_patching_type() { return NMethodPatchingType::stw_instruction_and_data_patch; }
   virtual void nmethod_entry_barrier(MacroAssembler* masm);
 };

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -63,8 +63,6 @@ public:
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register dst, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);
 
-  virtual void barrier_stubs_init() {}
-
   virtual NMethodPatchingType nmethod_patching_type() { return NMethodPatchingType::stw_instruction_and_data_patch; }
 
   virtual void nmethod_entry_barrier(MacroAssembler* masm, Register tmp);

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.hpp
@@ -88,8 +88,6 @@ public:
     bool is_far = false
   );
 
-  virtual void barrier_stubs_init() {}
-
   virtual NMethodPatchingType nmethod_patching_type() { return NMethodPatchingType::stw_instruction_and_data_patch; }
 
   virtual void nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation, Label* guard);

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -50,8 +50,6 @@ public:
                                              Register obj, Register tmp, Label& slowpath);
 
   virtual void nmethod_entry_barrier(MacroAssembler* masm);
-
-  virtual void barrier_stubs_init() {}
 };
 
 #endif // CPU_S390_GC_SHARED_BARRIERSETASSEMBLER_S390_HPP

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.hpp
@@ -100,8 +100,6 @@ public:
                              Register t1, Register t2,
                              Label& slow_case);
 
-  virtual void barrier_stubs_init() {}
-
   virtual void nmethod_entry_barrier(MacroAssembler* masm, Label* slow_path, Label* continuation);
   virtual void c2i_entry_barrier(MacroAssembler* masm);
 

--- a/src/hotspot/share/gc/shared/barrierSet.cpp
+++ b/src/hotspot/share/gc/shared/barrierSet.cpp
@@ -94,9 +94,8 @@ void BarrierSet::on_thread_attach(Thread* thread) {
 
 // Called from init.cpp
 void gc_barrier_stubs_init() {
-  BarrierSet* bs = BarrierSet::barrier_set();
 #ifndef ZERO
-  BarrierSetAssembler* bs_assembler = bs->barrier_set_assembler();
-  bs_assembler->barrier_stubs_init();
+  BarrierSet* bs = BarrierSet::barrier_set();
+  bs->barrier_stubs_init();
 #endif
 }

--- a/src/hotspot/share/gc/shared/barrierSet.hpp
+++ b/src/hotspot/share/gc/shared/barrierSet.hpp
@@ -146,6 +146,11 @@ public:
   // Print a description of the memory for the barrier set
   virtual void print_on(outputStream* st) const = 0;
 
+  // Generate the barrier stubs to reuse if needed.
+  // No GC or/and ARCH needs such barrier stubs now,
+  // but this method is remained for future use.
+  virtual void barrier_stubs_init() {}
+
   static BarrierSet* barrier_set() { return _barrier_set; }
   static void set_barrier_set(BarrierSet* barrier_set);
 


### PR DESCRIPTION
Hi all,

 This patch moves the method `barrier_stubs_init` from `BarrierSetAssembler` to `BarrierSet`.
The `BarrierSetAssembler` is an assember which is like `MacroAssembler`, but the method 
`barrier_stubs_init` generates and stores the stubs which is like `StubGenerator`.
So it is not good to place it in `BarrierSetAssembler`.

Thanks for taking the time to review.

Best Regards,
-- Guoixong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321640](https://bugs.openjdk.org/browse/JDK-8321640): Move the method barrier_stubs_init from BarrierSetAssembler to BarrierSet (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17044/head:pull/17044` \
`$ git checkout pull/17044`

Update a local copy of the PR: \
`$ git checkout pull/17044` \
`$ git pull https://git.openjdk.org/jdk.git pull/17044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17044`

View PR using the GUI difftool: \
`$ git pr show -t 17044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17044.diff">https://git.openjdk.org/jdk/pull/17044.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17044#issuecomment-1848863732)