### PR TITLE
JDK-8164094: javadoc allows to create a @link to a non-existent method

### DIFF
--- a/test/langtools/tools/javac/doctree/ReferenceTest.java
+++ b/test/langtools/tools/javac/doctree/ReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/tools/javac/doctree/ReferenceTest.java
+++ b/test/langtools/tools/javac/doctree/ReferenceTest.java
@@ -253,6 +253,10 @@ public class ReferenceTest extends AbstractProcessor {
  * @see #methodSearchPrimitive2(long, int)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive2(long, int)
  * @see #methodSearchPrimitive2(int, long)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive2(int, long)
  * @see #methodSearchPrimitive2(long, long)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive2(long, long)
+ *
+ * @see Inner#X    Bad
+ * @see Inner#X()  Bad
+ * @see Inner#m    Bad
  */
 class ReferenceTestExtras {
     int ReferenceTestExtras;            // field

--- a/test/langtools/tools/javac/doctree/ReferenceTest.java
+++ b/test/langtools/tools/javac/doctree/ReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8278373
+ * @bug 7021614 8278373 8164094
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @summary check references in at-see and {at-link} tags
  * @modules jdk.compiler
@@ -130,6 +130,12 @@ public class ReferenceTest extends AbstractProcessor {
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         for (Element e: roundEnv.getRootElements()) {
             new DocCommentScanner(trees.getPath(e)).scan();
+            for (Element enc: e.getEnclosedElements()) {
+                TreePath path = trees.getPath(enc);
+                if (trees.getDocCommentTree(path) != null) {
+                    new DocCommentScanner(path).scan();
+                }
+            }
         }
         return true;
     }
@@ -276,6 +282,16 @@ class ReferenceTestExtras {
     void methodSearchPrimitive2(int i, long j) {}
     void methodSearchPrimitive2(long i, int j) {}
     void methodSearchPrimitive2(int i, int j) {}
+
+    /**
+     * @see #X         Field
+     * @see #X()       Method
+     * @see #m         Method
+     * @see Inner#X    Bad
+     * @see Inner#X()  Bad
+     * @see Inner#m    Bad
+     */
+    interface Inner {}
 }
 
 


### PR DESCRIPTION
Please review a simple fix in `JavacTrees` to only look up member references in the enclosing type if the reference does not contain an explicit type name. For example, `@see #method()` in a a doc comment of class `Outer.Inner` should find method `Outer.method()`, but `@see Inner#method()` should not (regardless of comment location).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8325036](https://bugs.openjdk.org/browse/JDK-8325036) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issues
 * [JDK-8164094](https://bugs.openjdk.org/browse/JDK-8164094): javadoc allows to create a @<!---->link to a non-existent method (**Bug** - P3)
 * [JDK-8325036](https://bugs.openjdk.org/browse/JDK-8325036): javadoc allows to create a @<!---->link to a non-existent method (**CSR**)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to [4f08440e](https://git.openjdk.org/jdk/pull/17069/files/4f08440ef32e188b443a91dcc0153c828cb3842c)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [4f08440e](https://git.openjdk.org/jdk/pull/17069/files/4f08440ef32e188b443a91dcc0153c828cb3842c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17069/head:pull/17069` \
`$ git checkout pull/17069`

Update a local copy of the PR: \
`$ git checkout pull/17069` \
`$ git pull https://git.openjdk.org/jdk.git pull/17069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17069`

View PR using the GUI difftool: \
`$ git pr show -t 17069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17069.diff">https://git.openjdk.org/jdk/pull/17069.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17069#issuecomment-1850910724)