### PR TITLE
JDK-8322237: Heap dump contains duplicate thread records for mounted virtual threads

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1931,6 +1931,7 @@ void HeapObjectDumper::do_object(oop o) {
   if (o->is_instance()) {
     // create a HPROF_GC_INSTANCE record for each object
     DumperSupport::dump_instance(writer(), o, &_class_cache);
+    // If we encounter an unmounted virtual thread it needs to be dumped explicitly.
     if (java_lang_VirtualThread::is_instance(o)
         && ThreadDumper::should_dump_vthread(o) && !ThreadDumper::is_vthread_mounted(o)) {
       _vthread_dumper->dump_vthread(o, writer());

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1931,7 +1931,8 @@ void HeapObjectDumper::do_object(oop o) {
   if (o->is_instance()) {
     // create a HPROF_GC_INSTANCE record for each object
     DumperSupport::dump_instance(writer(), o, &_class_cache);
-    // If we encounter an unmounted virtual thread it needs to be dumped explicitly.
+    // If we encounter an unmounted virtual thread it needs to be dumped explicitly
+    // (mounted virtual threads are dumped with their carriers).
     if (java_lang_VirtualThread::is_instance(o)
         && ThreadDumper::should_dump_vthread(o) && !ThreadDumper::is_vthread_mounted(o)) {
       _vthread_dumper->dump_vthread(o, writer());

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
@@ -26,7 +26,9 @@ import java.lang.ref.Reference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -223,11 +225,22 @@ public class VThreadInHeapDump {
             // Log all threads with stack traces and stack references.
             List<ThreadObject> threads = snapshot.getThreads();
             List<Root> roots = Collections.list(snapshot.getRoots());
+            // And detect thread object duplicates.
+            Set<Long> uniqueThreads = new HashSet<>();
+            
             log("Threads:");
             for (ThreadObject thread: threads) {
+                JavaHeapObject threadObj = snapshot.findThing(thread.getId());
+                JavaClass threadClass = threadObj.getClazz();
                 StackTrace st = thread.getStackTrace();
                 StackFrame[] frames = st.getFrames();
-                log("thread " + thread.getIdString() + ", " + frames.length + " frames");
+                log("thread " + thread.getIdString() + " (" + threadClass.getName() + "), " + frames.length + " frames");
+                
+                if (uniqueThreads.contains(thread.getId())) {
+                    log(" - ERROR: duplicate");
+                } else {
+                    uniqueThreads.add(thread.getId());
+                }
 
                 List<Root> stackRoots = findStackRoot(roots, thread);
                 for (int i = 0; i < frames.length; i++) {
@@ -248,6 +261,10 @@ public class VThreadInHeapDump {
                         }
                     }
                 }
+            }
+
+            if (threads.size() != uniqueThreads.size()) {
+                throw new RuntimeException("Thread duplicates detected (" + (threads.size() - uniqueThreads.size()) + ")");
             }
 
             // Verify objects from thread stacks are dumped.

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
@@ -227,7 +227,7 @@ public class VThreadInHeapDump {
             List<Root> roots = Collections.list(snapshot.getRoots());
             // And detect thread object duplicates.
             Set<Long> uniqueThreads = new HashSet<>();
-            
+
             log("Threads:");
             for (ThreadObject thread: threads) {
                 JavaHeapObject threadObj = snapshot.findThing(thread.getId());
@@ -235,7 +235,7 @@ public class VThreadInHeapDump {
                 StackTrace st = thread.getStackTrace();
                 StackFrame[] frames = st.getFrames();
                 log("thread " + thread.getIdString() + " (" + threadClass.getName() + "), " + frames.length + " frames");
-                
+
                 if (uniqueThreads.contains(thread.getId())) {
                     log(" - ERROR: duplicate");
                 } else {


### PR DESCRIPTION
HeapDumper dumps virtual threads in 2 places:
- dumping platform threads (mounted virtual threads are dumped as separate thread object);
- dumping heap objects when the object is `java.lang.VirtualThread`.

In the 2nd case mounted virtual threads should be skipped (as they are already dumped with correct stack traces/stack references)
Check that a virtual thread is mounted is non-trivial, method from JvmtiEnvBase was used for this.

Testing: tier1..3, heapdump-related tests: open/test/hotspot/jtreg/serviceability,open/test/hotspot/jtreg/runtime/ErrorHandling,open/test/hotspot/jtreg/gc/epsilon,open/test/jdk/sun/tools/jhsdb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322237](https://bugs.openjdk.org/browse/JDK-8322237): Heap dump contains duplicate thread records for mounted virtual threads (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [0afd2a4f](https://git.openjdk.org/jdk/pull/17134/files/0afd2a4f273b3ca1bf2a51b2e1c5deb2add5495f)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17134/head:pull/17134` \
`$ git checkout pull/17134`

Update a local copy of the PR: \
`$ git checkout pull/17134` \
`$ git pull https://git.openjdk.org/jdk.git pull/17134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17134`

View PR using the GUI difftool: \
`$ git pr show -t 17134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17134.diff">https://git.openjdk.org/jdk/pull/17134.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17134#issuecomment-1861237618)