### PR TITLE
8322868: java/io/BufferedInputStream/TransferToTrusted.java has bad copyright header

### DIFF
--- a/test/jdk/java/io/BufferedInputStream/TransferToTrusted.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferToTrusted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Add missing comma after 2024.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322868](https://bugs.openjdk.org/browse/JDK-8322868): java/io/BufferedInputStream/TransferToTrusted.java has bad copyright header (**Bug** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17228/head:pull/17228` \
`$ git checkout pull/17228`

Update a local copy of the PR: \
`$ git checkout pull/17228` \
`$ git pull https://git.openjdk.org/jdk.git pull/17228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17228`

View PR using the GUI difftool: \
`$ git pr show -t 17228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17228.diff">https://git.openjdk.org/jdk/pull/17228.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17228#issuecomment-1874516675)