### PR TITLE
JDK-8322782: Clean up usages of unnecessary fully qualified class name "java.util.Arrays"

### DIFF
--- a/src/demo/share/jfc/J2Ddemo/java2d/Intro.java
+++ b/src/demo/share/jfc/J2Ddemo/java2d/Intro.java
@@ -1716,7 +1716,7 @@ public class Intro extends JPanel {
                 this.beginning = beg;
                 this.ending = end;
                 fm = surf.getMetrics(font);
-                java.util.Arrays.sort(members);
+                Arrays.sort(members);
                 cast.add("CONTRIBUTORS");
                 cast.add(" ");
                 cast.addAll(Arrays.asList(members));

--- a/src/demo/share/jfc/J2Ddemo/java2d/Intro.java
+++ b/src/demo/share/jfc/J2Ddemo/java2d/Intro.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESKey.java
@@ -85,7 +85,7 @@ final class DESKey implements SecretKey {
         // Use the cleaner to zero the key when no longer referenced
         final byte[] k = this.key;
         CleanerFactory.cleaner().register(this,
-                () -> java.util.Arrays.fill(k, (byte)0x00));
+                () -> Arrays.fill(k, (byte)0x00));
     }
 
     public byte[] getEncoded() {
@@ -136,7 +136,7 @@ final class DESKey implements SecretKey {
 
             byte[] thatKey = that.getEncoded();
             boolean ret = MessageDigest.isEqual(this.key, thatKey);
-            java.util.Arrays.fill(thatKey, (byte)0x00);
+            Arrays.fill(thatKey, (byte)0x00);
             return ret;
         } finally {
             // prevent this from being cleaned for the above block
@@ -168,7 +168,7 @@ final class DESKey implements SecretKey {
         // Use the cleaner to zero the key when no longer referenced
         final byte[] k = this.key;
         CleanerFactory.cleaner().register(this,
-                () -> java.util.Arrays.fill(k, (byte)0x00));
+                () -> Arrays.fill(k, (byte)0x00));
     }
 
     /**

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/DESedeKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DESedeKey.java
@@ -87,7 +87,7 @@ final class DESedeKey implements SecretKey {
         // Use the cleaner to zero the key when no longer referenced
         final byte[] k = this.key;
         CleanerFactory.cleaner().register(this,
-                () -> java.util.Arrays.fill(k, (byte)0x00));
+                () -> Arrays.fill(k, (byte)0x00));
     }
 
     public byte[] getEncoded() {
@@ -137,7 +137,7 @@ final class DESedeKey implements SecretKey {
 
             byte[] thatKey = that.getEncoded();
             boolean ret = MessageDigest.isEqual(this.key, thatKey);
-            java.util.Arrays.fill(thatKey, (byte)0x00);
+            Arrays.fill(thatKey, (byte)0x00);
             return ret;
         } finally {
             // prevent this from being cleaned for the above block
@@ -162,7 +162,7 @@ final class DESedeKey implements SecretKey {
         }
         byte[] temp = key;
         this.key = temp.clone();
-        java.util.Arrays.fill(temp, (byte)0x00);
+        Arrays.fill(temp, (byte)0x00);
 
         DESKeyGenerator.setParityBit(key, 0);
         DESKeyGenerator.setParityBit(key, 8);
@@ -171,7 +171,7 @@ final class DESedeKey implements SecretKey {
         // Use the cleaner to zero the key when no longer referenced
         final byte[] k = this.key;
         CleanerFactory.cleaner().register(this,
-                () -> java.util.Arrays.fill(k, (byte)0x00));
+                () -> Arrays.fill(k, (byte)0x00));
     }
 
     /**

--- a/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PBEKey.java
@@ -84,7 +84,7 @@ final class PBEKey implements SecretKey {
         // Use the cleaner to zero the key when no longer referenced
         final byte[] k = this.key;
         cleanable = CleanerFactory.cleaner().register(this,
-                () -> java.util.Arrays.fill(k, (byte)0x00));
+                () -> Arrays.fill(k, (byte)0x00));
     }
 
     public byte[] getEncoded() {
@@ -196,7 +196,7 @@ final class PBEKey implements SecretKey {
         // Use cleaner to zero the key when no longer referenced
         final byte[] k = this.key;
         cleanable = CleanerFactory.cleaner().register(this,
-                () -> java.util.Arrays.fill(k, (byte)0x00));
+                () -> Arrays.fill(k, (byte)0x00));
     }
 
 

--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/Invokers.java
+++ b/src/java.base/share/classes/java/lang/invoke/Invokers.java
@@ -190,7 +190,7 @@ class Invokers {
 
     private boolean checkInvoker(MethodHandle invoker) {
         assert(targetType.invokerType().equals(invoker.type()))
-                : java.util.Arrays.asList(targetType, targetType.invokerType(), invoker);
+                : Arrays.asList(targetType, targetType.invokerType(), invoker);
         assert(invoker.internalMemberName() == null ||
                invoker.internalMemberName().getMethodType().equals(targetType));
         assert(!invoker.isVarargsCollector());
@@ -200,7 +200,7 @@ class Invokers {
     private boolean checkVarHandleInvoker(MethodHandle invoker) {
         MethodType invokerType = targetType.insertParameterTypes(0, VarHandle.class);
         assert(invokerType.equals(invoker.type()))
-                : java.util.Arrays.asList(targetType, invokerType, invoker);
+                : Arrays.asList(targetType, invokerType, invoker);
         assert(invoker.internalMemberName() == null ||
                invoker.internalMemberName().getMethodType().equals(targetType));
         assert(!invoker.isVarargsCollector());

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -1774,7 +1774,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
             carry = product >>> 32;
         }
         if (carry == 0L) {
-            rmag = java.util.Arrays.copyOfRange(rmag, 1, rmag.length);
+            rmag = Arrays.copyOfRange(rmag, 1, rmag.length);
         } else {
             rmag[rstart] = (int)carry;
         }
@@ -1819,7 +1819,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
             rmag[0] = (int)carry;
         }
         if (carry == 0L)
-            rmag = java.util.Arrays.copyOfRange(rmag, 1, rmag.length);
+            rmag = Arrays.copyOfRange(rmag, 1, rmag.length);
         return new BigInteger(rmag, rsign);
     }
 
@@ -4593,7 +4593,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
         // Find first nonzero byte
         for (keep = 0; keep < vlen && val[keep] == 0; keep++)
             ;
-        return java.util.Arrays.copyOfRange(val, keep, vlen);
+        return Arrays.copyOfRange(val, keep, vlen);
     }
 
     /**
@@ -4607,7 +4607,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
         // Find first nonzero byte
         for (keep = 0; keep < vlen && val[keep] == 0; keep++)
             ;
-        return keep == 0 ? val : java.util.Arrays.copyOfRange(val, keep, vlen);
+        return keep == 0 ? val : Arrays.copyOfRange(val, keep, vlen);
     }
 
     private static int[] stripLeadingZeroBytes(byte[] a, int from, int len) {

--- a/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
+++ b/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
+++ b/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
@@ -204,7 +204,7 @@ public class FtpClient extends sun.net.ftp.FtpClient {
             47, 63, 58, 64, 38, 61, 43, 36, 44};
 
         byte[] b = chkS.getBytes(encoding);
-        return java.util.Arrays.equals(b, chkB);
+        return Arrays.equals(b, chkB);
     }
 
     private class DefaultParser implements FtpDirParser {

--- a/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
+++ b/src/java.desktop/share/classes/java/awt/image/IndexColorModel.java
@@ -592,7 +592,7 @@ public class IndexColorModel extends ColorModel {
     private BigInteger getAllValid() {
         int numbytes = (map_size+7)/8;
         byte[] valid = new byte[numbytes];
-        java.util.Arrays.fill(valid, (byte)0xff);
+        Arrays.fill(valid, (byte)0xff);
         valid[0] = (byte)(0xff >>> (numbytes*8 - map_size));
 
         return new BigInteger(1, valid);

--- a/src/java.management/share/classes/sun/management/ThreadImpl.java
+++ b/src/java.management/share/classes/sun/management/ThreadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.management/share/classes/sun/management/ThreadImpl.java
+++ b/src/java.management/share/classes/sun/management/ThreadImpl.java
@@ -267,7 +267,7 @@ public class ThreadImpl implements ThreadMXBean {
 
         int length = ids.length;
         long[] times = new long[length];
-        java.util.Arrays.fill(times, -1);
+        Arrays.fill(times, -1);
 
         if (verified) {
             if (length == 1) {
@@ -306,7 +306,7 @@ public class ThreadImpl implements ThreadMXBean {
 
         int length = ids.length;
         long[] times = new long[length];
-        java.util.Arrays.fill(times, -1);
+        Arrays.fill(times, -1);
 
         if (verified) {
             if (length == 1) {
@@ -390,7 +390,7 @@ public class ThreadImpl implements ThreadMXBean {
         boolean verified = verifyThreadAllocatedMemory(ids);
 
         long[] sizes = new long[ids.length];
-        java.util.Arrays.fill(sizes, -1);
+        Arrays.fill(sizes, -1);
 
         if (verified) {
             getThreadAllocatedMemory1(ids, sizes);


### PR DESCRIPTION
In [JDK-8322772](https://bugs.openjdk.org/browse/JDK-8322772) one similar cleanup has been proposed before (and was done in the change). But there are a number of other places in the codebase where the import is done and still the unneeded fully qualified class name "java.util.Arrays" is used so more cleanups can be done.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322782](https://bugs.openjdk.org/browse/JDK-8322782): Clean up usages of unnecessary fully qualified class name "java.util.Arrays" (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [af1c0375](https://git.openjdk.org/jdk/pull/17241/files/af1c0375dcda858122df8d6cf267df823f00027b)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17241/head:pull/17241` \
`$ git checkout pull/17241`

Update a local copy of the PR: \
`$ git checkout pull/17241` \
`$ git pull https://git.openjdk.org/jdk.git pull/17241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17241`

View PR using the GUI difftool: \
`$ git pr show -t 17241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17241.diff">https://git.openjdk.org/jdk/pull/17241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17241#issuecomment-1875248610)