### PR TITLE
8323095: Expand TraceOptoParse block output abbreviations

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1512,13 +1512,13 @@ void Parse::do_one_block() {
     int ns = b->num_successors();
     int nt = b->all_successors();
 
-    tty->print("Parsing block #%d at bci [%d,%d), successors: ",
+    tty->print("Parsing block #%d at bci [%d,%d), successors:",
                   block()->rpo(), block()->start(), block()->limit());
     for (int i = 0; i < nt; i++) {
-      tty->print((( i < ns) ? " %d" : " %d(e)"), b->successor_at(i)->rpo());
+      tty->print((( i < ns) ? " %d" : " %d(exception block)"), b->successor_at(i)->rpo());
     }
     if (b->is_loop_head()) {
-      tty->print("  lphd");
+      tty->print("  loop head");
     }
     if (b->is_irreducible_loop_entry()) {
       tty->print("  irreducible");


### PR DESCRIPTION
`e` -> `exception block`
`lphd` -> `loop head`

Also removing an unnecessary space. The successor ids have a space before them.

Examples from `java -Xcomp -XX:+TraceOptoParse -version`:

```
Parsing block #8 at bci [33,39), successors: 9 16(exception block)  loop head
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323095](https://bugs.openjdk.org/browse/JDK-8323095): Expand TraceOptoParse block output abbreviations (**Enhancement** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17289/head:pull/17289` \
`$ git checkout pull/17289`

Update a local copy of the PR: \
`$ git checkout pull/17289` \
`$ git pull https://git.openjdk.org/jdk.git pull/17289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17289`

View PR using the GUI difftool: \
`$ git pr show -t 17289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17289.diff">https://git.openjdk.org/jdk/pull/17289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17289#issuecomment-1879368319)