### PR TITLE
8322675: JFR: Fail-fast mode when constants cannot be resolved

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantMap.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,9 @@ final class ConstantMap {
         if (value == null) {
             // unless id is 0 which is used to represent null
             if (id != 0) {
-                Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, "Missing object id=" + id + " in pool " + getName() + ". All ids should reference an object");
+                String msg = "Missing object ID " + id + " in pool " + getName() + ". All IDs should reference an object";
+                Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, msg);
+                assert false : msg;
             }
             return null;
         }


### PR DESCRIPTION
Could I have a review of PR that adds an assertion if a constant can't be resolved. Purpose is to find regressions before they make it into the release.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322675](https://bugs.openjdk.org/browse/JDK-8322675): JFR: Fail-fast mode when constants cannot be resolved (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17254/head:pull/17254` \
`$ git checkout pull/17254`

Update a local copy of the PR: \
`$ git checkout pull/17254` \
`$ git pull https://git.openjdk.org/jdk.git pull/17254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17254`

View PR using the GUI difftool: \
`$ git pr show -t 17254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17254.diff">https://git.openjdk.org/jdk/pull/17254.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17254#issuecomment-1875964025)