### PR TITLE
8321542: C2: Missing ChaCha20 stub for x86_32 leads to crashes

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1149,7 +1149,7 @@ void VM_Version::get_processor_features() {
 #else
   // No support currently for ChaCha20 intrinsics on 32-bit platforms
   if (UseChaCha20Intrinsics) {
-      warning("Support for ChaCha20 intrinsics not available on this CPU.");
+      warning("ChaCha20 intrinsics are not available on this CPU.");
       FLAG_SET_DEFAULT(UseChaCha20Intrinsics, false);
   }
 #endif // _LP64

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1149,7 +1149,7 @@ void VM_Version::get_processor_features() {
 #else
   // No support currently for ChaCha20 intrinsics on 32-bit platforms
   if (UseChaCha20Intrinsics) {
-      warning("Intrinsics for ChaCha20 intrinsics not available on this CPU.");
+      warning("Support for ChaCha20 intrinsics not available on this CPU.");
       FLAG_SET_DEFAULT(UseChaCha20Intrinsics, false);
   }
 #endif // _LP64

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1130,6 +1130,7 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseGHASHIntrinsics, false);
   }
 
+#ifdef _LP64
   // ChaCha20 Intrinsics
   // As long as the system supports AVX as a baseline we can do a
   // SIMD-enabled block function.  StubGenerator makes the determination
@@ -1145,6 +1146,13 @@ void VM_Version::get_processor_features() {
       }
       FLAG_SET_DEFAULT(UseChaCha20Intrinsics, false);
   }
+#else
+  // No support currently for ChaCha20 intrinsics on 32-bit platforms
+  if (UseChaCha20Intrinsics) {
+      warning("Intrinsics for ChaCha20 intrinsics not available on this CPU.");
+      FLAG_SET_DEFAULT(UseChaCha20Intrinsics, false);
+  }
+#endif // _LP64
 
   // Base64 Intrinsics (Check the condition for which the intrinsic will be active)
   if (UseAVX >= 2) {


### PR DESCRIPTION
This fix corrects an oversight in the ChaCha20 intrinsics delivered by JDK-8247645.  An ifdef guard is now part of the x86 ChaCha20 intrinsics code which disables them by default on 32-bit platforms, as this architecture was not part of the feature delivery.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321542](https://bugs.openjdk.org/browse/JDK-8321542): C2: Missing ChaCha20 stub for x86_32 leads to crashes (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [fe0d4461](https://git.openjdk.org/jdk/pull/17072/files/fe0d4461096c2e239acd58077bd4bfe61f90ec7f)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [fe0d4461](https://git.openjdk.org/jdk/pull/17072/files/fe0d4461096c2e239acd58077bd4bfe61f90ec7f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17072/head:pull/17072` \
`$ git checkout pull/17072`

Update a local copy of the PR: \
`$ git checkout pull/17072` \
`$ git pull https://git.openjdk.org/jdk.git pull/17072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17072`

View PR using the GUI difftool: \
`$ git pr show -t 17072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17072.diff">https://git.openjdk.org/jdk/pull/17072.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17072#issuecomment-1851144891)