### PR TITLE
8322292: Rearrange comparison of fields in Record.equals()

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -216,8 +216,8 @@ public class ObjectMethods {
         MethodHandle isInstance = MethodHandles.dropArguments(CLASS_IS_INSTANCE.bindTo(receiverClass), 0, receiverClass); // (RO)Z
         MethodHandle accumulator = MethodHandles.dropArguments(TRUE, 0, receiverClass, receiverClass); // (RR)Z
 
-        var equalsGetters = new ArrayList<>(getters);
-        equalsGetters.sort((mh1, mh2) -> {
+        var equalsGetters = getters.toArray(new MethodHandle[0]);
+        Arrays.sort(equalsGetters, (mh1, mh2) -> {
             var rt1 = mh1.type().returnType();
             var rt2 = mh2.type().returnType();
             if (rt1.isPrimitive() == rt2.isPrimitive() || rt1.isEnum() == rt2.isEnum()) {

--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -223,7 +223,7 @@ public class ObjectMethods {
             if (rt1.isPrimitive() == rt2.isPrimitive() || rt1.isEnum() == rt2.isEnum()) {
                 return 0;
             }
-            return rt1.isPrimitive() || rt1.isEnum() ? 1 : rt1.isArray() || Iterable.class.isAssignableFrom(rt1) ? -1 : 0;
+            return rt1.isPrimitive() || rt1.isEnum() || rt1.isArray() ? 1 : Iterable.class.isAssignableFrom(rt1) ? -1 : 0;
         });
 
         for (MethodHandle getter : equalsGetters) {

--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -222,7 +222,7 @@ public class ObjectMethods {
             if (rt1.isPrimitive() == rt2.isPrimitive() || rt1.isEnum() == rt2.isEnum()) {
                 return 0;
             }
-            return rt1.isPrimitive() || rt1.isEnum() ? 1 : -1;
+            return rt1.isPrimitive() || rt1.isEnum() ? 1 : rt1.isArray() || Iterable.class.isAssignableFrom(rt1) ? -1 : 0;
         });
 
         for (MethodHandle getter : getters) {

--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -216,7 +216,8 @@ public class ObjectMethods {
         MethodHandle isInstance = MethodHandles.dropArguments(CLASS_IS_INSTANCE.bindTo(receiverClass), 0, receiverClass); // (RO)Z
         MethodHandle accumulator = MethodHandles.dropArguments(TRUE, 0, receiverClass, receiverClass); // (RR)Z
 
-        getters.sort((mh1, mh2) -> {
+        var equalsGetters = new ArrayList<>(getters);
+        equalsGetters.sort((mh1, mh2) -> {
             var rt1 = mh1.type().returnType();
             var rt2 = mh2.type().returnType();
             if (rt1.isPrimitive() == rt2.isPrimitive() || rt1.isEnum() == rt2.isEnum()) {
@@ -225,7 +226,7 @@ public class ObjectMethods {
             return rt1.isPrimitive() || rt1.isEnum() ? 1 : rt1.isArray() || Iterable.class.isAssignableFrom(rt1) ? -1 : 0;
         });
 
-        for (MethodHandle getter : getters) {
+        for (MethodHandle getter : equalsGetters) {
             MethodHandle equalator = equalator(getter.type().returnType()); // (TT)Z
             MethodHandle thisFieldEqual = MethodHandles.filterArguments(equalator, 0, getter, getter); // (RR)Z
             accumulator = MethodHandles.guardWithTest(thisFieldEqual, accumulator, instanceFalse.asType(rr));
@@ -428,7 +429,7 @@ public class ObjectMethods {
             if (!MethodHandle.class.equals(type))
                 throw new IllegalArgumentException(type.toString());
         }
-        List<MethodHandle> getterList = Arrays.asList(getters);
+        List<MethodHandle> getterList = List.of(getters);
         MethodHandle handle = switch (methodName) {
             case "equals"   -> {
                 if (methodType != null && !methodType.equals(MethodType.methodType(boolean.class, recordClass, Object.class)))

--- a/test/langtools/tools/javac/classreader/BadMethodParameter.java
+++ b/test/langtools/tools/javac/classreader/BadMethodParameter.java
@@ -29,17 +29,16 @@
  * @modules
  *      jdk.compiler/com.sun.tools.javac.api
  *      jdk.compiler/com.sun.tools.javac.main
- *      java.base/jdk.internal.classfile
- *      java.base/jdk.internal.classfile.attribute
  * @build toolbox.ToolBox toolbox.JavacTask
+ * @enablePreview
  * @run main BadMethodParameter
  */
 
-import jdk.internal.classfile.ClassModel;
-import jdk.internal.classfile.ClassTransform;
-import jdk.internal.classfile.Classfile;
-import jdk.internal.classfile.MethodTransform;
-import jdk.internal.classfile.attribute.MethodParametersAttribute;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.MethodTransform;
+import java.lang.classfile.attribute.MethodParametersAttribute;
 
 import toolbox.JavacTask;
 import toolbox.Task;
@@ -99,7 +98,9 @@ public class BadMethodParameter extends TestRunner {
         Path classDir = getClassDir();
         new JavacTask(tb)
                 .classpath(classes, classDir)
-                .options("-verbose", "-parameters", "-processor", P.class.getName())
+                .options("--enable-preview",
+                         "-source", String.valueOf(Runtime.version().feature()),
+                         "-verbose", "-parameters", "-processor", P.class.getName())
                 .classes(P.class.getName())
                 .outdir(classes)
                 .run(Task.Expect.SUCCESS);
@@ -132,7 +133,7 @@ public class BadMethodParameter extends TestRunner {
 
     private static void transform(Path path) throws IOException {
         byte[] bytes = Files.readAllBytes(path);
-        Classfile cf = Classfile.of();
+        ClassFile cf = ClassFile.of();
         ClassModel classModel = cf.parse(bytes);
         MethodTransform methodTransform =
                 (mb, me) -> {


### PR DESCRIPTION
Currently if we create a record it's fields are compared in their declaration order. This might be ineffective in cases when two objects have "heavy" fields equals to each other, but different "lightweight" fields (heavy and lightweight in terms of comparison) e.g. primitives, enums, nullable/non-nulls etc.

If we have declared a record like
```java
public record MyRecord(String field1, int field2) {}
```
It's equals() looks like:
```
  public final equals(Ljava/lang/Object;)Z
   L0
    LINENUMBER 3 L0
    ALOAD 0
    ALOAD 1
    INVOKEDYNAMIC equals(Lcom/caspianone/openbanking/productservice/controller/MyRecord;Ljava/lang/Object;)Z [
      // handle kind 0x6 : INVOKESTATIC
      java/lang/runtime/ObjectMethods.bootstrap(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;
      // arguments:
      com.caspianone.openbanking.productservice.controller.MyRecord.class,
      "field1;field2",
      // handle kind 0x1 : GETFIELD
      com/caspianone/openbanking/productservice/controller/MyRecord.field1(Ljava/lang/String;),
      // handle kind 0x1 : GETFIELD
      com/caspianone/openbanking/productservice/controller/MyRecord.field2(I)
    ]
    IRETURN
   L1
    LOCALVARIABLE this Lcom/caspianone/openbanking/productservice/controller/MyRecord; L0 L1 0
    LOCALVARIABLE o Ljava/lang/Object; L0 L1 1
    MAXSTACK = 2
    MAXLOCALS = 2
```
This can be improved by rearranging the comparison order of the fields moving enums and primitives upper, and collections/arrays lower.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322292](https://bugs.openjdk.org/browse/JDK-8322292): Rearrange comparison of fields in Record.equals() (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17143/head:pull/17143` \
`$ git checkout pull/17143`

Update a local copy of the PR: \
`$ git checkout pull/17143` \
`$ git pull https://git.openjdk.org/jdk.git pull/17143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17143`

View PR using the GUI difftool: \
`$ git pr show -t 17143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17143.diff">https://git.openjdk.org/jdk/pull/17143.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17143#issuecomment-1861190207)