### PR TITLE
8322989: New test serviceability/HeapDump/FullGCHeapDumpLimitTest.java fails

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -141,8 +141,6 @@ serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java 8315980 linux-all,windows-x64
 
-serviceability/HeapDump/FullGCHeapDumpLimitTest.java 8322989 generic-all
-
 #############################################################################
 
 # :hotspot_misc

--- a/test/hotspot/jtreg/serviceability/HeapDump/FullGCHeapDumpLimitTest.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/FullGCHeapDumpLimitTest.java
@@ -23,7 +23,8 @@
 
 /**
  * @test
- * @requires vm.flagless
+ * @requires vm.gc.Serial
+ * @requires vm.opt.DisableExplicitGC != "true"
  * @summary Test of option -XX:FullGCHeapDumpLimit
  * @library /test/lib
  * @run main/othervm -XX:+UseSerialGC -XX:+HeapDumpBeforeFullGC -XX:+HeapDumpAfterFullGC -XX:HeapDumpPath=test.hprof -XX:FullGCHeapDumpLimit=1 FullGCHeapDumpLimitTest

--- a/test/hotspot/jtreg/serviceability/HeapDump/FullGCHeapDumpLimitTest.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/FullGCHeapDumpLimitTest.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @requires vm.flagless
  * @summary Test of option -XX:FullGCHeapDumpLimit
  * @library /test/lib
  * @run main/othervm -XX:+UseSerialGC -XX:+HeapDumpBeforeFullGC -XX:+HeapDumpAfterFullGC -XX:HeapDumpPath=test.hprof -XX:FullGCHeapDumpLimit=1 FullGCHeapDumpLimitTest

--- a/test/hotspot/jtreg/serviceability/HeapDump/FullGCHeapDumpLimitTest.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/FullGCHeapDumpLimitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Alibaba Group Holding Limited. All Rights Reserved.
+ * Copyright (c) 2023, 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/HeapDump/FullGCHeapDumpLimitTest.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/FullGCHeapDumpLimitTest.java
@@ -23,8 +23,7 @@
 
 /**
  * @test
- * @requires vm.gc.Serial
- * @requires vm.opt.DisableExplicitGC != "true"
+ * @requires vm.gc.Serial & (vm.opt.DisableExplicitGC != "true")
  * @summary Test of option -XX:FullGCHeapDumpLimit
  * @library /test/lib
  * @run main/othervm -XX:+UseSerialGC -XX:+HeapDumpBeforeFullGC -XX:+HeapDumpAfterFullGC -XX:HeapDumpPath=test.hprof -XX:FullGCHeapDumpLimit=1 FullGCHeapDumpLimitTest


### PR DESCRIPTION
Hi,

Please help review this patch that fixes the failures of FullGCHeapDumpLimitTest.java caused by passing other gc flags.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322989](https://bugs.openjdk.org/browse/JDK-8322989): New test serviceability/HeapDump/FullGCHeapDumpLimitTest.java fails (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [734f1d7e](https://git.openjdk.org/jdk/pull/17263/files/734f1d7eff45db500d95d2f2335ce4387ab93b5d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17263/head:pull/17263` \
`$ git checkout pull/17263`

Update a local copy of the PR: \
`$ git checkout pull/17263` \
`$ git pull https://git.openjdk.org/jdk.git pull/17263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17263`

View PR using the GUI difftool: \
`$ git pr show -t 17263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17263.diff">https://git.openjdk.org/jdk/pull/17263.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17263#issuecomment-1876675901)