### PR TITLE
8323032: OptimizedModuleHandlingTest failed in dynamic CDS archive mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -113,7 +113,6 @@ runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
-runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java 8323032 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
@@ -345,20 +345,26 @@ public class OptimizeModuleHandlingTest {
                    .shouldNotContain(OPTIMIZE_ENABLED)
                    .shouldContain(MAP_FAILED);
             });
-        // Dump an archive with only -Xbootclasspath/a
-        output = TestCommon.createArchive(
-                                null,
-                                appClasses,
-                                "-Xbootclasspath/a:" + mainJar.toString());
-        TestCommon.checkDump(output);
-        tty("13. run with CDS on,  with the same -Xbootclasspath/a as dump time and adding a -cp with test.jar:  should pass");
-        TestCommon.run("-Xlog:cds,class+load",
-                       "-cp", testJar.toString(),
-                       "-Xbootclasspath/a:" + mainJar.toString(),
-                       MAIN_CLASS)
-            .assertNormalExit(out -> {
-                out.shouldMatch(MAIN_FROM_CDS)
-                   .shouldContain(OPTIMIZE_ENABLED);
+
+        // Skip the following test for dynamic CDS archive because the current
+        // dynamic dump test utililty does not support empty -cp with a classlist.
+        // (see createArchive(CDSOptions opts) in TestCommon.java)
+        if (!CDSTestUtils.isDynamicArchive()) {
+            // Dump an archive with only -Xbootclasspath/a
+            output = TestCommon.createArchive(
+                                    null,
+                                    appClasses,
+                                    "-Xbootclasspath/a:" + mainJar.toString());
+            TestCommon.checkDump(output);
+            tty("13. run with CDS on,  with the same -Xbootclasspath/a as dump time and adding a -cp with test.jar:  should pass");
+            TestCommon.run("-Xlog:cds,class+load",
+                           "-cp", testJar.toString(),
+                           "-Xbootclasspath/a:" + mainJar.toString(),
+                           MAIN_CLASS)
+                .assertNormalExit(out -> {
+                    out.shouldMatch(MAIN_FROM_CDS)
+                       .shouldContain(OPTIMIZE_ENABLED);
             });
+        }
     }
 }


### PR DESCRIPTION
Please review this simple test fix for excluding a test scenario when it is run with dynamic CDS archive mode (`-Dtest.dynamic.cds.archive=true`).

Passed tier1 and tier4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323032](https://bugs.openjdk.org/browse/JDK-8323032): OptimizedModuleHandlingTest failed in dynamic CDS archive mode (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17288/head:pull/17288` \
`$ git checkout pull/17288`

Update a local copy of the PR: \
`$ git checkout pull/17288` \
`$ git pull https://git.openjdk.org/jdk.git pull/17288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17288`

View PR using the GUI difftool: \
`$ git pr show -t 17288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17288.diff">https://git.openjdk.org/jdk/pull/17288.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17288#issuecomment-1879364428)