### PR TITLE
8322364: Parallel: Remove unused SizePolicyTrueValues enum members

### DIFF
--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
@@ -51,15 +51,11 @@ class AdaptiveSizePolicy : public CHeapObj<mtGC> {
     decrease_old_gen_for_throughput_true = -7,
     decrease_young_gen_for_througput_true = -6,
 
-    increase_old_gen_for_min_pauses_true = -5,
-    decrease_old_gen_for_min_pauses_true = -4,
-    decrease_young_gen_for_maj_pauses_true = -3,
     increase_young_gen_for_min_pauses_true = -2,
     increase_old_gen_for_maj_pauses_true = -1,
 
     decrease_young_gen_for_min_pauses_true = 1,
     decrease_old_gen_for_maj_pauses_true = 2,
-    increase_young_gen_for_maj_pauses_true = 3,
 
     increase_old_gen_for_throughput_true = 4,
     increase_young_gen_for_througput_true = 5,


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322364](https://bugs.openjdk.org/browse/JDK-8322364): Parallel: Remove unused SizePolicyTrueValues enum members (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17153/head:pull/17153` \
`$ git checkout pull/17153`

Update a local copy of the PR: \
`$ git checkout pull/17153` \
`$ git pull https://git.openjdk.org/jdk.git pull/17153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17153`

View PR using the GUI difftool: \
`$ git pr show -t 17153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17153.diff">https://git.openjdk.org/jdk/pull/17153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17153#issuecomment-1862372084)