### PR TITLE
8265372: Simplify PKCS9Attribute

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
@@ -267,27 +267,6 @@ public class PKCS9Attributes {
         return attributes.get(PKCS9Attribute.getOID(name));
     }
 
-
-    /**
-     * Get an array of all attributes in this set, in order of OID.
-     */
-    public PKCS9Attribute[] getAttributes() {
-        PKCS9Attribute[] attribs = new PKCS9Attribute[attributes.size()];
-
-        int j = 0;
-        for (int i=1; i < PKCS9Attribute.PKCS9_OIDS.length &&
-                      j < attribs.length; i++) {
-            if (PKCS9Attribute.PKCS9_OIDS[i] == null) {
-                continue;
-            }
-            attribs[j] = getAttribute(PKCS9Attribute.PKCS9_OIDS[i]);
-
-            if (attribs[j] != null)
-                j++;
-        }
-        return attribs;
-    }
-
     /**
      * Get an attribute value by OID.
      */
@@ -325,12 +304,10 @@ public class PKCS9Attributes {
         PKCS9Attribute value;
 
         boolean first = true;
-        for (int i = 1; i < PKCS9Attribute.PKCS9_OIDS.length; i++) {
-            if (PKCS9Attribute.PKCS9_OIDS[i] == null) {
-                continue;
-            }
-            value = getAttribute(PKCS9Attribute.PKCS9_OIDS[i]);
+        for (ObjectIdentifier oid : PKCS9Attribute.getOIDs()) {
+            if (oid == null) continue;
 
+            value = getAttribute(oid);
             if (value == null) continue;
 
             // we have a value; print it

--- a/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
+++ b/src/java.base/share/classes/sun/security/pkcs/PKCS9Attributes.java
@@ -297,6 +297,7 @@ public class PKCS9Attributes {
     /**
      * Returns the PKCS9 block in a printable string form.
      */
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(200);
         sb.append("PKCS9 Attributes: [\n\t");

--- a/test/jdk/sun/security/pkcs/pkcs9/EncodeDecode.java
+++ b/test/jdk/sun/security/pkcs/pkcs9/EncodeDecode.java
@@ -100,6 +100,7 @@ public class EncodeDecode {
         test(CMS_ALGORITHM_PROTECTION_OID, onev,
             "301b06092a864886f70d010934310e300c040a00000000000000000000");
 
+        //Test whether unsupported OIDs are handled properly
         test(AlgorithmId.SHA_oid,
             new DerOutputStream().write(DerValue.tag_Set, new DerOutputStream().putBoolean(true)).toByteArray(),
             "300c06052b0e03021a31030101ff");

--- a/test/jdk/sun/security/pkcs/pkcs9/EncodeDecode.java
+++ b/test/jdk/sun/security/pkcs/pkcs9/EncodeDecode.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8265372
+ * @summary checking PKCS#9 encoding and decoding
+ * @modules java.base/sun.security.pkcs:+open
+ *          java.base/sun.security.util
+ *          java.base/sun.security.x509
+ */
+import sun.security.pkcs.PKCS9Attribute;
+import sun.security.pkcs.SignerInfo;
+import sun.security.util.DerOutputStream;
+import sun.security.util.DerValue;
+import sun.security.util.KnownOIDs;
+import sun.security.util.ObjectIdentifier;
+import sun.security.x509.AlgorithmId;
+import sun.security.x509.BasicConstraintsExtension;
+import sun.security.x509.CertificateExtensions;
+import sun.security.x509.X500Name;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HexFormat;
+
+import static sun.security.pkcs.PKCS9Attribute.*;
+
+public class EncodeDecode {
+    public static void main(String[] args) throws Exception {
+        test(EMAIL_ADDRESS_OID, new String[]{"a@a.com", "b@b.org"},
+            "301f06092a864886f70d010901311216076140612e636f6d16076240622e6f7267");
+        test(UNSTRUCTURED_NAME_OID, new String[]{"a@a.com", "b@b.org"},
+            "301f06092a864886f70d010902311216076140612e636f6d16076240622e6f7267");
+        test(CONTENT_TYPE_OID, CONTENT_TYPE_OID,
+            "301806092a864886f70d010903310b06092a864886f70d010903");
+        test(MESSAGE_DIGEST_OID, new byte[10],
+            "301906092a864886f70d010904310c040a00000000000000000000");
+        test(SIGNING_TIME_OID, new Date(0),
+            "301c06092a864886f70d010905310f170d3730303130313030303030305a");
+
+        var sis = new SignerInfo[] {
+            new SignerInfo(new X500Name("CN=x"),
+                BigInteger.ONE,
+                AlgorithmId.get("SHA-256"),
+                AlgorithmId.get("Ed25519"),
+                new byte[10])
+        };
+        test(COUNTERSIGNATURE_OID, sis,
+            "304706092a864886f70d010906313a30380201013011300c310a30080603550403130178020101300d06096086480165030402010500300506032b6570040a00000000000000000000");
+
+        test(CHALLENGE_PASSWORD_OID, "password",
+            "301706092a864886f70d010907310a130870617373776f7264");
+        test(UNSTRUCTURED_ADDRESS_OID, new String[]{"a@a.com", "b@b.org"},
+            "301f06092a864886f70d010908311213076140612e636f6d13076240622e6f7267");
+
+        var exts = new CertificateExtensions();
+        exts.setExtension("bc", new BasicConstraintsExtension(true, true, 2));
+        test(EXTENSION_REQUEST_OID, exts,
+            "302306092a864886f70d01090e3116301430120603551d130101ff040830060101ff020102");
+
+        var c = Class.forName("sun.security.pkcs.SigningCertificateInfo");
+        var ctor = c.getDeclaredConstructor(byte[].class);
+        ctor.setAccessible(true);
+        // A SigningCertificateInfo with an empty ESSCertID
+        var sci = ctor.newInstance((Object) new DerOutputStream()
+            .write(DerValue.tag_Sequence, new DerOutputStream()
+                .write(DerValue.tag_Sequence, new DerOutputStream()))
+            .toByteArray());
+        test(SIGNING_CERTIFICATE_OID, sci,
+            "3013060b2a864886f70d010910020c310430023000");
+
+        var onev = new DerOutputStream().write(DerValue.tag_Sequence,
+                new DerOutputStream().putOctetString(new byte[10]))
+            .toByteArray();
+
+        test(SIGNATURE_TIMESTAMP_TOKEN_OID, onev,
+            "301d060b2a864886f70d010910020e310e300c040a00000000000000000000");
+        test(CMS_ALGORITHM_PROTECTION_OID, onev,
+            "301b06092a864886f70d010934310e300c040a00000000000000000000");
+
+        test(AlgorithmId.SHA_oid,
+            new DerOutputStream().write(DerValue.tag_Set, new DerOutputStream().putBoolean(true)).toByteArray(),
+            "300c06052b0e03021a31030101ff");
+    }
+
+    static void test(ObjectIdentifier oid, Object value, String expected) throws Exception {
+        System.out.println("---------- " + KnownOIDs.findMatch(oid.toString()).name());
+        var p9 = new PKCS9Attribute(oid, value);
+        var enc = new DerOutputStream().write(p9).toByteArray();
+        if (!HexFormat.of().formatHex(enc).equals(expected)) {
+            throw new RuntimeException("encode unmatch");
+        }
+        var nv = new PKCS9Attribute(new DerValue(enc)).getValue();
+        boolean equals;
+        if (value instanceof SignerInfo[] si) {
+            // equals not defined for SignerInfo
+            equals = Arrays.toString(si).equals(Arrays.toString((SignerInfo[])nv));
+        } else if (value instanceof byte[] bb) {
+            equals = Arrays.equals(bb, (byte[]) nv);
+        } else if (value.getClass().isArray()) {
+            equals = Arrays.equals((Object[]) value, (Object[]) nv);
+        } else if (value.getClass().getName().equals("sun.security.pkcs.SigningCertificateInfo")) {
+            // equals not defined for SigningCertificateInfo
+            equals = value.toString().equals(nv.toString());
+        } else {
+            equals = nv.equals(value);
+        }
+        if (!equals) {
+            throw new RuntimeException("decode unmatch");
+        }
+    }
+}

--- a/test/jdk/sun/security/x509/AlgorithmId/NonStandardNames.java
+++ b/test/jdk/sun/security/x509/AlgorithmId/NonStandardNames.java
@@ -65,7 +65,6 @@ public class NonStandardNames {
 
         // test PKCS9Attributes.toString(), PKCS9Attributes.getAttributes()
         System.out.println(authed);
-        authed.getAttributes();
 
         Signature s = Signature.getInstance("SHA256withRSA");
         s.initSign(cakg.getPrivateKey());


### PR DESCRIPTION
Refactored PKCS9Attribute to use a hash map instead of multiple arrays. The key for the hash map is an `ObjectIdentifier` and the values are a record `AttributeInfo` that stores the information previously contained in the arrays `PKCS9_VALUE_TAGS`, `VALUE_CLASSES`, and `SINGLE_VALUED`. 

It seems as though we should be able to get rid of constants such as `EMAIL_ADDRESS_OID` since they aren't heavily used with the hash map approach, but since the values are public it might cause compatibility issues.

Another question is how to handle `RSA DSI`, `S/MIME`, `Extended-certificate`, and `Issuer Serial Number` OIDs. The prior version threw an error but in this refactor they are treated as an "unknown OID" and only throw a debug warning. This was addressed in https://bugs.openjdk.org/browse/JDK-8011867 but prior to this refactor the aforementioned OIDs were treated differently than unknown OIDs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8265372](https://bugs.openjdk.org/browse/JDK-8265372): Simplify PKCS9Attribute (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17132/head:pull/17132` \
`$ git checkout pull/17132`

Update a local copy of the PR: \
`$ git checkout pull/17132` \
`$ git pull https://git.openjdk.org/jdk.git pull/17132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17132`

View PR using the GUI difftool: \
`$ git pr show -t 17132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17132.diff">https://git.openjdk.org/jdk/pull/17132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17132#issuecomment-1858460573)