### PR TITLE
8322279: Generational ZGC: Use ZFragmentationLimit and ZYoungCompactionLimit as percentage instead of multiples

### DIFF
--- a/src/hotspot/share/gc/z/zHeuristics.cpp
+++ b/src/hotspot/share/gc/z/zHeuristics.cpp
@@ -101,9 +101,9 @@ uint ZHeuristics::nconcurrent_workers() {
 }
 
 size_t ZHeuristics::significant_heap_overhead() {
-  return MaxHeapSize * ZFragmentationLimit;
+  return MaxHeapSize * (ZFragmentationLimit / 100);
 }
 
 size_t ZHeuristics::significant_young_overhead() {
-  return MaxHeapSize * ZYoungCompactionLimit;
+  return MaxHeapSize * (ZYoungCompactionLimit / 100);
 }


### PR DESCRIPTION
Hi all,

This patch fixes `ZHeuristics::significant_heap_overhead` and `ZHeuristics::significant_young_overhead` to use `ZFragmentationLimit` and `ZYoungCompactionLimit` as percentages instead of multiples.

Thanks for the review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322279](https://bugs.openjdk.org/browse/JDK-8322279): Generational ZGC: Use ZFragmentationLimit and ZYoungCompactionLimit as percentage instead of multiples (**Bug** - P2)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17139/head:pull/17139` \
`$ git checkout pull/17139`

Update a local copy of the PR: \
`$ git checkout pull/17139` \
`$ git pull https://git.openjdk.org/jdk.git pull/17139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17139`

View PR using the GUI difftool: \
`$ git pr show -t 17139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17139.diff">https://git.openjdk.org/jdk/pull/17139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17139#issuecomment-1860210734)