### PR TITLE
8322166: Files.isReadable/isWritable/isExecutable expensive when file does not exist

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -76,6 +76,7 @@ import java.util.Spliterators;
 import java.util.function.BiPredicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import sun.nio.fs.AbstractFileSystemProvider;
 
 import jdk.internal.util.ArraysSupport;
 import sun.nio.ch.FileChannelImpl;
@@ -2609,7 +2610,11 @@ public final class Files {
      *          is invoked to check read access to the file.
      */
     public static boolean isReadable(Path path) {
-        return isAccessible(path, AccessMode.READ);
+        FileSystemProvider provider = provider(path);
+        if (provider instanceof AbstractFileSystemProvider afsp)
+            return afsp.isReadable(path);
+        else
+            return isAccessible(path, AccessMode.READ);
     }
 
     /**
@@ -2640,7 +2645,11 @@ public final class Files {
      *          is invoked to check write access to the file.
      */
     public static boolean isWritable(Path path) {
-        return isAccessible(path, AccessMode.WRITE);
+        FileSystemProvider provider = provider(path);
+        if (provider instanceof AbstractFileSystemProvider afsp)
+            return afsp.isWritable(path);
+        else
+            return isAccessible(path, AccessMode.WRITE);
     }
 
     /**
@@ -2675,7 +2684,11 @@ public final class Files {
      *          checkExec} is invoked to check execute access to the file.
      */
     public static boolean isExecutable(Path path) {
-        return isAccessible(path, AccessMode.EXECUTE);
+        FileSystemProvider provider = provider(path);
+        if (provider instanceof AbstractFileSystemProvider afsp)
+            return afsp.isExecutable(path);
+        else
+            return isAccessible(path, AccessMode.EXECUTE);
     }
 
     // -- Recursive operations --

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -76,11 +76,11 @@ import java.util.Spliterators;
 import java.util.function.BiPredicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import sun.nio.fs.AbstractFileSystemProvider;
 
 import jdk.internal.util.ArraysSupport;
 import sun.nio.ch.FileChannelImpl;
 import sun.nio.cs.UTF_8;
+import sun.nio.fs.AbstractFileSystemProvider;
 
 /**
  * This class consists exclusively of static methods that operate on files,

--- a/src/java.base/share/classes/sun/nio/fs/AbstractFileSystemProvider.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,9 @@
 
 package sun.nio.fs;
 
-import java.nio.file.Path;
+import java.nio.file.AccessMode;
 import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
 import java.io.IOException;
 import java.util.Map;
@@ -115,4 +116,40 @@ public abstract class AbstractFileSystemProvider extends FileSystemProvider {
      * If path is empty, then an empty byte[] is returned.
      */
     public abstract byte[] getSunPathForSocketFile(Path path);
+
+    /**
+     * Tests whether a file is readable.
+     */
+    public boolean isReadable(Path path) {
+        try {
+            checkAccess(path, AccessMode.READ);
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Tests whether a file is writable.
+     */
+    public boolean isWritable(Path path) {
+        try {
+            checkAccess(path, AccessMode.WRITE);
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Tests whether a file is executable.
+     */
+    public boolean isExecutable(Path path) {
+        try {
+            checkAccess(path, AccessMode.EXECUTE);
+        } catch (IOException e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -1026,16 +1026,11 @@ abstract class UnixFileSystem
 
         // ensure source can be copied
         if (!sourceAttrs.isSymbolicLink() || flags.followLinks) {
-            try {
-                // the access(2) system call always follows links so it
-                // is suppressed if the source is an unfollowed link
-                int errno = access(source, R_OK);
-                if (errno != 0)
-                    throw new UnixException(errno);
-
-            } catch (UnixException exc) {
-                exc.rethrowAsIOException(source);
-            }
+            // the access(2) system call always follows links so it
+            // is suppressed if the source is an unfollowed link
+            int errno = access(source, R_OK);
+            if (errno != 0)
+                new UnixException(errno).rethrowAsIOException(source);
         }
 
         // get attributes of target file (don't follow links)

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -895,7 +895,7 @@ abstract class UnixFileSystem
                 // ensure source can be moved
                 int errno = access(source, W_OK);
                 if (errno != 0)
-                    throw new UnixException(errno);
+                    new UnixException(errno).rethrowAsIOException(source);
             }
         } catch (UnixException x) {
             x.rethrowAsIOException(source);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -893,7 +893,9 @@ abstract class UnixFileSystem
             sourceAttrs = UnixFileAttributes.get(source, false);
             if (sourceAttrs.isDirectory()) {
                 // ensure source can be moved
-                access(source, W_OK);
+                int errno = access(source, W_OK);
+                if (errno != 0)
+                    throw new UnixException(errno);
             }
         } catch (UnixException x) {
             x.rethrowAsIOException(source);
@@ -1027,7 +1029,10 @@ abstract class UnixFileSystem
             try {
                 // the access(2) system call always follows links so it
                 // is suppressed if the source is an unfollowed link
-                access(source, R_OK);
+                int errno = access(source, R_OK);
+                if (errno != 0)
+                    throw new UnixException(errno);
+
             } catch (UnixException exc) {
                 exc.rethrowAsIOException(source);
             }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -585,7 +585,7 @@ public abstract class UnixFileSystemProvider
         if (Util.followLinks(options)) {
             UnixPath file = UnixPath.toUnixPath(path);
             file.checkRead();
-            return access(file, F_OK) == 0 ? true : false;
+            return access(file, F_OK) == 0;
         } else {
             return super.exists(path, options);
         }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -349,13 +349,9 @@ public abstract class UnixFileSystemProvider
             }
             mode |= X_OK;
         }
-        try {
-            int errno = access(file, mode);
-            if (errno != 0)
-                throw new UnixException(errno);
-        } catch (UnixException exc) {
-            exc.rethrowAsIOException(file);
-        }
+        int errno = access(file, mode);
+        if (errno != 0)
+            new UnixException(errno).rethrowAsIOException(file);
     }
 
     @Override

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -358,14 +358,14 @@ public abstract class UnixFileSystemProvider
     public boolean isReadable(Path path) {
         UnixPath file = UnixPath.toUnixPath(path);
         file.checkRead();
-        return access(file, R_OK) == 0 ? true : false;
+        return access(file, R_OK) == 0;
     }
 
     @Override
     public boolean isWritable(Path path) {
         UnixPath file = UnixPath.toUnixPath(path);
         file.checkWrite();
-        return access(file, W_OK) == 0 ? true : false;
+        return access(file, W_OK) == 0;
     }
 
     @Override
@@ -377,7 +377,7 @@ public abstract class UnixFileSystemProvider
             // not cached
             sm.checkExec(file.getPathForPermissionCheck());
         }
-        return access(file, X_OK) == 0 ? true : false;
+        return access(file, X_OK) == 0;
     }
 
     @Override

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -610,23 +610,6 @@ class UnixNativeDispatcher {
     private static native int access0(long pathAddress, int amode);
 
     /**
-     * access(constant char* path, F_OK)
-     *
-     * @return true if the file exists, false otherwise
-     */
-    static boolean exists(UnixPath path) {
-        try (NativeBuffer buffer = copyToNativeBuffer(path)) {
-            long comp = Blocker.begin();
-            try {
-                return exists0(buffer.address());
-            } finally {
-                Blocker.end(comp);
-            }
-        }
-    }
-    private static native boolean exists0(long pathAddress);
-
-    /**
      * struct passwd *getpwuid(uid_t uid);
      *
      * @return  passwd->pw_name

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -597,17 +597,17 @@ class UnixNativeDispatcher {
     /**
      * access(const char* path, int amode);
      */
-    static void access(UnixPath path, int amode) throws UnixException {
+    static int access(UnixPath path, int amode) {
         try (NativeBuffer buffer = copyToNativeBuffer(path)) {
             long comp = Blocker.begin();
             try {
-                access0(buffer.address(), amode);
+                return access0(buffer.address(), amode);
             } finally {
                 Blocker.end(comp);
             }
         }
     }
-    private static native void access0(long pathAddress, int amode) throws UnixException;
+    private static native int access0(long pathAddress, int amode);
 
     /**
      * access(constant char* path, F_OK)

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -1190,7 +1190,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_realpath0(JNIEnv* env, jclass this,
     return result;
 }
 
-JNIEXPORT void JNICALL
+JNIEXPORT jint JNICALL
 Java_sun_nio_fs_UnixNativeDispatcher_access0(JNIEnv* env, jclass this,
     jlong pathAddress, jint amode)
 {
@@ -1198,17 +1198,8 @@ Java_sun_nio_fs_UnixNativeDispatcher_access0(JNIEnv* env, jclass this,
     const char* path = (const char*)jlong_to_ptr(pathAddress);
 
     RESTARTABLE(access(path, (int)amode), err);
-    if (err == -1) {
-        throwUnixException(env, errno);
-    }
-}
 
-JNIEXPORT jboolean JNICALL
-Java_sun_nio_fs_UnixNativeDispatcher_exists0(JNIEnv* env, jclass this, jlong pathAddress) {
-    int err;
-    const char* path = (const char*)jlong_to_ptr(pathAddress);
-    RESTARTABLE(access(path, F_OK), err);
-    return (err == 0) ? JNI_TRUE : JNI_FALSE;
+    return err == -1 ? errno : 0;
 }
 
 JNIEXPORT void JNICALL

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -1199,7 +1199,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_access0(JNIEnv* env, jclass this,
 
     RESTARTABLE(access(path, (int)amode), err);
 
-    return err == -1 ? errno : 0;
+    return (err == -1) ? errno : 0;
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
Add `isReadable`, `isWritable`, and `isExecutable` methods to `AbstractFileSystemProvider` and overrides to `UnixFileSystemProvider` and use these in the respective `Files` methods when the provider is an `AbstractFileSystemProvider`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322166](https://bugs.openjdk.org/browse/JDK-8322166): Files.isReadable/isWritable/isExecutable expensive when file does not exist (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [dc79cc2b](https://git.openjdk.org/jdk/pull/17133/files/dc79cc2b2acbf3214646179da30c7f871d4855d0)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17133/head:pull/17133` \
`$ git checkout pull/17133`

Update a local copy of the PR: \
`$ git checkout pull/17133` \
`$ git pull https://git.openjdk.org/jdk.git pull/17133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17133`

View PR using the GUI difftool: \
`$ git pr show -t 17133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17133.diff">https://git.openjdk.org/jdk/pull/17133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17133#issuecomment-1858584464)