### PR TITLE
8322877: java/io/BufferedInputStream/TransferTo.java failed with IndexOutOfBoundsException

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -644,7 +644,7 @@ public class BufferedInputStream extends FilterInputStream {
             int avail = count - pos;
             if (avail > 0) {
                 if (isTrusted(out)) {
-                    out.write(getBufIfOpen(), pos, count);
+                    out.write(getBufIfOpen(), pos, avail);
                 } else {
                     // Prevent poisoning and leaking of buf
                     byte[] buffer = Arrays.copyOfRange(getBufIfOpen(), pos, count);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -503,7 +503,6 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 # jdk_io
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
-java/io/BufferedInputStream/TransferTo.java                     8322877 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The final position instead of the number of bytes to write was being passed to `ByteArrayOuputStream.write(byte[],int,int)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322877](https://bugs.openjdk.org/browse/JDK-8322877): java/io/BufferedInputStream/TransferTo.java failed with IndexOutOfBoundsException (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Sergey Tsypanov](https://openjdk.org/census#stsypanov) (@stsypanov - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17250/head:pull/17250` \
`$ git checkout pull/17250`

Update a local copy of the PR: \
`$ git checkout pull/17250` \
`$ git pull https://git.openjdk.org/jdk.git pull/17250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17250`

View PR using the GUI difftool: \
`$ git pr show -t 17250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17250.diff">https://git.openjdk.org/jdk/pull/17250.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17250#issuecomment-1875766807)