### PR TITLE
8322018: Test java/lang/String/CompactString/MaxSizeUTF16String.java fails with -Xcomp

### DIFF
--- a/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
+++ b/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
@@ -43,6 +43,7 @@ public class MaxSizeUTF16String {
 
     private final static String EXPECTED_OOME_MESSAGE = "UTF16 String size is";
     private final static String EXPECTED_VM_LIMIT_MESSAGE = "Requested array size exceeds VM limit";
+    private final static String UNEXPECTED_JAVA_HEAP_SPACE = "Java heap space";
 
     // Create a large UTF-8 byte array with a single non-latin1 character
     private static byte[] generateUTF8Data(int byteSize) {
@@ -77,6 +78,10 @@ public class MaxSizeUTF16String {
                     fail("Expected OutOfMemoryError with message prefix: " + EXPECTED_OOME_MESSAGE);
                 }
             } catch (OutOfMemoryError ex) {
+                if (ex.getMessage().equals(UNEXPECTED_JAVA_HEAP_SPACE)) {
+                    // Insufficient heap size
+                    throw ex;
+                }
                 if (!ex.getMessage().startsWith(EXPECTED_OOME_MESSAGE) &&
                         !ex.getMessage().startsWith(EXPECTED_VM_LIMIT_MESSAGE)) {
                     fail("Failed: Not the OutOfMemoryError expected", ex);
@@ -102,6 +107,10 @@ public class MaxSizeUTF16String {
                     fail("Expected OutOfMemoryError with message prefix: " + EXPECTED_OOME_MESSAGE);
                 }
             } catch (OutOfMemoryError ex) {
+                if (ex.getMessage().equals(UNEXPECTED_JAVA_HEAP_SPACE)) {
+                    // Insufficient heap size
+                    throw ex;
+                }
                 if (!ex.getMessage().startsWith(EXPECTED_OOME_MESSAGE) &&
                         !ex.getMessage().startsWith(EXPECTED_VM_LIMIT_MESSAGE)) {
                     throw new RuntimeException("Wrong exception message: " + ex.getMessage(), ex);

--- a/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
+++ b/test/jdk/java/lang/String/CompactString/MaxSizeUTF16String.java
@@ -30,9 +30,11 @@ import java.nio.charset.StandardCharsets;
  * @test
  * @bug 8077559 8321180
  * @summary Tests Compact String for maximum size strings
- * @requires os.maxMemory >= 7g & vm.bits == 64
- * @run junit/othervm -XX:+CompactStrings -Xmx7g MaxSizeUTF16String
- * @run junit/othervm -XX:-CompactStrings -Xmx7g MaxSizeUTF16String
+ * @requires os.maxMemory >= 8g & vm.bits == 64
+ * @requires vm.flagless
+ * @run junit/othervm -XX:+CompactStrings -Xmx8g MaxSizeUTF16String
+ * @run junit/othervm -XX:-CompactStrings -Xmx8g MaxSizeUTF16String
+ * @run junit/othervm -Xcomp -Xmx8g MaxSizeUTF16String
  */
 
 public class MaxSizeUTF16String {
@@ -40,6 +42,7 @@ public class MaxSizeUTF16String {
     private final static int MAX_UTF16_STRING_LENGTH = Integer.MAX_VALUE / 2;
 
     private final static String EXPECTED_OOME_MESSAGE = "UTF16 String size is";
+    private final static String EXPECTED_VM_LIMIT_MESSAGE = "Requested array size exceeds VM limit";
 
     // Create a large UTF-8 byte array with a single non-latin1 character
     private static byte[] generateUTF8Data(int byteSize) {
@@ -74,7 +77,8 @@ public class MaxSizeUTF16String {
                     fail("Expected OutOfMemoryError with message prefix: " + EXPECTED_OOME_MESSAGE);
                 }
             } catch (OutOfMemoryError ex) {
-                if (!ex.getMessage().startsWith(EXPECTED_OOME_MESSAGE)) {
+                if (!ex.getMessage().startsWith(EXPECTED_OOME_MESSAGE) &&
+                        !ex.getMessage().startsWith(EXPECTED_VM_LIMIT_MESSAGE)) {
                     fail("Failed: Not the OutOfMemoryError expected", ex);
                 }
             }
@@ -98,7 +102,8 @@ public class MaxSizeUTF16String {
                     fail("Expected OutOfMemoryError with message prefix: " + EXPECTED_OOME_MESSAGE);
                 }
             } catch (OutOfMemoryError ex) {
-                if (!ex.getMessage().startsWith(EXPECTED_OOME_MESSAGE)) {
+                if (!ex.getMessage().startsWith(EXPECTED_OOME_MESSAGE) &&
+                        !ex.getMessage().startsWith(EXPECTED_VM_LIMIT_MESSAGE)) {
                     throw new RuntimeException("Wrong exception message: " + ex.getMessage(), ex);
                 }
             }


### PR DESCRIPTION
The test java/lang/String/CompactString/MaxSizeUTF16String.java fails when run with -Xcomp.

Both the java implementation and the intrinsic for StringUTF16.toBytes() allocate memory for a copy of the string.
The java implementation of `toBytes()` throws an exception with a message in terms of length of the string.
The intrinsic uses a generic message when allocating a byte array that is too large for the implementation.

Test should accept either message on the OOME exception, the message is an implementation detail and should reflect the cause of the error and not be confused with a general out of java heap message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322018](https://bugs.openjdk.org/browse/JDK-8322018): Test java/lang/String/CompactString/MaxSizeUTF16String.java fails with -Xcomp (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17095/head:pull/17095` \
`$ git checkout pull/17095`

Update a local copy of the PR: \
`$ git checkout pull/17095` \
`$ git pull https://git.openjdk.org/jdk.git pull/17095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17095`

View PR using the GUI difftool: \
`$ git pr show -t 17095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17095.diff">https://git.openjdk.org/jdk/pull/17095.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17095#issuecomment-1854747738)