### PR TITLE
8322300: Remove redundant arg in PSAdaptiveSizePolicy::adjust_promo_for_pause_time

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -455,7 +455,7 @@ void PSAdaptiveSizePolicy::compute_old_gen_free_space(
     // at a time.
     if (is_full_gc) {
       set_decide_at_full_gc(decide_at_full_gc_true);
-      adjust_promo_for_pause_time(is_full_gc, &desired_promo_size, &desired_eden_size);
+      adjust_promo_for_pause_time(&desired_promo_size, &desired_eden_size);
     }
   } else if (adjusted_mutator_cost() < _throughput_goal) {
     // This branch used to require that (mutator_cost() > 0.0 in 1.4.2.
@@ -592,16 +592,15 @@ void PSAdaptiveSizePolicy::adjust_eden_for_minor_pause_time(size_t* desired_eden
   }
 }
 
-void PSAdaptiveSizePolicy::adjust_promo_for_pause_time(bool is_full_gc,
-                                             size_t* desired_promo_size_ptr,
-                                             size_t* desired_eden_size_ptr) {
+void PSAdaptiveSizePolicy::adjust_promo_for_pause_time(size_t* desired_promo_size_ptr,
+                                                       size_t* desired_eden_size_ptr) {
 
   size_t promo_heap_delta = 0;
   // Add some checks for a threshold for a change.  For example,
   // a change less than the required alignment is probably not worth
   // attempting.
 
-  if (_avg_minor_pause->padded_average() <= _avg_major_pause->padded_average() && is_full_gc) {
+  if (_avg_minor_pause->padded_average() <= _avg_major_pause->padded_average()) {
     // Adjust for the major pause time only at full gc's because the
     // affects of a change can only be seen at full gc's.
 

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -119,9 +119,8 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
   void adjust_eden_for_minor_pause_time(size_t* desired_eden_size_ptr);
   // Change the generation sizes to achieve a GC pause time goal
   // Returned sizes are not necessarily aligned.
-  void adjust_promo_for_pause_time(bool is_full_gc,
-                         size_t* desired_promo_size_ptr,
-                         size_t* desired_eden_size_ptr);
+  void adjust_promo_for_pause_time(size_t* desired_promo_size_ptr,
+                                   size_t* desired_eden_size_ptr);
   void adjust_eden_for_pause_time(size_t* desired_promo_size_ptr, size_t* desired_eden_size_ptr);
   // Change the generation sizes to achieve an application throughput goal
   // Returned sizes are not necessarily aligned.


### PR DESCRIPTION
Trivial removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322300](https://bugs.openjdk.org/browse/JDK-8322300): Remove redundant arg in PSAdaptiveSizePolicy::adjust_promo_for_pause_time (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17148/head:pull/17148` \
`$ git checkout pull/17148`

Update a local copy of the PR: \
`$ git checkout pull/17148` \
`$ git pull https://git.openjdk.org/jdk.git pull/17148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17148`

View PR using the GUI difftool: \
`$ git pr show -t 17148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17148.diff">https://git.openjdk.org/jdk/pull/17148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17148#issuecomment-1860885420)