### PR TITLE
8322734: A redundant return in method padWithLen

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ISO10126Padding.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ISO10126Padding.java
@@ -74,7 +74,6 @@ final class ISO10126Padding implements Padding {
         SunJCE.getRandom().nextBytes(padding);
         System.arraycopy(padding, 0, in, off, len - 1);
         in[idx - 1] = paddingOctet;
-        return;
     }
 
     /**

--- a/src/java.base/share/classes/com/sun/crypto/provider/PKCS5Padding.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PKCS5Padding.java
@@ -71,7 +71,6 @@ final class PKCS5Padding implements Padding {
 
         byte paddingOctet = (byte) (len & 0xff);
         Arrays.fill(in, off, idx, paddingOctet);
-        return;
     }
 
     /**


### PR DESCRIPTION
It looks the `return`s in the methods `PKCS5Padding::padWithLen` and `ISO10126Padding::padWithLen` are redundant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322734](https://bugs.openjdk.org/browse/JDK-8322734): A redundant return in method padWithLen (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17189/head:pull/17189` \
`$ git checkout pull/17189`

Update a local copy of the PR: \
`$ git checkout pull/17189` \
`$ git pull https://git.openjdk.org/jdk.git pull/17189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17189`

View PR using the GUI difftool: \
`$ git pr show -t 17189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17189.diff">https://git.openjdk.org/jdk/pull/17189.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17189#issuecomment-1868889443)