### PR TITLE
JDK-8321975: Print when add_reserved_region fails even in product mode

### DIFF
--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -410,10 +410,12 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
                     "       new region: [" INTPTR_FORMAT "-" INTPTR_FORMAT "), flag %u.",
                     p2i(reserved_rgn->base()), p2i(reserved_rgn->end()), (unsigned)reserved_rgn->flag(),
                     p2i(base_addr), p2i(base_addr + size), (unsigned)flag);
-      tty->print_cr("Existing region allocated from:");
-      reserved_rgn->call_stack()->print_on(tty);
-      tty->print_cr("New region allocated from:");
-      stack.print_on(tty);
+      if (MemTracker::tracking_level() == NMT_detail) {
+        tty->print_cr("Existing region allocated from:");
+        reserved_rgn->call_stack()->print_on(tty);
+        tty->print_cr("New region allocated from:");
+        stack.print_on(tty);
+      }
       ShouldNotReachHere();
       return false;
     }

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -406,12 +406,14 @@ bool VirtualMemoryTracker::add_reserved_region(address base_addr, size_t size,
       }
 
       // Print some more details. Don't use UL here to avoid circularities.
-#ifdef ASSERT
       tty->print_cr("Error: existing region: [" INTPTR_FORMAT "-" INTPTR_FORMAT "), flag %u.\n"
                     "       new region: [" INTPTR_FORMAT "-" INTPTR_FORMAT "), flag %u.",
                     p2i(reserved_rgn->base()), p2i(reserved_rgn->end()), (unsigned)reserved_rgn->flag(),
                     p2i(base_addr), p2i(base_addr + size), (unsigned)flag);
-#endif
+      tty->print_cr("Existing region allocated from:");
+      reserved_rgn->call_stack()->print_on(tty);
+      tty->print_cr("New region allocated from:");
+      stack.print_on(tty);
       ShouldNotReachHere();
       return false;
     }


### PR DESCRIPTION
Hi,

We recently had a user e-mail hotspot-dev about a JVM crash which hit `ShouldNotReachHere` in `add_reserved_region`. As the logging is disabled in product builds the user couldn't supply us with all of the available information, quite unfortunate for us. I propose that we print the region information unconditionally and print the stacks also.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321975](https://bugs.openjdk.org/browse/JDK-8321975): Print when add_reserved_region fails even in product mode (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17086/head:pull/17086` \
`$ git checkout pull/17086`

Update a local copy of the PR: \
`$ git checkout pull/17086` \
`$ git pull https://git.openjdk.org/jdk.git pull/17086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17086`

View PR using the GUI difftool: \
`$ git pr show -t 17086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17086.diff">https://git.openjdk.org/jdk/pull/17086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17086#issuecomment-1853983865)