### PR TITLE
8233443: G1 DetailedUsage class names overly generic for global namespace

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapTransition.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.cpp
@@ -62,7 +62,7 @@ G1HeapTransition::Data::~Data() {
 
 G1HeapTransition::G1HeapTransition(G1CollectedHeap* g1_heap) : _g1_heap(g1_heap), _before(g1_heap) { }
 
-struct DetailedUsage : public StackObj {
+struct G1HeapTransition::DetailedUsage : public StackObj {
   size_t _eden_used;
   size_t _survivor_used;
   size_t _old_used;
@@ -79,7 +79,7 @@ struct DetailedUsage : public StackObj {
     _humongous_region_count(0) {}
 };
 
-class DetailedUsageClosure: public HeapRegionClosure {
+class G1HeapTransition::DetailedUsageClosure: public HeapRegionClosure {
 public:
   DetailedUsage _usage;
   bool do_heap_region(HeapRegion* r) {

--- a/src/hotspot/share/gc/g1/g1HeapTransition.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapTransition.hpp
@@ -31,6 +31,9 @@
 class G1CollectedHeap;
 
 class G1HeapTransition {
+  struct DetailedUsage;
+  class DetailedUsageClosure;
+
   struct Data {
     size_t _eden_length;
     size_t _survivor_length;


### PR DESCRIPTION
Description:
The classes DetailedUsage and DetailedUsageClosure are defined in G1HeapTransitions.cpp. These class names seem a bit generic for the global namespace. They could be G1-prefixed, but I think better would be to make them nested classes of G1HeapTransition. Just declare them in that class, with the definitions still in the .cpp file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8233443](https://bugs.openjdk.org/browse/JDK-8233443): G1 DetailedUsage class names overly generic for global namespace (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17186/head:pull/17186` \
`$ git checkout pull/17186`

Update a local copy of the PR: \
`$ git checkout pull/17186` \
`$ git pull https://git.openjdk.org/jdk.git pull/17186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17186`

View PR using the GUI difftool: \
`$ git pr show -t 17186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17186.diff">https://git.openjdk.org/jdk/pull/17186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17186#issuecomment-1867839126)