### PR TITLE
JDK-8322783: prioritize /etc/os-release over /etc/SuSE-release in hs_err/info output

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2015, 2022 SAP SE. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2097,7 +2097,6 @@ const char* distro_files[] = {
   "/etc/mandrake-release",
   "/etc/sun-release",
   "/etc/redhat-release",
-  "/etc/SuSE-release",
   "/etc/lsb-release",
   "/etc/turbolinux-release",
   "/etc/gentoo-release",
@@ -2105,6 +2104,7 @@ const char* distro_files[] = {
   "/etc/angstrom-version",
   "/etc/system-release",
   "/etc/os-release",
+  "/etc/SuSE-release",
   nullptr };
 
 void os::Linux::print_distro_info(outputStream* st) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2104,7 +2104,7 @@ const char* distro_files[] = {
   "/etc/angstrom-version",
   "/etc/system-release",
   "/etc/os-release",
-  "/etc/SuSE-release",
+  "/etc/SuSE-release", // Deprecated in favor of os-release since SuSE 12
   nullptr };
 
 void os::Linux::print_distro_info(outputStream* st) {


### PR DESCRIPTION
Currently, /etc/SuSE-release is prioritized over /etc/os-release in the hs_info/hs_err file output .
But this leads on SUSE 12 distros to output like this :

```
# This file is deprecated and will be removed in a future service pack or release.
# Please check /etc/os-release for details about this release.

```
So we probably better prioritize /etc/os-release over /etc/SuSE-release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322783](https://bugs.openjdk.org/browse/JDK-8322783): prioritize /etc/os-release over /etc/SuSE-release in hs_err/info output (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [364a2b9a](https://git.openjdk.org/jdk/pull/17222/files/364a2b9a69ae8a12a9868edce121fd775379066a)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17222/head:pull/17222` \
`$ git checkout pull/17222`

Update a local copy of the PR: \
`$ git checkout pull/17222` \
`$ git pull https://git.openjdk.org/jdk.git pull/17222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17222`

View PR using the GUI difftool: \
`$ git pr show -t 17222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17222.diff">https://git.openjdk.org/jdk/pull/17222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17222#issuecomment-1874119985)