### PR TITLE
8322735: C2: minor improvements of bubble sort used in SuperWord::packset_sort

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3516,7 +3516,7 @@ void SuperWord::remove_pack_at(int pos) {
 void SuperWord::packset_sort(int n) {
   // simple bubble sort so that we capitalize with O(n) when its already sorted
   do {
-    int newN = 0;
+    int max_swap_index = 0;
     for (int i = 1; i < n; i++) {
       Node_List* q_low = _packset.at(i-1);
       Node_List* q_i = _packset.at(i);
@@ -3526,10 +3526,10 @@ void SuperWord::packset_sort(int n) {
         Node_List* t = q_i;
         *(_packset.adr_at(i)) = q_low;
         *(_packset.adr_at(i-1)) = q_i;
-        newN = i;
+        max_swap_index = i;
       }
     }
-    n = newN;
+    n = max_swap_index;
   } while (n > 1);
 }
 

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3523,7 +3523,6 @@ void SuperWord::packset_sort(int n) {
 
       // only swap when we find something to swap
       if (alignment(q_low->at(0)) > alignment(q_i->at(0))) {
-        Node_List* t = q_i;
         *(_packset.adr_at(i)) = q_low;
         *(_packset.adr_at(i-1)) = q_i;
         max_swap_index = i;

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3515,8 +3515,8 @@ void SuperWord::remove_pack_at(int pos) {
 
 void SuperWord::packset_sort(int n) {
   // simple bubble sort so that we capitalize with O(n) when its already sorted
-  while (n != 0) {
-    bool swapped = false;
+  do {
+    int newN = 0;
     for (int i = 1; i < n; i++) {
       Node_List* q_low = _packset.at(i-1);
       Node_List* q_i = _packset.at(i);
@@ -3526,12 +3526,11 @@ void SuperWord::packset_sort(int n) {
         Node_List* t = q_i;
         *(_packset.adr_at(i)) = q_low;
         *(_packset.adr_at(i-1)) = q_i;
-        swapped = true;
+        newN = i;
       }
     }
-    if (swapped == false) break;
-    n--;
-  }
+    n = newN;
+  } while (n > 1);
 }
 
 LoadNode::ControlDependency SuperWord::control_dependency(Node_List* p) {


### PR DESCRIPTION
A minor improvement could be made for bubble sort in SuperWord::packset_sort to reduce the comparison count in bad cases.

See https://en.wikipedia.org/wiki/Bubble_sort

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322735](https://bugs.openjdk.org/browse/JDK-8322735): C2: minor improvements of bubble sort used in SuperWord::packset_sort (**Enhancement** - P5)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**) ⚠️ Review applies to [ba53ed56](https://git.openjdk.org/jdk/pull/17190/files/ba53ed56f9d480138f6bf4ddad9b48ca214d9a7d)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17190/head:pull/17190` \
`$ git checkout pull/17190`

Update a local copy of the PR: \
`$ git checkout pull/17190` \
`$ git pull https://git.openjdk.org/jdk.git pull/17190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17190`

View PR using the GUI difftool: \
`$ git pr show -t 17190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17190.diff">https://git.openjdk.org/jdk/pull/17190.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17190#issuecomment-1869031503)