### PR TITLE
8068958: Timestamp.from(Instant) should throw when conversion is not possible

### DIFF
--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.sql/share/classes/java/sql/Timestamp.java
+++ b/src/java.sql/share/classes/java/sql/Timestamp.java
@@ -542,7 +542,7 @@ public class Timestamp extends java.util.Date {
      */
     public static Timestamp from(Instant instant) {
         try {
-            Timestamp stamp = new Timestamp(instant.getEpochSecond() * MILLIS_PER_SECOND);
+            Timestamp stamp = new Timestamp(Math.multiplyExact(instant.getEpochSecond(), MILLIS_PER_SECOND));
             stamp.nanos = instant.getNano();
             return stamp;
         } catch (ArithmeticException ex) {

--- a/test/jdk/java/sql/testng/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/testng/test/sql/TimestampTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/sql/testng/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/testng/test/sql/TimestampTests.java
@@ -642,6 +642,35 @@ public class TimestampTests extends BaseTest {
         assertEquals(ts1.toString(), ts, "ts1.toString() != ts");
     }
 
+    @Test
+    public void test53() {
+        // The latest Instant that can be converted to a Timestamp.
+        Instant instant1 = Instant.ofEpochSecond(Long.MAX_VALUE / 1000, 999_999_999);
+        assertEquals(instant1, Timestamp.from(instant1).toInstant());
+
+        // One nanosecond more, and converting it gets an overflow.
+        Instant instant2 = instant1.plusNanos(1);
+        try {
+            Timestamp unused = Timestamp.from(instant2);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+
+        // The latest possible Instant will certainly overflow.
+        try {
+            Timestamp unused = Timestamp.from(Instant.MAX);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+
+        // The earliest possible Instant will certainly overflow.
+        try {
+            Timestamp unused = Timestamp.from(Instant.MIN);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
     /*
      * DataProvider used to provide Timestamps which are not valid and are used
      * to validate that an IllegalArgumentException will be thrown from the

--- a/test/jdk/java/sql/testng/test/sql/TimestampTests.java
+++ b/test/jdk/java/sql/testng/test/sql/TimestampTests.java
@@ -646,29 +646,25 @@ public class TimestampTests extends BaseTest {
     public void test53() {
         // The latest Instant that can be converted to a Timestamp.
         Instant instant1 = Instant.ofEpochSecond(Long.MAX_VALUE / 1000, 999_999_999);
-        assertEquals(instant1, Timestamp.from(instant1).toInstant());
+        assertEquals(Timestamp.from(instant1).toInstant(), instant1);
 
         // One nanosecond more, and converting it gets an overflow.
         Instant instant2 = instant1.plusNanos(1);
-        try {
-            Timestamp unused = Timestamp.from(instant2);
-            fail();
-        } catch (IllegalArgumentException expected) {
-        }
+        expectThrows(IllegalArgumentException.class, () -> Timestamp.from(instant2));
+
+        // The earliest Instant that can be converted to a Timestamp.
+        Instant instant3 = Instant.ofEpochSecond(Long.MIN_VALUE / 1000, 0);
+        assertEquals(Timestamp.from(instant3).toInstant(), instant3);
+
+        // One nanosecond less, and converting it gets an overflow.
+        Instant instant4 = instant3.minusNanos(1);
+        expectThrows(IllegalArgumentException.class, () -> Timestamp.from(instant4));
 
         // The latest possible Instant will certainly overflow.
-        try {
-            Timestamp unused = Timestamp.from(Instant.MAX);
-            fail();
-        } catch (IllegalArgumentException expected) {
-        }
+        expectThrows(IllegalArgumentException.class, () -> Timestamp.from(Instant.MAX));
 
         // The earliest possible Instant will certainly overflow.
-        try {
-            Timestamp unused = Timestamp.from(Instant.MIN);
-            fail();
-        } catch (IllegalArgumentException expected) {
-        }
+        expectThrows(IllegalArgumentException.class, () -> Timestamp.from(Instant.MIN));
     }
 
     /*


### PR DESCRIPTION
Multiplying with `*` never produces `ArithmeticException`, so the catch in the existing code is never triggered. `Math.multiplyExact` does produce `ArithmeticException` if the multiplication overflows. So we can use that, and rethrow `IllegalArgumentException` as the specification says.

There is a small compatibility risk, in that code may have been relying on the previous silent overflow, and will now get an exception. But an exception is surely better than the nonsense results that overflow produces.

Thanks to Kurt Kluever for the test cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8068958](https://bugs.openjdk.org/browse/JDK-8068958): Timestamp.from(Instant) should throw when conversion is not possible (**Bug** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17181/head:pull/17181` \
`$ git checkout pull/17181`

Update a local copy of the PR: \
`$ git checkout pull/17181` \
`$ git pull https://git.openjdk.org/jdk.git pull/17181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17181`

View PR using the GUI difftool: \
`$ git pr show -t 17181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17181.diff">https://git.openjdk.org/jdk/pull/17181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17181#issuecomment-1866980294)