### PR TITLE
8322294: Cleanup NativePostCallNop

### DIFF
--- a/src/hotspot/cpu/aarch64/frame_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.hpp
@@ -156,8 +156,6 @@
   static void verify_deopt_original_pc(   CompiledMethod* nm, intptr_t* unextended_sp);
 #endif
 
-  const ImmutableOopMap* get_oop_map() const;
-
  public:
   // Constructors
 

--- a/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
+++ b/src/hotspot/cpu/aarch64/frame_aarch64.inline.hpp
@@ -359,20 +359,6 @@ inline int frame::sender_sp_ret_address_offset() {
   return frame::sender_sp_offset - frame::return_addr_offset;
 }
 
-inline const ImmutableOopMap* frame::get_oop_map() const {
-  if (_cb == nullptr) return nullptr;
-  if (_cb->oop_maps() != nullptr) {
-    NativePostCallNop* nop = nativePostCallNop_at(_pc);
-    if (nop != nullptr && nop->displacement() != 0) {
-      int slot = ((nop->displacement() >> 24) & 0xff);
-      return _cb->oop_map_for_slot(slot, _pc);
-    }
-    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
-    return oop_map;
-  }
-  return nullptr;
-}
-
 //------------------------------------------------------------------------------
 // frame::sender
 inline frame frame::sender(RegisterMap* map) const {

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -560,18 +560,23 @@ static bool is_movk_to_zr(uint32_t insn) {
 }
 #endif
 
-void NativePostCallNop::patch(jint diff) {
+bool NativePostCallNop::patch(int32_t oopmap_slot, int32_t cb_offset) {
+  if (((oopmap_slot & 0xff) != oopmap_slot) || ((cb_offset & 0xffffff) != cb_offset)) {
+    return false; // cannot encode
+  }
+  uint32_t data = (oopmap_slot << 24) | cb_offset;
 #ifdef ASSERT
-  assert(diff != 0, "must be");
+  assert(data != 0, "must be");
   uint32_t insn1 = uint_at(4);
   uint32_t insn2 = uint_at(8);
   assert (is_movk_to_zr(insn1) && is_movk_to_zr(insn2), "must be");
 #endif
 
-  uint32_t lo = diff & 0xffff;
-  uint32_t hi = (uint32_t)diff >> 16;
+  uint32_t lo = data & 0xffff;
+  uint32_t hi = data >> 16;
   Instruction_aarch64::patch(addr_at(4), 20, 5, lo);
   Instruction_aarch64::patch(addr_at(8), 20, 5, hi);
+  return true; // successfully encoded
 }
 
 void NativeDeoptInstruction::verify() {

--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.hpp
@@ -691,16 +691,20 @@ public:
     return (insns & 0xffe0001fffffffff) == 0xf280001fd503201f;
   }
 
-  jint displacement() const {
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const {
     uint64_t movk_insns = *(uint64_t*)addr_at(4);
     uint32_t lo = (movk_insns >> 5) & 0xffff;
     uint32_t hi = (movk_insns >> (5 + 32)) & 0xffff;
-    uint32_t result = (hi << 16) | lo;
-
-    return (jint)result;
+    uint32_t data = (hi << 16) | lo;
+    if (data == 0) {
+      return false; // no information encoded
+    }
+    cb_offset = (data & 0xffffff);
+    oopmap_slot = (data >> 24) & 0xff;
+    return true; // decoding succeeded
   }
 
-  void patch(jint diff);
+  bool patch(int32_t oopmap_slot, int32_t cb_offset);
   void make_deopt();
 };
 

--- a/src/hotspot/cpu/arm/frame_arm.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.hpp
@@ -99,8 +99,6 @@
   }
 #endif
 
-  const ImmutableOopMap* get_oop_map() const;
-
  public:
   // Constructors
 

--- a/src/hotspot/cpu/arm/frame_arm.inline.hpp
+++ b/src/hotspot/cpu/arm/frame_arm.inline.hpp
@@ -218,20 +218,6 @@ inline int frame::frame_size() const {
   return sender_sp() - sp();
 }
 
-inline const ImmutableOopMap* frame::get_oop_map() const {
-  if (_cb == nullptr) return nullptr;
-  if (_cb->oop_maps() != nullptr) {
-    NativePostCallNop* nop = nativePostCallNop_at(_pc);
-    if (nop != nullptr && nop->displacement() != 0) {
-      int slot = ((nop->displacement() >> 24) & 0xff);
-      return _cb->oop_map_for_slot(slot, _pc);
-    }
-    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
-    return oop_map;
-  }
-  return nullptr;
-}
-
 inline int frame::compiled_frame_stack_argsize() const {
   Unimplemented();
   return 0;

--- a/src/hotspot/cpu/arm/nativeInst_arm_32.cpp
+++ b/src/hotspot/cpu/arm/nativeInst_arm_32.cpp
@@ -341,10 +341,6 @@ void NativePostCallNop::make_deopt() {
   NativeDeoptInstruction::insert(addr_at(0));
 }
 
-void NativePostCallNop::patch(jint diff) {
-  // unsupported for now
-}
-
 void NativeDeoptInstruction::verify() {
 }
 

--- a/src/hotspot/cpu/arm/nativeInst_arm_32.hpp
+++ b/src/hotspot/cpu/arm/nativeInst_arm_32.hpp
@@ -438,8 +438,8 @@ inline NativeCall* nativeCall_before(address return_address) {
 class NativePostCallNop: public NativeInstruction {
 public:
   bool check() const { return is_nop(); }
-  int displacement() const { return 0; }
-  void patch(jint diff);
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const { return false; }
+  bool patch(int32_t oopmap_slot, int32_t cb_offset) { return false; }
   void make_deopt();
 };
 

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -400,8 +400,6 @@
 
  public:
 
-  const ImmutableOopMap* get_oop_map() const;
-
   // Constructors
   inline frame(intptr_t* sp, intptr_t* fp, address pc);
   inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp = nullptr, intptr_t* fp = nullptr, CodeBlob* cb = nullptr);

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -361,20 +361,6 @@ inline void frame::set_saved_oop_result(RegisterMap* map, oop obj) {
   *result_adr = obj;
 }
 
-inline const ImmutableOopMap* frame::get_oop_map() const {
-  if (_cb == nullptr) return nullptr;
-  if (_cb->oop_maps() != nullptr) {
-    NativePostCallNop* nop = nativePostCallNop_at(_pc);
-    if (nop != nullptr && nop->displacement() != 0) {
-      int slot = ((nop->displacement() >> 24) & 0xff);
-      return _cb->oop_map_for_slot(slot, _pc);
-    }
-    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
-    return oop_map;
-  }
-  return nullptr;
-}
-
 inline int frame::compiled_frame_stack_argsize() const {
   assert(cb()->is_compiled(), "");
   return (cb()->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord;

--- a/src/hotspot/cpu/ppc/nativeInst_ppc.cpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.cpp
@@ -429,10 +429,6 @@ void NativePostCallNop::make_deopt() {
   NativeDeoptInstruction::insert(addr_at(0));
 }
 
-void NativePostCallNop::patch(jint diff) {
-  // unsupported for now
-}
-
 void NativeDeoptInstruction::verify() {
 }
 

--- a/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
+++ b/src/hotspot/cpu/ppc/nativeInst_ppc.hpp
@@ -508,8 +508,8 @@ class NativeMovRegMem: public NativeInstruction {
 class NativePostCallNop: public NativeInstruction {
 public:
   bool check() const { return is_nop(); }
-  int displacement() const { return 0; }
-  void patch(jint diff);
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const { return false; }
+  bool patch(int32_t oopmap_slot, int32_t cb_offset) { return false; }
   void make_deopt();
 };
 

--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -189,8 +189,6 @@
   static void verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp);
 #endif
 
-  const ImmutableOopMap* get_oop_map() const;
-
  public:
   // Constructors
 

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -345,20 +345,6 @@ inline int frame::sender_sp_ret_address_offset() {
   return frame::sender_sp_offset - frame::return_addr_offset;
 }
 
-inline const ImmutableOopMap* frame::get_oop_map() const {
-  if (_cb == nullptr) return nullptr;
-  if (_cb->oop_maps() != nullptr) {
-    NativePostCallNop* nop = nativePostCallNop_at(_pc);
-    if (nop != nullptr && nop->displacement() != 0) {
-      int slot = ((nop->displacement() >> 24) & 0xff);
-      return _cb->oop_map_for_slot(slot, _pc);
-    }
-    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
-    return oop_map;
-  }
-  return nullptr;
-}
-
 //------------------------------------------------------------------------------
 // frame::sender
 frame frame::sender(RegisterMap* map) const {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -451,16 +451,27 @@ void NativePostCallNop::make_deopt() {
   NativeDeoptInstruction::insert(addr_at(0));
 }
 
-int NativePostCallNop::displacement() const {
+bool NativePostCallNop::decode(int32_t& oopmap_slot, int32_t& cb_offset) const {
   // Discard the high 32 bits
-  return (int)(intptr_t)MacroAssembler::get_target_of_li32(addr_at(4));
+  int32_t data = (int32_t)(intptr_t)MacroAssembler::get_target_of_li32(addr_at(4));
+  if (data == 0) {
+    return false; // no information encoded
+  }
+  cb_offset = (data & 0xffffff);
+  oopmap_slot = (data >> 24) & 0xff;
+  return true; // decoding succeeded
 }
 
-void NativePostCallNop::patch(jint diff) {
-  assert(diff != 0, "must be");
+bool NativePostCallNop::patch(int32_t oopmap_slot, int32_t cb_offset) {
+  if (((oopmap_slot & 0xff) != oopmap_slot) || ((cb_offset & 0xffffff) != cb_offset)) {
+    return false; // cannot encode
+  }
+  int32_t data = (oopmap_slot << 24) | cb_offset;
+  assert(data != 0, "must be");
   assert(is_lui_to_zr_at(addr_at(4)) && is_addiw_to_zr_at(addr_at(8)), "must be");
 
-  MacroAssembler::patch_imm_in_li32(addr_at(4), diff);
+  MacroAssembler::patch_imm_in_li32(addr_at(4), data);
+  return true; // successfully encoded
 }
 
 void NativeDeoptInstruction::verify() {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -591,8 +591,8 @@ public:
     // an addiw as well.
     return is_nop() && is_lui_to_zr_at(addr_at(4));
   }
-  int displacement() const;
-  void patch(jint diff);
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const;
+  bool patch(int32_t oopmap_slot, int32_t cb_offset);
   void make_deopt();
 };
 

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -465,7 +465,6 @@
 
   // Initialize frame members (_pc and _sp must be given)
   inline void setup();
-  const ImmutableOopMap* get_oop_map() const;
 
  // Constructors
 

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -292,20 +292,6 @@ inline intptr_t* frame::real_fp() const {
   return fp();
 }
 
-inline const ImmutableOopMap* frame::get_oop_map() const {
-  if (_cb == nullptr) return nullptr;
-  if (_cb->oop_maps() != nullptr) {
-    NativePostCallNop* nop = nativePostCallNop_at(_pc);
-    if (nop != nullptr && nop->displacement() != 0) {
-      int slot = ((nop->displacement() >> 24) & 0xff);
-      return _cb->oop_map_for_slot(slot, _pc);
-    }
-    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
-    return oop_map;
-  }
-  return nullptr;
-}
-
 inline int frame::compiled_frame_stack_argsize() const {
   Unimplemented();
   return 0;

--- a/src/hotspot/cpu/s390/nativeInst_s390.hpp
+++ b/src/hotspot/cpu/s390/nativeInst_s390.hpp
@@ -657,9 +657,9 @@ class NativeGeneralJump: public NativeInstruction {
 class NativePostCallNop: public NativeInstruction {
 public:
   bool check() const { Unimplemented(); return false; }
-  int displacement() const { return 0; }
-  void patch(jint diff) { Unimplemented(); }
-  void make_deopt() { Unimplemented(); }
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const { return false; }
+  bool patch(int32_t oopmap_slot, int32_t cb_offset) { Unimplemented() ; return false; }
+  void make_deopt();
 };
 
 inline NativePostCallNop* nativePostCallNop_at(address address) {

--- a/src/hotspot/cpu/x86/frame_x86.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.hpp
@@ -149,8 +149,6 @@
   static void verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp);
 #endif
 
-  const ImmutableOopMap* get_oop_map() const;
-
  public:
   // Constructors
 

--- a/src/hotspot/cpu/x86/frame_x86.inline.hpp
+++ b/src/hotspot/cpu/x86/frame_x86.inline.hpp
@@ -343,20 +343,6 @@ inline int frame::sender_sp_ret_address_offset() {
   return frame::sender_sp_offset - frame::return_addr_offset;
 }
 
-inline const ImmutableOopMap* frame::get_oop_map() const {
-  if (_cb == nullptr) return nullptr;
-  if (_cb->oop_maps() != nullptr) {
-    NativePostCallNop* nop = nativePostCallNop_at(_pc);
-    if (nop != nullptr && nop->displacement() != 0) {
-      int slot = ((nop->displacement() >> 24) & 0xff);
-      return _cb->oop_map_for_slot(slot, _pc);
-    }
-    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
-    return oop_map;
-  }
-  return nullptr;
-}
-
 //------------------------------------------------------------------------------
 // frame::sender
 

--- a/src/hotspot/cpu/x86/nativeInst_x86.hpp
+++ b/src/hotspot/cpu/x86/nativeInst_x86.hpp
@@ -735,8 +735,16 @@ public:
   };
 
   bool check() const { return int_at(0) == 0x841f0f; }
-  int displacement() const { return (jint) int_at(displacement_offset); }
-  void patch(jint diff);
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const {
+    int32_t data = int_at(displacement_offset);
+    if (data == 0) {
+      return false; // no information encoded
+    }
+    cb_offset = (data & 0xffffff);
+    oopmap_slot = (data >> 24) & 0xff;
+    return true; // decoding succeeded
+  }
+  bool patch(int32_t oopmap_slot, int32_t cb_offset);
   void make_deopt();
 };
 

--- a/src/hotspot/cpu/zero/frame_zero.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.hpp
@@ -44,8 +44,6 @@
     align_wiggle     =  1
   };
 
- const ImmutableOopMap* get_oop_map() const;
-
   // Constructor
  public:
   frame(ZeroFrame* zeroframe, intptr_t* sp);

--- a/src/hotspot/cpu/zero/frame_zero.inline.hpp
+++ b/src/hotspot/cpu/zero/frame_zero.inline.hpp
@@ -176,11 +176,6 @@ inline intptr_t* frame::unextended_sp() const {
   return (intptr_t *) -1;
 }
 
-inline const ImmutableOopMap* frame::get_oop_map() const {
-  Unimplemented();
-  return nullptr;
-}
-
 inline int frame::compiled_frame_stack_argsize() const {
   Unimplemented();
   return 0;

--- a/src/hotspot/cpu/zero/nativeInst_zero.hpp
+++ b/src/hotspot/cpu/zero/nativeInst_zero.hpp
@@ -214,8 +214,8 @@ inline NativeGeneralJump* nativeGeneralJump_at(address address) {
 class NativePostCallNop: public NativeInstruction {
 public:
   bool check() const { Unimplemented(); return false; }
-  int displacement() const { Unimplemented(); return 0; }
-  void patch(jint diff) { Unimplemented(); }
+  bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const { Unimplemented(); return false; }
+  bool patch(int32_t oopmap_slot, int32_t cb_offset) { Unimplemented(); return false; }
   void make_deopt() { Unimplemented(); }
 };
 

--- a/src/hotspot/share/code/codeCache.inline.hpp
+++ b/src/hotspot/share/code/codeCache.inline.hpp
@@ -37,10 +37,9 @@ inline CodeBlob* CodeCache::find_blob_fast(void* pc) {
 inline CodeBlob* CodeCache::find_blob_and_oopmap(void* pc, int& slot) {
   NativePostCallNop* nop = nativePostCallNop_at((address) pc);
   CodeBlob* cb;
-  if (nop != nullptr && nop->displacement() != 0) {
-    int offset = (nop->displacement() & 0xffffff);
+  int offset;
+  if (nop != nullptr && nop->decode(slot, offset)) {
     cb = (CodeBlob*) ((address) pc - offset);
-    slot = ((nop->displacement() >> 24) & 0xff);
     assert(cb == CodeCache::find_blob(pc), "must be");
   } else {
     cb = CodeCache::find_blob(pc);
@@ -52,9 +51,12 @@ inline CodeBlob* CodeCache::find_blob_and_oopmap(void* pc, int& slot) {
 
 inline int CodeCache::find_oopmap_slot_fast(void* pc) {
   NativePostCallNop* nop = nativePostCallNop_at((address) pc);
-  return (nop != nullptr && nop->displacement() != 0)
-      ? ((nop->displacement() >> 24) & 0xff)
-      : -1;
+  int oopmap_slot;
+  int cb_offset;
+  if (nop != nullptr && nop->decode(oopmap_slot, cb_offset)) {
+    return oopmap_slot;
+  }
+  return -1;
 }
 
 #endif // SHARE_VM_COMPILER_CODECACHE_INLINE_HPP

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1137,10 +1137,7 @@ static void install_post_call_nop_displacement(nmethod* nm, address pc) {
   int oopmap_slot = nm->oop_maps()->find_slot_for_offset(int((intptr_t) pc - (intptr_t) nm->code_begin()));
   if (oopmap_slot < 0) { // this can happen at asynchronous (non-safepoint) stackwalks
     log_debug(codecache)("failed to find oopmap for cb: " INTPTR_FORMAT " offset: %d", cbaddr, (int) offset);
-  } else if (((oopmap_slot & 0xff) == oopmap_slot) && ((offset & 0xffffff) == offset)) {
-    jint value = (oopmap_slot << 24) | (jint) offset;
-    nop->patch(value);
-  } else {
+  } else if (!nop->patch(oopmap_slot, offset)) {
     log_debug(codecache)("failed to encode %d %d", oopmap_slot, (int) offset);
   }
 }

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -90,6 +90,8 @@ class frame {
   void assert_offset() const   { assert(_frame_index >= 0,  "Using offset with a non-chunk frame"); assert_on_heap(); }
   void assert_absolute() const { assert(_frame_index == -1, "Using absolute addresses with a chunk frame"); }
 
+  const ImmutableOopMap* get_oop_map() const;
+
  public:
   // Constructors
   frame();

--- a/src/hotspot/share/runtime/frame.inline.hpp
+++ b/src/hotspot/share/runtime/frame.inline.hpp
@@ -104,6 +104,21 @@ inline CodeBlob* frame::get_cb() const {
   return _cb;
 }
 
+inline const ImmutableOopMap* frame::get_oop_map() const {
+  if (_cb == nullptr) return nullptr;
+  if (_cb->oop_maps() != nullptr) {
+    NativePostCallNop* nop = nativePostCallNop_at(_pc);
+    int oopmap_slot;
+    int cb_offset;
+    if (nop != nullptr && nop->decode(oopmap_slot, cb_offset)) {
+      return _cb->oop_map_for_slot(oopmap_slot, _pc);
+    }
+    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
+    return oop_map;
+  }
+  return nullptr;
+}
+
 inline int frame::interpreter_frame_monitor_size_in_bytes() {
   // Number of bytes for a monitor.
   return frame::interpreter_frame_monitor_size() * wordSize;


### PR DESCRIPTION
This is a refactoring/cleanup of `NativePostCallNop` that simplifies the ppc64 port.

* `frame::get_oop_map()` is moved to shared code

* encoding / decoding details of the oopmap slot and the CodeBlob offset are moved from shared code to the platform dependent implementations of `bool NativePostCallNop::patch(int32_t oopmap_slot, int32_t cb_offset)` and `bool NativePostCallNop::decode(int32_t& oopmap_slot, int32_t& cb_offset)`

The change passed our CI testing. JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests.
All testing was done with fastdebug and release builds on the main platforms and also on Linux/PPC64le and AIX.
