### PR TITLE
8322971: KEM.getInstance() should check if a 3rd-party security provider is signed

### DIFF
--- a/src/java.base/share/classes/javax/crypto/KEM.java
+++ b/src/java.base/share/classes/javax/crypto/KEM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import sun.security.jca.GetInstance;
 import java.security.*;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -539,10 +540,19 @@ public final class KEM {
         List<Provider.Service> list = GetInstance.getServices(
                 "KEM",
                 Objects.requireNonNull(algorithm, "null algorithm name"));
-        if (list.isEmpty()) {
-            throw new NoSuchAlgorithmException(algorithm + " KEM not available");
+        List<Provider.Service> allowed = new ArrayList<>();
+        for (Provider.Service s : list) {
+            if (!JceSecurity.canUseProvider(s.getProvider())) {
+                continue;
+            }
+            allowed.add(s);
         }
-        return new KEM(algorithm, new DelayedKEM(list.toArray(new Provider.Service[0])));
+        if (allowed.isEmpty()) {
+            throw new NoSuchAlgorithmException
+                    (algorithm + " KEM not available");
+        }
+
+        return new KEM(algorithm, new DelayedKEM(allowed.toArray(new Provider.Service[0])));
     }
 
     /**
@@ -568,7 +578,7 @@ public final class KEM {
         if (provider == null) {
             return getInstance(algorithm);
         }
-        GetInstance.Instance instance = GetInstance.getInstance(
+        GetInstance.Instance instance = JceSecurity.getInstance(
                 "KEM",
                 KEMSpi.class,
                 Objects.requireNonNull(algorithm, "null algorithm name"),
@@ -601,7 +611,7 @@ public final class KEM {
         if (provider == null) {
             return getInstance(algorithm);
         }
-        GetInstance.Instance instance = GetInstance.getInstance(
+        GetInstance.Instance instance = JceSecurity.getInstance(
                 "KEM",
                 KEMSpi.class,
                 Objects.requireNonNull(algorithm, "null algorithm name"),

--- a/test/jdk/com/sun/crypto/provider/DHKEM/java.base/com/sun/crypto/provider/EvenKEMImpl.java
+++ b/test/jdk/com/sun/crypto/provider/DHKEM/java.base/com/sun/crypto/provider/EvenKEMImpl.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.crypto.provider;
+
+import java.security.*;
+import java.security.spec.*;
+import java.util.Arrays;
+
+// The alternate DHKEM implementation used by the Compliance.java test.
+public class EvenKEMImpl extends DHKEM {
+
+    public static boolean isEven(Key k) {
+        return Arrays.hashCode(k.getEncoded()) % 2 == 0;
+    }
+
+    @Override
+    public EncapsulatorSpi engineNewEncapsulator(
+            PublicKey pk, AlgorithmParameterSpec spec, SecureRandom secureRandom)
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
+        if (!isEven(pk)) throw new InvalidKeyException("Only accept even keys");
+        return super.engineNewEncapsulator(pk, spec, secureRandom);
+    }
+
+    @Override
+    public DecapsulatorSpi engineNewDecapsulator(
+            PrivateKey sk, AlgorithmParameterSpec spec)
+            throws InvalidAlgorithmParameterException, InvalidKeyException {
+        if (!isEven(sk)) throw new InvalidKeyException("Only accept even keys");
+        return super.engineNewDecapsulator(sk, spec);
+    }
+}


### PR DESCRIPTION
`KEM.getInstance` now checks if the implementation is from a signed provider if it's not builtin to JDK.

Several adjustments to the test:
1. Put one impl in `SunEC` to pretend it's builtin. This is necessary to test for provider selection.
2. When there is no need to choose a provider, use reflection to create a `KEM` object that bypasses the `getInstance` call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8322974](https://bugs.openjdk.org/browse/JDK-8322974) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8322971](https://bugs.openjdk.org/browse/JDK-8322971): KEM.getInstance() should check if a 3rd-party security provider is signed (**Bug** - P3)
 * [JDK-8322974](https://bugs.openjdk.org/browse/JDK-8322974): KEM.getInstance() should check if a 3rd-party security provider is signed (**CSR**)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17253/head:pull/17253` \
`$ git checkout pull/17253`

Update a local copy of the PR: \
`$ git checkout pull/17253` \
`$ git pull https://git.openjdk.org/jdk.git pull/17253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17253`

View PR using the GUI difftool: \
`$ git pr show -t 17253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17253.diff">https://git.openjdk.org/jdk/pull/17253.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17253#issuecomment-1875951700)