### PR TITLE
8322027: One XMLStreamException constructor fails to initialize cause

### DIFF
--- a/src/java.xml/share/classes/javax/xml/stream/XMLStreamException.java
+++ b/src/java.xml/share/classes/javax/xml/stream/XMLStreamException.java
@@ -95,7 +95,7 @@ public class XMLStreamException extends Exception {
   public XMLStreamException(String msg, Location location, Throwable th) {
     super("ParseError at [row,col]:["+location.getLineNumber()+","+
           location.getColumnNumber()+"]\n"+
-          "Message: "+msg);
+          "Message: "+msg, th);
     nested = th;
     this.location = location;
   }

--- a/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamExceptionTest/ExceptionCauseTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/stream/XMLStreamExceptionTest/ExceptionCauseTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package stream.XMLStreamExceptionTest;
+
+import java.io.IOException;
+
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLStreamException;
+
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @run testng/othervm -DrunSecMngr=true -Djava.security.manager=allow stream.XMLStreamExceptionTest.ExceptionCauseTest
+ * @run testng/othervm stream.XMLStreamExceptionTest.ExceptionCauseTest
+ * @summary Test XMLStreamException constructor initializes chained exception
+ */
+@Listeners({jaxp.library.BasePolicy.class})
+public class ExceptionCauseTest {
+
+    @Test
+    public void testExceptionCause() {
+
+        // Create exception with cause
+        Throwable cause = new Throwable("cause");
+        Location location = new Location() {
+            public int getLineNumber() { return 0; }
+            public int getColumnNumber() { return 0; }
+            public int getCharacterOffset() { return 0; }
+            public String getPublicId() { return null; }
+            public String getSystemId() { return null; }
+        };
+        XMLStreamException e = new XMLStreamException("message", location, cause);
+
+        // Verify cause
+        Assert.assertSame(e.getCause(), cause, "XMLStreamException has the wrong cause");
+    }
+}


### PR DESCRIPTION
One of the three `XMLStreamException` constructors that takes a `Throwable` fails to pass it to the superclass constructor.

This simple patch fixes that omission.

It's worth considering if there is any code out there that is working around this problem already by invoking `initCause()` manually. If so, that code would start throwing an `IllegalStateException` after this change.

So a more conservative fix would be to just add another constructor taking the same arguments in a different order. But then again that's not much better than just saying "always use initCause() with the broken constructor", i.e., don't change anything.

Hmm.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8322132](https://bugs.openjdk.org/browse/JDK-8322132) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8322027](https://bugs.openjdk.org/browse/JDK-8322027): One XMLStreamException constructor fails to initialize cause (**Bug** - P4)
 * [JDK-8322132](https://bugs.openjdk.org/browse/JDK-8322132): One XMLStreamException constructor fails to initialize cause (**CSR**)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17090/head:pull/17090` \
`$ git checkout pull/17090`

Update a local copy of the PR: \
`$ git checkout pull/17090` \
`$ git pull https://git.openjdk.org/jdk.git pull/17090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17090`

View PR using the GUI difftool: \
`$ git pr show -t 17090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17090.diff">https://git.openjdk.org/jdk/pull/17090.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17090#issuecomment-1854633982)