### PR TITLE
JDK-8318563: GetClassFields should not use random access to field

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -2896,26 +2896,21 @@ JvmtiEnv::GetClassFields(oop k_mirror, jint* field_count_ptr, jfieldID** fields_
     return JVMTI_ERROR_NONE;
   }
 
-
   InstanceKlass* ik = InstanceKlass::cast(k);
 
-  int result_count = 0;
-  // First, count the fields.
-  FilteredFieldStream flds(ik, true, true);
-  result_count = flds.field_count();
+  FilteredJavaFieldStream flds(ik);
 
-  // Allocate the result and fill it in
-  jfieldID* result_list = (jfieldID*) jvmtiMalloc(result_count * sizeof(jfieldID));
-  // The JVMTI spec requires fields in the order they occur in the class file,
-  // this is the reverse order of what FieldStream hands out.
-  int id_index = (result_count - 1);
+  int result_count = flds.field_count();
 
-  for (FilteredFieldStream src_st(ik, true, true); !src_st.eos(); src_st.next()) {
-    result_list[id_index--] = jfieldIDWorkaround::to_jfieldID(
-                                            ik, src_st.offset(),
-                                            src_st.access_flags().is_static());
+  // Allocate the result and fill it in.
+  jfieldID* result_list = (jfieldID*)jvmtiMalloc(result_count * sizeof(jfieldID));
+  for (int i = 0; i < result_count; i++, flds.next()) {
+    result_list[i] = jfieldIDWorkaround::to_jfieldID(
+          ik, flds.offset(),
+          flds.access_flags().is_static());
   }
-  assert(id_index == -1, "just checking");
+  assert(flds.done(), "just checking");
+
   // Fill in the results
   *field_count_ptr = result_count;
   *fields_ptr = result_list;

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -2905,9 +2905,8 @@ JvmtiEnv::GetClassFields(oop k_mirror, jint* field_count_ptr, jfieldID** fields_
   // Allocate the result and fill it in.
   jfieldID* result_list = (jfieldID*)jvmtiMalloc(result_count * sizeof(jfieldID));
   for (int i = 0; i < result_count; i++, flds.next()) {
-    result_list[i] = jfieldIDWorkaround::to_jfieldID(
-          ik, flds.offset(),
-          flds.access_flags().is_static());
+    result_list[i] = jfieldIDWorkaround::to_jfieldID(ik, flds.offset(),
+                                                     flds.access_flags().is_static());
   }
   assert(flds.done(), "just checking");
 

--- a/src/hotspot/share/runtime/reflectionUtils.hpp
+++ b/src/hotspot/share/runtime/reflectionUtils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/runtime/reflectionUtils.hpp
+++ b/src/hotspot/share/runtime/reflectionUtils.hpp
@@ -26,6 +26,7 @@
 #define SHARE_RUNTIME_REFLECTIONUTILS_HPP
 
 #include "memory/allStatic.hpp"
+#include "oops/fieldStreams.inline.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/objArrayOop.hpp"
 #include "oops/oopsHierarchy.hpp"
@@ -233,6 +234,38 @@ class FilteredFieldStream : public FieldStream {
   int field_count();
   void next() {
     _index -= 1;
+    skip_filtered_fields();
+  }
+};
+
+// Iterate over Java fields filtering fields like reflection does.
+class FilteredJavaFieldStream : public JavaFieldStream {
+private:
+  InstanceKlass* _klass;
+  int  _filtered_fields_count;
+  bool has_filtered_field() const { return (_filtered_fields_count > 0); }
+  void skip_filtered_fields() {
+    if (has_filtered_field()) {
+      while (!done() && FilteredFieldsMap::is_filtered_field((Klass*)_klass, offset())) {
+        JavaFieldStream::next();
+      }
+    }
+  }
+
+public:
+  FilteredJavaFieldStream(InstanceKlass* klass)
+    : JavaFieldStream(klass),
+      _klass(klass),
+      _filtered_fields_count(FilteredFieldsMap::filtered_fields_count(klass, true))
+  {
+    // skip filtered fields at the beginning
+    skip_filtered_fields();
+  }
+  int field_count() const {
+    return _klass->java_fields_count() - _filtered_fields_count;
+  }
+  void next() {
+    JavaFieldStream::next();
     skip_filtered_fields();
   }
 };


### PR DESCRIPTION
FieldStream/FilteredFieldStream classes from reflectionUtils.hpp iterate class fields in the reverse order and use field indexes to access instead of forward iteration. This is performance ineffective (see [JDK-8317692](https://bugs.openjdk.org/browse/JDK-8317692) for details).
The change introduces new class FilteredJavaFieldStream as a replacement for FilteredFieldStream.
It uses the same FilteredField/FilteredFieldsMap stuff as FilteredJavaFieldStream does.

FieldStream/FilteredFieldStream are still used by heap walking API, will be cleaned by [JDK-8317636](https://bugs.openjdk.org/browse/JDK-8317636)

Testing:
- tier1..3
- all tests which calls GetClassFields: open/test/hotspot/jtreg/serviceability/jvmti,open/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields,open/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap,open/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/IsSynthetic
including
  - test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007.java - tests that GetClassFields returns fields in correct order;
  - test/hotspot/jtreg/serviceability/jvmti/GetClassFields/FilteredFields/FilteredFieldsTest.java - test that GetClassFields filters out field like reflection.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318563](https://bugs.openjdk.org/browse/JDK-8318563): GetClassFields should not use random access to field (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [7a790887](https://git.openjdk.org/jdk/pull/17094/files/7a7908871d3655d611f5e3b9378b8d413297bd75)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17094/head:pull/17094` \
`$ git checkout pull/17094`

Update a local copy of the PR: \
`$ git checkout pull/17094` \
`$ git pull https://git.openjdk.org/jdk.git pull/17094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17094`

View PR using the GUI difftool: \
`$ git pr show -t 17094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17094.diff">https://git.openjdk.org/jdk/pull/17094.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17094#issuecomment-1854740522)