### PR TITLE
8322981

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ProcessAttachingConnector.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ProcessAttachingConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,7 +103,7 @@ public class ProcessAttachingConnector
             Properties props = vm.getAgentProperties();
             address = props.getProperty("sun.jdwp.listenerAddress");
         } catch (Exception x) {
-            throw new IOException(x.getMessage());
+            throw new IOException(x);
         } finally {
             if (vm != null) vm.detach();
         }

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineManagerImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -226,7 +226,7 @@ public class VirtualMachineManagerImpl implements VirtualMachineManagerService {
             vm = new VirtualMachineImpl(this, connection, process,
                                                    ++vmSequenceNumber);
         } catch (VMDisconnectedException e) {
-            throw new IOException(e.getMessage());
+            throw new IOException(e);
         }
         targets.add(vm);
         return vm;


### PR DESCRIPTION
Use "cause" argument when rethrowing an exception. See CR for details on how this helps.

Tested with all of tier1, and also ran tier2 and tier4 svc tests.

I'd like to push this as a trivial change.