### PR TITLE
8322661: Build broken due to missing jvmtiExport.hpp after JDK-8320139

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -45,6 +45,7 @@
 #include "memory/universe.hpp"
 #include "oops/compressedOops.hpp"
 #include "oops/klass.inline.hpp"
+#include "prims/jvmtiExport.hpp"
 #ifdef COMPILER2
 #include "opto/c2compiler.hpp"
 #endif


### PR DESCRIPTION
Add jvmtiExport.hpp in jvmciCompilerToVMInit.cpp to fix the build failure.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322661](https://bugs.openjdk.org/browse/JDK-8322661): Build broken due to missing jvmtiExport.hpp after JDK-8320139 (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17182/head:pull/17182` \
`$ git checkout pull/17182`

Update a local copy of the PR: \
`$ git checkout pull/17182` \
`$ git pull https://git.openjdk.org/jdk.git pull/17182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17182`

View PR using the GUI difftool: \
`$ git pr show -t 17182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17182.diff">https://git.openjdk.org/jdk/pull/17182.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17182#issuecomment-1867169375)