### PR TITLE
8322807: Eliminate -Wparentheses warnings in gc code

### DIFF
--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,7 @@ void PSVirtualSpace::verify() const {
 
   // Reserved region must be non-empty or both addrs must be 0.
   assert(reserved_low_addr() < reserved_high_addr() ||
-         reserved_low_addr() == nullptr && reserved_high_addr() == nullptr,
+         (reserved_low_addr() == nullptr && reserved_high_addr() == nullptr),
          "bad reserved addrs");
   assert(committed_low_addr() <= committed_high_addr(), "bad committed addrs");
 


### PR DESCRIPTION
Please review this trivial change to eliminate a -Wparentheses warning.
This involved simply adding parentheses to make the implicit operator
precedence explicit.

Testing: mach5 tier1

Also ran mach5 tier1 with these changes in conjunction enabling -Wparentheses
and other changes needed to make that work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322807](https://bugs.openjdk.org/browse/JDK-8322807): Eliminate -Wparentheses warnings in gc code (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17212/head:pull/17212` \
`$ git checkout pull/17212`

Update a local copy of the PR: \
`$ git checkout pull/17212` \
`$ git pull https://git.openjdk.org/jdk.git pull/17212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17212`

View PR using the GUI difftool: \
`$ git pr show -t 17212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17212.diff">https://git.openjdk.org/jdk/pull/17212.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17212#issuecomment-1873644246)