### PR TITLE
8322159: ThisEscapeAnalyzer crashes for erroneous code

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/ThisEscapeAnalyzer.java
@@ -506,7 +506,7 @@ class ThisEscapeAnalyzer extends TreeScanner {
     public void visitApply(JCMethodInvocation invoke) {
 
         // Get method symbol
-        MethodSymbol sym = (MethodSymbol)TreeInfo.symbolFor(invoke.meth);
+        Symbol sym = TreeInfo.symbolFor(invoke.meth);
 
         // Recurse on method expression
         scan(invoke.meth);
@@ -530,7 +530,7 @@ class ThisEscapeAnalyzer extends TreeScanner {
         invoke(invoke, sym, invoke.args, receiverRefs);
     }
 
-    private void invoke(JCTree site, MethodSymbol sym, List<JCExpression> args, RefSet<?> receiverRefs) {
+    private void invoke(JCTree site, Symbol sym, List<JCExpression> args, RefSet<?> receiverRefs) {
 
         // Skip if ignoring warnings for a constructor invoked via 'this()'
         if (suppressed.contains(sym))
@@ -810,6 +810,10 @@ class ThisEscapeAnalyzer extends TreeScanner {
 
     @Override
     public void visitReference(JCMemberReference tree) {
+        if (tree.type.isErroneous()) {
+            //error recovery - ignore erroneous member references
+            return ;
+        }
 
         // Scan target expression and extract 'this' references, if any
         scan(tree.expr);

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8301580
+ * @bug 8301580 8322159
  * @summary Verify error recovery w.r.t. Attr
  * @library /tools/lib
  * @enablePreview
@@ -80,6 +80,43 @@ public class AttrRecovery extends TestRunner {
                 "C.java:3:5: compiler.err.expected: '('",
                 "C.java:4:9: compiler.err.ret.outside.meth",
                 "2 errors"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+
+    @Test
+    public void testX() throws Exception {
+        String code = """
+                      public class C {
+                          public C() {
+                              Undefined.method();
+                              undefined1();
+                              Runnable r = this::undefined2;
+                              overridable(this); //to verify ThisEscapeAnalyzer has been run
+                          }
+                          public void overridable(C c) {}
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev",
+                         "-XDshould-stop.at=FLOW", "-Xlint:this-escape")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "C.java:3:9: compiler.err.cant.resolve.location: kindname.variable, Undefined, , , (compiler.misc.location: kindname.class, C, null)",
+                "C.java:4:9: compiler.err.cant.resolve.location.args: kindname.method, undefined1, , , (compiler.misc.location: kindname.class, C, null)",
+                "C.java:5:22: compiler.err.invalid.mref: kindname.method, (compiler.misc.cant.resolve.location.args: kindname.method, undefined2, , , (compiler.misc.location: kindname.class, C, null))",
+                "C.java:6:20: compiler.warn.possible.this.escape",
+                "3 errors",
+                "1 warning"
         );
 
         if (!Objects.equals(actual, expected)) {


### PR DESCRIPTION
When an unresolvable method is used in the code, the model is a bit strange (and not very easy to fix) - for method invocations, the symbol used is actually a `ClassSymbol` instead of `MethodSymbol`, and method references have fields like `kind` unfilled.

This is causing issues in ThisEscapeAnalyzer when there were unresolvable methods, and the analyzer is called (i.e. in practice when running with `-Xlint:this-escape -XDshould-stop.at=FLOW`, or similar):
 - `visitApply` has a hardcoded cast to `MethodSymbol`. Seems the case in not really necessary, so the proposal is to remove it.
 - `visitReference` crashes on an access to `JCMemberReference.kind`, as it is unfilled. The proposal is to skip the check if the method reference's type is errneous.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322159](https://bugs.openjdk.org/browse/JDK-8322159): ThisEscapeAnalyzer crashes for erroneous code (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17118/head:pull/17118` \
`$ git checkout pull/17118`

Update a local copy of the PR: \
`$ git checkout pull/17118` \
`$ git pull https://git.openjdk.org/jdk.git pull/17118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17118`

View PR using the GUI difftool: \
`$ git pr show -t 17118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17118.diff">https://git.openjdk.org/jdk/pull/17118.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17118#issuecomment-1857461415)