### PR TITLE
8322790: RISC-V: Tune costs for shuffles with no conversion

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1001,6 +1001,7 @@ definitions %{
   int_def LOAD_COST            (  300,  3 * DEFAULT_COST);          // load, fpload
   int_def STORE_COST           (  100,  1 * DEFAULT_COST);          // store, fpstore
   int_def XFER_COST            (  300,  3 * DEFAULT_COST);          // mfc, mtc, fcvt, fmove, fcmp
+  int_def FMVX_COST            (  100,  1 * DEFAULT_COST);          // shuffles with no conversion
   int_def BRANCH_COST          (  200,  2 * DEFAULT_COST);          // branch, jmp, call
   int_def IMUL_COST            ( 1000, 10 * DEFAULT_COST);          // imul
   int_def IDIVSI_COST          ( 3400, 34 * DEFAULT_COST);          // idivsi
@@ -8530,7 +8531,7 @@ instruct MoveF2I_stack_reg(iRegINoSp dst, stackSlotF src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(LOAD_COST);
+  ins_cost(ALU_COST + LOAD_COST);
 
   format %{ "lw  $dst, $src\t#@MoveF2I_stack_reg" %}
 
@@ -8548,7 +8549,7 @@ instruct MoveI2F_stack_reg(fRegF dst, stackSlotI src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(LOAD_COST);
+  ins_cost(ALU_COST + LOAD_COST);
 
   format %{ "flw  $dst, $src\t#@MoveI2F_stack_reg" %}
 
@@ -8566,7 +8567,7 @@ instruct MoveD2L_stack_reg(iRegLNoSp dst, stackSlotD src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(LOAD_COST);
+  ins_cost(ALU_COST + LOAD_COST);
 
   format %{ "ld  $dst, $src\t#@MoveD2L_stack_reg" %}
 
@@ -8584,7 +8585,7 @@ instruct MoveL2D_stack_reg(fRegD dst, stackSlotL src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(LOAD_COST);
+  ins_cost(ALU_COST + LOAD_COST);
 
   format %{ "fld  $dst, $src\t#@MoveL2D_stack_reg" %}
 
@@ -8602,7 +8603,7 @@ instruct MoveF2I_reg_stack(stackSlotI dst, fRegF src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(STORE_COST);
+  ins_cost(ALU_COST + STORE_COST);
 
   format %{ "fsw  $src, $dst\t#@MoveF2I_reg_stack" %}
 
@@ -8620,7 +8621,7 @@ instruct MoveI2F_reg_stack(stackSlotF dst, iRegI src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(STORE_COST);
+  ins_cost(ALU_COST + STORE_COST);
 
   format %{ "sw  $src, $dst\t#@MoveI2F_reg_stack" %}
 
@@ -8638,7 +8639,7 @@ instruct MoveD2L_reg_stack(stackSlotL dst, fRegD src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(STORE_COST);
+  ins_cost(ALU_COST + STORE_COST);
 
   format %{ "fsd  $dst, $src\t#@MoveD2L_reg_stack" %}
 
@@ -8656,7 +8657,7 @@ instruct MoveL2D_reg_stack(stackSlotD dst, iRegL src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(STORE_COST);
+  ins_cost(ALU_COST + STORE_COST);
 
   format %{ "sd  $src, $dst\t#@MoveL2D_reg_stack" %}
 
@@ -8674,7 +8675,7 @@ instruct MoveF2I_reg_reg(iRegINoSp dst, fRegF src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(XFER_COST);
+  ins_cost(FMVX_COST);
 
   format %{ "fmv.x.w  $dst, $src\t#@MoveF2I_reg_reg" %}
 
@@ -8692,7 +8693,7 @@ instruct MoveI2F_reg_reg(fRegF dst, iRegI src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(XFER_COST);
+  ins_cost(FMVX_COST);
 
   format %{ "fmv.w.x  $dst, $src\t#@MoveI2F_reg_reg" %}
 
@@ -8710,7 +8711,7 @@ instruct MoveD2L_reg_reg(iRegLNoSp dst, fRegD src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(XFER_COST);
+  ins_cost(FMVX_COST);
 
   format %{ "fmv.x.d $dst, $src\t#@MoveD2L_reg_reg" %}
 
@@ -8728,7 +8729,7 @@ instruct MoveL2D_reg_reg(fRegD dst, iRegL src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(XFER_COST);
+  ins_cost(FMVX_COST);
 
   format %{ "fmv.d.x  $dst, $src\t#@MoveL2D_reg_reg" %}
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8531,7 +8531,7 @@ instruct MoveF2I_stack_reg(iRegINoSp dst, stackSlotF src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(ALU_COST + LOAD_COST);
+  ins_cost(LOAD_COST);
 
   format %{ "lw  $dst, $src\t#@MoveF2I_stack_reg" %}
 
@@ -8549,7 +8549,7 @@ instruct MoveI2F_stack_reg(fRegF dst, stackSlotI src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(ALU_COST + LOAD_COST);
+  ins_cost(LOAD_COST);
 
   format %{ "flw  $dst, $src\t#@MoveI2F_stack_reg" %}
 
@@ -8567,7 +8567,7 @@ instruct MoveD2L_stack_reg(iRegLNoSp dst, stackSlotD src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(ALU_COST + LOAD_COST);
+  ins_cost(LOAD_COST);
 
   format %{ "ld  $dst, $src\t#@MoveD2L_stack_reg" %}
 
@@ -8585,7 +8585,7 @@ instruct MoveL2D_stack_reg(fRegD dst, stackSlotL src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(ALU_COST + LOAD_COST);
+  ins_cost(LOAD_COST);
 
   format %{ "fld  $dst, $src\t#@MoveL2D_stack_reg" %}
 
@@ -8603,7 +8603,7 @@ instruct MoveF2I_reg_stack(stackSlotI dst, fRegF src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(ALU_COST + STORE_COST);
+  ins_cost(STORE_COST);
 
   format %{ "fsw  $src, $dst\t#@MoveF2I_reg_stack" %}
 
@@ -8621,7 +8621,7 @@ instruct MoveI2F_reg_stack(stackSlotF dst, iRegI src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(ALU_COST + STORE_COST);
+  ins_cost(STORE_COST);
 
   format %{ "sw  $src, $dst\t#@MoveI2F_reg_stack" %}
 
@@ -8639,7 +8639,7 @@ instruct MoveD2L_reg_stack(stackSlotL dst, fRegD src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(ALU_COST + STORE_COST);
+  ins_cost(STORE_COST);
 
   format %{ "fsd  $dst, $src\t#@MoveD2L_reg_stack" %}
 
@@ -8657,7 +8657,7 @@ instruct MoveL2D_reg_stack(stackSlotD dst, iRegL src) %{
 
   effect(DEF dst, USE src);
 
-  ins_cost(ALU_COST + STORE_COST);
+  ins_cost(STORE_COST);
 
   format %{ "sd  $src, $dst\t#@MoveL2D_reg_stack" %}
 


### PR DESCRIPTION
Hi all, please review this small change to RISC-V nodes insertion costs.
Now we have several nodes which provide shuffles without conversion: https://github.com/openjdk/jdk/blob/32d80e2caf6063b58128bd5f3dc87b276f3bd0cb/src/hotspot/cpu/riscv/riscv.ad#L8525-L8741
On most RISC-V cpu`s we prefer reg<->reg operations, because they are faster, but now stack<->reg operations used (for details about reasons, please, visit connected jbs issue).
After changing insertion costs reg<->reg operations selected, and we can see performance improvements for benchmarks, which use such shuffles (tested on thead C910 board):
|              Benchmark              | Upstream build (ops/ms) | Patched build (ops/ms) | difference (%) |
|:-----------------------------------:|:-----------------------:|:----------------------:|:--------------:|
| MathBench.doubleToRawLongBitsDouble |        30935.139        |        32171.761       |      +4.00      |
|      StrictMathBench.ceilDouble     |        24682.810        |        29782.050       |      +20.66     |
|      StrictMathBench.cosDouble      |         6948.309        |        6938.276        |      -0.14     |
|      StrictMathBench.expDouble      |         6816.143        |        7211.021        |      +5.79      |
|     StrictMathBench.floorDouble     |        30699.630        |        34189.509       |      +11.37     |
|      StrictMathBench.maxDouble      |        35157.355        |        34675.191       |      -1.37     |
|      StrictMathBench.minDouble      |        35192.135        |        35183.015       |      -0.03     |
|      StrictMathBench.sinDouble      |         6698.405        |        6721.809        |      +0.35      |

New benchmark for changed nodes:
```
--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -540,4 +540,11 @@ public class MathBench {
         return  Math.ulp(float7);
     }
 
+    @Benchmark
+    public long doubleToRawLongBitsDouble() {
+        double dbl162Dot5 = double81 * 2.0d + double0Dot5;
+        double dbl3 = double2 + double1;
+        return Double.doubleToRawLongBits(dbl162Dot5) + Double.doubleToRawLongBits(dbl3);
+    }
+

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322790](https://bugs.openjdk.org/browse/JDK-8322790): RISC-V: Tune costs for shuffles with no conversion (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17206/head:pull/17206` \
`$ git checkout pull/17206`

Update a local copy of the PR: \
`$ git checkout pull/17206` \
`$ git pull https://git.openjdk.org/jdk.git pull/17206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17206`

View PR using the GUI difftool: \
`$ git pr show -t 17206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17206.diff">https://git.openjdk.org/jdk/pull/17206.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17206#issuecomment-1872597026)