### PR TITLE
8322781: C1: Debug build crash in GraphBuilder::vmap() when print stats

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -4468,7 +4468,9 @@ void GraphBuilder::append_unsafe_get_and_set(ciMethod* callee, bool is_add) {
 
 #ifndef PRODUCT
 void GraphBuilder::print_stats() {
-  vmap()->print();
+  if (UseLocalValueNumbering) {
+    vmap()->print();
+  }
 }
 #endif // PRODUCT
 

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -61,9 +61,10 @@
  * @test
  * @bug 8322781
  * @requires vm.debug
- * @summary Test flag with value numbering
+ * @summary Test flag with c1 value numbering
  *
  * @run main/othervm -XX:+PrintValueNumbering -XX:+Verbose -XX:-UseLocalValueNumbering
+ *                   -Xcomp -XX:TieredStopAtLevel=1
  *                   compiler.arguments.TestC1Globals
  *
  */

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -57,6 +57,17 @@
  *
  */
 
+/**
+ * @test
+ * @bug 8322781
+ * @requires vm.debug
+ * @summary Test flag with value numbering
+ *
+ * @run main/othervm -XX:+PrintValueNumbering -XX:+Verbose -XX:-UseLocalValueNumbering
+ *                   compiler.arguments.TestC1Globals
+ *
+ */
+
 package compiler.arguments;
 
 public class TestC1Globals {

--- a/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestC1Globals.java
@@ -66,7 +66,6 @@
  * @run main/othervm -XX:+PrintValueNumbering -XX:+Verbose -XX:-UseLocalValueNumbering
  *                   -Xcomp -XX:TieredStopAtLevel=1
  *                   compiler.arguments.TestC1Globals
- *
  */
 
 package compiler.arguments;


### PR DESCRIPTION
Hi,

Could I have a review of this fix patch that fixes a crash problem in the debug build when -XX:+PrintValueNumbering -XX:+Verbose -XX:-UseLocalValueNumbering

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322781](https://bugs.openjdk.org/browse/JDK-8322781): C1: Debug build crash in GraphBuilder::vmap() when print stats (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [49f90f41](https://git.openjdk.org/jdk/pull/17205/files/49f90f41d74492413dc59ccca52a6bfa91291303)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17205/head:pull/17205` \
`$ git checkout pull/17205`

Update a local copy of the PR: \
`$ git checkout pull/17205` \
`$ git pull https://git.openjdk.org/jdk.git pull/17205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17205`

View PR using the GUI difftool: \
`$ git pr show -t 17205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17205.diff">https://git.openjdk.org/jdk/pull/17205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17205#issuecomment-1872156285)