### PR TITLE
JDK-8322874: Redirection loop in index.html

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlConfiguration.java
@@ -342,9 +342,6 @@ public class HtmlConfiguration extends BaseConfiguration {
      * if only classes are provided on the command line.
      */
     protected void setTopFile() {
-        if (!checkForDeprecation()) {
-            return;
-        }
         if (options.createOverview()) {
             topFile = DocPaths.INDEX;
         } else {
@@ -366,15 +363,6 @@ public class HtmlConfiguration extends BaseConfiguration {
             }
         }
         return null;
-    }
-
-    protected boolean checkForDeprecation() {
-        for (TypeElement te : getIncludedTypeElements()) {
-            if (isGeneratedDoc(te)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/IndexRedirectWriter.java
@@ -26,6 +26,7 @@
 package jdk.javadoc.internal.doclets.formats.html;
 
 import java.util.List;
+import java.util.Objects;
 
 import jdk.javadoc.internal.doclets.formats.html.markup.Head;
 import jdk.javadoc.internal.doclets.formats.html.markup.ContentBuilder;
@@ -65,6 +66,8 @@ public class IndexRedirectWriter extends HtmlDocletWriter {
 
     private IndexRedirectWriter(HtmlConfiguration configuration, DocPath filename, DocPath target) {
         super(configuration, filename);
+        assert target != null && !target.isEmpty() && !Objects.equals(target, filename)
+                : "target: '" + target.getPath() + "'";
         this.target = target;
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIndexRedirect/TestIndexRedirect.java
+++ b/test/langtools/jdk/javadoc/doclet/testIndexRedirect/TestIndexRedirect.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8322874
+ * @summary Redirection loop in index.html
+ * @library /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build javadoc.tester.* toolbox.ToolBox builder.ClassBuilder
+ * @run main TestIndexRedirect
+ */
+
+
+import java.nio.file.Path;
+
+import toolbox.ToolBox;
+
+import javadoc.tester.JavadocTester;
+
+public class TestIndexRedirect extends JavadocTester {
+
+    final ToolBox tb = new ToolBox();
+
+    public static void main(String... args) throws Exception {
+        var tester = new TestIndexRedirect();
+        tester.runTests();
+    }
+
+    @Test
+    public void test(Path base) throws Exception {
+        Path src = base.resolve("src");
+        Path api = base.resolve("api");
+
+        tb.writeJavaFiles(src,
+                "/**  Module m. */ module m { requires java.se; }");
+
+        javadoc("-d", api.toString(),
+                "--source-path", src.toString(),
+                "--module", "m");
+        checkExit(Exit.OK);
+
+        checkOutput("index.html", true,
+                "<script type=\"text/javascript\">window.location.replace('m/module-summary.html')</script>",
+                "<meta http-equiv=\"Refresh\" content=\"0;m/module-summary.html\">"
+                );
+    }
+}


### PR DESCRIPTION
Please review a simple fix to address an apparently long-standing issue of generating a redirection loop in the top-level `index.html` file.

The fix is simply to remove some obsolete/unnecessary code in `HtmlConfiguration.setTopFile` that silently and incorrectly short-circuited the functionality of that method.

In addition to the fix, an `assert` statement is added in `IndexRedirectWriter` to ensure that invalid arguments are not provided. (An alternative would be explicit `if` statements than can throw NPE or ILA.

The test case is when there are no classes or interfaces specified in the command-line arguments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322874](https://bugs.openjdk.org/browse/JDK-8322874): Redirection loop in index.html (**Bug** - P3)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17270/head:pull/17270` \
`$ git checkout pull/17270`

Update a local copy of the PR: \
`$ git checkout pull/17270` \
`$ git pull https://git.openjdk.org/jdk.git pull/17270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17270`

View PR using the GUI difftool: \
`$ git pr show -t 17270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17270.diff">https://git.openjdk.org/jdk/pull/17270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17270#issuecomment-1877765794)