### PR TITLE
8323011: ProblemList serviceability/HeapDump/FullGCHeapDumpLimitTest.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -141,6 +141,8 @@ serviceability/attach/ConcAttachTest.java 8290043 linux-all
 
 serviceability/jvmti/stress/StackTrace/NotSuspended/GetStackTraceNotSuspendedStressTest.java 8315980 linux-all,windows-x64
 
+serviceability/HeapDump/FullGCHeapDumpLimitTest.java 8322989 generic-all
+
 #############################################################################
 
 # :hotspot_misc


### PR DESCRIPTION
A trivial fix to  ProblemList serviceability/HeapDump/FullGCHeapDumpLimitTest.java
on all platforms.

We're already up to 54 failures in Tier3 and Tier5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323011](https://bugs.openjdk.org/browse/JDK-8323011): ProblemList serviceability/HeapDump/FullGCHeapDumpLimitTest.java (**Sub-task** - P2)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Christian Tornqvist](https://openjdk.org/census#ctornqvi) (@ctornqvi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17269/head:pull/17269` \
`$ git checkout pull/17269`

Update a local copy of the PR: \
`$ git checkout pull/17269` \
`$ git pull https://git.openjdk.org/jdk.git pull/17269/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17269`

View PR using the GUI difftool: \
`$ git pr show -t 17269`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17269.diff">https://git.openjdk.org/jdk/pull/17269.diff</a>

</details>
