### PR TITLE
8322879: Eliminate -Wparentheses warnings in x86-32 code

### DIFF
--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -11142,7 +11142,7 @@ instruct convI2FPR_mem(regFPR dst, memory mem) %{
 
 // Convert an int to a float in xmm; no rounding step needed.
 instruct convI2F_reg(regF dst, rRegI src) %{
-  predicate( UseSSE==1 || UseSSE>=2 && !UseXmmI2F );
+  predicate( UseSSE==1 || ( UseSSE>=2 && !UseXmmI2F ));
   match(Set dst (ConvI2F src));
   format %{ "CVTSI2SS $dst, $src" %}
   ins_encode %{


### PR DESCRIPTION
Please review this trivial change to eliminate a -Wparentheses warning.
This involved simply adding parentheses to make the implicit operator
precedence explicit.

Testing: Locally (linux-x64) cross-compiled for linux-x86.  Also ran GHA with
-Wparentheses enabled along with this and other changes needed to make that
work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322879](https://bugs.openjdk.org/browse/JDK-8322879): Eliminate -Wparentheses warnings in x86-32 code (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17237/head:pull/17237` \
`$ git checkout pull/17237`

Update a local copy of the PR: \
`$ git checkout pull/17237` \
`$ git pull https://git.openjdk.org/jdk.git pull/17237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17237`

View PR using the GUI difftool: \
`$ git pr show -t 17237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17237.diff">https://git.openjdk.org/jdk/pull/17237.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17237#issuecomment-1874857962)