### PR TITLE
JDK-8321889: JavaDoc method references with wrong (nested) type

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1841,7 +1841,7 @@ public class MethodHandles {
          *                           <a href="MethodHandles.Lookup.html#secmgr">refuses access</a>
          * @throws NullPointerException if {@code bytes} is {@code null}
          * @since 9
-         * @see Lookup#privateLookupIn
+         * @see MethodHandles#privateLookupIn
          * @see Lookup#dropLookupMode
          * @see ClassLoader#defineClass(String,byte[],int,int,ProtectionDomain)
          */

--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -75,7 +75,7 @@
  * javax.lang.model.util.Elements.Origin#SYNTHETIC synthetic}
  * constructs in a class file, such as accessor methods used in
  * implementing nested classes and {@linkplain
- * javax.lang.model.util.Elements.Origin#isBridge(ExecutableElement)
+ * javax.lang.model.util.Elements#isBridge(ExecutableElement)
  * bridge methods} used in implementing covariant returns, are
  * translation artifacts strictly outside of this model. However, when
  * operating on class files, it is helpful be able to operate on such

--- a/src/java.smartcardio/share/classes/javax/smartcardio/CardTerminals.java
+++ b/src/java.smartcardio/share/classes/javax/smartcardio/CardTerminals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,12 +205,12 @@ public abstract class CardTerminals {
         CARD_ABSENT,
         /**
          * CardTerminals for which a card insertion was detected during the
-         * latest call to {@linkplain CardTerminals#waitForChange()} call.
+         * latest call to {@linkplain CardTerminals#waitForChange() waitForChange()}.
          */
         CARD_INSERTION,
         /**
          * CardTerminals for which a card removal was detected during the
-         * latest call to {@linkplain CardTerminals#waitForChange()} call.
+         * latest call to {@linkplain CardTerminals#waitForChange() waitForChange()}.
          */
         CARD_REMOVAL,
     }

--- a/src/java.smartcardio/share/classes/javax/smartcardio/CardTerminals.java
+++ b/src/java.smartcardio/share/classes/javax/smartcardio/CardTerminals.java
@@ -205,14 +205,12 @@ public abstract class CardTerminals {
         CARD_ABSENT,
         /**
          * CardTerminals for which a card insertion was detected during the
-         * latest call to {@linkplain State#waitForChange waitForChange()}
-         * call.
+         * latest call to {@linkplain CardTerminals#waitForChange()} call.
          */
         CARD_INSERTION,
         /**
          * CardTerminals for which a card removal was detected during the
-         * latest call to {@linkplain State#waitForChange waitForChange()}
-         * call.
+         * latest call to {@linkplain CardTerminals#waitForChange()} call.
          */
         CARD_REMOVAL,
     }


### PR DESCRIPTION
Please review a doc-only change for JavaDoc references using a nested class instead of the enclosing class containing the target method. Until now this is accepted by JavaDoc, but with [JDK-8164094](https://bugs.openjdk.org/browse/JDK-8164094) these references are reported as errors.

I made sure the rendered documentation is identical before and after the change (JavaDoc previously generated the correct links for these references).

Update: I also fixed two typos in `javax/smartcardio/CardTerminals.java` by removing the duplicate "call" in "... latest call to waitForChange() call".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321889](https://bugs.openjdk.org/browse/JDK-8321889): JavaDoc method references with wrong (nested) type (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17078/head:pull/17078` \
`$ git checkout pull/17078`

Update a local copy of the PR: \
`$ git checkout pull/17078` \
`$ git pull https://git.openjdk.org/jdk.git pull/17078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17078`

View PR using the GUI difftool: \
`$ git pr show -t 17078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17078.diff">https://git.openjdk.org/jdk/pull/17078.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17078#issuecomment-1851694731)