### PR TITLE
8322888: Parallel: Remove unused variables in PSPromotionManager

### DIFF
--- a/src/hotspot/share/gc/parallel/psPromotionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.cpp
@@ -173,12 +173,8 @@ void PSPromotionManager::reset_stats() {
 #endif // TASKQUEUE_STATS
 
 PSPromotionManager::PSPromotionManager() {
-  ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
-
   // We set the old lab's start array.
   _old_lab.set_start_array(old_gen()->start_array());
-
-  uint queue_size = claimed_stack_depth()->max_elems();
 
   if (ParallelGCThreads == 1) {
     _target_stack_size = 0;


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322888](https://bugs.openjdk.org/browse/JDK-8322888): Parallel: Remove unused variables in PSPromotionManager (**New Feature** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17238/head:pull/17238` \
`$ git checkout pull/17238`

Update a local copy of the PR: \
`$ git checkout pull/17238` \
`$ git pull https://git.openjdk.org/jdk.git pull/17238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17238`

View PR using the GUI difftool: \
`$ git pr show -t 17238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17238.diff">https://git.openjdk.org/jdk/pull/17238.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17238#issuecomment-1874899178)