### PR TITLE
8322278: Generational ZGC: Adjust the comment of ZHeuristics::use_per_cpu_shared_small_pages

### DIFF
--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -63,7 +63,7 @@ bool ZHeuristics::use_per_cpu_shared_small_pages() {
   // Use per-CPU shared small pages only if these pages occupy at most 3.125%
   // of the max heap size. Otherwise fall back to using a single shared small
   // page. This is useful when using small heaps on large machines.
-  const size_t per_cpu_share = significant_heap_overhead() / ZCPU::count();
+  const size_t per_cpu_share = (MaxHeapSize * 0.03125) / ZCPU::count();
   return per_cpu_share >= ZPageSizeSmall;
 }
 

--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -60,10 +60,10 @@ size_t ZHeuristics::relocation_headroom() {
 }
 
 bool ZHeuristics::use_per_cpu_shared_small_pages() {
-  // Use per-CPU shared small pages only if these pages occupy at most 3.125%
-  // of the max heap size. Otherwise fall back to using a single shared small
+  // Use per-CPU shared small pages only if these pages don't have a significant
+  // heap overhead. Otherwise fall back to using a single shared small
   // page. This is useful when using small heaps on large machines.
-  const size_t per_cpu_share = (MaxHeapSize * 0.03125) / ZCPU::count();
+  const size_t per_cpu_share = significant_heap_overhead() / ZCPU::count();
   return per_cpu_share >= ZPageSizeSmall;
 }
 


### PR DESCRIPTION
Hi all,

This trivial patch fixes the method `ZHeuristics::use_per_cpu_shared_small_pages` to meet its comment.

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322278](https://bugs.openjdk.org/browse/JDK-8322278): Generational ZGC: Adjust the comment of ZHeuristics::use_per_cpu_shared_small_pages (**Enhancement** - P5)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17138/head:pull/17138` \
`$ git checkout pull/17138`

Update a local copy of the PR: \
`$ git checkout pull/17138` \
`$ git pull https://git.openjdk.org/jdk.git pull/17138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17138`

View PR using the GUI difftool: \
`$ git pr show -t 17138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17138.diff">https://git.openjdk.org/jdk/pull/17138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17138#issuecomment-1860204632)