### PR TITLE
8322298: Obsolete unused AdaptiveSizePolicyCollectionCostMargin

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -408,11 +408,6 @@
           "Allowed collection cost difference between generations")         \
           range(0, 100)                                                     \
                                                                             \
-  product(uint, AdaptiveSizePolicyCollectionCostMargin, 50,                 \
-          "If collection costs are within margin, reduce both by full "     \
-          "delta")                                                          \
-          range(0, 100)                                                     \
-                                                                            \
   product(uint, YoungGenerationSizeIncrement, 20,                           \
           "Adaptive size percentage change in young generation")            \
           range(0, 100)                                                     \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -525,6 +525,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "RefDiscoveryPolicy",           JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
   { "MetaspaceReclaimPolicy",       JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
 
+  { "AdaptiveSizePolicyCollectionCostMargin",   JDK_Version::undefined(), JDK_Version::jdk(23), JDK_Version::jdk(24) },
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },
 #endif


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8322310](https://bugs.openjdk.org/browse/JDK-8322310) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8322298](https://bugs.openjdk.org/browse/JDK-8322298): Obsolete unused AdaptiveSizePolicyCollectionCostMargin (**Enhancement** - P4)
 * [JDK-8322310](https://bugs.openjdk.org/browse/JDK-8322310): Obsolete unused AdaptiveSizePolicyCollectionCostMargin (**CSR**)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [b3928403](https://git.openjdk.org/jdk/pull/17145/files/b39284038e977e9d9a437157ead750b26d4c6322)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17145/head:pull/17145` \
`$ git checkout pull/17145`

Update a local copy of the PR: \
`$ git checkout pull/17145` \
`$ git pull https://git.openjdk.org/jdk.git pull/17145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17145`

View PR using the GUI difftool: \
`$ git pr show -t 17145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17145.diff">https://git.openjdk.org/jdk/pull/17145.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17145#issuecomment-1860673239)