### PR TITLE
8323012: C2 fails with fatal error: no reachable node should have no use

### DIFF
--- a/src/hotspot/share/opto/cfgnode.cpp
+++ b/src/hotspot/share/opto/cfgnode.cpp
@@ -2170,7 +2170,7 @@ Node *PhiNode::Ideal(PhaseGVN *phase, bool can_reshape) {
               cast = phase->transform(cast);
               n = cast;
             }
-            cast = new CheckCastPPNode(r, uin, phi_type, ConstraintCastNode::StrongDependency, extra_types);
+            cast = new CheckCastPPNode(r, n, phi_type, ConstraintCastNode::StrongDependency, extra_types);
           }
           if (cast == nullptr) {
             cast = new CastPPNode(r, uin, phi_type, ConstraintCastNode::StrongDependency, extra_types);


### PR DESCRIPTION
Incorrect refactoring from [JDK-8322490](https://bugs.openjdk.org/browse/JDK-8322490), probably a copy-paste error, leads to a dead `CastPP` and might have other not yet observed effects. See JBS for details.

I wasn't able to extract a regression test for this but it reliably reproduced with replay compilation.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323012](https://bugs.openjdk.org/browse/JDK-8323012): C2 fails with fatal error: no reachable node should have no use (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17276/head:pull/17276` \
`$ git checkout pull/17276`

Update a local copy of the PR: \
`$ git checkout pull/17276` \
`$ git pull https://git.openjdk.org/jdk.git pull/17276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17276`

View PR using the GUI difftool: \
`$ git pr show -t 17276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17276.diff">https://git.openjdk.org/jdk/pull/17276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17276#issuecomment-1878377244)