### PR TITLE
7057369: (fs spec) FileStore getUsableSpace and getUnallocatedSpace could be clearer

### DIFF
--- a/src/java.base/share/classes/java/nio/file/FileStore.java
+++ b/src/java.base/share/classes/java/nio/file/FileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,18 +96,19 @@ public abstract class FileStore {
     public abstract long getTotalSpace() throws IOException;
 
     /**
-     * Returns the number of bytes available to this Java virtual machine on the
-     * file store.  If the number of bytes available is greater than
-     * {@link Long#MAX_VALUE}, then {@code Long.MAX_VALUE} will be returned.
+     * Returns the number of bytes of the file store available to this Java
+     * virtual machine as of invoking this method. If the number of bytes
+     * available is greater than {@link Long#MAX_VALUE}, then
+     * {@code Long.MAX_VALUE} will be returned.
      *
      * <p> The returned number of available bytes is a hint, but not a
      * guarantee, that it is possible to use most or any of these bytes.  The
      * number of usable bytes is most likely to be accurate immediately
-     * after the space attributes are obtained. It is likely to be made inaccurate
+     * after this method returns. It is likely to be made inaccurate
      * by any external I/O operations including those made on the system outside
      * of this Java virtual machine.
      *
-     * @return  the number of bytes available
+     * @return  the number of bytes available at the time of invocation
      *
      * @throws  IOException
      *          if an I/O error occurs
@@ -115,18 +116,18 @@ public abstract class FileStore {
     public abstract long getUsableSpace() throws IOException;
 
     /**
-     * Returns the number of unallocated bytes in the file store.
-     * If the number of unallocated bytes is greater than
+     * Returns the number of unallocated bytes in the file store as of invoking
+     * this method. If the number of unallocated bytes is greater than
      * {@link Long#MAX_VALUE}, then {@code Long.MAX_VALUE} will be returned.
      *
      * <p> The returned number of unallocated bytes is a hint, but not a
      * guarantee, that it is possible to use most or any of these bytes.  The
      * number of unallocated bytes is most likely to be accurate immediately
-     * after the space attributes are obtained. It is likely to be
+     * after this method returns. It is likely to be
      * made inaccurate by any external I/O operations including those made on
      * the system outside of this virtual machine.
      *
-     * @return  the number of unallocated bytes
+     * @return  the number of unallocated bytes at the time of invocation
      *
      * @throws  IOException
      *          if an I/O error occurs

--- a/src/java.base/share/classes/java/nio/file/FileStore.java
+++ b/src/java.base/share/classes/java/nio/file/FileStore.java
@@ -96,10 +96,9 @@ public abstract class FileStore {
     public abstract long getTotalSpace() throws IOException;
 
     /**
-     * Returns the number of bytes of the file store available to this Java
-     * virtual machine as of invoking this method. If the number of bytes
-     * available is greater than {@link Long#MAX_VALUE}, then
-     * {@code Long.MAX_VALUE} will be returned.
+     * Returns the number of bytes available to this Java virtual machine on the
+     * file store.  If the number of bytes available is greater than
+     * {@link Long#MAX_VALUE}, then {@code Long.MAX_VALUE} will be returned.
      *
      * <p> The returned number of available bytes is a hint, but not a
      * guarantee, that it is possible to use most or any of these bytes.  The
@@ -108,7 +107,7 @@ public abstract class FileStore {
      * by any external I/O operations including those made on the system outside
      * of this Java virtual machine.
      *
-     * @return  the number of bytes available at the time of invocation
+     * @return  the current number of usable bytes
      *
      * @throws  IOException
      *          if an I/O error occurs
@@ -116,8 +115,8 @@ public abstract class FileStore {
     public abstract long getUsableSpace() throws IOException;
 
     /**
-     * Returns the number of unallocated bytes in the file store as of invoking
-     * this method. If the number of unallocated bytes is greater than
+     * Returns the number of unallocated bytes in the file store.
+     * If the number of unallocated bytes is greater than
      * {@link Long#MAX_VALUE}, then {@code Long.MAX_VALUE} will be returned.
      *
      * <p> The returned number of unallocated bytes is a hint, but not a
@@ -127,7 +126,7 @@ public abstract class FileStore {
      * made inaccurate by any external I/O operations including those made on
      * the system outside of this virtual machine.
      *
-     * @return  the number of unallocated bytes at the time of invocation
+     * @return  the current number of unallocated bytes
      *
      * @throws  IOException
      *          if an I/O error occurs


### PR DESCRIPTION
Attempt to clarify when the values returned for a `FileStore`s usable and unallocated space are initialized and likely to be valid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8323084](https://bugs.openjdk.org/browse/JDK-8323084) to be approved

### Issues
 * [JDK-7057369](https://bugs.openjdk.org/browse/JDK-7057369): (fs spec) FileStore getUsableSpace and getUnallocatedSpace could be clearer (**Bug** - P4)
 * [JDK-8323084](https://bugs.openjdk.org/browse/JDK-8323084): (fs spec) FileStore getUsableSpace and getUnallocatedSpace could be clearer (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17271/head:pull/17271` \
`$ git checkout pull/17271`

Update a local copy of the PR: \
`$ git checkout pull/17271` \
`$ git pull https://git.openjdk.org/jdk.git pull/17271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17271`

View PR using the GUI difftool: \
`$ git pr show -t 17271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17271.diff">https://git.openjdk.org/jdk/pull/17271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17271#issuecomment-1877774412)