### PR TITLE
8314515: java/util/concurrent/SynchronousQueue/Fairness.java failed with "Error: fair=false i=8 j=0"

### DIFF
--- a/test/jdk/java/util/concurrent/SynchronousQueue/Fairness.java
+++ b/test/jdk/java/util/concurrent/SynchronousQueue/Fairness.java
@@ -23,20 +23,28 @@
 
 /*
  * @test
+ * @modules java.base/java.util.concurrent:open
  * @bug 4992438 6633113
  * @summary Checks that fairness setting is respected.
  */
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class Fairness {
     private static void testFairness(boolean fair,
-                                     final BlockingQueue<Integer> q)
+                                     final SynchronousQueue<Integer> q,
+                                     final VarHandle underlyingHandle)
         throws Throwable
     {
+        final LinkedTransferQueue<Integer> underlying =
+            (LinkedTransferQueue<Integer>)underlyingHandle.get(q);
+
         final ReentrantLock lock = new ReentrantLock();
         final Condition ready = lock.newCondition();
         final int threadCount = 10;
@@ -53,9 +61,12 @@ public class Fairness {
                 } catch (Throwable t) { badness[0] = t; }}};
             t.start();
             ready.await();
-            // Probably unnecessary, but should be bullet-proof
-            while (t.getState() == Thread.State.RUNNABLE)
+            // Wait until previous put:ing thread is provably parked
+            while (underlying.size() < (i + 1))
                 Thread.yield();
+
+            if (underlying.size() > (i + 1))
+                throw new Error("Unexpected number of waiting producers: " + i);
         }
         for (int i = 0; i < threadCount; i++) {
             int j = q.take();
@@ -68,8 +79,14 @@ public class Fairness {
     }
 
     public static void main(String[] args) throws Throwable {
-        testFairness(false, new SynchronousQueue<Integer>());
-        testFairness(false, new SynchronousQueue<Integer>(false));
-        testFairness(true,  new SynchronousQueue<Integer>(true));
+        var klazz = SynchronousQueue.class;
+        var underlyingKlazz = Class.forName(klazz.getName() + "$Transferer");
+        var underlying =
+            MethodHandles.privateLookupIn(klazz, MethodHandles.lookup())
+                         .findVarHandle(klazz, "transferer", underlyingKlazz);
+
+        testFairness(false, new SynchronousQueue(),      underlying);
+        testFairness(false, new SynchronousQueue(false), underlying);
+        testFairness(true,  new SynchronousQueue(true),  underlying);
     }
 }


### PR DESCRIPTION
While this might not fix 8314515, it should at least make it more exact.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314515](https://bugs.openjdk.org/browse/JDK-8314515): java/util/concurrent/SynchronousQueue/Fairness.java failed with "Error: fair=false i=8 j=0" (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17082/head:pull/17082` \
`$ git checkout pull/17082`

Update a local copy of the PR: \
`$ git checkout pull/17082` \
`$ git pull https://git.openjdk.org/jdk.git pull/17082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17082`

View PR using the GUI difftool: \
`$ git pr show -t 17082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17082.diff">https://git.openjdk.org/jdk/pull/17082.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17082#issuecomment-1878802012)