### PR TITLE
JDK-8321827: Remove unnecessary suppress warnings annotations from the printing processor

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/PrintingProcessor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/PrintingProcessor.java
@@ -118,7 +118,6 @@ public class PrintingProcessor extends AbstractProcessor {
         }
 
         @Override @DefinedBy(Api.LANGUAGE_MODEL)
-        @SuppressWarnings("preview") // isUnnamed
         public PrintingElementVisitor visitExecutable(ExecutableElement e, Boolean p) {
             ElementKind kind = e.getKind();
 
@@ -171,7 +170,6 @@ public class PrintingProcessor extends AbstractProcessor {
 
 
         @Override @DefinedBy(Api.LANGUAGE_MODEL)
-        @SuppressWarnings("preview") // isUnnamed
         public PrintingElementVisitor visitType(TypeElement e, Boolean p) {
             ElementKind kind = e.getKind();
             NestingKind nestingKind = e.getNestingKind();


### PR DESCRIPTION
With JEP 463, a utility method like "isUnnamed" is no longer included in javax.lang.model so there is no uses of methods associated with preview features. Therefore, the `@SuppressWarnings` annotations can (and should be) removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321827](https://bugs.openjdk.org/browse/JDK-8321827): Remove unnecessary suppress warnings annotations from the printing processor (**Enhancement** - P4)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17074/head:pull/17074` \
`$ git checkout pull/17074`

Update a local copy of the PR: \
`$ git checkout pull/17074` \
`$ git pull https://git.openjdk.org/jdk.git pull/17074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17074`

View PR using the GUI difftool: \
`$ git pr show -t 17074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17074.diff">https://git.openjdk.org/jdk/pull/17074.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17074#issuecomment-1851234013)