### PR TITLE
8321561: (fs) Clarify non-atomic behavior of Files.move

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1389,6 +1389,15 @@ public final class Files {
      *     Files.move(source, newdir.resolve(source.getFileName()), REPLACE_EXISTING);
      * }
      *
+     * @apiNote
+     * If the options array contains the {@code REPLACE_EXISTING} option, but
+     * the file cannot be moved as an atomic file system operation, then it
+     * might be moved by first deleting the target file and then copying or
+     * renaming the source file to the target location. If some other process
+     * creates a file at the target location after the deletion but before the
+     * copying or renaming, then a {@code FileAlreadyExistsException} may be
+     * thrown despite the {@code REPLACE_EXISTING} option having been specified.
+     *
      * @param   source
      *          the path to the file to move
      * @param   target

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1358,9 +1358,9 @@ public final class Files {
      *     associated with a different provider to this object. </td>
      * </tbody>
      * </table>
-     * If the {@code ATOMIC_MOVE} option is not specified, then the check for
-     * an existing file and the actual move might not be atomic with respect
-     * to other filesystem activities.
+     * If the {@code ATOMIC_MOVE} option is not specified, then the check
+     * whether the target file exists and the actual move might not be atomic
+     * with respect to other filesystem activities.
      *
      * <p> An implementation of this interface may support additional
      * implementation specific options.
@@ -1406,12 +1406,11 @@ public final class Files {
      *          if the array contains a copy option that is not supported
      * @throws  FileAlreadyExistsException
      *          if the target file exists but cannot be replaced because the
-     *          {@code REPLACE_EXISTING} option is <i>not</i> specified,
-     *          or if the {@code REPLACE_EXISTING} option <i>is</i> specified,
-     *          the target file does not exist, the move is not an atomic file
-     *          system operation, and a file is created at the target location
-     *          between the existence check and actually moving the source
-     *          <i>(optional specific exceptions)</i>
+     *          {@code REPLACE_EXISTING} option is <i>not</i> specified.
+     *          It may also be thrown when the {@code REPLACE_EXISTING} option
+     *          <i>is</i> specified, the move is not atomic, and the target
+     *          file is created by some other entity at around the same time
+     *          that this method is called
      * @throws  DirectoryNotEmptyException
      *          the {@code REPLACE_EXISTING} option is specified but the file
      *          cannot be replaced because it is a non-empty directory, or the

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1358,6 +1358,9 @@ public final class Files {
      *     associated with a different provider to this object. </td>
      * </tbody>
      * </table>
+     * If the {@code ATOMIC_MOVE} option is not specified, then the check for
+     * an existing file and the actual move might not be atomic with respect
+     * to other filesystem activities.
      *
      * <p> An implementation of this interface may support additional
      * implementation specific options.
@@ -1389,15 +1392,6 @@ public final class Files {
      *     Files.move(source, newdir.resolve(source.getFileName()), REPLACE_EXISTING);
      * }
      *
-     * @apiNote
-     * If the options array contains the {@code REPLACE_EXISTING} option, but
-     * the file cannot be moved as an atomic file system operation, then it
-     * might be moved by first deleting the target file and then copying or
-     * renaming the source file to the target location. If some other process
-     * creates a file at the target location after the deletion but before the
-     * copying or renaming, then a {@code FileAlreadyExistsException} may be
-     * thrown despite the {@code REPLACE_EXISTING} option having been specified.
-     *
      * @param   source
      *          the path to the file to move
      * @param   target
@@ -1412,8 +1406,12 @@ public final class Files {
      *          if the array contains a copy option that is not supported
      * @throws  FileAlreadyExistsException
      *          if the target file exists but cannot be replaced because the
-     *          {@code REPLACE_EXISTING} option is not specified <i>(optional
-     *          specific exception)</i>
+     *          {@code REPLACE_EXISTING} option is <i>not</i> specified,
+     *          or if the {@code REPLACE_EXISTING} option <i>is</i> specified,
+     *          the target file does not exist, the move is not an atomic file
+     *          system operation, and a file is created at the target location
+     *          between the existence check and actually moving the source
+     *          <i>(optional specific exceptions)</i>
      * @throws  DirectoryNotEmptyException
      *          the {@code REPLACE_EXISTING} option is specified but the file
      *          cannot be replaced because it is a non-empty directory, or the


### PR DESCRIPTION
Make it clear that a `FileAlreadyExistsException` may be thrown by `Files.move` even if the `REPLACE_EXISTING` option is specified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8323194](https://bugs.openjdk.org/browse/JDK-8323194) to be approved

### Issues
 * [JDK-8321561](https://bugs.openjdk.org/browse/JDK-8321561): (fs) Clarify non-atomic behavior of Files.move (**Enhancement** - P4)
 * [JDK-8323194](https://bugs.openjdk.org/browse/JDK-8323194): (fs) Clarify non-atomic behavior of Files.move (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17061/head:pull/17061` \
`$ git checkout pull/17061`

Update a local copy of the PR: \
`$ git checkout pull/17061` \
`$ git pull https://git.openjdk.org/jdk.git pull/17061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17061`

View PR using the GUI difftool: \
`$ git pr show -t 17061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17061.diff">https://git.openjdk.org/jdk/pull/17061.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17061#issuecomment-1850443449)