### PR TITLE
8321933: TestCDSVMCrash.java spawns two processes

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -31,35 +31,37 @@
  * @bug 8306583
  */
 
- import jdk.test.lib.cds.CDSTestUtils;
- import jdk.test.lib.process.OutputAnalyzer;
- import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
- public class TestCDSVMCrash {
+public class TestCDSVMCrash {
 
-     public static void main(String[] args) throws Exception {
-         if (args.length == 1) {
-             // This should guarantee to throw:
-             // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
-             try {
-                 Object[] oa = new Object[Integer.MAX_VALUE];
-                 throw new Error("OOME not triggered");
-             } catch (OutOfMemoryError err) {
-                 throw new Error("OOME didn't abort JVM!");
-             }
-         }
-         // else this is the main test
-         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
-                  "-XX:-CreateCoredumpOnCrash", "-Xmx128m", "-Xshare:on", TestCDSVMCrash.class.getName(),"throwOOME");
-         // executeAndLog should throw an exception in the VM crashed
-         try {
+    public static void main(String[] args) throws Exception {
+        if (args.length == 1) {
+            // This should guarantee to throw:
+            // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
+            try {
+                Object[] oa = new Object[Integer.MAX_VALUE];
+                throw new Error("OOME not triggered");
+            } catch (OutOfMemoryError err) {
+                throw new Error("OOME didn't abort JVM!");
+            }
+        }
+        // else this is the main test
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
+                                                                             "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
+                                                                             "-Xshare:on", TestCDSVMCrash.class.getName(),
+                                                                             "throwOOME");
+        // executeAndLog should throw an exception in the VM crashed
+        try {
             CDSTestUtils.executeAndLog(pb, "cds_vm_crash");
             throw new Error("Expected VM to crash");
-         } catch(RuntimeException e) {
+        } catch(RuntimeException e) {
             if (!e.getMessage().equals("Hotspot crashed")) {
-              throw new Error("Expected message: Hotspot crashed");
+                throw new Error("Expected message: Hotspot crashed");
             }
-         }
+        }
         System.out.println("PASSED");
-     }
- }
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -51,7 +51,6 @@
          // else this is the main test
          ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
                   "-XX:-CreateCoredumpOnCrash", "-Xmx128m", "-Xshare:on", TestCDSVMCrash.class.getName(),"throwOOME");
-         OutputAnalyzer output = new OutputAnalyzer(pb.start());
          // executeAndLog should throw an exception in the VM crashed
          try {
             CDSTestUtils.executeAndLog(pb, "cds_vm_crash");
@@ -61,12 +60,6 @@
               throw new Error("Expected message: Hotspot crashed");
             }
          }
-         int exitValue = output.getExitValue();
-         if (0 == exitValue) {
-             //expecting a non zero value
-             throw new Error("Expected to get non zero exit value");
-         }
-        output.shouldContain("A fatal error has been detected by the Java Runtime Environment");
         System.out.println("PASSED");
      }
  }


### PR DESCRIPTION
TestCDSVMCrash.java looks like it spawns two processes, once in the pb.start() call and then again in executeAndLog:
```
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         // executeAndLog should throw an exception in the VM crashed
         try {
            CDSTestUtils.executeAndLog(pb, "cds_vm_crash");
```
The test redundantly checks the result of the output since the expected exception will only be thrown if the checked conditions are true.

Note that fixing the indentation makes the diff hard to read, so I recommend looking at each commit separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321933](https://bugs.openjdk.org/browse/JDK-8321933): TestCDSVMCrash.java spawns two processes (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17092/head:pull/17092` \
`$ git checkout pull/17092`

Update a local copy of the PR: \
`$ git checkout pull/17092` \
`$ git pull https://git.openjdk.org/jdk.git pull/17092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17092`

View PR using the GUI difftool: \
`$ git pr show -t 17092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17092.diff">https://git.openjdk.org/jdk/pull/17092.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17092#issuecomment-1854726746)