### PR TITLE
8297573: Parallel: Rename do_oop_nv to do_oop_work in subclasses of OopClosure

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -47,9 +47,9 @@ private:
 public:
   PCMarkAndPushClosure(ParCompactionManager* cm) : _compaction_manager(cm) { }
 
-  template <typename T> void do_oop_nv(T* p)      { _compaction_manager->mark_and_push(p); }
-  virtual void do_oop(oop* p)                     { do_oop_nv(p); }
-  virtual void do_oop(narrowOop* p)               { do_oop_nv(p); }
+  template <typename T> void do_oop_work(T* p)      { _compaction_manager->mark_and_push(p); }
+  virtual void do_oop(oop* p)                     { do_oop_work(p); }
+  virtual void do_oop(narrowOop* p)               { do_oop_work(p); }
 };
 
 class PCIterateMarkAndPushClosure: public ClaimMetadataVisitingOopIterateClosure {
@@ -60,9 +60,9 @@ public:
     ClaimMetadataVisitingOopIterateClosure(ClassLoaderData::_claim_stw_fullgc_mark, rp),
     _compaction_manager(cm) { }
 
-  template <typename T> void do_oop_nv(T* p)      { _compaction_manager->mark_and_push(p); }
-  virtual void do_oop(oop* p)                     { do_oop_nv(p); }
-  virtual void do_oop(narrowOop* p)               { do_oop_nv(p); }
+  template <typename T> void do_oop_work(T* p)      { _compaction_manager->mark_and_push(p); }
+  virtual void do_oop(oop* p)                     { do_oop_work(p); }
+  virtual void do_oop(narrowOop* p)               { do_oop_work(p); }
 };
 
 inline bool ParCompactionManager::steal(int queue_num, oop& t) {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
@@ -130,9 +130,9 @@ class PCAdjustPointerClosure: public BasicOopIterateClosure {
 public:
   PCAdjustPointerClosure(ParCompactionManager* cm) : _cm(cm) {
   }
-  template <typename T> void do_oop_nv(T* p) { PSParallelCompact::adjust_pointer(p, _cm); }
-  virtual void do_oop(oop* p)                { do_oop_nv(p); }
-  virtual void do_oop(narrowOop* p)          { do_oop_nv(p); }
+  template <typename T> void do_oop_work(T* p) { PSParallelCompact::adjust_pointer(p, _cm); }
+  virtual void do_oop(oop* p)                { do_oop_work(p); }
+  virtual void do_oop(narrowOop* p)          { do_oop_work(p); }
 
   virtual ReferenceIterationMode reference_iteration_mode() { return DO_FIELDS; }
 private:

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -95,14 +95,14 @@ class PSPushContentsClosure: public BasicOopIterateClosure {
  public:
   PSPushContentsClosure(PSPromotionManager* pm) : BasicOopIterateClosure(PSScavenge::reference_processor()), _pm(pm) {}
 
-  template <typename T> void do_oop_nv(T* p) {
+  template <typename T> void do_oop_work(T* p) {
     if (PSScavenge::should_scavenge(p)) {
       _pm->claim_or_forward_depth(p);
     }
   }
 
-  virtual void do_oop(oop* p)       { do_oop_nv(p); }
-  virtual void do_oop(narrowOop* p) { do_oop_nv(p); }
+  virtual void do_oop(oop* p)       { do_oop_work(p); }
+  virtual void do_oop(narrowOop* p) { do_oop_work(p); }
 };
 
 //


### PR DESCRIPTION
Description:
From Stefan Karlsson: 

A good cleanup could be to rename the remaining do_oop_nv to do_oop_work, since that’s what those functions are typically named in other closures. The _nv suffix is a left-over from the earlier days when we had macros to devirtualize the closures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297573](https://bugs.openjdk.org/browse/JDK-8297573): Parallel: Rename do_oop_nv to do_oop_work in subclasses of OopClosure (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17185/head:pull/17185` \
`$ git checkout pull/17185`

Update a local copy of the PR: \
`$ git checkout pull/17185` \
`$ git pull https://git.openjdk.org/jdk.git pull/17185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17185`

View PR using the GUI difftool: \
`$ git pr show -t 17185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17185.diff">https://git.openjdk.org/jdk/pull/17185.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17185#issuecomment-1867777911)