### PR TITLE
8323065: Unneccesary CodeBlob lookup in CompiledIC::internal_set_ic_destination

### DIFF
--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -128,11 +128,13 @@ void CompiledIC::internal_set_ic_destination(address entry_point, bool is_icstub
     tty->cr();
   }
 
+#ifdef ASSERT
   {
     CodeBlob* cb = CodeCache::find_blob(_call->instruction_address());
     assert(cb != nullptr && cb->is_compiled(), "must be compiled");
-    _call->set_destination_mt_safe(entry_point);
   }
+#endif
+  _call->set_destination_mt_safe(entry_point);
 
   if (is_optimized() || is_icstub) {
     // Optimized call sites don't have a cache value and ICStub call


### PR DESCRIPTION
I was looking at hotpath for IC stub cleaning (happens at safepoint), and one obvious thing is that we look-up `CodeBlob` from `call->instruction_address()` only to assert that is compiled one. It used to be protected by `#ifdef ASSERT` before [JDK-8212681](https://bugs.openjdk.org/browse/JDK-8212681), and pulled from it to be used in Mutex in JDK 12: https://hg.openjdk.org/jdk/jdk/rev/d6dc479bcdd3#l15.62 And the Mutex was shortly gone after [JDK-8214257](https://bugs.openjdk.org/browse/JDK-8214257). So we are exposing this code to product binaries since JDK 12. 

This fix reinstates the `ASSERT` block again. There are small improvements (~1..10us) for safepoint cleanup on small ad-hoc tests in release builds on my Mac. But since this whole thing involves looking up things in code cache, it may cost quite a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323065](https://bugs.openjdk.org/browse/JDK-8323065): Unneccesary CodeBlob lookup in CompiledIC::internal_set_ic_destination (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17281/head:pull/17281` \
`$ git checkout pull/17281`

Update a local copy of the PR: \
`$ git checkout pull/17281` \
`$ git pull https://git.openjdk.org/jdk.git pull/17281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17281`

View PR using the GUI difftool: \
`$ git pr show -t 17281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17281.diff">https://git.openjdk.org/jdk/pull/17281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17281#issuecomment-1878788541)