### PR TITLE
8322747: StringTable should be AllStatic

### DIFF
--- a/src/hotspot/share/classfile/stringTable.hpp
+++ b/src/hotspot/share/classfile/stringTable.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_CLASSFILE_STRINGTABLE_HPP
 #define SHARE_CLASSFILE_STRINGTABLE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
 #include "memory/padded.hpp"
 #include "oops/oop.hpp"
 #include "oops/oopHandle.hpp"
@@ -37,15 +37,11 @@ class DumpedInternedStrings;
 class JavaThread;
 class SerializeClosure;
 
-class StringTable;
 class StringTableConfig;
-class StringTableCreateEntry;
 
-class StringTable : public CHeapObj<mtSymbol>{
+class StringTable : AllStatic {
   friend class VMStructs;
-  friend class Symbol;
   friend class StringTableConfig;
-  friend class StringTableCreateEntry;
 
   static volatile bool _has_work;
 


### PR DESCRIPTION
Please review this trivial change to StringTable, making it derive from
AllStatic rather than CHeapObj<mtSymbol>, to match the implementation.

While I was there, also did a little cleanup of related forward and friend
declarations.  StringTableCreateEntry doesn't exist.  Don't need forward
declaration for StringTable right before it's definition.  StringTable doesn't
need to befriend Symbol.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322747](https://bugs.openjdk.org/browse/JDK-8322747): StringTable should be AllStatic (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17193/head:pull/17193` \
`$ git checkout pull/17193`

Update a local copy of the PR: \
`$ git checkout pull/17193` \
`$ git pull https://git.openjdk.org/jdk.git pull/17193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17193`

View PR using the GUI difftool: \
`$ git pr show -t 17193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17193.diff">https://git.openjdk.org/jdk/pull/17193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17193#issuecomment-1869925319)