### PR TITLE
8322853: Should use ConditionalMutexLocker in NativeHeapTrimmerThread::print_state

### DIFF
--- a/src/hotspot/share/runtime/trimNativeHeap.cpp
+++ b/src/hotspot/share/runtime/trimNativeHeap.cpp
@@ -71,11 +71,6 @@ class NativeHeapTrimmerThread : public NamedThread {
     return --_suspend_count;
   }
 
-  bool is_stopped() const {
-    assert(_lock->is_locked(), "Must be");
-    return _stop;
-  }
-
   bool at_or_nearing_safepoint() const {
     return SafepointSynchronize::is_at_safepoint() ||
            SafepointSynchronize::is_synchronizing();

--- a/src/hotspot/share/runtime/trimNativeHeap.cpp
+++ b/src/hotspot/share/runtime/trimNativeHeap.cpp
@@ -49,10 +49,10 @@ class NativeHeapTrimmerThread : public NamedThread {
 
   Monitor* const _lock;
   bool volatile _stop;
-  uint16_t volatile _suspend_count;
+  uint16_t _suspend_count;
 
   // Statistics
-  uint64_t volatile _num_trims_performed;
+  uint64_t _num_trims_performed;
 
   bool is_suspended() const {
     assert(_lock->is_locked(), "Must be");

--- a/src/hotspot/share/runtime/trimNativeHeap.cpp
+++ b/src/hotspot/share/runtime/trimNativeHeap.cpp
@@ -48,7 +48,7 @@ class NativeHeapTrimmerThread : public NamedThread {
   static constexpr int64_t safepoint_poll_ms = 250;
 
   Monitor* const _lock;
-  bool volatile _stop;
+  bool _stop;
   uint16_t _suspend_count;
 
   // Statistics

--- a/src/hotspot/share/runtime/trimNativeHeap.cpp
+++ b/src/hotspot/share/runtime/trimNativeHeap.cpp
@@ -215,13 +215,12 @@ public:
   }
 
   void print_state(outputStream* st) const {
-    // Don't pull lock during error reporting
-    Mutex* const lock = VMError::is_error_reported() ? nullptr : _lock;
     int64_t num_trims = 0;
     bool stopped = false;
     uint16_t suspenders = 0;
     {
-      MutexLocker ml(lock, Mutex::_no_safepoint_check_flag);
+      // Don't pull lock during error reporting
+      ConditionalMutexLocker ml(_lock, !VMError::is_error_reported(), Mutex::_no_safepoint_check_flag);
       num_trims = _num_trims_performed;
       stopped = _stop;
       suspenders = _suspend_count;

--- a/src/hotspot/share/runtime/trimNativeHeap.cpp
+++ b/src/hotspot/share/runtime/trimNativeHeap.cpp
@@ -48,11 +48,11 @@ class NativeHeapTrimmerThread : public NamedThread {
   static constexpr int64_t safepoint_poll_ms = 250;
 
   Monitor* const _lock;
-  bool _stop;
-  uint16_t _suspend_count;
+  bool volatile _stop;
+  uint16_t volatile _suspend_count;
 
   // Statistics
-  uint64_t _num_trims_performed;
+  uint64_t volatile _num_trims_performed;
 
   bool is_suspended() const {
     assert(_lock->is_locked(), "Must be");


### PR DESCRIPTION
Hi all,

Please help review this small fix.

MutexLocker requires that mutex != nullptr, so we should use ConditionalMutexLocker instead.

~~Also, this patch made '_stop' volatile, since it will be read twice in run() but may be changed.~~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322853](https://bugs.openjdk.org/browse/JDK-8322853): Should use ConditionalMutexLocker in NativeHeapTrimmerThread::print_state (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [552593d7](https://git.openjdk.org/jdk/pull/17226/files/552593d7bdd6da4bc09579fbe20aafbaeedf42b5)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17226/head:pull/17226` \
`$ git checkout pull/17226`

Update a local copy of the PR: \
`$ git checkout pull/17226` \
`$ git pull https://git.openjdk.org/jdk.git pull/17226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17226`

View PR using the GUI difftool: \
`$ git pr show -t 17226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17226.diff">https://git.openjdk.org/jdk/pull/17226.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17226#issuecomment-1874226364)