### PR TITLE
8321820: TestLoadNIdeal fails on 32-bit because -XX:+UseCompressedOops is not recognized

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestLoadNIdeal.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestLoadNIdeal.java
@@ -28,6 +28,7 @@ import compiler.lib.ir_framework.*;
 /*
  * @test
  * @bug 8310524
+ * @requires vm.bits == 64
  * @summary Test that IGVN optimizes away one of two identical LoadNs.
  * @library /test/lib /
  * @run driver compiler.c2.irTests.igvn.TestLoadNIdeal


### PR DESCRIPTION
This changeset fixes an issue where `TestLoadNIdeal.java` fails on 32-bit, where `-XX:+UseCompressedOops` is not available.

Changes:
- Only run the test on 64-bit platforms.

### Testing
windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64:
- tier1, HotSpot parts of tier2 and tier3

linux-x86 (32-bit)
- tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321820](https://bugs.openjdk.org/browse/JDK-8321820): TestLoadNIdeal fails on 32-bit because -XX:+UseCompressedOops is not recognized (**Bug** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17083/head:pull/17083` \
`$ git checkout pull/17083`

Update a local copy of the PR: \
`$ git checkout pull/17083` \
`$ git pull https://git.openjdk.org/jdk.git pull/17083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17083`

View PR using the GUI difftool: \
`$ git pr show -t 17083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17083.diff">https://git.openjdk.org/jdk/pull/17083.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17083#issuecomment-1853593938)