### PR TITLE
8322583: RISC-V: Enable fast class initialization checks

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -209,6 +209,9 @@ class VM_Version : public Abstract_VM_Version {
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
   static bool supports_on_spin_wait() { return UseZihintpause; }
+
+  // RISCV64 supports fast class initialization checks
+  static bool supports_fast_class_init_checks() { return true; }
 };
 
 #endif // CPU_RISCV_VM_VERSION_RISCV_HPP


### PR DESCRIPTION
Hi, Please review this small change enabling fast class initialization checks on linux-riscv. As discussed on [1], we noticed that VM_Version::supports_fast_class_init_checks is false on linux-riscv64 platform. But the needed code of this optimization on this platform is there which is supposed to solve a performance issue https://bugs.openjdk.org/browse/JDK-8219233 at that time. I found that this performance issue is still reproduciable on linux-riscv64. And the original performance issue reported by JDK-8219233 is resolved when this optimization is enabled (x2.5 improvement for reported case on linux-riscv64).

Once this is in, I'd like to request approval for backporting to JDK 21u and JDK 17u since corresponding fixes for the other ports are already there, unless the community feels otherwise.

[1] https://github.com/openjdk/jdk/pull/17006#issuecomment-1865582796

OpenJDK23 linux-riscv64 when setting VM_Version::supports_fast_class_init_checks returns false(default):

```
$ clojure -A:user
"Elapsed time: 91597.717028 msecs"
$ clojure -A:user
"Elapsed time: 91851.01435 msecs"
$ clojure -A:user
"Elapsed time: 92149.106378 msecs"
$ clojure foo.clj
"Elapsed time: 35663.36249 msecs"
$ clojure foo.clj
"Elapsed time: 35677.387338 msecs"
$ clojure foo.clj
"Elapsed time: 35253.330701 msecs"
```

OpenJDK23 linux-riscv64 when setting VM_Version::supports_fast_class_init_checks returns true:

```
$ clojure -A:user
"Elapsed time: 37425.063258 msecs"
$ clojure -A:user
"Elapsed time: 36338.252422 msecs"
$ clojure -A:user
"Elapsed time: 37441.73001 msecs"
$ clojure foo.clj
"Elapsed time: 36018.857489 msecs"
$ clojure foo.clj
"Elapsed time: 34750.533297 msecs"
$ clojure foo.clj
"Elapsed time: 35499.890121 msecs"
```

### Testing:

- [x]  Run tier1-3 tests on qemu 8.1.0 with UseRVV (fastdebug)
- [x]  Run tier1-3 tests on qemu 8.1.0 with UseRVV (release)
- [x]  Run tier1-3, hotspot:tier4 tests with SiFive unmatched (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322583](https://bugs.openjdk.org/browse/JDK-8322583): RISC-V: Enable fast class initialization checks (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17192/head:pull/17192` \
`$ git checkout pull/17192`

Update a local copy of the PR: \
`$ git checkout pull/17192` \
`$ git pull https://git.openjdk.org/jdk.git pull/17192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17192`

View PR using the GUI difftool: \
`$ git pr show -t 17192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17192.diff">https://git.openjdk.org/jdk/pull/17192.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17192#issuecomment-1873562058)