### PR TITLE
8322477: order of subclasses in the permits clause can differ between compilations

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -27,6 +27,7 @@ package com.sun.tools.javac.code;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -1303,9 +1304,11 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         // sealed classes related fields
         /** The classes, or interfaces, permitted to extend this class, or interface
          */
-        public List<Symbol> permitted;
+        private java.util.List<PermittedClassWithPos> permitted;
 
         public boolean isPermittedExplicit = false;
+
+        private record PermittedClassWithPos(Symbol permittedClass, int pos) {}
 
         public ClassSymbol(long flags, Name name, Type type, Symbol owner) {
             super(TYP, flags, name, type, owner);
@@ -1315,7 +1318,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             this.sourcefile = null;
             this.classfile = null;
             this.annotationTypeMetadata = AnnotationTypeMetadata.notAnAnnotationType();
-            this.permitted = List.nil();
+            this.permitted = new ArrayList<>();
         }
 
         public ClassSymbol(long flags, Name name, Symbol owner) {
@@ -1325,6 +1328,41 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
                 new ClassType(Type.noType, null, null),
                 owner);
             this.type.tsym = this;
+        }
+
+        public void addPermittedSubclass(ClassSymbol csym, int pos) {
+            if (isPermittedExplicit) {
+                // in this case just add the permitted subclasses clause is explicit
+                permitted.add(new PermittedClassWithPos(csym, pos));
+            } else {
+                // in this case we need to insert at the right pos
+                PermittedClassWithPos element = new PermittedClassWithPos(csym, pos);
+                int index = Collections.binarySearch(permitted, element, java.util.Comparator.comparing(PermittedClassWithPos::pos));
+                if (index < 0) {
+                    index = -index - 1;
+                }
+                permitted.add(index, element);
+            }
+        }
+
+        public boolean isPermittedSubclass(Symbol csym) {
+            for (PermittedClassWithPos permittedClassWithPos : permitted) {
+                if (permittedClassWithPos.permittedClass.equals(csym)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void clearPermittedSubclasses() {
+            permitted.clear();
+        }
+
+        public void setPermittedSubclasses(List<Symbol> permittedSubs) {
+            permitted.clear();
+            for (Symbol csym : permittedSubs) {
+                permitted.add(new PermittedClassWithPos(csym, 0));
+            }
         }
 
         /** The Java source which this symbol represents.
@@ -1643,7 +1681,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
         @DefinedBy(Api.LANGUAGE_MODEL)
         public List<Type> getPermittedSubclasses() {
-            return permitted.map(s -> s.type);
+            return permitted.stream().map(s -> s.permittedClass().type).collect(List.collector());
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1331,18 +1331,14 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         }
 
         public void addPermittedSubclass(ClassSymbol csym, int pos) {
-            if (isPermittedExplicit) {
-                // in this case just add the permitted subclasses clause is explicit
-                permitted.add(new PermittedClassWithPos(csym, pos));
-            } else {
-                // in this case we need to insert at the right pos
-                PermittedClassWithPos element = new PermittedClassWithPos(csym, pos);
-                int index = Collections.binarySearch(permitted, element, java.util.Comparator.comparing(PermittedClassWithPos::pos));
-                if (index < 0) {
-                    index = -index - 1;
-                }
-                permitted.add(index, element);
+            Assert.check(!isPermittedExplicit);
+            // we need to insert at the right pos
+            PermittedClassWithPos element = new PermittedClassWithPos(csym, pos);
+            int index = Collections.binarySearch(permitted, element, java.util.Comparator.comparing(PermittedClassWithPos::pos));
+            if (index < 0) {
+                index = -index - 1;
             }
+            permitted.add(index, element);
         }
 
         public boolean isPermittedSubclass(Symbol csym) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1701,7 +1701,7 @@ public class Types {
                     // permitted subtypes have to be disjoint with the other symbol
                     ClassSymbol sealedOne = ts.isSealed() ? ts : ss;
                     ClassSymbol other = sealedOne == ts ? ss : ts;
-                    return sealedOne.permitted.stream().allMatch(sym -> areDisjoint((ClassSymbol)sym, other));
+                    return sealedOne.getPermittedSubclasses().stream().allMatch(type -> areDisjoint((ClassSymbol)type.tsym, other));
                 }
                 return false;
             }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5383,58 +5383,58 @@ public class Attr extends JCTree.Visitor {
                 if (c.isSealed() &&
                         !c.isEnum() &&
                         !c.isPermittedExplicit &&
-                        c.permitted.isEmpty()) {
+                        c.getPermittedSubclasses().isEmpty()) {
                     log.error(TreeInfo.diagnosticPositionFor(c, env.tree), Errors.SealedClassMustHaveSubclasses);
                 }
 
                 if (c.isSealed()) {
                     Set<Symbol> permittedTypes = new HashSet<>();
                     boolean sealedInUnnamed = c.packge().modle == syms.unnamedModule || c.packge().modle == syms.noModule;
-                    for (Symbol subTypeSym : c.permitted) {
+                    for (Type subType : c.getPermittedSubclasses()) {
                         boolean isTypeVar = false;
-                        if (subTypeSym.type.getTag() == TYPEVAR) {
+                        if (subType.getTag() == TYPEVAR) {
                             isTypeVar = true; //error recovery
-                            log.error(TreeInfo.diagnosticPositionFor(subTypeSym, env.tree),
-                                    Errors.InvalidPermitsClause(Fragments.IsATypeVariable(subTypeSym.type)));
+                            log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
+                                    Errors.InvalidPermitsClause(Fragments.IsATypeVariable(subType)));
                         }
-                        if (subTypeSym.isAnonymous() && !c.isEnum()) {
-                            log.error(TreeInfo.diagnosticPositionFor(subTypeSym, env.tree),  Errors.LocalClassesCantExtendSealed(Fragments.Anonymous));
+                        if (subType.tsym.isAnonymous() && !c.isEnum()) {
+                            log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),  Errors.LocalClassesCantExtendSealed(Fragments.Anonymous));
                         }
-                        if (permittedTypes.contains(subTypeSym)) {
+                        if (permittedTypes.contains(subType.tsym)) {
                             DiagnosticPosition pos =
                                     env.enclClass.permitting.stream()
-                                            .filter(permittedExpr -> TreeInfo.diagnosticPositionFor(subTypeSym, permittedExpr, true) != null)
+                                            .filter(permittedExpr -> TreeInfo.diagnosticPositionFor(subType.tsym, permittedExpr, true) != null)
                                             .limit(2).collect(List.collector()).get(1);
-                            log.error(pos, Errors.InvalidPermitsClause(Fragments.IsDuplicated(subTypeSym.type)));
+                            log.error(pos, Errors.InvalidPermitsClause(Fragments.IsDuplicated(subType)));
                         } else {
-                            permittedTypes.add(subTypeSym);
+                            permittedTypes.add(subType.tsym);
                         }
                         if (sealedInUnnamed) {
-                            if (subTypeSym.packge() != c.packge()) {
-                                log.error(TreeInfo.diagnosticPositionFor(subTypeSym, env.tree),
+                            if (subType.tsym.packge() != c.packge()) {
+                                log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
                                         Errors.ClassInUnnamedModuleCantExtendSealedInDiffPackage(c)
                                 );
                             }
-                        } else if (subTypeSym.packge().modle != c.packge().modle) {
-                            log.error(TreeInfo.diagnosticPositionFor(subTypeSym, env.tree),
+                        } else if (subType.tsym.packge().modle != c.packge().modle) {
+                            log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
                                     Errors.ClassInModuleCantExtendSealedInDiffModule(c, c.packge().modle)
                             );
                         }
-                        if (subTypeSym == c.type.tsym || types.isSuperType(subTypeSym.type, c.type)) {
-                            log.error(TreeInfo.diagnosticPositionFor(subTypeSym, ((JCClassDecl)env.tree).permitting),
+                        if (subType.tsym == c.type.tsym || types.isSuperType(subType, c.type)) {
+                            log.error(TreeInfo.diagnosticPositionFor(subType.tsym, ((JCClassDecl)env.tree).permitting),
                                     Errors.InvalidPermitsClause(
-                                            subTypeSym == c.type.tsym ?
+                                            subType.tsym == c.type.tsym ?
                                                     Fragments.MustNotBeSameClass :
-                                                    Fragments.MustNotBeSupertype(subTypeSym.type)
+                                                    Fragments.MustNotBeSupertype(subType)
                                     )
                             );
                         } else if (!isTypeVar) {
-                            boolean thisIsASuper = types.directSupertypes(subTypeSym.type)
+                            boolean thisIsASuper = types.directSupertypes(subType)
                                                         .stream()
                                                         .anyMatch(d -> d.tsym == c);
                             if (!thisIsASuper) {
-                                log.error(TreeInfo.diagnosticPositionFor(subTypeSym, env.tree),
-                                        Errors.InvalidPermitsClause(Fragments.DoesntExtendSealed(subTypeSym.type)));
+                                log.error(TreeInfo.diagnosticPositionFor(subType.tsym, env.tree),
+                                        Errors.InvalidPermitsClause(Fragments.DoesntExtendSealed(subType)));
                             }
                         }
                     }
@@ -5469,7 +5469,7 @@ public class Attr extends JCTree.Visitor {
 
                     if (!c.type.isCompound()) {
                         for (ClassSymbol supertypeSym : sealedSupers) {
-                            if (!supertypeSym.permitted.contains(c.type.tsym)) {
+                            if (!supertypeSym.isPermittedSubclass(c.type.tsym)) {
                                 log.error(TreeInfo.diagnosticPositionFor(c.type.tsym, env.tree), Errors.CantInheritFromSealed(supertypeSym));
                             }
                         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -945,8 +945,8 @@ public class Flow {
                 current.complete();
 
                 if (current.isSealed() && current.isAbstract()) {
-                    for (Symbol sym : current.permitted) {
-                        ClassSymbol csym = (ClassSymbol) sym;
+                    for (Type t : current.getPermittedSubclasses()) {
+                        ClassSymbol csym = (ClassSymbol) t.tsym;
 
                         if (accept.test(csym)) {
                             permittedSubtypesClosure = permittedSubtypesClosure.prepend(csym);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -919,7 +919,7 @@ public class TypeEnter implements Completer {
                             !supClass.isPermittedExplicit &&
                             supClassEnv != null &&
                             supClassEnv.toplevel == baseEnv.toplevel) {
-                            supClass.permitted = supClass.permitted.append(sym);
+                            supClass.addPermittedSubclass(sym, tree.pos);
                         }
                     }
                 }
@@ -932,7 +932,7 @@ public class TypeEnter implements Completer {
                     Type pt = attr.attribBase(permitted, baseEnv, false, false, false);
                     permittedSubtypeSymbols.append(pt.tsym);
                 }
-                sym.permitted = permittedSubtypeSymbols.toList();
+                sym.setPermittedSubclasses(permittedSubtypeSymbols.toList());
             }
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1298,7 +1298,7 @@ public class ClassReader {
                         for (int i = 0; i < numberOfPermittedSubtypes; i++) {
                             subtypes.add(poolReader.getClass(nextChar()));
                         }
-                        ((ClassSymbol)sym).permitted = subtypes.toList();
+                        ((ClassSymbol)sym).setPermittedSubclasses(subtypes.toList());
                     }
                 }
             },
@@ -2930,7 +2930,7 @@ public class ClassReader {
         for (int i = 0; i < methodCount; i++) skipMember();
         readClassAttrs(c);
 
-        if (c.permitted != null && !c.permitted.isEmpty()) {
+        if (!c.getPermittedSubclasses().isEmpty()) {
             c.flags_field |= SEALED;
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -922,11 +922,11 @@ public class ClassWriter extends ClassFile {
     /** Write "PermittedSubclasses" attribute.
      */
     int writePermittedSubclassesIfNeeded(ClassSymbol csym) {
-        if (csym.permitted.nonEmpty()) {
+        if (csym.getPermittedSubclasses().nonEmpty()) {
             int alenIdx = writeAttr(names.PermittedSubclasses);
-            databuf.appendChar(csym.permitted.size());
-            for (Symbol c : csym.permitted) {
-                databuf.appendChar(poolWriter.putClass((ClassSymbol) c));
+            databuf.appendChar(csym.getPermittedSubclasses().size());
+            for (Type t : csym.getPermittedSubclasses()) {
+                databuf.appendChar(poolWriter.putClass((ClassSymbol) t.tsym));
             }
             endAttr(alenIdx);
             return 1;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/processing/JavacProcessingEnvironment.java
@@ -1643,7 +1643,7 @@ public class JavacProcessingEnvironment implements ProcessingEnvironment, Closea
                         originalAnnos.forEach(a -> visitAnnotation(a));
                     }
                     // we should empty the list of permitted subclasses for next round
-                    node.sym.permitted = List.nil();
+                    node.sym.clearPermittedSubclasses();
                 }
                 node.sym = null;
             }

--- a/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
+++ b/test/langtools/tools/javac/sealed/SealedDiffConfigurationsTest.java
@@ -696,23 +696,26 @@ public class SealedDiffConfigurationsTest extends TestRunner {
     }
 
     @Test
-    public void testClientSwapsOrder(Path base) throws Exception {
+    public void testClientSwapsPermittedSubclassesOrder(Path base) throws Exception {
         Path src = base.resolve("src");
         Path foo = src.resolve("Foo.java");
         Path fooUser = src.resolve("FooUser.java");
-
-        tb.writeFile(fooUser,
-                """
-                public class FooUser {
-                    public void blah(Foo.R2 a, Foo.R1 b) {}
-                }
-                """);
 
         tb.writeFile(foo,
                 """
                 public sealed interface Foo {
                     record R1() implements Foo {}
                     record R2() implements Foo {}
+                }
+                """);
+
+        tb.writeFile(fooUser,
+                """
+                public class FooUser {
+                    // see that the order of arguments differ from the order of subclasses of Foo in the source above
+                    // we need to check that the order of permitted subclasses of Foo in the class file corresponds to the
+                    // original order in the source code
+                    public void blah(Foo.R2 a, Foo.R1 b) {}
                 }
                 """);
 


### PR DESCRIPTION
This is a very interesting issue. Given code like:
```
sealed interface Sealed {
    record R1() implements Sealed {}
    record R2() implements Sealed {}
}
```

As we know javac will infer the `permits` clause of sealed interface `Sealed` logically the order should correspond to the order in which the permitted subclasses appear in the source code. Well it has been consistently observed by the reported of this bug, that some tools like Gradle while doing incremental compilation can make javac infer either `R1, R2` or `R2, R1` as permitted subclasses. The reason is not clear still under investigation on their side but the fact is that javac is generating inconsistent output for some classes with this shape. The proposed solution is to store the position of the permitted subclasses being discovered by javac so that the order of the permitted subclasses corresponds to the original order in the source file. Efforts to reduce the project where the issue was discovered to a small reproductor have been unsuccessful but the proposed patch have fixed the issue observed by the reporter.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322477](https://bugs.openjdk.org/browse/JDK-8322477): order of subclasses in the permits clause can differ between compilations (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [20ff11bc](https://git.openjdk.org/jdk/pull/17284/files/20ff11bcfb114fad2e79287cb9dc941a1aec947d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17284/head:pull/17284` \
`$ git checkout pull/17284`

Update a local copy of the PR: \
`$ git checkout pull/17284` \
`$ git pull https://git.openjdk.org/jdk.git pull/17284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17284`

View PR using the GUI difftool: \
`$ git pr show -t 17284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17284.diff">https://git.openjdk.org/jdk/pull/17284.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17284#issuecomment-1879047035)