### PR TITLE
8323110: Eliminate -Wparentheses warnings in ppc code

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -78,8 +78,8 @@ inline void frame::setup() {
   // Continuation frames on the java heap are not aligned.
   // When thawing interpreted frames the sp can be unaligned (see new_stack_frame()).
   assert(_on_heap ||
-         (is_aligned(_sp, alignment_in_bytes) || is_interpreted_frame()) &&
-         (is_aligned(_fp, alignment_in_bytes) || !is_fully_initialized()),
+         ((is_aligned(_sp, alignment_in_bytes) || is_interpreted_frame()) &&
+          (is_aligned(_fp, alignment_in_bytes) || !is_fully_initialized())),
          "invalid alignment sp:" PTR_FORMAT " unextended_sp:" PTR_FORMAT " fp:" PTR_FORMAT, p2i(_sp), p2i(_unextended_sp), p2i(_fp));
 }
 


### PR DESCRIPTION
Please review this trivial change to eliminate a -Wparentheses warning.
This involved simply adding parentheses to make the implicit operator
precedence explicit.

Testing: Locally (linux-x64) cross-compiled for linux-ppc64le. Also ran GHA with
-Wparentheses enabled along with this and other changes needed to make that
work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323110](https://bugs.openjdk.org/browse/JDK-8323110): Eliminate -Wparentheses warnings in ppc code (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17293/head:pull/17293` \
`$ git checkout pull/17293`

Update a local copy of the PR: \
`$ git checkout pull/17293` \
`$ git pull https://git.openjdk.org/jdk.git pull/17293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17293`

View PR using the GUI difftool: \
`$ git pr show -t 17293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17293.diff">https://git.openjdk.org/jdk/pull/17293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17293#issuecomment-1880341056)