### PR TITLE
JDK-8322248: Fix inconsistent wording in ElementFilter.typesIn

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -169,7 +169,7 @@ public class ElementFilter {
     }
 
     /**
-     * {@return a set of types in {@code elements}}
+     * {@return a set of classes and interfaces in {@code elements}}
      * @param elements the elements to filter
      */
     public static Set<TypeElement>


### PR DESCRIPTION
Correct small oversight made during the fix for

    JDK-8257638: Update usage of "type" terminology in javax.lang.model

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322248](https://bugs.openjdk.org/browse/JDK-8322248): Fix inconsistent wording in ElementFilter.typesIn (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17231/head:pull/17231` \
`$ git checkout pull/17231`

Update a local copy of the PR: \
`$ git checkout pull/17231` \
`$ git pull https://git.openjdk.org/jdk.git pull/17231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17231`

View PR using the GUI difftool: \
`$ git pr show -t 17231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17231.diff">https://git.openjdk.org/jdk/pull/17231.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17231#issuecomment-1874645987)