### PR TITLE
8227713: Convert G1's assert_ macros into NOT_DEBUG_RETURN functions

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -124,7 +124,7 @@ void G1Allocator::reuse_retained_old_region(G1EvacInfo* evacuation_info,
 }
 
 void G1Allocator::init_gc_alloc_regions(G1EvacInfo* evacuation_info) {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   _survivor_is_full = false;
   _old_is_full = false;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -761,7 +761,7 @@ void G1CollectedHeap::prepare_heap_for_full_collection() {
 }
 
 void G1CollectedHeap::verify_before_full_collection() {
-  assert_used_and_recalculate_used_equal(this);
+  assert_used_and_recalculate_used_equal();
   if (!VerifyBeforeGC) {
     return;
   }
@@ -2845,7 +2845,7 @@ void G1CollectedHeap::rebuild_region_sets(bool free_list_only) {
   if (!free_list_only) {
     set_used(cl.total_used());
   }
-  assert_used_and_recalculate_used_equal(this);
+  assert_used_and_recalculate_used_equal();
 }
 
 // Methods for the mutator alloc region

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -315,7 +315,7 @@ public:
   inline static void assert_heap_not_locked() NOT_DEBUG_RETURN;
   inline static void assert_heap_not_locked_and_not_at_safepoint() NOT_DEBUG_RETURN;
   inline static void assert_at_safepoint_on_vm_thread() NOT_DEBUG_RETURN;
-  inline static void assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) NOT_DEBUG_RETURN;
+  inline void assert_used_and_recalculate_used_equal() const NOT_DEBUG_RETURN;
 
 private:
   // The young region list.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -309,13 +309,13 @@ private:
   // These are assert functions so that, if the assert fires, we get the correct
   // line number, file, etc.
 public:
-  static void assert_heap_locked() NOT_DEBUG_RETURN;
-  static void assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) NOT_DEBUG_RETURN;
-  static void assert_heap_locked_and_not_at_safepoint() NOT_DEBUG_RETURN;
-  static void assert_heap_not_locked() NOT_DEBUG_RETURN;
-  static void assert_heap_not_locked_and_not_at_safepoint() NOT_DEBUG_RETURN;
-  static void assert_at_safepoint_on_vm_thread() NOT_DEBUG_RETURN;
-  static void assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) NOT_DEBUG_RETURN;
+  inline static void assert_heap_locked() NOT_DEBUG_RETURN;
+  inline static void assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) NOT_DEBUG_RETURN;
+  inline static void assert_heap_locked_and_not_at_safepoint() NOT_DEBUG_RETURN;
+  inline static void assert_heap_not_locked() NOT_DEBUG_RETURN;
+  inline static void assert_heap_not_locked_and_not_at_safepoint() NOT_DEBUG_RETURN;
+  inline static void assert_at_safepoint_on_vm_thread() NOT_DEBUG_RETURN;
+  inline static void assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) NOT_DEBUG_RETURN;
 
 private:
   // The young region list.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -306,72 +306,16 @@ private:
 
   void trace_heap(GCWhen::Type when, const GCTracer* tracer) override;
 
-  // These are macros so that, if the assert fires, we get the correct
+  // These are assert functions so that, if the assert fires, we get the correct
   // line number, file, etc.
 
-#define heap_locking_asserts_params(_extra_message_)                          \
-  "%s : Heap_lock locked: %s, at safepoint: %s, is VM thread: %s",            \
-  (_extra_message_),                                                          \
-  BOOL_TO_STR(Heap_lock->owned_by_self()),                                    \
-  BOOL_TO_STR(SafepointSynchronize::is_at_safepoint()),                       \
-  BOOL_TO_STR(Thread::current()->is_VM_thread())
-
-#define assert_heap_locked()                                                  \
-  do {                                                                        \
-    assert(Heap_lock->owned_by_self(),                                        \
-           heap_locking_asserts_params("should be holding the Heap_lock"));   \
-  } while (0)
-
-#define assert_heap_locked_or_at_safepoint(_should_be_vm_thread_)             \
-  do {                                                                        \
-    assert(Heap_lock->owned_by_self() ||                                      \
-           (SafepointSynchronize::is_at_safepoint() &&                        \
-             ((_should_be_vm_thread_) == Thread::current()->is_VM_thread())), \
-           heap_locking_asserts_params("should be holding the Heap_lock or "  \
-                                        "should be at a safepoint"));         \
-  } while (0)
-
-#define assert_heap_locked_and_not_at_safepoint()                             \
-  do {                                                                        \
-    assert(Heap_lock->owned_by_self() &&                                      \
-                                    !SafepointSynchronize::is_at_safepoint(), \
-          heap_locking_asserts_params("should be holding the Heap_lock and "  \
-                                       "should not be at a safepoint"));      \
-  } while (0)
-
-#define assert_heap_not_locked()                                              \
-  do {                                                                        \
-    assert(!Heap_lock->owned_by_self(),                                       \
-        heap_locking_asserts_params("should not be holding the Heap_lock"));  \
-  } while (0)
-
-#define assert_heap_not_locked_and_not_at_safepoint()                         \
-  do {                                                                        \
-    assert(!Heap_lock->owned_by_self() &&                                     \
-                                    !SafepointSynchronize::is_at_safepoint(), \
-      heap_locking_asserts_params("should not be holding the Heap_lock and "  \
-                                   "should not be at a safepoint"));          \
-  } while (0)
-
-#define assert_at_safepoint_on_vm_thread()                                        \
-  do {                                                                            \
-    assert_at_safepoint();                                                        \
-    assert(Thread::current_or_null() != nullptr, "no current thread");            \
-    assert(Thread::current()->is_VM_thread(), "current thread is not VM thread"); \
-  } while (0)
-
-#ifdef ASSERT
-#define assert_used_and_recalculate_used_equal(g1h)                           \
-  do {                                                                        \
-    size_t cur_used_bytes = g1h->used();                                      \
-    size_t recal_used_bytes = g1h->recalculate_used();                        \
-    assert(cur_used_bytes == recal_used_bytes, "Used(" SIZE_FORMAT ") is not" \
-           " same as recalculated used(" SIZE_FORMAT ").",                    \
-           cur_used_bytes, recal_used_bytes);                                 \
-  } while (0)
-#else
-#define assert_used_and_recalculate_used_equal(g1h) do {} while(0)
-#endif
+  void assert_heap_locked() const NOT_DEBUG_RETURN;
+  void assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) const NOT_DEBUG_RETURN;
+  void assert_heap_locked_and_not_at_safepoint() const NOT_DEBUG_RETURN;
+  void assert_heap_not_locked() const NOT_DEBUG_RETURN;
+  void assert_heap_not_locked_and_not_at_safepoint() const NOT_DEBUG_RETURN;
+  void assert_at_safepoint_on_vm_thread() const NOT_DEBUG_RETURN;
+  void assert_used_and_recalculate_used_equal() const NOT_DEBUG_RETURN;
 
   // The young region list.
   G1EdenRegions _eden;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -308,15 +308,16 @@ private:
 
   // These are assert functions so that, if the assert fires, we get the correct
   // line number, file, etc.
+public:
+  static void assert_heap_locked() NOT_DEBUG_RETURN;
+  static void assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) NOT_DEBUG_RETURN;
+  static void assert_heap_locked_and_not_at_safepoint() NOT_DEBUG_RETURN;
+  static void assert_heap_not_locked() NOT_DEBUG_RETURN;
+  static void assert_heap_not_locked_and_not_at_safepoint() NOT_DEBUG_RETURN;
+  static void assert_at_safepoint_on_vm_thread() NOT_DEBUG_RETURN;
+  static void assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) NOT_DEBUG_RETURN;
 
-  void assert_heap_locked() const NOT_DEBUG_RETURN;
-  void assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) const NOT_DEBUG_RETURN;
-  void assert_heap_locked_and_not_at_safepoint() const NOT_DEBUG_RETURN;
-  void assert_heap_not_locked() const NOT_DEBUG_RETURN;
-  void assert_heap_not_locked_and_not_at_safepoint() const NOT_DEBUG_RETURN;
-  void assert_at_safepoint_on_vm_thread() const NOT_DEBUG_RETURN;
-  void assert_used_and_recalculate_used_equal() const NOT_DEBUG_RETURN;
-
+private:
   // The young region list.
   G1EdenRegions _eden;
   G1SurvivorRegions _survivor;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -320,11 +320,13 @@ inline bool G1CollectedHeap::is_collection_set_candidate(const HeapRegion* r) co
   BOOL_TO_STR(SafepointSynchronize::is_at_safepoint()),                       \
   BOOL_TO_STR(Thread::current()->is_VM_thread())
 
+DEBUG_ONLY(
 inline void G1CollectedHeap::assert_heap_locked() {
   assert(Heap_lock->owned_by_self(),
           heap_locking_asserts_params("should be holding the Heap_lock"));
-}
+})
 
+DEBUG_ONLY(
 inline void G1CollectedHeap::
 assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) {
   assert(Heap_lock->owned_by_self() ||
@@ -332,33 +334,38 @@ assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) {
             ((should_be_vm_thread) == Thread::current()->is_VM_thread())),
           heap_locking_asserts_params("should be holding the Heap_lock or "
                                       "should be at a safepoint"));
-}
+})
 
+DEBUG_ONLY(
 inline void G1CollectedHeap::assert_heap_locked_and_not_at_safepoint() {
   assert(Heap_lock->owned_by_self() &&
                                   !SafepointSynchronize::is_at_safepoint(),
         heap_locking_asserts_params("should be holding the Heap_lock and "
                                       "should not be at a safepoint"));
-}
+})
 
+DEBUG_ONLY(
 inline void G1CollectedHeap::assert_heap_not_locked() {
   assert(!Heap_lock->owned_by_self(),
       heap_locking_asserts_params("should not be holding the Heap_lock"));
-}
+})
 
+DEBUG_ONLY(
 inline void G1CollectedHeap::assert_heap_not_locked_and_not_at_safepoint() {
   assert(!Heap_lock->owned_by_self() &&
                                   !SafepointSynchronize::is_at_safepoint(),
     heap_locking_asserts_params("should not be holding the Heap_lock and "
                                   "should not be at a safepoint"));
-}
+})
 
+DEBUG_ONLY(
 inline void G1CollectedHeap::assert_at_safepoint_on_vm_thread() {
   assert_at_safepoint();
   assert(Thread::current_or_null() != nullptr, "no current thread");
   assert(Thread::current()->is_VM_thread(), "current thread is not VM thread");
-}
+})
 
+DEBUG_ONLY(
 inline void G1CollectedHeap::
 assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) {
 #ifdef ASSERT
@@ -368,6 +375,6 @@ assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) {
           " same as recalculated used(" SIZE_FORMAT ").",
           cur_used_bytes, recal_used_bytes);
 #endif
-}
+})
 
 #endif // SHARE_GC_G1_G1COLLECTEDHEAP_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -361,7 +361,7 @@ inline void G1CollectedHeap::assert_at_safepoint_on_vm_thread() {
 
 inline void G1CollectedHeap::
 assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) {
-#if ASSERT
+#ifdef ASSERT
   size_t cur_used_bytes = g1h->used();
   size_t recal_used_bytes = g1h->recalculate_used();
   assert(cur_used_bytes == recal_used_bytes, "Used(" SIZE_FORMAT ") is not"

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -320,13 +320,13 @@ inline bool G1CollectedHeap::is_collection_set_candidate(const HeapRegion* r) co
   BOOL_TO_STR(SafepointSynchronize::is_at_safepoint()),                       \
   BOOL_TO_STR(Thread::current()->is_VM_thread())
 
-inline void G1CollectedHeap::assert_heap_locked() const {
+inline void G1CollectedHeap::assert_heap_locked() {
   assert(Heap_lock->owned_by_self(),
           heap_locking_asserts_params("should be holding the Heap_lock"));
 }
 
 inline void G1CollectedHeap::
-assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) const {
+assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) {
   assert(Heap_lock->owned_by_self() ||
           (SafepointSynchronize::is_at_safepoint() &&
             ((should_be_vm_thread) == Thread::current()->is_VM_thread())),
@@ -334,35 +334,36 @@ assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) const {
                                       "should be at a safepoint"));
 }
 
-inline void G1CollectedHeap::assert_heap_locked_and_not_at_safepoint() const {
+inline void G1CollectedHeap::assert_heap_locked_and_not_at_safepoint() {
   assert(Heap_lock->owned_by_self() &&
                                   !SafepointSynchronize::is_at_safepoint(),
         heap_locking_asserts_params("should be holding the Heap_lock and "
                                       "should not be at a safepoint"));
 }
 
-inline void G1CollectedHeap::assert_heap_not_locked() const {
+inline void G1CollectedHeap::assert_heap_not_locked() {
   assert(!Heap_lock->owned_by_self(),
       heap_locking_asserts_params("should not be holding the Heap_lock"));
 }
 
-inline void G1CollectedHeap::assert_heap_not_locked_and_not_at_safepoint() const {
+inline void G1CollectedHeap::assert_heap_not_locked_and_not_at_safepoint() {
   assert(!Heap_lock->owned_by_self() &&
                                   !SafepointSynchronize::is_at_safepoint(),
     heap_locking_asserts_params("should not be holding the Heap_lock and "
                                   "should not be at a safepoint"));
 }
 
-inline void G1CollectedHeap::assert_at_safepoint_on_vm_thread() const {
+inline void G1CollectedHeap::assert_at_safepoint_on_vm_thread() {
   assert_at_safepoint();
   assert(Thread::current_or_null() != nullptr, "no current thread");
   assert(Thread::current()->is_VM_thread(), "current thread is not VM thread");
 }
 
-inline void G1CollectedHeap::assert_used_and_recalculate_used_equal() const {
+inline void G1CollectedHeap::
+assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) {
 #if ASSERT
-  size_t cur_used_bytes = used();
-  size_t recal_used_bytes = recalculate_used();
+  size_t cur_used_bytes = g1h->used();
+  size_t recal_used_bytes = g1h->recalculate_used();
   assert(cur_used_bytes == recal_used_bytes, "Used(" SIZE_FORMAT ") is not"
           " same as recalculated used(" SIZE_FORMAT ").",
           cur_used_bytes, recal_used_bytes);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -361,9 +361,9 @@ inline void G1CollectedHeap::assert_at_safepoint_on_vm_thread() {
 }
 
 inline void G1CollectedHeap::
-assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) {
-  size_t cur_used_bytes = g1h->used();
-  size_t recal_used_bytes = g1h->recalculate_used();
+assert_used_and_recalculate_used_equal() const {
+  size_t cur_used_bytes = used();
+  size_t recal_used_bytes = recalculate_used();
   assert(cur_used_bytes == recal_used_bytes, "Used(" SIZE_FORMAT ") is not"
           " same as recalculated used(" SIZE_FORMAT ").",
           cur_used_bytes, recal_used_bytes);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -320,13 +320,12 @@ inline bool G1CollectedHeap::is_collection_set_candidate(const HeapRegion* r) co
   BOOL_TO_STR(SafepointSynchronize::is_at_safepoint()),                       \
   BOOL_TO_STR(Thread::current()->is_VM_thread())
 
-DEBUG_ONLY(
+#ifdef ASSERT
 inline void G1CollectedHeap::assert_heap_locked() {
   assert(Heap_lock->owned_by_self(),
           heap_locking_asserts_params("should be holding the Heap_lock"));
-})
+}
 
-DEBUG_ONLY(
 inline void G1CollectedHeap::
 assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) {
   assert(Heap_lock->owned_by_self() ||
@@ -334,47 +333,41 @@ assert_heap_locked_or_at_safepoint(bool should_be_vm_thread) {
             ((should_be_vm_thread) == Thread::current()->is_VM_thread())),
           heap_locking_asserts_params("should be holding the Heap_lock or "
                                       "should be at a safepoint"));
-})
+}
 
-DEBUG_ONLY(
 inline void G1CollectedHeap::assert_heap_locked_and_not_at_safepoint() {
   assert(Heap_lock->owned_by_self() &&
                                   !SafepointSynchronize::is_at_safepoint(),
         heap_locking_asserts_params("should be holding the Heap_lock and "
                                       "should not be at a safepoint"));
-})
+}
 
-DEBUG_ONLY(
 inline void G1CollectedHeap::assert_heap_not_locked() {
   assert(!Heap_lock->owned_by_self(),
       heap_locking_asserts_params("should not be holding the Heap_lock"));
-})
+}
 
-DEBUG_ONLY(
 inline void G1CollectedHeap::assert_heap_not_locked_and_not_at_safepoint() {
   assert(!Heap_lock->owned_by_self() &&
                                   !SafepointSynchronize::is_at_safepoint(),
     heap_locking_asserts_params("should not be holding the Heap_lock and "
                                   "should not be at a safepoint"));
-})
+}
 
-DEBUG_ONLY(
 inline void G1CollectedHeap::assert_at_safepoint_on_vm_thread() {
   assert_at_safepoint();
   assert(Thread::current_or_null() != nullptr, "no current thread");
   assert(Thread::current()->is_VM_thread(), "current thread is not VM thread");
-})
+}
 
-DEBUG_ONLY(
 inline void G1CollectedHeap::
 assert_used_and_recalculate_used_equal(G1CollectedHeap* g1h) {
-#ifdef ASSERT
   size_t cur_used_bytes = g1h->used();
   size_t recal_used_bytes = g1h->recalculate_used();
   assert(cur_used_bytes == recal_used_bytes, "Used(" SIZE_FORMAT ") is not"
           " same as recalculated used(" SIZE_FORMAT ").",
           cur_used_bytes, recal_used_bytes);
-#endif
-})
+}
+#endif // ASSERT
 
 #endif // SHARE_GC_G1_G1COLLECTEDHEAP_INLINE_HPP

--- a/src/hotspot/share/gc/g1/g1CollectionSet.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectionSet.cpp
@@ -69,7 +69,7 @@ G1CollectionSet::~G1CollectionSet() {
 
 void G1CollectionSet::init_region_lengths(uint eden_cset_region_length,
                                           uint survivor_cset_region_length) {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   _eden_region_length     = eden_cset_region_length;
   _survivor_region_length = survivor_cset_region_length;
@@ -96,7 +96,7 @@ void G1CollectionSet::abandon_all_candidates() {
 }
 
 void G1CollectionSet::add_old_region(HeapRegion* hr) {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   assert(_inc_build_state == Active,
          "Precondition, actively building cset or adding optional later on");
@@ -125,7 +125,7 @@ void G1CollectionSet::finalize_incremental_building() {
 }
 
 void G1CollectionSet::clear() {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
   _collection_set_cur_length = 0;
 }
 
@@ -233,7 +233,7 @@ public:
 };
 
 bool G1CollectionSet::verify_young_ages() {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   G1VerifyYoungAgesClosure cl;
   iterate(&cl);
@@ -502,7 +502,7 @@ public:
 };
 
 void G1CollectionSet::verify_young_cset_indices() const {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   G1VerifyYoungCSetIndicesClosure cl(_collection_set_cur_length);
   iterate(&cl);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -625,7 +625,7 @@ void G1ConcurrentMark::set_concurrency_and_phase(uint active_tasks, bool concurr
 
   if (!concurrent) {
     // At this point we should be in a STW phase, and completed marking.
-    assert_at_safepoint_on_vm_thread();
+    G1CollectedHeap::assert_at_safepoint_on_vm_thread();
     assert(out_of_regions(),
            "only way to get here: _finger: " PTR_FORMAT ", _heap_end: " PTR_FORMAT,
            p2i(_finger), p2i(_heap.end()));
@@ -791,7 +791,7 @@ void G1ConcurrentMark::cleanup_for_next_mark() {
 }
 
 void G1ConcurrentMark::clear_bitmap(WorkerThreads* workers) {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
   // To avoid fragmentation the full collection requesting to clear the bitmap
   // might use fewer workers than available. To ensure the bitmap is cleared
   // as efficiently as possible the number of active workers are temporarily
@@ -864,7 +864,7 @@ G1PreConcurrentStartTask::G1PreConcurrentStartTask(GCCause::Cause cause, G1Concu
 };
 
 void G1ConcurrentMark::pre_concurrent_start(GCCause::Cause cause) {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   G1CollectedHeap::start_codecache_marking_cycle_if_inactive(true /* concurrent_mark_start */);
 
@@ -1303,7 +1303,7 @@ public:
 };
 
 void G1ConcurrentMark::remark() {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   // If a full collection has happened, we should not continue. However we might
   // have ended up here as the Remark VM operation has been scheduled already.
@@ -1522,7 +1522,7 @@ void G1ConcurrentMark::compute_new_sizes() {
 }
 
 void G1ConcurrentMark::cleanup() {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   // If a full collection has happened, we shouldn't do this.
   if (has_aborted()) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -86,7 +86,7 @@ inline bool G1ConcurrentMark::mark_in_bitmap(uint const worker_id, oop const obj
 #ifndef PRODUCT
 template<typename Fn>
 inline void G1CMMarkStack::iterate(Fn fn) const {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   size_t num_chunks = 0;
 

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -329,7 +329,7 @@ bool G1HeapVerifier::should_verify(G1VerifyType type) {
 }
 
 void G1HeapVerifier::verify(VerifyOption vo) {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
   assert(Heap_lock->is_locked(), "heap must be locked");
 
   log_debug(gc, verify)("Roots");
@@ -422,7 +422,7 @@ public:
 };
 
 void G1HeapVerifier::verify_region_sets() {
-  assert_heap_locked_or_at_safepoint(true /* should_be_vm_thread */);
+  G1CollectedHeap::assert_heap_locked_or_at_safepoint(true /* should_be_vm_thread */);
 
   // First, check the explicit lists.
   _g1h->_hrm.verify();

--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.cpp
@@ -231,7 +231,7 @@ GrowableArray<MemoryPool*> G1MonitoringSupport::memory_pools() {
 }
 
 void G1MonitoringSupport::recalculate_sizes() {
-  assert_heap_locked_or_at_safepoint(true);
+  G1CollectedHeap::assert_heap_locked_or_at_safepoint(true);
 
   MutexLocker x(MonitoringSupport_lock, Mutex::_no_safepoint_check_flag);
   // Recalculate all the sizes from scratch.

--- a/src/hotspot/share/gc/g1/g1MonotonicArenaFreeMemoryTask.cpp
+++ b/src/hotspot/share/gc/g1/g1MonotonicArenaFreeMemoryTask.cpp
@@ -196,7 +196,7 @@ void G1MonotonicArenaFreeMemoryTask::execute() {
 
 void G1MonotonicArenaFreeMemoryTask::notify_new_stats(G1MonotonicArenaMemoryStats* young_gen_stats,
                                                       G1MonotonicArenaMemoryStats* collection_set_candidate_stats) {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   _total_used = *young_gen_stats;
   _total_used.add(*collection_set_candidate_stats);

--- a/src/hotspot/share/gc/g1/g1MonotonicArenaFreeMemoryTask.cpp
+++ b/src/hotspot/share/gc/g1/g1MonotonicArenaFreeMemoryTask.cpp
@@ -25,7 +25,7 @@
 #include "precompiled.hpp"
 #include "ci/ciUtilities.hpp"
 #include "gc/g1/g1CardSetMemory.inline.hpp"
-#include "gc/g1/g1CollectedHeap.hpp"
+#include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1MonotonicArenaFreeMemoryTask.hpp"
 #include "gc/g1/g1MonotonicArenaFreePool.hpp"
 #include "gc/g1/g1_globals.hpp"

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -682,7 +682,7 @@ void G1Policy::record_young_collection_start() {
   assert(max_survivor_regions() + _g1h->num_used_regions() <= _g1h->max_regions(),
          "Maximum survivor regions %u plus used regions %u exceeds max regions %u",
          max_survivor_regions(), _g1h->num_used_regions(), _g1h->max_regions());
-  G1CollectedHeap::assert_used_and_recalculate_used_equal(_g1h);
+  G1CollectedHeap::heap()->assert_used_and_recalculate_used_equal();
 
   phase_times()->record_cur_collection_start_sec(now.seconds());
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -682,7 +682,7 @@ void G1Policy::record_young_collection_start() {
   assert(max_survivor_regions() + _g1h->num_used_regions() <= _g1h->max_regions(),
          "Maximum survivor regions %u plus used regions %u exceeds max regions %u",
          max_survivor_regions(), _g1h->num_used_regions(), _g1h->max_regions());
-  assert_used_and_recalculate_used_equal(_g1h);
+  G1CollectedHeap::assert_used_and_recalculate_used_equal(_g1h);
 
   phase_times()->record_cur_collection_start_sec(now.seconds());
 

--- a/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
+++ b/src/hotspot/share/gc/g1/g1UncommitRegionTask.cpp
@@ -55,7 +55,7 @@ G1UncommitRegionTask* G1UncommitRegionTask::instance() {
 }
 
 void G1UncommitRegionTask::enqueue() {
-  assert_at_safepoint_on_vm_thread();
+  G1CollectedHeap::assert_at_safepoint_on_vm_thread();
 
   G1UncommitRegionTask* uncommit_task = instance();
   if (!uncommit_task->is_active()) {

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -1012,7 +1012,7 @@ void G1YoungCollector::post_evacuate_collection_set(G1EvacInfo* evacuation_info,
 
   _evac_failure_regions.post_collection();
 
-  G1CollectedHeap::assert_used_and_recalculate_used_equal(_g1h);
+  G1CollectedHeap::heap()->assert_used_and_recalculate_used_equal();
 
   _g1h->rebuild_free_region_list();
 

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -1012,7 +1012,7 @@ void G1YoungCollector::post_evacuate_collection_set(G1EvacInfo* evacuation_info,
 
   _evac_failure_regions.post_collection();
 
-  assert_used_and_recalculate_used_equal(_g1h);
+  G1CollectedHeap::assert_used_and_recalculate_used_equal(_g1h);
 
   _g1h->rebuild_free_region_list();
 


### PR DESCRIPTION
Description:
In G1CollectedHeap there are several "assert_*" macros (e.g. assert_heap_locked_and_not_at_safepoint) that were presumably implemented as macros due to bad stack traces in hs_err files. 

Convert them to functions using NOT_DEBUG_RETURN to avoid the macros.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8227713](https://bugs.openjdk.org/browse/JDK-8227713): Convert G1's assert_ macros into NOT_DEBUG_RETURN functions (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17188/head:pull/17188` \
`$ git checkout pull/17188`

Update a local copy of the PR: \
`$ git checkout pull/17188` \
`$ git pull https://git.openjdk.org/jdk.git pull/17188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17188`

View PR using the GUI difftool: \
`$ git pr show -t 17188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17188.diff">https://git.openjdk.org/jdk/pull/17188.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17188#issuecomment-1868162473)