### PR TITLE
8321619: Generational ZGC: ZColorStoreGoodOopClosure is only valid for young objects

### DIFF
--- a/src/hotspot/share/gc/z/zBarrierSet.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.cpp
@@ -152,6 +152,17 @@ void ZBarrierSet::on_slowpath_allocation_exit(JavaThread* thread, oop new_obj) {
   deoptimize_allocation(thread);
 }
 
+void ZBarrierSet::clone_obj_array(objArrayOop src_obj, objArrayOop dst_obj, size_t size) {
+  volatile zpointer* src = (volatile zpointer*)src_obj->base();
+  volatile zpointer* dst = (volatile zpointer*)dst_obj->base();
+
+  for (const zpointer* const end = cast_from_oop<const zpointer*>(src_obj) + size; src < end; src++, dst++) {
+    zaddress elem = ZBarrier::load_barrier_on_oop_field(src);
+    ZBarrier::store_barrier_on_heap_oop_field(dst, false /* heal */);
+    Atomic::store(dst, ZAddress::store_good(elem));
+  }
+}
+
 void ZBarrierSet::print_on(outputStream* st) const {
   st->print_cr("ZBarrierSet");
 }

--- a/src/hotspot/share/gc/z/zBarrierSet.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.cpp
@@ -158,6 +158,8 @@ void ZBarrierSet::clone_obj_array(objArrayOop src_obj, objArrayOop dst_obj, size
 
   for (const zpointer* const end = cast_from_oop<const zpointer*>(src_obj) + size; src < end; src++, dst++) {
     zaddress elem = ZBarrier::load_barrier_on_oop_field(src);
+    // We avoid healing here because the store below colors the pointer store good,
+    // hence avoiding the cost of a CAS.
     ZBarrier::store_barrier_on_heap_oop_field(dst, false /* heal */);
     Atomic::store(dst, ZAddress::store_good(elem));
   }

--- a/src/hotspot/share/gc/z/zBarrierSet.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.hpp
@@ -48,6 +48,8 @@ public:
 
   virtual void print_on(outputStream* st) const;
 
+  static void clone_obj_array(objArrayOop src, objArrayOop dst, size_t size);
+
   template <DecoratorSet decorators, typename BarrierSetT = ZBarrierSet>
   class AccessBarrier : public BarrierSet::AccessBarrier<decorators, BarrierSetT> {
   private:

--- a/src/hotspot/share/gc/z/zBarrierSet.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.hpp
@@ -39,6 +39,8 @@ public:
   static ZBarrierSetAssembler* assembler();
   static bool barrier_needed(DecoratorSet decorators, BasicType type);
 
+  static void clone_obj_array(objArrayOop src, objArrayOop dst, size_t size);
+
   virtual void on_thread_create(Thread* thread);
   virtual void on_thread_destroy(Thread* thread);
   virtual void on_thread_attach(Thread* thread);
@@ -47,8 +49,6 @@ public:
   virtual void on_slowpath_allocation_exit(JavaThread* thread, oop new_obj);
 
   virtual void print_on(outputStream* st) const;
-
-  static void clone_obj_array(objArrayOop src, objArrayOop dst, size_t size);
 
   template <DecoratorSet decorators, typename BarrierSetT = ZBarrierSet>
   class AccessBarrier : public BarrierSet::AccessBarrier<decorators, BarrierSetT> {

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -440,6 +440,7 @@ inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::clone_in_heap(o
     // and arraycopy sequence, so the performance of this runtime call
     // does not matter for object arrays.
     clone_obj_array(objArrayOop(src), objArrayOop(dst), size);
+    return;
   }
 
   // Fix the oops

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -403,14 +403,13 @@ inline bool ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::oop_arraycopy_i
   return oop_arraycopy_in_heap_no_check_cast(dst, src, length);
 }
 
-class ZStoreBarrierOopClosure : public BasicOopIterateClosure {
+class ZColorStoreGoodOopClosure : public BasicOopIterateClosure {
 public:
   virtual void do_oop(oop* p_) {
     volatile zpointer* const p = (volatile zpointer*)p_;
     const zpointer ptr = ZBarrier::load_atomic(p);
     const zaddress addr = ZPointer::uncolor(ptr);
-    ZBarrier::store_barrier_on_heap_oop_field(p, false /* heal */);
-    *p = ZAddress::store_good(addr);
+    Atomic::store(p, ZAddress::store_good(addr));
   }
 
   virtual void do_oop(narrowOop* p) {
@@ -433,6 +432,16 @@ template <DecoratorSet decorators, typename BarrierSetT>
 inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::clone_in_heap(oop src, oop dst, size_t size) {
   assert_is_valid(to_zaddress(src));
 
+  if (dst->is_objArray()) {
+    // Cloning an object array is similar to performing array copy.
+    // If an array is large enough to have its allocation segmented,
+    // this operation might require GC barriers. However, the intrinsics
+    // for cloning arrays transform the clone to an optimized allocation
+    // and arraycopy sequence, so the performance of this runtime call
+    // does not matter for object arrays.
+    clone_obj_array(objArrayOop(src), objArrayOop(dst), size);
+  }
+
   // Fix the oops
   ZLoadBarrierOopClosure cl;
   ZIterator::oop_iterate(src, &cl);
@@ -440,10 +449,10 @@ inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::clone_in_heap(o
   // Clone the object
   Raw::clone_in_heap(src, dst, size);
 
-  assert(ZHeap::heap()->is_young(to_zaddress(dst)), "ZColorStoreGoodOopClosure is only valid for young objects");
+  assert(dst->is_typeArray() || ZHeap::heap()->is_young(to_zaddress(dst)), "ZColorStoreGoodOopClosure is only valid for young objects");
 
   // Color store good before handing out
-  ZStoreBarrierOopClosure cl_sg;
+  ZColorStoreGoodOopClosure cl_sg;
   ZIterator::oop_iterate(dst, &cl_sg);
 }
 


### PR DESCRIPTION
When cloning object arrays, we should do something more similar to arraycopy. The intrinsics for C2 already do that, but there are colder paths where the runtime version of cloning is used, and objects being cloned can potentially end up in the old generation. This could hypothetically be a problem if the source object is being concurrently modified by an external thread, storing store good pointers into its elements. Then, the destination array will look like it doesn't need any store barriers, while in fact no entries have been inserted to the remembered set.

This patch modifies cold object array cloning to be done more like array copy and relaxes the related assert for primitive arrays, which is what triggered the assertion that opened this investigation.

I have tested generational ZGC tier 1-7, general testing tier 1-5, and confirmed the individual test that triggered the assert triggers without this fix and doesn't trigger with this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321619](https://bugs.openjdk.org/browse/JDK-8321619): Generational ZGC: ZColorStoreGoodOopClosure is only valid for young objects (**Bug** - P1)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17141/head:pull/17141` \
`$ git checkout pull/17141`

Update a local copy of the PR: \
`$ git checkout pull/17141` \
`$ git pull https://git.openjdk.org/jdk.git pull/17141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17141`

View PR using the GUI difftool: \
`$ git pr show -t 17141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17141.diff">https://git.openjdk.org/jdk/pull/17141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17141#issuecomment-1860427793)