### PR TITLE
8322818: Thread::getStackTrace can fail with InternalError if virtual thread is timed-parked when pinned

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -975,12 +975,12 @@ final class VirtualThread extends BaseVirtualThread {
      * Returns null if the thread is mounted or in transition.
      */
     private StackTraceElement[] tryGetStackTrace() {
-        int initialState = state();
+        int initialState = state() & ~SUSPENDED;
         switch (initialState) {
             case NEW, STARTED, TERMINATED -> {
                 return new StackTraceElement[0];  // unmounted, empty stack
             }
-            case RUNNING, PINNED -> {
+            case RUNNING, PINNED, TIMED_PINNED -> {
                 return null;   // mounted
             }
             case PARKED, TIMED_PARKED -> {
@@ -992,7 +992,7 @@ final class VirtualThread extends BaseVirtualThread {
             case PARKING, TIMED_PARKING, YIELDING -> {
                 return null;  // in transition
             }
-            default -> throw new InternalError();
+            default -> throw new InternalError("" + initialState);
         }
 
         // thread is unmounted, prevent it from continuing

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -25,13 +25,13 @@
  * @test
  * @bug 8322818
  * @summary Stress test Thread.getStackTrace on a virtual thread that is pinned
- * @requires vm.debug != true & vm.continuations
+ * @requires vm.debug != true
  * @run main GetStackTraceALotWhenPinned 100000
  */
 
 /*
  * @test
- * @requires vm.debug == true & vm.continuations
+ * @requires vm.debug == true
  * @run main/timeout=300 GetStackTraceALotWhenPinned 10000
  */
 

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8322818
+ * @summary Stress test Thread.getStackTrace on a virtual thread that is pinned
+ * @requires vm.debug != true & vm.continuations
+ * @run main GetStackTraceALotWhenPinned 100000
+ */
+
+/*
+ * @test
+ * @requires vm.debug == true & vm.continuations
+ * @run main/timeout=300 GetStackTraceALotWhenPinned 10000
+ */
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+public class GetStackTraceALotWhenPinned {
+
+    public static void main(String[] args) throws Exception {
+        var counter = new AtomicInteger(Integer.parseInt(args[0]));
+
+        // Start a virtual thread that loops doing Thread.yield and parking while pinned.
+        // This loop creates the conditions for the main thread to sample the stack trace
+        // as it transitions from being unmounted to parking while pinned.
+        var thread = Thread.startVirtualThread(() -> {
+            boolean timed = false;
+            while (counter.decrementAndGet() > 0) {
+                Thread.yield();
+                synchronized (GetStackTraceALotWhenPinned.class) {
+                    if (timed) {
+                        LockSupport.parkNanos(Long.MAX_VALUE);
+                    } else {
+                        LockSupport.park();
+                    }
+                }
+                timed = !timed;
+            }
+        });
+
+        long lastTimestamp = System.currentTimeMillis();
+        while (thread.isAlive()) {
+            thread.getStackTrace();
+            LockSupport.unpark(thread);
+            long currentTime = System.currentTimeMillis();
+            if ((currentTime - lastTimestamp) > 500) {
+                System.out.println(counter.get() + " remaining ...");
+                lastTimestamp = currentTime;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Missed by JDK-8312498, VirtualThread::tryGetStackTrace doesn't handle the TIMED_PINNED state so it's possible for Thread::getStackTrace to throw InternalError when invoked on a virtual thread that quickly transitions from unmounted to  timed-park-while-pinned. This one is needs a stress test to reproduce.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322818](https://bugs.openjdk.org/browse/JDK-8322818): Thread::getStackTrace can fail with InternalError if virtual thread is timed-parked when pinned (**Bug** - P3)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17217/head:pull/17217` \
`$ git checkout pull/17217`

Update a local copy of the PR: \
`$ git checkout pull/17217` \
`$ git pull https://git.openjdk.org/jdk.git pull/17217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17217`

View PR using the GUI difftool: \
`$ git pr show -t 17217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17217.diff">https://git.openjdk.org/jdk/pull/17217.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17217#issuecomment-1874167255)