### PR TITLE
8322751: ZGC: Fix comments about marking roots

### DIFF
--- a/src/hotspot/share/gc/x/xHeap.cpp
+++ b/src/hotspot/share/gc/x/xHeap.cpp
@@ -249,7 +249,7 @@ void XHeap::mark_start() {
   // Enter mark phase
   XGlobalPhase = XPhaseMark;
 
-  // Reset marking information and mark roots
+  // Reset marking information
   _mark.start();
 
   // Update statistics

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -861,7 +861,7 @@ void ZGenerationYoung::mark_start() {
   // Enter mark phase
   set_phase(Phase::Mark);
 
-  // Reset marking information and mark roots
+  // Reset marking information
   _mark.start();
 
   // Flip remembered set bits
@@ -1213,7 +1213,7 @@ void ZGenerationOld::mark_start() {
   // Enter mark phase
   set_phase(Phase::Mark);
 
-  // Reset marking information and mark roots
+  // Reset marking information
   _mark.start();
 
   // Update statistics


### PR DESCRIPTION
Hi all,

This trivial patch fixes comments about marking roots.

Thread-stack processing has been concurrent after [JDK-8253180](https://bugs.openjdk.org/browse/JDK-8253180).
And the code about marking root in `ZMark::start` has been removed after [JDK-8254562](https://bugs.openjdk.org/browse/JDK-8254562).
But some comments in ZGC and generational ZGC have not fixed, which may mislead the newbies of the ZGC.

Thanks for review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322751](https://bugs.openjdk.org/browse/JDK-8322751): ZGC: Fix comments about marking roots (**Enhancement** - P5)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17195/head:pull/17195` \
`$ git checkout pull/17195`

Update a local copy of the PR: \
`$ git checkout pull/17195` \
`$ git pull https://git.openjdk.org/jdk.git pull/17195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17195`

View PR using the GUI difftool: \
`$ git pr show -t 17195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17195.diff">https://git.openjdk.org/jdk/pull/17195.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17195#issuecomment-1870092870)