### PR TITLE
6356745: (coll) Add PriorityQueue(Collection, Comparator)

### DIFF
--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -211,8 +211,8 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
     /**
      * Creates a {@code PriorityQueue} containing the elements in the
-     * specified collection that orders its elements according to the
-     * specified comparator.
+     * specified collection. The {@code PriorityQueue} will order its
+     * elements according to the specified comparator.
      *
      * @param  c the collection whose elements are to be placed
      *         into this priority queue

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -211,9 +211,8 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
     /**
      * Creates a {@code PriorityQueue} containing the elements in the
-     * specified collection. The {@code PriorityQueue} will order the
-     * priority queue's elements elements according to the specified
-     * comparator.
+     * specified collection. The elements of the new {@code PriorityQueue}
+     * will be ordered according to the specified comparator.
      *
      * @param  c the collection whose elements are to be placed
      *         into this priority queue

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -221,6 +221,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      *         natural ordering} of the elements will be used.
      * @throws NullPointerException if the specified collection or any
      *         of its elements are null
+     * @since 23
      */
     public PriorityQueue(Collection<? extends E> c,
                          Comparator<? super E> comparator) {

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -211,7 +211,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
     /**
      * Creates a {@code PriorityQueue} containing the elements in the
-     * specified collection that orders its elements according to the 
+     * specified collection that orders its elements according to the
      * specified comparator.
      *
      * @param  c the collection whose elements are to be placed
@@ -223,7 +223,7 @@ public class PriorityQueue<E> extends AbstractQueue<E>
      *         of its elements are null
      */
     public PriorityQueue(Collection<? extends E> c,
-    		             Comparator<? super E> comparator) {
+                         Comparator<? super E> comparator) {
         this.comparator = comparator;
         initFromCollection(c);
     }

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -211,8 +211,9 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
     /**
      * Creates a {@code PriorityQueue} containing the elements in the
-     * specified collection. The {@code PriorityQueue} will order its
-     * elements according to the specified comparator.
+     * specified collection. The {@code PriorityQueue} will order the
+     * priority queue's elements elements according to the specified
+     * comparator.
      *
      * @param  c the collection whose elements are to be placed
      *         into this priority queue

--- a/src/java.base/share/classes/java/util/PriorityQueue.java
+++ b/src/java.base/share/classes/java/util/PriorityQueue.java
@@ -211,6 +211,25 @@ public class PriorityQueue<E> extends AbstractQueue<E>
 
     /**
      * Creates a {@code PriorityQueue} containing the elements in the
+     * specified collection that orders its elements according to the 
+     * specified comparator.
+     *
+     * @param  c the collection whose elements are to be placed
+     *         into this priority queue
+     * @param  comparator the comparator that will be used to order this
+     *         priority queue.  If {@code null}, the {@linkplain Comparable
+     *         natural ordering} of the elements will be used.
+     * @throws NullPointerException if the specified collection or any
+     *         of its elements are null
+     */
+    public PriorityQueue(Collection<? extends E> c,
+    		             Comparator<? super E> comparator) {
+        this.comparator = comparator;
+        initFromCollection(c);
+    }
+
+    /**
+     * Creates a {@code PriorityQueue} containing the elements in the
      * specified priority queue.  This priority queue will be
      * ordered according to the same ordering as the given priority
      * queue.

--- a/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
+++ b/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
@@ -184,7 +184,7 @@ public class PriorityQueueTest extends JSR166TestCase {
 
     /**
      * Initializing from Collection with a comparator has the order
-     * of its elements the same as the queue initialized with a comparator 
+     * of its elements the same as the queue initialized with a comparator
      * and populated with Collection after initialization
      */
     public void testConstructor9() {

--- a/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
+++ b/test/jdk/java/util/concurrent/tck/PriorityQueueTest.java
@@ -30,7 +30,7 @@
  * Expert Group and released to the public domain, as explained at
  * http://creativecommons.org/publicdomain/zero/1.0/
  * Other contributors include Andrew Wright, Jeffrey Hayes,
- * Pat Fisher, Mike Judd.
+ * Pat Fisher, Mike Judd, Valeh Hajiyev.
  */
 
 import java.util.Arrays;
@@ -166,6 +166,37 @@ public class PriorityQueueTest extends JSR166TestCase {
         q.addAll(Arrays.asList(items));
         for (int i = SIZE - 1; i >= 0; --i)
             mustEqual(items[i], q.poll());
+    }
+
+    /**
+     * Queue contains all elements of collection used to initialize and
+     * uses the custom comparator provided to order its elements
+     */
+    public void testConstructor8() {
+        Item[] items = seqItems(SIZE);
+        MyReverseComparator cmp = new MyReverseComparator();
+        @SuppressWarnings("unchecked")
+        PriorityQueue<Item> q = new PriorityQueue<>(Arrays.asList(items), cmp);
+        assertEquals(cmp, q.comparator());
+        for (int i = SIZE - 1; i >= 0; --i)
+            mustEqual(items[i], q.poll());
+    }
+
+    /**
+     * Initializing from Collection with a comparator has the order
+     * of its elements the same as the queue initialized with a comparator 
+     * and populated with Collection after initialization
+     */
+    public void testConstructor9() {
+        Item[] items = seqItems(SIZE);
+        MyReverseComparator cmp = new MyReverseComparator();
+        @SuppressWarnings("unchecked")
+        PriorityQueue<Item> q1 = new PriorityQueue<>(Arrays.asList(items), cmp);
+        @SuppressWarnings("unchecked")
+        PriorityQueue<Item> q2 = new PriorityQueue<>(SIZE, cmp);
+        q2.addAll(Arrays.asList(items));
+        for (int i = 0; i < SIZE; ++i)
+            mustEqual(q1.poll(), q2.poll());
     }
 
     /**


### PR DESCRIPTION
This commit addresses the current limitation in the `PriorityQueue` implementation, which lacks a constructor to efficiently create a priority queue with a custom comparator and an existing collection. In order to create such a queue, we currently need to initialize a new queue with custom comparator, and after that populate the queue using `addAll()` method, which in the background calls `add()` method (which takes `O(logn)` time) for each element of the collection (`n` times).  This is resulting in an overall time complexity of `O(nlogn)`. 

```Java
PriorityQueue<String> pq = new PriorityQueue<>(customComparator);
pq.addAll(existingCollection);
```

The pull request introduces a new constructor to streamline this process and reduce the time complexity to `O(n)`.  If you create the queue above using the new constructor, the contents of the collection will be copied (which takes `O(n)` time) and then later  `heapify()` operation (Floyd's algorithm) will be called once (another `O(n)` time). Overall the operation will be reduced from `O(nlogn)` to `O(2n)` -> `O(n)` time.

```
PriorityQueue<String> pq = new PriorityQueue<>(existingCollection, customComparator);
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 23 to be approved (needs to be created)

### Issue
 * [JDK-6356745](https://bugs.openjdk.org/browse/JDK-6356745): (coll) Add PriorityQueue(Collection, Comparator) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17045/head:pull/17045` \
`$ git checkout pull/17045`

Update a local copy of the PR: \
`$ git checkout pull/17045` \
`$ git pull https://git.openjdk.org/jdk.git pull/17045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17045`

View PR using the GUI difftool: \
`$ git pr show -t 17045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17045.diff">https://git.openjdk.org/jdk/pull/17045.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17045#issuecomment-1856538425)