### PR TITLE
8321940: Improve CDSHeapVerifier in handling of interned strings

### DIFF
--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -92,11 +92,6 @@ CDSHeapVerifier::CDSHeapVerifier() : _archived_objs(0), _problems(0)
   //
   //       class                                         field                     type
   ADD_EXCL("java/lang/ClassLoader",                      "scl");                   // A
-  ADD_EXCL("java/lang/invoke/InvokerBytecodeGenerator",  "DONTINLINE_SIG",         // B
-                                                         "FORCEINLINE_SIG",        // B
-                                                         "HIDDEN_SIG",             // B
-                                                         "INJECTEDPROFILE_SIG",    // B
-                                                         "LF_COMPILED_SIG");       // B
   ADD_EXCL("java/lang/Module",                           "ALL_UNNAMED_MODULE",     // A
                                                          "ALL_UNNAMED_MODULE_SET", // A
                                                          "EVERYONE_MODULE",        // A
@@ -106,10 +101,6 @@ CDSHeapVerifier::CDSHeapVerifier() : _archived_objs(0), _problems(0)
   ADD_EXCL("java/lang/reflect/AccessFlag$Location",      "EMPTY_SET");             // E
 
   ADD_EXCL("java/lang/System",                           "bootLayer");             // A
-  ADD_EXCL("java/lang/VersionProps",                     "VENDOR_URL_BUG",         // C
-                                                         "VENDOR_URL_VM_BUG",      // C
-                                                         "VENDOR_VERSION");        // C
-  ADD_EXCL("java/net/URL$DefaultFactory",                "PREFIX");                // B FIXME: JDK-8276561
 
   // A dummy object used by HashSet. The value doesn't matter and it's never
   // tested for equality.
@@ -118,7 +109,6 @@ CDSHeapVerifier::CDSHeapVerifier() : _archived_objs(0), _problems(0)
   ADD_EXCL("jdk/internal/loader/ClassLoaders",           "BOOT_LOADER",            // A
                                                          "APP_LOADER",             // A
                                                          "PLATFORM_LOADER");       // A
-  ADD_EXCL("jdk/internal/loader/URLClassPath",           "JAVA_VERSION");          // B
   ADD_EXCL("jdk/internal/module/Builder",                "cachedVersion");         // D
   ADD_EXCL("jdk/internal/module/ModuleLoaderMap$Mapper", "APP_CLASSLOADER",        // A
                                                          "APP_LOADER_INDEX",       // A
@@ -128,30 +118,10 @@ CDSHeapVerifier::CDSHeapVerifier() : _archived_objs(0), _problems(0)
 
   // This just points to an empty Map
   ADD_EXCL("jdk/internal/reflect/Reflection",            "methodFilterMap");       // E
-  ADD_EXCL("jdk/internal/util/StaticProperty",           "FILE_ENCODING",          // C
-                                                 "JAVA_LOCALE_USE_OLD_ISO_CODES",  // C
-                                                 "USER_LANGUAGE",                  // C
-                                                 "USER_LANGUAGE_DISPLAY",          // C
-                                                 "USER_LANGUAGE_FORMAT",           // C
-                                                 "USER_SCRIPT",                    // C
-                                                 "USER_SCRIPT_DISPLAY",            // C
-                                                 "USER_SCRIPT_FORMAT",             // C
-                                                 "USER_COUNTRY",                   // C
-                                                 "USER_COUNTRY_DISPLAY",           // C
-                                                 "USER_COUNTRY_FORMAT",            // C
-                                                 "USER_VARIANT",                   // C
-                                                 "USER_VARIANT_DISPLAY",           // C
-                                                 "USER_VARIANT_FORMAT",            // C
-                                                 "USER_EXTENSIONS",                // C
-                                                 "USER_EXTENSIONS_DISPLAY",        // C
-                                                 "USER_EXTENSIONS_FORMAT",         // C
-                                                 "USER_REGION");                   // C
 
   // Integer for 0 and 1 are in java/lang/Integer$IntegerCache and are archived
   ADD_EXCL("sun/invoke/util/ValueConversions",           "ONE_INT",                // E
                                                          "ZERO_INT");              // E
-  ADD_EXCL("sun/security/util/SecurityConstants",        "PROVIDER_VER");          // C
-
 
 # undef ADD_EXCL
 
@@ -245,6 +215,9 @@ inline bool CDSHeapVerifier::do_entry(oop& orig_obj, HeapShared::CachedOopInfo& 
 
   StaticFieldInfo* info = _table.get(orig_obj);
   if (info != nullptr) {
+    if (value.orig_referrer() == nullptr && java_lang_String::is_instance(orig_obj)) {
+      return true; /* keep on iterating */
+    }
     ResourceMark rm;
     LogStream ls(Log(cds, heap)::warning());
     ls.print_cr("Archive heap points to a static field that may be reinitialized at runtime:");

--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -216,6 +216,9 @@ inline bool CDSHeapVerifier::do_entry(oop& orig_obj, HeapShared::CachedOopInfo& 
   StaticFieldInfo* info = _table.get(orig_obj);
   if (info != nullptr) {
     if (value.orig_referrer() == nullptr && java_lang_String::is_instance(orig_obj)) {
+      // This string object is not refernced by any of the archived object graphs. It's archived
+      // only because it's in the interned string table. So we are not in a condition that
+      // should be flagged by CDSHeapVerifier.
       return true; /* keep on iterating */
     }
     ResourceMark rm;

--- a/src/hotspot/share/cds/cdsHeapVerifier.cpp
+++ b/src/hotspot/share/cds/cdsHeapVerifier.cpp
@@ -216,7 +216,7 @@ inline bool CDSHeapVerifier::do_entry(oop& orig_obj, HeapShared::CachedOopInfo& 
   StaticFieldInfo* info = _table.get(orig_obj);
   if (info != nullptr) {
     if (value.orig_referrer() == nullptr && java_lang_String::is_instance(orig_obj)) {
-      // This string object is not refernced by any of the archived object graphs. It's archived
+      // This string object is not referenced by any of the archived object graphs. It's archived
       // only because it's in the interned string table. So we are not in a condition that
       // should be flagged by CDSHeapVerifier.
       return true; /* keep on iterating */


### PR DESCRIPTION
The PR fixes the CDSHeapVerifier so that it no longer warns about interned strings that are not referenced by any of the archived heap object graphs. Please see the bug report for more details.

Tests: tiers 1-4, builds-tier5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321940](https://bugs.openjdk.org/browse/JDK-8321940): Improve CDSHeapVerifier in handling of interned strings (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) ⚠️ Review applies to [842ad51c](https://git.openjdk.org/jdk/pull/17102/files/842ad51cf209eb13b551b70117d8caf2c1e7bd8d)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17102/head:pull/17102` \
`$ git checkout pull/17102`

Update a local copy of the PR: \
`$ git checkout pull/17102` \
`$ git pull https://git.openjdk.org/jdk.git pull/17102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17102`

View PR using the GUI difftool: \
`$ git pr show -t 17102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17102.diff">https://git.openjdk.org/jdk/pull/17102.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17102#issuecomment-1855216324)