### PR TITLE
8322539: Parallel: Remove duplicated methods in PSAdaptiveSizePolicy

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -873,17 +873,6 @@ size_t PSAdaptiveSizePolicy::scale_down(size_t change,
   return reduced_change;
 }
 
-size_t PSAdaptiveSizePolicy::eden_increment(size_t cur_eden,
-                                            uint percent_change) {
-  size_t eden_heap_delta;
-  eden_heap_delta = cur_eden / 100 * percent_change;
-  return eden_heap_delta;
-}
-
-size_t PSAdaptiveSizePolicy::eden_increment(size_t cur_eden) {
-  return eden_increment(cur_eden, YoungGenerationSizeIncrement);
-}
-
 size_t PSAdaptiveSizePolicy::eden_increment_with_supplement_aligned_up(
   size_t cur_eden) {
   size_t result = eden_increment(cur_eden,
@@ -896,23 +885,6 @@ size_t PSAdaptiveSizePolicy::eden_decrement_aligned_down(size_t cur_eden) {
   return align_down(eden_heap_delta, _space_alignment);
 }
 
-size_t PSAdaptiveSizePolicy::eden_decrement(size_t cur_eden) {
-  size_t eden_heap_delta = eden_increment(cur_eden) /
-    AdaptiveSizeDecrementScaleFactor;
-  return eden_heap_delta;
-}
-
-size_t PSAdaptiveSizePolicy::promo_increment(size_t cur_promo,
-                                             uint percent_change) {
-  size_t promo_heap_delta;
-  promo_heap_delta = cur_promo / 100 * percent_change;
-  return promo_heap_delta;
-}
-
-size_t PSAdaptiveSizePolicy::promo_increment(size_t cur_promo) {
-  return promo_increment(cur_promo, TenuredGenerationSizeIncrement);
-}
-
 size_t PSAdaptiveSizePolicy::promo_increment_with_supplement_aligned_up(
   size_t cur_promo) {
   size_t result =  promo_increment(cur_promo,
@@ -923,12 +895,6 @@ size_t PSAdaptiveSizePolicy::promo_increment_with_supplement_aligned_up(
 size_t PSAdaptiveSizePolicy::promo_decrement_aligned_down(size_t cur_promo) {
   size_t promo_heap_delta = promo_decrement(cur_promo);
   return align_down(promo_heap_delta, _space_alignment);
-}
-
-size_t PSAdaptiveSizePolicy::promo_decrement(size_t cur_promo) {
-  size_t promo_heap_delta = promo_increment(cur_promo);
-  promo_heap_delta = promo_heap_delta / AdaptiveSizeDecrementScaleFactor;
-  return promo_heap_delta;
 }
 
 uint PSAdaptiveSizePolicy::compute_survivor_space_size_and_threshold(

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -135,14 +135,10 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
                                    size_t desired_total);
 
   // Size in bytes for an increment or decrement of eden.
-  virtual size_t eden_increment(size_t cur_eden, uint percent_change);
-  virtual size_t eden_decrement(size_t cur_eden);
   size_t eden_decrement_aligned_down(size_t cur_eden);
   size_t eden_increment_with_supplement_aligned_up(size_t cur_eden);
 
   // Size in bytes for an increment or decrement of the promotion area
-  virtual size_t promo_increment(size_t cur_promo, uint percent_change);
-  virtual size_t promo_decrement(size_t cur_promo);
   size_t promo_decrement_aligned_down(size_t cur_promo);
   size_t promo_increment_with_supplement_aligned_up(size_t cur_promo);
 
@@ -173,9 +169,6 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
   virtual GCPolicyKind kind() const { return _gc_ps_adaptive_size_policy; }
 
  public:
-  virtual size_t eden_increment(size_t cur_eden);
-  virtual size_t promo_increment(size_t cur_promo);
-
   // Accessors for use by performance counters
   AdaptivePaddedNoZeroDevAverage*  avg_promoted() const {
     return _gc_stats.avg_promoted();

--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.hpp
@@ -263,12 +263,12 @@ class AdaptiveSizePolicy : public CHeapObj<mtGC> {
     // to use minor_collection_end() in its current form.
   }
 
-  virtual size_t eden_increment(size_t cur_eden);
-  virtual size_t eden_increment(size_t cur_eden, uint percent_change);
-  virtual size_t eden_decrement(size_t cur_eden);
-  virtual size_t promo_increment(size_t cur_eden);
-  virtual size_t promo_increment(size_t cur_eden, uint percent_change);
-  virtual size_t promo_decrement(size_t cur_eden);
+  size_t eden_increment(size_t cur_eden);
+  size_t eden_increment(size_t cur_eden, uint percent_change);
+  size_t eden_decrement(size_t cur_eden);
+  size_t promo_increment(size_t cur_eden);
+  size_t promo_increment(size_t cur_eden, uint percent_change);
+  size_t promo_decrement(size_t cur_eden);
 
   virtual void clear_generation_free_space_flags();
 


### PR DESCRIPTION
Trivial removing duplicate code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322539](https://bugs.openjdk.org/browse/JDK-8322539): Parallel: Remove duplicated methods in PSAdaptiveSizePolicy (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17167/head:pull/17167` \
`$ git checkout pull/17167`

Update a local copy of the PR: \
`$ git checkout pull/17167` \
`$ git pull https://git.openjdk.org/jdk.git pull/17167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17167`

View PR using the GUI difftool: \
`$ git pr show -t 17167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17167.diff">https://git.openjdk.org/jdk/pull/17167.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17167#issuecomment-1864278979)