### PR TITLE
8322078: ZipSourceCache.testKeySourceMapping() test fails with The process cannot access the file because it is being used by another process

### DIFF
--- a/test/jdk/java/util/zip/ZipFile/ZipSourceCache.java
+++ b/test/jdk/java/util/zip/ZipFile/ZipSourceCache.java
@@ -25,6 +25,7 @@
  * @bug 8317678
  * @modules java.base/java.util.zip:open
  * @summary Fix up hashCode() for ZipFile.Source.Key
+ * @library /test/lib
  * @run junit/othervm ZipSourceCache
  */
 
@@ -34,6 +35,7 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.zip.*;
+import jdk.test.lib.util.FileUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
@@ -62,7 +64,7 @@ public class ZipSourceCache {
 
     @AfterAll
     public static void cleanup() throws IOException {
-        Files.deleteIfExists(Path.of(ZIPFILE_NAME));
+        FileUtils.deleteFileIfExistsWithRetry(Path.of(ZIPFILE_NAME));
     }
 
     /*


### PR DESCRIPTION
trivial test edit to use FileUtils.deleteFileIfExistsWithRetry test library API

tested on CI system with test-repeat = 20 - no issues seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322078](https://bugs.openjdk.org/browse/JDK-8322078): ZipSourceCache.testKeySourceMapping() test fails with The process cannot access the file because it is being used by another process (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17169/head:pull/17169` \
`$ git checkout pull/17169`

Update a local copy of the PR: \
`$ git checkout pull/17169` \
`$ git pull https://git.openjdk.org/jdk.git pull/17169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17169`

View PR using the GUI difftool: \
`$ git pr show -t 17169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17169.diff">https://git.openjdk.org/jdk/pull/17169.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17169#issuecomment-1864710320)