### PR TITLE
8318971 : Better Error Handling for Jar Tool When Processing Non-existent Files

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -292,6 +292,9 @@ public class Main {
                     }
                 }
                 expand();
+                if (!ok) {
+                    return false;
+                }
                 if (!moduleInfos.isEmpty()) {
                     // All actual file entries (excl manifest and module-info.class)
                     Set<String> jentries = new HashSet<>();
@@ -338,6 +341,9 @@ public class Main {
                     tmpFile = createTemporaryFile("tmpjar", ".jar");
                 }
                 expand();
+                if (!ok) {
+                    return false;
+                }
                 try (FileInputStream in = (fname != null) ? new FileInputStream(inputFile)
                         : new FileInputStream(FileDescriptor.in);
                      FileOutputStream out = new FileOutputStream(tmpFile);

--- a/test/jdk/tools/jar/InputFilesTest.java
+++ b/test/jdk/tools/jar/InputFilesTest.java
@@ -158,16 +158,16 @@ public class InputFilesTest {
      * The final jar should not be created and correct error message should be caught.
      * IOException is triggered as expected.
      */
-    @Test(expectedExceptions = {IOException.class})
+    @Test
     public void testNonExistentFileInput() throws IOException {
         touch("existingTestFile.txt");
         onCompletion = () -> rm("existingTestFile.txt");
         try {
             jar("cf test.jar existingTestFile.txt nonExistentTestFile.txt");
+            Assert.fail("jar tool unexpectedly completed successfully");
         } catch (IOException e) {
             Assert.assertEquals(e.getMessage().trim(), "nonExistentTestFile.txt : no such file or directory");
             Assert.assertTrue(Files.notExists(Path.of("test.jar")), "Jar file should not be created.");
-            throw e;
         }
     }
 
@@ -177,7 +177,7 @@ public class InputFilesTest {
      * The final jar should not be created and correct error message should be caught.
      * IOException is triggered as expected.
      */
-    @Test(expectedExceptions = {IOException.class})
+    @Test
     public void testNonExistentFileInputClassList() throws IOException {
         touch("existingTestFile.txt");
         touch("classes.list");
@@ -189,13 +189,46 @@ public class InputFilesTest {
         onCompletion = () -> rm("existingTestFile.txt classes.list");
         try {
             jar("cf test.jar @classes.list");
+            Assert.fail("jar tool unexpectedly completed successfully");
         } catch (IOException e) {
             String msg = e.getMessage().trim();
             Assert.assertTrue(msg.contains("nonExistentTestFile.txt : no such file or directory"));
             Assert.assertTrue(msg.trim().contains("nonExistentDirectory : no such file or directory"));
             Assert.assertTrue(Files.notExists(Path.of("test.jar")), "Jar file should not be created.");
-            throw e;
         }
+
+    }
+
+    /**
+     * Create a jar file; then with @File as a part of jar command line, where the File is containing one or more
+     * non-existent files or directories
+     * The final jar should not be created and correct error message should be caught.
+     * IOException is triggered as expected.
+     */
+    @Test
+    public void testUpdateNonExistentFileInputClassList() throws IOException {
+        touch("existingTestFileUpdate.txt");
+        touch("existingTestFileUpdate2.txt");
+        touch("classesUpdate.list");
+        Files.writeString(Path.of("classesUpdate.list"), """
+                existingTestFileUpdate2.txt
+                nonExistentTestFileUpdate.txt
+                nonExistentDirectoryUpdate
+                 """);
+        onCompletion = () -> rm("existingTestFileUpdate.txt existingTestFileUpdate2.txt " +
+                "classesUpdate.list testUpdate.jar");
+        try {
+            jar("cf testUpdate.jar existingTestFileUpdate.txt");
+            Assert.assertTrue(Files.exists(Path.of("testUpdate.jar")));
+            jar("uf testUpdate.jar @classesUpdate.list");
+            Assert.fail("jar tool unexpectedly completed successfully");
+        } catch (IOException e) {
+            String msg = e.getMessage().trim();
+            Assert.assertFalse(msg.contains("existingTestFileUpdate.txt : no such file or directory"));
+            Assert.assertTrue(msg.contains("nonExistentTestFileUpdate.txt : no such file or directory"));
+            Assert.assertTrue(msg.trim().contains("nonExistentDirectoryUpdate : no such file or directory"));
+        }
+
     }
 
     private Stream<Path> mkpath(String... args) {

--- a/test/jdk/tools/jar/InputFilesTest.java
+++ b/test/jdk/tools/jar/InputFilesTest.java
@@ -137,23 +137,6 @@ public class InputFilesTest {
         Assert.assertEquals(baos.toByteArray(), output.getBytes());
     }
 
-    @Test
-    public void testMultipleFilesInClassesList() throws IOException {
-        touch("test");
-        touch("classes.list");
-        Files.writeString(Path.of("classes.list"), """
-                test
-                 """);
-        jar("cf test.jar @classes.list");
-        jar("tf test.jar");
-        println();
-        String output = "META-INF/" + nl +
-                "META-INF/MANIFEST.MF" + nl +
-                "test" + nl;
-        rm("test.jar test classes.list");
-        Assert.assertEquals(baos.toByteArray(), output.getBytes());
-    }
-
     @Test(expectedExceptions = {ZipException.class})
     public void test5() throws IOException {
         mkdir("a");
@@ -170,6 +153,11 @@ public class InputFilesTest {
         jar("cf test.jar --release 9 -C test1 a -C test2 a");
     }
 
+    /**
+     * Containing non-existent file in the file list
+     * The final jar should not be created and correct error message should be caught.
+     * IOException is triggered as expected.
+     */
     @Test(expectedExceptions = {IOException.class})
     public void testNonExistentFileInput() throws IOException {
         touch("existingTestFile.txt");
@@ -183,6 +171,11 @@ public class InputFilesTest {
         }
     }
 
+    /**
+     * With @File as a part of jar command line, where the File is containing one or more non-existent files
+     * The final jar should not be created and correct error message should be caught.
+     * IOException is triggered as expected.
+     */
     @Test(expectedExceptions = {IOException.class})
     public void testNonExistentFileInputClassList() throws IOException {
         touch("existingTestFile.txt");

--- a/test/jdk/tools/jar/InputFilesTest.java
+++ b/test/jdk/tools/jar/InputFilesTest.java
@@ -172,7 +172,8 @@ public class InputFilesTest {
     }
 
     /**
-     * With @File as a part of jar command line, where the File is containing one or more non-existent files
+     * With @File as a part of jar command line, where the File is containing one or more
+     * non-existent files or directories
      * The final jar should not be created and correct error message should be caught.
      * IOException is triggered as expected.
      */
@@ -183,12 +184,15 @@ public class InputFilesTest {
         Files.writeString(Path.of("classes.list"), """
                 existingTestFile.txt
                 nonExistentTestFile.txt
+                nonExistentDirectory
                  """);
         onCompletion = () -> rm("existingTestFile.txt classes.list");
         try {
             jar("cf test.jar @classes.list");
         } catch (IOException e) {
-            Assert.assertEquals(e.getMessage().trim(), "nonExistentTestFile.txt : no such file or directory");
+            String msg = e.getMessage().trim();
+            Assert.assertTrue(msg.contains("nonExistentTestFile.txt : no such file or directory"));
+            Assert.assertTrue(msg.trim().contains("nonExistentDirectory : no such file or directory"));
             Assert.assertTrue(Files.notExists(Path.of("test.jar")), "Jar file should not be created.");
             throw e;
         }


### PR DESCRIPTION
Better Error Handling for Jar Tool Processing of "@File" <br>

This is a new PR for this PR since the original developer left the team. See all of the review history at https://github.com/openjdk/jdk/pull/16423.

Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318971](https://bugs.openjdk.org/browse/JDK-8318971): Better Error Handling for Jar Tool When Processing Non-existent Files (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [b944aac8](https://git.openjdk.org/jdk/pull/17088/files/b944aac84f3dad70609192d4545d2f3c9ab19636)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17088/head:pull/17088` \
`$ git checkout pull/17088`

Update a local copy of the PR: \
`$ git checkout pull/17088` \
`$ git pull https://git.openjdk.org/jdk.git pull/17088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17088`

View PR using the GUI difftool: \
`$ git pr show -t 17088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17088.diff">https://git.openjdk.org/jdk/pull/17088.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17088#issuecomment-1854490284)