### PR TITLE
8321400: java/foreign/TestStubAllocFailure.java fails with code cache exhaustion

### DIFF
--- a/test/jdk/java/foreign/TestAddressDereference.java
+++ b/test/jdk/java/foreign/TestAddressDereference.java
@@ -128,8 +128,8 @@ public class TestAddressDereference extends UpcallTestHelper {
         if (!badAlign) return;
         runInNewProcess(UpcallTestRunner.class, true,
                 new String[] {Long.toString(alignment), layout.toString() })
-                .assertFailed()
-                .assertStdErrContains("alignment constraint for address");
+                .shouldNotHaveExitValue(0)
+                .stderrShouldContain("alignment constraint for address");
     }
 
     public static class UpcallTestRunner {

--- a/test/jdk/java/foreign/TestUpcallException.java
+++ b/test/jdk/java/foreign/TestUpcallException.java
@@ -48,8 +48,8 @@ public class TestUpcallException extends UpcallTestHelper {
     @Test(dataProvider = "exceptionCases")
     public void testException(Class<?> target, boolean useSpec) throws InterruptedException, IOException {
         runInNewProcess(target, useSpec)
-                .assertFailed()
-                .assertStdErrContains("Testing upcall exceptions");
+                .shouldNotHaveExitValue(0)
+                .stderrShouldContain("Testing upcall exceptions");
     }
 
     @DataProvider

--- a/test/jdk/java/foreign/critical/TestCriticalUpcall.java
+++ b/test/jdk/java/foreign/critical/TestCriticalUpcall.java
@@ -43,7 +43,9 @@ public class TestCriticalUpcall extends UpcallTestHelper {
     @Test
     public void testUpcallFailure() throws IOException, InterruptedException {
         // test to see if we catch a trivial downcall doing an upcall
-        runInNewProcess(Runner.class, true).assertFailed().assertStdOutContains("wrong thread state for upcall");
+        runInNewProcess(Runner.class, true)
+            .shouldNotHaveExitValue(0)
+            .stdoutShouldContain("wrong thread state for upcall");
     }
 
     public static class Runner extends NativeTestHelper {

--- a/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
+++ b/test/jdk/java/foreign/passheapsegment/TestPassHeapSegment.java
@@ -53,7 +53,9 @@ public class TestPassHeapSegment extends UpcallTestHelper  {
 
     @Test(dataProvider = "specs")
     public void testNoHeapReturns(boolean spec) throws IOException, InterruptedException {
-        runInNewProcess(Runner.class, spec).assertFailed().assertStdErrContains("Heap segment not allowed");
+        runInNewProcess(Runner.class, spec)
+            .shouldNotHaveExitValue(0)
+            .stderrShouldContain("Heap segment not allowed");
     }
 
     public static class Runner {

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -42,6 +42,8 @@ public final class OutputAnalyzer {
 
     private static final String deprecatedmsg = ".* VM warning:.* deprecated.*";
 
+    private static final String FATAL_ERROR_PAT = "# A fatal error has been detected";
+
     private final OutputBuffer buffer;
     /**
      * Create an OutputAnalyzer, a utility class for verifying output and exit
@@ -860,6 +862,13 @@ public final class OutputAnalyzer {
 
     public void shouldContainMultiLinePattern(String... needles) {
         shouldContainMultiLinePattern(needles, true);
+    }
+
+    /**
+     * Assert that we did not crash with a hard VM error (generating an hs_err_pidXXX.log)
+     */
+    public void shouldNotHaveFatalError() {
+        shouldNotContain(FATAL_ERROR_PAT);
     }
 
 }

--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -42,7 +42,7 @@ public final class OutputAnalyzer {
 
     private static final String deprecatedmsg = ".* VM warning:.* deprecated.*";
 
-    private static final String FATAL_ERROR_PAT = "# A fatal error has been detected";
+    private static final String FATAL_ERROR_PAT = "# A fatal error has been detected.*";
 
     private final OutputBuffer buffer;
     /**
@@ -868,7 +868,7 @@ public final class OutputAnalyzer {
      * Assert that we did not crash with a hard VM error (generating an hs_err_pidXXX.log)
      */
     public void shouldNotHaveFatalError() {
-        shouldNotContain(FATAL_ERROR_PAT);
+        shouldNotMatch(FATAL_ERROR_PAT);
     }
 
 }


### PR DESCRIPTION
Improve the test by being more lenient to related code cache exhaustion errors. The important thing is that we don't terminate with a fatal error, which the new code now checks for explicitly. The check for that is based on what is done by `./test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java` .

The existing `UpcallTestHelper.Output` class that was previously used to assert on stdout/stderr contents did not have the capability to look for patterns in the output. So, I've taken the opportunity to replace it with the more canonical `OutputAnalyzer` which comes from the test library.

Finally, I've also added back the test for downcall stub allocation failure which was removed as part of the initial patch because it was too inconsistent [1]. With the new approach, it should pass reliably as well.

Testing: `jdk_foreign`  suite (which contains all the affected tests)

[1]: https://github.com/openjdk/jdk/pull/16311/commits/9a1360598a91871ce6ec48330849c0e4e0279c64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321400](https://bugs.openjdk.org/browse/JDK-8321400): java/foreign/TestStubAllocFailure.java fails with code cache exhaustion (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17056/head:pull/17056` \
`$ git checkout pull/17056`

Update a local copy of the PR: \
`$ git checkout pull/17056` \
`$ git pull https://git.openjdk.org/jdk.git pull/17056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17056`

View PR using the GUI difftool: \
`$ git pr show -t 17056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17056.diff">https://git.openjdk.org/jdk/pull/17056.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17056#issuecomment-1850113043)