### PR TITLE
8322543: Parallel: Remove unused _major_pause_old_slope_counter

### DIFF
--- a/src/hotspot/share/gc/parallel/gcAdaptivePolicyCounters.hpp
+++ b/src/hotspot/share/gc/parallel/gcAdaptivePolicyCounters.hpp
@@ -60,7 +60,6 @@ class GCAdaptivePolicyCounters : public GCPolicyCounters {
   PerfVariable*         _decrease_for_footprint_counter;
 
   PerfVariable*         _minor_pause_young_slope_counter;
-  PerfVariable*         _major_pause_old_slope_counter;
 
   PerfVariable*         _decide_at_full_gc_counter;
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322543](https://bugs.openjdk.org/browse/JDK-8322543): Parallel: Remove unused _major_pause_old_slope_counter (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17168/head:pull/17168` \
`$ git checkout pull/17168`

Update a local copy of the PR: \
`$ git checkout pull/17168` \
`$ git pull https://git.openjdk.org/jdk.git pull/17168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17168`

View PR using the GUI difftool: \
`$ git pr show -t 17168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17168.diff">https://git.openjdk.org/jdk/pull/17168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17168#issuecomment-1864347798)