### PR TITLE
8221261: Deadlock on macOS in JFXPanel app when handling IME calls

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CInputMethod.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CInputMethod.java
@@ -623,7 +623,7 @@ public class CInputMethod extends InputMethodAdapter {
 
                     retString[0] = new String(selectedText);
                 }}
-            }, fAwtFocussedComponent);
+            }, fAwtFocussedComponent, true);
         } catch (InvocationTargetException ite) { ite.printStackTrace(); }
 
         synchronized(retString) { return retString[0]; }
@@ -671,7 +671,7 @@ public class CInputMethod extends InputMethodAdapter {
                     returnValue[1] = theIterator.getEndIndex() - theIterator.getBeginIndex();
 
                 }}
-            }, fAwtFocussedComponent);
+            }, fAwtFocussedComponent, true);
         } catch (InvocationTargetException ite) { ite.printStackTrace(); }
 
         synchronized(returnValue) { return returnValue; }
@@ -696,7 +696,7 @@ public class CInputMethod extends InputMethodAdapter {
                     // insert spot less the length of the composed text.
                     returnValue[0] = fIMContext.getInsertPositionOffset();
                 }}
-            }, fAwtFocussedComponent);
+            }, fAwtFocussedComponent, true);
         } catch (InvocationTargetException ite) { ite.printStackTrace(); }
 
         returnValue[1] = fCurrentTextLength;
@@ -743,7 +743,7 @@ public class CInputMethod extends InputMethodAdapter {
                         }
                     }
                 }}
-            }, fAwtFocussedComponent);
+            }, fAwtFocussedComponent, true);
         } catch (InvocationTargetException ite) { ite.printStackTrace(); }
 
         synchronized(rect) { return rect; }
@@ -763,7 +763,7 @@ public class CInputMethod extends InputMethodAdapter {
                     offsetInfo[0] = fIMContext.getLocationOffset(screenX, screenY);
                     insertPositionOffset[0] = fIMContext.getInsertPositionOffset();
                 }}
-            }, fAwtFocussedComponent);
+            }, fAwtFocussedComponent, true);
         } catch (InvocationTargetException ite) { ite.printStackTrace(); }
 
         // This bit of gymnastics ensures that the returned location is within the composed text.


### PR DESCRIPTION
As described in the JBS bug, there is a long-standing deadlock that happens on macOS between the AWT EDT and the JavaFX Application thread (which on macOS is the AppKit thread) when processing Input Method Events (IME) in a WebView node in a JFXPanel.

This is happening much more often on recent macOS versions, and in macOS 14, pressing CAPS LOCK is sufficient to trigger IME calls.

A similar deadlock was observed while trying to fix a threading problem in JFXPanel's handling of  the IME calls as described in [JDK-8322784](https://bugs.openjdk.org/browse/JDK-8322784), so it isn't necessarily limited to using WebView.

This PR proposes to fix the bug by allowing the event loop to process native events in the event loop that is run  by `invokeAndWait` when called from the IME methods. This is essentially the fix proposed by Anton Tarasov @forantar in the JBS bug, expanded to cover all of the necessary calls.

There were three possible solutions mentioned in the bug report. This PR implements the second approach described below.

1. Change `LWCToolkit::invokeAndWait` to always call `doAWTRunLoop` with `processEvents=true`, meaning that the nested event loop will process input events for all calls to `invokeAndWait`. Arunprasad proposed this as a quick fix. PR #17184 was submitted proposing this version of the fix.
2. Add a new (package-scope) flavor of `LWCToolkit::invokeAndWait` that takes a `processEvents` as a flag and passes it to `doAWTRunLoop`. The existing public `LWCToolkit::invokeAndWait` method will continue to pass `processEvents=false`. Change the IME event calls in `CInputMethod` to call the new flavor of `invokeAndWait` with `processEvents=true`. Anton proposed this as a more targeted (and safer) version of 1. This PR implements this approach. I took Anton's proposed fix and expanded it to cover all of the calls to invokeAndWait in `CInputMethod` (else deadlock could still happen).
3. Check whether the focused component is a JFXPanel and, if so, call the IME handler methods on the existing AppKit thread. This would avoid jumping on the EDT, calling the FX handler, which would then jump back on the AppKit thread.

All three approaches fix the deadlock, but solution 2 (a completed version of Anton's fix) seems the best approach. I instrumented the code and can see no ill effects from processing events while waiting in invokeAndWait in those cases.

The instrumented code for 2 is in [kevinrushforth:WIP-2-8221261-jfx-ime-deadlock](https://github.com/kevinrushforth/jdk/tree/WIP-2-8221261-jfx-ime-deadlock) and for 3 in [kevinrushforth:WIP-1-8221261-jfx-ime-deadlock](https://github.com/kevinrushforth/jdk/tree/WIP-1-8221261-jfx-ime-deadlock).

This PR is currently in Draft, but after additional testing and discussion with @prrace and @prsadhuk I plan to make this "rfr".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8221261](https://bugs.openjdk.org/browse/JDK-8221261): Deadlock on macOS in JFXPanel app when handling IME calls (**Bug** - P2)(⚠️ The fixVersion in this issue is [jfx22] but the fixVersion in .jcheck/conf is 23, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17290/head:pull/17290` \
`$ git checkout pull/17290`

Update a local copy of the PR: \
`$ git checkout pull/17290` \
`$ git pull https://git.openjdk.org/jdk.git pull/17290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17290`

View PR using the GUI difftool: \
`$ git pr show -t 17290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17290.diff">https://git.openjdk.org/jdk/pull/17290.diff</a>

</details>
