### PR TITLE
8322209: RISC-V: Enable some tests related to MD5 instrinsic

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseMD5IntrinsicsOptionOnUnsupportedCPU.java
@@ -39,6 +39,7 @@ package compiler.intrinsics.sha.cli;
 
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForOtherCPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedAArch64CPU;
+import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRISCV64CPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedX86CPU;
 import compiler.intrinsics.sha.cli.testcases.UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU;
 
@@ -48,6 +49,8 @@ public class TestUseMD5IntrinsicsOptionOnUnsupportedCPU {
                 new GenericTestCaseForUnsupportedX86CPU(
                         DigestOptionsBase.USE_MD5_INTRINSICS_OPTION, /* checkUseSHA = */ false),
                 new GenericTestCaseForUnsupportedAArch64CPU(
+                        DigestOptionsBase.USE_MD5_INTRINSICS_OPTION, /* checkUseSHA = */ false),
+                new GenericTestCaseForUnsupportedRISCV64CPU(
                         DigestOptionsBase.USE_MD5_INTRINSICS_OPTION, /* checkUseSHA = */ false),
                 new GenericTestCaseForOtherCPU(
                         DigestOptionsBase.USE_MD5_INTRINSICS_OPTION, /* checkUseSHA = */ false)).test();

--- a/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
+++ b/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
@@ -61,10 +61,11 @@ public class IntrinsicPredicates {
 
     public static final BooleanSupplier MD5_INSTRUCTION_AVAILABLE
             = new OrPredicate(new CPUSpecificPredicate("aarch64.*", null, null),
+              new OrPredicate(new CPUSpecificPredicate("riscv64.*", null, null),
               // x86 variants
               new OrPredicate(new CPUSpecificPredicate("amd64.*",   null, null),
               new OrPredicate(new CPUSpecificPredicate("i386.*",    null, null),
-                              new CPUSpecificPredicate("x86.*",     null, null))));
+                              new CPUSpecificPredicate("x86.*",     null, null)))));
 
     public static final BooleanSupplier SHA1_INSTRUCTION_AVAILABLE
             = new OrPredicate(new CPUSpecificPredicate("aarch64.*", new String[] { "sha1" }, null),


### PR DESCRIPTION
Hi,
Can you review this simple patch to enable some tests for MD5 instrinsic?
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322209](https://bugs.openjdk.org/browse/JDK-8322209): RISC-V: Enable some tests related to MD5 instrinsic (**Enhancement** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17126/head:pull/17126` \
`$ git checkout pull/17126`

Update a local copy of the PR: \
`$ git checkout pull/17126` \
`$ git pull https://git.openjdk.org/jdk.git pull/17126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17126`

View PR using the GUI difftool: \
`$ git pr show -t 17126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17126.diff">https://git.openjdk.org/jdk/pull/17126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17126#issuecomment-1858160618)