### PR TITLE
8322859: Parallel: Move transform_stack_chunk

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -251,8 +251,6 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
 
   // Parallel GC claims with a release - so other threads might access this object
   // after claiming and they should see the "completed" object.
-  ContinuationGCSupport::transform_stack_chunk(new_obj);
-
   // Now we have to CAS in the header.
   // Because the forwarding is done with memory_order_relaxed there is no
   // ordering with the above copy.  Clients that get the forwardee must not
@@ -290,6 +288,8 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
           psStringDedup::is_candidate_from_evacuation(new_obj, new_obj_is_tenured)) {
         _string_dedup_requests.add(o);
       }
+
+      ContinuationGCSupport::transform_stack_chunk(new_obj);
     }
     return new_obj;
   } else {

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -249,8 +249,6 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
   // Copy obj
   Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(o), cast_from_oop<HeapWord*>(new_obj), new_obj_size);
 
-  // Parallel GC claims with a release - so other threads might access this object
-  // after claiming and they should see the "completed" object.
   // Now we have to CAS in the header.
   // Because the forwarding is done with memory_order_relaxed there is no
   // ordering with the above copy.  Clients that get the forwardee must not
@@ -268,6 +266,8 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
       new_obj->incr_age();
       assert(young_space()->contains(new_obj), "Attempt to push non-promoted obj");
     }
+
+    ContinuationGCSupport::transform_stack_chunk(new_obj);
 
     // Do the size comparison first with new_obj_size, which we
     // already have. Hopefully, only a few objects are larger than
@@ -288,8 +288,6 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
           psStringDedup::is_candidate_from_evacuation(new_obj, new_obj_is_tenured)) {
         _string_dedup_requests.add(o);
       }
-
-      ContinuationGCSupport::transform_stack_chunk(new_obj);
     }
     return new_obj;
   } else {


### PR DESCRIPTION
Simple moving the `transform_stack_chunk` call to match its counterpart in G1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322859](https://bugs.openjdk.org/browse/JDK-8322859): Parallel: Move transform_stack_chunk (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17227/head:pull/17227` \
`$ git checkout pull/17227`

Update a local copy of the PR: \
`$ git checkout pull/17227` \
`$ git pull https://git.openjdk.org/jdk.git pull/17227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17227`

View PR using the GUI difftool: \
`$ git pr show -t 17227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17227.diff">https://git.openjdk.org/jdk/pull/17227.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17227#issuecomment-1874280040)