### PR TITLE
8322142: JFR: Periodic tasks aren't orphaned between recordings

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/Batch.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/Batch.java
@@ -40,7 +40,6 @@ final class Batch {
     private final List<PeriodicTask> tasks = new ArrayList<>();
     private final long period;
     private long delta;
-    private boolean orphaned;
 
     public Batch(long period) {
         this.period = period;
@@ -71,15 +70,7 @@ final class Batch {
         tasks.clear();
     }
 
-    public boolean mustRemove() {
-        boolean empty = tasks.isEmpty();
-        if (empty) {
-            orphaned = true;
-        }
-        return empty;
-    }
-
-    public boolean isOrphaned() {
-        return orphaned;
+    public boolean isEmpty() {
+        return tasks.isEmpty();
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/Batch.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/Batch.java
@@ -40,6 +40,7 @@ final class Batch {
     private final List<PeriodicTask> tasks = new ArrayList<>();
     private final long period;
     private long delta;
+    private boolean orphaned;
 
     public Batch(long period) {
         this.period = period;
@@ -70,7 +71,15 @@ final class Batch {
         tasks.clear();
     }
 
-    public boolean isEmpty() {
-        return tasks.isEmpty();
+    public boolean mustRemove() {
+        boolean empty = tasks.isEmpty();
+        if (empty) {
+            orphaned = true;
+        }
+        return empty;
+    }
+
+    public boolean isOrphaned() {
+        return orphaned;
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
@@ -65,14 +65,14 @@ final class BatchManager {
             if (task.isSchedulable()) {
                 Batch batch = task.getBatch();
                 // If new task, or period has changed, find new batch
-                if (batch == null) {
+                if (batch == null || batch.isOrphaned()) {
                     batch = findBatch(task.getPeriod());
                 }
                 batch.add(task);
             }
         }
         // Remove unused batches
-        batches.removeIf(Batch::isEmpty);
+        batches.removeIf(Batch::mustRemove);
     }
 
     private List<PeriodicTask> activeSortedTasks(List<PeriodicTask> unsorted) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
@@ -63,16 +63,12 @@ final class BatchManager {
         }
         for (PeriodicTask task : activeSortedTasks(tasks)) {
             if (task.isSchedulable()) {
-                Batch batch = task.getBatch();
-                // If new task, or period has changed, find new batch
-                if (batch == null || batch.isOrphaned()) {
-                    batch = findBatch(task.getPeriod());
-                }
+                Batch batch = findOrInsertBatch(task.getPeriod(), task.getBatch());
                 batch.add(task);
             }
         }
         // Remove unused batches
-        batches.removeIf(Batch::mustRemove);
+        batches.removeIf(Batch::isEmpty);
     }
 
     private List<PeriodicTask> activeSortedTasks(List<PeriodicTask> unsorted) {
@@ -89,7 +85,7 @@ final class BatchManager {
         return tasks;
     }
 
-    private Batch findBatch(long period) {
+    private Batch findOrInsertBatch(long period, Batch maybeCachedBatch) {
         // All events with a period less than 1000 ms
         // get their own unique batch. The rationale for
         // this is to avoid a scenario where a user (mistakenly) specifies
@@ -102,7 +98,7 @@ final class BatchManager {
                 return batch;
             }
         }
-        Batch batch = new Batch(period);
+        Batch batch = maybeCachedBatch != null ? maybeCachedBatch : new Batch(period);
         batches.add(batch);
         return batch;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/BatchManager.java
@@ -63,7 +63,7 @@ final class BatchManager {
         }
         for (PeriodicTask task : activeSortedTasks(tasks)) {
             if (task.isSchedulable()) {
-                Batch batch = findOrInsertBatch(task.getPeriod(), task.getBatch());
+                Batch batch = findBatch(task.getPeriod(), task.getBatch());
                 batch.add(task);
             }
         }
@@ -85,7 +85,7 @@ final class BatchManager {
         return tasks;
     }
 
-    private Batch findOrInsertBatch(long period, Batch maybeCachedBatch) {
+    private Batch findBatch(long period, Batch oldBatch) {
         // All events with a period less than 1000 ms
         // get their own unique batch. The rationale for
         // this is to avoid a scenario where a user (mistakenly) specifies
@@ -98,7 +98,7 @@ final class BatchManager {
                 return batch;
             }
         }
-        Batch batch = maybeCachedBatch != null ? maybeCachedBatch : new Batch(period);
+        Batch batch = oldBatch != null ? oldBatch : new Batch(period);
         batches.add(batch);
         return batch;
     }


### PR DESCRIPTION
This issue is described on the jfr-dev mailing list here:
https://mail.openjdk.org/pipermail/hotspot-jfr-dev/2023-December/005697.html
With a minimal reproducer here:
https://github.com/carterkozak/periodic-event-repro

Currently a draft because I don't have a ticket for this issue, and I haven't had a chance to add a test for this. I have verified that a build with this change resolves the bug I encountered.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322142](https://bugs.openjdk.org/browse/JDK-8322142): JFR: Periodic tasks aren't orphaned between recordings (**Bug** - P2)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17114/head:pull/17114` \
`$ git checkout pull/17114`

Update a local copy of the PR: \
`$ git checkout pull/17114` \
`$ git pull https://git.openjdk.org/jdk.git pull/17114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17114`

View PR using the GUI difftool: \
`$ git pr show -t 17114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17114.diff">https://git.openjdk.org/jdk/pull/17114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17114#issuecomment-1874531236)