### PR TITLE
8322959: vectorapi: get wrong argument for `limit` in indexPartiallyInUpperRange intrinsic

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -3148,7 +3148,7 @@ bool LibraryCallKit::inline_index_partially_in_upper_range() {
   }
 
   Node* offset = argument(3);
-  Node* limit = argument(5);
+  Node* limit = argument(4);
   if (offset == nullptr || limit == nullptr) {
     if (C->print_intrinsics()) {
       tty->print_cr("  ** offset or limit argument is null");


### PR DESCRIPTION
Hi,
Can you review this simple fix for indexPartiallyInUpperRange intrinsic?
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322959](https://bugs.openjdk.org/browse/JDK-8322959): vectorapi: get wrong argument for `limit` in indexPartiallyInUpperRange intrinsic (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17247/head:pull/17247` \
`$ git checkout pull/17247`

Update a local copy of the PR: \
`$ git checkout pull/17247` \
`$ git pull https://git.openjdk.org/jdk.git pull/17247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17247`

View PR using the GUI difftool: \
`$ git pr show -t 17247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17247.diff">https://git.openjdk.org/jdk/pull/17247.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17247#issuecomment-1875617267)