### PR TITLE
8322154: RISC-V: JDK-8315743 missed change in MacroAssembler::load_reserved

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2771,7 +2771,7 @@ void MacroAssembler::load_reserved(Register dst,
       break;
     case uint32:
       lr_w(dst, addr, acquire);
-      zero_extend(t0, t0, 32);
+      zero_extend(dst, dst, 32);
       break;
     default:
       ShouldNotReachHere();


### PR DESCRIPTION
The fix for https://bugs.openjdk.org/browse/JDK-8315743 touches MacroAssembler::load_reserved replacing `t0` with `dst`. But it missed change for the third case (that is `uint32`) of the switch in this assember function. We should also replace `t0` used in `zero_extend` with `dst`. @robehn can you help confirm this?

- [x]  Run tier1 tests on qemu 8.1.50 with UseRVV (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322154](https://bugs.openjdk.org/browse/JDK-8322154): RISC-V: JDK-8315743 missed change in MacroAssembler::load_reserved (**Bug** - P3)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17117/head:pull/17117` \
`$ git checkout pull/17117`

Update a local copy of the PR: \
`$ git checkout pull/17117` \
`$ git pull https://git.openjdk.org/jdk.git pull/17117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17117`

View PR using the GUI difftool: \
`$ git pr show -t 17117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17117.diff">https://git.openjdk.org/jdk/pull/17117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17117#issuecomment-1857237868)