### PR TITLE
JDK-8322163: runtime/Unsafe/InternalErrorTest.java fails on Alpine after JDK-8320886

### DIFF
--- a/src/hotspot/share/utilities/copy.cpp
+++ b/src/hotspot/share/utilities/copy.cpp
@@ -243,6 +243,16 @@ void Copy::fill_to_memory_atomic(void* to, size_t size, jubyte value) {
     }
   } else {
     // Not aligned, so no need to be atomic.
+#if defined(LINUX) && defined(AARCH64)
     Copy::fill_to_bytes(dst, size, value);
+#else
+    // This code is used by Unsafe and may hit the next page after truncation of mapped memory.
+    // Therefore, we use volatile to prevent compilers from replacing the loop by memset which
+    // may not trigger SIGBUS as needed (observed on Alpine Linux x86_64)
+    jbyte fill = value;
+    for (uintptr_t off = 0; off < size; off += sizeof(jbyte)) {
+      *(volatile jbyte*)(dst + off) = fill;
+    }
+#endif
   }
 }

--- a/src/hotspot/share/utilities/copy.cpp
+++ b/src/hotspot/share/utilities/copy.cpp
@@ -243,9 +243,7 @@ void Copy::fill_to_memory_atomic(void* to, size_t size, jubyte value) {
     }
   } else {
     // Not aligned, so no need to be atomic.
-#if defined(LINUX) && defined(AARCH64)
-    Copy::fill_to_bytes(dst, size, value);
-#else
+#ifdef MUSL_LIBC
     // This code is used by Unsafe and may hit the next page after truncation of mapped memory.
     // Therefore, we use volatile to prevent compilers from replacing the loop by memset which
     // may not trigger SIGBUS as needed (observed on Alpine Linux x86_64)
@@ -253,6 +251,8 @@ void Copy::fill_to_memory_atomic(void* to, size_t size, jubyte value) {
     for (uintptr_t off = 0; off < size; off += sizeof(jbyte)) {
       *(volatile jbyte*)(dst + off) = fill;
     }
+#else
+    Copy::fill_to_bytes(dst, size, value);
 #endif
   }
 }


### PR DESCRIPTION
We notice failures/crashes on Alpine Linux, maybe after [JDK-8320886](https://bugs.openjdk.org/browse/JDK-8320886).
test runtime/Unsafe/InternalErrorTest.java crashes on Alpine (works fine on other test OS/CPU platforms) :

```
#
# SIGSEGV (0xb) at pc=0x00007fd3c080064f, pid=7075, tid=7161
#
# JRE version: OpenJDK Runtime Environment (23.0) (build 23-internal-adhoc.jenkinsi.jdk)
# Java VM: OpenJDK 64-Bit Server VM (23-internal-adhoc.jenkinsi.jdk, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# C [ld-musl-x86_64.so.1+0x5464f] memset+0xa7
#
```

Looks like the Alpine memset triggers unexpected SIGSEGV  (not the expected SIGBUS).  So we switch to a loop instead of memset.    However I noticed that on Linux aarch64  the test starts to fail when the loop is used instead of the memset, so I keep the old coding on this platform .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322163](https://bugs.openjdk.org/browse/JDK-8322163): runtime/Unsafe/InternalErrorTest.java fails on Alpine after JDK-8320886 (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17175/head:pull/17175` \
`$ git checkout pull/17175`

Update a local copy of the PR: \
`$ git checkout pull/17175` \
`$ git pull https://git.openjdk.org/jdk.git pull/17175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17175`

View PR using the GUI difftool: \
`$ git pr show -t 17175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17175.diff">https://git.openjdk.org/jdk/pull/17175.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17175#issuecomment-1865920148)