### PR TITLE
8322322: Support archived full module graph when -Xbootclasspath/a is used

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2214,10 +2214,6 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
     // -bootclasspath/a:
     } else if (match_option(option, "-Xbootclasspath/a:", &tail)) {
       Arguments::append_sysclasspath(tail);
-#if INCLUDE_CDS
-      MetaspaceShared::disable_optimized_module_handling();
-      log_info(cds)("optimized module handling: disabled because bootclasspath was appended");
-#endif
     // -bootclasspath/p:
     } else if (match_option(option, "-Xbootclasspath/p:", &tail)) {
         jio_fprintf(defaultStream::output_stream(),

--- a/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
+++ b/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
@@ -64,19 +64,20 @@ public class ClassLoaders {
     // Creates the built-in class loaders.
     static {
         ArchivedClassLoaders archivedClassLoaders = ArchivedClassLoaders.get();
+        // -Xbootclasspath/a or -javaagent with Boot-Class-Path attribute
+        String append = VM.getSavedProperty("jdk.boot.class.path.append");
+        URLClassPath bootAppendUcp = (append != null && !append.isEmpty())
+                ? new URLClassPath(append, true)
+                : null;
         if (archivedClassLoaders != null) {
             // assert VM.getSavedProperty("jdk.boot.class.path.append") == null
             BOOT_LOADER = (BootClassLoader) archivedClassLoaders.bootLoader();
             setArchivedServicesCatalog(BOOT_LOADER);
+            BOOT_LOADER.setClassPath(bootAppendUcp);
             PLATFORM_LOADER = (PlatformClassLoader) archivedClassLoaders.platformLoader();
             setArchivedServicesCatalog(PLATFORM_LOADER);
         } else {
-            // -Xbootclasspath/a or -javaagent with Boot-Class-Path attribute
-            String append = VM.getSavedProperty("jdk.boot.class.path.append");
-            URLClassPath ucp = (append != null && !append.isEmpty())
-                    ? new URLClassPath(append, true)
-                    : null;
-            BOOT_LOADER = new BootClassLoader(ucp);
+            BOOT_LOADER = new BootClassLoader(bootAppendUcp);
             PLATFORM_LOADER = new PlatformClassLoader(BOOT_LOADER);
         }
         // A class path is required when no initial module is specified.

--- a/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
+++ b/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
@@ -66,18 +66,17 @@ public class ClassLoaders {
         ArchivedClassLoaders archivedClassLoaders = ArchivedClassLoaders.get();
         // -Xbootclasspath/a or -javaagent with Boot-Class-Path attribute
         String append = VM.getSavedProperty("jdk.boot.class.path.append");
-        URLClassPath bootAppendUcp = (append != null && !append.isEmpty())
+        URLClassPath bootUcp = (append != null && !append.isEmpty())
                 ? new URLClassPath(append, true)
                 : null;
         if (archivedClassLoaders != null) {
-            // assert VM.getSavedProperty("jdk.boot.class.path.append") == null
             BOOT_LOADER = (BootClassLoader) archivedClassLoaders.bootLoader();
+            BOOT_LOADER.setClassPath(bootUcp);
             setArchivedServicesCatalog(BOOT_LOADER);
-            BOOT_LOADER.setClassPath(bootAppendUcp);
             PLATFORM_LOADER = (PlatformClassLoader) archivedClassLoaders.platformLoader();
             setArchivedServicesCatalog(PLATFORM_LOADER);
         } else {
-            BOOT_LOADER = new BootClassLoader(bootAppendUcp);
+            BOOT_LOADER = new BootClassLoader(bootUcp);
             PLATFORM_LOADER = new PlatformClassLoader(BOOT_LOADER);
         }
         // A class path is required when no initial module is specified.

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
@@ -345,5 +345,20 @@ public class OptimizeModuleHandlingTest {
                    .shouldNotContain(OPTIMIZE_ENABLED)
                    .shouldContain(MAP_FAILED);
             });
+        // Dump an archive with only -Xbootclasspath/a
+        output = TestCommon.createArchive(
+                                null,
+                                appClasses,
+                                "-Xbootclasspath/a:" + mainJar.toString());
+        TestCommon.checkDump(output);
+        tty("13. run with CDS on,  with the same -Xbootclasspath/a as dump time and adding a -cp with test.jar:  should pass");
+        TestCommon.run("-Xlog:cds,class+load",
+                       "-cp", testJar.toString(),
+                       "-Xbootclasspath/a:" + mainJar.toString(),
+                       MAIN_CLASS)
+            .assertNormalExit(out -> {
+                out.shouldMatch(MAIN_FROM_CDS)
+                   .shouldContain(OPTIMIZE_ENABLED);
+            });
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
@@ -306,7 +306,7 @@ public class OptimizeModuleHandlingTest {
                    .shouldNotContain(OPTIMIZE_ENABLED)
                    .shouldNotContain(OPTIMIZE_DISABLED);
             });
-        tty("10. run with CDS on,  with main/test jars on classpath also with -Xbootclasspath/a:  should not pass");
+        tty("10. run with CDS on,  with main/test jars on classpath also with -Xbootclasspath/a:  should pass");
         TestCommon.run("-Xlog:cds",
                        "-cp", mainJar.toString() + PATH_SEPARATOR + testJar.toString(),
                        "-Xbootclasspath/a:", ".",
@@ -314,7 +314,34 @@ public class OptimizeModuleHandlingTest {
             .assertAbnormalExit(out -> {
                 out.shouldNotContain(CLASS_FOUND_MESSAGE)
                    .shouldNotContain(CLASS_NOT_FOUND_MESSAGE)
-                   .shouldContain(OPTIMIZE_DISABLED)
+                   .shouldNotContain(OPTIMIZE_ENABLED)
+                   .shouldContain(MAP_FAILED);
+            });
+
+        // Dump an archive with -Xbootclasspath/a
+        output = TestCommon.createArchive(
+                                testJar.toString(),
+                                appClasses,
+                                "-Xbootclasspath/a:" + mainJar.toString());
+        TestCommon.checkDump(output);
+        tty("11. run with CDS on,  with test jar on classpath and with main jar on -Xbootclasspath/a:  should pass");
+        TestCommon.run("-Xlog:cds",
+                       "-cp", testJar.toString(),
+                       "-Xbootclasspath/a:" + mainJar.toString(),
+                       MAIN_CLASS)
+            .assertNormalExit(out -> {
+                out.shouldNotContain(CLASS_FOUND_MESSAGE)
+                   .shouldNotContain(CLASS_NOT_FOUND_MESSAGE)
+                   .shouldContain(OPTIMIZE_ENABLED);
+            });
+        tty("12. run with CDS on,  with main jar on classpath and with test jar on -Xbootclasspath/a:  should not pass due to class paths mismatch");
+        TestCommon.run("-Xlog:cds",
+                       "-cp", mainJar.toString(),
+                       "-Xbootclasspath/a:" + testJar.toString(),
+                       MAIN_CLASS)
+            .assertAbnormalExit(out -> {
+                out.shouldNotContain(CLASS_FOUND_MESSAGE)
+                   .shouldNotContain(CLASS_NOT_FOUND_MESSAGE)
                    .shouldNotContain(OPTIMIZE_ENABLED)
                    .shouldContain(MAP_FAILED);
             });

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
@@ -190,6 +190,8 @@ public class ReplaceCriticalClasses {
                 if (checkSubgraph) {
                     if (expectShared) {
                         if (!out.getOutput().contains("Unable to map at required address in java heap")) {
+                            out.shouldContain("initialize_from_archived_subgraph java.lang.module.Configuration");
+                            out.shouldContain("initialize_from_archived_subgraph java.lang.ModuleLayer");
                             // If the subgraph is successfully initialized, the specified shared class must not be rewritten.
                             out.shouldNotContain("Rewriting done.");
                         }

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
@@ -190,8 +190,7 @@ public class ReplaceCriticalClasses {
                 if (checkSubgraph) {
                     if (expectShared) {
                         if (!out.getOutput().contains("Unable to map at required address in java heap")) {
-                            out.shouldContain("initialize_from_archived_subgraph java.lang.module.Configuration");
-                            out.shouldContain("initialize_from_archived_subgraph java.lang.ModuleLayer");
+                            out.shouldContain(subgraphInit);
                             // If the subgraph is successfully initialized, the specified shared class must not be rewritten.
                             out.shouldNotContain("Rewriting done.");
                         }

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClasses.java
@@ -190,7 +190,6 @@ public class ReplaceCriticalClasses {
                 if (checkSubgraph) {
                     if (expectShared) {
                         if (!out.getOutput().contains("Unable to map at required address in java heap")) {
-                            out.shouldContain(subgraphInit);
                             // If the subgraph is successfully initialized, the specified shared class must not be rewritten.
                             out.shouldNotContain("Rewriting done.");
                         }

--- a/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
+++ b/test/hotspot/jtreg/runtime/cds/serviceability/ReplaceCriticalClassesForSubgraphs.java
@@ -47,7 +47,8 @@ public class ReplaceCriticalClassesForSubgraphs extends ReplaceCriticalClasses {
 
             // CDS should not be disabled -- these critical classes cannot be replaced because
             // JvmtiExport::early_class_hook_env() is false.
-            "-subgraph java/lang/module/ResolvedModule jdk.internal.module.ArchivedModuleGraph",
+            "-subgraph java/lang/module/Configuration java.lang.module.Configuration",
+            "-subgraph java/lang/ModuleLayer java.lang.ModuleLayer",
             "-subgraph java/lang/Integer java.lang.Integer$IntegerCache",
 
             // Tests for archived full module graph. We cannot use whitebox, which requires appending to bootclasspath.


### PR DESCRIPTION
Please review this change for enabling full module graph even when -Xbootclasspath/a is specified. The validation of -Xbootclasspath/a is already being done in `FileMapInfo::validate_boot_class_paths()`. The full module graph will be disabled if there's a mismatch in -Xbootclasspath/a between dump time and runtime.

The changes in ClassLoaders.java is for setting up the append class path for the boot loader retrieved from the CDS archive. It is required because some existing tests are using the `getResourceAsStream()` api. Those tests would fail without the change.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322322](https://bugs.openjdk.org/browse/JDK-8322322): Support archived full module graph when -Xbootclasspath/a is used (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [d06b98ff](https://git.openjdk.org/jdk/pull/17178/files/d06b98ff68b08c38e0377dcda3b449b566a17bcb)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17178/head:pull/17178` \
`$ git checkout pull/17178`

Update a local copy of the PR: \
`$ git checkout pull/17178` \
`$ git pull https://git.openjdk.org/jdk.git pull/17178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17178`

View PR using the GUI difftool: \
`$ git pr show -t 17178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17178.diff">https://git.openjdk.org/jdk/pull/17178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17178#issuecomment-1866811242)