### PR TITLE
8322538: remove fatal from JVM_VirtualThread functions for !INCLUDE_JVMTI

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3933,8 +3933,6 @@ JVM_ENTRY(void, JVM_VirtualThreadStart(JNIEnv* env, jobject vthread))
     // set VTMS transition bit value in JavaThread and java.lang.VirtualThread object
     JvmtiVTMSTransitionDisabler::set_is_in_VTMS_transition(thread, vthread, false);
   }
-#else
-  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 
@@ -3950,8 +3948,6 @@ JVM_ENTRY(void, JVM_VirtualThreadEnd(JNIEnv* env, jobject vthread))
     // set VTMS transition bit value in JavaThread and java.lang.VirtualThread object
     JvmtiVTMSTransitionDisabler::set_is_in_VTMS_transition(thread, vthread, true);
   }
-#else
-  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 
@@ -3969,8 +3965,6 @@ JVM_ENTRY(void, JVM_VirtualThreadMount(JNIEnv* env, jobject vthread, jboolean hi
     // set VTMS transition bit value in JavaThread and java.lang.VirtualThread object
     JvmtiVTMSTransitionDisabler::set_is_in_VTMS_transition(thread, vthread, hide);
   }
-#else
-  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 
@@ -3988,8 +3982,6 @@ JVM_ENTRY(void, JVM_VirtualThreadUnmount(JNIEnv* env, jobject vthread, jboolean 
     // set VTMS transition bit value in JavaThread and java.lang.VirtualThread object
     JvmtiVTMSTransitionDisabler::set_is_in_VTMS_transition(thread, vthread, hide);
   }
-#else
-  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 
@@ -4003,8 +3995,6 @@ JVM_ENTRY(void, JVM_VirtualThreadHideFrames(JNIEnv* env, jobject vthread, jboole
   assert(!thread->is_in_VTMS_transition(), "sanity check");
   assert(thread->is_in_tmp_VTMS_transition() != (bool)hide, "sanity check");
   thread->toggle_is_in_tmp_VTMS_transition();
-#else
-  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 
@@ -4019,8 +4009,6 @@ JVM_ENTRY(void, JVM_VirtualThreadDisableSuspend(JNIEnv* env, jobject vthread, jb
   assert(thread->is_disable_suspend() != (bool)enter,
          "nested or unbalanced monitor enter/exit is not allowed");
   thread->toggle_is_disable_suspend();
-#else
-  fatal("Should only be called with JVMTI enabled");
 #endif
 JVM_END
 


### PR DESCRIPTION
The macro `#else` branch conditions of `#if INCLUDE_JVMTI` in the `JVM_VirtualThread*` methods/functions (see `jvm.cpp`) are incorrect and have to be removed.
For example, the lines 4022-4023 have to be removed from the fragment below:
```
  4013	JVM_ENTRY(void, JVM_VirtualThreadDisableSuspend(JNIEnv* env, jobject vthread, jboolean enter))
  4014	#if INCLUDE_JVMTI
  4015	  if (!DoJVMTIVirtualThreadTransitions) {
  4016	    assert(!JvmtiExport::can_support_virtual_threads(), "sanity check");
  4017	    return;
  4018	  }
  4019	  assert(thread->is_disable_suspend() != (bool)enter,
  4020	         "nested or unbalanced monitor enter/exit is not allowed");
  4021	  thread->toggle_is_disable_suspend();
  4022	#else
  4023	  fatal("Should only be called with JVMTI enabled");
  4024	#endif
  4025	JVM_END
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322538](https://bugs.openjdk.org/browse/JDK-8322538): remove fatal from JVM_VirtualThread functions for !INCLUDE_JVMTI (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17174/head:pull/17174` \
`$ git checkout pull/17174`

Update a local copy of the PR: \
`$ git checkout pull/17174` \
`$ git pull https://git.openjdk.org/jdk.git pull/17174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17174`

View PR using the GUI difftool: \
`$ git pr show -t 17174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17174.diff">https://git.openjdk.org/jdk/pull/17174.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17174#issuecomment-1865393573)