### PR TITLE
8321514: UTF16 string gets constructed incorrectly from codepoints if CompactStrings is not enabled

### DIFF
--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -420,7 +420,7 @@ final class StringUTF16 {
         int n = computeCodePointSize(val, index, end);
 
         byte[] buf = newBytesFor(n);
-        return extractCodepoints(val, index, len, buf, 0);
+        return extractCodepoints(val, index, end, buf, 0);
      }
 
     public static byte[] toBytes(char c) {

--- a/test/jdk/java/lang/String/CodePoints.java
+++ b/test/jdk/java/lang/String/CodePoints.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, 2023, BELLSOFT. All rights reserved. 
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8311906 8321514
+ * @summary test UTF16 string construction from codepoints
+ * @run junit/othervm -XX:-CompactStrings CodePoints
+ */
+
+import java.io.UnsupportedEncodingException;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CodePoints {
+
+  private final String sUTF16 = "\u041e\u0434\u043d\u0430\u0436\u0434\u044b";
+
+  @Test
+  public void TestUTF16() throws UnsupportedEncodingException{
+      int codePoints[] = sUTF16.codePoints().toArray();
+      String cut = new String(codePoints, 3, 3);
+      assertEquals("\u0430\u0436\u0434", cut);
+  }
+}


### PR DESCRIPTION
Since JDK-8311906, if CompactStrings is not enabled, index is not considered when calling extractCodepoints from StringUTF16.toBytes(). Because of that the last elements of the source codepoints array are stripped from the resulting UTF16 string, which fires in other places (e.g. during RegEx processing).
 
The fix replaces len in extractCodepoints parameters with end that is index + len.