### PR TITLE
8322175: test/langtools/tools/javac/classreader/BadMethodParameter.java doesn't compile

### DIFF
--- a/test/langtools/tools/javac/classreader/BadMethodParameter.java
+++ b/test/langtools/tools/javac/classreader/BadMethodParameter.java
@@ -29,17 +29,16 @@
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api
  *      jdk.compiler/com.sun.tools.javac.main
- *      java.base/jdk.internal.classfile
- *      java.base/jdk.internal.classfile.attribute
  * @build toolbox.ToolBox toolbox.JavacTask
+ * @enablePreview
  * @run main BadMethodParameter
  */
 
-import jdk.internal.classfile.ClassModel;
-import jdk.internal.classfile.ClassTransform;
-import jdk.internal.classfile.Classfile;
-import jdk.internal.classfile.MethodTransform;
-import jdk.internal.classfile.attribute.MethodParametersAttribute;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.MethodTransform;
+import java.lang.classfile.attribute.MethodParametersAttribute;
 
 import toolbox.JavacTask;
 import toolbox.Task;
@@ -99,7 +98,9 @@ public class BadMethodParameter extends TestRunner {
         Path classDir = getClassDir();
         new JavacTask(tb)
                 .classpath(classes, classDir)
-                .options("-verbose", "-parameters", "-processor", P.class.getName())
+                .options("--enable-preview", 
+                         "-source", String.valueOf(Runtime.version().feature()),
+                         "-verbose", "-parameters", "-processor", P.class.getName())
                 .classes(P.class.getName())
                 .outdir(classes)
                 .run(Task.Expect.SUCCESS);
@@ -132,7 +133,7 @@ public class BadMethodParameter extends TestRunner {
 
     private static void transform(Path path) throws IOException {
         byte[] bytes = Files.readAllBytes(path);
-        Classfile cf = Classfile.of();
+        ClassFile cf = ClassFile.of();
         ClassModel classModel = cf.parse(bytes);
         MethodTransform methodTransform =
                 (mb, me) -> {

--- a/test/langtools/tools/javac/classreader/BadMethodParameter.java
+++ b/test/langtools/tools/javac/classreader/BadMethodParameter.java
@@ -98,7 +98,7 @@ public class BadMethodParameter extends TestRunner {
         Path classDir = getClassDir();
         new JavacTask(tb)
                 .classpath(classes, classDir)
-                .options("--enable-preview", 
+                .options("--enable-preview",
                          "-source", String.valueOf(Runtime.version().feature()),
                          "-verbose", "-parameters", "-processor", P.class.getName())
                 .classes(P.class.getName())


### PR DESCRIPTION
Hello, please consider this fix for a compilation error in a test introduced by [JDK-8322040](https://bugs.openjdk.org/browse/JDK-8322040).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322175](https://bugs.openjdk.org/browse/JDK-8322175): test/langtools/tools/javac/classreader/BadMethodParameter.java doesn't compile (**Bug** - P1)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17120/head:pull/17120` \
`$ git checkout pull/17120`

Update a local copy of the PR: \
`$ git checkout pull/17120` \
`$ git pull https://git.openjdk.org/jdk.git pull/17120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17120`

View PR using the GUI difftool: \
`$ git pr show -t 17120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17120.diff">https://git.openjdk.org/jdk/pull/17120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17120#issuecomment-1857778859)