### PR TITLE
JDK-8322141: SequenceInputStream.transferTo should not return as soon as Long.MAX_VALUE bytes have been transferred

### DIFF
--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -242,9 +242,12 @@ public class SequenceInputStream extends InputStream {
         if (getClass() == SequenceInputStream.class) {
             long transferred = 0;
             while (in != null) {
+                long numTransferred = in.transferTo(out);
+                // increment the total transferred byte count
+                // only if we haven't already reached the Long.MAX_VALUE
                 if (transferred < Long.MAX_VALUE) {
                     try {
-                        transferred = Math.addExact(transferred, in.transferTo(out));
+                        transferred = Math.addExact(transferred, numTransferred);
                     } catch (ArithmeticException ignore) {
                         transferred = Long.MAX_VALUE;
                     }

--- a/src/java.base/share/classes/java/io/SequenceInputStream.java
+++ b/src/java.base/share/classes/java/io/SequenceInputStream.java
@@ -246,7 +246,7 @@ public class SequenceInputStream extends InputStream {
                     try {
                         transferred = Math.addExact(transferred, in.transferTo(out));
                     } catch (ArithmeticException ignore) {
-                        return Long.MAX_VALUE;
+                        transferred = Long.MAX_VALUE;
                     }
                 }
                 nextStream();


### PR DESCRIPTION
Fixes JDK-8322141

As suggested by @vlsi and documented by @bplb this PR does not return, but only sets the maximum result value.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322141](https://bugs.openjdk.org/browse/JDK-8322141): SequenceInputStream.transferTo should not return as soon as Long.MAX_VALUE bytes have been transferred (**Bug** - P4)


### Reviewers
 * [Vladimir Sitnikov](https://openjdk.org/census#vsitnikov) (@vlsi - no project role) ⚠️ Review applies to [2b175c07](https://git.openjdk.org/jdk/pull/17119/files/2b175c07516655dc4e9c9774ad36680802950db1)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17119/head:pull/17119` \
`$ git checkout pull/17119`

Update a local copy of the PR: \
`$ git checkout pull/17119` \
`$ git pull https://git.openjdk.org/jdk.git pull/17119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17119`

View PR using the GUI difftool: \
`$ git pr show -t 17119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17119.diff">https://git.openjdk.org/jdk/pull/17119.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17119#issuecomment-1857479019)