### PR TITLE
8321814: G1: Remove unused G1RemSetScanState::_collection_set_iter_state

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -91,11 +91,6 @@ class G1RemSetScanState : public CHeapObj<mtGC> {
 
   size_t _max_reserved_regions;
 
-  // Has this region that is part of the regions in the collection set been processed yet.
-  typedef bool G1RemsetIterState;
-
-  G1RemsetIterState volatile* _collection_set_iter_state;
-
   // Card table iteration claim for each heap region, from 0 (completely unscanned)
   // to (>=) HeapRegion::CardsPerRegion (completely scanned).
   uint volatile* _card_table_scan_state;


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321814](https://bugs.openjdk.org/browse/JDK-8321814): G1: Remove unused G1RemSetScanState::_collection_set_iter_state (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17068/head:pull/17068` \
`$ git checkout pull/17068`

Update a local copy of the PR: \
`$ git checkout pull/17068` \
`$ git pull https://git.openjdk.org/jdk.git pull/17068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17068`

View PR using the GUI difftool: \
`$ git pr show -t 17068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17068.diff">https://git.openjdk.org/jdk/pull/17068.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17068#issuecomment-1850780667)