### PR TITLE
8322779: C1: Remove the unused counter 'totalInstructionNodes'

### DIFF
--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -76,7 +76,6 @@ static const char * timer_name[] = {
 };
 
 static elapsedTimer timers[max_phase_timers];
-static uint totalInstructionNodes = 0;
 
 class PhaseTraceTime: public TraceTime {
  private:
@@ -494,7 +493,6 @@ void Compilation::compile_method() {
   if (log() != nullptr) // Print code cache state into compiler log
     log()->code_cache_state();
 
-  totalInstructionNodes += Instruction::number_of_instructions();
 }
 
 


### PR DESCRIPTION
Hi,

Could I have a review of this small cleanup patch that removes the unused counter 'totalInstructionNodes'.  JDK-8058968 refactored the Compiler time traces and deleted the only place that read the counter.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322779](https://bugs.openjdk.org/browse/JDK-8322779): C1: Remove the unused counter 'totalInstructionNodes' (**Enhancement** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17204/head:pull/17204` \
`$ git checkout pull/17204`

Update a local copy of the PR: \
`$ git checkout pull/17204` \
`$ git pull https://git.openjdk.org/jdk.git pull/17204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17204`

View PR using the GUI difftool: \
`$ git pr show -t 17204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17204.diff">https://git.openjdk.org/jdk/pull/17204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17204#issuecomment-1872143526)