### PR TITLE
8322858: compiler/c2/aarch64/TestFarJump.java fails on AArch64 due to unexpected PrintAssembly output

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestFarJump.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestFarJump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, BELLSOFT. All rights reserved.
+ * Copyright (c) 2024, BELLSOFT. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,10 +89,9 @@ public class TestFarJump {
             "-Xbatch",
             "-XX:+TieredCompilation",
             "-XX:+SegmentedCodeCache",
-            "-XX:CompileOnly=" + className + "::main",
             "-XX:ReservedCodeCacheSize=" + (bigCodeHeap ? "256M" : "200M"),
             "-XX:+UnlockDiagnosticVMOptions",
-            "-XX:+PrintAssembly",
+            "-XX:CompileCommand=option," + className + "::main,bool,PrintAssembly,true",
             className};
 
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(procArgs);


### PR DESCRIPTION
Test checks for the ADRP instruction in the [Exception Handler] section of the TestFarJump::main PrintAssembly output.

The -XX:CompileOnly=TestFarJump::main option is not sufficient to restrict PrintAssembly output to a specific method. A number of method assemblies precede the output of the TestFarJump::main method:
- java.lang.invoke.MethodHandle::linkToStatic(LLLLLLL)L
- java.lang.invoke.MethodHandle::linkToStatic(LLLL)V
- java.lang.invoke.MethodHandle::invokeBasic(LLLLLL)L
- java.lang.invoke.MethodHandle::linkToSpecial(LLLLLLLL)L
- java.lang.invoke.MethodHandle::linkToSpecial(LLLLL)V
- java.lang.invoke.MethodHandle::invokeBasic(LLL)L
- java.lang.invoke.MethodHandle::linkToSpecial(LLLLL)L
- java.lang.invoke.MethodHandle::linkToStatic(LL)L
- java.lang.invoke.MethodHandle::linkToSpecial(LL)V
- java.lang.invoke.MethodHandle::invokeBasic()L
- java.lang.invoke.MethodHandle::linkToSpecial(LL)L
- java.lang.invoke.MethodHandle::linkToStatic(LLL)L
- java.lang.invoke.MethodHandle::linkToStatic(LLLL)L
- java.lang.invoke.MethodHandle::linkToSpecial(LLL)V
- java.lang.invoke.MethodHandle::invokeBasic(L)L
- java.lang.invoke.MethodHandle::linkToSpecial(LLL)L
- java.lang.invoke.MethodHandle::linkToStatic(LLL)V
- java.lang.invoke.MethodHandle::linkToStatic(LL)I
- jdk.internal.vm.Continuation::enterSpecial
- compiler.c2.aarch64.TestFarJump::main

With this change, I use the -XX:CompileCommand=option,TestFarJump::main,bool,PrintAssembly,true option to restrict the PrintAssembly output to a specific method. Now the only [Exception Handler] in the listing is the section of TestFarJump::main method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322858](https://bugs.openjdk.org/browse/JDK-8322858): compiler/c2/aarch64/TestFarJump.java fails on AArch64 due to unexpected PrintAssembly output (**Bug** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17278/head:pull/17278` \
`$ git checkout pull/17278`

Update a local copy of the PR: \
`$ git checkout pull/17278` \
`$ git pull https://git.openjdk.org/jdk.git pull/17278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17278`

View PR using the GUI difftool: \
`$ git pr show -t 17278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17278.diff">https://git.openjdk.org/jdk/pull/17278.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17278#issuecomment-1878532018)