### PR TITLE
8322149: ConcurrentHashMap smarter presizing for copy constructor and putAll

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -848,7 +848,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @param m the map
      */
     public ConcurrentHashMap(Map<? extends K, ? extends V> m) {
-        this(m.size(), LOAD_FACTOR, 1);
+        this(m.size());
         putAll(m);
     }
 

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -848,7 +848,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @param m the map
      */
     public ConcurrentHashMap(Map<? extends K, ? extends V> m) {
-        this.sizeCtl = DEFAULT_CAPACITY;
+        this(m.size(), LOAD_FACTOR, 1);
         putAll(m);
     }
 
@@ -1084,7 +1084,9 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @param m mappings to be stored in this map
      */
     public void putAll(Map<? extends K, ? extends V> m) {
-        tryPresize(m.size());
+        if (table != null) {
+            tryPresize(m.size());
+        }
         for (Map.Entry<? extends K, ? extends V> e : m.entrySet())
             putVal(e.getKey(), e.getValue(), false);
     }

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -1085,7 +1085,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      */
     public void putAll(Map<? extends K, ? extends V> m) {
         if (table != null) {
-            tryPresize(m.size());
+            tryPresize(size() + m.size());
         }
         for (Map.Entry<? extends K, ? extends V> e : m.entrySet())
             putVal(e.getKey(), e.getValue(), false);

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -50,7 +50,6 @@ public class Maps {
     private SimpleRandom rng;
     private Map<Integer, Integer> map;
     private Map<Integer, Integer> staticMap;
-    private Map<Integer, Integer> dummy;
     private Integer[] key;
 
     private int removesPerMaxRandom;
@@ -70,17 +69,14 @@ public class Maps {
 
         rng = new SimpleRandom();
         map = new ConcurrentHashMap<>();
+        staticMap = new ConcurrentHashMap<>();
         total = 0;
         key = new Integer[nkeys];
         for (int i = 0; i < key.length; ++i) {
             key[i] = rng.next();
-        }
-        position = key.length / 2;
-
-        staticMap = new ConcurrentHashMap<>();
-        for (int i = 0; i < nkeys; ++i) {
             staticMap.put(rng.next(), rng.next());
         }
+        position = key.length / 2;
     }
 
     @Benchmark
@@ -117,9 +113,8 @@ public class Maps {
     }
 
     @Benchmark
-    public void testCopyConstructor() {
-        ConcurrentHashMap<Integer, Integer> clone = new ConcurrentHashMap<>(staticMap);
-        dummy = clone;
+    public ConcurrentHashMap<Integer, Integer> testConcurrentHashMapCopyConstructor() {
+        return new ConcurrentHashMap<>(staticMap);
     }
 
     private static class SimpleRandom {

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -48,6 +49,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class Maps {
     private SimpleRandom rng;
     private Map<Integer, Integer> map;
+    private Map<Integer, Integer> staticMap;
+    private Map<Integer, Integer> dummy;
     private Integer[] key;
 
     private int removesPerMaxRandom;
@@ -55,9 +58,11 @@ public class Maps {
     private int total;
     private int position;
 
+    @Param("10000")
+    private int nkeys;
+
     @Setup
     public void initTest() {
-        int nkeys = 10000;
         int pRemove = 10;
         int pInsert = 90;
         removesPerMaxRandom = (int) ((pRemove / 100.0 * 0x7FFFFFFFL));
@@ -71,6 +76,11 @@ public class Maps {
             key[i] = rng.next();
         }
         position = key.length / 2;
+
+        staticMap = new ConcurrentHashMap<>();
+        for (int i = 0; i < nkeys; ++i) {
+            staticMap.put(rng.next(), rng.next());
+        }
     }
 
     @Benchmark
@@ -104,6 +114,12 @@ public class Maps {
         }
         total += r;
         position = pos;
+    }
+
+    @Benchmark
+    public void testCopyConstructor() {
+        ConcurrentHashMap<Integer, Integer> clone = new ConcurrentHashMap<>(staticMap);
+        dummy = clone;
     }
 
     private static class SimpleRandom {

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -117,6 +117,16 @@ public class Maps {
         return new ConcurrentHashMap<>(staticMap);
     }
 
+    @Benchmark
+    public ConcurrentHashMap<Integer, Integer> testConcurrentHashMapPutAll() {
+        ConcurrentHashMap<Integer, Integer> map = new ConcurrentHashMap<>();
+        for (int i = 0; i < nkeys; ++i) {
+            map.put(rng.next(), rng.next());
+        }
+        map.putAll(staticMap);
+        return map;
+    }
+
     private static class SimpleRandom {
         private final static long multiplier = 0x5DEECE66DL;
         private final static long addend = 0xBL;

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -119,7 +119,7 @@ public class Maps {
 
     @Benchmark
     public ConcurrentHashMap<Integer, Integer> testConcurrentHashMapPutAll() {
-        ConcurrentHashMap<Integer, Integer> map = new ConcurrentHashMap<>();
+        ConcurrentHashMap<Integer, Integer> map = new ConcurrentHashMap<>(nkeys);
         for (int i = 0; i < nkeys; ++i) {
             map.put(rng.next(), rng.next());
         }


### PR DESCRIPTION
ConcurrentHashMap's copy constructor calls `putAll()` -> `tryPresize()` -> `transfer()`. When coming from the copy constructor, the Map is empty, so there is nothing to transfer. But `transfer()` will still copy all the empty nodes from the old table to the new table.

This patch avoids this work by only calling `tryPresize()` if the table is already initialized. If `table` is null, the initialization is deferred to `putVal()`, which calls `initTable()`.

---

### JMH results for testCopyConstructor

before patch:

```
Result "org.openjdk.bench.java.util.concurrent.Maps.testCopyConstructor":
  937395.686 ±(99.9%) 99074.324 ns/op [Average]
  (min, avg, max) = (825732.550, 937395.686, 1072024.041), stdev = 92674.184
  CI (99.9%): [838321.362, 1036470.010] (assumes normal distribution)
```

after patch:

```
Result "org.openjdk.bench.java.util.concurrent.Maps.testCopyConstructor":
  620871.469 ±(99.9%) 59195.406 ns/op [Average]
  (min, avg, max) = (545304.633, 620871.469, 689013.573), stdev = 55371.419
  CI (99.9%): [561676.063, 680066.875] (assumes normal distribution)
```

Average time is decreased by about 33%.

### JMH results for testPutAll (size = 10000)

before patch:

```
Result "org.openjdk.bench.java.util.concurrent.Maps.testConcurrentHashMapPutAll":
  4315291.542 ±(99.9%) 336034.190 ns/op [Average]
  (min, avg, max) = (3974688.194, 4315291.542, 4871772.209), stdev = 314326.589
  CI (99.9%): [3979257.352, 4651325.731] (assumes normal distribution)
```

after patch:

```
Result "org.openjdk.bench.java.util.concurrent.Maps.testConcurrentHashMapPutAll":
  3006955.723 ±(99.9%) 271757.969 ns/op [Average]
  (min, avg, max) = (2801264.198, 3006955.723, 3553084.135), stdev = 254202.573
  CI (99.9%): [2735197.754, 3278713.692] (assumes normal distribution)
```

Average time is decreased about 30%.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8322149](https://bugs.openjdk.org/browse/JDK-8322149): ConcurrentHashMap smarter presizing for copy constructor and putAll (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [3632649c](https://git.openjdk.org/jdk/pull/17116/files/3632649cb70646b0db291d42faf4ac657a908c0d)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17116/head:pull/17116` \
`$ git checkout pull/17116`

Update a local copy of the PR: \
`$ git checkout pull/17116` \
`$ git pull https://git.openjdk.org/jdk.git pull/17116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17116`

View PR using the GUI difftool: \
`$ git pr show -t 17116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17116.diff">https://git.openjdk.org/jdk/pull/17116.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17116#issuecomment-1857121414)