### PR TITLE
JDK-8321984: IGV: Upgrade to Netbeans Platform 20

### DIFF
--- a/src/utils/IdealGraphVisualizer/Filter/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Filter/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/src/utils/IdealGraphVisualizer/Filter/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Filter/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/src/utils/IdealGraphVisualizer/Filter/pom.xml
+++ b/src/utils/IdealGraphVisualizer/Filter/pom.xml
@@ -86,21 +86,12 @@
             <artifactId>org-openide-filesystems</artifactId>
             <version>${netbeans.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.3</version>
+        </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <activation>
-                <jdk>[15,)</jdk>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.openjdk.nashorn</groupId>
-                    <artifactId>nashorn-core</artifactId>
-                    <version>15.3</version>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
     <build>
         <plugins>
             <plugin>

--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -77,8 +77,8 @@
                             <configuration>
                                 <rules>
                                     <requireJavaVersion>
-                                      <version>[11,18)</version>
-                                      <message>IGV requires a JDK version between 11 and 17</message>
+                                      <version>[17,22)</version>
+                                      <message>IGV requires a JDK version between 17 and 21</message>
                                     </requireJavaVersion>
                                 </rules>
                             </configuration>
@@ -109,16 +109,16 @@
         <module>View</module>
     </modules>
     <properties>
-        <netbeans.version>RELEASE150</netbeans.version>
+        <netbeans.version>RELEASE200</netbeans.version>
         <swinglayouts.version>1.0.2</swinglayouts.version>
-        <nbmmvnplugin.version>4.8</nbmmvnplugin.version>
-        <mvncompilerplugin.version>3.10.1</mvncompilerplugin.version>
-        <mvnjarplugin.version>3.2.2</mvnjarplugin.version>
-        <mvnenforcerplugin.version>3.1.0</mvnenforcerplugin.version>
+        <nbmmvnplugin.version>14.0</nbmmvnplugin.version>
+        <mvncompilerplugin.version>3.11.0</mvncompilerplugin.version>
+        <mvnjarplugin.version>3.3.0</mvnjarplugin.version>
+        <mvnenforcerplugin.version>3.4.1</mvnenforcerplugin.version>
         <junit.version>4.13.2</junit.version>
-        <batik.version>1.14</batik.version>
-        <openpdf.version>1.3.29</openpdf.version>
-        <wala.version>1.5.8</wala.version>
+        <batik.version>1.17</batik.version>
+        <openpdf.version>1.3.34</openpdf.version>
+        <wala.version>1.6.2</wala.version>
         <brandingToken>idealgraphvisualizer</brandingToken>
     </properties>
 </project>

--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
- Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
- Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -77,8 +77,8 @@
                             <configuration>
                                 <rules>
                                     <requireJavaVersion>
-                                      <version>[17,22)</version>
-                                      <message>IGV requires a JDK version between 17 and 21</message>
+                                      <version>17</version>
+                                      <message>IGV requires JDK version 17 or newer</message>
                                     </requireJavaVersion>
                                 </rules>
                             </configuration>

--- a/src/utils/IdealGraphVisualizer/pom.xml
+++ b/src/utils/IdealGraphVisualizer/pom.xml
@@ -77,8 +77,8 @@
                             <configuration>
                                 <rules>
                                     <requireJavaVersion>
-                                      <version>17</version>
-                                      <message>IGV requires JDK version 17 or newer</message>
+                                      <version>[17,22)</version>
+                                      <message>IGV requires a JDK version between 17 and 21</message>
                                     </requireJavaVersion>
                                 </rules>
                             </configuration>


### PR DESCRIPTION
Upgraded IGV and dependencies to the newest Netbeans Platform 20 which was released on December 2023.

Tested that IGV still behaves as expected after the upgrade.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321984](https://bugs.openjdk.org/browse/JDK-8321984): IGV: Upgrade to Netbeans Platform 20 (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17106/head:pull/17106` \
`$ git checkout pull/17106`

Update a local copy of the PR: \
`$ git checkout pull/17106` \
`$ git pull https://git.openjdk.org/jdk.git pull/17106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17106`

View PR using the GUI difftool: \
`$ git pr show -t 17106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17106.diff">https://git.openjdk.org/jdk/pull/17106.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17106#issuecomment-1855693620)