### PR TITLE
8322647: Short name for the `Europe/Lisbon` time zone is incorrect

### DIFF
--- a/test/jdk/java/time/test/java/time/format/TestUTCParse.java
+++ b/test/jdk/java/time/test/java/time/format/TestUTCParse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 /*
  * @test
  * @modules jdk.localedata
- * @bug 8303440 8317979
+ * @bug 8303440 8317979 8322647
  * @summary Test parsing "UTC-XX:XX" text works correctly
  */
 package test.java.time.format;
@@ -43,8 +43,8 @@ import static org.testng.Assert.assertEquals;
 public class TestUTCParse {
 
     static {
-        // Assuming CLDR's SHORT name for "America/Juneau"
-        // produces "UTC\u212209:00"
+        // Assuming CLDR's SHORT name for "America/Manaus"
+        // produces "UTC\u221204:00"
         System.setProperty("java.locale.providers", "CLDR");
     }
 
@@ -60,9 +60,9 @@ public class TestUTCParse {
     @Test
     public void testUTCShortNameRoundTrip() {
         var fmt = DateTimeFormatter.ofPattern("z", Locale.FRANCE);
-        var zdt = ZonedDateTime.of(2023, 3, 3, 0, 0, 0, 0, ZoneId.of("America/Juneau"));
+        var zdt = ZonedDateTime.of(2023, 3, 3, 0, 0, 0, 0, ZoneId.of("America/Manaus"));
         var formatted = fmt.format(zdt);
-        assertEquals(formatted, "UTC\u221209:00");
+        assertEquals(formatted, "UTC\u221204:00");
         assertEquals(fmt.parse(formatted).query(TemporalQueries.zoneId()), zdt.getZone());
     }
 


### PR DESCRIPTION
This is a regression caused by the fix to [JDK-8317979](https://bugs.openjdk.org/browse/JDK-8317979), where the parsing of TZDB files was incorrect. With this fix, `TimeZoneNames_en.java` which is generated during the build time has the following diffs from the previous (incorrect) one:
```
--- master/build/macosx-aarch64/support/gensrc/java.base/sun/util/resources/cldr/TimeZoneNames_en.java	2023-12-18 10:28:57
+++ tz/build/macosx-aarch64/support/gensrc/java.base/sun/util/resources/cldr/TimeZoneNames_en.java	2023-12-22 10:09:13
@@ -304,11 +304,11 @@
             };
         final String[] Azores = new String[] {
                "Azores Standard Time",
-               "HMT",
+               "",
                "Azores Summer Time",
-               "HMT",
+               "",
                "Azores Time",
-               "HMT",
+               "",
             };
         final String[] Bhutan = new String[] {
                "Bhutan Time",
@@ -968,11 +968,11 @@
             };
         final String[] Africa_Central = new String[] {
                "Central Africa Time",
-               "SAST",
-               "",
-               "SAST",
+               "CAT",
                "",
-               "SAST",
+               "CAT",
+               "",
+               "CAT",
             };
         final String[] Africa_Eastern = new String[] {
                "East Africa Time",
@@ -1016,11 +1016,11 @@
             };
         final String[] Europe_Western = new String[] {
                "Western European Standard Time",
-               "FMT",
-               "Western European Summer Time",
-               "FMT",
+               "WET",
+               "Western European Summer Time",
+               "WEST",
                "Western European Time",
-               "FMT",
+               "WET",
             };
         final String[] Mexico_Pacific = new String[] {
                "Mexican Pacific Standard Time",
@@ -1152,11 +1152,11 @@
             };
         final String[] Australia_Western = new String[] {
                "Australian Western Standard Time",
-               "",
+               "AWST",
                "Australian Western Daylight Time",
-               "",
+               "AWDT",
                "Western Australia Time",
-               "",
+               "AWT",
             };
         final String[] Greenland_Eastern = new String[] {
                "East Greenland Standard Time",
```
Previously, they all had wrong short names due to incorrect parsing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322647](https://bugs.openjdk.org/browse/JDK-8322647): Short name for the `Europe/Lisbon` time zone is incorrect (**Bug** - P3)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17187/head:pull/17187` \
`$ git checkout pull/17187`

Update a local copy of the PR: \
`$ git checkout pull/17187` \
`$ git pull https://git.openjdk.org/jdk.git pull/17187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17187`

View PR using the GUI difftool: \
`$ git pr show -t 17187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17187.diff">https://git.openjdk.org/jdk/pull/17187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17187#issuecomment-1867997127)