### PR TITLE
8322255: Generational ZGC: ZPageSizeMedium should be set before MaxTenuringThreshold

### DIFF
--- a/src/hotspot/share/gc/z/zArguments.cpp
+++ b/src/hotspot/share/gc/z/zArguments.cpp
@@ -143,6 +143,9 @@ void ZArguments::initialize() {
     FLAG_SET_DEFAULT(ZFragmentationLimit, 5.0);
   }
 
+  // Set medium page size here because MaxTenuringThreshold may use it.
+  ZHeuristics::set_medium_page_size();
+
   if (!FLAG_IS_DEFAULT(ZTenuringThreshold) && ZTenuringThreshold != -1) {
     FLAG_SET_ERGO_IF_DEFAULT(MaxTenuringThreshold, ZTenuringThreshold);
     if (MaxTenuringThreshold == 0) {

--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -63,7 +63,7 @@ bool ZHeuristics::use_per_cpu_shared_small_pages() {
   // Use per-CPU shared small pages only if these pages occupy at most 3.125%
   // of the max heap size. Otherwise fall back to using a single shared small
   // page. This is useful when using small heaps on large machines.
-  const size_t per_cpu_share = (MaxHeapSize * 0.03125) / ZCPU::count();
+  const size_t per_cpu_share = significant_heap_overhead() / ZCPU::count();
   return per_cpu_share >= ZPageSizeSmall;
 }
 
@@ -101,9 +101,9 @@ uint ZHeuristics::nconcurrent_workers() {
 }
 
 size_t ZHeuristics::significant_heap_overhead() {
-  return MaxHeapSize * (ZFragmentationLimit / 100);
+  return MaxHeapSize * ZFragmentationLimit;
 }
 
 size_t ZHeuristics::significant_young_overhead() {
-  return MaxHeapSize * (ZYoungCompactionLimit / 100);
+  return MaxHeapSize * ZYoungCompactionLimit;
 }

--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -63,7 +63,7 @@ bool ZHeuristics::use_per_cpu_shared_small_pages() {
   // Use per-CPU shared small pages only if these pages occupy at most 3.125%
   // of the max heap size. Otherwise fall back to using a single shared small
   // page. This is useful when using small heaps on large machines.
-  const size_t per_cpu_share = significant_heap_overhead() / ZCPU::count();
+  const size_t per_cpu_share = (MaxHeapSize * 0.03125) / ZCPU::count();
   return per_cpu_share >= ZPageSizeSmall;
 }
 
@@ -101,9 +101,9 @@ uint ZHeuristics::nconcurrent_workers() {
 }
 
 size_t ZHeuristics::significant_heap_overhead() {
-  return MaxHeapSize * ZFragmentationLimit;
+  return MaxHeapSize * (ZFragmentationLimit / 100);
 }
 
 size_t ZHeuristics::significant_young_overhead() {
-  return MaxHeapSize * ZYoungCompactionLimit;
+  return MaxHeapSize * (ZYoungCompactionLimit / 100);
 }

--- a/src/hotspot/share/gc/z/zInitialize.cpp
+++ b/src/hotspot/share/gc/z/zInitialize.cpp
@@ -28,7 +28,6 @@
 #include "gc/z/zDriver.hpp"
 #include "gc/z/zGCIdPrinter.hpp"
 #include "gc/z/zGlobals.hpp"
-#include "gc/z/zHeuristics.hpp"
 #include "gc/z/zInitialize.hpp"
 #include "gc/z/zJNICritical.hpp"
 #include "gc/z/zLargePages.hpp"
@@ -54,7 +53,6 @@ ZInitialize::ZInitialize(ZBarrierSet* barrier_set) {
   ZThreadLocalAllocBuffer::initialize();
   ZTracer::initialize();
   ZLargePages::initialize();
-  ZHeuristics::set_medium_page_size();
   ZBarrierSet::set_barrier_set(barrier_set);
   ZJNICritical::initialize();
   ZDriver::initialize();


### PR DESCRIPTION
Hi all,

This patch fixes several issues about heuristics.

1. Move `ZHeuristics::set_medium_page_size` to `ZArguments::initialize` so that the setting of `MaxTenuringThreshold` can use `ZPageSizeMedium` correctly.
2. Fix `ZHeuristics::use_per_cpu_shared_small_pages` to meet its comment.
3. Fix `ZHeuristics::significant_heap_overhead` and `ZHeuristics::significant_young_overhead` to use `ZFragmentationLimit` and `ZYoungCompactionLimit` as percentages instead of multiples.

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322255](https://bugs.openjdk.org/browse/JDK-8322255): Generational ZGC: ZPageSizeMedium should be set before MaxTenuringThreshold (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17137/head:pull/17137` \
`$ git checkout pull/17137`

Update a local copy of the PR: \
`$ git checkout pull/17137` \
`$ git pull https://git.openjdk.org/jdk.git pull/17137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17137`

View PR using the GUI difftool: \
`$ git pr show -t 17137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17137.diff">https://git.openjdk.org/jdk/pull/17137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17137#issuecomment-1859205688)