### PR TITLE
JDK-8320405: [Windows Server 2016] java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java shows issues in awt_Win32GraphicsDevice.cpp

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
@@ -137,7 +137,13 @@ HDC AwtWin32GraphicsDevice::MakeDCFromMonitor(HMONITOR hmMonitor) {
             HDC hDC = CreateDC(mieInfo.szDevice, NULL, NULL, NULL);
             if (NULL != hDC) {
                 retCode = hDC;
+            } else {
+                J2dTraceLn1(J2D_TRACE_WARNING,
+                       "CreateDC failed, so we cannot store the DC for later usage, mieInfo.szDevice is %S",
+                       mieInfo.szDevice);
             }
+        } else {
+            J2dTraceLn(J2D_TRACE_WARNING, "GetMonitorInfo failed, so we cannot create the DC as well");
         }
     }
     return retCode;
@@ -179,7 +185,13 @@ void AwtWin32GraphicsDevice::Initialize()
     }
     gpBitmapInfo->bmiHeader.biBitCount = 0;
     HDC hBMDC = this->GetDC();
+    if (hBMDC == NULL) {
+        J2dTraceLn(J2D_TRACE_WARNING, "AwtWin32GraphicsDevice::Initialize GetDC failed");
+    }
     HBITMAP hBM = ::CreateCompatibleBitmap(hBMDC, 1, 1);
+    if (hBM == NULL) {
+        J2dTraceLn(J2D_TRACE_WARNING, "AwtWin32GraphicsDevice::Initialize CreateCompatibleBitmap failed");
+    }
     VERIFY(::GetDIBits(hBMDC, hBM, 0, 1, NULL, gpBitmapInfo, DIB_RGB_COLORS));
 
     if (colorData->bitsperpixel > 8) {
@@ -293,8 +305,8 @@ void AwtWin32GraphicsDevice::Initialize()
         }
         palette->UpdateLogical();
     }
-    VERIFY(::DeleteObject(hBM));
-    VERIFY(::DeleteDC(hBMDC));
+    if (hBM != NULL) VERIFY(::DeleteObject(hBM));
+    if (hBMDC != NULL) VERIFY(::DeleteDC(hBMDC));
 }
 
 /**

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
@@ -192,7 +192,11 @@ void AwtWin32GraphicsDevice::Initialize()
     if (hBM == NULL) {
         J2dTraceLn(J2D_TRACE_WARNING, "AwtWin32GraphicsDevice::Initialize CreateCompatibleBitmap failed");
     }
-    VERIFY(::GetDIBits(hBMDC, hBM, 0, 1, NULL, gpBitmapInfo, DIB_RGB_COLORS));
+
+    bool cbf = false;
+    if (::GetDIBits(hBMDC, hBM, 0, 1, NULL, gpBitmapInfo, DIB_RGB_COLORS) == 0) {
+        cbf = true;
+    }
 
     if (colorData->bitsperpixel > 8) {
         if (MONITORINFOF_PRIMARY & pMonitorInfo->dwFlags) {
@@ -201,7 +205,7 @@ void AwtWin32GraphicsDevice::Initialize()
         if (colorData->bitsperpixel != 24) { // 15, 16, or 32 bpp
             int foo;
             gpBitmapInfo->bmiHeader.biCompression = BI_BITFIELDS;
-            if (::GetDIBits(hBMDC, hBM, 0, 1, &foo, gpBitmapInfo,
+            if (cbf || ::GetDIBits(hBMDC, hBM, 0, 1, &foo, gpBitmapInfo,
                             DIB_RGB_COLORS) == 0)
             {
                 // Bug 4684966: If GetDIBits returns an error, we could
@@ -305,8 +309,8 @@ void AwtWin32GraphicsDevice::Initialize()
         }
         palette->UpdateLogical();
     }
-    if (hBM != NULL) VERIFY(::DeleteObject(hBM));
-    if (hBMDC != NULL) VERIFY(::DeleteDC(hBMDC));
+    if (hBM != NULL) { VERIFY(::DeleteObject(hBM)); }
+    if (hBMDC != NULL) { VERIFY(::DeleteDC(hBMDC)); }
 }
 
 /**

--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsDevice.cpp
@@ -185,17 +185,21 @@ void AwtWin32GraphicsDevice::Initialize()
     }
     gpBitmapInfo->bmiHeader.biBitCount = 0;
     HDC hBMDC = this->GetDC();
+    HBITMAP hBM = NULL;
     if (hBMDC == NULL) {
         J2dTraceLn(J2D_TRACE_WARNING, "AwtWin32GraphicsDevice::Initialize GetDC failed");
-    }
-    HBITMAP hBM = ::CreateCompatibleBitmap(hBMDC, 1, 1);
-    if (hBM == NULL) {
-        J2dTraceLn(J2D_TRACE_WARNING, "AwtWin32GraphicsDevice::Initialize CreateCompatibleBitmap failed");
+    } else {
+        hBM = ::CreateCompatibleBitmap(hBMDC, 1, 1);
+        if (hBM == NULL) {
+            J2dTraceLn(J2D_TRACE_WARNING, "AwtWin32GraphicsDevice::Initialize CreateCompatibleBitmap failed");
+        }
     }
 
     bool cbf = false;
-    if (::GetDIBits(hBMDC, hBM, 0, 1, NULL, gpBitmapInfo, DIB_RGB_COLORS) == 0) {
-        cbf = true;
+    if (hBM != NULL) {
+        if (::GetDIBits(hBMDC, hBM, 0, 1, NULL, gpBitmapInfo, DIB_RGB_COLORS) == 0) {
+            cbf = true;
+        }
     }
 
     if (colorData->bitsperpixel > 8) {


### PR DESCRIPTION
When running with fastdebug binaries we run intermittent into the issue below in
jtreg test java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java .
Seems we miss checking of successful HBITMAP creation before calling GetDIBits.

  HDC hBMDC = this->GetDC();
  HBITMAP hBM = ::CreateCompatibleBitmap(hBMDC, 1, 1);
  VERIFY(::GetDIBits(hBMDC, hBM, 0, 1, NULL, gpBitmapInfo, DIB_RGB_COLORS));

in awt_Win32GraphicsDevice.cpp . Thats why the releast of hBMDC / hBM fails as well at the end of the function causing the seond and third warning.


Sat Nov 18 17:29:23 CET 2023

*********************
AWT Assertion Failure
*********************
::GetDIBits(hBMDC, hBM, 0, 1, 0, gpBitmapInfo, 0)
File 'e:\openjdk\openjdk-21u-windows_x86_64-dbg\jdk\src\java.desktop\windows\native\libawt\windows\awt_Win32GraphicsDevice.cpp', at line 184
GetLastError() is 57 : The parameter is incorrect.

Do you want to break into the debugger?
*********************
*********************
AWT Assertion Failure
*********************
::DeleteObject(hBM)
File 'e:\openjdk\openjdk-21u-windows_x86_64-dbg\jdk\src\java.desktop\windows\native\libawt\windows\awt_Win32GraphicsDevice.cpp', at line 297
GetLastError() is 57 : The parameter is incorrect.

So it seems, we should have some additional checks/tracing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320405](https://bugs.openjdk.org/browse/JDK-8320405): [Windows Server 2016] java/awt/image/MultiResolutionImage/MultiResolutionImageObserverTest.java shows issues in awt_Win32GraphicsDevice.cpp (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17197/head:pull/17197` \
`$ git checkout pull/17197`

Update a local copy of the PR: \
`$ git checkout pull/17197` \
`$ git pull https://git.openjdk.org/jdk.git pull/17197/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17197`

View PR using the GUI difftool: \
`$ git pr show -t 17197`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17197.diff">https://git.openjdk.org/jdk/pull/17197.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17197#issuecomment-1871008622)