### PR TITLE
[S390-Port]: Remove IC Safepoint

### DIFF
--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -76,10 +76,7 @@ int LIR_Assembler::initial_frame_size_in_bytes() const {
 // We fetch the class of the receiver and compare it with the cached class.
 // If they do not match we jump to the slow case.
 int LIR_Assembler::check_icache() {
-  Register receiver = receiverOpr()->as_register();
-  int offset = __ offset();
-  __ inline_cache_check(receiver, Z_inline_cache);
-  return offset;
+  return __ ic_check(CodeEntryAlignment);
 }
 
 void LIR_Assembler::clinit_barrier(ciMethod* method) {

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -40,31 +40,6 @@
 #include "runtime/stubRoutines.hpp"
 #include "utilities/macros.hpp"
 
-void C1_MacroAssembler::inline_cache_check(Register receiver, Register iCache) {
-  Label ic_miss, ic_hit;
-  verify_oop(receiver, FILE_AND_LINE);
-  int klass_offset = oopDesc::klass_offset_in_bytes();
-
-  if (!ImplicitNullChecks || MacroAssembler::needs_explicit_null_check(klass_offset)) {
-    if (VM_Version::has_CompareBranch()) {
-      z_cgij(receiver, 0, Assembler::bcondEqual, ic_miss);
-    } else {
-      z_ltgr(receiver, receiver);
-      z_bre(ic_miss);
-    }
-  }
-
-  compare_klass_ptr(iCache, klass_offset, receiver, false);
-  z_bre(ic_hit);
-
-  // If icache check fails, then jump to runtime routine.
-  // Note: RECEIVER must still contain the receiver!
-  load_const_optimized(Z_R1_scratch, AddressLiteral(SharedRuntime::get_ic_miss_stub()));
-  z_br(Z_R1_scratch);
-  align(CodeEntryAlignment);
-  bind(ic_hit);
-}
-
 void C1_MacroAssembler::explicit_null_check(Register base) {
   ShouldNotCallThis(); // unused
 }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "asm/codeBuffer.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "code/compiledIC.hpp"
 #include "compiler/disassembler.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
@@ -1097,7 +1098,13 @@ void MacroAssembler::clear_mem(const Address& addr, unsigned int size) {
 }
 
 void MacroAssembler::align(int modulus) {
-  while (offset() % modulus != 0) z_nop();
+  align(modulus, offset());
+}
+
+void MacroAssembler::align(int modulus, int target) {
+  assert(!((modulus&1) || (target&1)), "needs to be even");
+  int delta = target - offset();
+  while ((offset() + delta) % modulus != 0) z_nop();
 }
 
 // Special version for non-relocateable code if required alignment
@@ -2148,6 +2155,40 @@ void MacroAssembler::call_VM_leaf_base(address entry_point, bool allow_relocatio
 void MacroAssembler::call_VM_leaf_base(address entry_point) {
   bool allow_relocation = true;
   call_VM_leaf_base(entry_point, allow_relocation);
+}
+
+int MacroAssembler::ic_check_size() {
+  return 30 + (ImplicitNullChecks ? 0 : 6);
+}
+
+int MacroAssembler::ic_check(int end_alignment) {
+  Register R2_receiver = Z_ARG1;
+  Register R0_scratch  = Z_R0_scratch;
+  Register R1_scratch  = Z_R1_scratch;
+  Register R9_data     = Z_inline_cache;
+  Label success, failure;
+  align(end_alignment, offset() + ic_check_size());
+
+  int uep_offset = offset();
+  if (!ImplicitNullChecks) {
+    z_cgij(R2_receiver, 0, Assembler::bcondEqual, failure);
+  }
+
+  if (UseCompressedClassPointers) {
+    z_llgf(R1_scratch, Address(R2_receiver, oopDesc::klass_offset_in_bytes()));
+  } else {
+    z_lg(R1_scratch, Address(R2_receiver, oopDesc::klass_offset_in_bytes()));
+  }
+  z_cg(R1_scratch, Address(R9_data, in_bytes(CompiledICData::speculated_klass_offset())));
+  z_bre(success);
+
+  bind(failure);
+  load_const(R1_scratch, AddressLiteral(SharedRuntime::get_ic_miss_stub()));
+  z_br(R1_scratch);
+  bind(success);
+
+  assert((offset() % end_alignment) == 0, "Misaligned verified entry point, offset() = %d, end_alignment = %d", offset(), end_alignment);
+  return uep_offset;
 }
 
 void MacroAssembler::call_VM_base(Register oop_result,

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -1102,7 +1102,7 @@ void MacroAssembler::align(int modulus) {
 }
 
 void MacroAssembler::align(int modulus, int target) {
-  assert(!((modulus&1) || (target&1)), "needs to be even");
+  assert(((modulus % 2 == 0) && (target % 2 == 0)), "needs to be even");
   int delta = target - offset();
   while ((offset() + delta) % modulus != 0) z_nop();
 }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -257,6 +257,7 @@ class MacroAssembler: public Assembler {
 
   // nop padding
   void align(int modulus);
+  void align(int modulus, int target);
   void align_address(int modulus);
 
   //
@@ -565,6 +566,9 @@ class MacroAssembler: public Assembler {
 
   // Get the pc where the last call will return to. Returns _last_calls_return_pc.
   inline address last_calls_return_pc();
+
+  static int ic_check_size();
+  int ic_check(int end_alignment);
 
  private:
   static bool is_call_far_patchable_variant0_at(address instruction_addr); // Dynamic TOC: load target addr from CP and call.

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1341,51 +1341,9 @@ void MachUEPNode::format(PhaseRegAlloc *ra_, outputStream *os) const {
 #endif
 
 void MachUEPNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
+  // This is Unverified Entry Point
   C2_MacroAssembler _masm(&cbuf);
-  const int ic_miss_offset = 2;
-
-  // Inline_cache contains a klass.
-  Register ic_klass = as_Register(Matcher::inline_cache_reg_encode());
-  // ARG1 is the receiver oop.
-  Register R2_receiver = Z_ARG1;
-  int      klass_offset = oopDesc::klass_offset_in_bytes();
-  AddressLiteral icmiss(SharedRuntime::get_ic_miss_stub());
-  Register R1_ic_miss_stub_addr = Z_R1_scratch;
-
-  // Null check of receiver.
-  // This is the null check of the receiver that actually should be
-  // done in the caller. It's here because in case of implicit null
-  // checks we get it for free.
-  assert(!MacroAssembler::needs_explicit_null_check(oopDesc::klass_offset_in_bytes()),
-         "second word in oop should not require explicit null check.");
-  if (!ImplicitNullChecks) {
-    Label valid;
-    if (VM_Version::has_CompareBranch()) {
-      __ z_cgij(R2_receiver, 0, Assembler::bcondNotEqual, valid);
-    } else {
-      __ z_ltgr(R2_receiver, R2_receiver);
-      __ z_bre(valid);
-    }
-    // The ic_miss_stub will handle the null pointer exception.
-    __ load_const_optimized(R1_ic_miss_stub_addr, icmiss);
-    __ z_br(R1_ic_miss_stub_addr);
-    __ bind(valid);
-  }
-
-  // Check whether this method is the proper implementation for the class of
-  // the receiver (ic miss check).
-  {
-    Label valid;
-    // Compare cached class against klass from receiver.
-    // This also does an implicit null check!
-    __ compare_klass_ptr(ic_klass, klass_offset, R2_receiver, false);
-    __ z_bre(valid);
-    // The inline cache points to the wrong method. Call the
-    // ic_miss_stub to find the proper method.
-    __ load_const_optimized(R1_ic_miss_stub_addr, icmiss);
-    __ z_br(R1_ic_miss_stub_addr);
-    __ bind(valid);
-  }
+  __ ic_check(CodeEntryAlignment);
 }
 
 uint MachUEPNode::size(PhaseRegAlloc *ra_) const {

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -28,6 +28,7 @@
 #include "code/debugInfoRec.hpp"
 #include "code/icBuffer.hpp"
 #include "code/vtableStubs.hpp"
+#include "code/compiledIC.hpp"
 #include "compiler/oopMap.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/gcLocker.hpp"
@@ -1500,17 +1501,15 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   unsigned int wrapper_FrameDone;
   unsigned int wrapper_CRegsSet;
   Label     handle_pending_exception;
-  Label     ic_miss;
 
   //---------------------------------------------------------------------
   // Unverified entry point (UEP)
   //---------------------------------------------------------------------
-  wrapper_UEPStart = __ offset();
 
   // check ic: object class <-> cached class
-  if (!method_is_static) __ nmethod_UEP(ic_miss);
-  // Fill with nops (alignment of verified entry point).
-  __ align(CodeEntryAlignment);
+  if (!method_is_static) {
+    wrapper_UEPStart = __ ic_check(CodeEntryAlignment /* end_alignment */);
+  }
 
   //---------------------------------------------------------------------
   // Verified entry point (VEP)
@@ -2026,13 +2025,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
   __ restore_return_pc();
   __ z_br(Z_R1_scratch);
 
-  //---------------------------------------------------------------------
-  // Handler for a cache miss (out-of-line)
-  //---------------------------------------------------------------------
-  __ call_ic_miss_handler(ic_miss, 0x77, 0, Z_R1_scratch);
   __ flush();
-
-
   //////////////////////////////////////////////////////////////////////
   // end of code generation
   //////////////////////////////////////////////////////////////////////
@@ -2318,9 +2311,6 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
   Label skip_fixup;
   {
     Label ic_miss;
-    const int klass_offset           = oopDesc::klass_offset_in_bytes();
-    const int holder_klass_offset    = in_bytes(CompiledICHolder::holder_klass_offset());
-    const int holder_metadata_offset = in_bytes(CompiledICHolder::holder_metadata_offset());
 
     // Out-of-line call to ic_miss handler.
     __ call_ic_miss_handler(ic_miss, 0x11, 0, Z_R1_scratch);
@@ -2329,27 +2319,11 @@ AdapterHandlerEntry* SharedRuntime::generate_i2c2i_adapters(MacroAssembler *masm
     __ align(CodeEntryAlignment);
     c2i_unverified_entry = __ pc();
 
-    // Check the pointers.
-    if (!ImplicitNullChecks || MacroAssembler::needs_explicit_null_check(klass_offset)) {
-      __ z_ltgr(Z_ARG1, Z_ARG1);
-      __ z_bre(ic_miss);
-    }
-    __ verify_oop(Z_ARG1, FILE_AND_LINE);
-
-    // Check ic: object class <-> cached class
-    // Compress cached class for comparison. That's more efficient.
-    if (UseCompressedClassPointers) {
-      __ z_lg(Z_R11, holder_klass_offset, Z_method);             // Z_R11 is overwritten a few instructions down anyway.
-      __ compare_klass_ptr(Z_R11, klass_offset, Z_ARG1, false); // Cached class can't be zero.
-    } else {
-      __ z_clc(klass_offset, sizeof(void *)-1, Z_ARG1, holder_klass_offset, Z_method);
-    }
-    __ z_brne(ic_miss);  // Cache miss: call runtime to handle this.
-
+    __ ic_check(2);
+    __ z_lg(Z_method, Address(Z_method, CompiledICData::speculated_method_offset()));
     // This def MUST MATCH code in gen_c2i_adapter!
     const Register code = Z_R11;
 
-    __ z_lg(Z_method, holder_metadata_offset, Z_method);
     __ load_and_test_long(Z_R0, method_(code));
     __ z_brne(ic_miss);  // Cache miss: call runtime to handle this.
 

--- a/src/hotspot/cpu/s390/vtableStubs_s390.cpp
+++ b/src/hotspot/cpu/s390/vtableStubs_s390.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2021 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "code/compiledIC.hpp"
 #include "code/vtableStubs.hpp"
 #include "interp_masm_s390.hpp"
 #include "memory/resourceArea.hpp"
@@ -197,12 +198,12 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   __ load_klass(rcvr_klass, Z_ARG1);
 
   // Receiver subtype check against REFC.
-  __ z_lg(interface, Address(Z_method, CompiledICHolder::holder_klass_offset()));
+  __ z_lg(interface, Address(Z_method, CompiledICData::itable_refc_klass_offset()));
   __ lookup_interface_method(rcvr_klass, interface, noreg,
                              noreg, Z_R1, no_such_interface, /*return_method=*/ false);
 
   // Get Method* and entrypoint for compiler
-  __ z_lg(interface, Address(Z_method, CompiledICHolder::holder_metadata_offset()));
+  __ z_lg(interface, Address(Z_method, CompiledICData::itable_defc_klass_offset()));
   __ lookup_interface_method(rcvr_klass, interface, itable_index,
                              Z_method, Z_R1, no_such_interface, /*return_method=*/ true);
 


### PR DESCRIPTION
Update: With current code changes only `CastNullCheckDroppingsTest.java` test is failing.


contains s390x changes for ic-safepoint removal port. Build for slowdebug, fastdebug & release are working. But few of additional test failure are seen in tier-1 testing. 

```file
CastNullCheckDroppingsTest.java
SortingDeoptimizationTest.java
java/lang/StrictMath/ExhaustingTests.java 
java/math/BigInteger/LargeValueExceptions.java 
java/util/Random/RandomCanaryPi.java 
java/util/Spliterator/SpliteratorCollisions.java 
java/util/stream/test/org/openjdk/tests/java/util/SplittableRandomTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/CollectorsTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/CountLargeTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/InfiniteStreamWithLimitOpTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/MapOpTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/SliceOpTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/StreamLinkTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/ToArrayOpTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpTest.java 
java/util/stream/test/org/openjdk/tests/java/util/stream/mapMultiOpTest.java 
java/util/zip/ZipFile/TestZipFileEncodings.java 
```



These changes needs to applied on top of https://github.com/openjdk/jdk/compare/master...fisk:jdk:remove-ic-safepoints-v2. 

Changes in diff file: 
[ic_safepoint_change.patch](https://github.com/openjdk/jdk/files/13668385/ic_safepoint_change.patch)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17100/head:pull/17100` \
`$ git checkout pull/17100`

Update a local copy of the PR: \
`$ git checkout pull/17100` \
`$ git pull https://git.openjdk.org/jdk.git pull/17100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17100`

View PR using the GUI difftool: \
`$ git pr show -t 17100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17100.diff">https://git.openjdk.org/jdk/pull/17100.diff</a>

</details>
