### PR TITLE
8322532: JShell : Unnamed variable issue

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/CompletenessAnalyzer.java
@@ -190,7 +190,7 @@ class CompletenessAnalyzer {
         EOF(TokenKind.EOF, 0),  //
         ERROR(TokenKind.ERROR, XERRO),  //
         IDENTIFIER(TokenKind.IDENTIFIER, XEXPR1|XDECL1|XTERM),  //
-        UNDERSCORE(TokenKind.UNDERSCORE, XDECL1),  //  _
+        UNDERSCORE(TokenKind.UNDERSCORE, XDECL1|XEXPR),  //  _
         CLASS(TokenKind.CLASS, XEXPR|XDECL1|XBRACESNEEDED),  //  class decl (MAPPED: DOTCLASS)
         MONKEYS_AT(TokenKind.MONKEYS_AT, XEXPR|XDECL1),  //  @
         IMPORT(TokenKind.IMPORT, XDECL1|XSTART),  //  import -- consider declaration

--- a/test/langtools/jdk/jshell/VariablesTest.java
+++ b/test/langtools/jdk/jshell/VariablesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236 8252409 8294431
+ * @bug 8144903 8177466 8191842 8211694 8213725 8239536 8257236 8252409 8294431 8322532
  * @summary Tests for EvaluationState.variables
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -619,6 +619,12 @@ public class VariablesTest extends KullaTesting {
 
     public void varAnonymousClassAndStaticField() { //JDK-8294431
         assertEval("var obj = new Object() { public static final String msg = \"hello\"; };");
+    }
+
+    public void underscoreAsLambdaParameter() { //JDK-8322532
+        assertAnalyze("Func f = _ -> 0; int i;",
+                      "Func f = _ -> 0;",
+                      " int i;", true);
     }
 
 }


### PR DESCRIPTION
The parser that estimates the type and completeness of snippets categorizes tokens to several categories. Underscore is currently not considered to be a token that may appear in an expression, and hence:
```
Func f = _ -> 0;
```

is not recognized as a full valid variable declaration snippet, leading to further problems with splitting input into snippets, like:
```
jshell> interface Func { public void t(int i); }
   ...> Func f = _ -> {};
   ...> System.err.println("This should be printed, but is not!");
   ...> 
|  created interface Func
f ==> $Lambda/0x00000000b3099000@2833cc44

jshell> 
```

Note the output `This should be printed, but is not!` is missing.

The proposed change here is to mark underscore as an expression token, which then allows JShell to split the snippets correctly:
```
jshell> interface Func { public void t(int i); }
   ...> Func f = _ -> {};
   ...> System.err.println("This should be printed, but is not!");
|  created interface Func
f ==> $Lambda/0x0000000084099000@2833cc44
This should be printed, but is not!
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322532](https://bugs.openjdk.org/browse/JDK-8322532): JShell : Unnamed variable issue (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17225/head:pull/17225` \
`$ git checkout pull/17225`

Update a local copy of the PR: \
`$ git checkout pull/17225` \
`$ git pull https://git.openjdk.org/jdk.git pull/17225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17225`

View PR using the GUI difftool: \
`$ git pr show -t 17225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17225.diff">https://git.openjdk.org/jdk/pull/17225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17225#issuecomment-1874163356)