### PR TITLE
8322828: Parallel: Rename ParallelCompactData::_region_start

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -415,8 +415,8 @@ print_initial_summary_data(ParallelCompactData& summary_data,
 #endif  // #ifndef PRODUCT
 
 ParallelCompactData::ParallelCompactData() :
-  _region_start(nullptr),
-  DEBUG_ONLY(_region_end(nullptr) COMMA)
+  _heap_start(nullptr),
+  DEBUG_ONLY(_heap_end(nullptr) COMMA)
   _region_vspace(nullptr),
   _reserved_byte_size(0),
   _region_data(nullptr),
@@ -425,16 +425,16 @@ ParallelCompactData::ParallelCompactData() :
   _block_data(nullptr),
   _block_count(0) {}
 
-bool ParallelCompactData::initialize(MemRegion covered_region)
+bool ParallelCompactData::initialize(MemRegion reserved_heap)
 {
-  _region_start = covered_region.start();
-  const size_t region_size = covered_region.word_size();
-  DEBUG_ONLY(_region_end = _region_start + region_size;)
+  _heap_start = reserved_heap.start();
+  const size_t heap_size = reserved_heap.word_size();
+  DEBUG_ONLY(_heap_end = _heap_start + heap_size;)
 
-  assert(region_align_down(_region_start) == _region_start,
+  assert(region_align_down(_heap_start) == _heap_start,
          "region start not aligned");
 
-  bool result = initialize_region_data(region_size) && initialize_block_data();
+  bool result = initialize_region_data(heap_size) && initialize_block_data();
   return result;
 }
 
@@ -467,12 +467,11 @@ ParallelCompactData::create_vspace(size_t count, size_t element_size)
   return 0;
 }
 
-bool ParallelCompactData::initialize_region_data(size_t region_size)
+bool ParallelCompactData::initialize_region_data(size_t heap_size)
 {
-  assert((region_size & RegionSizeOffsetMask) == 0,
-         "region size not a multiple of RegionSize");
+  assert(is_aligned(heap_size, RegionSize), "precondition");
 
-  const size_t count = region_size >> Log2RegionSize;
+  const size_t count = heap_size >> Log2RegionSize;
   _region_vspace = create_vspace(count, sizeof(RegionData));
   if (_region_vspace != 0) {
     _region_data = (RegionData*)_region_vspace->reserved_low_addr();
@@ -530,7 +529,7 @@ HeapWord* ParallelCompactData::partial_obj_end(size_t region_idx) const
 
 void ParallelCompactData::add_obj(HeapWord* addr, size_t len)
 {
-  const size_t obj_ofs = pointer_delta(addr, _region_start);
+  const size_t obj_ofs = pointer_delta(addr, _heap_start);
   const size_t beg_region = obj_ofs >> Log2RegionSize;
   // end_region is inclusive
   const size_t end_region = (obj_ofs + len - 1) >> Log2RegionSize;

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -399,7 +399,7 @@ public:
 
 public:
   ParallelCompactData();
-  bool initialize(MemRegion covered_region);
+  bool initialize(MemRegion reserved_heap);
 
   size_t region_count() const { return _region_count; }
   size_t reserved_byte_size() const { return _reserved_byte_size; }
@@ -481,13 +481,12 @@ public:
 
 private:
   bool initialize_block_data();
-  bool initialize_region_data(size_t region_size);
+  bool initialize_region_data(size_t heap_size);
   PSVirtualSpace* create_vspace(size_t count, size_t element_size);
 
-private:
-  HeapWord*       _region_start;
+  HeapWord*       _heap_start;
 #ifdef  ASSERT
-  HeapWord*       _region_end;
+  HeapWord*       _heap_end;
 #endif  // #ifdef ASSERT
 
   PSVirtualSpace* _region_vspace;
@@ -662,18 +661,18 @@ ParallelCompactData::block(size_t n) const {
 inline size_t
 ParallelCompactData::region_offset(const HeapWord* addr) const
 {
-  assert(addr >= _region_start, "bad addr");
+  assert(addr >= _heap_start, "bad addr");
   // would mistakenly return 0 for _region_end
-  assert(addr < _region_end, "bad addr");
+  assert(addr < _heap_end, "bad addr");
   return (size_t(addr) & RegionAddrOffsetMask) >> LogHeapWordSize;
 }
 
 inline size_t
 ParallelCompactData::addr_to_region_idx(const HeapWord* addr) const
 {
-  assert(addr >= _region_start, "bad addr " PTR_FORMAT " _region_start " PTR_FORMAT, p2i(addr), p2i(_region_start));
-  assert(addr <= _region_end, "bad addr " PTR_FORMAT " _region_end " PTR_FORMAT, p2i(addr), p2i(_region_end));
-  return pointer_delta(addr, _region_start) >> Log2RegionSize;
+  assert(addr >= _heap_start, "bad addr " PTR_FORMAT " _region_start " PTR_FORMAT, p2i(addr), p2i(_heap_start));
+  assert(addr <= _heap_end, "bad addr " PTR_FORMAT " _region_end " PTR_FORMAT, p2i(addr), p2i(_heap_end));
+  return pointer_delta(addr, _heap_start) >> Log2RegionSize;
 }
 
 inline ParallelCompactData::RegionData*
@@ -686,7 +685,7 @@ inline HeapWord*
 ParallelCompactData::region_to_addr(size_t region) const
 {
   assert(region <= _region_count, "region out of range");
-  return _region_start + (region << Log2RegionSize);
+  return _heap_start + (region << Log2RegionSize);
 }
 
 inline HeapWord*
@@ -707,16 +706,16 @@ ParallelCompactData::region_to_addr(size_t region, size_t offset) const
 inline HeapWord*
 ParallelCompactData::region_align_down(HeapWord* addr) const
 {
-  assert(addr >= _region_start, "bad addr");
-  assert(addr < _region_end + RegionSize, "bad addr");
+  assert(addr >= _heap_start, "bad addr");
+  assert(addr < _heap_end + RegionSize, "bad addr");
   return (HeapWord*)(size_t(addr) & RegionAddrMask);
 }
 
 inline HeapWord*
 ParallelCompactData::region_align_up(HeapWord* addr) const
 {
-  assert(addr >= _region_start, "bad addr");
-  assert(addr <= _region_end, "bad addr");
+  assert(addr >= _heap_start, "bad addr");
+  assert(addr <= _heap_end, "bad addr");
   return region_align_down(addr + RegionSizeOffsetMask);
 }
 
@@ -729,17 +728,17 @@ ParallelCompactData::is_region_aligned(HeapWord* addr) const
 inline size_t
 ParallelCompactData::block_offset(const HeapWord* addr) const
 {
-  assert(addr >= _region_start, "bad addr");
-  assert(addr <= _region_end, "bad addr");
+  assert(addr >= _heap_start, "bad addr");
+  assert(addr <= _heap_end, "bad addr");
   return (size_t(addr) & BlockAddrOffsetMask) >> LogHeapWordSize;
 }
 
 inline size_t
 ParallelCompactData::addr_to_block_idx(const HeapWord* addr) const
 {
-  assert(addr >= _region_start, "bad addr");
-  assert(addr <= _region_end, "bad addr");
-  return pointer_delta(addr, _region_start) >> Log2BlockSize;
+  assert(addr >= _heap_start, "bad addr");
+  assert(addr <= _heap_end, "bad addr");
+  return pointer_delta(addr, _heap_start) >> Log2BlockSize;
 }
 
 inline ParallelCompactData::BlockData*
@@ -752,7 +751,7 @@ inline HeapWord*
 ParallelCompactData::block_to_addr(size_t block) const
 {
   assert(block < _block_count, "block out of range");
-  return _region_start + (block << Log2BlockSize);
+  return _heap_start + (block << Log2BlockSize);
 }
 
 inline size_t
@@ -764,16 +763,16 @@ ParallelCompactData::region_to_block_idx(size_t region) const
 inline HeapWord*
 ParallelCompactData::block_align_down(HeapWord* addr) const
 {
-  assert(addr >= _region_start, "bad addr");
-  assert(addr < _region_end + RegionSize, "bad addr");
+  assert(addr >= _heap_start, "bad addr");
+  assert(addr < _heap_end + RegionSize, "bad addr");
   return (HeapWord*)(size_t(addr) & BlockAddrMask);
 }
 
 inline HeapWord*
 ParallelCompactData::block_align_up(HeapWord* addr) const
 {
-  assert(addr >= _region_start, "bad addr");
-  assert(addr <= _region_end, "bad addr");
+  assert(addr >= _heap_start, "bad addr");
+  assert(addr <= _heap_end, "bad addr");
   return block_align_down(addr + BlockSizeOffsetMask);
 }
 


### PR DESCRIPTION
Simple renaming to avoid overloading the name "region" in its context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322828](https://bugs.openjdk.org/browse/JDK-8322828): Parallel: Rename ParallelCompactData::_region_start (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Erik Duveblad](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17218/head:pull/17218` \
`$ git checkout pull/17218`

Update a local copy of the PR: \
`$ git checkout pull/17218` \
`$ git pull https://git.openjdk.org/jdk.git pull/17218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17218`

View PR using the GUI difftool: \
`$ git pr show -t 17218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17218.diff">https://git.openjdk.org/jdk/pull/17218.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17218#issuecomment-1873799739)