### PR TITLE
8315040: Remove redundant check in WorkerPolicy::parallel_worker_threads

### DIFF
--- a/src/hotspot/share/gc/shared/workerPolicy.cpp
+++ b/src/hotspot/share/gc/shared/workerPolicy.cpp
@@ -73,11 +73,7 @@ uint WorkerPolicy::calc_parallel_worker_threads() {
 
 uint WorkerPolicy::parallel_worker_threads() {
   if (!_parallel_worker_threads_initialized) {
-    if (FLAG_IS_DEFAULT(ParallelGCThreads)) {
-      _parallel_worker_threads = WorkerPolicy::calc_parallel_worker_threads();
-    } else {
-      _parallel_worker_threads = ParallelGCThreads;
-    }
+    _parallel_worker_threads = WorkerPolicy::calc_parallel_worker_threads();
     _parallel_worker_threads_initialized = true;
   }
   return _parallel_worker_threads;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315040](https://bugs.openjdk.org/browse/JDK-8315040): Remove redundant check in WorkerPolicy::parallel_worker_threads (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17128/head:pull/17128` \
`$ git checkout pull/17128`

Update a local copy of the PR: \
`$ git checkout pull/17128` \
`$ git pull https://git.openjdk.org/jdk.git pull/17128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17128`

View PR using the GUI difftool: \
`$ git pr show -t 17128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17128.diff">https://git.openjdk.org/jdk/pull/17128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17128#issuecomment-1858229315)