### PR TITLE
8322034: Parallel: Remove unused methods in PSAdaptiveSizePolicy

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -116,7 +116,6 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
  private:
 
   // Accessors
-  AdaptivePaddedAverage* avg_major_pause() const { return _avg_major_pause; }
   double gc_minor_pause_goal_sec() const { return _gc_minor_pause_goal_sec; }
 
   void adjust_eden_for_minor_pause_time(bool is_full_gc,
@@ -160,7 +159,6 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
   size_t scale_down(size_t change, double part, double total);
 
  protected:
-  // Time accessors
 
   // Footprint accessors
   size_t live_space() const {
@@ -226,10 +224,6 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
 
   size_t calculated_old_free_size_in_bytes() const;
 
-  size_t average_old_live_in_bytes() const {
-    return (size_t) avg_old_live()->average();
-  }
-
   size_t average_promoted_in_bytes() const {
     return (size_t)avg_promoted()->average();
   }
@@ -252,40 +246,6 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
     _change_old_gen_for_min_pauses = v;
   }
 
-  // Return true if the old generation size was changed
-  // to try to reach a pause time goal.
-  bool old_gen_changed_for_pauses() {
-    bool result = _change_old_gen_for_maj_pauses != 0 ||
-                  _change_old_gen_for_min_pauses != 0;
-    return result;
-  }
-
-  // Return true if the young generation size was changed
-  // to try to reach a pause time goal.
-  bool young_gen_changed_for_pauses() {
-    bool result = _change_young_gen_for_min_pauses != 0 ||
-                  _change_young_gen_for_maj_pauses != 0;
-    return result;
-  }
-  // end flags for pause goal
-
-  // Return true if the old generation size was changed
-  // to try to reach a throughput goal.
-  bool old_gen_changed_for_throughput() {
-    bool result = _change_old_gen_for_throughput != 0;
-    return result;
-  }
-
-  // Return true if the young generation size was changed
-  // to try to reach a throughput goal.
-  bool young_gen_changed_for_throughput() {
-    bool result = _change_young_gen_for_throughput != 0;
-    return result;
-  }
-
-  int decrease_for_footprint() { return _decrease_for_footprint; }
-
-
   // Accessors for estimators.  The slope of the linear fit is
   // currently all that is used for making decisions.
 
@@ -293,18 +253,12 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
     return _major_pause_old_estimator;
   }
 
-  LinearLeastSquareFit* major_pause_young_estimator() {
-    return _major_pause_young_estimator;
-  }
-
-
   virtual void clear_generation_free_space_flags();
 
   double major_pause_old_slope() { return _major_pause_old_estimator->slope(); }
   double major_pause_young_slope() {
     return _major_pause_young_estimator->slope();
   }
-  double major_collection_slope() { return _major_collection_estimator->slope();}
 
   // Calculates optimal (free) space sizes for both the young and old
   // generations.  Stores results in _eden_size and _promo_size.


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322034](https://bugs.openjdk.org/browse/JDK-8322034): Parallel: Remove unused methods in PSAdaptiveSizePolicy (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17091/head:pull/17091` \
`$ git checkout pull/17091`

Update a local copy of the PR: \
`$ git checkout pull/17091` \
`$ git pull https://git.openjdk.org/jdk.git pull/17091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17091`

View PR using the GUI difftool: \
`$ git pr show -t 17091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17091.diff">https://git.openjdk.org/jdk/pull/17091.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17091#issuecomment-1854650134)