### PR TITLE
8311306: Test com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java failed: out of expected range

### DIFF
--- a/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
+++ b/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
  * @summary Basic test of ThreadMXBean.getThreadCpuTime(long[]) and
  *          getThreadUserTime(long[]).
  * @author  Paul Hohensee
+ * @run main/othervm ThreadCpuTimeArray
  */
 
 import java.lang.management.*;


### PR DESCRIPTION
Trivial test update to run in "othervm".   This test has failed due to interrupted threads: the interruption interferes with timing, but also the test is designed to fail if interrupted.

Other tests in the same directory have the same requirement that threads/sleeps are not interrupted, and they run with othervm and are not known to fail.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311306](https://bugs.openjdk.org/browse/JDK-8311306): Test com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java failed: out of expected range (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17054/head:pull/17054` \
`$ git checkout pull/17054`

Update a local copy of the PR: \
`$ git checkout pull/17054` \
`$ git pull https://git.openjdk.org/jdk.git pull/17054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17054`

View PR using the GUI difftool: \
`$ git pr show -t 17054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17054.diff">https://git.openjdk.org/jdk/pull/17054.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17054#issuecomment-1849942442)