### PR TITLE
8319757: java/nio/channels/DatagramChannel/InterruptibleOrNot.java failed: wrong exception thrown

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/InterruptibleOrNot.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/InterruptibleOrNot.java
@@ -114,7 +114,8 @@ public class InterruptibleOrNot {
     }
 
     /**
-     * Test interrupting a thread blocked in DatagramChannel.receive. ??
+     * Test interrupting a thread blocked in DatagramChannel.receive, the DatagramChannel
+     * is not interruptible.
      */
     @Test
     public void testInterruptDuringUninterruptibleReceive() throws Exception {

--- a/test/jdk/java/nio/channels/DatagramChannel/InterruptibleOrNot.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/InterruptibleOrNot.java
@@ -69,6 +69,7 @@ public class InterruptibleOrNot {
             ByteBuffer buf = ByteBuffer.allocate(100);
             Thread.currentThread().interrupt();
             assertThrows(ClosedByInterruptException.class, () -> dc.receive(buf));
+            assertFalse(dc.isOpen());
         } finally {
             Thread.interrupted();  // clear interrupt status
         }
@@ -85,6 +86,7 @@ public class InterruptibleOrNot {
             Thread thread = Thread.currentThread();
             onReceive(thread::interrupt);
             assertThrows(ClosedByInterruptException.class, () -> dc.receive(buf));
+            assertFalse(dc.isOpen());
         } finally {
             Thread.interrupted();  // clear interrupt status
         }
@@ -105,6 +107,7 @@ public class InterruptibleOrNot {
             });
             Thread.currentThread().interrupt();
             assertThrows(AsynchronousCloseException.class, () -> dc.receive(buf));
+            assertFalse(dc.isOpen());
         } finally {
             Thread.interrupted();  // clear interrupt status
         }
@@ -128,6 +131,7 @@ public class InterruptibleOrNot {
                 dc.close();
             });
             assertThrows(AsynchronousCloseException.class, () -> dc.receive(buf));
+            assertFalse(dc.isOpen());
         } finally {
             Thread.interrupted();  // clear interrupt status
         }
@@ -144,6 +148,7 @@ public class InterruptibleOrNot {
             SocketAddress target = dc.getLocalAddress();
             Thread.currentThread().interrupt();
             assertThrows(ClosedByInterruptException.class, () -> dc.send(buf, target));
+            assertFalse(dc.isOpen());
         } finally {
             Thread.interrupted();  // clear interrupt
         }
@@ -160,7 +165,8 @@ public class InterruptibleOrNot {
             SocketAddress target = dc.getLocalAddress();
             Thread.currentThread().interrupt();
             int n = dc.send(buf, target);
-            assertTrue(n == 100);
+            assertEquals(100, n);
+            assertTrue(dc.isOpen());
         } finally {
             Thread.interrupted();  // clear interrupt status
         }


### PR DESCRIPTION
InterruptibleOrNot.testInterruptBeforeInterruptibleReceive has failed a few times. It calls DatagramChannel.receive with the interrupt status set and expects ClosedByInterruptException to be thrown. The shared part of the test is also used for the non-interruptible scenario which needs a delayed close to ensure the thread calling receive wakes up. The 2s delay is not sufficient and thus it's possible for the async close to beat the detection of the interrupt status. This leads to AsynchronousCloseException instead of the expected ClosedByInterruptException.

The test is re-worked to split the interruptible and non-interruptible tests. The test is also changed to drop the delayed interrupt/close and instead use a thread to poll under the target thread is in DatagramChannel.receive. The overall test is simpler. I changed it to be a JUnit test, that part is only a few lines of changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319757](https://bugs.openjdk.org/browse/JDK-8319757): java/nio/channels/DatagramChannel/InterruptibleOrNot.java failed: wrong exception thrown (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17251/head:pull/17251` \
`$ git checkout pull/17251`

Update a local copy of the PR: \
`$ git checkout pull/17251` \
`$ git pull https://git.openjdk.org/jdk.git pull/17251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17251`

View PR using the GUI difftool: \
`$ git pr show -t 17251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17251.diff">https://git.openjdk.org/jdk/pull/17251.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17251#issuecomment-1877025663)