### PR TITLE
8322870: validate-source failure after JDK-8320971

### DIFF
--- a/test/jdk/java/io/BufferedInputStream/TransferToTrusted.java
+++ b/test/jdk/java/io/BufferedInputStream/TransferToTrusted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial copyright fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8322870](https://bugs.openjdk.org/browse/JDK-8322870): validate-source failure after JDK-8320971 (**Bug** - P1) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17229/head:pull/17229` \
`$ git checkout pull/17229`

Update a local copy of the PR: \
`$ git checkout pull/17229` \
`$ git pull https://git.openjdk.org/jdk.git pull/17229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17229`

View PR using the GUI difftool: \
`$ git pr show -t 17229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17229.diff">https://git.openjdk.org/jdk/pull/17229.diff</a>

</details>
