### PR TITLE
8320002: Remove obsolete CDS check in Reflection::verify_class_access()

### DIFF
--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -458,12 +458,6 @@ Reflection::VerifyClassAccessResults Reflection::verify_class_access(
 
   // module boundaries
   if (new_class->is_public()) {
-    // Ignore modules for -Xshare:dump because we do not have any package
-    // or module information for modules other than java.base.
-    if (CDSConfig::is_dumping_static_archive()) {
-      return ACCESS_OK;
-    }
-
     // Find the module entry for current_class, the accessor
     ModuleEntry* module_from = current_class->module();
     // Find the module entry for new_class, the accessee


### PR DESCRIPTION
This fix removes an obsolete CDS check. Please review.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320002](https://bugs.openjdk.org/browse/JDK-8320002): Remove obsolete CDS check in Reflection::verify_class_access() (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17232/head:pull/17232` \
`$ git checkout pull/17232`

Update a local copy of the PR: \
`$ git checkout pull/17232` \
`$ git pull https://git.openjdk.org/jdk.git pull/17232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17232`

View PR using the GUI difftool: \
`$ git pr show -t 17232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17232.diff">https://git.openjdk.org/jdk/pull/17232.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17232#issuecomment-1874729416)