### PR TITLE
8321825: Remove runtime/CompressedOops/CompressedClassPointers.java from the ProblemList

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -114,8 +114,6 @@ applications/jcstress/copy.java 8229852 linux-all
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-all
 
-runtime/CompressedOops/CompressedClassPointers.java 8317610 linux-x64,windows-x64
-
 #############################################################################
 
 # :hotspot_serviceability


### PR DESCRIPTION
Please review this trivial update.

`runtime/CompressedOops/CompressedClassPointers.java` was added to the ProblemList against [JDK-8317610](https://bugs.openjdk.org/browse/JDK-8317610) but that bug was closed as a duplicate of [JDK-8318485](https://bugs.openjdk.org/browse/JDK-8318485) which is now resolved. The ProblemList entry needs to be removed and if the test continues to fail then a new issue filed.

Testing:
 - local testing of test (passed)
 - tiers 1-3 passed

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321825](https://bugs.openjdk.org/browse/JDK-8321825): Remove runtime/CompressedOops/CompressedClassPointers.java from the ProblemList (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17075/head:pull/17075` \
`$ git checkout pull/17075`

Update a local copy of the PR: \
`$ git checkout pull/17075` \
`$ git pull https://git.openjdk.org/jdk.git pull/17075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17075`

View PR using the GUI difftool: \
`$ git pr show -t 17075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17075.diff">https://git.openjdk.org/jdk/pull/17075.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17075#issuecomment-1851727263)