### PR TITLE
8221261: deadlock of CInputMethod.characterIndexForPoint and webkit.InputMethodClientImpl.getLocationOffset

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/LWCToolkit.java
@@ -737,7 +737,7 @@ public final class LWCToolkit extends LWToolkit {
         SunToolkit.postEvent(appContext, invocationEvent);
         // 3746956 - flush events from PostEventQueue to prevent them from getting stuck and causing a deadlock
         SunToolkit.flushPendingEvents(appContext);
-        doAWTRunLoop(mediator, false);
+        doAWTRunLoop(mediator, true);
 
         checkException(invocationEvent);
     }


### PR DESCRIPTION
A dead-lock is caused by the interaction of MacOS, the AWTEventQueue and JavaFX when the users pressed the Caps Lock key while the AWTEventQueue is processing another event (more on this in the issue). The bug depends on the specific timing of the event sending and can apparently be prevented by finishing all incoming OS events directly while the LWCToolkit.invokeAndWait method is executed.

This fix is tested and fixes the issue.

I attached a small
[reproducer](https://github.com/openjdk/jdk/files/13751865/Archive.zip), just run it with `mvn install package javafx:run`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8221261](https://bugs.openjdk.org/browse/JDK-8221261)

### Issue
 * [JDK-8221261](https://bugs.openjdk.org/browse/JDK-8221261): Deadlock on macOS in JFXPanel app when handling IME calls (**Bug** - P2) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17184/head:pull/17184` \
`$ git checkout pull/17184`

Update a local copy of the PR: \
`$ git checkout pull/17184` \
`$ git pull https://git.openjdk.org/jdk.git pull/17184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17184`

View PR using the GUI difftool: \
`$ git pr show -t 17184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17184.diff">https://git.openjdk.org/jdk/pull/17184.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17184#issuecomment-1867579067)