### PR TITLE
8321683: Tests fail with AssertionError in RangeWithPageSize

### DIFF
--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -350,7 +350,7 @@ class RangeWithPageSize {
         this.start = Long.parseUnsignedLong(start, 16);
         this.end = Long.parseUnsignedLong(end, 16);
         this.pageSize = Long.parseLong(pageSize);
-        this.thpEligible = Integer.parseInt(thpEligible) == 1;
+        this.thpEligible = thpEligible == null ? false : (Integer.parseInt(thpEligible) == 1);
 
         vmFlagHG = false;
         vmFlagHT = false;

--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -365,12 +365,11 @@ class RangeWithPageSize {
             }
         }
 
-        // When the THP policy is 'always' instead of 'madvise, the vmFlagHG property is false.
-        // Check the THPeligible property instead.
-        isTHP = !vmFlagHT && this.thpEligible;
+        // When the THP policy is 'always' instead of 'madvise, the vmFlagHG property is false,
+        // therefore also check thpEligible. If this is still cauing problems in the future,
+        // we might have to check the AnonHugePages field.
 
-        // vmFlagHG should imply isTHP
-        assert !vmFlagHG || isTHP;
+        isTHP = vmFlagHG || this.thpEligible;
     }
 
     public long getPageSize() {

--- a/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
+++ b/test/hotspot/jtreg/runtime/os/TestTracePageSizes.java
@@ -366,7 +366,7 @@ class RangeWithPageSize {
         }
 
         // When the THP policy is 'always' instead of 'madvise, the vmFlagHG property is false,
-        // therefore also check thpEligible. If this is still cauing problems in the future,
+        // therefore also check thpEligible. If this is still causing problems in the future,
         // we might have to check the AnonHugePages field.
 
         isTHP = vmFlagHG || this.thpEligible;


### PR DESCRIPTION
The test was recently changed to check the THPeligible value in the smaps file, instead of checking the hg flag. This was done because hg isn't set if the THP policy is set to 'always'. With that change I added an assert that if the "hg" flag is set, then THPeligible should also be set. This turns out to not be true, and the assert fails.

My proposal is to check both properties and set isTHP to true if either is set. The isTHP property is later only used to make the page size checks more lenient in the presence of transparent huge pages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321683](https://bugs.openjdk.org/browse/JDK-8321683): Tests fail with AssertionError in RangeWithPageSize (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [cecabbdf](https://git.openjdk.org/jdk/pull/17064/files/cecabbdfc746437a4d31c6a1228b4ae121b33c71)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [cecabbdf](https://git.openjdk.org/jdk/pull/17064/files/cecabbdfc746437a4d31c6a1228b4ae121b33c71)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17064/head:pull/17064` \
`$ git checkout pull/17064`

Update a local copy of the PR: \
`$ git checkout pull/17064` \
`$ git pull https://git.openjdk.org/jdk.git pull/17064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17064`

View PR using the GUI difftool: \
`$ git pr show -t 17064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17064.diff">https://git.openjdk.org/jdk/pull/17064.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17064#issuecomment-1850636498)