### PR TITLE
8322287: Parallel: Remove unused arg in adjust_eden_for_pause_time and adjust_eden_for_minor_pause_time

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -280,11 +280,11 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
     //
     // Make changes only to affect one of the pauses (the larger)
     // at a time.
-    adjust_eden_for_pause_time(is_full_gc, &desired_promo_size, &desired_eden_size);
+    adjust_eden_for_pause_time(&desired_promo_size, &desired_eden_size);
 
   } else if (_avg_minor_pause->padded_average() > gc_minor_pause_goal_sec()) {
     // Adjust only for the minor pause time goal
-    adjust_eden_for_minor_pause_time(is_full_gc, &desired_eden_size);
+    adjust_eden_for_minor_pause_time(&desired_eden_size);
 
   } else if(adjusted_mutator_cost() < _throughput_goal) {
     // This branch used to require that (mutator_cost() > 0.0 in 1.4.2.
@@ -570,9 +570,7 @@ void PSAdaptiveSizePolicy::decay_supplemental_growth(bool is_full_gc) {
   }
 }
 
-void PSAdaptiveSizePolicy::adjust_eden_for_minor_pause_time(bool is_full_gc,
-    size_t* desired_eden_size_ptr) {
-
+void PSAdaptiveSizePolicy::adjust_eden_for_minor_pause_time(size_t* desired_eden_size_ptr) {
   // Adjust the young generation size to reduce pause time of
   // of collections.
   //
@@ -585,12 +583,12 @@ void PSAdaptiveSizePolicy::adjust_eden_for_minor_pause_time(bool is_full_gc,
           decrease_young_gen_for_min_pauses_true);
     *desired_eden_size_ptr = *desired_eden_size_ptr -
       eden_decrement_aligned_down(*desired_eden_size_ptr);
-    } else {
-      // EXPERIMENTAL ADJUSTMENT
-      // Only record that the estimator indicated such an action.
-      // *desired_eden_size_ptr = *desired_eden_size_ptr + eden_heap_delta;
-      set_change_young_gen_for_min_pauses(
-          increase_young_gen_for_min_pauses_true);
+  } else {
+    // EXPERIMENTAL ADJUSTMENT
+    // Only record that the estimator indicated such an action.
+    // *desired_eden_size_ptr = *desired_eden_size_ptr + eden_heap_delta;
+    set_change_young_gen_for_min_pauses(
+      increase_young_gen_for_min_pauses_true);
   }
 }
 
@@ -630,16 +628,15 @@ void PSAdaptiveSizePolicy::adjust_promo_for_pause_time(bool is_full_gc,
     *desired_promo_size_ptr, promo_heap_delta);
 }
 
-void PSAdaptiveSizePolicy::adjust_eden_for_pause_time(bool is_full_gc,
-                                             size_t* desired_promo_size_ptr,
-                                             size_t* desired_eden_size_ptr) {
+void PSAdaptiveSizePolicy::adjust_eden_for_pause_time(size_t* desired_promo_size_ptr,
+                                                      size_t* desired_eden_size_ptr) {
 
   size_t eden_heap_delta = 0;
   // Add some checks for a threshold for a change.  For example,
   // a change less than the required alignment is probably not worth
   // attempting.
   if (_avg_minor_pause->padded_average() > _avg_major_pause->padded_average()) {
-    adjust_eden_for_minor_pause_time(is_full_gc, desired_eden_size_ptr);
+    adjust_eden_for_minor_pause_time(desired_eden_size_ptr);
   }
   log_trace(gc, ergo)(
     "PSAdaptiveSizePolicy::adjust_eden_for_pause_time "

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -116,16 +116,13 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
   // Accessors
   double gc_minor_pause_goal_sec() const { return _gc_minor_pause_goal_sec; }
 
-  void adjust_eden_for_minor_pause_time(bool is_full_gc,
-                                   size_t* desired_eden_size_ptr);
+  void adjust_eden_for_minor_pause_time(size_t* desired_eden_size_ptr);
   // Change the generation sizes to achieve a GC pause time goal
   // Returned sizes are not necessarily aligned.
   void adjust_promo_for_pause_time(bool is_full_gc,
                          size_t* desired_promo_size_ptr,
                          size_t* desired_eden_size_ptr);
-  void adjust_eden_for_pause_time(bool is_full_gc,
-                         size_t* desired_promo_size_ptr,
-                         size_t* desired_eden_size_ptr);
+  void adjust_eden_for_pause_time(size_t* desired_promo_size_ptr, size_t* desired_eden_size_ptr);
   // Change the generation sizes to achieve an application throughput goal
   // Returned sizes are not necessarily aligned.
   void adjust_promo_for_throughput(bool is_full_gc,


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322287](https://bugs.openjdk.org/browse/JDK-8322287): Parallel: Remove unused arg in adjust_eden_for_pause_time and adjust_eden_for_minor_pause_time (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17142/head:pull/17142` \
`$ git checkout pull/17142`

Update a local copy of the PR: \
`$ git checkout pull/17142` \
`$ git pull https://git.openjdk.org/jdk.git pull/17142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17142`

View PR using the GUI difftool: \
`$ git pr show -t 17142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17142.diff">https://git.openjdk.org/jdk/pull/17142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17142#issuecomment-1860479528)