### PR TITLE
8264102: JTable Keyboards Navigation differs with Test Instructions.

### DIFF
--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation/KeyBoardNavigation.java
@@ -103,6 +103,7 @@ public class KeyBoardNavigation extends JApplet
         // Turn off auto-resizing so that we can set column sizes programmatically.
         // In this mode, all columns will get their preferred widths, as set blow.
         tableView.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+        tableView.setColumnSelectionAllowed(true);
 
         // Create a combo box to show that you can use one in a table.
         JComboBox comboBox = new JComboBox();


### PR DESCRIPTION
By default `JTable.setColumnSelectionAllowed()` is set to false in `DefaultTableColumnModel` class and `JTable.setRowSelectionAllowed()` is set to true in `JTable` class. In order to navigate table as per [JDK-4112270](https://bugs.openjdk.org/browse/JDK-4112270), column selection to be made true.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8264102](https://bugs.openjdk.org/browse/JDK-8264102): JTable Keyboards Navigation differs with Test Instructions. (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17105/head:pull/17105` \
`$ git checkout pull/17105`

Update a local copy of the PR: \
`$ git checkout pull/17105` \
`$ git pull https://git.openjdk.org/jdk.git pull/17105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17105`

View PR using the GUI difftool: \
`$ git pr show -t 17105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17105.diff">https://git.openjdk.org/jdk/pull/17105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17105#issuecomment-1855647360)