### PR TITLE
8321151: JDK-8294427 breaks Windows L&F on all older Windows versions

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -113,7 +113,7 @@ static PFNGETTHEMETRANSITIONDURATION GetThemeTransitionDurationFunc = NULL;
 
 constexpr unsigned int defaultDPI = 96;
 
-BOOL InitThemes() {
+static BOOL InitThemes() {
     static HMODULE hModThemes = NULL;
     hModThemes = JDK_LoadSystemLibrary("UXTHEME.DLL");
     DTRACE_PRINTLN1("InitThemes hModThemes = %x\n", hModThemes);
@@ -472,7 +472,7 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
     ReleaseDC(NULL,defaultDC);
 }
 
-void rescale(SIZE *size) {
+static void rescale(SIZE *size) {
     static int dpiX = -1;
     static int dpiY = -1;
 

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -157,9 +157,7 @@ static BOOL InitThemes() {
             (PFNGETTHEMETRANSITIONDURATION)GetProcAddress(hModThemes,
                                         "GetThemeTransitionDuration");
 
-        OpenThemeDataForDpiFunc = NULL;
-
-        if(OpenThemeDataFunc
+        if((OpenThemeDataForDpiFunc || OpenThemeDataFunc)
            && DrawThemeBackgroundFunc
            && CloseThemeDataFunc
            && DrawThemeTextFunc

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -113,6 +113,7 @@ static PFNGETTHEMETRANSITIONDURATION GetThemeTransitionDurationFunc = NULL;
 
 constexpr unsigned int defaultDPI = 96;
 
+
 static BOOL InitThemes() {
     static HMODULE hModThemes = NULL;
     hModThemes = JDK_LoadSystemLibrary("UXTHEME.DLL");
@@ -190,8 +191,8 @@ static BOOL InitThemes() {
                   return TRUE;
               }
             } else {
-                FreeLibrary(hModThemes);
-                hModThemes = NULL;
+               FreeLibrary(hModThemes);
+               hModThemes = NULL;
             }
     }
     return FALSE;
@@ -440,13 +441,12 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
     rect.left = 0;
     rect.top = 0;
 
-    if(!OpenThemeDataForDpiFunc) {
-        rect.bottom = h;
-        rect.right = w;
-    }
-    else {
+    if (OpenThemeDataForDpiFunc) {
         rect.bottom = rectBottom;
         rect.right = rectRight;
+    } else {
+        rect.bottom = h;
+        rect.right = w;
     }
     ZeroMemory(pSrcBits,(BITS_PER_PIXEL>>3)*w*h);
 
@@ -483,11 +483,11 @@ static void rescale(SIZE *size) {
     }
 
     if (dpiX !=0 && dpiX != defaultDPI) {
-        float invScaleX = (float)defaultDPI / dpiX;
+        float invScaleX = (float) defaultDPI / dpiX;
         size->cx = (int) round(size->cx * invScaleX);
     }
     if (dpiY != 0 && dpiY != defaultDPI) {
-        float invScaleY = (float)defaultDPI / dpiY;
+        float invScaleY = (float) defaultDPI / dpiY;
         size->cy = (int) round(size->cy * invScaleY);
     }
 }
@@ -783,7 +783,7 @@ JNIEXPORT jobject JNICALL Java_sun_awt_windows_ThemeReader_getPartSize
                 CHECK_NULL_RETURN(dimMID, NULL);
             }
 
-            if(!OpenThemeDataForDpiFunc) {
+            if (!OpenThemeDataForDpiFunc) {
                 rescale(&size);
             }
 

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -180,9 +180,11 @@ BOOL InitThemes() {
               DTRACE_PRINTLN("Loaded function pointers.\n");
               // We need to make sure we can load the Theme.
               // Use the default DPI value of 96 on windows.
-              HTHEME hTheme = OpenThemeDataForDpiFunc ? OpenThemeDataForDpiFunc(AwtToolkit::GetInstance().GetHWnd(),
-                                                                         L"Button", defaultDPI) :
-                                                 OpenThemeDataFunc(AwtToolkit::GetInstance().GetHWnd(), L"Button");
+              HTHEME hTheme = OpenThemeDataForDpiFunc
+                              ? OpenThemeDataForDpiFunc(AwtToolkit::GetInstance().GetHWnd(),
+                                                        L"Button", defaultDPI)
+                              : OpenThemeDataFunc(AwtToolkit::GetInstance().GetHWnd(),
+                                                  L"Button");
 
               if(hTheme) {
                   DTRACE_PRINTLN("Loaded Theme data.\n");
@@ -254,12 +256,11 @@ JNIEXPORT jlong JNICALL Java_sun_awt_windows_ThemeReader_openTheme
         return 0;
     }
 
-     HTHEME htheme = NULL;
     // We need to open the Theme on a Window that will stick around.
     // The best one for that purpose is the Toolkit window.
-
-     htheme = OpenThemeDataForDpiFunc ? OpenThemeDataForDpiFunc(AwtToolkit::GetInstance().GetHWnd(), str, dpi) :
-                                        OpenThemeDataFunc(AwtToolkit::GetInstance().GetHWnd(), str);
+    HTHEME htheme = OpenThemeDataForDpiFunc
+                    ? OpenThemeDataForDpiFunc(AwtToolkit::GetInstance().GetHWnd(), str, dpi)
+                    : OpenThemeDataFunc(AwtToolkit::GetInstance().GetHWnd(), str);
 
     JNU_ReleaseStringPlatformChars(env, widget, str);
     return (jlong) htheme;

--- a/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ThemeReader.cpp
@@ -111,6 +111,8 @@ static PFNISTHEMEBACKGROUNDPARTIALLYTRANSPARENT
                                IsThemeBackgroundPartiallyTransparentFunc = NULL;
 static PFNGETTHEMETRANSITIONDURATION GetThemeTransitionDurationFunc = NULL;
 
+constexpr unsigned int defaultDPI = 96;
+
 BOOL InitThemes() {
     static HMODULE hModThemes = NULL;
     hModThemes = JDK_LoadSystemLibrary("UXTHEME.DLL");
@@ -178,8 +180,6 @@ BOOL InitThemes() {
               DTRACE_PRINTLN("Loaded function pointers.\n");
               // We need to make sure we can load the Theme.
               // Use the default DPI value of 96 on windows.
-              constexpr unsigned int defaultDPI = 96;
-
               HTHEME hTheme = OpenThemeDataForDpiFunc ? OpenThemeDataForDpiFunc(AwtToolkit::GetInstance().GetHWnd(),
                                                                          L"Button", defaultDPI) :
                                                  OpenThemeDataFunc(AwtToolkit::GetInstance().GetHWnd(), L"Button");
@@ -474,7 +474,6 @@ JNIEXPORT void JNICALL Java_sun_awt_windows_ThemeReader_paintBackground
 void rescale(SIZE *size) {
     static int dpiX = -1;
     static int dpiY = -1;
-    constexpr unsigned int defaultDPI = 96;
 
     if (dpiX == -1 || dpiY == -1) {
         HWND hWnd = ::GetDesktopWindow();


### PR DESCRIPTION
**Issue:**
https://bugs.openjdk.org/browse/JDK-8294427 starts to use this API
https://learn.microsoft.com/en-us/windows/win32/api/uxtheme/nf-uxtheme-openthemedatafordpi

which was introduced only in Windows 10 1703.
So the theming engine won't load on anything earlier like the original windows 10 or windows 8.1 etc.

So as an undocumented side-effect it completely breaks the theming of Windows L&F on anything earlier
and it falls back to hard-coded rendering like Windows NT/Windows 2000

Whilst those older versions are technically out of at least "mainstream" support, this is not the way
to make that breaking change and I see this fix has been backported to older releases which expect stability

it seems to me that this code should NOT fail if the new API is missing and instead fall back to the old code.
No one will care about a pixel being off on hi-dpi if the entire UI is wrong.

**Fix:**
Added fallback path to support older versions of Windows that do not support OpenThemeDataForDpi().

**Testing:**
Tested on my Windows 10 machine with and without the fallback path and it works as expected.
Alexey tested on Windows 7 and on Windows 10 v1607 — it works correctly (jdk 21.0.2 can't render themes as reported).
He also tested on Windows 11 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8321151](https://bugs.openjdk.org/browse/JDK-8321151): JDK-8294427 breaks Windows L&amp;F on all older Windows versions (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17173/head:pull/17173` \
`$ git checkout pull/17173`

Update a local copy of the PR: \
`$ git checkout pull/17173` \
`$ git pull https://git.openjdk.org/jdk.git pull/17173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17173`

View PR using the GUI difftool: \
`$ git pr show -t 17173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17173.diff">https://git.openjdk.org/jdk/pull/17173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17173#issuecomment-1865348543)