### PR TITLE
JDK-8276809: java/awt/font/JNICheck/FreeTypeScalerJNICheck.java shows JNI warning on Windows

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,9 +126,15 @@ BOOL DWMIsCompositionEnabled() {
     dwmIsCompositionEnabled = bRes;
 
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
-    JNU_CallStaticMethodByName(env, NULL,
+    jboolean hasException;
+    JNU_CallStaticMethodByName(env, &hasException,
                               "sun/awt/Win32GraphicsEnvironment",
                               "dwmCompositionChanged", "(Z)V", (jboolean)bRes);
+    if (hasException) {
+        J2dTraceLn(J2D_TRACE_INFO, "Exception occurred in DWMIsCompositionEnabled");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+    }
     return bRes;
 }
 


### PR DESCRIPTION
The new test java/awt/font/JNICheck/FreeTypeScalerJNICheck.java introduced with https://bugs.openjdk.java.net/browse/JDK-8269223 adds -Xcheck:jni , and shows on Windows server 2019 the following JNI warning , so the test fails on this Windows version.

 stdout: [WARNING in native method: JNI call made without checking exceptions when required to from CallStaticVoidMethodV
	at sun.awt.Win32GraphicsEnvironment.initDisplay(java.desktop@23-internal/Native Method)
	at sun.awt.Win32GraphicsEnvironment.initDisplayWrapper(java.desktop@23-internal/Win32GraphicsEnvironment.java:95)
	at sun.awt.Win32GraphicsEnvironment.<clinit>(java.desktop@23-internal/Win32GraphicsEnvironment.java:63)
	at sun.awt.PlatformGraphicsInfo.createGE(java.desktop@23-internal/PlatformGraphicsInfo.java:34)
	at java.awt.GraphicsEnvironment$LocalGE.createGE(java.desktop@23-internal/GraphicsEnvironment.java:93)
	at java.awt.GraphicsEnvironment$LocalGE.<clinit>(java.desktop@23-internal/GraphicsEnvironment.java:84)
	at java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment(java.desktop@23-internal/GraphicsEnvironment.java:106)
	at FreeTypeScalerJNICheck.runTest(FreeTypeScalerJNICheck.java:53)
	at FreeTypeScalerJNICheck.main(FreeTypeScalerJNICheck.java:44)


We better add an exception check to get rid of the JNI warning (and also of the test failure) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8276809](https://bugs.openjdk.org/browse/JDK-8276809): java/awt/font/JNICheck/FreeTypeScalerJNICheck.java shows JNI warning on Windows (**Bug** - P4)


### Reviewers
 * [Ralf Schmelter](https://openjdk.org/census#rschmelter) (@schmelter-sap - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17224/head:pull/17224` \
`$ git checkout pull/17224`

Update a local copy of the PR: \
`$ git checkout pull/17224` \
`$ git pull https://git.openjdk.org/jdk.git pull/17224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17224`

View PR using the GUI difftool: \
`$ git pr show -t 17224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17224.diff">https://git.openjdk.org/jdk/pull/17224.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17224#issuecomment-1874148501)