### PR TITLE
8322214: Return value of XMLInputFactory.getProperty() changed from boolean to String in JDK 22 early access builds

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/PropertyManager.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/PropertyManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import jdk.xml.internal.XMLSecurityManager;
  * @author K Venugopal
  * @author Sunitha Reddy
  *
- * @LastModified: Nov 2023
+ * @LastModified: Jan 2024
  */
 public class PropertyManager {
 
@@ -184,6 +184,9 @@ public class PropertyManager {
      * @return the value of a property
      */
     public Object getProperty(String property) {
+        if (XMLInputFactory.SUPPORT_DTD.equals(property)) {
+            return fSecurityManager.is(XMLSecurityManager.Limit.STAX_SUPPORT_DTD);
+        }
         /**
          * Check to see if the property is managed by the security manager *
          */

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/AbstractSAXParser.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/AbstractSAXParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -79,7 +79,7 @@ import org.xml.sax.helpers.LocatorImpl;
  * @author Arnaud Le Hors, IBM
  * @author Andy Clark, IBM
  *
- * @LastModified: July 2023
+ * @LastModified: Jan 2024
  */
 @SuppressWarnings("deprecation")
 public abstract class AbstractSAXParser
@@ -1830,6 +1830,11 @@ public abstract class AbstractSAXParser
                 //
             }
             */
+
+            // Handle properties managed by XMLSecurityManager
+            if (featureId.equals(XMLSecurityManager.DISALLOW_DTD)) {
+                return securityManager.is(XMLSecurityManager.Limit.XERCES_DISALLOW_DTD);
+            }
 
             return fConfiguration.getFeature(featureId);
         }

--- a/test/jaxp/javax/xml/jaxp/unittest/common/dtd/DTDPropertiesTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/dtd/DTDPropertiesTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package common.dtd;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.xml.sax.XMLReader;
+
+/*
+ * @test
+ * @bug 8322214
+ * @library /javax/xml/jaxp/libs /javax/xml/jaxp/unittest
+ * @run testng common.dtd.DTDPropertiesTest
+ * @summary Verifies the getProperty function on DTD properties works the same
+ * as before the property 'jdk.xml.dtd.support' was introduced.
+ */
+public class DTDPropertiesTest {
+    // Xerces Property
+    public static final String DISALLOW_DTD = "http://apache.org/xml/features/disallow-doctype-decl";
+
+    /*
+     * DataProvider for verifying Xerces' disallow-DTD feature
+     * Fields: property name, setting (null indicates not specified), expected
+     */
+    @DataProvider(name = "XercesProperty")
+    public Object[][] getXercesProperty() throws Exception {
+        return new Object[][] {
+            { DISALLOW_DTD, null, false},
+            { DISALLOW_DTD, true, true},
+            { DISALLOW_DTD, false, false},
+        };
+    }
+
+    /*
+     * DataProvider for verifying StAX's supportDTD feature
+     * Fields: property name, setting (null indicates not specified), expected
+     */
+    @DataProvider(name = "StAXProperty")
+    public Object[][] getStAXProperty() throws Exception {
+        return new Object[][] {
+            { XMLInputFactory.SUPPORT_DTD, null, true},
+            { XMLInputFactory.SUPPORT_DTD, true, true},
+            { XMLInputFactory.SUPPORT_DTD, false, false},
+        };
+    }
+
+    /**
+     * Verifies the disallow DTD feature with SAX.
+     *
+     * @param name the name of the property
+     * @param setting the setting of the property, null means not specified
+     * @param expected the expected value
+     * @throws Exception if the test fails
+     */
+    @Test(dataProvider = "XercesProperty")
+    public void testSAX(String name, Boolean setting, Boolean expected) throws Exception {
+        SAXParserFactory spf = SAXParserFactory.newDefaultInstance();
+        if (setting != null) {
+            spf.setFeature(name, setting);
+        }
+        Assert.assertEquals((Boolean)spf.getFeature(name), expected);
+        System.out.println(spf.getFeature(name));
+
+
+        SAXParser saxParser = spf.newSAXParser();
+        XMLReader reader = saxParser.getXMLReader();
+        Assert.assertEquals((Boolean)reader.getFeature(name), expected);
+        System.out.println(reader.getFeature(name));
+    }
+
+    /**
+     * Verifies the disallow DTD feature with DOM.
+     *
+     * @param name the name of the property
+     * @param setting the setting of the property, null means not specified
+     * @param expected the expected value
+     * @throws Exception if the test fails
+     */
+    @Test(dataProvider = "XercesProperty")
+    public void testDOM(String name, Boolean setting, Boolean expected) throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+        if (setting != null) {
+            dbf.setFeature(name, setting);
+        }
+        Assert.assertEquals((Boolean)dbf.getFeature(name), expected);
+        System.out.println(dbf.getFeature(name));
+    }
+
+    /**
+     * Verifies the StAX's supportDTD feature.
+     *
+     * @param name the name of the property
+     * @param setting the setting of the property, null means not specified
+     * @param expected the expected value
+     * @throws Exception if the test fails
+     */
+    @Test(dataProvider = "StAXProperty")
+    public void testStAX(String name, Boolean setting, Boolean expected) throws Exception {
+        XMLInputFactory xif = XMLInputFactory.newInstance();
+        if (setting != null) {
+            xif.setProperty(name, setting);
+        }
+        Assert.assertEquals((Boolean)xif.getProperty(name), expected);
+        System.out.println((Boolean)xif.getProperty(name));
+    }
+}


### PR DESCRIPTION
Fix the get (return) operation by using the same method as that used for checking the values of the DTD features during the resolution process.

Note: this patch also addresses the issue reported in https://bugs.openjdk.org/browse/JDK-8322216

Test: new test added covers DTD properties for SAX/DOM/StAX.
         Existing tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322214](https://bugs.openjdk.org/browse/JDK-8322214): Return value of XMLInputFactory.getProperty() changed from boolean to String in JDK 22 early access builds (**Bug** - P3)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17252/head:pull/17252` \
`$ git checkout pull/17252`

Update a local copy of the PR: \
`$ git checkout pull/17252` \
`$ git pull https://git.openjdk.org/jdk.git pull/17252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17252`

View PR using the GUI difftool: \
`$ git pr show -t 17252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17252.diff">https://git.openjdk.org/jdk/pull/17252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17252#issuecomment-1875871424)