### PR TITLE
8322772: Clean up code after JDK-8322417

### DIFF
--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -120,7 +120,7 @@ public final class JdkConsoleImpl implements JdkConsole {
                             ioe.addSuppressed(x);
                     }
                     if (ioe != null) {
-                        java.util.Arrays.fill(passwd, ' ');
+                        Arrays.fill(passwd, ' ');
                         try {
                             if (reader instanceof LineReader lr) {
                                 lr.zeroOut();


### PR DESCRIPTION
In the review of the PR for JDK-8322417 it was noted that a fully qualified class name "java.util.Arrays" is unnecessary but it was forgotten to clean it up prior to integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322772](https://bugs.openjdk.org/browse/JDK-8322772): Clean up code after JDK-8322417 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17203/head:pull/17203` \
`$ git checkout pull/17203`

Update a local copy of the PR: \
`$ git checkout pull/17203` \
`$ git pull https://git.openjdk.org/jdk.git pull/17203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17203`

View PR using the GUI difftool: \
`$ git pr show -t 17203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17203.diff">https://git.openjdk.org/jdk/pull/17203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17203#issuecomment-1872104623)