### PR TITLE
8322768: Optimize non-subword vector compress and expand APIs for AVX2 target.

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -816,8 +816,8 @@ private:
   void check_relocation(RelocationHolder const& rspec, int format);
 #endif
 
-  void emit_data(jint data, relocInfo::relocType    rtype, int format);
-  void emit_data(jint data, RelocationHolder const& rspec, int format);
+  void emit_data(jint data, relocInfo::relocType    rtype, int format = 0);
+  void emit_data(jint data, RelocationHolder const& rspec, int format = 0);
   void emit_data64(jlong data, relocInfo::relocType rtype, int format = 0);
   void emit_data64(jlong data, RelocationHolder const& rspec, int format = 0);
 

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -390,6 +390,9 @@ public:
 
   void vector_round_float_avx(XMMRegister dst, XMMRegister src, AddressLiteral float_sign_flip, AddressLiteral new_mxcsr, int vec_enc,
                               Register tmp, XMMRegister xtmp1, XMMRegister xtmp2, XMMRegister xtmp3, XMMRegister xtmp4);
+
+  void vector_compress_expand_avx2(int opcode, XMMRegister dst, XMMRegister src, XMMRegister mask, Register rtmp,
+                                   Register rscratch, XMMRegister permv, XMMRegister xtmp, BasicType bt, int vec_enc);
 #endif // _LP64
 
   void udivI(Register rax, Register divisor, Register rdx);
@@ -481,6 +484,7 @@ public:
 
   void vector_signum_evex(int opcode, XMMRegister dst, XMMRegister src, XMMRegister zero, XMMRegister one,
                           KRegister ktmp1, int vec_enc);
+
 
   void vmovmask(BasicType elem_bt, XMMRegister dst, Address src, XMMRegister mask, int vec_enc);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
@@ -99,6 +99,10 @@ class StubGenerator: public StubCodeGenerator {
 
   address generate_fp_mask(const char *stub_name, int64_t mask);
 
+  address generate_compress_perm_table(const char *stub_name, int32_t esize);
+
+  address generate_expand_perm_table(const char *stub_name, int32_t esize);
+
   address generate_vector_mask(const char *stub_name, int64_t mask);
 
   address generate_vector_byte_perm_mask(const char *stub_name);

--- a/src/hotspot/cpu/x86/stubRoutines_x86.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.cpp
@@ -82,6 +82,10 @@ address StubRoutines::x86::_join_0_1_base64 = nullptr;
 address StubRoutines::x86::_join_1_2_base64 = nullptr;
 address StubRoutines::x86::_join_2_3_base64 = nullptr;
 address StubRoutines::x86::_decoding_table_base64 = nullptr;
+address StubRoutines::x86::_compress_perm_table32 = nullptr;
+address StubRoutines::x86::_compress_perm_table64 = nullptr;
+address StubRoutines::x86::_expand_perm_table32 = nullptr;
+address StubRoutines::x86::_expand_perm_table64 = nullptr;
 #endif
 address StubRoutines::x86::_pshuffle_byte_flip_mask_addr = nullptr;
 

--- a/src/hotspot/cpu/x86/stubRoutines_x86.hpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86.hpp
@@ -37,7 +37,7 @@ enum platform_dependent_constants {
   _continuation_stubs_code_size =  1000 LP64_ONLY(+1000),
   // AVX512 intrinsics add more code in 64-bit VM,
   // Windows have more code to save/restore registers
-  _compiler_stubs_code_size     = 20000 LP64_ONLY(+32000) WINDOWS_ONLY(+2000),
+  _compiler_stubs_code_size     = 20000 LP64_ONLY(+39000) WINDOWS_ONLY(+2000),
   _final_stubs_code_size        = 10000 LP64_ONLY(+20000) WINDOWS_ONLY(+2000) ZGC_ONLY(+20000)
 };
 
@@ -58,6 +58,10 @@ class x86 {
   static address _float_sign_flip;
   static address _double_sign_mask;
   static address _double_sign_flip;
+  static address _compress_perm_table32;
+  static address _compress_perm_table64;
+  static address _expand_perm_table32;
+  static address _expand_perm_table64;
 
  public:
 
@@ -338,6 +342,10 @@ class x86 {
   static address base64_decoding_table_addr() { return _decoding_table_base64; }
   static address base64_AVX2_decode_tables_addr() { return _avx2_decode_tables_base64; }
   static address base64_AVX2_decode_LUT_tables_addr() { return _avx2_decode_lut_tables_base64; }
+  static address compress_perm_table32() { return _compress_perm_table32; }
+  static address compress_perm_table64() { return _compress_perm_table64; }
+  static address expand_perm_table32() { return _expand_perm_table32; }
+  static address expand_perm_table64() { return _expand_perm_table64; }
 #endif
   static address pshuffle_byte_flip_mask_addr() { return _pshuffle_byte_flip_mask_addr; }
   static address arrays_hashcode_powers_of_31() { return (address)_arrays_hashcode_powers_of_31; }

--- a/src/hotspot/cpu/x86/stubRoutines_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubRoutines_x86_64.cpp
@@ -44,4 +44,3 @@ address StubRoutines::x86::_float_sign_mask = nullptr;
 address StubRoutines::x86::_float_sign_flip = nullptr;
 address StubRoutines::x86::_double_sign_mask = nullptr;
 address StubRoutines::x86::_double_sign_flip = nullptr;
-

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1425,6 +1425,8 @@ bool Matcher::match_rule_supported(int opcode) {
         return false;
       }
       break;
+    case Op_CompressV:
+    case Op_ExpandV:
     case Op_PopCountVL:
       if (UseAVX < 2) {
         return false;
@@ -1656,12 +1658,6 @@ bool Matcher::match_rule_supported(int opcode) {
       break;
     case Op_CompressM:
       if (!VM_Version::supports_avx512vl() || !VM_Version::supports_bmi2()) {
-        return false;
-      }
-      break;
-    case Op_CompressV:
-    case Op_ExpandV:
-      if (!VM_Version::supports_avx512vl()) {
         return false;
       }
       break;
@@ -1952,13 +1948,12 @@ bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
       if (is_subword_type(bt) && !VM_Version::supports_avx512_vbmi2()) {
         return false;
       }
+      if (!is_LP64 && !VM_Version::supports_avx512vl() && size_in_bits < 512) {
+        return false;
+      }
       if (size_in_bits < 128 ) {
         return false;
       }
-      if (size_in_bits < 512 && !VM_Version::supports_avx512vl()) {
-        return false;
-      }
-      break;
     case Op_VectorLongToMask:
       if (UseAVX < 1 || !is_LP64) {
         return false;
@@ -9163,8 +9158,26 @@ instruct vmask_first_or_last_true_avx(rRegI dst, vec mask, immI size, rRegL tmp,
 %}
 
 // --------------------------------- Compress/Expand Operations ---------------------------
+#ifdef _LP64
+instruct vcompress_reg_avx(vec dst, vec src, vec mask, rRegI rtmp, rRegL rscratch, vec perm, vec xtmp, rFlagsReg cr) %{
+  predicate(!VM_Version::supports_avx512vl() && Matcher::vector_length_in_bytes(n) <= 32);
+  match(Set dst (CompressV src mask));
+  match(Set dst (ExpandV src mask));
+  effect(TEMP_DEF dst, TEMP perm, TEMP xtmp, TEMP rtmp, TEMP rscratch, KILL cr);
+  format %{ "vector_compress $dst, $src, $mask \t!using $xtmp, $rtmp, $rscratch and $perm as TEMP" %}
+  ins_encode %{
+    int opcode = this->ideal_Opcode();
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt  = Matcher::vector_element_basic_type(this);
+    __ vector_compress_expand_avx2(opcode, $dst$$XMMRegister, $src$$XMMRegister, $mask$$XMMRegister, $rtmp$$Register,
+                                   $rscratch$$Register, $perm$$XMMRegister, $xtmp$$XMMRegister, bt, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+#endif
 
 instruct vcompress_expand_reg_evex(vec dst, vec src, kReg mask) %{
+  predicate(VM_Version::supports_avx512vl() || Matcher::vector_length_in_bytes(n) == 64);
   match(Set dst (CompressV src mask));
   match(Set dst (ExpandV src mask));
   format %{ "vector_compress_expand $dst, $src, $mask" %}

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/ColumnFilterBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/ColumnFilterBenchmark.java
@@ -1,0 +1,157 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+package org.openjdk.bench.jdk.incubator.vector;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+import jdk.incubator.vector.*;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector", "-XX:UseAVX=2"})
+public class ColumnFilterBenchmark {
+    @Param({"1024","2047", "4096"})
+    int size;
+
+    float [] floatinCol;
+    float [] floatoutCol;
+    float fpivot;
+
+    double [] doubleinCol;
+    double [] doubleoutCol;
+    double dpivot;
+
+    int [] intinCol;
+    int [] intoutCol;
+    int ipivot;
+
+    long [] longinCol;
+    long [] longoutCol;
+    long lpivot;
+
+    static final VectorSpecies<Float> fspecies = FloatVector.SPECIES_256;
+    static final VectorSpecies<Double> dspecies = DoubleVector.SPECIES_256;
+    static final VectorSpecies<Integer> ispecies = IntVector.SPECIES_256;
+    static final VectorSpecies<Long> lspecies = LongVector.SPECIES_256;
+
+    @Setup(Level.Trial)
+    public void BmSetup() {
+        Random r = new Random(2048);
+
+        floatinCol = new float[size];
+        floatoutCol = new float[size];
+        fpivot = (float) (size / 2);
+        doubleinCol = new double[size];
+        doubleoutCol = new double[size];
+        dpivot = (double) (size / 2);
+        intinCol = new int[size];
+        intoutCol = new int[size];
+        ipivot = size / 2;
+        longinCol = new long[size];
+        longoutCol = new long[size];
+        lpivot = size / 2;
+
+        for (int i = 4; i < size; i++) {
+            floatinCol[i] = r.nextFloat() * size;
+            doubleinCol[i] = r.nextDouble() * size;
+            intinCol[i] = r.nextInt(size);
+            longinCol[i] = (long)intinCol[i];
+        }
+    }
+
+    @Benchmark
+    public void filterIntColumn() {
+       int i = 0;
+       int j = 0;
+       int endIndex = ispecies.loopBound(size);
+       for (; i < endIndex; i += ispecies.length()) {
+           IntVector vec = IntVector.fromArray(ispecies, intinCol, i);
+           VectorMask<Integer> pred = vec.compare(VectorOperators.GT, ipivot);
+           vec.compress(pred).intoArray(intoutCol, j);
+           j += pred.trueCount();
+       }
+       for (; i < endIndex; i++) {
+           if (intinCol[i] > ipivot) {
+               intoutCol[j++] = intinCol[i];
+           }
+       }
+   }
+
+   @Benchmark
+   public void filterLongColumn() {
+       int i = 0;
+       int j = 0;
+       int endIndex = lspecies.loopBound(size);
+       for (; i < endIndex; i += lspecies.length()) {
+           LongVector vec = LongVector.fromArray(lspecies, longinCol, i);
+           VectorMask<Long> pred = vec.compare(VectorOperators.GT, lpivot);
+           vec.compress(pred).intoArray(longoutCol, j);
+           j += pred.trueCount();
+       }
+       for (; i < endIndex; i++) {
+           if (longinCol[i] > lpivot) {
+               longoutCol[j++] = longinCol[i];
+           }
+       }
+   }
+
+   @Benchmark
+   public void filterFloatColumn() {
+       int i = 0;
+       int j = 0;
+       int endIndex = fspecies.loopBound(size);
+       for (; i < endIndex; i += fspecies.length()) {
+           FloatVector vec = FloatVector.fromArray(fspecies, floatinCol, i);
+           VectorMask<Float> pred = vec.compare(VectorOperators.GT, fpivot);
+           vec.compress(pred).intoArray(floatoutCol, j);
+           j += pred.trueCount();
+       }
+       for (; i < endIndex; i++) {
+           if (floatinCol[i] > fpivot) {
+               floatoutCol[j++] = floatinCol[i];
+           }
+       }
+   }
+
+   @Benchmark
+   public void filterDoubleColumn() {
+       int i = 0;
+       int j = 0;
+       int endIndex = dspecies.loopBound(size);
+       for (; i < endIndex; i += dspecies.length()) {
+           DoubleVector vec = DoubleVector.fromArray(dspecies, doubleinCol, i);
+           VectorMask<Double> pred = vec.compare(VectorOperators.GT, dpivot);
+           vec.compress(pred).intoArray(doubleoutCol, j);
+           j += pred.trueCount();
+       }
+       for (; i < endIndex; i++) {
+           if (doubleinCol[i] > dpivot) {
+               doubleoutCol[j++] = doubleinCol[i];
+           }
+       }
+   }
+}


### PR DESCRIPTION
Hi,

Patch optimizes non-subword vector compress and expand APIs for x86 AVX2 only targets.
Upcoming E-core Xeons (Sierra Forest) and Hybrid CPUs only support AVX2 instruction set.
These are very frequently used operation in columnar database filter operation.

Implementation uses a lookup table to record permute indices. Table index is computed using
mask argument of compress/expand operation.

Following are the performance number of JMH micro included with the patch.

```
System : Intel(R) Xeon(R) Platinum 8480+ (Sapphire Rapids)

Baseline:
Benchmark                                 (size)   Mode  Cnt    Score   Error   Units
ColumnFilterBenchmark.filterDoubleColumn    1024  thrpt    2  142.767          ops/ms
ColumnFilterBenchmark.filterDoubleColumn    2047  thrpt    2   71.436          ops/ms
ColumnFilterBenchmark.filterDoubleColumn    4096  thrpt    2   35.992          ops/ms
ColumnFilterBenchmark.filterFloatColumn     1024  thrpt    2  182.151          ops/ms
ColumnFilterBenchmark.filterFloatColumn     2047  thrpt    2   91.096          ops/ms
ColumnFilterBenchmark.filterFloatColumn     4096  thrpt    2   44.757          ops/ms
ColumnFilterBenchmark.filterIntColumn       1024  thrpt    2  184.099          ops/ms
ColumnFilterBenchmark.filterIntColumn       2047  thrpt    2   91.981          ops/ms
ColumnFilterBenchmark.filterIntColumn       4096  thrpt    2   45.170          ops/ms
ColumnFilterBenchmark.filterLongColumn      1024  thrpt    2  148.017          ops/ms
ColumnFilterBenchmark.filterLongColumn      2047  thrpt    2   73.516          ops/ms
ColumnFilterBenchmark.filterLongColumn      4096  thrpt    2   36.844          ops/ms

Withopt:
Benchmark                                 (size)   Mode  Cnt     Score   Error   Units
ColumnFilterBenchmark.filterDoubleColumn    1024  thrpt    2  2051.707          ops/ms
ColumnFilterBenchmark.filterDoubleColumn    2047  thrpt    2   914.072          ops/ms
ColumnFilterBenchmark.filterDoubleColumn    4096  thrpt    2   489.898          ops/ms
ColumnFilterBenchmark.filterFloatColumn     1024  thrpt    2  5324.195          ops/ms
ColumnFilterBenchmark.filterFloatColumn     2047  thrpt    2  2587.229          ops/ms
ColumnFilterBenchmark.filterFloatColumn     4096  thrpt    2  1278.665          ops/ms
ColumnFilterBenchmark.filterIntColumn       1024  thrpt    2  4149.384          ops/ms
ColumnFilterBenchmark.filterIntColumn       2047  thrpt    2  1791.170          ops/ms
ColumnFilterBenchmark.filterIntColumn       4096  thrpt    2   974.888          ops/ms
ColumnFilterBenchmark.filterLongColumn      1024  thrpt    2  1128.281          ops/ms
ColumnFilterBenchmark.filterLongColumn      2047  thrpt    2   686.334          ops/ms
ColumnFilterBenchmark.filterLongColumn      4096  thrpt    2   337.170          ops/ms
```

Kindly review and share your feedback.

Best Regards,
Jatin