### PR TITLE
8321729: Remove 'orb' field in RMIConnector

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnector.java
@@ -2298,12 +2298,6 @@ public class RMIConnector implements JMXConnector, Serializable, JMXAddressable 
 
     private transient ClientCommunicatorAdmin communicatorAdmin;
 
-    /**
-     * A static WeakReference to an {@link org.omg.CORBA.ORB ORB} to
-     * connect unconnected stubs.
-     **/
-    private static volatile WeakReference<Object> orb = null;
-
     // TRACES & DEBUG
     //---------------
     private static String objects(final Object[] objs) {


### PR DESCRIPTION
Tidyup change, looks like this field was not removed when IIOP was removed from RMIConnector.

The field is not required for interoperability: 
with the field removed, I can still connect an older JMX client to a running app with the updated JDK.

Since the JDK9 change https://hg.openjdk.org/jdk9/jdk9/jdk/rev/09daaf1e4c53
did not change serialVersionUID, this update does not either.

Tests continue to pass, e.g.
javax/management (including remote which has RMI tests)
jdk/com/sun/management

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321729](https://bugs.openjdk.org/browse/JDK-8321729): Remove 'orb' field in RMIConnector (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17055/head:pull/17055` \
`$ git checkout pull/17055`

Update a local copy of the PR: \
`$ git checkout pull/17055` \
`$ git pull https://git.openjdk.org/jdk.git pull/17055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17055`

View PR using the GUI difftool: \
`$ git pr show -t 17055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17055.diff">https://git.openjdk.org/jdk/pull/17055.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17055#issuecomment-1850050202)