### PR TITLE
8322089: Parallel: Remove PSAdaptiveSizePolicy::set_survivor_size

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -173,9 +173,6 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
   void set_promo_size(size_t new_size) {
     _promo_size = new_size;
   }
-  void set_survivor_size(size_t new_size) {
-    _survivor_size = new_size;
-  }
 
   // Update estimators
   void update_minor_pause_old_estimator(double minor_pause_in_ms);


### PR DESCRIPTION
Trivial removing effectively dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322089](https://bugs.openjdk.org/browse/JDK-8322089): Parallel: Remove PSAdaptiveSizePolicy::set_survivor_size (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17109/head:pull/17109` \
`$ git checkout pull/17109`

Update a local copy of the PR: \
`$ git checkout pull/17109` \
`$ git pull https://git.openjdk.org/jdk.git pull/17109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17109`

View PR using the GUI difftool: \
`$ git pr show -t 17109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17109.diff">https://git.openjdk.org/jdk/pull/17109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17109#issuecomment-1855913629)