### PR TITLE
8322476: Remove GrowableArray C-Heap version, replace usages with GrowableArrayCHeap

### DIFF
--- a/src/hotspot/os/linux/gc/x/xPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/x/xPhysicalMemoryBacking_linux.cpp
@@ -623,7 +623,7 @@ retry:
 }
 
 static int offset_to_node(size_t offset) {
-  const GrowableArray<int>* mapping = os::Linux::numa_nindex_to_node();
+  const GrowableArrayCHeap<int, mtInternal>* mapping = os::Linux::numa_nindex_to_node();
   const size_t nindex = (offset >> XGranuleSizeShift) % mapping->length();
   return mapping->at((int)nindex);
 }

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -627,7 +627,7 @@ retry:
 }
 
 static int offset_to_node(zoffset offset) {
-  const GrowableArray<int>* mapping = os::Linux::numa_nindex_to_node();
+  const GrowableArrayCHeap<int, mtInternal>* mapping = os::Linux::numa_nindex_to_node();
   const size_t nindex = (untype(offset) >> ZGranuleSizeShift) % mapping->length();
   return mapping->at((int)nindex);
 }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3145,10 +3145,10 @@ bool os::Linux::libnuma_init() {
         set_numa_interleave_bitmask(_numa_get_interleave_mask());
         set_numa_membind_bitmask(_numa_get_membind());
         // Create an index -> node mapping, since nodes are not always consecutive
-        _nindex_to_node = new (mtInternal) GrowableArray<int>(0, mtInternal);
+        _nindex_to_node = new GrowableArrayCHeap<int, mtInternal>(0);
         rebuild_nindex_to_node_map();
         // Create a cpu -> node mapping
-        _cpu_to_node = new (mtInternal) GrowableArray<int>(0, mtInternal);
+        _cpu_to_node = new GrowableArrayCHeap<int, mtInternal>(0);
         rebuild_cpu_to_node_map();
         return true;
       }
@@ -3307,8 +3307,8 @@ int os::Linux::get_node_by_cpu(int cpu_id) {
   return -1;
 }
 
-GrowableArray<int>* os::Linux::_cpu_to_node;
-GrowableArray<int>* os::Linux::_nindex_to_node;
+GrowableArrayCHeap<int, mtInternal>* os::Linux::_cpu_to_node;
+GrowableArrayCHeap<int, mtInternal>* os::Linux::_nindex_to_node;
 os::Linux::sched_getcpu_func_t os::Linux::_sched_getcpu;
 os::Linux::numa_node_to_cpus_func_t os::Linux::_numa_node_to_cpus;
 os::Linux::numa_node_to_cpus_v2_func_t os::Linux::_numa_node_to_cpus_v2;

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -45,8 +45,8 @@ class os::Linux {
 
   static bool _supports_fast_thread_cpu_time;
 
-  static GrowableArray<int>* _cpu_to_node;
-  static GrowableArray<int>* _nindex_to_node;
+  static GrowableArrayCHeap<int, mtInternal>* _cpu_to_node;
+  static GrowableArrayCHeap<int, mtInternal>* _nindex_to_node;
 
   static julong available_memory_in_container();
 
@@ -71,8 +71,8 @@ class os::Linux {
 
   static void rebuild_cpu_to_node_map();
   static void rebuild_nindex_to_node_map();
-  static GrowableArray<int>* cpu_to_node()    { return _cpu_to_node; }
-  static GrowableArray<int>* nindex_to_node()  { return _nindex_to_node; }
+  static GrowableArrayCHeap<int, mtInternal>* cpu_to_node() { return _cpu_to_node; }
+  static GrowableArrayCHeap<int, mtInternal>* nindex_to_node() { return _nindex_to_node; }
 
   static void print_process_memory_info(outputStream* st);
   static void print_system_memory_info(outputStream* st);
@@ -384,7 +384,7 @@ class os::Linux {
     }
   }
 
-  static const GrowableArray<int>* numa_nindex_to_node() {
+  static const GrowableArrayCHeap<int, mtInternal>* numa_nindex_to_node() {
     return _nindex_to_node;
   }
 

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -67,7 +67,7 @@ ArchiveBuilder::OtherROAllocMark::~OtherROAllocMark() {
 
 ArchiveBuilder::SourceObjList::SourceObjList() : _ptrmap(16 * K, mtClassShared) {
   _total_bytes = 0;
-  _objs = new (mtClassShared) GrowableArray<SourceObjInfo*>(128 * K, mtClassShared);
+  _objs = new GrowableArrayCHeap<SourceObjInfo*, mtClassShared>(128 * K);
 }
 
 ArchiveBuilder::SourceObjList::~SourceObjList() {
@@ -166,8 +166,8 @@ ArchiveBuilder::ArchiveBuilder() :
   _estimated_metaspaceobj_bytes(0),
   _estimated_hashtable_bytes(0)
 {
-  _klasses = new (mtClassShared) GrowableArray<Klass*>(4 * K, mtClassShared);
-  _symbols = new (mtClassShared) GrowableArray<Symbol*>(256 * K, mtClassShared);
+  _klasses = new GrowableArrayCHeap<Klass*, mtClassShared>(4 * K);
+  _symbols = new GrowableArrayCHeap<Symbol*, mtClassShared>(256 * K);
 
   assert(_current == nullptr, "must be");
   _current = this;

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -177,14 +177,14 @@ private:
 
   class SourceObjList {
     uintx _total_bytes;
-    GrowableArray<SourceObjInfo*>* _objs;     // Source objects to be archived
+    GrowableArrayCHeap<SourceObjInfo*, mtClassShared>* _objs; // Source objects to be archived
     CHeapBitMap _ptrmap;                      // Marks the addresses of the pointer fields
                                               // in the source objects
   public:
     SourceObjList();
     ~SourceObjList();
 
-    GrowableArray<SourceObjInfo*>* objs() const { return _objs; }
+    GrowableArrayCHeap<SourceObjInfo*, mtClassShared>* objs() const { return _objs; }
 
     void append(SourceObjInfo* src_info);
     void remember_embedded_pointer(SourceObjInfo* pointing_obj, MetaspaceClosure::Ref* ref);
@@ -210,8 +210,8 @@ private:
   SourceObjList _ro_src_objs;                 // objs to put in ro region
   ResizeableResourceHashtable<address, SourceObjInfo, AnyObj::C_HEAP, mtClassShared> _src_obj_table;
   ResizeableResourceHashtable<address, address, AnyObj::C_HEAP, mtClassShared> _buffered_to_src_table;
-  GrowableArray<Klass*>* _klasses;
-  GrowableArray<Symbol*>* _symbols;
+  GrowableArrayCHeap<Klass*, mtClassShared>* _klasses;
+  GrowableArrayCHeap<Symbol*, mtClassShared>* _symbols;
 
   // statistics
   DumpAllocStats _alloc_stats;
@@ -401,8 +401,8 @@ public:
   }
 
   // All klasses and symbols that will be copied into the archive
-  GrowableArray<Klass*>*  klasses() const { return _klasses; }
-  GrowableArray<Symbol*>* symbols() const { return _symbols; }
+  GrowableArrayCHeap<Klass*, mtClassShared>*  klasses() const { return _klasses; }
+  GrowableArrayCHeap<Symbol*, mtClassShared>* symbols() const { return _symbols; }
 
   static bool is_active() {
     return (_current != nullptr);

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -74,8 +74,8 @@ ClassListParser::ClassListParser(const char* file, ParseMode parse_mode) : _id2k
   }
   _line_no = 0;
   _token = _line;
-  _interfaces = new (mtClass) GrowableArray<int>(10, mtClass);
-  _indy_items = new (mtClass) GrowableArray<const char*>(9, mtClass);
+  _interfaces = new GrowableArrayCHeap<int, mtClass>(10);
+  _indy_items = new GrowableArrayCHeap<const char*, mtClass>(9);
   _parse_mode = parse_mode;
 
   // _instance should only be accessed by the thread that created _instance.

--- a/src/hotspot/share/cds/classListParser.hpp
+++ b/src/hotspot/share/cds/classListParser.hpp
@@ -107,10 +107,10 @@ private:
   int                 _line_len;              // Original length of the input line.
   int                 _line_no;               // Line number for current line being parsed
   const char*         _class_name;
-  GrowableArray<const char*>* _indy_items;    // items related to invoke dynamic for archiving lambda proxy classes
+  GrowableArrayCHeap<const char*, mtClass>* _indy_items; // items related to invoke dynamic for archiving lambda proxy classes
   int                 _id;
   int                 _super;
-  GrowableArray<int>* _interfaces;
+  GrowableArrayCHeap<int, mtClass>* _interfaces;
   bool                _interfaces_specified;
   const char*         _source;
   bool                _lambda_form_line;

--- a/src/hotspot/share/cds/dumpTimeClassInfo.cpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.cpp
@@ -51,12 +51,12 @@ size_t DumpTimeClassInfo::runtime_info_bytesize() const {
 void DumpTimeClassInfo::add_verification_constraint(InstanceKlass* k, Symbol* name,
          Symbol* from_name, bool from_field_is_protected, bool from_is_array, bool from_is_object) {
   if (_verifier_constraints == nullptr) {
-    _verifier_constraints = new (mtClass) GrowableArray<DTVerifierConstraint>(4, mtClass);
+    _verifier_constraints = new GrowableArrayCHeap<DTVerifierConstraint, mtClass>(4);
   }
   if (_verifier_constraint_flags == nullptr) {
-    _verifier_constraint_flags = new (mtClass) GrowableArray<char>(4, mtClass);
+    _verifier_constraint_flags = new GrowableArrayCHeap<char, mtClass>(4);
   }
-  GrowableArray<DTVerifierConstraint>* vc_array = _verifier_constraints;
+  GrowableArrayCHeap<DTVerifierConstraint, mtClass>* vc_array = _verifier_constraints;
   for (int i = 0; i < vc_array->length(); i++) {
     if (vc_array->at(i).equals(name, from_name)) {
       return;
@@ -65,7 +65,7 @@ void DumpTimeClassInfo::add_verification_constraint(InstanceKlass* k, Symbol* na
   DTVerifierConstraint cons(name, from_name);
   vc_array->append(cons);
 
-  GrowableArray<char>* vcflags_array = _verifier_constraint_flags;
+  GrowableArrayCHeap<char, mtClass>* vcflags_array = _verifier_constraint_flags;
   char c = 0;
   c |= from_field_is_protected ? SystemDictionaryShared::FROM_FIELD_IS_PROTECTED : 0;
   c |= from_is_array           ? SystemDictionaryShared::FROM_IS_ARRAY           : 0;
@@ -96,7 +96,7 @@ void DumpTimeClassInfo::record_linking_constraint(Symbol* name, Handle loader1, 
   assert(loader1 != loader2, "sanity");
   LogTarget(Info, class, loader, constraints) log;
   if (_loader_constraints == nullptr) {
-    _loader_constraints = new (mtClass) GrowableArray<DTLoaderConstraint>(4, mtClass);
+    _loader_constraints = new GrowableArrayCHeap<DTLoaderConstraint, mtClass>(4);
   }
   char lt1 = get_loader_type_by(loader1());
   char lt2 = get_loader_type_by(loader2());
@@ -128,7 +128,7 @@ void DumpTimeClassInfo::record_linking_constraint(Symbol* name, Handle loader1, 
 
 void DumpTimeClassInfo::add_enum_klass_static_field(int archived_heap_root_index) {
   if (_enum_klass_static_fields == nullptr) {
-    _enum_klass_static_fields = new (mtClass) GrowableArray<int>(20, mtClass);
+    _enum_klass_static_fields = new GrowableArrayCHeap<int, mtClass>(20);
   }
   _enum_klass_static_fields->append(archived_heap_root_index);
 }

--- a/src/hotspot/share/cds/dumpTimeClassInfo.hpp
+++ b/src/hotspot/share/cds/dumpTimeClassInfo.hpp
@@ -126,10 +126,10 @@ public:
   int                          _id;
   int                          _clsfile_size;
   int                          _clsfile_crc32;
-  GrowableArray<DTVerifierConstraint>* _verifier_constraints;
-  GrowableArray<char>*                 _verifier_constraint_flags;
-  GrowableArray<DTLoaderConstraint>*   _loader_constraints;
-  GrowableArray<int>*                  _enum_klass_static_fields;
+  GrowableArrayCHeap<DTVerifierConstraint, mtClass>* _verifier_constraints;
+  GrowableArrayCHeap<char, mtClass>*                 _verifier_constraint_flags;
+  GrowableArrayCHeap<DTLoaderConstraint, mtClass>*   _loader_constraints;
+  GrowableArrayCHeap<int, mtClass>*                  _enum_klass_static_fields;
 
   DumpTimeClassInfo() {
     _klass = nullptr;
@@ -159,7 +159,7 @@ public:
 
 private:
   template <typename T>
-  static int array_length_or_zero(GrowableArray<T>* array) {
+  static int array_length_or_zero(GrowableArrayCHeap<T, mtClass>* array) {
     if (array == nullptr) {
       return 0;
     } else {

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -399,12 +399,12 @@ public:
 
 // _array_klasses and _dynamic_archive_array_klasses only hold the array klasses
 // which have element klass in the static archive.
-GrowableArray<ObjArrayKlass*>* DynamicArchive::_array_klasses = nullptr;
+GrowableArrayCHeap<ObjArrayKlass*, mtClassShared>* DynamicArchive::_array_klasses = nullptr;
 Array<ObjArrayKlass*>* DynamicArchive::_dynamic_archive_array_klasses = nullptr;
 
 void DynamicArchive::append_array_klass(ObjArrayKlass* ak) {
   if (_array_klasses == nullptr) {
-    _array_klasses = new (mtClassShared) GrowableArray<ObjArrayKlass*>(50, mtClassShared);
+    _array_klasses = new GrowableArrayCHeap<ObjArrayKlass*, mtClassShared>(50);
   }
   _array_klasses->append(ak);
 }

--- a/src/hotspot/share/cds/dynamicArchive.hpp
+++ b/src/hotspot/share/cds/dynamicArchive.hpp
@@ -61,7 +61,7 @@ public:
 
 class DynamicArchive : AllStatic {
 private:
-  static GrowableArray<ObjArrayKlass*>* _array_klasses;
+  static GrowableArrayCHeap<ObjArrayKlass*, mtClassShared>* _array_klasses;
   static Array<ObjArrayKlass*>* _dynamic_archive_array_klasses;
 public:
   static void check_for_dynamic_dump();

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -542,7 +542,7 @@ void FileMapInfo::record_non_existent_class_path_entry(const char* path) {
   assert(CDSConfig::is_dumping_archive(), "sanity");
   log_info(class, path)("non-existent Class-Path entry %s", path);
   if (_non_existent_class_paths == nullptr) {
-    _non_existent_class_paths = new (mtClass) GrowableArray<const char*>(10, mtClass);
+    _non_existent_class_paths = new GrowableArrayCHeap<const char*, mtClass>(10);
   }
   _non_existent_class_paths->append(os::strdup(path));
 }
@@ -2246,7 +2246,7 @@ bool FileMapInfo::_heap_pointers_need_patching = false;
 SharedPathTable FileMapInfo::_shared_path_table;
 bool FileMapInfo::_validating_shared_path_table = false;
 bool FileMapInfo::_memory_mapping_failed = false;
-GrowableArray<const char*>* FileMapInfo::_non_existent_class_paths = nullptr;
+GrowableArrayCHeap<const char*, mtClass>* FileMapInfo::_non_existent_class_paths = nullptr;
 
 // Open the shared archive file, read and validate the header
 // information (version, boot classpath, etc.). If initialization

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -49,6 +49,9 @@ class ClassLoaderData;
 class ClassPathEntry;
 class outputStream;
 
+template<class E> class GrowableArray;
+template<class E, MEMFLAGS F> class GrowableArrayCHeap;
+
 class SharedClassPathEntry : public MetaspaceObj {
   enum {
     modules_image_entry,
@@ -342,7 +345,7 @@ private:
   static FileMapInfo* _dynamic_archive_info;
   static bool _heap_pointers_need_patching;
   static bool _memory_mapping_failed;
-  static GrowableArray<const char*>* _non_existent_class_paths;
+  static GrowableArrayCHeap<const char*, mtClass>* _non_existent_class_paths;
 
 public:
   FileMapHeader *header() const       { return _header; }

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -390,7 +390,7 @@ void HeapShared::archive_java_mirrors() {
     }
   }
 
-  GrowableArray<Klass*>* klasses = ArchiveBuilder::current()->klasses();
+  GrowableArrayCHeap<Klass*, mtClassShared>* klasses = ArchiveBuilder::current()->klasses();
   assert(klasses != nullptr, "sanity");
   for (int i = 0; i < klasses->length(); i++) {
     Klass* orig_k = klasses->at(i);
@@ -621,8 +621,7 @@ KlassSubGraphInfo* HeapShared::get_subgraph_info(Klass* k) {
 void KlassSubGraphInfo::add_subgraph_entry_field(int static_field_offset, oop v) {
   assert(CDSConfig::is_dumping_heap(), "dump time only");
   if (_subgraph_entry_fields == nullptr) {
-    _subgraph_entry_fields =
-      new (mtClass) GrowableArray<int>(10, mtClass);
+    _subgraph_entry_fields = new GrowableArrayCHeap<int, mtClass>(10);
   }
   _subgraph_entry_fields->append(static_field_offset);
   _subgraph_entry_fields->append(HeapShared::append_root(v));
@@ -635,8 +634,7 @@ void KlassSubGraphInfo::add_subgraph_object_klass(Klass* orig_k) {
   Klass* buffered_k = ArchiveBuilder::get_buffered_klass(orig_k);
 
   if (_subgraph_object_klasses == nullptr) {
-    _subgraph_object_klasses =
-      new (mtClass) GrowableArray<Klass*>(50, mtClass);
+    _subgraph_object_klasses = new GrowableArrayCHeap<Klass*, mtClass>(50);
   }
 
   assert(ArchiveBuilder::current()->is_in_buffer_space(buffered_k), "must be a shared class");
@@ -751,7 +749,7 @@ void ArchivedKlassSubGraphInfoRecord::init(KlassSubGraphInfo* info) {
   }
 
   // populate the entry fields
-  GrowableArray<int>* entry_fields = info->subgraph_entry_fields();
+  GrowableArrayCHeap<int, mtClass>* entry_fields = info->subgraph_entry_fields();
   if (entry_fields != nullptr) {
     int num_entry_fields = entry_fields->length();
     assert(num_entry_fields % 2 == 0, "sanity");
@@ -763,7 +761,7 @@ void ArchivedKlassSubGraphInfoRecord::init(KlassSubGraphInfo* info) {
   }
 
   // the Klasses of the objects in the sub-graphs
-  GrowableArray<Klass*>* subgraph_object_klasses = info->subgraph_object_klasses();
+  GrowableArrayCHeap<Klass*, mtClass>* subgraph_object_klasses = info->subgraph_object_klasses();
   if (subgraph_object_klasses != nullptr) {
     int num_subgraphs_klasses = subgraph_object_klasses->length();
     _subgraph_object_klasses =
@@ -1341,7 +1339,7 @@ void HeapShared::verify_reachable_objects_from(oop obj) {
 // Make sure that these are only instances of the very few specific types
 // that we can handle.
 void HeapShared::check_default_subgraph_classes() {
-  GrowableArray<Klass*>* klasses = _default_subgraph_info->subgraph_object_klasses();
+  GrowableArrayCHeap<Klass*, mtClass>* klasses = _default_subgraph_info->subgraph_object_klasses();
   int num = klasses->length();
   for (int i = 0; i < num; i++) {
     Klass* subgraph_k = klasses->at(i);

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -63,10 +63,10 @@ class KlassSubGraphInfo: public CHeapObj<mtClass> {
   Klass* _k;
   // A list of classes need to be loaded and initialized before the archived
   // object sub-graphs can be accessed at runtime.
-  GrowableArray<Klass*>* _subgraph_object_klasses;
+  GrowableArrayCHeap<Klass*, mtClass>* _subgraph_object_klasses;
   // A list of _k's static fields as the entry points of archived sub-graphs.
   // For each entry field, it is a tuple of field_offset, field_value
-  GrowableArray<int>* _subgraph_entry_fields;
+  GrowableArrayCHeap<int, mtClass>* _subgraph_entry_fields;
 
   // Does this KlassSubGraphInfo belong to the archived full module graph
   bool _is_full_module_graph;
@@ -94,10 +94,10 @@ class KlassSubGraphInfo: public CHeapObj<mtClass> {
   };
 
   Klass* klass()            { return _k; }
-  GrowableArray<Klass*>* subgraph_object_klasses() {
+  GrowableArrayCHeap<Klass*, mtClass>* subgraph_object_klasses() {
     return _subgraph_object_klasses;
   }
-  GrowableArray<int>* subgraph_entry_fields() {
+  GrowableArrayCHeap<int, mtClass>* subgraph_entry_fields() {
     return _subgraph_entry_fields;
   }
   void add_subgraph_entry_field(int static_field_offset, oop v);

--- a/src/hotspot/share/cds/lambdaProxyClassDictionary.hpp
+++ b/src/hotspot/share/cds/lambdaProxyClassDictionary.hpp
@@ -112,14 +112,14 @@ public:
 
 class DumpTimeLambdaProxyClassInfo {
 public:
-  GrowableArray<InstanceKlass*>* _proxy_klasses;
+  GrowableArrayCHeap<InstanceKlass*, mtClassShared>* _proxy_klasses;
   DumpTimeLambdaProxyClassInfo() : _proxy_klasses(nullptr) {}
   DumpTimeLambdaProxyClassInfo& operator=(const DumpTimeLambdaProxyClassInfo&) = delete;
   ~DumpTimeLambdaProxyClassInfo();
 
   void add_proxy_klass(InstanceKlass* proxy_klass) {
     if (_proxy_klasses == nullptr) {
-      _proxy_klasses = new (mtClassShared) GrowableArray<InstanceKlass*>(5, mtClassShared);
+      _proxy_klasses = new GrowableArrayCHeap<InstanceKlass*, mtClassShared>(5);
     }
     assert(_proxy_klasses != nullptr, "sanity");
     _proxy_klasses->append(proxy_klass);

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -437,8 +437,8 @@ class VM_PopulateDumpSharedSpace : public VM_Operation {
 private:
   ArchiveHeapInfo _heap_info;
 
-  void dump_java_heap_objects(GrowableArray<Klass*>* klasses) NOT_CDS_JAVA_HEAP_RETURN;
-  void dump_shared_symbol_table(GrowableArray<Symbol*>* symbols) {
+  void dump_java_heap_objects(GrowableArrayCHeap<Klass*, mtClassShared>* klasses) NOT_CDS_JAVA_HEAP_RETURN;
+  void dump_shared_symbol_table(GrowableArrayView<Symbol*>* symbols) {
     log_info(cds)("Dumping symbol table ...");
     SymbolTable::write_to_archive(symbols);
   }
@@ -837,7 +837,7 @@ bool MetaspaceShared::try_link_class(JavaThread* current, InstanceKlass* ik) {
 }
 
 #if INCLUDE_CDS_JAVA_HEAP
-void VM_PopulateDumpSharedSpace::dump_java_heap_objects(GrowableArray<Klass*>* klasses) {
+void VM_PopulateDumpSharedSpace::dump_java_heap_objects(GrowableArrayCHeap<Klass*, mtClassShared>* klasses) {
   if(!HeapShared::can_write()) {
     log_info(cds)(
       "Archived java heap is not supported as UseG1GC "

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -35,8 +35,6 @@ class FileMapInfo;
 class outputStream;
 class SerializeClosure;
 
-template<class E> class GrowableArray;
-
 enum MapArchiveResult {
   MAP_ARCHIVE_SUCCESS,
   MAP_ARCHIVE_MMAP_FAILURE,

--- a/src/hotspot/share/classfile/classLoader.hpp
+++ b/src/hotspot/share/classfile/classLoader.hpp
@@ -44,6 +44,7 @@ class JImageFile;
 class ClassFileStream;
 class PackageEntry;
 template <typename T> class GrowableArray;
+template <typename T, MEMFLAGS F> class GrowableArrayCHeap;
 
 class ClassPathEntry : public CHeapObj<mtClass> {
 private:
@@ -181,14 +182,14 @@ class ClassLoader: AllStatic {
   // to load a class.
 
   // 1. Contains the module/path pairs specified to --patch-module
-  static GrowableArray<ModuleClassPathList*>* _patch_mod_entries;
+  static GrowableArrayCHeap<ModuleClassPathList*, mtModule>* _patch_mod_entries;
 
   // 2. the base piece
   //    Contains the ClassPathEntry of the modular java runtime image.
   //    If no java runtime image is present, this indicates a
   //    build with exploded modules is being used instead.
   static ClassPathEntry* _jrt_entry;
-  static GrowableArray<ModuleClassPathList*>* _exploded_entries;
+  static GrowableArrayCHeap<ModuleClassPathList*, mtModule>* _exploded_entries;
   enum { EXPLODED_ENTRY_SIZE = 80 }; // Initial number of exploded modules
 
   // 3. the boot loader's append path
@@ -294,7 +295,7 @@ class ClassLoader: AllStatic {
 
   // Attempt load of individual class from either the patched or exploded modules build lists
   static ClassFileStream* search_module_entries(JavaThread* current,
-                                                const GrowableArray<ModuleClassPathList*>* const module_list,
+                                                const GrowableArrayCHeap<ModuleClassPathList*, mtModule>* const module_list,
                                                 const char* const class_name,
                                                 const char* const file_name);
 

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -862,7 +862,7 @@ void ClassLoaderData::add_to_deallocate_list(Metadata* m) {
   if (!m->is_shared()) {
     MutexLocker ml(metaspace_lock(),  Mutex::_no_safepoint_check_flag);
     if (_deallocate_list == nullptr) {
-      _deallocate_list = new (mtClass) GrowableArray<Metadata*>(100, mtClass);
+      _deallocate_list = new GrowableArrayCHeap<Metadata*, mtClass>(100);
     }
     _deallocate_list->append_if_missing(m);
     ResourceMark rm;

--- a/src/hotspot/share/classfile/classLoaderData.hpp
+++ b/src/hotspot/share/classfile/classLoaderData.hpp
@@ -150,7 +150,7 @@ class ClassLoaderData : public CHeapObj<mtClass> {
 
   // Metadata to be deallocated when it's safe at class unloading, when
   // this class loader isn't unloaded itself.
-  GrowableArray<Metadata*>*      _deallocate_list;
+  GrowableArrayCHeap<Metadata*, mtClass>* _deallocate_list;
 
   // Support for walking class loader data objects
   //

--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -51,9 +51,9 @@ CompactHashtableWriter::CompactHashtableWriter(int num_entries,
   assert(_num_buckets > 0, "no buckets");
 
   _num_entries_written = 0;
-  _buckets = NEW_C_HEAP_ARRAY(GrowableArray<Entry>*, _num_buckets, mtSymbol);
+  _buckets = NEW_C_HEAP_ARRAY(EntryBucket*, _num_buckets, mtSymbol);
   for (int i=0; i<_num_buckets; i++) {
-    _buckets[i] = new (mtSymbol) GrowableArray<Entry>(0, mtSymbol);
+    _buckets[i] = new EntryBucket(0);
   }
 
   _stats = stats;
@@ -66,11 +66,11 @@ CompactHashtableWriter::CompactHashtableWriter(int num_entries,
 
 CompactHashtableWriter::~CompactHashtableWriter() {
   for (int index = 0; index < _num_buckets; index++) {
-    GrowableArray<Entry>* bucket = _buckets[index];
+    EntryBucket* bucket = _buckets[index];
     delete bucket;
   }
 
-  FREE_C_HEAP_ARRAY(GrowableArray<Entry>*, _buckets);
+  FREE_C_HEAP_ARRAY(EntryBucket*, _buckets);
 }
 
 size_t CompactHashtableWriter::estimate_size(int num_entries) {
@@ -96,7 +96,7 @@ void CompactHashtableWriter::add(unsigned int hash, u4 value) {
 void CompactHashtableWriter::allocate_table() {
   int entries_space = 0;
   for (int index = 0; index < _num_buckets; index++) {
-    GrowableArray<Entry>* bucket = _buckets[index];
+    EntryBucket* bucket = _buckets[index];
     int bucket_size = bucket->length();
     if (bucket_size == 1) {
       entries_space++;
@@ -125,7 +125,7 @@ void CompactHashtableWriter::allocate_table() {
 void CompactHashtableWriter::dump_table(NumberSeq* summary) {
   u4 offset = 0;
   for (int index = 0; index < _num_buckets; index++) {
-    GrowableArray<Entry>* bucket = _buckets[index];
+    EntryBucket* bucket = _buckets[index];
     int bucket_size = bucket->length();
     if (bucket_size == 1) {
       // bucket with one entry is compacted and only has the symbol offset

--- a/src/hotspot/share/classfile/compactHashtable.hpp
+++ b/src/hotspot/share/classfile/compactHashtable.hpp
@@ -111,7 +111,8 @@ private:
   int _num_empty_buckets;
   int _num_value_only_buckets;
   int _num_other_buckets;
-  GrowableArray<Entry>** _buckets;
+  typedef GrowableArrayCHeap<Entry, mtSymbol> EntryBucket;
+  EntryBucket** _buckets;
   CompactHashtableStats* _stats;
   Array<u4>* _compact_buckets;
   Array<u4>* _compact_entries;

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -409,7 +409,7 @@ void Dictionary::validate_protection_domain(InstanceKlass* klass,
 
 // During class loading we may have cached a protection domain that has
 // since been unreferenced, so this entry should be cleared.
-void Dictionary::clean_cached_protection_domains(GrowableArray<ProtectionDomainEntry*>* delete_list) {
+void Dictionary::clean_cached_protection_domains(GrowableArrayCHeap<ProtectionDomainEntry*, mtClass>* delete_list) {
   assert(Thread::current()->is_Java_thread(), "only called by JavaThread");
   assert_lock_strong(SystemDictionary_lock);
   assert(!loader_data()->has_class_mirror_holder(), "cld should have a ClassLoader holder not a Class holder");

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -73,7 +73,7 @@ public:
   void all_entries_do(KlassClosure* closure);
   void classes_do(MetaspaceClosure* it);
 
-  void clean_cached_protection_domains(GrowableArray<ProtectionDomainEntry*>* delete_list);
+  void clean_cached_protection_domains(GrowableArrayCHeap<ProtectionDomainEntry*, mtClass>* delete_list);
 
   // Protection domains
   InstanceKlass* find(Thread* current, Symbol* name, Handle protection_domain);

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -795,8 +795,8 @@ int java_lang_Class::_classData_offset;
 int java_lang_Class::_classRedefinedCount_offset;
 
 bool java_lang_Class::_offsets_computed = false;
-GrowableArray<Klass*>* java_lang_Class::_fixup_mirror_list = nullptr;
-GrowableArray<Klass*>* java_lang_Class::_fixup_module_field_list = nullptr;
+GrowableArrayCHeap<Klass*, mtClass>* java_lang_Class::_fixup_mirror_list = nullptr;
+GrowableArrayCHeap<Klass*, mtModule>* java_lang_Class::_fixup_module_field_list = nullptr;
 
 #ifdef ASSERT
 inline static void assert_valid_static_string_field(fieldDescriptor* fd) {
@@ -962,13 +962,8 @@ void java_lang_Class::set_mirror_module_field(JavaThread* current, Klass* k, Han
 
 // Statically allocate fixup lists because they always get created.
 void java_lang_Class::allocate_fixup_lists() {
-  GrowableArray<Klass*>* mirror_list =
-    new (mtClass) GrowableArray<Klass*>(40, mtClass);
-  set_fixup_mirror_list(mirror_list);
-
-  GrowableArray<Klass*>* module_list =
-    new (mtModule) GrowableArray<Klass*>(500, mtModule);
-  set_fixup_module_field_list(module_list);
+  set_fixup_mirror_list(new GrowableArrayCHeap<Klass*, mtClass>(40));
+  set_fixup_module_field_list(new GrowableArrayCHeap<Klass*, mtModule>(500));
 }
 
 void java_lang_Class::allocate_mirror(Klass* k, bool is_scratch, Handle protection_domain, Handle classData,
@@ -1778,8 +1773,8 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
     const Handle _java_thread;
     int _depth;
     bool _retry_handshake;
-    GrowableArray<Method*>* _methods;
-    GrowableArray<int>*     _bcis;
+    GrowableArrayCHeap<Method*, mtInternal>* _methods;
+    GrowableArrayCHeap<int, mtInternal>*     _bcis;
 
     GetStackTraceClosure(Handle java_thread) :
         HandshakeClosure("GetStackTraceClosure"), _java_thread(java_thread), _depth(0), _retry_handshake(false),
@@ -1826,8 +1821,8 @@ oop java_lang_Thread::async_get_stack_trace(oop java_thread, TRAPS) {
 
       // Pick minimum length that will cover most cases
       int init_length = 64;
-      _methods = new (mtInternal) GrowableArray<Method*>(init_length, mtInternal);
-      _bcis = new (mtInternal) GrowableArray<int>(init_length, mtInternal);
+      _methods = new GrowableArrayCHeap<Method*, mtInternal>(init_length);
+      _bcis = new GrowableArrayCHeap<int, mtInternal>(init_length);
 
       int total_count = 0;
       for (vframeStream vfst(thread, false, false, carrier); // we don't process frames as we don't care about oops

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -237,8 +237,8 @@ class java_lang_Class : AllStatic {
 
   static bool _offsets_computed;
 
-  static GrowableArray<Klass*>* _fixup_mirror_list;
-  static GrowableArray<Klass*>* _fixup_module_field_list;
+  static GrowableArrayCHeap<Klass*, mtClass>* _fixup_mirror_list;
+  static GrowableArrayCHeap<Klass*, mtModule>* _fixup_module_field_list;
 
   static void set_protection_domain(oop java_class, oop protection_domain);
   static void set_class_loader(oop java_class, oop class_loader);
@@ -314,17 +314,17 @@ class java_lang_Class : AllStatic {
   static int static_oop_field_count(oop java_class);
   static void set_static_oop_field_count(oop java_class, int size);
 
-  static GrowableArray<Klass*>* fixup_mirror_list() {
+  static GrowableArrayCHeap<Klass*, mtClass>* fixup_mirror_list() {
     return _fixup_mirror_list;
   }
-  static void set_fixup_mirror_list(GrowableArray<Klass*>* v) {
+  static void set_fixup_mirror_list(GrowableArrayCHeap<Klass*, mtClass>* v) {
     _fixup_mirror_list = v;
   }
 
-  static GrowableArray<Klass*>* fixup_module_field_list() {
+  static GrowableArrayCHeap<Klass*, mtModule>* fixup_module_field_list() {
     return _fixup_module_field_list;
   }
-  static void set_fixup_module_field_list(GrowableArray<Klass*>* v) {
+  static void set_fixup_module_field_list(GrowableArrayCHeap<Klass*, mtModule>* v) {
     _fixup_module_field_list = v;
   }
 

--- a/src/hotspot/share/classfile/loaderConstraints.cpp
+++ b/src/hotspot/share/classfile/loaderConstraints.cpp
@@ -84,11 +84,11 @@ class LoaderConstraint : public CHeapObj<mtClass> {
   // Loader constraints enforce correct linking behavior.
   // Thus, it really operates on ClassLoaderData which represents linking domain,
   // not class loaders.
-  GrowableArray<ClassLoaderData*>*  _loaders;                // initiating loaders
+  GrowableArrayCHeap<ClassLoaderData*, mtClass>* _loaders; // initiating loaders
  public:
   LoaderConstraint(InstanceKlass* klass, ClassLoaderData* loader1, ClassLoaderData* loader2) :
      _klass(klass) {
-    _loaders = new (mtClass) GrowableArray<ClassLoaderData*>(10, mtClass);
+    _loaders = new GrowableArrayCHeap<ClassLoaderData*, mtClass>(10);
     add_loader_data(loader1);
     add_loader_data(loader2);
   }
@@ -115,7 +115,7 @@ class LoaderConstraint : public CHeapObj<mtClass> {
 // For this class name, these are the set of LoaderConstraints for classes loaded with this name.
 class ConstraintSet {                               // copied into hashtable as value
  private:
-  GrowableArray<LoaderConstraint*>*  _constraints;   // loader constraints for this class name.
+  GrowableArrayCHeap<LoaderConstraint*, mtClass>* _constraints; // loader constraints for this class name.
 
  public:
   ConstraintSet() : _constraints(nullptr) {}
@@ -123,7 +123,7 @@ class ConstraintSet {                               // copied into hashtable as 
   ConstraintSet& operator=(const ConstraintSet&) = delete;
 
   void initialize(LoaderConstraint* constraint) {
-    _constraints = new (mtClass) GrowableArray<LoaderConstraint*>(5, mtClass);
+    _constraints = new GrowableArrayCHeap<LoaderConstraint*, mtClass>(5);
     _constraints->push(constraint);
   }
 

--- a/src/hotspot/share/classfile/moduleEntry.cpp
+++ b/src/hotspot/share/classfile/moduleEntry.cpp
@@ -166,7 +166,7 @@ void ModuleEntry::add_read(ModuleEntry* m) {
   } else {
     if (_reads == nullptr) {
       // Lazily create a module's reads list
-      _reads = new (mtModule) GrowableArray<ModuleEntry*>(MODULE_READS_SIZE, mtModule);
+      _reads = new GrowableArrayCHeap<ModuleEntry*, mtModule>(MODULE_READS_SIZE);
     }
 
     // Determine, based on this newly established read edge to module m,
@@ -430,7 +430,7 @@ ModuleEntry* ModuleEntry::get_archived_entry(ModuleEntry* orig_entry) {
 // This function is used to archive ModuleEntry::_reads and PackageEntry::_qualified_exports.
 // GrowableArray cannot be directly archived, as it needs to be expandable at runtime.
 // Write it out as an Array, and convert it back to GrowableArray at runtime.
-Array<ModuleEntry*>* ModuleEntry::write_growable_array(GrowableArray<ModuleEntry*>* array) {
+Array<ModuleEntry*>* ModuleEntry::write_growable_array(GrowableArrayCHeap<ModuleEntry*, mtModule>* array) {
   Array<ModuleEntry*>* archived_array = nullptr;
   int length = (array == nullptr) ? 0 : array->length();
   if (length > 0) {
@@ -445,11 +445,11 @@ Array<ModuleEntry*>* ModuleEntry::write_growable_array(GrowableArray<ModuleEntry
   return archived_array;
 }
 
-GrowableArray<ModuleEntry*>* ModuleEntry::restore_growable_array(Array<ModuleEntry*>* archived_array) {
-  GrowableArray<ModuleEntry*>* array = nullptr;
+GrowableArrayCHeap<ModuleEntry*, mtModule>* ModuleEntry::restore_growable_array(Array<ModuleEntry*>* archived_array) {
+  GrowableArrayCHeap<ModuleEntry*, mtModule>* array = nullptr;
   int length = (archived_array == nullptr) ? 0 : archived_array->length();
   if (length > 0) {
-    array = new (mtModule) GrowableArray<ModuleEntry*>(length, mtModule);
+    array = new GrowableArrayCHeap<ModuleEntry*, mtModule>(length);
     for (int i = 0; i < length; i++) {
       ModuleEntry* archived_entry = archived_array->at(i);
       array->append(archived_entry);
@@ -474,7 +474,7 @@ void ModuleEntry::init_as_archived_entry() {
     _name = ArchiveBuilder::get_buffered_symbol(_name);
     ArchivePtrMarker::mark_pointer((address*)&_name);
   }
-  _reads = (GrowableArray<ModuleEntry*>*)archived_reads;
+  _reads = (GrowableArrayCHeap<ModuleEntry*, mtModule>*)archived_reads;
   if (_version != nullptr) {
     _version = ArchiveBuilder::get_buffered_symbol(_version);
   }
@@ -687,7 +687,7 @@ void ModuleEntryTable::patch_javabase_entries(JavaThread* current, Handle module
   java_lang_Class::set_module(Universe::void_mirror(), module_handle());
 
   // Do the fixups for classes that have already been created.
-  GrowableArray <Klass*>* list = java_lang_Class::fixup_module_field_list();
+  GrowableArrayCHeap <Klass*, mtModule>* list = java_lang_Class::fixup_module_field_list();
   int list_length = list->length();
   for (int i = 0; i < list_length; i++) {
     Klass* k = list->at(i);

--- a/src/hotspot/share/classfile/moduleEntry.hpp
+++ b/src/hotspot/share/classfile/moduleEntry.hpp
@@ -68,7 +68,7 @@ private:
                                        // for shared classes from this module
   Symbol*          _name;              // name of this module
   ClassLoaderData* _loader_data;
-  GrowableArray<ModuleEntry*>* _reads; // list of modules that are readable by this module
+  GrowableArrayCHeap<ModuleEntry*, mtModule>* _reads; // list of modules that are readable by this module
   Symbol* _version;                    // module version number
   Symbol* _location;                   // module location
   CDS_ONLY(int _shared_path_index;)    // >=0 if classes in this module are in CDS archive
@@ -177,8 +177,8 @@ public:
   void init_as_archived_entry();
   static ModuleEntry* get_archived_entry(ModuleEntry* orig_entry);
   bool has_been_archived();
-  static Array<ModuleEntry*>* write_growable_array(GrowableArray<ModuleEntry*>* array);
-  static GrowableArray<ModuleEntry*>* restore_growable_array(Array<ModuleEntry*>* archived_array);
+  static Array<ModuleEntry*>* write_growable_array(GrowableArrayCHeap<ModuleEntry*, mtModule>* array);
+  static GrowableArrayCHeap<ModuleEntry*, mtModule>* restore_growable_array(Array<ModuleEntry*>* archived_array);
   void load_from_archive(ClassLoaderData* loader_data);
   void restore_archived_oops(ClassLoaderData* loader_data);
   void clear_archived_oops();

--- a/src/hotspot/share/classfile/packageEntry.cpp
+++ b/src/hotspot/share/classfile/packageEntry.cpp
@@ -80,7 +80,7 @@ void PackageEntry::add_qexport(ModuleEntry* m) {
   if (!has_qual_exports_list()) {
     // Lazily create a package's qualified exports list.
     // Initial size is small, do not anticipate export lists to be large.
-    _qualified_exports = new (mtModule) GrowableArray<ModuleEntry*>(QUAL_EXP_SIZE, mtModule);
+    _qualified_exports = new GrowableArrayCHeap<ModuleEntry*, mtModule>(QUAL_EXP_SIZE);
   }
 
   // Determine, based on this newly established export to module m,
@@ -250,7 +250,7 @@ void PackageEntry::init_as_archived_entry() {
 
   _name = ArchiveBuilder::get_buffered_symbol(_name);
   _module = ModuleEntry::get_archived_entry(_module);
-  _qualified_exports = (GrowableArray<ModuleEntry*>*)archived_qualified_exports;
+  _qualified_exports = (GrowableArrayCHeap<ModuleEntry*, mtModule>*)archived_qualified_exports;
   _defined_by_cds_in_class_path = 0;
   JFR_ONLY(set_trace_id(0)); // re-init at runtime
 

--- a/src/hotspot/share/classfile/packageEntry.hpp
+++ b/src/hotspot/share/classfile/packageEntry.hpp
@@ -114,7 +114,7 @@ private:
   bool _must_walk_exports;
   // Contains list of modules this package is qualifiedly exported to.  Access
   // to this list is protected by the Module_lock.
-  GrowableArray<ModuleEntry*>* _qualified_exports;
+  GrowableArrayCHeap<ModuleEntry*, mtModule>* _qualified_exports;
   JFR_ONLY(DEFINE_TRACE_ID_FIELD;)
 
   // Initial size of a package entry's list of qualified exports.

--- a/src/hotspot/share/classfile/protectionDomainCache.cpp
+++ b/src/hotspot/share/classfile/protectionDomainCache.cpp
@@ -69,9 +69,9 @@ void ProtectionDomainCacheTable::trigger_cleanup() {
 }
 
 class CleanProtectionDomainEntries : public CLDClosure {
-  GrowableArray<ProtectionDomainEntry*>* _delete_list;
+  GrowableArrayCHeap<ProtectionDomainEntry*, mtClass>* _delete_list;
  public:
-  CleanProtectionDomainEntries(GrowableArray<ProtectionDomainEntry*>* delete_list) :
+  CleanProtectionDomainEntries(GrowableArrayCHeap<ProtectionDomainEntry*, mtClass>* delete_list) :
                                _delete_list(delete_list) {}
 
   void do_cld(ClassLoaderData* data) {
@@ -82,7 +82,7 @@ class CleanProtectionDomainEntries : public CLDClosure {
   }
 };
 
-static GrowableArray<ProtectionDomainEntry*>* _delete_list = nullptr;
+static GrowableArrayCHeap<ProtectionDomainEntry*, mtClass>* _delete_list = nullptr;
 
 class HandshakeForPD : public HandshakeClosure {
  public:
@@ -120,8 +120,7 @@ void ProtectionDomainCacheTable::unlink() {
 
   // Create a list for holding deleted entries
   if (_delete_list == nullptr) {
-    _delete_list = new (mtClass)
-                       GrowableArray<ProtectionDomainEntry*>(20, mtClass);
+    _delete_list = new GrowableArrayCHeap<ProtectionDomainEntry*, mtClass>(20);
   }
 
   {

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -649,7 +649,7 @@ void SymbolTable::dump(outputStream* st, bool verbose) {
 }
 
 #if INCLUDE_CDS
-void SymbolTable::copy_shared_symbol_table(GrowableArray<Symbol*>* symbols,
+void SymbolTable::copy_shared_symbol_table(const GrowableArrayView<Symbol*>* symbols,
                                            CompactHashtableWriter* writer) {
   ArchiveBuilder* builder = ArchiveBuilder::current();
   int len = symbols->length();
@@ -670,7 +670,7 @@ size_t SymbolTable::estimate_size_for_archive() {
   return CompactHashtableWriter::estimate_size(int(_items_count));
 }
 
-void SymbolTable::write_to_archive(GrowableArray<Symbol*>* symbols) {
+void SymbolTable::write_to_archive(const GrowableArrayView<Symbol*>* symbols) {
   CompactHashtableWriter writer(int(_items_count), ArchiveBuilder::symbol_stats());
   copy_shared_symbol_table(symbols, &writer);
   if (CDSConfig::is_dumping_static_archive()) {

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -32,7 +32,7 @@
 #include "utilities/tableStatistics.hpp"
 
 class JavaThread;
-template <typename T> class GrowableArray;
+template <typename T> class GrowableArrayView;
 
 // TempNewSymbol in symbolHandle.hpp is used with SymbolTable operations,
 // so include it here.
@@ -163,11 +163,11 @@ public:
   // Sharing
   static void shared_symbols_do(SymbolClosure *cl);  // no safepoint iteration.
 private:
-  static void copy_shared_symbol_table(GrowableArray<Symbol*>* symbols,
+  static void copy_shared_symbol_table(const GrowableArrayView<Symbol*>* symbols,
                                        CompactHashtableWriter* ch_table);
 public:
   static size_t estimate_size_for_archive() NOT_CDS_RETURN_(0);
-  static void write_to_archive(GrowableArray<Symbol*>* symbols) NOT_CDS_RETURN;
+  static void write_to_archive(const GrowableArrayView<Symbol*>* symbols) NOT_CDS_RETURN;
   static void serialize_shared_table_header(SerializeClosure* soc,
                                             bool is_static_archive = true) NOT_CDS_RETURN;
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -173,10 +173,10 @@ volatile int CodeCache::_number_of_nmethods_with_dependencies = 0;
 ExceptionCache* volatile CodeCache::_exception_cache_purge_list = nullptr;
 
 // Initialize arrays of CodeHeap subsets
-GrowableArray<CodeHeap*>* CodeCache::_heaps = new(mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
-GrowableArray<CodeHeap*>* CodeCache::_compiled_heaps = new(mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
-GrowableArray<CodeHeap*>* CodeCache::_nmethod_heaps = new(mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
-GrowableArray<CodeHeap*>* CodeCache::_allocable_heaps = new(mtCode) GrowableArray<CodeHeap*> (static_cast<int>(CodeBlobType::All), mtCode);
+CodeCache::CodeHeapArray* CodeCache::_heaps           = new CodeHeapArray(static_cast<int>(CodeBlobType::All));
+CodeCache::CodeHeapArray* CodeCache::_compiled_heaps  = new CodeHeapArray(static_cast<int>(CodeBlobType::All));
+CodeCache::CodeHeapArray* CodeCache::_nmethod_heaps   = new CodeHeapArray(static_cast<int>(CodeBlobType::All));
+CodeCache::CodeHeapArray* CodeCache::_allocable_heaps = new CodeHeapArray(static_cast<int>(CodeBlobType::All));
 
 void CodeCache::check_heap_sizes(size_t non_nmethod_size, size_t profiled_size, size_t non_profiled_size, size_t cache_size, bool all_set) {
   size_t total_size = non_nmethod_size + profiled_size + non_profiled_size;
@@ -1301,11 +1301,11 @@ CompiledMethod* CodeCache::find_compiled(void* start) {
 #if INCLUDE_JVMTI
 // RedefineClasses support for saving nmethods that are dependent on "old" methods.
 // We don't really expect this table to grow very large.  If it does, it can become a hashtable.
-static GrowableArray<CompiledMethod*>* old_compiled_method_table = nullptr;
+static GrowableArrayCHeap<CompiledMethod*, mtCode>* old_compiled_method_table = nullptr;
 
 static void add_to_old_table(CompiledMethod* c) {
   if (old_compiled_method_table == nullptr) {
-    old_compiled_method_table = new (mtCode) GrowableArray<CompiledMethod*>(100, mtCode);
+    old_compiled_method_table = new GrowableArrayCHeap<CompiledMethod*, mtCode>(100);
   }
   old_compiled_method_table->push(c);
 }

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -89,10 +89,11 @@ class CodeCache : AllStatic {
   friend class ShenandoahParallelCodeHeapIterator;
  private:
   // CodeHeaps of the cache
-  static GrowableArray<CodeHeap*>* _heaps;
-  static GrowableArray<CodeHeap*>* _compiled_heaps;
-  static GrowableArray<CodeHeap*>* _nmethod_heaps;
-  static GrowableArray<CodeHeap*>* _allocable_heaps;
+  typedef GrowableArrayCHeap<CodeHeap*, mtCode> CodeHeapArray;
+  static CodeHeapArray* _heaps;
+  static CodeHeapArray* _compiled_heaps;
+  static CodeHeapArray* _nmethod_heaps;
+  static CodeHeapArray* _allocable_heaps;
 
   static address _low_bound;                                 // Lower bound of CodeHeap addresses
   static address _high_bound;                                // Upper bound of CodeHeap addresses
@@ -143,9 +144,9 @@ class CodeCache : AllStatic {
   static int code_heap_compare(CodeHeap* const &lhs, CodeHeap* const &rhs);
 
   static void add_heap(CodeHeap* heap);
-  static const GrowableArray<CodeHeap*>* heaps() { return _heaps; }
-  static const GrowableArray<CodeHeap*>* compiled_heaps() { return _compiled_heaps; }
-  static const GrowableArray<CodeHeap*>* nmethod_heaps() { return _nmethod_heaps; }
+  static const GrowableArrayCHeap<CodeHeap*, mtCode>* heaps() { return _heaps; }
+  static const GrowableArrayCHeap<CodeHeap*, mtCode>* compiled_heaps() { return _compiled_heaps; }
+  static const GrowableArrayCHeap<CodeHeap*, mtCode>* nmethod_heaps() { return _nmethod_heaps; }
 
   // Allocation/administration
   static CodeBlob* allocate(uint size, CodeBlobType code_blob_type, bool handle_alloc_failure = true, CodeBlobType orig_code_blob_type = CodeBlobType::All); // allocates a new CodeBlob
@@ -442,18 +443,18 @@ private:
 
 struct CompiledMethodFilter {
   static bool apply(CodeBlob* cb) { return cb->is_compiled(); }
-  static const GrowableArray<CodeHeap*>* heaps() { return CodeCache::compiled_heaps(); }
+  static const GrowableArrayCHeap<CodeHeap*, mtCode>* heaps() { return CodeCache::compiled_heaps(); }
 };
 
 
 struct NMethodFilter {
   static bool apply(CodeBlob* cb) { return cb->is_nmethod(); }
-  static const GrowableArray<CodeHeap*>* heaps() { return CodeCache::nmethod_heaps(); }
+  static const GrowableArrayCHeap<CodeHeap*, mtCode>* heaps() { return CodeCache::nmethod_heaps(); }
 };
 
 struct AllCodeBlobsFilter {
   static bool apply(CodeBlob* cb) { return true; }
-  static const GrowableArray<CodeHeap*>* heaps() { return CodeCache::heaps(); }
+  static const GrowableArrayCHeap<CodeHeap*, mtCode>* heaps() { return CodeCache::heaps(); }
 };
 
 typedef CodeBlobIterator<CompiledMethod, CompiledMethodFilter, false /* is_relaxed */> CompiledMethodIterator;

--- a/src/hotspot/share/compiler/compilerEvent.cpp
+++ b/src/hotspot/share/compiler/compilerEvent.cpp
@@ -57,7 +57,7 @@ class PhaseTypeGuard : public StackObj {
 Semaphore PhaseTypeGuard::_mutex_semaphore(1);
 
 // Table for mapping compiler phases names to int identifiers.
-static GrowableArray<const char*>* phase_names = nullptr;
+static GrowableArrayCHeap<const char*, mtCompiler>* phase_names = nullptr;
 
 class CompilerPhaseTypeConstant : public JfrSerializer {
  public:
@@ -90,7 +90,7 @@ int CompilerEvent::PhaseEvent::get_phase_id(const char* phase_name, bool may_exi
   {
     PhaseTypeGuard guard(sync);
     if (phase_names == nullptr) {
-      phase_names = new (mtInternal) GrowableArray<const char*>(100, mtCompiler);
+      phase_names = new GrowableArrayCHeap<const char*, mtCompiler>(100);
       register_jfr_serializer = true;
     } else if (may_exist) {
       index = lookup_phase(phase_name);

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -196,7 +196,7 @@ class decode_env {
 
   static SourceFileInfoTable* _src_table;
   static const char* _cached_src;
-  static GrowableArray<const char*>* _cached_src_lines;
+  static GrowableArrayCHeap<const char*, mtCode>* _cached_src_lines;
 
   static SourceFileInfoTable& src_table() {
     if (_src_table == nullptr) {
@@ -230,7 +230,7 @@ bool decode_env::_optionsParsed = false;
 
 decode_env::SourceFileInfoTable* decode_env::_src_table = nullptr;
 const char* decode_env::_cached_src = nullptr;
-GrowableArray<const char*>* decode_env::_cached_src_lines = nullptr;
+GrowableArrayCHeap<const char*, mtCode>* decode_env::_cached_src_lines = nullptr;
 
 void decode_env::hook(const char* file, int line, address pc) {
   // For simplication, we never free from this table. It's really not
@@ -265,7 +265,7 @@ void decode_env::print_hook_comments(address pc, bool newline) {
           }
           _cached_src_lines->clear();
         } else {
-          _cached_src_lines = new (mtCode) GrowableArray<const char*>(0, mtCode);
+          _cached_src_lines = new GrowableArrayCHeap<const char*, mtCode>(0);
         }
 
         if ((fp = os::fopen(file, "r")) == nullptr) {

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.cpp
@@ -29,7 +29,7 @@
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/growableArray.hpp"
 
-G1CollectionCandidateList::G1CollectionCandidateList() : _candidates(2, mtGC) { }
+G1CollectionCandidateList::G1CollectionCandidateList() : _candidates(2) { }
 
 void G1CollectionCandidateList::set(G1CollectionSetCandidateInfo* candidate_infos, uint num_infos) {
   assert(_candidates.is_empty(), "must be");
@@ -58,7 +58,7 @@ void G1CollectionCandidateList::remove(G1CollectionCandidateRegionList* other) {
   // Create a list from scratch, copying over the elements from the candidate
   // list not in the other list. Finally deallocate and overwrite the old list.
   int new_length = _candidates.length() - other->length();
-  GrowableArray<G1CollectionSetCandidateInfo> new_list(new_length, mtGC);
+  GrowableArrayCHeap<G1CollectionSetCandidateInfo, mtGC> new_list(new_length);
 
   uint other_idx = 0;
 
@@ -118,7 +118,7 @@ int G1CollectionCandidateList::compare(G1CollectionSetCandidateInfo* ci1, G1Coll
   }
 }
 
-G1CollectionCandidateRegionList::G1CollectionCandidateRegionList() : _regions(2, mtGC) { }
+G1CollectionCandidateRegionList::G1CollectionCandidateRegionList() : _regions(2) { }
 
 void G1CollectionCandidateRegionList::append(HeapRegion* r) {
   assert(!_regions.contains(r), "must be");

--- a/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSetCandidates.hpp
@@ -43,7 +43,7 @@ using G1CollectionCandidateRegionListIterator = GrowableArrayIterator<HeapRegion
 
 // A set of HeapRegion*, a thin wrapper around GrowableArray.
 class G1CollectionCandidateRegionList {
-  GrowableArray<HeapRegion*> _regions;
+  GrowableArrayCHeap<HeapRegion*, mtGC> _regions;
 
 public:
   G1CollectionCandidateRegionList();
@@ -99,7 +99,7 @@ public:
 class G1CollectionCandidateList : public CHeapObj<mtGC> {
   friend class G1CollectionCandidateListIterator;
 
-  GrowableArray<G1CollectionSetCandidateInfo> _candidates;
+  GrowableArrayCHeap<G1CollectionSetCandidateInfo, mtGC> _candidates;
 
 public:
   G1CollectionCandidateList();

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -87,7 +87,7 @@ void G1FullGCCompactTask::compact_region(HeapRegion* hr) {
 
 void G1FullGCCompactTask::work(uint worker_id) {
   Ticks start = Ticks::now();
-  GrowableArray<HeapRegion*>* compaction_queue = collector()->compaction_point(worker_id)->regions();
+  GrowableArrayCHeap<HeapRegion*, mtGC>* compaction_queue = collector()->compaction_point(worker_id)->regions();
   for (GrowableArrayIterator<HeapRegion*> it = compaction_queue->begin();
        it != compaction_queue->end();
        ++it) {
@@ -97,7 +97,7 @@ void G1FullGCCompactTask::work(uint worker_id) {
 
 void G1FullGCCompactTask::serial_compaction() {
   GCTraceTime(Debug, gc, phases) tm("Phase 4: Serial Compaction", collector()->scope()->timer());
-  GrowableArray<HeapRegion*>* compaction_queue = collector()->serial_compaction_point()->regions();
+  GrowableArrayCHeap<HeapRegion*, mtGC>* compaction_queue = collector()->serial_compaction_point()->regions();
   for (GrowableArrayIterator<HeapRegion*> it = compaction_queue->begin();
        it != compaction_queue->end();
        ++it) {

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -34,7 +34,7 @@ G1FullGCCompactionPoint::G1FullGCCompactionPoint(G1FullCollector* collector) :
     _collector(collector),
     _current_region(nullptr),
     _compaction_top(nullptr) {
-  _compaction_regions = new (mtGC) GrowableArray<HeapRegion*>(32, mtGC);
+  _compaction_regions = new GrowableArrayCHeap<HeapRegion*, mtGC>(32);
   _compaction_region_iterator = _compaction_regions->begin();
 }
 
@@ -75,7 +75,7 @@ HeapRegion* G1FullGCCompactionPoint::next_region() {
   return next;
 }
 
-GrowableArray<HeapRegion*>* G1FullGCCompactionPoint::regions() {
+GrowableArrayCHeap<HeapRegion*, mtGC>* G1FullGCCompactionPoint::regions() {
   return _compaction_regions;
 }
 

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.hpp
@@ -37,7 +37,7 @@ class G1FullGCCompactionPoint : public CHeapObj<mtGC> {
   G1FullCollector* _collector;
   HeapRegion* _current_region;
   HeapWord*   _compaction_top;
-  GrowableArray<HeapRegion*>* _compaction_regions;
+  GrowableArrayCHeap<HeapRegion*, mtGC>* _compaction_regions;
   GrowableArrayIterator<HeapRegion*> _compaction_region_iterator;
 
   bool object_will_fit(size_t size);
@@ -62,7 +62,7 @@ public:
   void remove_at_or_above(uint bottom);
   HeapRegion* current_region();
 
-  GrowableArray<HeapRegion*>* regions();
+  GrowableArrayCHeap<HeapRegion*, mtGC>* regions();
 };
 
 #endif // SHARE_GC_G1_G1FULLGCCOMPACTIONPOINT_HPP

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -507,7 +507,7 @@ uint G1Policy::calculate_desired_eden_length_before_mixed(double base_time_ms,
 }
 
 double G1Policy::predict_survivor_regions_evac_time() const {
-  const GrowableArray<HeapRegion*>* survivor_regions = _g1h->survivor()->regions();
+  const GrowableArrayCHeap<HeapRegion*, mtGC>* survivor_regions = _g1h->survivor()->regions();
   double survivor_regions_evac_time = predict_young_region_other_time_ms(_g1h->survivor()->length());
   for (GrowableArrayIterator<HeapRegion*> it = survivor_regions->begin();
        it != survivor_regions->end();

--- a/src/hotspot/share/gc/g1/g1SurvivorRegions.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvivorRegions.cpp
@@ -29,7 +29,7 @@
 #include "utilities/debug.hpp"
 
 G1SurvivorRegions::G1SurvivorRegions() :
-  _regions(new (mtGC) GrowableArray<HeapRegion*>(8, mtGC)),
+  _regions(new GrowableArrayCHeap<HeapRegion*, mtGC>(8)),
   _used_bytes(0),
   _regions_on_node() {}
 

--- a/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
+++ b/src/hotspot/share/gc/g1/g1SurvivorRegions.hpp
@@ -28,15 +28,14 @@
 #include "gc/g1/g1RegionsOnNodes.hpp"
 #include "runtime/globals.hpp"
 
-template <typename T>
-class GrowableArray;
+template <typename T, MEMFLAGS F> class GrowableArrayCHeap;
 class HeapRegion;
 
 class G1SurvivorRegions {
 private:
-  GrowableArray<HeapRegion*>* _regions;
-  volatile size_t             _used_bytes;
-  G1RegionsOnNodes            _regions_on_node;
+  GrowableArrayCHeap<HeapRegion*, mtGC>* _regions;
+  volatile size_t                        _used_bytes;
+  G1RegionsOnNodes                       _regions_on_node;
 
 public:
   G1SurvivorRegions();
@@ -50,7 +49,7 @@ public:
   uint length() const;
   uint regions_on_node(uint node_index) const;
 
-  const GrowableArray<HeapRegion*>* regions() const {
+  const GrowableArrayCHeap<HeapRegion*, mtGC>* regions() const {
     return _regions;
   }
 

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -39,7 +39,7 @@
 #include "utilities/align.hpp"
 
 MutableNUMASpace::MutableNUMASpace(size_t alignment) : MutableSpace(alignment), _must_use_large_pages(false) {
-  _lgrp_spaces = new (mtGC) GrowableArray<LGRPSpace*>(0, mtGC);
+  _lgrp_spaces = new GrowableArrayCHeap<LGRPSpace*, mtGC>(0);
   _page_size = os::vm_page_size();
   _adaptation_cycles = 0;
   _samples_count = 0;

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -120,7 +120,7 @@ class MutableNUMASpace : public MutableSpace {
     void accumulate_statistics(size_t page_size);
   };
 
-  GrowableArray<LGRPSpace*>* _lgrp_spaces;
+  GrowableArrayCHeap<LGRPSpace*, mtGC>* _lgrp_spaces;
   size_t _page_size;
   unsigned _adaptation_cycles, _samples_count;
 
@@ -157,7 +157,7 @@ class MutableNUMASpace : public MutableSpace {
   int lgrp_space_index(int lgrp_id) const;
 
 public:
-  GrowableArray<LGRPSpace*>* lgrp_spaces() const     { return _lgrp_spaces;       }
+  GrowableArrayCHeap<LGRPSpace*, mtGC>* lgrp_spaces() const { return _lgrp_spaces; }
   MutableNUMASpace(size_t alignment);
   virtual ~MutableNUMASpace();
   // Space initialization.

--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -48,7 +48,7 @@ ParCompactionManager::RegionTaskQueueSet*   ParCompactionManager::_region_task_q
 
 ObjectStartArray*    ParCompactionManager::_start_array = nullptr;
 ParMarkBitMap*       ParCompactionManager::_mark_bitmap = nullptr;
-GrowableArray<size_t >* ParCompactionManager::_shadow_region_array = nullptr;
+GrowableArrayCHeap<size_t, mtGC>* ParCompactionManager::_shadow_region_array = nullptr;
 Monitor*                ParCompactionManager::_shadow_region_monitor = nullptr;
 
 ParCompactionManager::ParCompactionManager() {
@@ -60,7 +60,7 @@ ParCompactionManager::ParCompactionManager() {
 
   reset_bitmap_query_cache();
 
-  _deferred_obj_array = new (mtGC) GrowableArray<HeapWord*>(10, mtGC);
+  _deferred_obj_array = new GrowableArrayCHeap<HeapWord*, mtGC>(10);
 }
 
 void ParCompactionManager::initialize(ParMarkBitMap* mbm) {
@@ -89,7 +89,7 @@ void ParCompactionManager::initialize(ParMarkBitMap* mbm) {
   assert(ParallelScavengeHeap::heap()->workers().max_workers() != 0,
     "Not initialized?");
 
-  _shadow_region_array = new (mtGC) GrowableArray<size_t >(10, mtGC);
+  _shadow_region_array = new GrowableArrayCHeap<size_t, mtGC>(10);
 
   _shadow_region_monitor = new Monitor(Mutex::nosafepoint, "CompactionManager_lock");
 }

--- a/src/hotspot/share/gc/parallel/psCompactionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.hpp
@@ -75,13 +75,13 @@ class ParCompactionManager : public CHeapObj<mtGC> {
   // type of TaskQueue.
   RegionTaskQueue              _region_stack;
 
-  GrowableArray<HeapWord*>*    _deferred_obj_array;
+  GrowableArrayCHeap<HeapWord*, mtGC>* _deferred_obj_array;
 
   static ParMarkBitMap* _mark_bitmap;
 
   // Contains currently free shadow regions. We use it in
   // a LIFO fashion for better data locality and utilization.
-  static GrowableArray<size_t>* _shadow_region_array;
+  static GrowableArrayCHeap<size_t, mtGC>* _shadow_region_array;
 
   // Provides mutual exclusive access of _shadow_region_array.
   // See pop/push_shadow_region_mt_safe() below

--- a/src/hotspot/share/gc/shared/gcTimer.cpp
+++ b/src/hotspot/share/gc/shared/gcTimer.cpp
@@ -114,7 +114,7 @@ GCPhase::PhaseType TimePartitions::current_phase_type() const {
 }
 
 TimePartitions::TimePartitions() {
-  _phases = new (mtGC) GrowableArray<GCPhase>(INITIAL_CAPACITY, mtGC);
+  _phases = new GrowableArrayCHeap<GCPhase, mtGC>(INITIAL_CAPACITY);
   clear();
 }
 

--- a/src/hotspot/share/gc/shared/gcTimer.hpp
+++ b/src/hotspot/share/gc/shared/gcTimer.hpp
@@ -33,7 +33,7 @@ class ConcurrentPhase;
 class GCPhase;
 class PausePhase;
 
-template <class E> class GrowableArray;
+template <class E, MEMFLAGS F> class GrowableArrayCHeap;
 
 class PhaseVisitor {
  public:
@@ -99,7 +99,7 @@ class TimePartitions {
 
   static const int INITIAL_CAPACITY = 10;
 
-  GrowableArray<GCPhase>* _phases;
+  GrowableArrayCHeap<GCPhase, mtGC>* _phases;
   PhasesStack _active_phases;
 
   Tickspan _sum_of_pauses;

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1288,8 +1288,8 @@ void SignatureHandlerLibrary::initialize() {
                                       SignatureHandlerLibrary::buffer_size);
   _buffer = bb->code_begin();
 
-  _fingerprints = new (mtCode) GrowableArray<uint64_t>(32, mtCode);
-  _handlers     = new (mtCode) GrowableArray<address>(32, mtCode);
+  _fingerprints = new GrowableArrayCHeap<uint64_t, mtCode>(32);
+  _handlers     = new GrowableArrayCHeap<address, mtCode>(32);
 }
 
 address SignatureHandlerLibrary::set_handler(CodeBuffer* buffer) {
@@ -1439,11 +1439,11 @@ void SignatureHandlerLibrary::add(uint64_t fingerprint, address handler) {
 }
 
 
-BufferBlob*              SignatureHandlerLibrary::_handler_blob = nullptr;
-address                  SignatureHandlerLibrary::_handler      = nullptr;
-GrowableArray<uint64_t>* SignatureHandlerLibrary::_fingerprints = nullptr;
-GrowableArray<address>*  SignatureHandlerLibrary::_handlers     = nullptr;
-address                  SignatureHandlerLibrary::_buffer       = nullptr;
+BufferBlob*                           SignatureHandlerLibrary::_handler_blob = nullptr;
+address                               SignatureHandlerLibrary::_handler      = nullptr;
+GrowableArrayCHeap<uint64_t, mtCode>* SignatureHandlerLibrary::_fingerprints = nullptr;
+GrowableArrayCHeap<address, mtCode>*  SignatureHandlerLibrary::_handlers     = nullptr;
+address                               SignatureHandlerLibrary::_buffer       = nullptr;
 
 
 JRT_ENTRY(void, InterpreterRuntime::prepare_native_call(JavaThread* current, Method* method))

--- a/src/hotspot/share/interpreter/interpreterRuntime.hpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.hpp
@@ -166,11 +166,11 @@ class SignatureHandlerLibrary: public AllStatic {
   enum { blob_size   = 32*K }; // the size of a handler code blob.
 
  private:
-  static BufferBlob*              _handler_blob; // the current buffer blob containing the generated handlers
-  static address                  _handler;      // next available address within _handler_blob;
-  static GrowableArray<uint64_t>* _fingerprints; // the fingerprint collection
-  static GrowableArray<address>*  _handlers;     // the corresponding handlers
-  static address                  _buffer;       // the temporary code buffer
+  static BufferBlob*                           _handler_blob; // the current buffer blob containing the generated handlers
+  static address                               _handler;      // next available address within _handler_blob;
+  static GrowableArrayCHeap<uint64_t, mtCode>* _fingerprints; // the fingerprint collection
+  static GrowableArrayCHeap<address, mtCode>*  _handlers;     // the corresponding handlers
+  static address                               _buffer;       // the temporary code buffer
 
   static address set_handler_blob();
   static void initialize();

--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -1663,7 +1663,7 @@ static void copy_traceid(const InstanceKlass* ik, const InstanceKlass* new_ik) {
 static const Klass* klass_being_redefined(const InstanceKlass* ik, JvmtiThreadState* state) {
   assert(ik != nullptr, "invariant");
   assert(state != nullptr, "invariant");
-  const GrowableArray<Klass*>* const redef_klasses = state->get_classes_being_redefined();
+  const GrowableArrayCHeap<Klass*, mtClass>* const redef_klasses = state->get_classes_being_redefined();
   if (redef_klasses == nullptr || redef_klasses->is_empty()) {
     return nullptr;
   }

--- a/src/hotspot/share/jfr/leakprofiler/chains/edgeStore.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/chains/edgeStore.cpp
@@ -217,7 +217,7 @@ bool EdgeStore::put_edges(StoredEdge** previous, const Edge** current, size_t li
   return nullptr == *current;
 }
 
-static GrowableArray<const StoredEdge*>* _leak_context_edges = nullptr;
+static GrowableArrayCHeap<const StoredEdge*, mtTracing>* _leak_context_edges = nullptr;
 
 EdgeStore::EdgeStore() : _edges(new EdgeHashTable(this)) {}
 
@@ -284,7 +284,7 @@ static const int initial_size = 64;
 static int save(const StoredEdge* edge) {
   assert(edge != nullptr, "invariant");
   if (_leak_context_edges == nullptr) {
-    _leak_context_edges = new (mtTracing) GrowableArray<const StoredEdge*>(initial_size, mtTracing);
+    _leak_context_edges = new GrowableArrayCHeap<const StoredEdge*, mtTracing>(initial_size);
     _leak_context_edges->append(nullptr); // next idx now at 1, for disambiguation in markword.
   }
   return _leak_context_edges->append(edge);

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
@@ -51,11 +51,11 @@
 const int initial_array_size = 64;
 
 template <typename T>
-static GrowableArray<T>* c_heap_allocate_array(int size = initial_array_size) {
-  return new (mtTracing) GrowableArray<T>(size, mtTracing);
+static GrowableArrayCHeap<T, mtTracing>* c_heap_allocate_array(int size = initial_array_size) {
+  return new GrowableArrayCHeap<T, mtTracing>(size);
 }
 
-static GrowableArray<traceid>* unloaded_thread_id_set = nullptr;
+static GrowableArrayCHeap<traceid, mtTracing>* unloaded_thread_id_set = nullptr;
 
 class ThreadIdExclusiveAccess : public StackObj {
  private:

--- a/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrNetworkUtilization.cpp
@@ -42,7 +42,7 @@ struct InterfaceEntry {
   mutable bool written;
 };
 
-static GrowableArray<InterfaceEntry>* _interfaces = nullptr;
+static GrowableArrayCHeap<InterfaceEntry, mtTracing>* _interfaces = nullptr;
 
 void JfrNetworkUtilization::destroy() {
   if (_interfaces != nullptr) {
@@ -54,7 +54,7 @@ void JfrNetworkUtilization::destroy() {
   }
 }
 
-static InterfaceEntry& new_entry(const NetworkInterface* iface, GrowableArray<InterfaceEntry>* interfaces) {
+static InterfaceEntry& new_entry(const NetworkInterface* iface, GrowableArrayCHeap<InterfaceEntry, mtTracing>* interfaces) {
   assert(iface != nullptr, "invariant");
   assert(interfaces != nullptr, "invariant");
 
@@ -75,9 +75,9 @@ static InterfaceEntry& new_entry(const NetworkInterface* iface, GrowableArray<In
   return _interfaces->at(_interfaces->append(entry));
 }
 
-static GrowableArray<InterfaceEntry>* get_interfaces() {
+static GrowableArrayCHeap<InterfaceEntry, mtTracing>* get_interfaces() {
   if (_interfaces == nullptr) {
-    _interfaces = new (mtTracing) GrowableArray<InterfaceEntry>(10, mtTracing);
+    _interfaces = new GrowableArrayCHeap<InterfaceEntry, mtTracing>(10);
   }
   return _interfaces;
 }
@@ -87,7 +87,7 @@ static InterfaceEntry& get_entry(const NetworkInterface* iface) {
   // in the same order every time.
   static int saved_index = -1;
 
-  GrowableArray<InterfaceEntry>* interfaces = get_interfaces();
+  GrowableArrayCHeap<InterfaceEntry, mtTracing>* interfaces = get_interfaces();
   assert(interfaces != nullptr, "invariant");
   for (int i = 0; i < _interfaces->length(); ++i) {
     saved_index = (saved_index + 1) % _interfaces->length();

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadGroup.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadGroup.cpp
@@ -263,7 +263,7 @@ void JfrThreadGroup::JfrThreadGroupEntry::set_thread_group(JfrThreadGroupPointer
 }
 
 JfrThreadGroup::JfrThreadGroup() :
-  _list(new (mtTracing) GrowableArray<JfrThreadGroupEntry*>(initial_array_size, mtTracing)) {}
+  _list(new GrowableArrayCHeap<JfrThreadGroupEntry*, mtTracing>(initial_array_size)) {}
 
 JfrThreadGroup::~JfrThreadGroup() {
   if (_list != nullptr) {

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadGroup.hpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrThreadGroup.hpp
@@ -40,7 +40,7 @@ class JfrThreadGroup : public JfrCHeapObj {
  private:
   static JfrThreadGroup* _instance;
   class JfrThreadGroupEntry;
-  GrowableArray<JfrThreadGroupEntry*>* _list;
+  GrowableArrayCHeap<JfrThreadGroupEntry*, mtTracing>* _list;
 
   JfrThreadGroup();
   JfrThreadGroupEntry* find_entry(const JfrThreadGroupPointers& ptrs) const;

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/traceid/jfrTraceId.cpp
@@ -127,7 +127,7 @@ void JfrTraceId::assign(const Klass* klass) {
   if (state == nullptr) {
     return;
   }
-  const GrowableArray<Klass*>* const redef_klasses = state->get_classes_being_redefined();
+  const GrowableArrayCHeap<Klass*, mtClass>* const redef_klasses = state->get_classes_being_redefined();
   if (redef_klasses == nullptr || redef_klasses->is_empty()) {
     return;
   }

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
@@ -108,7 +108,7 @@ bool JfrRecorder::on_create_vm_1() {
   return JfrTime::initialize();
 }
 
-static GrowableArray<JfrStartFlightRecordingDCmd*>* dcmd_recordings_array = nullptr;
+static GrowableArrayCHeap<JfrStartFlightRecordingDCmd*, mtTracing>* dcmd_recordings_array = nullptr;
 
 static void release_recordings() {
   if (dcmd_recordings_array != nullptr) {
@@ -141,14 +141,14 @@ static bool parse_recording_options(const char* options, JfrStartFlightRecording
 }
 
 static bool validate_recording_options(TRAPS) {
-  const GrowableArray<const char*>* options = JfrOptionSet::start_flight_recording_options();
+  const GrowableArrayCHeap<const char*, mtTracing>* options = JfrOptionSet::start_flight_recording_options();
   if (options == nullptr) {
     return true;
   }
   const int length = options->length();
   assert(length >= 1, "invariant");
   assert(dcmd_recordings_array == nullptr, "invariant");
-  dcmd_recordings_array = new (mtTracing) GrowableArray<JfrStartFlightRecordingDCmd*>(length, mtTracing);
+  dcmd_recordings_array = new GrowableArrayCHeap<JfrStartFlightRecordingDCmd*, mtTracing>(length);
   assert(dcmd_recordings_array != nullptr, "invariant");
   for (int i = 0; i < length; ++i) {
     JfrStartFlightRecordingDCmd* const dcmd_recording = new (mtTracing) JfrStartFlightRecordingDCmd(tty, true);

--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -250,7 +250,7 @@ static int64_t file_size(fio_fd fd) {
 
 class RepositoryIterator : public StackObj {
  private:
-  GrowableArray<const char*>* _file_names;
+  GrowableArrayCHeap<const char*, mtTracing>* _file_names;
   int _path_buffer_file_name_offset;
   mutable int _iterator;
   const char* fully_qualified(const char* file_name) const;
@@ -328,7 +328,7 @@ RepositoryIterator::RepositoryIterator(const char* repository_path) :
     if (_path_buffer_file_name_offset == -1) {
       return;
     }
-    _file_names = new (mtTracing) GrowableArray<const char*>(10, mtTracing);
+    _file_names = new GrowableArrayCHeap<const char*, mtTracing>(10);
     if (_file_names == nullptr) {
       log_error(jfr, system)("Unable to malloc memory during jfr emergency dump");
       return;

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.cpp
@@ -758,7 +758,7 @@ bool JfrOptionSet::parse_flight_recorder_option(const JavaVMOption** option, cha
   return false;
 }
 
-static GrowableArray<const char*>* start_flight_recording_options_array = nullptr;
+static GrowableArrayCHeap<const char*, mtTracing>* start_flight_recording_options_array = nullptr;
 
 bool JfrOptionSet::parse_start_flight_recording_option(const JavaVMOption** option, char* delimiter) {
   assert(option != nullptr, "invariant");
@@ -782,7 +782,7 @@ bool JfrOptionSet::parse_start_flight_recording_option(const JavaVMOption** opti
   const size_t value_length = strlen(value);
 
   if (start_flight_recording_options_array == nullptr) {
-    start_flight_recording_options_array = new (mtTracing) GrowableArray<const char*>(8, mtTracing);
+    start_flight_recording_options_array = new GrowableArrayCHeap<const char*, mtTracing>(8);
   }
   assert(start_flight_recording_options_array != nullptr, "invariant");
   char* const startup_value = NEW_C_HEAP_ARRAY(char, value_length + 1, mtTracing);
@@ -792,7 +792,7 @@ bool JfrOptionSet::parse_start_flight_recording_option(const JavaVMOption** opti
   return false;
 }
 
-const GrowableArray<const char*>* JfrOptionSet::start_flight_recording_options() {
+const GrowableArrayCHeap<const char*, mtTracing>* JfrOptionSet::start_flight_recording_options() {
   return start_flight_recording_options_array;
 }
 

--- a/src/hotspot/share/jfr/recorder/service/jfrOptionSet.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrOptionSet.hpp
@@ -29,8 +29,7 @@
 #include "memory/allStatic.hpp"
 #include "utilities/exceptions.hpp"
 
-template <typename>
-class GrowableArray;
+template <typename E, MEMFLAGS F> class GrowableArrayCHeap;
 
 //
 // Command-line options and defaults
@@ -77,7 +76,7 @@ class JfrOptionSet : public AllStatic {
 
   static bool parse_flight_recorder_option(const JavaVMOption** option, char* delimiter);
   static bool parse_start_flight_recording_option(const JavaVMOption** option, char* delimiter);
-  static const GrowableArray<const char*>* start_flight_recording_options();
+  static const GrowableArrayCHeap<const char*, mtTracing>* start_flight_recording_options();
   static void release_start_flight_recording_options();
 };
 

--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
@@ -49,11 +49,6 @@ static oop new_java_util_arraylist(TRAPS) {
 
 static const int initial_array_size = 64;
 
-template <typename T>
-static GrowableArray<T>* c_heap_allocate_array(int size = initial_array_size) {
-  return new (mtTracing) GrowableArray<T>(size, mtTracing);
-}
-
 static bool initialize(TRAPS) {
   static bool initialized = false;
   if (!initialized) {

--- a/src/hotspot/share/jfr/support/jfrKlassUnloading.cpp
+++ b/src/hotspot/share/jfr/support/jfrKlassUnloading.cpp
@@ -35,43 +35,43 @@
 static const int initial_array_size = 64;
 
 template <typename T>
-static GrowableArray<T>* c_heap_allocate_array(int size = initial_array_size) {
-  return new (mtTracing) GrowableArray<T>(size, mtTracing);
+static GrowableArrayCHeap<T, mtTracing>* c_heap_allocate_array(int size = initial_array_size) {
+  return new GrowableArrayCHeap<T, mtTracing>(size);
 }
 
 // Track the set of unloaded klasses during a chunk / epoch.
-static GrowableArray<traceid>* _unload_set_epoch_0 = nullptr;
-static GrowableArray<traceid>* _unload_set_epoch_1 = nullptr;
+static GrowableArrayCHeap<traceid, mtTracing>* _unload_set_epoch_0 = nullptr;
+static GrowableArrayCHeap<traceid, mtTracing>* _unload_set_epoch_1 = nullptr;
 
 static s8 event_klass_unloaded_count = 0;
 
-static GrowableArray<traceid>* unload_set_epoch_0() {
+static GrowableArrayCHeap<traceid, mtTracing>* unload_set_epoch_0() {
   if (_unload_set_epoch_0 == nullptr) {
     _unload_set_epoch_0 = c_heap_allocate_array<traceid>(initial_array_size);
   }
   return _unload_set_epoch_0;
 }
 
-static GrowableArray<traceid>* unload_set_epoch_1() {
+static GrowableArrayCHeap<traceid, mtTracing>* unload_set_epoch_1() {
   if (_unload_set_epoch_1 == nullptr) {
     _unload_set_epoch_1 = c_heap_allocate_array<traceid>(initial_array_size);
   }
   return _unload_set_epoch_1;
 }
 
-static GrowableArray<traceid>* get_unload_set(u1 epoch) {
+static GrowableArrayCHeap<traceid, mtTracing>* get_unload_set(u1 epoch) {
   return epoch == 0 ? unload_set_epoch_0() : unload_set_epoch_1();
 }
 
-static GrowableArray<traceid>* get_unload_set() {
+static GrowableArrayCHeap<traceid, mtTracing>* get_unload_set() {
   return get_unload_set(JfrTraceIdEpoch::current());
 }
 
-static GrowableArray<traceid>* get_unload_set_previous_epoch() {
+static GrowableArrayCHeap<traceid, mtTracing>* get_unload_set_previous_epoch() {
   return get_unload_set(JfrTraceIdEpoch::previous());
 }
 
-static void sort_set(GrowableArray<traceid>* set) {
+static void sort_set(GrowableArrayCHeap<traceid, mtTracing>* set) {
   assert(set != nullptr, "invariant");
   assert(set->is_nonempty(), "invariant");
   set->sort(sort_traceid);
@@ -103,7 +103,7 @@ void JfrKlassUnloading::clear() {
 
 static bool add_to_unloaded_klass_set(traceid klass_id, bool current_epoch) {
   assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
-  GrowableArray<traceid>* const unload_set = current_epoch ? get_unload_set() : get_unload_set_previous_epoch();
+  GrowableArrayCHeap<traceid, mtTracing>* const unload_set = current_epoch ? get_unload_set() : get_unload_set_previous_epoch();
   assert(unload_set != nullptr, "invariant");
   assert(unload_set->find(klass_id) == -1, "invariant");
   unload_set->append(klass_id);

--- a/src/hotspot/share/jfr/utilities/jfrPredicate.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrPredicate.hpp
@@ -34,7 +34,7 @@
 template <typename T, int cmp(const T&, const T&)>
 class JfrPredicate : AllStatic {
  public:
-  static bool test(GrowableArray<T>* set, T value) {
+  static bool test(GrowableArrayView<T>* set, T value) {
     assert(set != nullptr, "invariant");
     bool found = false;
     set->template find_sorted<T, cmp>(value, found);
@@ -48,6 +48,16 @@ class JfrPredicate : AllStatic {
 template <typename T, int cmp(const T&, const T&)>
 class JfrMutablePredicate : AllStatic {
  public:
+  static bool test(GrowableArrayCHeap<T, mtTracing>* set, T value) {
+    assert(set != nullptr, "invariant");
+    bool found = false;
+    const int location = set->template find_sorted<T, cmp>(value, found);
+    if (!found) {
+      set->insert_before(location, value);
+    }
+    return found;
+  }
+
   static bool test(GrowableArray<T>* set, T value) {
     assert(set != nullptr, "invariant");
     bool found = false;

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -919,13 +919,6 @@ static bool is_referent_non_null(oop* handle) {
   return handle != nullptr && *handle != nullptr;
 }
 
-// Swaps the elements in `array` at index `a` and index `b`
-static void swap(GrowableArray<oop*>* array, int a, int b) {
-  oop* tmp = array->at(a);
-  array->at_put(a, array->at(b));
-  array->at_put(b, tmp);
-}
-
 int JVMCIRuntime::release_cleared_oop_handles() {
   // Despite this lock, it's possible for another thread
   // to clear a handle's referent concurrently (e.g., a thread
@@ -949,7 +942,7 @@ int JVMCIRuntime::release_cleared_oop_handles() {
       if (is_referent_non_null(handle)) {
         if (i != next && !is_referent_non_null(_oop_handles.at(next))) {
           // Swap elements at index `next` and `i`
-          swap(&_oop_handles, next, i);
+          _oop_handles.at_swap(next, i);
         }
         next++;
       }
@@ -967,7 +960,7 @@ int JVMCIRuntime::release_cleared_oop_handles() {
       if (handle != nullptr) {
         if (i != next && _oop_handles.at(next) == nullptr) {
           // Swap elements at index `next` and `i`
-          swap(&_oop_handles, next, i);
+          _oop_handles.at_swap(next, i);
         }
         next++;
       }
@@ -1045,7 +1038,7 @@ JVMCIRuntime::JVMCIRuntime(JVMCIRuntime* next, int id, bool for_compile_broker) 
   _id(id),
   _next(next),
   _metadata_handles(new MetadataHandles()),
-  _oop_handles(100, mtJVMCI),
+  _oop_handles(100),
   _num_attached_threads(0),
   _for_compile_broker(for_compile_broker)
 {

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -205,7 +205,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
   // List of oop handles allocated via make_oop_handle. This is to support
   // destroying remaining oop handles when the JavaVM associated
   // with this runtime is shutdown.
-  GrowableArray<oop*> _oop_handles;
+  GrowableArrayCHeap<oop*, mtJVMCI> _oop_handles;
 
   // Number of threads attached or about to be attached to this runtime.
   // Must only be mutated under JVMCI_lock to facilitate safely moving

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -357,3 +357,9 @@ bool Arena::contains( const void *ptr ) const {
   }
   return false;                 // Not in any Chunk, so not in Arena
 }
+
+#ifdef ASSERT
+bool Arena_contains(const Arena* arena, const void* ptr) {
+  return arena->contains(ptr);
+}
+#endif // ASSERT

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -205,4 +205,8 @@ private:
 #define NEW_ARENA_OBJ(arena, type) \
   NEW_ARENA_ARRAY(arena, type, 1)
 
+#ifdef ASSERT
+bool Arena_contains(const Arena* arena, const void* ptr);
+#endif // ASSERT
+
 #endif // SHARE_MEMORY_ARENA_HPP

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -51,7 +51,7 @@ inline KlassInfoEntry::~KlassInfoEntry() {
 
 inline void KlassInfoEntry::add_subclass(KlassInfoEntry* cie) {
   if (_subclasses == nullptr) {
-    _subclasses = new (mtServiceability) GrowableArray<KlassInfoEntry*>(4, mtServiceability);
+    _subclasses = new GrowableArrayCHeap<KlassInfoEntry*, mtServiceability>(4);
   }
   _subclasses->append(cie);
 }
@@ -279,7 +279,7 @@ int KlassInfoHisto::sort_helper(KlassInfoEntry** e1, KlassInfoEntry** e2) {
 
 KlassInfoHisto::KlassInfoHisto(KlassInfoTable* cit) :
   _cit(cit) {
-  _elements = new (mtServiceability) GrowableArray<KlassInfoEntry*>(_histo_initial_size, mtServiceability);
+  _elements = new GrowableArrayCHeap<KlassInfoEntry*, mtServiceability>(_histo_initial_size);
 }
 
 KlassInfoHisto::~KlassInfoHisto() {
@@ -614,10 +614,11 @@ void HeapInspection::heap_inspection(outputStream* st, WorkerThreads* workers) {
 class FindInstanceClosure : public ObjectClosure {
  private:
   Klass* _klass;
-  GrowableArray<oop>* _result;
+  GrowableArrayCHeap<oop, mtServiceability>* _result;
 
  public:
-  FindInstanceClosure(Klass* k, GrowableArray<oop>* result) : _klass(k), _result(result) {};
+  FindInstanceClosure(Klass* k, GrowableArrayCHeap<oop, mtServiceability>* result) :
+    _klass(k), _result(result) {};
 
   void do_object(oop obj) {
     if (obj->is_a(_klass)) {
@@ -630,7 +631,7 @@ class FindInstanceClosure : public ObjectClosure {
   }
 };
 
-void HeapInspection::find_instances_at_safepoint(Klass* k, GrowableArray<oop>* result) {
+void HeapInspection::find_instances_at_safepoint(Klass* k, GrowableArrayCHeap<oop, mtServiceability>* result) {
   assert(SafepointSynchronize::is_at_safepoint(), "all threads are stopped");
   assert(Heap_lock->is_locked(), "should have the Heap_lock");
 

--- a/src/hotspot/share/memory/heapInspection.hpp
+++ b/src/hotspot/share/memory/heapInspection.hpp
@@ -58,7 +58,7 @@ class KlassInfoEntry: public CHeapObj<mtInternal> {
   size_t          _instance_words;
   int64_t         _index;
   bool            _do_print; // True if we should print this class when printing the class hierarchy.
-  GrowableArray<KlassInfoEntry*>* _subclasses;
+  GrowableArrayCHeap<KlassInfoEntry*, mtServiceability>* _subclasses;
 
  public:
   KlassInfoEntry(Klass* k, KlassInfoEntry* next) :
@@ -75,7 +75,7 @@ class KlassInfoEntry: public CHeapObj<mtInternal> {
   void set_words(size_t wds)     { _instance_words = wds; }
   void set_index(int64_t index)  { _index = index; }
   int64_t index()    const       { return _index; }
-  GrowableArray<KlassInfoEntry*>* subclasses() const { return _subclasses; }
+  GrowableArrayCHeap<KlassInfoEntry*, mtServiceability>* subclasses() const { return _subclasses; }
   void add_subclass(KlassInfoEntry* cie);
   void set_do_print(bool do_print) { _do_print = do_print; }
   bool do_print() const      { return _do_print; }
@@ -147,8 +147,8 @@ class KlassInfoHisto : public StackObj {
  private:
   static const int _histo_initial_size = 1000;
   KlassInfoTable *_cit;
-  GrowableArray<KlassInfoEntry*>* _elements;
-  GrowableArray<KlassInfoEntry*>* elements() const { return _elements; }
+  GrowableArrayCHeap<KlassInfoEntry*, mtServiceability>* _elements;
+  GrowableArrayCHeap<KlassInfoEntry*, mtServiceability>* elements() const { return _elements; }
   static int sort_helper(KlassInfoEntry** e1, KlassInfoEntry** e2);
   void print_elements(outputStream* st) const;
   bool is_selected(const char *col_name);
@@ -202,7 +202,7 @@ class HeapInspection : public StackObj {
  public:
   void heap_inspection(outputStream* st, WorkerThreads* workers) NOT_SERVICES_RETURN;
   uintx populate_table(KlassInfoTable* cit, BoolObjectClosure* filter, WorkerThreads* workers) NOT_SERVICES_RETURN_(0);
-  static void find_instances_at_safepoint(Klass* k, GrowableArray<oop>* result) NOT_SERVICES_RETURN;
+  static void find_instances_at_safepoint(Klass* k, GrowableArrayCHeap<oop, mtServiceability>* result) NOT_SERVICES_RETURN;
 };
 
 // Parallel heap inspection task. Parallel inspection can fail due to

--- a/src/hotspot/share/memory/resourceArea.hpp
+++ b/src/hotspot/share/memory/resourceArea.hpp
@@ -27,7 +27,7 @@
 
 #include "memory/allocation.hpp"
 #include "memory/arena.hpp"
-#include "runtime/javaThread.hpp"
+#include "runtime/thread.hpp"
 
 // The resource area holds temporary data structures in the VM.
 // The actual allocation areas are thread local. Typical usage:

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -503,7 +503,7 @@ void Universe::fixup_mirrors(TRAPS) {
     InstanceMirrorKlass::init_offset_of_static_fields();
   }
 
-  GrowableArray <Klass*>* list = java_lang_Class::fixup_mirror_list();
+  GrowableArrayCHeap<Klass*, mtClass>* list = java_lang_Class::fixup_mirror_list();
   int list_length = list->length();
   for (int i = 0; i < list_length; i++) {
     Klass* k = list->at(i);

--- a/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
+++ b/src/hotspot/share/prims/jvmtiCodeBlobEvents.cpp
@@ -61,11 +61,11 @@
 
 class CodeBlobCollector : StackObj {
  private:
-  GrowableArray<JvmtiCodeBlobDesc*>* _code_blobs;   // collected blobs
-  int _pos;                                         // iterator position
+  GrowableArrayCHeap<JvmtiCodeBlobDesc*, mtServiceability>* _code_blobs; // collected blobs
+  int _pos; // iterator position
 
   // used during a collection
-  static GrowableArray<JvmtiCodeBlobDesc*>* _global_code_blobs;
+  static GrowableArrayCHeap<JvmtiCodeBlobDesc*, mtServiceability>* _global_code_blobs;
   static void do_blob(CodeBlob* cb);
   static void do_vtable_stub(VtableStub* vs);
  public:
@@ -107,7 +107,7 @@ class CodeBlobCollector : StackObj {
 };
 
 // used during collection
-GrowableArray<JvmtiCodeBlobDesc*>* CodeBlobCollector::_global_code_blobs;
+GrowableArrayCHeap<JvmtiCodeBlobDesc*, mtServiceability>* CodeBlobCollector::_global_code_blobs;
 
 
 // called for each CodeBlob in the CodeCache
@@ -173,7 +173,7 @@ void CodeBlobCollector::collect() {
   assert(_global_code_blobs == nullptr, "checking");
 
   // create the global list
-  _global_code_blobs = new (mtServiceability) GrowableArray<JvmtiCodeBlobDesc*>(50, mtServiceability);
+  _global_code_blobs = new GrowableArrayCHeap<JvmtiCodeBlobDesc*, mtServiceability>(50);
 
   // iterate over the stub code descriptors and put them in the list first.
   for (StubCodeDesc* desc = StubCodeDesc::first(); desc != nullptr; desc = StubCodeDesc::next(desc)) {

--- a/src/hotspot/share/prims/jvmtiDeferredUpdates.cpp
+++ b/src/hotspot/share/prims/jvmtiDeferredUpdates.cpp
@@ -62,7 +62,7 @@ int JvmtiDeferredUpdates::get_and_reset_relock_count_after_wait(JavaThread* jt) 
 void JvmtiDeferredUpdates::delete_updates_for_frame(JavaThread* jt, intptr_t* frame_id) {
   JvmtiDeferredUpdates* updates = jt->deferred_updates();
   if (updates != nullptr) {
-    GrowableArray<jvmtiDeferredLocalVariableSet*>* list = updates->deferred_locals();
+    GrowableArrayCHeap<jvmtiDeferredLocalVariableSet*, mtCompiler>* list = updates->deferred_locals();
     assert(list->length() > 0, "Updates holder not deleted");
     int i = 0;
     do {

--- a/src/hotspot/share/prims/jvmtiDeferredUpdates.hpp
+++ b/src/hotspot/share/prims/jvmtiDeferredUpdates.hpp
@@ -72,7 +72,7 @@ private:
   int       _bci;
   intptr_t* _id;
   int       _vframe_id;
-  GrowableArray<jvmtiDeferredLocalVariable*>* _locals;
+  GrowableArrayCHeap<jvmtiDeferredLocalVariable*, mtCompiler>* _locals;
   bool      _objects_are_deoptimized;
 
   void      update_value(StackValueCollection* locals, BasicType type, int index, jvalue value);
@@ -116,7 +116,7 @@ class JvmtiDeferredUpdates : public CHeapObj<mtCompiler> {
   int _relock_count_after_wait;
 
   // Deferred updates of locals, expressions, and monitors
-  GrowableArray<jvmtiDeferredLocalVariableSet*> _deferred_locals_updates;
+  GrowableArrayCHeap<jvmtiDeferredLocalVariableSet*, mtCompiler> _deferred_locals_updates;
 
   void inc_relock_count_after_wait() {
     _relock_count_after_wait++;
@@ -128,19 +128,18 @@ class JvmtiDeferredUpdates : public CHeapObj<mtCompiler> {
     return result;
   }
 
-  GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred_locals() { return &_deferred_locals_updates; }
+  GrowableArrayCHeap<jvmtiDeferredLocalVariableSet*, mtCompiler>* deferred_locals() { return &_deferred_locals_updates; }
 
   JvmtiDeferredUpdates() :
     _relock_count_after_wait(0),
-    _deferred_locals_updates((AnyObj::set_allocation_type((address) &_deferred_locals_updates,
-                             AnyObj::C_HEAP), 1), mtCompiler) { }
+    _deferred_locals_updates(1) { }
 
 public:
   ~JvmtiDeferredUpdates();
 
   static void create_for(JavaThread* thread);
 
-  static GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred_locals(JavaThread* jt) {
+  static GrowableArrayCHeap<jvmtiDeferredLocalVariableSet*, MEMFLAGS::mtCompiler>* deferred_locals(JavaThread* jt) {
     return jt->deferred_updates() == nullptr ? nullptr : jt->deferred_updates()->deferred_locals();
   }
 

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1354,8 +1354,8 @@ JvmtiEnv::GetOwnedMonitorInfo(jthread thread, jint* owned_monitor_count_ptr, job
   HandleMark hm(calling_thread);
 
   // growable array of jvmti monitors info on the C-heap
-  GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list =
-      new (mtServiceability) GrowableArray<jvmtiMonitorStackDepthInfo*>(1, mtServiceability);
+  GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors_list =
+    new GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>(1);
 
   JvmtiVTMSTransitionDisabler disabler(thread);
   ThreadsListHandle tlh(calling_thread);
@@ -1427,8 +1427,8 @@ JvmtiEnv::GetOwnedMonitorStackDepthInfo(jthread thread, jint* monitor_info_count
   HandleMark hm(calling_thread);
 
   // growable array of jvmti monitors info on the C-heap
-  GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list =
-         new (mtServiceability) GrowableArray<jvmtiMonitorStackDepthInfo*>(1, mtServiceability);
+  GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors_list =
+    new GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>(1);
 
   JvmtiVTMSTransitionDisabler disabler(thread);
   ThreadsListHandle tlh(calling_thread);

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -952,7 +952,7 @@ JvmtiEnvBase::get_current_contended_monitor(JavaThread *calling_thread, JavaThre
 
 jvmtiError
 JvmtiEnvBase::get_owned_monitors(JavaThread *calling_thread, JavaThread* java_thread,
-                                 GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list) {
+                                 GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors_list) {
   // Note:
   // calling_thread is the thread that requested the list of monitors for java_thread.
   // java_thread is the thread owning the monitors.
@@ -999,7 +999,7 @@ JvmtiEnvBase::get_owned_monitors(JavaThread *calling_thread, JavaThread* java_th
 
 jvmtiError
 JvmtiEnvBase::get_owned_monitors(JavaThread* calling_thread, JavaThread* java_thread, javaVFrame* jvf,
-                                 GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list) {
+                                 GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability> *owned_monitors_list) {
   jvmtiError err = JVMTI_ERROR_NONE;
   Thread *current_thread = Thread::current();
   assert(java_thread->is_handshake_safe_for(current_thread),
@@ -1027,7 +1027,8 @@ JvmtiEnvBase::get_owned_monitors(JavaThread* calling_thread, JavaThread* java_th
 // Save JNI local handles for any objects that this frame owns.
 jvmtiError
 JvmtiEnvBase::get_locked_objects_in_frame(JavaThread* calling_thread, JavaThread* java_thread,
-                                 javaVFrame *jvf, GrowableArray<jvmtiMonitorStackDepthInfo*>* owned_monitors_list, jint stack_depth) {
+                                 javaVFrame *jvf,
+                                 GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors_list, jint stack_depth) {
   jvmtiError err = JVMTI_ERROR_NONE;
   Thread* current_thread = Thread::current();
   ResourceMark rm(current_thread);
@@ -1814,7 +1815,7 @@ JvmtiEnvBase::resume_thread(oop thread_oop, JavaThread* java_thread, bool single
 
 ResourceTracker::ResourceTracker(JvmtiEnv* env) {
   _env = env;
-  _allocations = new (mtServiceability) GrowableArray<unsigned char*>(20, mtServiceability);
+  _allocations = new GrowableArrayCHeap<unsigned char*, mtServiceability>(20);
   _failed = false;
 }
 ResourceTracker::~ResourceTracker() {

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -359,7 +359,7 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
   jvmtiError get_locked_objects_in_frame(JavaThread *calling_thread,
                                    JavaThread* java_thread,
                                    javaVFrame *jvf,
-                                   GrowableArray<jvmtiMonitorStackDepthInfo*>* owned_monitors_list,
+                                   GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors_list,
                                    jint depth);
  public:
   static javaVFrame* jvf_for_thread_and_depth(JavaThread* java_thread, jint depth);
@@ -420,9 +420,9 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
   jvmtiError get_current_contended_monitor(JavaThread* calling_thread, JavaThread* java_thread,
                                            jobject* monitor_ptr, bool is_virtual);
   jvmtiError get_owned_monitors(JavaThread* calling_thread, JavaThread* java_thread,
-                                GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list);
+                                GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors_list);
   jvmtiError get_owned_monitors(JavaThread* calling_thread, JavaThread* java_thread, javaVFrame* jvf,
-                                GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list);
+                                GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors_list);
   static jvmtiError check_top_frame(Thread* current_thread, JavaThread* java_thread,
                                     jvalue value, TosState tos, Handle* ret_ob_h);
   jvmtiError force_early_return(jthread thread, jvalue value, TosState tos);
@@ -543,11 +543,11 @@ class GetOwnedMonitorInfoClosure : public JvmtiHandshakeClosure {
 private:
   JavaThread* _calling_thread;
   JvmtiEnv *_env;
-  GrowableArray<jvmtiMonitorStackDepthInfo*> *_owned_monitors_list;
+  GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* _owned_monitors_list;
 
 public:
   GetOwnedMonitorInfoClosure(JavaThread* calling_thread, JvmtiEnv* env,
-                             GrowableArray<jvmtiMonitorStackDepthInfo*>* owned_monitor_list)
+                             GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitor_list)
     : JvmtiHandshakeClosure("GetOwnedMonitorInfo"),
       _calling_thread(calling_thread),
       _env(env),
@@ -769,13 +769,13 @@ class VirtualThreadGetOwnedMonitorInfoClosure : public HandshakeClosure {
 private:
   JvmtiEnv *_env;
   Handle _vthread_h;
-  GrowableArray<jvmtiMonitorStackDepthInfo*> *_owned_monitors_list;
+  GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* _owned_monitors_list;
   jvmtiError _result;
 
 public:
   VirtualThreadGetOwnedMonitorInfoClosure(JvmtiEnv* env,
                                           Handle vthread_h,
-                                          GrowableArray<jvmtiMonitorStackDepthInfo*>* owned_monitors_list)
+                                          GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors_list)
     : HandshakeClosure("VirtualThreadGetOwnedMonitorInfo"),
       _env(env),
       _vthread_h(vthread_h),
@@ -842,7 +842,7 @@ public:
 class ResourceTracker : public StackObj {
  private:
   JvmtiEnv* _env;
-  GrowableArray<unsigned char*> *_allocations;
+  GrowableArrayCHeap<unsigned char*, mtServiceability> *_allocations;
   bool _failed;
  public:
   ResourceTracker(JvmtiEnv* env);
@@ -857,13 +857,13 @@ class ResourceTracker : public StackObj {
 class JvmtiMonitorClosure: public MonitorClosure {
  private:
   JavaThread *_calling_thread;
-  GrowableArray<jvmtiMonitorStackDepthInfo*> *_owned_monitors_list;
+  GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* _owned_monitors_list;
   jvmtiError _error;
   JvmtiEnvBase *_env;
 
  public:
   JvmtiMonitorClosure(JavaThread *calling_thread,
-                      GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors,
+                      GrowableArrayCHeap<jvmtiMonitorStackDepthInfo*, mtServiceability>* owned_monitors,
                       JvmtiEnvBase *env) {
     _calling_thread = calling_thread;
     _owned_monitors_list = owned_monitors;

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -95,7 +95,7 @@ JvmtiFramePops::clear_to(JvmtiFramePop& fp) {
 //
 
 JvmtiFramePops::JvmtiFramePops() {
-  _pops = new (mtServiceability) GrowableArray<int> (2, mtServiceability);
+  _pops = new GrowableArrayCHeap<int, mtServiceability> (2);
 }
 
 JvmtiFramePops::~JvmtiFramePops() {

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.hpp
@@ -78,7 +78,7 @@ class JvmtiFramePop {
 
 class JvmtiFramePops : public CHeapObj<mtInternal> {
  private:
-  GrowableArray<int>* _pops;
+  GrowableArrayCHeap<int, mtServiceability>* _pops;
 
   // should only be used by JvmtiEventControllerPrivate
   // to insure they only occur at safepoints.

--- a/src/hotspot/share/prims/jvmtiEventController.hpp
+++ b/src/hotspot/share/prims/jvmtiEventController.hpp
@@ -35,6 +35,7 @@ class JvmtiEventController;
 class JvmtiEnvThreadState;
 class JvmtiFramePop;
 class JvmtiEnvBase;
+class JvmtiThreadState;
 
 
 // Extension event support

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -3053,7 +3053,7 @@ JvmtiDynamicCodeEventCollector::~JvmtiDynamicCodeEventCollector() {
 // register a stub
 void JvmtiDynamicCodeEventCollector::register_stub(const char* name, address start, address end) {
  if (_code_blobs == nullptr) {
-   _code_blobs = new (mtServiceability) GrowableArray<JvmtiCodeBlobDesc*>(1, mtServiceability);
+   _code_blobs = new GrowableArrayCHeap<JvmtiCodeBlobDesc*, mtServiceability>(1);
  }
  _code_blobs->append(new JvmtiCodeBlobDesc(name, start, end));
 }
@@ -3082,7 +3082,7 @@ void JvmtiObjectAllocEventCollector::generate_call_for_allocated() {
 void JvmtiObjectAllocEventCollector::record_allocation(oop obj) {
   assert(is_enabled(), "Object alloc event collector is not enabled");
   if (_allocated == nullptr) {
-    _allocated = new (mtServiceability) GrowableArray<OopHandle>(1, mtServiceability);
+    _allocated = new GrowableArrayCHeap<OopHandle, mtServiceability>(1);
   }
   _allocated->push(OopHandle(JvmtiExport::jvmti_oop_storage(), obj));
 }

--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -502,7 +502,7 @@ class JvmtiEventCollector : public StackObj {
 
 class JvmtiDynamicCodeEventCollector : public JvmtiEventCollector {
  private:
-  GrowableArray<JvmtiCodeBlobDesc*>* _code_blobs;           // collected code blob events
+  GrowableArrayCHeap<JvmtiCodeBlobDesc*, mtServiceability>* _code_blobs; // collected code blob events
 
   friend class JvmtiExport;
   void register_stub(const char* name, address start, address end);
@@ -519,7 +519,7 @@ class JvmtiDynamicCodeEventCollector : public JvmtiEventCollector {
 //
 class JvmtiObjectAllocEventCollector : public JvmtiEventCollector {
  protected:
-  GrowableArray<OopHandle>* _allocated;      // field to record collected allocated object oop.
+  GrowableArrayCHeap<OopHandle, mtServiceability>* _allocated; // field to record collected allocated object oop.
   bool _enable;                   // This flag is enabled in constructor if set up in the thread state
                                   // and disabled in destructor before posting event. To avoid
                                   // collection of objects allocated while running java code inside

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -32,10 +32,10 @@
 #include "runtime/jniHandles.inline.hpp"
 
 // the list of extension functions
-GrowableArray<jvmtiExtensionFunctionInfo*>* JvmtiExtensions::_ext_functions;
+GrowableArrayCHeap<jvmtiExtensionFunctionInfo*, mtServiceability>* JvmtiExtensions::_ext_functions;
 
 // the list of extension events
-GrowableArray<jvmtiExtensionEventInfo*>* JvmtiExtensions::_ext_events;
+GrowableArrayCHeap<jvmtiExtensionEventInfo*, mtServiceability>* JvmtiExtensions::_ext_events;
 
 
 //
@@ -170,8 +170,8 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
 // event. The function and the event are registered here.
 //
 void JvmtiExtensions::register_extensions() {
-  _ext_functions = new (mtServiceability) GrowableArray<jvmtiExtensionFunctionInfo*>(1, mtServiceability);
-  _ext_events = new (mtServiceability) GrowableArray<jvmtiExtensionEventInfo*>(1, mtServiceability);
+  _ext_functions = new GrowableArrayCHeap<jvmtiExtensionFunctionInfo*, mtServiceability>(1);
+  _ext_events = new GrowableArrayCHeap<jvmtiExtensionEventInfo*, mtServiceability>(1);
 
   // Register our extension functions.
   static jvmtiParamInfo func_params0[] = {

--- a/src/hotspot/share/prims/jvmtiExtensions.hpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.hpp
@@ -38,8 +38,8 @@
 
 class JvmtiExtensions : public AllStatic {
  private:
-  static GrowableArray<jvmtiExtensionFunctionInfo*>* _ext_functions;
-  static GrowableArray<jvmtiExtensionEventInfo*>* _ext_events;
+  static GrowableArrayCHeap<jvmtiExtensionFunctionInfo*, mtServiceability>* _ext_functions;
+  static GrowableArrayCHeap<jvmtiExtensionEventInfo*, mtServiceability>* _ext_events;
 
  public:
   // register extensions function

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -139,7 +139,7 @@ GrowableCache::~GrowableCache() {
 void GrowableCache::initialize(void *this_obj, void listener_fun(void *, address*) ) {
   _this_obj       = this_obj;
   _listener_fun   = listener_fun;
-  _elements       = new (mtServiceability) GrowableArray<GrowableElement*>(5, mtServiceability);
+  _elements       = new GrowableArrayCHeap<GrowableElement*, mtServiceability>(5);
   recache();
 }
 

--- a/src/hotspot/share/prims/jvmtiImpl.hpp
+++ b/src/hotspot/share/prims/jvmtiImpl.hpp
@@ -78,7 +78,7 @@ private:
   void *_this_obj;
 
   // Array of elements in the collection
-  GrowableArray<GrowableElement *> *_elements;
+  GrowableArrayCHeap<GrowableElement*, mtServiceability> *_elements;
 
   // Parallel array of cached values
   address *_cache;

--- a/src/hotspot/share/prims/jvmtiRawMonitor.cpp
+++ b/src/hotspot/share/prims/jvmtiRawMonitor.cpp
@@ -36,8 +36,8 @@ JvmtiRawMonitor::QNode::QNode(Thread* thread) : _next(nullptr), _prev(nullptr),
                                                 _notified(0), _t_state(TS_RUN) {
 }
 
-GrowableArray<JvmtiRawMonitor*>* JvmtiPendingMonitors::_monitors =
-  new (mtServiceability) GrowableArray<JvmtiRawMonitor*>(1, mtServiceability);
+GrowableArrayCHeap<JvmtiRawMonitor*, mtServiceability>* JvmtiPendingMonitors::_monitors =
+  new GrowableArrayCHeap<JvmtiRawMonitor*, mtServiceability>(1);
 
 void JvmtiPendingMonitors::transition_raw_monitors() {
   assert((Threads::number_of_threads()==1),

--- a/src/hotspot/share/prims/jvmtiRawMonitor.hpp
+++ b/src/hotspot/share/prims/jvmtiRawMonitor.hpp
@@ -133,9 +133,10 @@ class JvmtiRawMonitor : public CHeapObj<mtSynchronizer>  {
 class JvmtiPendingMonitors : public AllStatic {
 
  private:
-  static GrowableArray<JvmtiRawMonitor*>* _monitors; // Cache raw monitor enter
+  // Cache raw monitor enter
+  static GrowableArrayCHeap<JvmtiRawMonitor*, mtServiceability>* _monitors;
 
-  inline static GrowableArray<JvmtiRawMonitor*>* monitors() { return _monitors; }
+  inline static GrowableArrayCHeap<JvmtiRawMonitor*, mtServiceability>* monitors() { return _monitors; }
 
   static void dispose() {
     delete monitors();

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -100,12 +100,12 @@ static inline InstanceKlass* get_ik(jclass def) {
 // Parallel constant pool merging leads to indeterminate constant pools.
 void VM_RedefineClasses::lock_classes() {
   JvmtiThreadState *state = JvmtiThreadState::state_for(JavaThread::current());
-  GrowableArray<Klass*>* redef_classes = state->get_classes_being_redefined();
+  GrowableArrayCHeap<Klass*, mtClass>* redef_classes = state->get_classes_being_redefined();
 
   MonitorLocker ml(RedefineClasses_lock);
 
   if (redef_classes == nullptr) {
-    redef_classes = new (mtClass) GrowableArray<Klass*>(1, mtClass);
+    redef_classes = new GrowableArrayCHeap<Klass*, mtClass>(1);
     state->set_classes_being_redefined(redef_classes);
   }
 
@@ -141,7 +141,7 @@ void VM_RedefineClasses::lock_classes() {
 
 void VM_RedefineClasses::unlock_classes() {
   JvmtiThreadState *state = JvmtiThreadState::state_for(JavaThread::current());
-  GrowableArray<Klass*>* redef_classes = state->get_classes_being_redefined();
+  GrowableArrayCHeap<Klass*, mtClass>* redef_classes = state->get_classes_being_redefined();
   assert(redef_classes != nullptr, "_classes_being_redefined is not allocated");
 
   MonitorLocker ml(RedefineClasses_lock);

--- a/src/hotspot/share/prims/jvmtiTagMap.cpp
+++ b/src/hotspot/share/prims/jvmtiTagMap.cpp
@@ -392,7 +392,7 @@ class ClassFieldMap: public CHeapObj<mtInternal> {
   };
 
   // list of field descriptors
-  GrowableArray<ClassFieldDescriptor*>* _fields;
+  GrowableArrayCHeap<ClassFieldDescriptor*, mtServiceability>* _fields;
 
   // constructor
   ClassFieldMap();
@@ -413,8 +413,7 @@ class ClassFieldMap: public CHeapObj<mtInternal> {
 };
 
 ClassFieldMap::ClassFieldMap() {
-  _fields = new (mtServiceability)
-    GrowableArray<ClassFieldDescriptor*>(initial_field_count, mtServiceability);
+  _fields = new GrowableArrayCHeap<ClassFieldDescriptor*, mtServiceability>(initial_field_count);
 }
 
 ClassFieldMap::~ClassFieldMap() {
@@ -495,7 +494,7 @@ class JvmtiCachedClassFieldMap : public CHeapObj<mtInternal> {
   JvmtiCachedClassFieldMap(ClassFieldMap* field_map);
   ~JvmtiCachedClassFieldMap();
 
-  static GrowableArray<InstanceKlass*>* _class_list;
+  static GrowableArrayCHeap<InstanceKlass*, mtServiceability>* _class_list;
   static void add_to_class_list(InstanceKlass* ik);
 
  public:
@@ -511,7 +510,7 @@ class JvmtiCachedClassFieldMap : public CHeapObj<mtInternal> {
   static int cached_field_map_count();
 };
 
-GrowableArray<InstanceKlass*>* JvmtiCachedClassFieldMap::_class_list;
+GrowableArrayCHeap<InstanceKlass*, mtServiceability>* JvmtiCachedClassFieldMap::_class_list;
 
 JvmtiCachedClassFieldMap::JvmtiCachedClassFieldMap(ClassFieldMap* field_map) {
   _field_map = field_map;
@@ -547,8 +546,7 @@ bool ClassFieldMapCacheMark::_is_active;
 // record that the given InstanceKlass is caching a field map
 void JvmtiCachedClassFieldMap::add_to_class_list(InstanceKlass* ik) {
   if (_class_list == nullptr) {
-    _class_list = new (mtServiceability)
-      GrowableArray<InstanceKlass*>(initial_class_count, mtServiceability);
+    _class_list = new GrowableArrayCHeap<InstanceKlass*, mtServiceability>(initial_class_count);
   }
   _class_list->push(ik);
 }
@@ -1216,8 +1214,8 @@ class TagObjectCollector : public JvmtiTagMapKeyClosure {
   jint _tag_count;
   bool _some_dead_found;
 
-  GrowableArray<jobject>* _object_results;  // collected objects (JNI weak refs)
-  GrowableArray<uint64_t>* _tag_results;    // collected tags
+  GrowableArrayCHeap<jobject, mtServiceability>* _object_results;  // collected objects (JNI weak refs)
+  GrowableArrayCHeap<uint64_t, mtServiceability>* _tag_results;    // collected tags
 
  public:
   TagObjectCollector(JvmtiEnv* env, const jlong* tags, jint tag_count) :
@@ -1226,8 +1224,8 @@ class TagObjectCollector : public JvmtiTagMapKeyClosure {
     _tags((jlong*)tags),
     _tag_count(tag_count),
     _some_dead_found(false),
-    _object_results(new (mtServiceability) GrowableArray<jobject>(1, mtServiceability)),
-    _tag_results(new (mtServiceability) GrowableArray<uint64_t>(1, mtServiceability)) { }
+    _object_results(new GrowableArrayCHeap<jobject, mtServiceability>(1)),
+    _tag_results(new GrowableArrayCHeap<uint64_t, mtServiceability>(1)) { }
 
   ~TagObjectCollector() {
     delete _object_results;
@@ -1449,13 +1447,13 @@ class CallbackInvoker : AllStatic {
   // context needed for all heap walks
   static JvmtiTagMap* _tag_map;
   static const void* _user_data;
-  static GrowableArray<oop>* _visit_stack;
+  static GrowableArrayCHeap<oop, mtServiceability>* _visit_stack;
   static JVMTIBitSet* _bitset;
 
   // accessors
-  static JvmtiTagMap* tag_map()                        { return _tag_map; }
-  static const void* user_data()                       { return _user_data; }
-  static GrowableArray<oop>* visit_stack()             { return _visit_stack; }
+  static JvmtiTagMap* tag_map()                                   { return _tag_map; }
+  static const void* user_data()                                  { return _user_data; }
+  static GrowableArrayCHeap<oop, mtServiceability>* visit_stack() { return _visit_stack; }
 
   // if the object hasn't been visited then push it onto the visit stack
   // so that it will be visited later
@@ -1489,14 +1487,14 @@ class CallbackInvoker : AllStatic {
  public:
   // initialize for basic mode
   static void initialize_for_basic_heap_walk(JvmtiTagMap* tag_map,
-                                             GrowableArray<oop>* visit_stack,
+                                             GrowableArrayCHeap<oop, mtServiceability>* visit_stack,
                                              const void* user_data,
                                              BasicHeapWalkContext context,
                                              JVMTIBitSet* bitset);
 
   // initialize for advanced mode
   static void initialize_for_advanced_heap_walk(JvmtiTagMap* tag_map,
-                                                GrowableArray<oop>* visit_stack,
+                                                GrowableArrayCHeap<oop, mtServiceability>* visit_stack,
                                                 const void* user_data,
                                                 AdvancedHeapWalkContext context,
                                                 JVMTIBitSet* bitset);
@@ -1531,12 +1529,12 @@ BasicHeapWalkContext CallbackInvoker::_basic_context;
 AdvancedHeapWalkContext CallbackInvoker::_advanced_context;
 JvmtiTagMap* CallbackInvoker::_tag_map;
 const void* CallbackInvoker::_user_data;
-GrowableArray<oop>* CallbackInvoker::_visit_stack;
+GrowableArrayCHeap<oop, mtServiceability>* CallbackInvoker::_visit_stack;
 JVMTIBitSet* CallbackInvoker::_bitset;
 
 // initialize for basic heap walk (IterateOverReachableObjects et al)
 void CallbackInvoker::initialize_for_basic_heap_walk(JvmtiTagMap* tag_map,
-                                                     GrowableArray<oop>* visit_stack,
+                                                     GrowableArrayCHeap<oop, mtServiceability>* visit_stack,
                                                      const void* user_data,
                                                      BasicHeapWalkContext context,
                                                      JVMTIBitSet* bitset) {
@@ -1551,7 +1549,7 @@ void CallbackInvoker::initialize_for_basic_heap_walk(JvmtiTagMap* tag_map,
 
 // initialize for advanced heap walk (FollowReferences)
 void CallbackInvoker::initialize_for_advanced_heap_walk(JvmtiTagMap* tag_map,
-                                                        GrowableArray<oop>* visit_stack,
+                                                        GrowableArrayCHeap<oop, mtServiceability>* visit_stack,
                                                         const void* user_data,
                                                         AdvancedHeapWalkContext context,
                                                         JVMTIBitSet* bitset) {
@@ -2385,7 +2383,7 @@ class VM_HeapWalkOperation: public VM_Operation {
   bool _is_advanced_heap_walk;                      // indicates FollowReferences
   JvmtiTagMap* _tag_map;
   Handle _initial_object;
-  GrowableArray<oop>* _visit_stack;                 // the visit stack
+  GrowableArrayCHeap<oop, mtServiceability>* _visit_stack; // the visit stack
 
   JVMTIBitSet _bitset;
 
@@ -2398,8 +2396,8 @@ class VM_HeapWalkOperation: public VM_Operation {
   bool _reporting_primitive_array_values;
   bool _reporting_string_values;
 
-  GrowableArray<oop>* create_visit_stack() {
-    return new (mtServiceability) GrowableArray<oop>(initial_visit_stack_size, mtServiceability);
+  GrowableArrayCHeap<oop, mtServiceability>* create_visit_stack() {
+    return new GrowableArrayCHeap<oop, mtServiceability>(initial_visit_stack_size);
   }
 
   // accessors
@@ -2413,7 +2411,7 @@ class VM_HeapWalkOperation: public VM_Operation {
   bool is_reporting_primitive_array_values() const { return _reporting_primitive_array_values; }
   bool is_reporting_string_values() const          { return _reporting_string_values; }
 
-  GrowableArray<oop>* visit_stack() const          { return _visit_stack; }
+  GrowableArrayCHeap<oop, mtServiceability>* visit_stack() const { return _visit_stack; }
 
   // iterate over the various object types
   inline bool iterate_over_array(oop o);

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -209,7 +209,7 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   // info to the class file load hook event handler.
   Klass*                _class_being_redefined;
   JvmtiClassLoadKind    _class_load_kind;
-  GrowableArray<Klass*>* _classes_being_redefined;
+  GrowableArrayCHeap<Klass*, mtClass>* _classes_being_redefined;
 
   // This is only valid when is_interp_only_mode() returns true
   int               _cur_stack_depth;
@@ -382,11 +382,11 @@ class JvmtiThreadState : public CHeapObj<mtInternal> {
   }
 
   // Get the classes that are currently being redefined by this thread.
-  inline GrowableArray<Klass*>* get_classes_being_redefined() {
+  inline GrowableArrayCHeap<Klass*, mtClass>* get_classes_being_redefined() {
     return _classes_being_redefined;
   }
 
-  inline void set_classes_being_redefined(GrowableArray<Klass*>* redef_classes) {
+  inline void set_classes_being_redefined(GrowableArrayCHeap<Klass*, mtClass>* redef_classes) {
     _classes_being_redefined = redef_classes;
   }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -118,7 +118,7 @@ SystemProperty *Arguments::_java_class_path = nullptr;
 SystemProperty *Arguments::_jdk_boot_class_path_append = nullptr;
 SystemProperty *Arguments::_vm_info = nullptr;
 
-GrowableArray<ModulePatchPath*> *Arguments::_patch_mod_prefix = nullptr;
+GrowableArrayCHeap<ModulePatchPath*, mtArguments> *Arguments::_patch_mod_prefix = nullptr;
 PathString *Arguments::_boot_class_path = nullptr;
 bool Arguments::_has_jimage = false;
 
@@ -2837,7 +2837,7 @@ void Arguments::add_patch_mod_prefix(const char* module_name, const char* path, 
 
   // Create GrowableArray lazily, only if --patch-module has been specified
   if (_patch_mod_prefix == nullptr) {
-    _patch_mod_prefix = new (mtArguments) GrowableArray<ModulePatchPath*>(10, mtArguments);
+    _patch_mod_prefix = new GrowableArrayCHeap<ModulePatchPath*, mtArguments>(10);
   }
 
   _patch_mod_prefix->push(new ModulePatchPath(module_name, path));

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -211,7 +211,7 @@ class Arguments : AllStatic {
   // --patch-module=module=<file>(<pathsep><file>)*
   // Each element contains the associated module name, path
   // string pair as specified to --patch-module.
-  static GrowableArray<ModulePatchPath*>* _patch_mod_prefix;
+  static GrowableArrayCHeap<ModulePatchPath*, mtArguments>* _patch_mod_prefix;
 
   // The constructed value of the system class path after
   // argument processing and JVMTI OnLoad additions via
@@ -481,7 +481,7 @@ class Arguments : AllStatic {
     _jdk_boot_class_path_append->append_value(value);
   }
 
-  static GrowableArray<ModulePatchPath*>* get_patch_mod_prefix() { return _patch_mod_prefix; }
+  static GrowableArrayCHeap<ModulePatchPath*, mtArguments>* get_patch_mod_prefix() { return _patch_mod_prefix; }
   static char* get_boot_class_path() { return _boot_class_path->value(); }
   static bool has_jimage() { return _has_jimage; }
 

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -1248,18 +1248,18 @@ extern "C" bool dbg_is_safe(const void* p, intptr_t errvalue);
 
 class FrameValuesOopClosure: public OopClosure, public DerivedOopClosure {
 private:
-  GrowableArray<oop*>* _oops;
-  GrowableArray<narrowOop*>* _narrow_oops;
-  GrowableArray<derived_base*>* _base;
-  GrowableArray<derived_pointer*>* _derived;
+  GrowableArrayCHeap<oop*, mtThread>* _oops;
+  GrowableArrayCHeap<narrowOop*, mtThread>* _narrow_oops;
+  GrowableArrayCHeap<derived_base*, mtThread>* _base;
+  GrowableArrayCHeap<derived_pointer*, mtThread>* _derived;
   NoSafepointVerifier nsv;
 
 public:
   FrameValuesOopClosure() {
-    _oops = new (mtThread) GrowableArray<oop*>(100, mtThread);
-    _narrow_oops = new (mtThread) GrowableArray<narrowOop*>(100, mtThread);
-    _base = new (mtThread) GrowableArray<derived_base*>(100, mtThread);
-    _derived = new (mtThread) GrowableArray<derived_pointer*>(100, mtThread);
+    _oops = new GrowableArrayCHeap<oop*, mtThread>(100);
+    _narrow_oops = new GrowableArrayCHeap<narrowOop*, mtThread>(100);
+    _base = new GrowableArrayCHeap<derived_base*, mtThread>(100);
+    _derived = new GrowableArrayCHeap<derived_pointer*, mtThread>(100);
   }
   ~FrameValuesOopClosure() {
     delete _oops;

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1364,7 +1364,7 @@ void JavaThread::oops_do_no_frames(OopClosure* f, CodeBlobClosure* cf) {
   assert(vframe_array_head() == nullptr, "deopt in progress at a safepoint!");
   // If we have deferred set_locals there might be oops waiting to be
   // written
-  GrowableArray<jvmtiDeferredLocalVariableSet*>* list = JvmtiDeferredUpdates::deferred_locals(this);
+  GrowableArrayCHeap<jvmtiDeferredLocalVariableSet*, mtCompiler>* list = JvmtiDeferredUpdates::deferred_locals(this);
   if (list != nullptr) {
     for (int i = 0; i < list->length(); i++) {
       list->at(i)->oops_do(f);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -115,6 +115,7 @@ class Mutex;
 struct jvmtiTimerInfo;
 
 template<class E> class GrowableArray;
+template<class E, MEMFLAGS F> class GrowableArrayCHeap;
 
 // %%%%% Moved ThreadState, START_FN, OSThread to new osThread.hpp. -- Rose
 

--- a/src/hotspot/share/runtime/perfData.cpp
+++ b/src/hotspot/share/runtime/perfData.cpp
@@ -492,12 +492,12 @@ PerfLongCounter* PerfDataManager::create_long_counter(CounterNS ns,
 
 PerfDataList::PerfDataList(int length) {
 
-  _set = new (mtInternal) PerfDataArray(length, mtInternal);
+  _set = new PerfDataArray(length);
 }
 
 PerfDataList::PerfDataList(PerfDataList* p) {
 
-  _set = new (mtInternal) PerfDataArray(p->length(), mtInternal);
+  _set = new PerfDataArray(p->length());
 
   _set->appendAll(p->get_impl());
 }

--- a/src/hotspot/share/runtime/perfData.hpp
+++ b/src/hotspot/share/runtime/perfData.hpp
@@ -30,7 +30,7 @@
 #include "runtime/perfMemory.hpp"
 #include "runtime/timer.hpp"
 
-template <typename T> class GrowableArray;
+template <typename T, MEMFLAGS F> class GrowableArrayCHeap;
 
 /* jvmstat global and subsystem counter name space - enumeration value
  * serve as an index into the PerfDataManager::_name_space[] array
@@ -575,7 +575,7 @@ class PerfDataList : public CHeapObj<mtInternal> {
   private:
 
     // GrowableArray implementation
-    typedef GrowableArray<PerfData*> PerfDataArray;
+    typedef GrowableArrayCHeap<PerfData*, mtInternal> PerfDataArray;
 
     PerfDataArray* _set;
 

--- a/src/hotspot/share/runtime/reflectionUtils.cpp
+++ b/src/hotspot/share/runtime/reflectionUtils.cpp
@@ -71,8 +71,8 @@ bool KlassStream::eos() {
 
 int FieldStream::length() { return _klass->java_fields_count(); }
 
-GrowableArray<FilteredField*> *FilteredFieldsMap::_filtered_fields =
-  new (mtServiceability) GrowableArray<FilteredField*>(3, mtServiceability);
+GrowableArrayCHeap<FilteredField*, mtServiceability> *FilteredFieldsMap::_filtered_fields =
+  new GrowableArrayCHeap<FilteredField*, mtServiceability>(3);
 
 
 void FilteredFieldsMap::initialize() {

--- a/src/hotspot/share/runtime/reflectionUtils.hpp
+++ b/src/hotspot/share/runtime/reflectionUtils.hpp
@@ -173,7 +173,7 @@ class FilteredField : public CHeapObj<mtInternal>  {
 
 class FilteredFieldsMap : AllStatic {
  private:
-  static GrowableArray<FilteredField *> *_filtered_fields;
+  static GrowableArrayCHeap<FilteredField*, mtServiceability> *_filtered_fields;
  public:
   static void initialize();
   static bool is_filtered_field(Klass* klass, int field_offset) {

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -79,7 +79,7 @@ Thread::Thread() {
   set_resource_area(new (mtThread)ResourceArea());
   DEBUG_ONLY(_current_resource_mark = nullptr;)
   set_handle_area(new (mtThread) HandleArea(nullptr));
-  set_metadata_handles(new (mtClass) GrowableArray<Metadata*>(30, mtClass));
+  set_metadata_handles(new GrowableArrayCHeap<Metadata*, mtClass>(30));
   set_last_handle_mark(nullptr);
   DEBUG_ONLY(_missed_ic_stub_refill_verifier = nullptr);
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -409,8 +409,8 @@ class Thread: public ThreadShadow {
   HandleArea* handle_area() const                { return _handle_area; }
   void set_handle_area(HandleArea* area)         { _handle_area = area; }
 
-  GrowableArray<Metadata*>* metadata_handles() const          { return _metadata_handles; }
-  void set_metadata_handles(GrowableArray<Metadata*>* handles){ _metadata_handles = handles; }
+  GrowableArrayCHeap<Metadata*, mtClass>* metadata_handles() const { return _metadata_handles; }
+  void set_metadata_handles(GrowableArrayCHeap<Metadata*, mtClass>* handles){ _metadata_handles = handles; }
 
   // Thread-Local Allocation Buffer (TLAB) support
   ThreadLocalAllocBuffer& tlab()                 { return _tlab; }
@@ -529,7 +529,7 @@ protected:
 
   // Thread local handle area for allocation of handles within the VM
   HandleArea* _handle_area;
-  GrowableArray<Metadata*>* _metadata_handles;
+  GrowableArrayCHeap<Metadata*, mtClass>* _metadata_handles;
 
   // Support for stack overflow handling, get_thread, etc.
   address          _stack_base;

--- a/src/hotspot/share/runtime/threads.hpp
+++ b/src/hotspot/share/runtime/threads.hpp
@@ -37,6 +37,7 @@ class Thread;
 class ThreadClosure;
 class ThreadsList;
 class outputStream;
+class ObjectMonitor;
 
 class CodeBlobClosure;
 class MetadataClosure;

--- a/src/hotspot/share/runtime/unhandledOops.cpp
+++ b/src/hotspot/share/runtime/unhandledOops.cpp
@@ -35,8 +35,7 @@ const int free_list_size = 256;
 
 UnhandledOops::UnhandledOops(Thread* thread) {
   _thread = thread;
-  _oop_list = new (mtThread)
-                    GrowableArray<UnhandledOopEntry>(free_list_size, mtThread);
+  _oop_list = new GrowableArrayCHeap<UnhandledOopEntry, mtThread>(free_list_size);
   _level = 0;
 }
 

--- a/src/hotspot/share/runtime/unhandledOops.hpp
+++ b/src/hotspot/share/runtime/unhandledOops.hpp
@@ -69,7 +69,7 @@ class UnhandledOops : public CHeapObj<mtThread> {
  private:
   Thread* _thread;
   int _level;
-  GrowableArray<UnhandledOopEntry> *_oop_list;
+  GrowableArrayCHeap<UnhandledOopEntry, mtThread> *_oop_list;
   void allow_unhandled_oop(oop* op);
   void clear_unhandled_oops();
   UnhandledOops(Thread* thread);

--- a/src/hotspot/share/runtime/vframe_hp.cpp
+++ b/src/hotspot/share/runtime/vframe_hp.cpp
@@ -69,7 +69,7 @@ StackValueCollection* compiledVFrame::locals() const {
   // Replace the original values with any stores that have been
   // performed through compiledVFrame::update_locals.
   if (!register_map()->in_cont()) { // LOOM TODO
-    GrowableArray<jvmtiDeferredLocalVariableSet*>* list = JvmtiDeferredUpdates::deferred_locals(thread());
+    GrowableArrayCHeap<jvmtiDeferredLocalVariableSet*, mtCompiler>* list = JvmtiDeferredUpdates::deferred_locals(thread());
     if (list != nullptr ) {
       // In real life this never happens or is typically a single element search
       for (int i = 0; i < list->length(); i++) {
@@ -110,7 +110,7 @@ void compiledVFrame::update_monitor(int index, MonitorInfo* val) {
 void compiledVFrame::update_deferred_value(BasicType type, int index, jvalue value) {
   assert(fr().is_deoptimized_frame(), "frame must be scheduled for deoptimization");
   assert(!Continuation::is_frame_in_continuation(thread(), fr()), "No support for deferred values in continuations");
-  GrowableArray<jvmtiDeferredLocalVariableSet*>* deferred = JvmtiDeferredUpdates::deferred_locals(thread());
+  GrowableArrayCHeap<jvmtiDeferredLocalVariableSet*, mtCompiler>* deferred = JvmtiDeferredUpdates::deferred_locals(thread());
   jvmtiDeferredLocalVariableSet* locals = nullptr;
   if (deferred != nullptr ) {
     // See if this vframe has already had locals with deferred writes
@@ -202,7 +202,7 @@ StackValueCollection* compiledVFrame::expressions() const {
   if (!register_map()->in_cont()) { // LOOM TODO
     // Replace the original values with any stores that have been
     // performed through compiledVFrame::update_stack.
-    GrowableArray<jvmtiDeferredLocalVariableSet*>* list = JvmtiDeferredUpdates::deferred_locals(thread());
+    GrowableArrayCHeap<jvmtiDeferredLocalVariableSet*, mtCompiler>* list = JvmtiDeferredUpdates::deferred_locals(thread());
     if (list != nullptr ) {
       // In real life this never happens or is typically a single element search
       for (int i = 0; i < list->length(); i++) {
@@ -413,7 +413,7 @@ jvmtiDeferredLocalVariableSet::jvmtiDeferredLocalVariableSet(Method* method, int
   _id = id;
   _vframe_id = vframe_id;
   // Always will need at least one, must be on C heap
-  _locals = new(mtCompiler) GrowableArray<jvmtiDeferredLocalVariable*> (1, mtCompiler);
+  _locals = new GrowableArrayCHeap<jvmtiDeferredLocalVariable*, mtCompiler>(1);
   _objects_are_deoptimized = false;
 }
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -498,7 +498,7 @@
   /* CodeCache (NOTE: incomplete) */                                                                                                 \
   /********************************/                                                                                                 \
                                                                                                                                      \
-     static_field(CodeCache,                   _heaps,                                        GrowableArray<CodeHeap*>*)             \
+     static_field(CodeCache,                   _heaps,                                        CodeCache::CodeHeapArray*)             \
      static_field(CodeCache,                   _low_bound,                                    address)                               \
      static_field(CodeCache,                   _high_bound,                                   address)                               \
                                                                                                                                      \
@@ -1237,6 +1237,7 @@
                                                                           \
   declare_toplevel_type(GrowableArrayBase)                                \
   declare_toplevel_type(GrowableArray<int>)                               \
+  declare_toplevel_type(CodeCache::CodeHeapArray)                         \
   declare_toplevel_type(Arena)                                            \
     declare_type(ResourceArea, Arena)                                     \
                                                                           \

--- a/src/hotspot/share/services/diagnosticArgument.cpp
+++ b/src/hotspot/share/services/diagnosticArgument.cpp
@@ -31,7 +31,7 @@
 #include "utilities/globalDefinitions.hpp"
 
 StringArrayArgument::StringArrayArgument() {
-  _array = new (mtServiceability) GrowableArray<char *>(32, mtServiceability);
+  _array = new GrowableArrayCHeap<char*, mtServiceability>(32);
   assert(_array != nullptr, "Sanity check");
 }
 

--- a/src/hotspot/share/services/diagnosticArgument.hpp
+++ b/src/hotspot/share/services/diagnosticArgument.hpp
@@ -33,14 +33,14 @@
 
 class StringArrayArgument : public CHeapObj<mtInternal> {
 private:
-  GrowableArray<char*>* _array;
+  GrowableArrayCHeap<char*, mtServiceability>* _array;
 public:
   StringArrayArgument();
   ~StringArrayArgument();
 
   void add(const char* str, size_t len);
 
-  GrowableArray<char*>* array() {
+  GrowableArrayCHeap<char*, mtServiceability>* array() {
     return _array;
   }
 };

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1623,7 +1623,7 @@ private:
   JavaThread* _java_thread;
   oop _thread_oop;
 
-  GrowableArray<StackFrameInfo*>* _frames;
+  GrowableArrayCHeap<StackFrameInfo*, mtServiceability>* _frames;
   // non-null if the thread is OOM thread
   Method* _oome_constructor;
   int _thread_serial_num;
@@ -1673,7 +1673,7 @@ public:
 
   // writes HPROF_TRACE and HPROF_FRAME records
   // returns number of dumped frames
-  void dump_stack_traces(AbstractDumpWriter* writer, GrowableArray<Klass*>* klass_map);
+  void dump_stack_traces(AbstractDumpWriter* writer, GrowableArrayCHeap<Klass*, mtServiceability>* klass_map);
 
   // writes HPROF_GC_ROOT_THREAD_OBJ subrecord
   void dump_thread_obj(AbstractDumpWriter* writer);
@@ -1699,7 +1699,7 @@ ThreadDumper::ThreadDumper(ThreadType thread_type, JavaThread* java_thread, oop 
     assert(_thread_oop != nullptr, "sanity");
   }
 
-  _frames = new (mtServiceability) GrowableArray<StackFrameInfo*>(10, mtServiceability);
+  _frames = new GrowableArrayCHeap<StackFrameInfo*, mtServiceability>(10);
   bool stop_at_vthread_entry = _thread_type == ThreadType::MountedVirtual;
 
   // vframes are resource allocated
@@ -1720,7 +1720,7 @@ ThreadDumper::ThreadDumper(ThreadType thread_type, JavaThread* java_thread, oop 
   }
 }
 
-void ThreadDumper::dump_stack_traces(AbstractDumpWriter* writer, GrowableArray<Klass*>* klass_map) {
+void ThreadDumper::dump_stack_traces(AbstractDumpWriter* writer, GrowableArrayCHeap<Klass*, mtServiceability>* klass_map) {
   assert(_thread_serial_num != 0 && _start_frame_serial_num != 0, "serial_nums are not initialized");
 
   // write HPROF_FRAME records for this thread's stack trace
@@ -2173,7 +2173,7 @@ class VM_HeapDumper : public VM_GC_Operation, public WorkerTask, public Unmounte
   JavaThread*             _oome_thread;
   Method*                 _oome_constructor;
   bool                    _gc_before_heap_dump;
-  GrowableArray<Klass*>*  _klass_map;
+  GrowableArrayCHeap<Klass*, mtServiceability>*  _klass_map;
 
   ThreadDumper**          _thread_dumpers; // platform, carrier and mounted virtual threads
   int                     _thread_dumpers_count;
@@ -2238,7 +2238,7 @@ class VM_HeapDumper : public VM_GC_Operation, public WorkerTask, public Unmounte
     WorkerTask("dump heap") {
     _local_writer = writer;
     _gc_before_heap_dump = gc_before_heap_dump;
-    _klass_map = new (mtServiceability) GrowableArray<Klass*>(INITIAL_CLASS_COUNT, mtServiceability);
+    _klass_map = new GrowableArrayCHeap<Klass*, mtServiceability>(INITIAL_CLASS_COUNT);
 
     _thread_dumpers = nullptr;
     _thread_dumpers_count = 0;

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1258,7 +1258,7 @@ JVM_ENTRY(jobjectArray, jmm_DumpThreads(JNIEnv *env, jlongArray thread_ids, jboo
       for (int depth = 0; depth < num_frames; depth++) {
         StackFrameInfo* frame = stacktrace->stack_frame_at(depth);
         int len = frame->num_locked_monitors();
-        GrowableArray<OopHandle>* locked_monitors = frame->locked_monitors();
+        GrowableArrayCHeap<OopHandle, mtServiceability>* locked_monitors = frame->locked_monitors();
         for (j = 0; j < len; j++) {
           oop monitor = locked_monitors->at(j).resolve();
           assert(monitor != nullptr, "must be a Java object");
@@ -1268,7 +1268,7 @@ JVM_ENTRY(jobjectArray, jmm_DumpThreads(JNIEnv *env, jlongArray thread_ids, jboo
         }
       }
 
-      GrowableArray<OopHandle>* jni_locked_monitors = stacktrace->jni_locked_monitors();
+      GrowableArrayCHeap<OopHandle, mtServiceability>* jni_locked_monitors = stacktrace->jni_locked_monitors();
       for (j = 0; j < jni_locked_monitors->length(); j++) {
         oop object = jni_locked_monitors->at(j).resolve();
         assert(object != nullptr, "must be a Java object");
@@ -1284,7 +1284,7 @@ JVM_ENTRY(jobjectArray, jmm_DumpThreads(JNIEnv *env, jlongArray thread_ids, jboo
       // Create Object[] filled with locked JSR-166 synchronizers
       assert(ts->threadObj() != nullptr, "Must be a valid JavaThread");
       ThreadConcurrentLocks* tcl = ts->get_concurrent_locks();
-      GrowableArray<OopHandle>* locks = (tcl != nullptr ? tcl->owned_locks() : nullptr);
+      GrowableArrayCHeap<OopHandle, mtServiceability>* locks = (tcl != nullptr ? tcl->owned_locks() : nullptr);
       int num_locked_synchronizers = (locks != nullptr ? locks->length() : 0);
 
       objArrayOop array = oopFactory::new_objArray(vmClasses::Object_klass(), num_locked_synchronizers, CHECK_NULL);
@@ -1759,7 +1759,7 @@ static Handle find_deadlocks(bool object_monitors_only, TRAPS) {
 
   int index = 0;
   for (cycle = deadlocks; cycle != nullptr; cycle = cycle->next()) {
-    GrowableArray<JavaThread*>* deadlock_threads = cycle->threads();
+    GrowableArrayCHeap<JavaThread*, mtServiceability>* deadlock_threads = cycle->threads();
     int len = deadlock_threads->length();
     for (int i = 0; i < len; i++) {
       threads_ah->obj_at_put(index, deadlock_threads->at(i)->threadObj());

--- a/src/hotspot/share/services/memoryService.cpp
+++ b/src/hotspot/share/services/memoryService.cpp
@@ -43,14 +43,14 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 
-GrowableArray<MemoryPool*>* MemoryService::_pools_list =
-  new (mtServiceability) GrowableArray<MemoryPool*>(init_pools_list_size, mtServiceability);
-GrowableArray<MemoryManager*>* MemoryService::_managers_list =
-  new (mtServiceability) GrowableArray<MemoryManager*>(init_managers_list_size, mtServiceability);
+GrowableArrayCHeap<MemoryPool*, mtServiceability>* MemoryService::_pools_list =
+  new GrowableArrayCHeap<MemoryPool*, mtServiceability>(init_pools_list_size);
+GrowableArrayCHeap<MemoryManager*, mtServiceability>* MemoryService::_managers_list =
+  new GrowableArrayCHeap<MemoryManager*, mtServiceability>(init_managers_list_size);
 
 MemoryManager*   MemoryService::_code_cache_manager    = nullptr;
-GrowableArray<MemoryPool*>* MemoryService::_code_heap_pools =
-    new (mtServiceability) GrowableArray<MemoryPool*>(init_code_heap_pools_size, mtServiceability);
+GrowableArrayCHeap<MemoryPool*, mtServiceability>* MemoryService::_code_heap_pools =
+  new GrowableArrayCHeap<MemoryPool*, mtServiceability>(init_code_heap_pools_size);
 MemoryPool*      MemoryService::_metaspace_pool        = nullptr;
 MemoryPool*      MemoryService::_compressed_class_pool = nullptr;
 

--- a/src/hotspot/share/services/memoryService.hpp
+++ b/src/hotspot/share/services/memoryService.hpp
@@ -49,15 +49,15 @@ private:
     init_code_heap_pools_size = 9
   };
 
-  static GrowableArray<MemoryPool*>*    _pools_list;
-  static GrowableArray<MemoryManager*>* _managers_list;
+  static GrowableArrayCHeap<MemoryPool*, mtServiceability>*    _pools_list;
+  static GrowableArrayCHeap<MemoryManager*, mtServiceability>* _managers_list;
 
   // memory manager and code heap pools for the CodeCache
-  static MemoryManager*                 _code_cache_manager;
-  static GrowableArray<MemoryPool*>*    _code_heap_pools;
+  static MemoryManager*                                        _code_cache_manager;
+  static GrowableArrayCHeap<MemoryPool*, mtServiceability>*    _code_heap_pools;
 
-  static MemoryPool*                    _metaspace_pool;
-  static MemoryPool*                    _compressed_class_pool;
+  static MemoryPool*                                           _metaspace_pool;
+  static MemoryPool*                                           _compressed_class_pool;
 
 public:
   static void set_universe_heap(CollectedHeap* heap);

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -609,7 +609,7 @@ StackFrameInfo::StackFrameInfo(javaVFrame* jvf, bool with_lock_info) {
     GrowableArray<MonitorInfo*>* list = jvf->locked_monitors();
     int length = list->length();
     if (length > 0) {
-      _locked_monitors = new (mtServiceability) GrowableArray<OopHandle>(length, mtServiceability);
+      _locked_monitors = new GrowableArrayCHeap<OopHandle, mtServiceability>(length);
       for (int i = 0; i < length; i++) {
         MonitorInfo* monitor = list->at(i);
         assert(monitor->owner() != nullptr, "This monitor must have an owning object");
@@ -661,11 +661,11 @@ public:
 
 ThreadStackTrace::ThreadStackTrace(JavaThread* t, bool with_locked_monitors) {
   _thread = t;
-  _frames = new (mtServiceability) GrowableArray<StackFrameInfo*>(INITIAL_ARRAY_SIZE, mtServiceability);
+  _frames = new GrowableArrayCHeap<StackFrameInfo*, mtServiceability>(INITIAL_ARRAY_SIZE);
   _depth = 0;
   _with_locked_monitors = with_locked_monitors;
   if (_with_locked_monitors) {
-    _jni_locked_monitors = new (mtServiceability) GrowableArray<OopHandle>(INITIAL_ARRAY_SIZE, mtServiceability);
+    _jni_locked_monitors = new GrowableArrayCHeap<OopHandle, mtServiceability>(INITIAL_ARRAY_SIZE);
   } else {
     _jni_locked_monitors = nullptr;
   }
@@ -737,7 +737,7 @@ bool ThreadStackTrace::is_owned_monitor_on_stack(oop object) {
   for (int depth = 0; depth < num_frames; depth++) {
     StackFrameInfo* frame = stack_frame_at(depth);
     int len = frame->num_locked_monitors();
-    GrowableArray<OopHandle>* locked_monitors = frame->locked_monitors();
+    GrowableArrayCHeap<OopHandle, mtServiceability>* locked_monitors = frame->locked_monitors();
     for (int j = 0; j < len; j++) {
       oop monitor = locked_monitors->at(j).resolve();
       assert(monitor != nullptr, "must be a Java object");
@@ -796,7 +796,7 @@ void ConcurrentLocksDump::dump_at_safepoint() {
   // dump all locked concurrent locks
   assert(SafepointSynchronize::is_at_safepoint(), "all threads are stopped");
 
-  GrowableArray<oop>* aos_objects = new (mtServiceability) GrowableArray<oop>(INITIAL_ARRAY_SIZE, mtServiceability);
+  GrowableArrayCHeap<oop, mtServiceability>* aos_objects = new GrowableArrayCHeap<oop, mtServiceability>(INITIAL_ARRAY_SIZE);
 
   // Find all instances of AbstractOwnableSynchronizer
   HeapInspection::find_instances_at_safepoint(vmClasses::java_util_concurrent_locks_AbstractOwnableSynchronizer_klass(),
@@ -809,7 +809,7 @@ void ConcurrentLocksDump::dump_at_safepoint() {
 
 
 // build a map of JavaThread to all its owned AbstractOwnableSynchronizer
-void ConcurrentLocksDump::build_map(GrowableArray<oop>* aos_objects) {
+void ConcurrentLocksDump::build_map(GrowableArrayCHeap<oop, mtServiceability>* aos_objects) {
   int length = aos_objects->length();
   for (int i = 0; i < length; i++) {
     oop o = aos_objects->at(i);
@@ -854,7 +854,7 @@ ThreadConcurrentLocks* ConcurrentLocksDump::thread_concurrent_locks(JavaThread* 
 void ConcurrentLocksDump::print_locks_on(JavaThread* t, outputStream* st) {
   st->print_cr("   Locked ownable synchronizers:");
   ThreadConcurrentLocks* tcl = thread_concurrent_locks(t);
-  GrowableArray<OopHandle>* locks = (tcl != nullptr ? tcl->owned_locks() : nullptr);
+  GrowableArrayCHeap<OopHandle, mtServiceability>* locks = (tcl != nullptr ? tcl->owned_locks() : nullptr);
   if (locks == nullptr || locks->is_empty()) {
     st->print_cr("\t- None");
     st->cr();
@@ -870,7 +870,7 @@ void ConcurrentLocksDump::print_locks_on(JavaThread* t, outputStream* st) {
 
 ThreadConcurrentLocks::ThreadConcurrentLocks(JavaThread* thread) {
   _thread = thread;
-  _owned_locks = new (mtServiceability) GrowableArray<OopHandle>(INITIAL_ARRAY_SIZE, mtServiceability);
+  _owned_locks = new GrowableArrayCHeap<OopHandle, mtServiceability>(INITIAL_ARRAY_SIZE);
   _next = nullptr;
 }
 
@@ -993,7 +993,7 @@ void ThreadSnapshot::metadata_do(void f(Metadata*)) {
 
 
 DeadlockCycle::DeadlockCycle() {
-  _threads = new (mtServiceability) GrowableArray<JavaThread*>(INITIAL_ARRAY_SIZE, mtServiceability);
+  _threads = new GrowableArrayCHeap<JavaThread*, mtServiceability>(INITIAL_ARRAY_SIZE);
   _next = nullptr;
 }
 

--- a/src/hotspot/share/services/threadService.hpp
+++ b/src/hotspot/share/services/threadService.hpp
@@ -271,11 +271,11 @@ public:
 
 class ThreadStackTrace : public CHeapObj<mtInternal> {
  private:
-  JavaThread*                     _thread;
-  int                             _depth;  // number of stack frames added
-  bool                            _with_locked_monitors;
-  GrowableArray<StackFrameInfo*>* _frames;
-  GrowableArray<OopHandle>*       _jni_locked_monitors;
+  JavaThread*                                            _thread;
+  int                                                    _depth;  // number of stack frames added
+  bool                                                   _with_locked_monitors;
+  GrowableArrayCHeap<StackFrameInfo*, mtServiceability>* _frames;
+  GrowableArrayCHeap<OopHandle, mtServiceability>*       _jni_locked_monitors;
 
  public:
 
@@ -290,7 +290,7 @@ class ThreadStackTrace : public CHeapObj<mtInternal> {
   void            dump_stack_at_safepoint(int max_depth, ObjectMonitorsView* monitors, bool full);
   Handle          allocate_fill_stack_trace_element_array(TRAPS);
   void            metadata_do(void f(Metadata*));
-  GrowableArray<OopHandle>* jni_locked_monitors() { return _jni_locked_monitors; }
+  GrowableArrayCHeap<OopHandle, mtServiceability>* jni_locked_monitors() { return _jni_locked_monitors; }
   int             num_jni_locked_monitors() { return (_jni_locked_monitors != nullptr ? _jni_locked_monitors->length() : 0); }
 
   bool            is_owned_monitor_on_stack(oop object);
@@ -304,7 +304,8 @@ class StackFrameInfo : public CHeapObj<mtInternal> {
  private:
   Method*             _method;
   int                 _bci;
-  GrowableArray<OopHandle>* _locked_monitors; // list of object monitors locked by this frame
+  // list of object monitors locked by this frame
+  GrowableArrayCHeap<OopHandle, mtServiceability>* _locked_monitors;
   // We need to save the mirrors in the backtrace to keep the class
   // from being unloaded while we still have this stack trace.
   OopHandle           _class_holder;
@@ -318,14 +319,14 @@ class StackFrameInfo : public CHeapObj<mtInternal> {
   void      metadata_do(void f(Metadata*));
 
   int       num_locked_monitors()       { return (_locked_monitors != nullptr ? _locked_monitors->length() : 0); }
-  GrowableArray<OopHandle>* locked_monitors() { return _locked_monitors; }
+  GrowableArrayCHeap<OopHandle, mtServiceability>* locked_monitors() { return _locked_monitors; }
 
   void      print_on(outputStream* st) const;
 };
 
 class ThreadConcurrentLocks : public CHeapObj<mtInternal> {
 private:
-  GrowableArray<OopHandle>*   _owned_locks;
+  GrowableArrayCHeap<OopHandle, mtServiceability>* _owned_locks;
   ThreadConcurrentLocks*      _next;
   // This JavaThread* is protected in one of two different ways
   // depending on the usage of the ThreadConcurrentLocks object:
@@ -342,7 +343,7 @@ private:
   void                        set_next(ThreadConcurrentLocks* n) { _next = n; }
   ThreadConcurrentLocks*      next() { return _next; }
   JavaThread*                 java_thread()                      { return _thread; }
-  GrowableArray<OopHandle>*   owned_locks()                      { return _owned_locks; }
+  GrowableArrayCHeap<OopHandle, mtServiceability>* owned_locks() { return _owned_locks; }
 };
 
 class ConcurrentLocksDump : public StackObj {
@@ -351,7 +352,7 @@ class ConcurrentLocksDump : public StackObj {
   ThreadConcurrentLocks* _last;   // Last ThreadConcurrentLocks in the map
   bool                   _retain_map_on_free;
 
-  void build_map(GrowableArray<oop>* aos_objects);
+  void build_map(GrowableArrayCHeap<oop, mtServiceability>* aos_objects);
   void add_lock(JavaThread* thread, instanceOop o);
 
  public:
@@ -401,8 +402,8 @@ class ThreadDumpResult : public StackObj {
 
 class DeadlockCycle : public CHeapObj<mtInternal> {
  private:
-  GrowableArray<JavaThread*>* _threads;
-  DeadlockCycle*              _next;
+  GrowableArrayCHeap<JavaThread*, mtServiceability>* _threads;
+  DeadlockCycle* _next;
  public:
   DeadlockCycle();
   ~DeadlockCycle();
@@ -412,7 +413,7 @@ class DeadlockCycle : public CHeapObj<mtInternal> {
   void           add_thread(JavaThread* t)  { _threads->append(t); }
   void           reset()                    { _threads->clear(); }
   int            num_threads()              { return _threads->length(); }
-  GrowableArray<JavaThread*>* threads()     { return _threads; }
+  GrowableArrayCHeap<JavaThread*, mtServiceability>* threads() { return _threads; }
   void           print_on_with(ThreadsList * t_list, outputStream* st) const;
 };
 

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -188,7 +188,10 @@ class BitMap {
   BitMap(bm_word_t* map, idx_t size_in_bits) : _map(map), _size(size_in_bits) {
     verify_size(size_in_bits);
   }
-  ~BitMap() {}
+
+  // Declare destructor protected, so we cannot destruct only the
+  // base class part. And keep it trivial by making it default.
+  ~BitMap() = default;
 
  public:
   // Pretouch the entire range of memory this BitMap covers.

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -630,7 +630,7 @@ public:
 // the arena / resource area, but rather just abandons it until the memory is
 // released by the arena or by the ResourceMark from the resource area.
 // Because GrowableArrays are often just abandoned rather than properly destructed,
-// is is recommended that elements are trivially destructible, so that it makes no
+// we require that the element type E is trivially destructible, so that it makes no
 // difference if the destructors are called or not.
 //
 // GrowableArray is copyable, but it only creates a shallow copy. Hence, one has

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -60,7 +60,7 @@
 /*    ...                                                                */
 /* }                                                                     */
 /*                                                                       */
-/* If the GrowableArrays you are creating is C_Heap allocated then it    */
+/* If you are using a GrowableArrayCHeap (allocates on C-Heap) then it   */
 /* should not hold handles since the handles could trivially try and     */
 /* outlive their HandleMark. In some situations you might need to do     */
 /* this and it would be legal but be very careful and see if you can do  */

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -756,27 +756,11 @@ public:
     init_checks();
   }
 
-  GrowableArray(int initial_capacity, MEMFLAGS memflags) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
-          allocate(initial_capacity, memflags),
-          initial_capacity),
-      _metadata(memflags) {
-    init_checks();
-  }
-
   GrowableArray(int initial_capacity, int initial_len, const E& filler) :
       GrowableArrayWithAllocator<E, GrowableArray<E> >(
           allocate(initial_capacity),
           initial_capacity, initial_len, filler),
       _metadata() {
-    init_checks();
-  }
-
-  GrowableArray(int initial_capacity, int initial_len, const E& filler, MEMFLAGS memflags) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
-          allocate(initial_capacity, memflags),
-          initial_capacity, initial_len, filler),
-      _metadata(memflags) {
     init_checks();
   }
 

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -748,7 +748,7 @@ class GrowableArrayCHeap : public GrowableArrayWithAllocator<E, GrowableArrayCHe
   }
 
 public:
-  GrowableArrayCHeap(int initial_capacity = 0) :
+  explicit GrowableArrayCHeap(int initial_capacity = 0) :
       GrowableArrayWithAllocator<E, GrowableArrayCHeap<E, F> >(
           allocate(initial_capacity, F),
           initial_capacity) {}

--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -188,6 +188,12 @@ public:
     _data[i] = elem;
   }
 
+  void at_swap(int i, int j) {
+    E tmp = this->at(i);
+    this->at_put(i, this->at(j));
+    this->at_put(j, tmp);
+  }
+
   bool contains(const E& elem) const {
     for (int i = 0; i < _len; i++) {
       if (_data[i] == elem) return true;

--- a/test/hotspot/gtest/utilities/test_growableArray.cpp
+++ b/test/hotspot/gtest/utilities/test_growableArray.cpp
@@ -51,20 +51,6 @@ struct WithEmbeddedCHeapArray {
 // Test fixture to work with TEST_VM_F
 class GrowableArrayTest : public ::testing::Test {
 protected:
-  // friend -> private accessors
-  template <typename E>
-  static bool elements_on_C_heap(const GrowableArray<E>* array) {
-    return array->on_C_heap();
-  }
-  template <typename E>
-  static bool elements_on_resource_area(const GrowableArray<E>* array) {
-    return array->on_resource_area();
-  }
-  template <typename E>
-  static bool elements_on_arena(const GrowableArray<E>* array) {
-    return array->on_arena();
-  }
-
   template <typename ArrayClass>
   static void test_append(ArrayClass* a) {
     // Add elements
@@ -477,7 +463,7 @@ TEST_VM_F(GrowableArrayTest, where) {
     ResourceMark rm;
     GrowableArray<int>* a = new GrowableArray<int>();
     ASSERT_TRUE(a->allocated_on_res_area());
-    ASSERT_TRUE(elements_on_resource_area(a));
+    ASSERT_TRUE(a->on_resource_area());
   }
 
   // Resource/CHeap allocated
@@ -504,7 +490,7 @@ TEST_VM_F(GrowableArrayTest, where) {
     ResourceMark rm;
     GrowableArray<int> a(0);
     ASSERT_TRUE(a.allocated_on_stack_or_embedded());
-    ASSERT_TRUE(elements_on_resource_area(&a));
+    ASSERT_TRUE(a.on_resource_area());
   }
 
   // Stack/CHeap allocated
@@ -518,7 +504,7 @@ TEST_VM_F(GrowableArrayTest, where) {
     Arena arena(mtTest);
     GrowableArray<int> a(&arena, 0, 0, 0);
     ASSERT_TRUE(a.allocated_on_stack_or_embedded());
-    ASSERT_TRUE(elements_on_arena(&a));
+    ASSERT_TRUE(!a.on_resource_area());
   }
 
   // Embedded/Resource allocated
@@ -526,7 +512,7 @@ TEST_VM_F(GrowableArrayTest, where) {
     ResourceMark rm;
     WithEmbeddedArray w(0);
     ASSERT_TRUE(w._a.allocated_on_stack_or_embedded());
-    ASSERT_TRUE(elements_on_resource_area(&w._a));
+    ASSERT_TRUE(w._a.on_resource_area());
   }
 
   // Embedded/CHeap allocated
@@ -540,7 +526,7 @@ TEST_VM_F(GrowableArrayTest, where) {
     Arena arena(mtTest);
     WithEmbeddedArray w(&arena, 0);
     ASSERT_TRUE(w._a.allocated_on_stack_or_embedded());
-    ASSERT_TRUE(elements_on_arena(&w._a));
+    ASSERT_TRUE(!w._a.on_resource_area());
   }
 }
 #endif


### PR DESCRIPTION
[JDK-8247755](https://bugs.openjdk.org/browse/JDK-8247755) introduced the `GrowableArrayCHeap`. This duplicates the current C-Heap allocation capability in `GrowableArray`. I now remove that from `GrowableArray` and move all usages to `GrowableArrayCHeap`.

This has a few advantages:
- Clear separation between arena (and resource area) allocating array and C-heap allocating array.
- We can prevent assigning / copying between arrays of different allocation strategies already at compile time, and not only with asserts at runtime.
- We should not have multiple implementations of the same thing (C-Heap backed array).
- `GrowableArrayCHeap` is NONCOPYABLE. This is a nice restriction, we now know that C-Heap backed arrays do not get copied unknowingly.

**Bonus**
We can now restrict `GrowableArray` element type `E` to be `std::is_trivially_destructible<E>::value == true`. The idea is that arena / resource allocated arrays get abandoned, often without being even cleared. Hence, the elements in the array are never destructed. But if we only use elements that are trivially destructible, then it makes no difference if the destructors are ever called, or the elements simply abandoned.

For `GrowableArrayCHeap`, we expect that the user eventually calls the destructor for the array, which in turn calls the destructors of the remaining elements. Hence, it is up to the user to ensure the cleanup. And so we can allow non-trivial destructors.

**Testing**
Tier1-3 + stress testing: pending

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blockers
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with updated jcheck configuration in pull request)
&nbsp;⚠️ Whitespace errors (failed with updated jcheck configuration in pull request)

### Issue
 * [JDK-8322476](https://bugs.openjdk.org/browse/JDK-8322476): Remove GrowableArray C-Heap version, replace usages with GrowableArrayCHeap (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17160/head:pull/17160` \
`$ git checkout pull/17160`

Update a local copy of the PR: \
`$ git checkout pull/17160` \
`$ git pull https://git.openjdk.org/jdk.git pull/17160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17160`

View PR using the GUI difftool: \
`$ git pr show -t 17160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17160.diff">https://git.openjdk.org/jdk/pull/17160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17160#issuecomment-1864429960)