### PR TITLE
8321973: Parallel: Remove unused methods in AdaptiveSizePolicy

### DIFF
--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
@@ -344,17 +344,11 @@ class AdaptiveSizePolicy : public CHeapObj<mtGC> {
   AdaptiveWeightedAverage* avg_eden_live() const { return _avg_eden_live; }
   AdaptiveWeightedAverage* avg_old_live() const { return _avg_old_live; }
 
-  AdaptivePaddedAverage*  avg_survived() const { return _avg_survived; }
-  AdaptivePaddedNoZeroDevAverage*  avg_pretenured() { return _avg_pretenured; }
-
   // Methods indicating events of interest to the adaptive size policy,
   // called by GC algorithms. It is the responsibility of users of this
   // policy to call these methods at the correct times!
   virtual void minor_collection_begin();
   virtual void minor_collection_end(GCCause::Cause gc_cause);
-  virtual LinearLeastSquareFit* minor_pause_old_estimator() const {
-    return _minor_pause_old_estimator;
-  }
 
   LinearLeastSquareFit* minor_pause_young_estimator() {
     return _minor_pause_young_estimator;
@@ -402,10 +396,6 @@ class AdaptiveSizePolicy : public CHeapObj<mtGC> {
   }
   void set_gc_overhead_limit_exceeded(bool v) {
     _overhead_checker.set_gc_overhead_limit_exceeded(v);
-  }
-
-  bool gc_overhead_limit_near() {
-    return _overhead_checker.gc_overhead_limit_near();
   }
 
   void reset_gc_overhead_limit_count() {


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321973](https://bugs.openjdk.org/browse/JDK-8321973): Parallel: Remove unused methods in AdaptiveSizePolicy (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17084/head:pull/17084` \
`$ git checkout pull/17084`

Update a local copy of the PR: \
`$ git checkout pull/17084` \
`$ git pull https://git.openjdk.org/jdk.git pull/17084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17084`

View PR using the GUI difftool: \
`$ git pr show -t 17084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17084.diff">https://git.openjdk.org/jdk/pull/17084.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17084#issuecomment-1853751378)