### PR TITLE
8322936: Update blessed-modifier-order.sh for default, sealed, and non-sealed

### DIFF
--- a/bin/blessed-modifier-order.sh
+++ b/bin/blessed-modifier-order.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2015 Google, Inc.  All Rights Reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -26,12 +27,17 @@ usage() {
     echo "$0 DIR ..."
     echo "Modifies in place all the java source files found"
     echo "in the given directories so that all java language modifiers"
-    echo "are in the canonical order given by Modifier#toString()."
+    echo "are in the canonical order."
     echo "Tries to get it right even within javadoc comments,"
     echo "and even if the list of modifiers spans 2 lines."
     echo
     echo "See:"
-    echo "https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Modifier.html#toString-int-"
+    echo "https://docs.oracle.com/javase/specs/jls/se21/html/jls-8.html#jls-8.1.1"
+    echo "https://docs.oracle.com/javase/specs/jls/se21/html/jls-8.html#jls-8.3.1"
+    echo "https://docs.oracle.com/javase/specs/jls/se21/html/jls-8.html#jls-8.4.3"
+    echo "https://docs.oracle.com/javase/specs/jls/se21/html/jls-8.html#jls-8.8.3"
+    echo "https://docs.oracle.com/javase/specs/jls/se21/html/jls-9.html#jls-9.1.1"
+    echo "https://docs.oracle.com/javase/specs/jls/se21/html/jls-9.html#jls-9.4"
     echo
     echo "Example:"
     echo "$0 jdk/src/java.base jdk/test/java/{util,io,lang}"
@@ -46,7 +52,7 @@ for dir in "${dirs[@]}"; do [[ -d "$dir" ]] || usage; done
 
 declare -ar modifiers=(
   public protected private
-  abstract static final transient
+  abstract default static final sealed non-sealed transient
   volatile synchronized native strictfp
 )
 declare -r SAVE_IFS="$IFS"


### PR DESCRIPTION
Please review this PR to update `blessed-modifier.order.sh` for the `default`, `sealed`, `non-sealed`, and `strictfp` modifiers.

In a [discussion][] preceding this PR, it was agreed that the script should better refer to relevant JLS sections rather than to [`java.lang.reflect.Modifier#toString`][], which does not model Java source.

- the `sealed` and `non-sealed` class or interface modifiers were introduced in JEP 409, but have never been accounted for

- the `default` method modifier was introduced in Java 8, but has not been explicitly accounted for. It's unclear whether it was an omission or a conscious decision. The current edition of JLS [suggests] that in compilable, modern and customary formatted code, `default` appears alone and, thus, is always canonically ordered.

  However, a somewhat similar argument applies to the `public` modifier on an interface method. Its use is discouraged, yet the script would enforce its order if `public` appears not alone.

  So for completeness, this PR proposes to explicitly account for `default`.

* While not proposing to do anyting about it, this PR recognises (for the record) that `strictfp` class, interface, or method modifier became [obsolete][] in JDK 17.

I've run the updated script on JDK. The script found 8 missorted `sealed` and 20 missorted `default`. The script also found 3 false positive `default`:

- https://github.com/openjdk/jdk/blob/249d553659ab75a2271e98c77e7d62f662ffa684/src/java.desktop/share/classes/java/awt/dnd/DragSource.java#L526-L527
- https://github.com/openjdk/jdk/blob/98da03af50e2372817a7b5e381eea5ee6f2cb919/src/java.management/share/classes/javax/management/MBeanServerFactory.java#L91
- https://github.com/openjdk/jdk/blob/6765f902505fbdd02f25b599f942437cd805cad1/src/java.desktop/share/classes/javax/print/PrintServiceLookup.java#L193

None of those findings are addressed in this PR.

[discussion]: https://mail.openjdk.org/pipermail/core-libs-dev/2024-January/117347.html
[`java.lang.reflect.Modifier#toString`]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/reflect/Modifier.html#toString(int)
[suggests]: https://docs.oracle.com/javase/specs/jls/se21/html/jls-9.html#jls-9.4
[obsolete]: https://openjdk.org/jeps/306

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322936](https://bugs.openjdk.org/browse/JDK-8322936): Update blessed-modifier-order.sh for default, sealed, and non-sealed (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17242/head:pull/17242` \
`$ git checkout pull/17242`

Update a local copy of the PR: \
`$ git checkout pull/17242` \
`$ git pull https://git.openjdk.org/jdk.git pull/17242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17242`

View PR using the GUI difftool: \
`$ git pr show -t 17242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17242.diff">https://git.openjdk.org/jdk/pull/17242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17242#issuecomment-1875280778)