### PR TITLE
8321958: @param/@return descriptions of ZoneRules#isDaylightSavings() are incorrect

### DIFF
--- a/src/java.base/share/classes/java/time/zone/ZoneRules.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneRules.java
@@ -828,7 +828,7 @@ public final class ZoneRules implements Serializable {
      * This default implementation compares the {@link #getOffset(java.time.Instant) actual}
      * and {@link #getStandardOffset(java.time.Instant) standard} offsets.
      *
-     * @param instant  the instant to find the offset information for, not null, but null
+     * @param instant  the instant to check the daylight savings for, not null, but null
      *  may be ignored if the rules have a single offset for all instants
      * @return true if the specified instant is in daylight savings, false otherwise.
      */

--- a/src/java.base/share/classes/java/time/zone/ZoneRules.java
+++ b/src/java.base/share/classes/java/time/zone/ZoneRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -830,7 +830,7 @@ public final class ZoneRules implements Serializable {
      *
      * @param instant  the instant to find the offset information for, not null, but null
      *  may be ignored if the rules have a single offset for all instants
-     * @return the standard offset, not null
+     * @return true if the specified instant is in daylight savings, false otherwise.
      */
     public boolean isDaylightSavings(Instant instant) {
         return (getStandardOffset(instant).equals(getOffset(instant)) == false);


### PR DESCRIPTION
Small document correction on a return description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8322044](https://bugs.openjdk.org/browse/JDK-8322044) to be approved

### Issues
 * [JDK-8321958](https://bugs.openjdk.org/browse/JDK-8321958): @<!---->param/@<!---->return descriptions of ZoneRules#isDaylightSavings() are incorrect (**Bug** - P4)
 * [JDK-8322044](https://bugs.openjdk.org/browse/JDK-8322044): @<!---->param/@<!---->return descriptions of ZoneRules#isDaylightSavings() are incorrect (**CSR**)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [1025c8a0](https://git.openjdk.org/jdk/pull/17098/files/1025c8a0fbada443cb0f402370c7b2d02677eb48)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [1025c8a0](https://git.openjdk.org/jdk/pull/17098/files/1025c8a0fbada443cb0f402370c7b2d02677eb48)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17098/head:pull/17098` \
`$ git checkout pull/17098`

Update a local copy of the PR: \
`$ git checkout pull/17098` \
`$ git pull https://git.openjdk.org/jdk.git pull/17098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17098`

View PR using the GUI difftool: \
`$ git pr show -t 17098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17098.diff">https://git.openjdk.org/jdk/pull/17098.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17098#issuecomment-1854841140)