### PR TITLE
8322980: Debug agent's dumpThread() API should update thread's name before printing it

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2662,10 +2662,10 @@ dumpThread(ThreadNode *node) {
     setThreadName(node);
     tty_message("\tname: %s", node->name);
 #endif
+    tty_message("\tsuspendCount: %d", node->suspendCount);
 #if 0
     // More fields can be printed here when needed. The amount of output is intentionally
     // kept small so it doesn't generate too much output.
-    tty_message("\tsuspendCount: %d", node->suspendCount);
     tty_message("\tsuspendAllCount: %d", suspendAllCount);
     tty_message("\tthreadState: 0x%x", getThreadState(node));
     tty_message("\ttoBeResumed: %d", node->toBeResumed);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2623,15 +2623,58 @@ dumpThreadList(ThreadList *list)
     }
 }
 
+#ifdef DEBUG_THREADNAME
+static void
+setThreadName(ThreadNode *node)
+{
+  /*
+   * Sometimes the debuggee changes the thread name, so we need to fetch
+   * and set it again.
+   */
+  jvmtiThreadInfo info;
+  jvmtiError error;
+
+  memset(&info, 0, sizeof(info));
+  error = JVMTI_FUNC_PTR(gdata->jvmti,GetThreadInfo)
+    (gdata->jvmti, node->thread, &info);
+  if (info.name != NULL) {
+    strncpy(node->name, info.name, sizeof(node->name) - 1);
+    jvmtiDeallocate(info.name);
+  }
+}
+#endif
+
+#if 0
+static jint
+getThreadState(ThreadNode *node)
+{
+  jint state = 0;
+  jvmtiError error = FUNC_PTR(gdata->jvmti,GetThreadState)
+    (gdata->jvmti, node->thread, &state);
+  return state;
+}
+#endif
+
 static void
 dumpThread(ThreadNode *node) {
-    tty_message("  Thread: node = %p, jthread = %p", node, node->thread);
+    tty_message("Thread: node = %p, jthread = %p", node, node->thread);
 #ifdef DEBUG_THREADNAME
+    setThreadName(node);
     tty_message("\tname: %s", node->name);
 #endif
+#if 0
     // More fields can be printed here when needed. The amount of output is intentionally
     // kept small so it doesn't generate too much output.
     tty_message("\tsuspendCount: %d", node->suspendCount);
+    tty_message("\tsuspendAllCount: %d", suspendAllCount);
+    tty_message("\tthreadState: 0x%x", getThreadState(node));
+    tty_message("\ttoBeResumed: %d", node->toBeResumed);
+    tty_message("\tis_vthread: %d", node->is_vthread);
+    tty_message("\tcurrentInvoke.pending: %d", node->currentInvoke.pending);
+    tty_message("\tcurrentInvoke.started: %d", node->currentInvoke.started);
+    tty_message("\tcurrentInvoke.available: %d", node->currentInvoke.available);
+    tty_message("\tobjID: %d", commonRef_refToID(getEnv(), node->thread));
+#endif
 }
 
 #endif /* DEBUG */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2662,10 +2662,10 @@ dumpThread(ThreadNode *node) {
     setThreadName(node);
     tty_message("\tname: %s", node->name);
 #endif
-    tty_message("\tsuspendCount: %d", node->suspendCount);
-#if 0
     // More fields can be printed here when needed. The amount of output is intentionally
     // kept small so it doesn't generate too much output.
+    tty_message("\tsuspendCount: %d", node->suspendCount);
+#if 0
     tty_message("\tsuspendAllCount: %d", suspendAllCount);
     tty_message("\tthreadState: 0x%x", getThreadState(node));
     tty_message("\ttoBeResumed: %d", node->toBeResumed);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -2627,20 +2627,20 @@ dumpThreadList(ThreadList *list)
 static void
 setThreadName(ThreadNode *node)
 {
-  /*
-   * Sometimes the debuggee changes the thread name, so we need to fetch
-   * and set it again.
-   */
-  jvmtiThreadInfo info;
-  jvmtiError error;
+    /*
+     * Sometimes the debuggee changes the thread name, so we need to fetch
+     * and set it again.
+     */
+    jvmtiThreadInfo info;
+    jvmtiError error;
 
-  memset(&info, 0, sizeof(info));
-  error = JVMTI_FUNC_PTR(gdata->jvmti,GetThreadInfo)
-    (gdata->jvmti, node->thread, &info);
-  if (info.name != NULL) {
-    strncpy(node->name, info.name, sizeof(node->name) - 1);
-    jvmtiDeallocate(info.name);
-  }
+    memset(&info, 0, sizeof(info));
+    error = JVMTI_FUNC_PTR(gdata->jvmti,GetThreadInfo)
+        (gdata->jvmti, node->thread, &info);
+    if (info.name != NULL) {
+        strncpy(node->name, info.name, sizeof(node->name) - 1);
+        jvmtiDeallocate(info.name);
+    }
 }
 #endif
 
@@ -2648,10 +2648,10 @@ setThreadName(ThreadNode *node)
 static jint
 getThreadState(ThreadNode *node)
 {
-  jint state = 0;
-  jvmtiError error = FUNC_PTR(gdata->jvmti,GetThreadState)
-    (gdata->jvmti, node->thread, &state);
-  return state;
+    jint state = 0;
+    jvmtiError error = FUNC_PTR(gdata->jvmti,GetThreadState)
+        (gdata->jvmti, node->thread, &state);
+    return state;
 }
 #endif
 


### PR DESCRIPTION
In threadControl.c, at build time you can decide to keep track of thread names by compiling with "#define DEBUG_THREADNAME". If this is also a debug build, some extra debugging functions are included in the build, including "dumpThread(ThreadNode *node)". These are intended to be called from gdb, or possibly from somewhere in the debug agent implementation, to aid with debugging. When dumpThread() prints the thread's name, it just uses the name that was stored when the thread was created. However, the thread name can change, so dumpThread() should really fetch the current thread name and print it. 

I also added some commented out code to print other useful fields of the ThreadNode, including the ThreadState. These can be enabled by the user as needed.

Tested with all of tier1, and also ran tier2 and tier4 svc tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322980](https://bugs.openjdk.org/browse/JDK-8322980): Debug agent's dumpThread() API should update thread's name before printing it (**Enhancement** - P5)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [eb318d81](https://git.openjdk.org/jdk/pull/17259/files/eb318d81ff9102808651aa12cb3551dd6c98782a)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17259/head:pull/17259` \
`$ git checkout pull/17259`

Update a local copy of the PR: \
`$ git checkout pull/17259` \
`$ git pull https://git.openjdk.org/jdk.git pull/17259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17259`

View PR using the GUI difftool: \
`$ git pr show -t 17259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17259.diff">https://git.openjdk.org/jdk/pull/17259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17259#issuecomment-1876216236)