### PR TITLE
8322205: Parallel: Remove unused arg in PSCardTable::pre_scavenge

### DIFF
--- a/src/hotspot/share/gc/parallel/psCardTable.cpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.cpp
@@ -111,7 +111,7 @@ void PSCardTable::scan_obj_with_limit(PSPromotionManager* pm,
   }
 }
 
-void PSCardTable::pre_scavenge(HeapWord* old_gen_bottom, uint active_workers) {
+void PSCardTable::pre_scavenge(uint active_workers) {
   _preprocessing_active_workers = active_workers;
 }
 

--- a/src/hotspot/share/gc/parallel/psCardTable.hpp
+++ b/src/hotspot/share/gc/parallel/psCardTable.hpp
@@ -73,7 +73,7 @@ class PSCardTable: public CardTable {
                                       _preprocessing_active_workers(0) {}
 
   // Scavenge support
-  void pre_scavenge(HeapWord* old_gen_bottom, uint active_workers);
+  void pre_scavenge(uint active_workers);
   // Scavenge contents of stripes with the given index.
   void scavenge_contents_parallel(ObjectStartArray* start_array,
                                   HeapWord* old_gen_bottom,

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -302,7 +302,7 @@ public:
 
     if (!_is_old_gen_empty) {
       PSCardTable* card_table = ParallelScavengeHeap::heap()->card_table();
-      card_table->pre_scavenge(_old_gen->object_space()->bottom(), active_workers);
+      card_table->pre_scavenge(active_workers);
     }
   }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322205](https://bugs.openjdk.org/browse/JDK-8322205): Parallel: Remove unused arg in PSCardTable::pre_scavenge (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17127/head:pull/17127` \
`$ git checkout pull/17127`

Update a local copy of the PR: \
`$ git checkout pull/17127` \
`$ git pull https://git.openjdk.org/jdk.git pull/17127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17127`

View PR using the GUI difftool: \
`$ git pr show -t 17127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17127.diff">https://git.openjdk.org/jdk/pull/17127.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17127#issuecomment-1858209475)