### PR TITLE
8322057: Memory leaks in creating jfr symbol array

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -525,6 +525,12 @@ const char* JfrJavaSupport::c_str(jstring string, Thread* thread, bool c_heap /*
   return string != nullptr ? c_str(resolve_non_null(string), thread, c_heap) : nullptr;
 }
 
+void JfrJavaSupport::free_c_str(const char* str, bool c_heap) {
+  if (c_heap) {
+    FREE_C_HEAP_ARRAY(char, str);
+  }
+}
+
 static Symbol** allocate_symbol_array(bool c_heap, int length, Thread* thread) {
   return c_heap ?
            NEW_C_HEAP_ARRAY(Symbol*, length, mtTracing) :
@@ -546,6 +552,7 @@ Symbol** JfrJavaSupport::symbol_array(jobjectArray string_array, JavaThread* thr
     if (object != nullptr) {
       const char* text = c_str(arrayOop->obj_at(i), thread, c_heap);
       symbol = SymbolTable::new_symbol(text);
+      free_c_str(text, c_heap);
     }
     result_array[i] = symbol;
   }

--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.hpp
@@ -86,6 +86,7 @@ class JfrJavaSupport : public AllStatic {
   static Klass* klass(const jobject handle);
   static const char* c_str(jstring string, Thread* thread, bool c_heap = false);
   static const char* c_str(oop string, Thread* thread, bool c_heap = false);
+  static void free_c_str(const char* str, bool c_heap);
   static Symbol** symbol_array(jobjectArray string_array, JavaThread* thread, intptr_t* result_size, bool c_heap = false);
 
   // exceptions


### PR DESCRIPTION
A small fix to avoid memory leak when temporary c string is allocated in c heap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322057](https://bugs.openjdk.org/browse/JDK-8322057): Memory leaks in creating jfr symbol array (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17099/head:pull/17099` \
`$ git checkout pull/17099`

Update a local copy of the PR: \
`$ git checkout pull/17099` \
`$ git pull https://git.openjdk.org/jdk.git pull/17099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17099`

View PR using the GUI difftool: \
`$ git pr show -t 17099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17099.diff">https://git.openjdk.org/jdk/pull/17099.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17099#issuecomment-1854963682)