### PR TITLE
8322636: [JVMCI] HotSpotSpeculationLog can be inconsistent across a single compile

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
@@ -209,9 +209,6 @@ public class HotSpotSpeculationLog implements SpeculationLog {
 
     @Override
     public boolean maySpeculate(SpeculationReason reason) {
-        if (failedSpeculations == null) {
-            collectFailedSpeculations();
-        }
         if (failedSpeculations != null && failedSpeculations.length != 0) {
             byte[] encoding = encode(reason);
             return !contains(failedSpeculations, 0, encoding);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java
@@ -207,6 +207,12 @@ public class HotSpotSpeculationLog implements SpeculationLog {
         return result;
     }
 
+    /**
+     * @return {@code true} if the given speculation can be performed, i.e., it never failed so far, otherwise
+     * return {@code false}. Note, that this method returns consistent results for any given speculation for the
+     * entire lifetime of the enclosing SpeculationLog object. This means that speculations failed during a
+     * compilation will not be updated.
+     */
     @Override
     public boolean maySpeculate(SpeculationReason reason) {
         if (failedSpeculations != null && failedSpeculations.length != 0) {


### PR DESCRIPTION
This PR fixes a subtle inconsistency in `HotSpotSpeculationLog` .

Normal uses of `HotSpotSpeculationLog` work by using a `SpeculationReason` and asking the speculation log via `maySpeculate` if the speculation can be performed, i.e., if it failed before for the given method.  An example for this can be seen in Graal https://github.com/oracle/graal/blob/master/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/loop/CountedLoopInfo.java#L591C15-L591C15 
The implicit assumption is that the speculation log, `HotSpotSpeculationLog` in particular collects failed speculations at the beginning of a compile and then stays consistent during the compile. Why is that? - Because if there are new failed speculations added to the failed speculations during the compile - the compiler would speculate again on those in an inconsistent way. E.g. at the beginning of a compile a certain speculation has not failed yet and the compiler thinks it can do optimization xyz using a speculation  - later during the compilation process it consults the speculation log but gets a different answer. All those inconsistent speculations that already failed will anyway later fail code installation in jvmci (they will throw a bailout during `HotSpotCodeCacheProvider#installCode` https://github.com/openjdk/jdk/blob/master/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotSpeculationLog.java#L192 ). Thus, we should at least return a consistent result during a compile.
The problem for consistency here, that also makes troubles on the graal side, is that `maySpeculate` itself can collect failed speculations if there have not been any previously, i.e., `failedSpeculations == null`.
In order to make the speculation log consistent across an entire JVMCI compile this PR removes the collection of failed speculations in `maySpeculate`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322636](https://bugs.openjdk.org/browse/JDK-8322636): [JVMCI] HotSpotSpeculationLog can be inconsistent across a single compile (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**) ⚠️ Review applies to [810e42ad](https://git.openjdk.org/jdk/pull/17183/files/810e42ad74761e700eb09162e48907c4a8722111)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17183/head:pull/17183` \
`$ git checkout pull/17183`

Update a local copy of the PR: \
`$ git checkout pull/17183` \
`$ git pull https://git.openjdk.org/jdk.git pull/17183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17183`

View PR using the GUI difftool: \
`$ git pr show -t 17183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17183.diff">https://git.openjdk.org/jdk/pull/17183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17183#issuecomment-1867570779)