### PR TITLE
8323002: test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java times out on macosx-x64

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8322818
  * @summary Stress test Thread.getStackTrace on a virtual thread that is pinned
  * @requires vm.debug != true
- * @run main GetStackTraceALotWhenPinned 100000
+ * @run main GetStackTraceALotWhenPinned 25000
  */
 
 /*
@@ -35,6 +35,7 @@
  * @run main/timeout=300 GetStackTraceALotWhenPinned 10000
  */
 
+import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
@@ -67,7 +68,7 @@ public class GetStackTraceALotWhenPinned {
             LockSupport.unpark(thread);
             long currentTime = System.currentTimeMillis();
             if ((currentTime - lastTimestamp) > 500) {
-                System.out.println(counter.get() + " remaining ...");
+                System.out.format("%s %d remaining ...%n", Instant.now(), counter.get());
                 lastTimestamp = currentTime;
             }
         }


### PR DESCRIPTION
This test was recently added by JDK-8322818. On some test systems, the test passes a bit after the timeout so the test is marked as failed. The changes here dial down the iterations from 100k to 25k to reduce the execution time for release builds. No change for debug builds as this already uses a small number of iterations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323002](https://bugs.openjdk.org/browse/JDK-8323002): test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java times out on macosx-x64 (**Bug** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17265/head:pull/17265` \
`$ git checkout pull/17265`

Update a local copy of the PR: \
`$ git checkout pull/17265` \
`$ git pull https://git.openjdk.org/jdk.git pull/17265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17265`

View PR using the GUI difftool: \
`$ git pr show -t 17265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17265.diff">https://git.openjdk.org/jdk/pull/17265.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17265#issuecomment-1877035345)