### PR TITLE
JDK-8322235: Split up and improve LocaleProvidersRun

### DIFF
--- a/src/java.base/macosx/native/libjava/HostLocaleProviderAdapter_md.c
+++ b/src/java.base/macosx/native/libjava/HostLocaleProviderAdapter_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/macosx/native/libjava/HostLocaleProviderAdapter_md.c
+++ b/src/java.base/macosx/native/libjava/HostLocaleProviderAdapter_md.c
@@ -427,6 +427,9 @@ JNIEXPORT jstring JNICALL Java_sun_util_locale_provider_HostLocaleProviderAdapte
 JNIEXPORT jint JNICALL Java_sun_util_locale_provider_HostLocaleProviderAdapterImpl_getCalendarInt
   (JNIEnv *env, jclass cls, jstring jlangtag, jint type) {
     jint ret = 0;
+    // Majority of MacOSX fixed locales return Gregorian cal identifier
+    // Using CFCalendarCopyCurrent() provides a cal that is based off OS settings
+    // which is more accurate than one created with a Gregorian identifier
     CFCalendarRef cfcal = CFCalendarCopyCurrent();
 
     if (cfcal != NULL) {

--- a/test/jdk/java/util/Locale/LocaleProviders.java
+++ b/test/jdk/java/util/Locale/LocaleProviders.java
@@ -481,14 +481,16 @@ public class LocaleProviders {
         }
     }
 
-    // Method is used by the LocaleProviders* related tests to launch a
-    // LocaleProviders test method with the appropriate LocaleProvider (e.g. CLDR,
-    // COMPAT, ETC.)
+    /* Method is used by the LocaleProviders* related tests to launch a
+     * LocaleProviders test method with the appropriate LocaleProvider (e.g. CLDR,
+     * COMPAT, ETC.)
+     */
     static void testRun(String prefList, String methodName, String... params) throws Throwable {
 
         List<String> command = List.of(
                 "-ea", "-esa",
                 "-cp", Utils.TEST_CLASS_PATH,
+                // Required for LocaleProvidersLogger
                 "-Djava.util.logging.config.class=LocaleProviders$LogConfig",
                 "-Djava.locale.providers=" + prefList,
                 "--add-exports=java.base/sun.util.locale.provider=ALL-UNNAMED",

--- a/test/jdk/java/util/Locale/LocaleProviders.java
+++ b/test/jdk/java/util/Locale/LocaleProviders.java
@@ -485,7 +485,7 @@ public class LocaleProviders {
      * LocaleProviders test method with the appropriate LocaleProvider (e.g. CLDR,
      * COMPAT, ETC.)
      */
-    static void testRun(String prefList, String methodName, String... params) throws Throwable {
+    static void test(String prefList, String methodName, String... params) throws Throwable {
 
         List<String> command = List.of(
                 "-ea", "-esa",

--- a/test/jdk/java/util/Locale/LocaleProviders.java
+++ b/test/jdk/java/util/Locale/LocaleProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,10 @@ import java.util.logging.LogRecord;
 import java.util.logging.StreamHandler;
 import java.util.spi.*;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.ProcessTools;
 import sun.util.locale.provider.LocaleProviderAdapter;
 
 import static java.util.logging.LogManager.*;
@@ -474,6 +478,30 @@ public class LocaleProviders {
                     "Default format locale is not Locale.UK: " + defLoc + ", or\n" +
                     "OS is neither macOS/Windows, or\n" +
                     "provider is not HOST: " + type);
+        }
+    }
+
+    // Method is used by the LocaleProviders* related tests to launch a
+    // LocaleProviders test method with the appropriate LocaleProvider (e.g. CLDR,
+    // COMPAT, ETC.)
+    static void testRun(String prefList, String methodName, String... params) throws Throwable {
+
+        List<String> command = List.of(
+                "-ea", "-esa",
+                "-cp", Utils.TEST_CLASS_PATH,
+                "-Djava.util.logging.config.class=LocaleProviders$LogConfig",
+                "-Djava.locale.providers=" + prefList,
+                "--add-exports=java.base/sun.util.locale.provider=ALL-UNNAMED",
+                "LocaleProviders", methodName);
+
+        // Build process with arguments, if required by the method
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                Stream.concat(command.stream(), Stream.of(params)).toList());
+
+        // Evaluate process status
+        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
+        if (exitCode != 0) {
+            throw new RuntimeException("Unexpected exit code: " + exitCode);
         }
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProviders.java
+++ b/test/jdk/java/util/Locale/LocaleProviders.java
@@ -451,7 +451,8 @@ public class LocaleProviders {
         }
     }
 
-    // Run only if the platform locale is en-GB
+    // Run only if the underlying platform locale is en-GB
+    // (Setting the java locale via command line properties does not substitute this)
     static void bug8257964Test() {
         var defLoc = Locale.getDefault(Locale.Category.FORMAT);
         var type = LocaleProviderAdapter.getAdapter(CalendarNameProvider.class, Locale.UK)

--- a/test/jdk/java/util/Locale/LocaleProvidersCalendar.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersCalendar.java
@@ -47,7 +47,7 @@ public class LocaleProvidersCalendar {
     @Test
     @EnabledOnOs(WINDOWS)
     public void gregCalEraHost() throws Throwable {
-        LocaleProviders.testRun("HOST", "bug8228465Test");
+        LocaleProviders.test("HOST", "bug8228465Test");
     }
 
     /*
@@ -57,7 +57,7 @@ public class LocaleProvidersCalendar {
     @Test
     @EnabledOnOs(MAC)
     public void japaneseCalValuesHost() throws Throwable {
-        LocaleProviders.testRun("HOST", "bug8232871Test");
+        LocaleProviders.test("HOST", "bug8232871Test");
     }
 
     /*
@@ -69,6 +69,6 @@ public class LocaleProvidersCalendar {
     @EnabledIfSystemProperty(named = "user.language", matches = "en")
     @EnabledIfSystemProperty(named = "user.country", matches = "GB")
     public void minDaysFirstWeekHost() throws Throwable {
-        LocaleProviders.testRun("HOST", "bug8257964Test");
+        LocaleProviders.test("HOST", "bug8257964Test");
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProvidersCalendar.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersCalendar.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8228465 8232871 8257964
+ * @summary Test any Calendar Locale provider related issues
+ * @library /test/lib
+ * @build LocaleProviders
+ * @modules java.base/sun.util.locale.provider
+ * @run junit/othervm LocaleProvidersCalendar
+ * @run junit/othervm -Duser.language=en -Duser.country=GB LocaleProvidersCalendar
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+public class LocaleProvidersCalendar {
+
+    /*
+     * 8228465 (Windows only): Ensure correct ERA display name under HOST Windows
+     */
+    @Test
+    @EnabledOnOs(WINDOWS)
+    public void gregCalEraHost() throws Throwable {
+        LocaleProviders.testRun("HOST", "bug8228465Test");
+    }
+
+    /*
+     * 8232871 (macOS only): Ensure correct Japanese calendar values under
+     * HOST Mac.
+     */
+    @Test
+    @EnabledOnOs(MAC)
+    public void japaneseCalValuesHost() throws Throwable {
+        LocaleProviders.testRun("HOST", "bug8232871Test");
+    }
+
+    /*
+     * 8257964 (macOS/Windows only): Ensure correct Calendar::getMinimalDaysInFirstWeek
+     * value under HOST Windows / Mac. Only runs under GB country.
+     */
+    @Test
+    @EnabledOnOs({WINDOWS, MAC})
+    @EnabledIfSystemProperty(named = "user.language", matches = "en")
+    @EnabledIfSystemProperty(named = "user.country", matches = "GB")
+    public void minDaysFirstWeekHost() throws Throwable {
+        LocaleProviders.testRun("HOST", "bug8257964Test");
+    }
+}

--- a/test/jdk/java/util/Locale/LocaleProvidersCalendar.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersCalendar.java
@@ -29,7 +29,6 @@
  * @build LocaleProviders
  * @modules java.base/sun.util.locale.provider
  * @run junit/othervm LocaleProvidersCalendar
- * @run junit/othervm -Duser.language=en -Duser.country=GB LocaleProvidersCalendar
  */
 
 import org.junit.jupiter.api.Test;
@@ -62,7 +61,8 @@ public class LocaleProvidersCalendar {
 
     /*
      * 8257964 (macOS/Windows only): Ensure correct Calendar::getMinimalDaysInFirstWeek
-     * value under HOST Windows / Mac. Only runs under GB country.
+     * value under HOST Windows / Mac. Only run against machine with underlying
+     * OS locale of en-GB.
      */
     @Test
     @EnabledOnOs({WINDOWS, MAC})

--- a/test/jdk/java/util/Locale/LocaleProvidersDateTimeFormatter.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersDateTimeFormatter.java
@@ -41,6 +41,6 @@ public class LocaleProvidersDateTimeFormatter {
      */
     @Test
     public void dateOnlyJavaTimePattern() throws Throwable {
-        LocaleProviders.testRun("HOST", "bug8248695Test");
+        LocaleProviders.test("HOST", "bug8248695Test");
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProvidersDateTimeFormatter.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersDateTimeFormatter.java
@@ -35,8 +35,10 @@ import org.junit.jupiter.api.Test;
 
 public class LocaleProvidersDateTimeFormatter {
 
-    // 8248695: Ensure DateTimeFormatter::ofLocalizedDate does not throw exception
-    // under HOST (date only pattern leaks time field)
+    /*
+     * 8248695: Ensure DateTimeFormatter::ofLocalizedDate does not throw exception
+     * under HOST (date only pattern leaks time field)
+     */
     @Test
     public void dateOnlyJavaTimePattern() throws Throwable {
         LocaleProviders.testRun("HOST", "bug8248695Test");

--- a/test/jdk/java/util/Locale/LocaleProvidersDateTimeFormatter.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersDateTimeFormatter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8248695
+ * @summary Test any java.time.DateTimeFormatter Locale provider related issues
+ * @library /test/lib
+ * @build LocaleProviders
+ * @modules java.base/sun.util.locale.provider
+ * @run junit/othervm LocaleProvidersDateTimeFormatter
+ */
+
+import org.junit.jupiter.api.Test;
+
+public class LocaleProvidersDateTimeFormatter {
+
+    // 8248695: Ensure DateTimeFormatter::ofLocalizedDate does not throw exception
+    // under HOST (date only pattern leaks time field)
+    @Test
+    public void dateOnlyJavaTimePattern() throws Throwable {
+        LocaleProviders.testRun("HOST", "bug8248695Test");
+    }
+}

--- a/test/jdk/java/util/Locale/LocaleProvidersFormat.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersFormat.java
@@ -49,7 +49,7 @@ public class LocaleProvidersFormat {
     @Test
     @EnabledOnOs(WINDOWS)
     public void dateFormatExtraSpace() throws Throwable {
-        LocaleProviders.testRun("HOST", "bug7198834Test");
+        LocaleProviders.test("HOST", "bug7198834Test");
     }
 
     /*
@@ -59,7 +59,7 @@ public class LocaleProvidersFormat {
      */
     @Test
     public void formatWithInvalidLocaleExtension() throws Throwable {
-        LocaleProviders.testRun("CLDR", "bug8001440Test");
+        LocaleProviders.test("CLDR", "bug8001440Test");
     }
 
     /*
@@ -69,8 +69,8 @@ public class LocaleProvidersFormat {
      */
     @Test
     public void simpleDateFormatWithTZNProvider() throws Throwable {
-        LocaleProviders.testRun("JRE,SPI", "bug8013086Test", "ja", "JP");
-        LocaleProviders.testRun("COMPAT,SPI", "bug8013086Test", "ja", "JP");
+        LocaleProviders.test("JRE,SPI", "bug8013086Test", "ja", "JP");
+        LocaleProviders.test("COMPAT,SPI", "bug8013086Test", "ja", "JP");
     }
 
     /*
@@ -80,9 +80,9 @@ public class LocaleProvidersFormat {
     @Test
     @EnabledOnOs(WINDOWS)
     public void windowsJapaneseDateFields() throws Throwable {
-        LocaleProviders.testRun("HOST,JRE", "bug8013903Test");
-        LocaleProviders.testRun("HOST", "bug8013903Test");
-        LocaleProviders.testRun("HOST,COMPAT", "bug8013903Test");
+        LocaleProviders.test("HOST,JRE", "bug8013903Test");
+        LocaleProviders.test("HOST", "bug8013903Test");
+        LocaleProviders.test("HOST,COMPAT", "bug8013903Test");
     }
 
     /*
@@ -94,9 +94,9 @@ public class LocaleProvidersFormat {
     @EnabledIfSystemProperty(named = "user.language", matches = "zh")
     @EnabledIfSystemProperty(named = "user.country", matches = "CN")
     public void windowsChineseCurrencySymbol() throws Throwable {
-        LocaleProviders.testRun("JRE,HOST", "bug8027289Test", "FFE5");
-        LocaleProviders.testRun("COMPAT,HOST", "bug8027289Test", "FFE5");
-        LocaleProviders.testRun("HOST", "bug8027289Test", "00A5");
+        LocaleProviders.test("JRE,HOST", "bug8027289Test", "FFE5");
+        LocaleProviders.test("COMPAT,HOST", "bug8027289Test", "FFE5");
+        LocaleProviders.test("HOST", "bug8027289Test", "00A5");
     }
 
     /*
@@ -106,6 +106,6 @@ public class LocaleProvidersFormat {
     @Test
     @EnabledOnOs({WINDOWS, MAC})
     public void hostOptionalFracDigits() throws Throwable {
-        LocaleProviders.testRun("HOST", "bug8232860Test");
+        LocaleProviders.test("HOST", "bug8232860Test");
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProvidersFormat.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersFormat.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 7198834 8001440 8013086 8013903 8027289 8232860
+ * @summary Test any java.text.Format Locale provider related issues
+ * @library /test/lib
+ * @build LocaleProviders
+ *        providersrc.spi.src.tznp8013086
+ * @modules java.base/sun.util.locale.provider
+ * @run junit/othervm LocaleProvidersFormat
+ * @run junit/othervm -Duser.language=zh -Duser.country=CN LocaleProvidersFormat
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+
+import static org.junit.jupiter.api.condition.OS.MAC;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+public class LocaleProvidersFormat {
+
+    /*
+     * 7198834: Ensure under Windows/HOST, adapter does not append an extra space for date patterns.
+     */
+    @Test
+    @EnabledOnOs(WINDOWS)
+    public void dateFormatExtraSpace() throws Throwable {
+        LocaleProviders.testRun("HOST", "bug7198834Test");
+    }
+
+    /*
+     * 8001440: Ensure under CLDR, when number extension of the language
+     * tag is invalid, test program does not throw exception when calling
+     * NumberFormat::format.
+     */
+    @Test
+    public void formatWithInvalidLocaleExtension() throws Throwable {
+        LocaleProviders.testRun("CLDR", "bug8001440Test");
+    }
+
+    /*
+     * 8013086: Ensure a custom TimeZoneNameProvider does not cause an NPE
+     * in simpleDateFormat, as SimpleDateFormat::matchZoneString expects the
+     * name array is fully filled with non-null names.
+     */
+    @Test
+    public void simpleDateFormatWithTZNProvider() throws Throwable {
+        LocaleProviders.testRun("JRE,SPI", "bug8013086Test", "ja", "JP");
+        LocaleProviders.testRun("COMPAT,SPI", "bug8013086Test", "ja", "JP");
+    }
+
+    /*
+     * 8013903 (Windows only): Ensure HOST adapter with Japanese locale produces
+     * the correct Japanese era, month, day names.
+     */
+    @Test
+    @EnabledOnOs(WINDOWS)
+    public void windowsJapaneseDateFields() throws Throwable {
+        LocaleProviders.testRun("HOST,JRE", "bug8013903Test");
+        LocaleProviders.testRun("HOST", "bug8013903Test");
+        LocaleProviders.testRun("HOST,COMPAT", "bug8013903Test");
+    }
+
+    /*
+     * 8027289: Ensure if system format locale is zh_CN, the Window's currency
+     * symbol under HOST provider is \u00A5, the yen (yuan) sign.
+     */
+    @Test
+    @EnabledOnOs(WINDOWS)
+    @EnabledIfSystemProperty(named = "user.language", matches = "zh")
+    @EnabledIfSystemProperty(named = "user.country", matches = "CN")
+    public void windowsChineseCurrencySymbol() throws Throwable {
+        LocaleProviders.testRun("JRE,HOST", "bug8027289Test", "FFE5");
+        LocaleProviders.testRun("COMPAT,HOST", "bug8027289Test", "FFE5");
+        LocaleProviders.testRun("HOST", "bug8027289Test", "00A5");
+    }
+
+    /*
+     * 8232860 (macOS/Windows only): Ensure the Host adapter returns the number
+     * pattern for number/integer instances, which require optional fraction digits.
+     */
+    @Test
+    @EnabledOnOs({WINDOWS, MAC})
+    public void hostOptionalFracDigits() throws Throwable {
+        LocaleProviders.testRun("HOST", "bug8232860Test");
+    }
+}

--- a/test/jdk/java/util/Locale/LocaleProvidersFormat.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersFormat.java
@@ -27,6 +27,7 @@
  * @summary Test any java.text.Format Locale provider related issues
  * @library /test/lib
  * @build LocaleProviders
+ *        providersrc.spi.src.tznp
  *        providersrc.spi.src.tznp8013086
  * @modules java.base/sun.util.locale.provider
  * @run junit/othervm LocaleProvidersFormat

--- a/test/jdk/java/util/Locale/LocaleProvidersFormat.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersFormat.java
@@ -31,7 +31,6 @@
  *        providersrc.spi.src.tznp8013086
  * @modules java.base/sun.util.locale.provider
  * @run junit/othervm LocaleProvidersFormat
- * @run junit/othervm -Duser.language=zh -Duser.country=CN LocaleProvidersFormat
  */
 
 import org.junit.jupiter.api.Test;
@@ -86,7 +85,7 @@ public class LocaleProvidersFormat {
     }
 
     /*
-     * 8027289: Ensure if system format locale is zh_CN, the Window's currency
+     * 8027289: Ensure if underlying system format locale is zh_CN, the Window's currency
      * symbol under HOST provider is \u00A5, the yen (yuan) sign.
      */
     @Test

--- a/test/jdk/java/util/Locale/LocaleProvidersLogger.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersLogger.java
@@ -33,7 +33,7 @@
 
 import org.junit.jupiter.api.Test;
 
-public class LocaleProvidersLogger extends LocaleProvidersRun {
+public class LocaleProvidersLogger {
 
     /*
      * 8245241 8246721 8261919: Ensure if an incorrect system property for locale providers is set,

--- a/test/jdk/java/util/Locale/LocaleProvidersLogger.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersLogger.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8245241 8246721 8261919
+ * @summary Test the Locale provider preference is logged
+ * @library /test/lib
+ * @build LocaleProviders
+ * @modules java.base/sun.util.locale.provider
+ * @run junit/othervm -Djdk.lang.Process.allowAmbiguousCommands=false LocaleProvidersLogger
+ */
+
+import org.junit.jupiter.api.Test;
+
+public class LocaleProvidersLogger extends LocaleProvidersRun {
+
+    /*
+     * 8245241 8246721 8261919: Ensure if an incorrect system property for locale providers is set,
+     * it should be logged and presented to the user. The option
+     * jdk.lang.Process.allowAmbiguousCommands=false is needed for properly escaping
+     * double quotes in the string argument.
+     */
+    @Test
+    public void logIncorrectLocaleProvider() throws Throwable {
+        LocaleProviders.testRun("FOO", "bug8245241Test",
+                "Invalid locale provider adapter \"FOO\" ignored.");
+    }
+}

--- a/test/jdk/java/util/Locale/LocaleProvidersLogger.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersLogger.java
@@ -43,7 +43,7 @@ public class LocaleProvidersLogger {
      */
     @Test
     public void logIncorrectLocaleProvider() throws Throwable {
-        LocaleProviders.testRun("FOO", "bug8245241Test",
+        LocaleProviders.test("FOO", "bug8245241Test",
                 "Invalid locale provider adapter \"FOO\" ignored.");
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -39,6 +39,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -161,9 +162,8 @@ public class LocaleProvidersRun {
     // under HOST Windows (non-english locale)
     @Test
     @EnabledOnOs(WINDOWS)
+    @DisabledIfSystemProperty(named = "user.language", matches = "en")
     public void nonEnglishDisplayCountryHost() throws Throwable {
-        if (!defLang.equals("en")) {
-            LocaleProviders.testRun("HOST", "bug8220227Test");
-        }
+        LocaleProviders.testRun("HOST", "bug8220227Test");
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -149,8 +149,10 @@ public class LocaleProvidersRun {
             );
     }
 
-    // 8010666: Test to ensure correct implementation of Currency/LocaleNameProvider
-    // in HOST Windows provider (English locale)
+    /*
+     * 8010666: Test to ensure correct implementation of Currency/LocaleNameProvider
+     * in HOST Windows provider (English locale)
+     */
     @Test
     @EnabledOnOs(WINDOWS)
     @EnabledIfSystemProperty(named = "user.language", matches = "en")
@@ -158,8 +160,10 @@ public class LocaleProvidersRun {
         LocaleProviders.testRun("HOST", "bug8010666Test");
     }
 
-    // 8220227: Ensure Locale::getDisplayCountry does not display error message
-    // under HOST Windows (non-english locale)
+    /*
+     * 8220227: Ensure Locale::getDisplayCountry does not display error message
+     * under HOST Windows (non-english locale)
+     */
     @Test
     @EnabledOnOs(WINDOWS)
     @DisabledIfSystemProperty(named = "user.language", matches = "en")

--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,175 +23,147 @@
 
 /*
  * @test
- * @bug 6336885 7196799 7197573 7198834 8000245 8000615 8001440 8008577
- *      8010666 8013086 8013233 8013903 8015960 8028771 8054482 8062006
- *      8150432 8215913 8220227 8228465 8232871 8232860 8236495 8245241
- *      8246721 8248695 8257964 8261919
- * @summary tests for "java.locale.providers" system property
- * @requires vm.flagless
+ * @bug 6336885 7196799 7197573 8008577 8010666 8013233 8015960 8028771
+ *      8054482 8062006 8150432 8215913 8220227 8236495
+ * @summary General Locale provider test (ex: adapter loading). See the
+ *          other LocaleProviders* test classes for more specific tests (ex:
+ *          java.text.Format related bugs).
  * @library /test/lib
  * @build LocaleProviders
- *        providersrc.spi.src.tznp
- *        providersrc.spi.src.tznp8013086
- * @modules java.base/sun.util.locale
- *          java.base/sun.util.locale.provider
- * @run main/othervm -Djdk.lang.Process.allowAmbiguousCommands=false LocaleProvidersRun
+ * @modules java.base/sun.util.locale.provider
+ * @run junit/othervm LocaleProvidersRun
  */
 
 import java.util.Locale;
+import java.util.stream.Stream;
 
-import jdk.test.lib.process.ProcessTools;
-import jdk.test.lib.Utils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+/*
+ * Note: If this test launches too many JVMs, consider increasing timeout.
+ * As the LocaleProvider is set during java startup time, this test and the subclasses
+ * will always have to launch a separate JVM for testing of different providers.
+ */
 public class LocaleProvidersRun {
-    public static void main(String[] args) throws Throwable {
-        //get the platform default locales
+
+    private static String defLang;
+    private static String defCtry;
+    private static String defFmtLang;
+    private static String defFmtCtry;
+
+    // Get the system default locale values. Used to decide param values for tests.
+    @BeforeAll
+    static void setUp() {
         Locale platDefLoc = Locale.getDefault(Locale.Category.DISPLAY);
-        String defLang = platDefLoc.getLanguage();
-        String defCtry = platDefLoc.getCountry();
-        System.out.println("DEFLANG = " + defLang);
-        System.out.println("DEFCTRY = " + defCtry);
-
         Locale platDefFormat = Locale.getDefault(Locale.Category.FORMAT);
-        String defFmtLang = platDefFormat.getLanguage();
-        String defFmtCtry = platDefFormat.getCountry();
-        System.out.println("DEFFMTLANG = " + defFmtLang);
-        System.out.println("DEFFMTCTRY = " + defFmtCtry);
+        defLang = platDefLoc.getLanguage();
+        defCtry = platDefLoc.getCountry();
+        defFmtLang = platDefFormat.getLanguage();
+        defFmtCtry = platDefFormat.getCountry();
 
-        //Run Test
-        //testing HOST is selected for the default locale,
-        // if specified on Windows or MacOSX
+        // Print out system defaults for diagnostic purposes
+        System.out.printf("DEFLANG = %s, DEFCTRY = %s, DEFFMTLANG = %s, DEFFMTCTRY = %s",
+                defLang, defCtry, defFmtLang, defFmtCtry);
+    }
+
+    /*
+     * Test the adapter loading logic in LocaleProviderAdapter.
+     * Ensures that correct fallbacks are implemented.
+     */
+    @ParameterizedTest
+    @MethodSource
+    public void adapterTest(String prefList, String param1,
+                            String param2, String param3) throws Throwable {
+        LocaleProviders.testRun(prefList, "adapterTest", param1, param2, param3);
+    }
+
+    /*
+     * Data provider which only launches against the LocaleProvider::adapterTest
+     * method. The arguments are dictated based off the operating system/platform
+     * Locale. Tests against variety of provider orders.
+     */
+    private static Stream<Arguments> adapterTest() {
+        // Testing HOST is selected for the default locale if specified on Windows or MacOSX
         String osName = System.getProperty("os.name");
         String param1 = "JRE";
-        if(osName.startsWith("Windows") || osName.startsWith("Mac")) {
+        if (osName.startsWith("Windows") || osName.startsWith("Mac")) {
             param1 = "HOST";
         }
-        testRun("HOST,JRE", "adapterTest", param1, defLang, defCtry);
 
-        //testing HOST is NOT selected for the non-default locale, if specified
-        //Try to find the locale JRE supports which is not the platform default
+        // Testing HOST is NOT selected for the non-default locale, if specified
+        // try to find the locale JRE supports which is not the platform default
         // (HOST supports that one)
         String param2;
         String param3;
-        if (!defLang.equals("en") && !defFmtLang.equals("en")){
+        if (!defLang.equals("en") && !defFmtLang.equals("en")) {
             param2 = "en";
             param3 = "US";
-        } else if(!defLang.equals("ja") && !defFmtLang.equals("ja")){
+        } else if (!defLang.equals("ja") && !defFmtLang.equals("ja")) {
             param2 = "ja";
             param3 = "JP";
         } else {
             param2 = "zh";
             param3 = "CN";
         }
-        testRun("HOST,JRE", "adapterTest", "JRE", param2, param3);
 
-        //testing SPI is NOT selected, as there is none.
-        testRun("SPI,JRE", "adapterTest", "JRE", "en", "US");
-        testRun("SPI,COMPAT", "adapterTest", "JRE", "en", "US");
+        return Stream.of(
+                Arguments.of("HOST,JRE", param1, defLang, defCtry),
+                Arguments.of("HOST,JRE", "JRE", param2, param3),
 
-        //testing the order, variant #1. This assumes en_GB DateFormat data are
-        // available both in JRE & CLDR
-        testRun("CLDR,JRE", "adapterTest", "CLDR", "en", "GB");
-        testRun("CLDR,COMPAT", "adapterTest", "CLDR", "en", "GB");
+                // Testing SPI is NOT selected, as there is none.
+                Arguments.of("SPI,JRE", "JRE", "en", "US"),
+                Arguments.of("SPI,COMPAT", "JRE", "en", "US"),
 
-        //testing the order, variant #2. This assumes en_GB DateFormat data are
-        // available both in JRE & CLDR
-        testRun("JRE,CLDR", "adapterTest", "JRE", "en", "GB");
-        testRun("COMPAT,CLDR", "adapterTest", "JRE", "en", "GB");
+                // Testing the order, variant #1. This assumes en_GB DateFormat data are
+                // available both in JRE & CLDR
+                Arguments.of("CLDR,JRE", "CLDR", "en", "GB"),
+                Arguments.of("CLDR,COMPAT", "CLDR", "en", "GB"),
 
-        //testing the order, variant #3 for non-existent locale in JRE
-        // assuming "haw" is not in JRE.
-        testRun("JRE,CLDR", "adapterTest", "CLDR", "haw", "");
-        testRun("COMPAT,CLDR", "adapterTest", "CLDR", "haw", "");
+                // Testing the order, variant #2. This assumes en_GB DateFormat data are
+                // available both in JRE & CLDR
+                Arguments.of("JRE,CLDR", "JRE", "en", "GB"),
+                Arguments.of("COMPAT,CLDR", "JRE", "en", "GB"),
 
-        //testing the order, variant #4 for the bug 7196799. CLDR's "zh" data
-        // should be used in "zh_CN"
-        testRun("CLDR", "adapterTest", "CLDR", "zh", "CN");
+                // Testing the order, variant #3 for non-existent locale in JRE
+                // assuming "haw" is not in JRE.
+                Arguments.of("JRE,CLDR", "CLDR", "haw", ""),
+                Arguments.of("COMPAT,CLDR", "CLDR", "haw", ""),
 
-        //testing FALLBACK provider. SPI and invalid one cases.
-        testRun("SPI", "adapterTest", "FALLBACK", "en", "US");
-        testRun("FOO", "adapterTest", "CLDR", "en", "US");
-        testRun("BAR,SPI", "adapterTest", "FALLBACK", "en", "US");
+                // Testing the order, variant #4 for the bug 7196799. CLDR's "zh" data
+                // should be used in "zh_CN"
+                Arguments.of("CLDR", "CLDR", "zh", "CN"),
 
-        //testing 7198834 fix.
-        testRun("HOST", "bug7198834Test", "", "", "");
-
-        //testing 8000245 fix.
-        testRun("JRE", "tzNameTest", "Europe/Moscow", "", "");
-        testRun("COMPAT", "tzNameTest", "Europe/Moscow", "", "");
-
-        //testing 8000615 fix.
-        testRun("JRE", "tzNameTest", "America/Los_Angeles", "", "");
-        testRun("COMPAT", "tzNameTest", "America/Los_Angeles", "", "");
-
-        //testing 8001440 fix.
-        testRun("CLDR", "bug8001440Test", "", "", "");
-
-        //testing 8010666 fix.
-        if (defLang.equals("en")) {
-            testRun("HOST", "bug8010666Test", "", "", "");
-        }
-
-        //testing 8013086 fix.
-        testRun("JRE,SPI", "bug8013086Test", "ja", "JP", "");
-        testRun("COMPAT,SPI", "bug8013086Test", "ja", "JP", "");
-
-        //testing 8013903 fix. (Windows only)
-        testRun("HOST,JRE", "bug8013903Test", "", "", "");
-        testRun("HOST", "bug8013903Test", "", "", "");
-        testRun("HOST,COMPAT", "bug8013903Test", "", "", "");
-
-        //testing 8027289 fix, if the platform format default is zh_CN
-        // this assumes Windows' currency symbol for zh_CN is \u00A5, the yen
-        // (yuan) sign.
-        if (defFmtLang.equals("zh") && defFmtCtry.equals("CN")) {
-            testRun("JRE,HOST", "bug8027289Test", "FFE5", "", "");
-            testRun("COMPAT,HOST", "bug8027289Test", "FFE5", "", "");
-            testRun("HOST", "bug8027289Test", "00A5", "", "");
-        }
-
-        //testing 8220227 fix. (Windows only)
-        if (!defLang.equals("en")) {
-            testRun("HOST", "bug8220227Test", "", "", "");
-        }
-
-        //testing 8228465 fix. (Windows only)
-        testRun("HOST", "bug8228465Test", "", "", "");
-
-        //testing 8232871 fix. (macOS only)
-        testRun("HOST", "bug8232871Test", "", "", "");
-
-        //testing 8232860 fix. (macOS/Windows only)
-        testRun("HOST", "bug8232860Test", "", "", "");
-
-        //testing 8245241 fix.
-        //jdk.lang.Process.allowAmbiguousCommands=false is needed for properly escaping
-        //double quotes in the string argument.
-        testRun("FOO", "bug8245241Test",
-            "Invalid locale provider adapter \"FOO\" ignored.", "", "");
-
-        //testing 8248695 fix.
-        testRun("HOST", "bug8248695Test", "", "", "");
-
-        //testing 8257964 fix. (macOS/Windows only)
-        testRun("HOST", "bug8257964Test", "", "", "");
+                // Testing FALLBACK provider. SPI and invalid one cases.
+                Arguments.of("SPI", "FALLBACK", "en", "US"),
+                Arguments.of("FOO", "CLDR", "en", "US"),
+                Arguments.of("BAR,SPI", "FALLBACK", "en", "US")
+            );
     }
 
-    private static void testRun(String prefList, String methodName,
-            String param1, String param2, String param3) throws Throwable {
+    // 8010666: Test to ensure correct implementation of Currency/LocaleNameProvider
+    // in HOST Windows provider (English locale)
+    @Test
+    @EnabledOnOs(WINDOWS)
+    @EnabledIfSystemProperty(named = "user.language", matches = "en")
+    public void currencyNameProviderWindowsHost() throws Throwable {
+        LocaleProviders.testRun("HOST", "bug8010666Test");
+    }
 
-        // Build process (without VM flags)
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-                "-ea", "-esa",
-                "-cp", Utils.TEST_CLASS_PATH,
-                "-Djava.util.logging.config.class=LocaleProviders$LogConfig",
-                "-Djava.locale.providers=" + prefList,
-                "--add-exports=java.base/sun.util.locale.provider=ALL-UNNAMED",
-                "LocaleProviders", methodName, param1, param2, param3);
-        // Evaluate process status
-        int exitCode = ProcessTools.executeCommand(pb).getExitValue();
-        if (exitCode != 0) {
-            throw new RuntimeException("Unexpected exit code: " + exitCode);
+    // 8220227: Ensure Locale::getDisplayCountry does not display error message
+    // under HOST Windows (non-english locale)
+    @Test
+    @EnabledOnOs(WINDOWS)
+    public void nonEnglishDisplayCountryHost() throws Throwable {
+        if (!defLang.equals("en")) {
+            LocaleProviders.testRun("HOST", "bug8220227Test");
         }
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProvidersRun.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersRun.java
@@ -83,7 +83,7 @@ public class LocaleProvidersRun {
     @MethodSource
     public void adapterTest(String prefList, String param1,
                             String param2, String param3) throws Throwable {
-        LocaleProviders.testRun(prefList, "adapterTest", param1, param2, param3);
+        LocaleProviders.test(prefList, "adapterTest", param1, param2, param3);
     }
 
     /*
@@ -157,7 +157,7 @@ public class LocaleProvidersRun {
     @EnabledOnOs(WINDOWS)
     @EnabledIfSystemProperty(named = "user.language", matches = "en")
     public void currencyNameProviderWindowsHost() throws Throwable {
-        LocaleProviders.testRun("HOST", "bug8010666Test");
+        LocaleProviders.test("HOST", "bug8010666Test");
     }
 
     /*
@@ -168,6 +168,6 @@ public class LocaleProvidersRun {
     @EnabledOnOs(WINDOWS)
     @DisabledIfSystemProperty(named = "user.language", matches = "en")
     public void nonEnglishDisplayCountryHost() throws Throwable {
-        LocaleProviders.testRun("HOST", "bug8220227Test");
+        LocaleProviders.test("HOST", "bug8220227Test");
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProvidersTimeZone.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersTimeZone.java
@@ -28,6 +28,7 @@
  * @library /test/lib
  * @build LocaleProviders
  *        providersrc.spi.src.tznp
+ *        providersrc.spi.src.tznp8013086
  * @modules java.base/sun.util.locale.provider
  * @run junit/othervm LocaleProvidersTimeZone
  */

--- a/test/jdk/java/util/Locale/LocaleProvidersTimeZone.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersTimeZone.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8000245 8000615
+ * @summary Test any TimeZone Locale provider related issues
+ * @library /test/lib
+ * @build LocaleProviders
+ *        providersrc.spi.src.tznp
+ * @modules java.base/sun.util.locale.provider
+ * @run junit/othervm LocaleProvidersTimeZone
+ */
+
+import org.junit.jupiter.api.Test;
+
+public class LocaleProvidersTimeZone {
+
+    // 8000245 and 8000615: Ensure preference is followed, even with a custom
+    // SPI defined.
+    @Test
+    public void timeZoneWithCustomProvider() throws Throwable {
+        LocaleProviders.testRun("JRE", "tzNameTest", "Europe/Moscow");
+        LocaleProviders.testRun("COMPAT", "tzNameTest", "Europe/Moscow");
+        LocaleProviders.testRun("JRE", "tzNameTest", "America/Los_Angeles");
+        LocaleProviders.testRun("COMPAT", "tzNameTest", "America/Los_Angeles");
+    }
+}

--- a/test/jdk/java/util/Locale/LocaleProvidersTimeZone.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersTimeZone.java
@@ -43,9 +43,9 @@ public class LocaleProvidersTimeZone {
      */
     @Test
     public void timeZoneWithCustomProvider() throws Throwable {
-        LocaleProviders.testRun("JRE", "tzNameTest", "Europe/Moscow");
-        LocaleProviders.testRun("COMPAT", "tzNameTest", "Europe/Moscow");
-        LocaleProviders.testRun("JRE", "tzNameTest", "America/Los_Angeles");
-        LocaleProviders.testRun("COMPAT", "tzNameTest", "America/Los_Angeles");
+        LocaleProviders.test("JRE", "tzNameTest", "Europe/Moscow");
+        LocaleProviders.test("COMPAT", "tzNameTest", "Europe/Moscow");
+        LocaleProviders.test("JRE", "tzNameTest", "America/Los_Angeles");
+        LocaleProviders.test("COMPAT", "tzNameTest", "America/Los_Angeles");
     }
 }

--- a/test/jdk/java/util/Locale/LocaleProvidersTimeZone.java
+++ b/test/jdk/java/util/Locale/LocaleProvidersTimeZone.java
@@ -37,8 +37,10 @@ import org.junit.jupiter.api.Test;
 
 public class LocaleProvidersTimeZone {
 
-    // 8000245 and 8000615: Ensure preference is followed, even with a custom
-    // SPI defined.
+    /*
+     * 8000245 and 8000615: Ensure preference is followed, even with a custom
+     * SPI defined.
+     */
     @Test
     public void timeZoneWithCustomProvider() throws Throwable {
         LocaleProviders.testRun("JRE", "tzNameTest", "Europe/Moscow");


### PR DESCRIPTION
Please review this PR which splits up the _LocaleProvidersRun_ test file for performance and maintenance reasons.

_LocaleProvidersRun_ which tests against the various Locale Providers (CLDR, HOST, SPI, etc.) was getting rather long, as all related bugs were added to the single test file. To improve maintainability, this change splits up the single test file into separate test files focused on specific areas (ex: _j.text.Format_).  The original _LocaleProvidersRun_ test file remains and is used for more general Locale Provider testing such as the adapter loading.

In addition, the previously single test file used to suffer from performance issues, as each test method had to launch a new JVM (since Locale Providers are set at Java startup time). With this change, these tests files can be ran with VM flags and not cause timeout, thus `@requires vm.flagless` is no longer needed (Tiers 6-8 tested).

Other updates
- For OS/locale specific tests, the OS/locale is now checked before (not after) launching a JVM
- Added comments for each test method

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322235](https://bugs.openjdk.org/browse/JDK-8322235): Split up and improve LocaleProvidersRun (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [c754893f](https://git.openjdk.org/jdk/pull/17257/files/c754893fa40bb76bbce0b254f04338ad714ddd43)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17257/head:pull/17257` \
`$ git checkout pull/17257`

Update a local copy of the PR: \
`$ git checkout pull/17257` \
`$ git pull https://git.openjdk.org/jdk.git pull/17257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17257`

View PR using the GUI difftool: \
`$ git pr show -t 17257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17257.diff">https://git.openjdk.org/jdk/pull/17257.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17257#issuecomment-1876114090)