### PR TITLE
8321808: G1: Use unsigned type for non-negative G1 flags

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -117,7 +117,7 @@
           "Confidence level for MMU/pause predictions")                     \
           range(0, 100)                                                     \
                                                                             \
-  product(intx, G1SummarizeRSetStatsPeriod, 0, DIAGNOSTIC,                  \
+  product(uintx, G1SummarizeRSetStatsPeriod, 0, DIAGNOSTIC,                  \
           "The period (in number of GCs) at which we will generate "        \
           "update buffer processing info "                                  \
           "(0 means do not periodically generate this info); "              \
@@ -148,7 +148,7 @@
           "Number of entries in an SATB log buffer.")                       \
           constraint(G1SATBBufferSizeConstraintFunc, AtParse)               \
                                                                             \
-  develop(intx, G1SATBProcessCompletedThreshold, 20,                        \
+  develop(uintx, G1SATBProcessCompletedThreshold, 20,                        \
           "Number of completed buffers that triggers log processing.")      \
           range(0, max_jint)                                                \
                                                                             \

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -113,11 +113,11 @@
           "of the optimal occupancy to start marking.")                     \
           range(1, max_intx)                                                \
                                                                             \
-  product(uint, G1ConfidencePercent, 50,                                   \
+  product(uint, G1ConfidencePercent, 50,                                    \
           "Confidence level for MMU/pause predictions")                     \
           range(0, 100)                                                     \
                                                                             \
-  product(uintx, G1SummarizeRSetStatsPeriod, 0, DIAGNOSTIC,                  \
+  product(uintx, G1SummarizeRSetStatsPeriod, 0, DIAGNOSTIC,                 \
           "The period (in number of GCs) at which we will generate "        \
           "update buffer processing info "                                  \
           "(0 means do not periodically generate this info); "              \
@@ -148,7 +148,7 @@
           "Number of entries in an SATB log buffer.")                       \
           constraint(G1SATBBufferSizeConstraintFunc, AtParse)               \
                                                                             \
-  develop(uintx, G1SATBProcessCompletedThreshold, 20,                        \
+  develop(uintx, G1SATBProcessCompletedThreshold, 20,                       \
           "Number of completed buffers that triggers log processing.")      \
           range(0, max_jint)                                                \
                                                                             \


### PR DESCRIPTION
Simple type update for some G1 flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321808](https://bugs.openjdk.org/browse/JDK-8321808): G1: Use unsigned type for non-negative G1 flags (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17063/head:pull/17063` \
`$ git checkout pull/17063`

Update a local copy of the PR: \
`$ git checkout pull/17063` \
`$ git pull https://git.openjdk.org/jdk.git pull/17063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17063`

View PR using the GUI difftool: \
`$ git pr show -t 17063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17063.diff">https://git.openjdk.org/jdk/pull/17063.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17063#issuecomment-1850474323)