### PR TITLE
8321641: ClassFile ModuleAttribute.ModuleAttributeBuilder::moduleVersion spec contains a copy-paste error

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
@@ -202,7 +202,7 @@ public sealed interface ModuleAttribute
         }
 
         /**
-         * Sets the module flags
+         * Sets the module version
          * @param version the module version
          * @return this builder
          */


### PR DESCRIPTION
This is a fix of ClassFile ModuleAttribute.ModuleAttributeBuilder::moduleVersion javadoc copy-paste error.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321641](https://bugs.openjdk.org/browse/JDK-8321641): ClassFile ModuleAttribute.ModuleAttributeBuilder::moduleVersion spec contains a copy-paste error (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17051/head:pull/17051` \
`$ git checkout pull/17051`

Update a local copy of the PR: \
`$ git checkout pull/17051` \
`$ git pull https://git.openjdk.org/jdk.git pull/17051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17051`

View PR using the GUI difftool: \
`$ git pr show -t 17051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17051.diff">https://git.openjdk.org/jdk/pull/17051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17051#issuecomment-1849725868)