### PR TITLE
JDK-8320200: Use Elements predicates for record constructors to improve print output

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/PrintingProcessor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/PrintingProcessor.java
@@ -156,14 +156,25 @@ public class PrintingProcessor extends AbstractProcessor {
                     break;
                 }
 
-                writer.print("(");
-                printParameters(e);
-                writer.print(")");
-                AnnotationValue defaultValue = e.getDefaultValue();
-                if (defaultValue != null)
-                    writer.print(" default " + defaultValue);
+                if (elementUtils.isCompactConstructor(e)) {
+                    // A record's compact constructor by definition
+                    // lacks source-explicit parameters and lacks a
+                    // throws clause.
+                    writer.print(" {} /* compact constructor */ ");
+                } else {
+                    writer.print("(");
+                    printParameters(e);
+                    writer.print(")");
 
-                printThrows(e);
+                    // Display any default values for an annotation
+                    // interface element
+                    AnnotationValue defaultValue = e.getDefaultValue();
+                    if (defaultValue != null)
+                        writer.print(" default " + defaultValue);
+
+                    printThrows(e);
+                }
+
                 writer.println(";");
             }
             return this;


### PR DESCRIPTION
Please review this small increase for source fidelity by customizing the printing processor output for record compact constructors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320200](https://bugs.openjdk.org/browse/JDK-8320200): Use Elements predicates for record constructors to improve print output (**Enhancement** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17073/head:pull/17073` \
`$ git checkout pull/17073`

Update a local copy of the PR: \
`$ git checkout pull/17073` \
`$ git pull https://git.openjdk.org/jdk.git pull/17073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17073`

View PR using the GUI difftool: \
`$ git pr show -t 17073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17073.diff">https://git.openjdk.org/jdk/pull/17073.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17073#issuecomment-1851219852)