### PR TITLE
8322841: Parallel: Remove unused using-declaration in MutableNUMASpace

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -184,8 +184,6 @@ public:
   virtual size_t used_in_words() const;
   virtual size_t free_in_words() const;
 
-  using MutableSpace::capacity_in_words;
-
   virtual size_t tlab_capacity(Thread* thr) const;
   virtual size_t tlab_used(Thread* thr) const;
   virtual size_t unsafe_max_tlab_alloc(Thread* thr) const;


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322841](https://bugs.openjdk.org/browse/JDK-8322841): Parallel: Remove unused using-declaration in MutableNUMASpace (**New Feature** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17220/head:pull/17220` \
`$ git checkout pull/17220`

Update a local copy of the PR: \
`$ git checkout pull/17220` \
`$ git pull https://git.openjdk.org/jdk.git pull/17220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17220`

View PR using the GUI difftool: \
`$ git pr show -t 17220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17220.diff">https://git.openjdk.org/jdk/pull/17220.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17220#issuecomment-1873904704)