### PR TITLE
8322873: Duplicate -ljava -ljvm options for libinstrument

### DIFF
--- a/make/modules/java.instrument/Lib.gmk
+++ b/make/modules/java.instrument/Lib.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBINSTRUMENT, \
     LDFLAGS_macosx := -L$(call FindLibDirForModule, java.base), \
     LDFLAGS_aix := -L$(SUPPORT_OUTPUTDIR)/native/java.base, \
     LIBS := $(JDKLIB_LIBS), \
-    LIBS_unix := -ljava -ljvm $(LIBZ_LIBS), \
+    LIBS_unix := $(LIBZ_LIBS), \
     LIBS_linux := -ljli $(LIBDL), \
     LIBS_aix := -liconv -ljli_static $(LIBDL), \
     LIBS_macosx := -ljli -liconv -framework Cocoa -framework Security \


### PR DESCRIPTION
The libinstrument library is linked against libjava and libjvm, twice. This is mostly harmless but Xcode 15.x generates a warning:

Creating support/modules_libs/java.instrument/libinstrument.dylib from 12 file(s)
ld: warning: ignoring duplicate libraries: '-ljava', '-ljvm'

In particular, note that the `JDKLIB_LIBS` variable passed in to `LIBS` already contains the -ljava -ljvm options. Digging through the history it seems like this issue was introduced with [JDK-8141290](https://bugs.openjdk.org/browse/JDK-8141290).

Testing: tier1,builds-tier[2-5]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322873](https://bugs.openjdk.org/browse/JDK-8322873): Duplicate -ljava -ljvm options for libinstrument (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17230/head:pull/17230` \
`$ git checkout pull/17230`

Update a local copy of the PR: \
`$ git checkout pull/17230` \
`$ git pull https://git.openjdk.org/jdk.git pull/17230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17230`

View PR using the GUI difftool: \
`$ git pr show -t 17230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17230.diff">https://git.openjdk.org/jdk/pull/17230.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17230#issuecomment-1874609380)