### PR TITLE
8322801: RISC-V: The riscv path of the debian sysroot had been changed

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -1499,9 +1499,7 @@ like this:</p>
   --resolve-deps \
   buster \
   ~/sysroot-arm64 \
-  https://httpredir.debian.org/debian/</code></pre>
-<p>If the target architecture is <code>riscv64</code>, the path should
-be <code>debian-ports</code> instead of <code>debian</code>.</p></li>
+  https://httpredir.debian.org/debian/</code></pre></li>
 <li><p>To create an Ubuntu-based chroot:</p>
 <pre><code>sudo debootstrap \
   --arch=arm64 \

--- a/doc/building.md
+++ b/doc/building.md
@@ -1316,9 +1316,6 @@ For example, cross-compiling to AArch64 from x86_64 could be done like this:
     https://httpredir.debian.org/debian/
   ```
 
-  If the target architecture is `riscv64`, the path should be `debian-ports`
-  instead of `debian`.
-
 * To create an Ubuntu-based chroot:
 
   ```


### PR DESCRIPTION
Hi all,

This trivial patch removes the information about the path `debian-ports` because the riscv related packages had been moved to the path `debian` at 2024-01-01. Now the arm and riscv use the same url `https://httpredir.debian.org/debian/`.

Thanks for your review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322801](https://bugs.openjdk.org/browse/JDK-8322801): RISC-V: The riscv path of the debian sysroot had been changed (**Enhancement** - P5)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [0174b502](https://git.openjdk.org/jdk/pull/17208/files/0174b502e399ae2c953645d19172e7d86a590efe)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17208/head:pull/17208` \
`$ git checkout pull/17208`

Update a local copy of the PR: \
`$ git checkout pull/17208` \
`$ git pull https://git.openjdk.org/jdk.git pull/17208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17208`

View PR using the GUI difftool: \
`$ git pr show -t 17208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17208.diff">https://git.openjdk.org/jdk/pull/17208.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17208#issuecomment-1873280258)