### PR TITLE
8321972: test runtime/Unsafe/InternalErrorTest.java timeout on linux-riscv64 platform

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2940,6 +2940,17 @@ public:
     return uabs(target - branch) < branch_range;
   }
 
+  // Decode the given instruction, checking if it's a 16-bit compressed
+  // instruction and return the address of the next instruction.
+  static address locate_next_instruction(address inst) {
+    // Instruction wider than 16 bits has the two least-significant bits set.
+    if ((0x3 & *inst) == 0x3) {
+      return inst + instruction_size;
+    } else {
+      return inst + compressed_instruction_size;
+    }
+  }
+
   Assembler(CodeBuffer* code) : AbstractAssembler(code), _in_compressible_region(true) {}
 };
 

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -232,7 +232,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
         CompiledMethod* nm = (cb != nullptr) ? cb->as_compiled_method_or_null() : nullptr;
         bool is_unsafe_arraycopy = (thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc));
         if ((nm != nullptr && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
-          address next_pc = pc + NativeCall::instruction_size;
+          address next_pc = Assembler::locate_next_instruction(pc);
           if (is_unsafe_arraycopy) {
             next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
           }
@@ -271,7 +271,7 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                 thread->thread_state() == _thread_in_native) &&
                 sig == SIGBUS && /* info->si_code == BUS_OBJERR && */
                 thread->doing_unsafe_access()) {
-      address next_pc = pc + NativeCall::instruction_size;
+      address next_pc = Assembler::locate_next_instruction(pc);
       if (UnsafeCopyMemory::contains_pc(pc)) {
         next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
       }


### PR DESCRIPTION
As described on the JBS issue, JDK-8320886 extended InternalErrorTest.java adding extra test for Unsafe_SetMemory0 trying to access next page after truncation. This triggers SIGBUS error and control flow is transfered to JVM signal handler [1]. But the current logic doesn't consider 16-bit compressed instructions when calculating next_pc. It always add NativeCall::instruction_size which is 4 to pc and use the result as next_pc. This is not correct as the memset invoked in this case contains compressed instructions and it is those instructions that are triggering the SIGBUS error.

The proposed fix is similar with other platform with variable-length instruction encoding like x86.
The encoding of the instruction triggering the SIGBUS error is checked to see if it is a compressed instruction and then calculate next_pc based on that. The test case can now pass normally with this fix. 

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp#L274

### Testing:
- [x]  Run tier1-3 tests on qemu 8.1.50 with UseRVV (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321972](https://bugs.openjdk.org/browse/JDK-8321972): test runtime/Unsafe/InternalErrorTest.java timeout on linux-riscv64 platform (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17103/head:pull/17103` \
`$ git checkout pull/17103`

Update a local copy of the PR: \
`$ git checkout pull/17103` \
`$ git pull https://git.openjdk.org/jdk.git pull/17103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17103`

View PR using the GUI difftool: \
`$ git pr show -t 17103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17103.diff">https://git.openjdk.org/jdk/pull/17103.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17103#issuecomment-1855408071)