### PR TITLE
8321802: (zipfs) Add validation of incorrect LOC signature in ZipFileSystem

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -2575,6 +2575,9 @@ class ZipFileSystem extends FileSystem {
                 if (readNBytesAt(buf, 0, buf.length, pos) != LOCHDR) {
                     throw new ZipException("invalid loc " + pos + " for entry reading");
                 }
+                if (LOCSIG(buf) != LOCSIG) {
+                    throw new ZipException("invalid loc header (bad signature)");
+                }
                 pos += LOCHDR + LOCNAM(buf) + LOCEXT(buf);
             }
         }

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -2573,10 +2573,10 @@ class ZipFileSystem extends FileSystem {
                 pos = -pos + locpos;
                 byte[] buf = new byte[LOCHDR];
                 if (readNBytesAt(buf, 0, buf.length, pos) != LOCHDR) {
-                    throw new ZipException("invalid loc " + pos + " for entry reading");
+                    throw new ZipException("invalid LOC " + pos + " for entry reading");
                 }
                 if (LOCSIG(buf) != LOCSIG) {
-                    throw new ZipException("invalid loc header (bad signature)");
+                    throw new ZipException("invalid LOC header (bad signature)");
                 }
                 pos += LOCHDR + LOCNAM(buf) + LOCEXT(buf);
             }

--- a/test/jdk/jdk/nio/zipfs/CorruptedZipFilesTest.java
+++ b/test/jdk/jdk/nio/zipfs/CorruptedZipFilesTest.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8316141
+ * @bug 8316141 8321802
  * @summary test for correct detection and reporting of corrupted zip files
  * @run junit CorruptedZipFilesTest
  */
@@ -285,6 +285,16 @@ public class CorruptedZipFilesTest {
     public void unsupportedCompressionMethod() throws IOException {
         copy[cenpos+CENHOW] = 2;
         assertZipException(".*unsupported compression method.*");
+    }
+
+    /*
+     * A ZipException is thrown when a LOC header has an unexpected signature
+     */
+    @Test
+    public void invalidLOCSignature() throws IOException {
+        int existingSignature = buffer.getInt(locpos);
+        buffer.putInt(locpos, existingSignature +1);
+        assertZipException(".*bad signature.*");
     }
 
     /*


### PR DESCRIPTION
Please review this PR which adds validation of incorrect LOC signatures in `ZipFileSystem`.

`ZipFile` already rejects the case where the  offset pointed to from the CEN header does not start with the expected LOC signature. It makes sense to add this check to `ZipFileSystem` as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321802](https://bugs.openjdk.org/browse/JDK-8321802): (zipfs) Add validation of incorrect LOC signature in ZipFileSystem (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17059/head:pull/17059` \
`$ git checkout pull/17059`

Update a local copy of the PR: \
`$ git checkout pull/17059` \
`$ git pull https://git.openjdk.org/jdk.git pull/17059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17059`

View PR using the GUI difftool: \
`$ git pr show -t 17059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17059.diff">https://git.openjdk.org/jdk/pull/17059.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17059#issuecomment-1851692069)