### PR TITLE
8322802: Add testing for ZipFile.getEntry respecting the 'Language encoding' flag

### DIFF
--- a/test/jdk/java/util/zip/ZipCoding.java
+++ b/test/jdk/java/util/zip/ZipCoding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/zip/ZipCoding.java
+++ b/test/jdk/java/util/zip/ZipCoding.java
@@ -125,9 +125,9 @@ public class ZipCoding {
              ZipInputStream zis = new ZipInputStream(in, Charset.forName(readCharset))) {
             ZipEntry e = zis.getNextEntry();
             assertNotNull(e);
-            assertEquals(name, e.getName());
+            assertEquals(name, e.getName(), "Entry name does not match");
             assertNull(e.getComment()); // No comment in the LOC header
-            assertArrayEquals(ENTRY_DATA, zis.readAllBytes(), "ZipIS content doesn't match!");
+            assertArrayEquals(ENTRY_DATA, zis.readAllBytes(), "ZIP entry data does not match");
         }
     }
 
@@ -160,19 +160,19 @@ public class ZipCoding {
             Enumeration<? extends ZipEntry> zes = zf.entries();
             ZipEntry e = (ZipEntry)zes.nextElement();
             assertNotNull(e);
-            assertEquals(name, e.getName(), "ZipFile.entries(): name doesn't match!");
-            assertEquals(comment, e.getComment(), "ZipFile.entries(): comment doesn't match!");
+            assertEquals(name, e.getName(), "ZipFile.entries() returned unexpected entry name");
+            assertEquals(comment, e.getComment(), "ZipFile.entries() returned unexpected entry comment");
 
             // Test using ZipFile.getEntry
             e = zf.getEntry(name);
             assertNotNull(e,
-                    String.format("Entry not found for ZipFile encoded with %s and opened with %s",
+                    String.format("Entry lookup failed on ZIP encoded with %s and opened with %s",
                             writeCharset, readCharset));
-            assertEquals(name, e.getName(), "ZipFile.getEntry(): name doesn't match!");
-            assertEquals(comment, e.getComment(), "ZipFile.getEntry(): comment doesn't match!");
+            assertEquals(name, e.getName(), "ZipFile.getEntry() returned unexpected entry name");
+            assertEquals(comment, e.getComment(), "ZipFile.getEntry() returned unexpected entry comment");
             try (InputStream is = zf.getInputStream(e)) {
                 assertNotNull(is);
-                assertArrayEquals(ENTRY_DATA, is.readAllBytes(), "ZipFile content doesn't match!");
+                assertArrayEquals(ENTRY_DATA, is.readAllBytes(), "ZIP entry data does not match");
             }
         }
 

--- a/test/jdk/java/util/zip/ZipCoding.java
+++ b/test/jdk/java/util/zip/ZipCoding.java
@@ -151,6 +151,11 @@ public class ZipCoding {
             assertEquals(expectedName, e.getName(), "ZipFile.entries(): name doesn't match!");
             assertEquals(expectedComment, e.getComment(), "ZipFile.entries(): comment doesn't match!");
 
+            // Test using ZipFile.getEntry
+            e = zf.getEntry(expectedName);
+            assertNotNull(e, "ZipFile.getEntry(): Entry not found using charset " + openCharset.name());
+            assertEquals(expectedName, e.getName(), "ZipFile.getEntry(): name doesn't match!");
+            assertEquals(expectedComment, e.getComment(), "ZipFile.getEntry(): comment doesn't match!");
             try (InputStream is = zf.getInputStream(e)) {
                 assertNotNull(is);
                 byte[] actualContent = is.readAllBytes();

--- a/test/jdk/java/util/zip/ZipCoding.java
+++ b/test/jdk/java/util/zip/ZipCoding.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 4244499 4532049 4700978 4820807 4980042 7009069
+ * @bug 4244499 4532049 4700978 4820807 4980042 7009069 8322802
  * @summary Test ZipInputStream, ZipOutputStream and ZipFile with non-UTF8 encoding
  * @modules jdk.charsets
  * @run junit ZipCoding

--- a/test/jdk/java/util/zip/ZipCoding.java
+++ b/test/jdk/java/util/zip/ZipCoding.java
@@ -82,10 +82,21 @@ public class ZipCoding {
                         "Surrogates \ud800\udc00 in comment"),
 
                 // ZipOutputStream sets the 'Language encoding flag' when writing using UTF-8
-                // UTF-8 should be used for decoding, even when opening with a different charset
+                // UTF-8 should be used for decoding, regardless of the opening charset
+
+                // UTF-8 with Japanese characters, opened with MS932
+                Arguments.of("utf-8", "MS932",
+                        "\u4e00\u4e01",
+                        "\uff67\uff68\uff69\uff6a\uff6b\uff6c"),
+
+                // UTF-8 with characters in latin1 range, opened with iso-8859-1
                 Arguments.of("utf-8", "iso-8859-1",
                         "\u00e4\u00fc",
-                        "German Umlaut \u00fc in comment")
+                        "German Umlaut \u00fc in comment"),
+                // UTF-8 with surrogate pairs, opened with MS932
+                Arguments.of("utf-8", "MS932",
+                        "Surrogate\ud801\udc01",
+                        "Surrogates \ud800\udc00 in comment")
         );
     }
 

--- a/test/jdk/java/util/zip/ZipCoding.java
+++ b/test/jdk/java/util/zip/ZipCoding.java
@@ -125,9 +125,10 @@ public class ZipCoding {
              ZipInputStream zis = new ZipInputStream(in, Charset.forName(readCharset))) {
             ZipEntry e = zis.getNextEntry();
             assertNotNull(e);
-            assertEquals(name, e.getName(), "Entry name does not match");
+            assertEquals(name, e.getName(),
+                    "ZipInputStream.getNextEntry() returned unexpected entry name");
             assertNull(e.getComment()); // No comment in the LOC header
-            assertArrayEquals(ENTRY_DATA, zis.readAllBytes(), "ZIP entry data does not match");
+            assertArrayEquals(ENTRY_DATA, zis.readAllBytes(), "Unexpected ZIP entry data");
         }
     }
 
@@ -172,7 +173,7 @@ public class ZipCoding {
             assertEquals(comment, e.getComment(), "ZipFile.getEntry() returned unexpected entry comment");
             try (InputStream is = zf.getInputStream(e)) {
                 assertNotNull(is);
-                assertArrayEquals(ENTRY_DATA, is.readAllBytes(), "ZIP entry data does not match");
+                assertArrayEquals(ENTRY_DATA, is.readAllBytes(), "Unexpected ZIP entry data");
             }
         }
 


### PR DESCRIPTION
Please review this test-only PR which adds test coverage for `ZipFile.getEntry` under certain charset conditions. 

When `ZipFile.getEntry` is called for an entry which has the `Language encoding flag` general purpose bit flag set,  then `ZipCoder.UTF8` is used unconditionally, even when a different charset was supplied to the `ZipFile` constructor.

It turns out we do not have any testing for this particular case, as can be verified by commenting out the following line of code in `ZipFile.Source.getEntryPos`:

```java
//ZipCoder zc = zipCoderForPos(pos);
``` 

and then running `make test TEST="test/jdk/java/util/zip"`

The current test verifies that the correct ZipCoder is used by `ZipFile.entries()`, but does not exercise `ZipFile.getEntry` the same way.

Seeing that [JDK-7009069](https://bugs.openjdk.org/browse/JDK-7009069) was (accidentally?) fixed by [JDK-8243469](https://bugs.openjdk.org/browse/JDK-8243469), I think it is worthwhile to add explicit testing for this case to avoid regressions.

While visiting `ZipCoding.java`, I took the opportunity to convert it to JUnit 5. The conversion and modernization of the code is done in the first commit 1384850ed51ec845af06dd6d13616f20f8bbaa6a in this PR, while the second commit 1776b258b0fe8383709ae0c095f2631a4e6237f6 actually adds the code required to verify the `Language encoding flag` condition for `ZipFile.getEntry`.

Testing: Verified that the test indeed fails when `ZipFile.Source.getEntryPos` is updated to use the ZipFile's ZipCoder as suggested above.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322802](https://bugs.openjdk.org/browse/JDK-8322802): Add testing for ZipFile.getEntry respecting the 'Language encoding' flag (**Enhancement** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [4f53308c](https://git.openjdk.org/jdk/pull/17207/files/4f53308cfb6110fd5cb68cc2fb094b41c0a1e09f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17207/head:pull/17207` \
`$ git checkout pull/17207`

Update a local copy of the PR: \
`$ git checkout pull/17207` \
`$ git pull https://git.openjdk.org/jdk.git pull/17207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17207`

View PR using the GUI difftool: \
`$ git pr show -t 17207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17207.diff">https://git.openjdk.org/jdk/pull/17207.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17207#issuecomment-1873023163)