### PR TITLE
Extend testing of new String of int [] to cover subranges

### DIFF
--- a/test/jdk/java/lang/String/Chars.java
+++ b/test/jdk/java/lang/String/Chars.java
@@ -23,8 +23,10 @@
 
 /*
  * @test
- * @bug 8054307 8311906
+ * @bug 8054307 8311906 8321514
  * @summary test String chars() and codePoints()
+ * @run main/othervm -XX:+CompactStrings Chars
+ * @run main/othervm -XX:-CompactStrings Chars
  */
 
 import java.util.Arrays;
@@ -45,6 +47,7 @@ public class Chars {
             }
             testChars(cc, ccExp);
             testCharsSubrange(cc, ccExp);
+            testIntsSubrange(ccExp);
             testCPs(cc, cpExp);
 
             // bmp without surrogates
@@ -90,6 +93,27 @@ public class Chars {
             int offset = Math.max(0, offsets[i]);       // confine to the input array
             int count = Math.min(LENGTH, cc.length - offset);
             String str = new String(cc, offset, count);
+            int[] actual = str.chars().toArray();
+            int errOffset = Arrays.mismatch(actual, 0, actual.length,
+                    expected, offset, offset + count);
+            if (errOffset >= 0) {
+                System.err.printf("expected[%d] (%d) != actual[%d] (%d)%n",
+                        offset + errOffset, expected[offset + errOffset],
+                        errOffset, actual[errOffset]);
+                System.err.println("expected: " + Arrays.toString(expected));
+                System.err.println("actual: " + Arrays.toString(actual));
+                throw new RuntimeException("testCharsSubrange failed!");
+            }
+        }
+    }
+
+    static void testIntsSubrange(int[] expected) {
+        int[] offsets = { 7, 31 };   // offsets to test
+        int LENGTH = 13;
+        for (int i = 0; i < offsets.length; i++) {
+            int offset = Math.max(0, offsets[i]);       // confine to the input array
+            int count = Math.min(LENGTH, expected.length - offset);
+            String str = new String(expected, offset, count);
             int[] actual = str.chars().toArray();
             int errOffset = Arrays.mismatch(actual, 0, actual.length,
                     expected, offset, offset + count);


### PR DESCRIPTION
Issue JDK-8321514 and [PR 17057](https://github.com/openjdk/jdk/pull/17057#top)
show a gap in testing of string constructors from int arrays.
Some additional tests would be useful for creating subranges.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #17057 must be integrated first

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17066/head:pull/17066` \
`$ git checkout pull/17066`

Update a local copy of the PR: \
`$ git checkout pull/17066` \
`$ git pull https://git.openjdk.org/jdk.git pull/17066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17066`

View PR using the GUI difftool: \
`$ git pr show -t 17066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17066.diff">https://git.openjdk.org/jdk/pull/17066.diff</a>

</details>
