### PR TITLE
8322954: Shenandoah: Convert evac-update closures asserts to rich asserts

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSet.inline.hpp
@@ -357,7 +357,7 @@ void ShenandoahBarrierSet::arraycopy_work(T* src, size_t count) {
         if (EVAC && obj == fwd) {
           fwd = _heap->evacuate_object(obj, thread);
         }
-        assert(obj != fwd || _heap->cancelled_gc(), "must be forwarded");
+        shenandoah_assert_forwarded_except(elem_ptr, obj, _heap->cancelled_gc());
         ShenandoahHeap::atomic_update_oop(fwd, elem_ptr, o);
         obj = fwd;
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetClone.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetClone.inline.hpp
@@ -53,7 +53,7 @@ private:
         if (EVAC && obj == fwd) {
           fwd = _heap->evacuate_object(obj, _thread);
         }
-        assert(obj != fwd || _heap->cancelled_gc(), "must be forwarded");
+        shenandoah_assert_forwarded_except(p, obj, _heap->cancelled_gc());
         ShenandoahHeap::atomic_update_oop(fwd, p, o);
         obj = fwd;
       }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -705,10 +705,8 @@ void ShenandoahEvacUpdateCleanupOopStorageRootsClosure::do_oop(oop* p) {
       if (resolved == obj) {
         resolved = _heap->evacuate_object(obj, _thread);
       }
+      shenandoah_assert_not_in_cset_except(p, resolved, _heap->cancelled_gc());
       ShenandoahHeap::atomic_update_oop(resolved, p, obj);
-      assert(_heap->cancelled_gc() ||
-             _mark_context->is_marked(resolved) && !_heap->in_collection_set(resolved),
-             "Sanity");
     }
   }
 }


### PR DESCRIPTION
Over the years, we seem to have introduced new asserts that should really be the rich Shenandoah asserts. I looked around and found at least three places in evac-update closures.

We also do not need ` _mark_context->is_marked(resolved)` in `ShenandoahEvacUpdateCleanupOopStorageRootsClosure`, because evac-ed objects are supposed to be after TAMS and thus implicitly marked.

Additional testing:
 - [x] macos-aarch64-server-fastdebug, `hotspot_gc_shenandoah`
 - [x] linux-x86_64-server-fastdebug, `tier{1,2,3}` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322954](https://bugs.openjdk.org/browse/JDK-8322954): Shenandoah: Convert evac-update closures asserts to rich asserts (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Author)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17245/head:pull/17245` \
`$ git checkout pull/17245`

Update a local copy of the PR: \
`$ git checkout pull/17245` \
`$ git pull https://git.openjdk.org/jdk.git pull/17245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17245`

View PR using the GUI difftool: \
`$ git pr show -t 17245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17245.diff">https://git.openjdk.org/jdk/pull/17245.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17245#issuecomment-1875456041)