### PR TITLE
8313739: ZipOutputStream.close() should always close the wrapped stream

### DIFF
--- a/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java
@@ -240,6 +240,7 @@ public class DeflaterOutputStream extends FilterOutputStream {
      */
     public void close() throws IOException {
         if (!closed) {
+            closed = true;
             IOException finishException = null;
             try {
                 finish();
@@ -250,15 +251,18 @@ public class DeflaterOutputStream extends FilterOutputStream {
                 if (usesDefaultDeflater) {
                     def.end();
                 }
-                try {
+                if (finishException == null) {
                     out.close();
-                } catch (IOException ioe) {
-                    if (finishException != ioe) {
-                        ioe.addSuppressed(finishException);
+                } else {
+                    try {
+                        out.close();
+                    } catch (IOException ioe) {
+                        if (finishException != ioe) {
+                            ioe.addSuppressed(finishException);
+                        }
+                        throw ioe;
                     }
-                    throw ioe;
                 }
-                closed = true;
             }
         }
     }

--- a/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,11 +243,12 @@ public class DeflaterOutputStream extends FilterOutputStream {
             try {
                 finish();
             } finally {
-                if (usesDefaultDeflater)
+                if (usesDefaultDeflater) {
                     def.end();
+                }
+                out.close();
+                closed = true;
             }
-            out.close();
-            closed = true;
         }
     }
 

--- a/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java
@@ -240,13 +240,24 @@ public class DeflaterOutputStream extends FilterOutputStream {
      */
     public void close() throws IOException {
         if (!closed) {
+            IOException finishException = null;
             try {
                 finish();
+            } catch (IOException ioe){
+                finishException = ioe;
+                throw ioe;
             } finally {
                 if (usesDefaultDeflater) {
                     def.end();
                 }
-                out.close();
+                try {
+                    out.close();
+                } catch (IOException ioe) {
+                    if (finishException != ioe) {
+                        ioe.addSuppressed(finishException);
+                    }
+                    throw ioe;
+                }
                 closed = true;
             }
         }

--- a/test/jdk/java/util/zip/ZipOutputStream/CloseWrappedStream.java
+++ b/test/jdk/java/util/zip/ZipOutputStream/CloseWrappedStream.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8313739
+   @summary Verify that ZipOutputStream closes the wrapped stream even after failed writes
+   @run junit CloseWrappedStream
+   */
+
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CloseWrappedStream {
+
+    @Test
+    public void shouldCloseWrappedStream() throws IOException {
+        // A wrapped stream which should be closed even after a write failure
+        WrappedOutputStream wrappedStream = new WrappedOutputStream();
+
+        IOException exception = assertThrows(IOException.class, () -> {
+            try (ZipOutputStream zo = new ZipOutputStream(wrappedStream)) {
+                zo.putNextEntry(new ZipEntry("file.txt"));
+                zo.write("hello".getBytes(StandardCharsets.UTF_8));
+                // Make next write throw IOException
+                wrappedStream.fail = true;
+            } // Close throws when deflated data is flushed to wrapped stream
+        });
+
+        // Sanity check that we failed with the expected message
+        assertEquals(WrappedOutputStream.MSG, exception.getMessage());
+        // Verify that the wrapped stream was closed
+        assertTrue(wrappedStream.closed, "Expected wrapped output stream to be closed");
+    }
+
+    /**
+     * Output stream which conditionally throws IOException on writes
+     * and tracks its close status.
+     */
+    static class WrappedOutputStream extends FilterOutputStream {
+        static final String MSG = "injected failure";
+        boolean fail = false;
+        boolean closed = false;
+
+        public WrappedOutputStream() {
+            super(new ByteArrayOutputStream());
+        }
+
+        @Override
+        public synchronized void write(byte[] b, int off, int len) throws IOException{
+            if (fail) {
+                throw new IOException(MSG);
+            } else {
+                super.write(b, off, len);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+}

--- a/test/jdk/java/util/zip/ZipOutputStream/CloseWrappedStream.java
+++ b/test/jdk/java/util/zip/ZipOutputStream/CloseWrappedStream.java
@@ -38,8 +38,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CloseWrappedStream {
 
+    /**
+     * Verify that closing a ZipOutputStream closes the wrapped output stream,
+     * also when the wrapped stream throws when remaining data is flushed
+     */
     @Test
-    public void shouldCloseWrappedStream() throws IOException {
+    public void closeWrappedStreamAfterFailure()  {
         // A wrapped stream which should be closed even after a write failure
         WrappedOutputStream wrappedStream = new WrappedOutputStream();
 
@@ -54,6 +58,25 @@ public class CloseWrappedStream {
 
         // Sanity check that we failed with the expected message
         assertEquals(WrappedOutputStream.MSG, exception.getMessage());
+        // Verify that the wrapped stream was closed
+        assertTrue(wrappedStream.closed, "Expected wrapped output stream to be closed");
+    }
+
+    /**
+     * Sanity check that the wrapped stream is closed also for the normal case
+     * where the wrapped stream does not throw
+     * @throws IOException if an unexpected IOException occurs
+     */
+    @Test
+    public void closeWrappedStreamNormal() throws IOException {
+
+        WrappedOutputStream wrappedStream = new WrappedOutputStream();
+
+        try (ZipOutputStream zo = new ZipOutputStream(wrappedStream)) {
+            zo.putNextEntry(new ZipEntry("file.txt"));
+            zo.write("hello".getBytes(StandardCharsets.UTF_8));
+        }
+
         // Verify that the wrapped stream was closed
         assertTrue(wrappedStream.closed, "Expected wrapped output stream to be closed");
     }

--- a/test/jdk/java/util/zip/ZipOutputStream/CloseWrappedStream.java
+++ b/test/jdk/java/util/zip/ZipOutputStream/CloseWrappedStream.java
@@ -44,7 +44,7 @@ public class CloseWrappedStream {
      * also when the wrapped stream throws while remaining data is flushed
      */
     @Test
-    public void exceptionDuringFinish()  {
+    public void exceptionDuringFinish() {
         // A wrapped stream which should be closed even after a write failure
         WrappedOutputStream wrappedStream = new WrappedOutputStream();
 


### PR DESCRIPTION
Please consider this PR which makes `DeflaterOutputStream.close()` always close its wrapped output stream exactly once.

Currently, closing of the wrapped output stream happens outside the finally block where `finish()` is called. If `finish()` throws, this means the wrapped stream will not be closed. This can potentially lead to leaking resources such as file descriptors or sockets.

This fix is to move the closing of the wrapped stream inside the finally block.

Additionally, the `closed = true;` statement is moved to the start of the close method. This makes sure we only ever close the wrapped stream once (this aligns with the overridden method `FilterOutputStream.close´)

Specification: This change brings the implementation of `DeflaterOutputStream.close()` in line with its specification:  *Writes remaining compressed data to the output stream and closes the underlying stream.*

Risk: This is a behavioural change. There is a small risk that existing code depends on the close method not following its specification.

Testing: The PR adds a new JUnit 5 test `CloseWrappedStream.java` which simulates the failure condition and verifies that the wrapped stream was closed under failing and non-failing conditions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8322871](https://bugs.openjdk.org/browse/JDK-8322871) to be approved

### Issues
 * [JDK-8313739](https://bugs.openjdk.org/browse/JDK-8313739): ZipOutputStream.close() should always close the wrapped stream (**Bug** - P4)
 * [JDK-8322871](https://bugs.openjdk.org/browse/JDK-8322871): ZipOutputStream.close() should always close the wrapped stream (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [96deca07](https://git.openjdk.org/jdk/pull/17209/files/96deca07831beb37017239f15fab72f995463eab)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17209/head:pull/17209` \
`$ git checkout pull/17209`

Update a local copy of the PR: \
`$ git checkout pull/17209` \
`$ git pull https://git.openjdk.org/jdk.git pull/17209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17209`

View PR using the GUI difftool: \
`$ git pr show -t 17209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17209.diff">https://git.openjdk.org/jdk/pull/17209.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17209#issuecomment-1873403275)