### PR TITLE
8322321: Add man page doc for -XX:+VerifySharedSpaces

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1581,8 +1581,8 @@ See \f[B]Application Class Data Sharing\f[R].
 .TP
 \f[V]-XX:+VerifySharedSpaces\f[R]
 If this option is specified, the JVM will load a CDS archive file only
-if it passes an integrity check based on CRC32 checkums.
-The purpose of this flag is to check for unintentional damages of CDS
+if it passes an integrity check based on CRC32 checksums.
+The purpose of this flag is to check for unintentional damages to CDS
 archive files in transmission or storage.
 To guarantee the security and proper operation of CDS, the user must
 ensure that the CDS archive files used by Java applications cannot be

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1579,6 +1579,15 @@ Specifies the path and name of the class data sharing (CDS) archive file
 See \f[B]Application Class Data Sharing\f[R].
 .RE
 .TP
+\f[V]-XX:+VerifySharedSpaces\f[R]
+If this option is specified, the JVM will load a CDS archive file only
+if it passes an integrity check based on CRC32 checkums.
+The purpose of this flag is to check for unintentional damages of CDS
+archive files in transmission or storage.
+To guarantee the security and proper operation of CDS, the user must
+ensure that the CDS archive files used by Java applications cannot be
+modified without proper authorization.
+.TP
 \f[V]-XX:SharedArchiveConfigFile=\f[R]\f[I]shared_config_file\f[R]
 Specifies additional shared data added to the archive file.
 .TP

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1582,7 +1582,7 @@ See \f[B]Application Class Data Sharing\f[R].
 \f[V]-XX:+VerifySharedSpaces\f[R]
 If this option is specified, the JVM will load a CDS archive file only
 if it passes an integrity check based on CRC32 checksums.
-The purpose of this flag is to check for unintentional damages to CDS
+The purpose of this flag is to check for unintentional damage to CDS
 archive files in transmission or storage.
 To guarantee the security and proper operation of CDS, the user must
 ensure that the CDS archive files used by Java applications cannot be


### PR DESCRIPTION
`VerifySharedSpaces` was disabled in [JDK-8221478](https://bugs.openjdk.org/browse/JDK-8221478) by default. We should add an entry in the "java" man page about the intended use for this flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322321](https://bugs.openjdk.org/browse/JDK-8322321): Add man page doc for -XX:+VerifySharedSpaces (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17152/head:pull/17152` \
`$ git checkout pull/17152`

Update a local copy of the PR: \
`$ git checkout pull/17152` \
`$ git pull https://git.openjdk.org/jdk.git pull/17152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17152`

View PR using the GUI difftool: \
`$ git pr show -t 17152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17152.diff">https://git.openjdk.org/jdk/pull/17152.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17152#issuecomment-1862285116)