### PR TITLE
8323000: Parallel: Remove unused class declarations in psScavenge

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.hpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.hpp
@@ -33,12 +33,10 @@
 #include "oops/oop.hpp"
 #include "utilities/stack.hpp"
 
-class OopStack;
 class ReferenceProcessor;
 class ParallelScavengeHeap;
 class ParallelScavengeTracer;
 class PSIsAliveClosure;
-class PSRefProcTaskExecutor;
 class STWGCTimer;
 
 class PSScavenge: AllStatic {


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323000](https://bugs.openjdk.org/browse/JDK-8323000): Parallel: Remove unused class declarations in psScavenge (**New Feature** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17264/head:pull/17264` \
`$ git checkout pull/17264`

Update a local copy of the PR: \
`$ git checkout pull/17264` \
`$ git pull https://git.openjdk.org/jdk.git pull/17264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17264`

View PR using the GUI difftool: \
`$ git pr show -t 17264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17264.diff">https://git.openjdk.org/jdk/pull/17264.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17264#issuecomment-1876775417)