### PR TITLE
8318112: CSS percentage values are capped at 100%

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -2627,7 +2627,7 @@ public class CSS implements Serializable {
                 case 1:
                     // %
                     lv = new LengthValue();
-                    lv.span = Math.max(0, Math.min(1, lu.value));
+                    lv.span = Math.max(0, lu.value);
                     lv.percentage = true;
                     break;
                 default:

--- a/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
+++ b/test/jdk/javax/swing/text/html/CSS/CSSAttributeEqualityBug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import javax.swing.text.html.StyleSheet;
 
 /*
  * @test
- * @bug 7083187 8318113
+ * @bug 7083187 8318113 8318112
  * @summary  Verifies if CSS.CSSValue attribute is same
  * @run main CSSAttributeEqualityBug
  */
@@ -91,6 +91,7 @@ public class CSSAttributeEqualityBug {
             {"margin-top: 100%", "margin-top: 50%"},
 
             {"background-image: none", "background-image: url(image.png)"},
+            {"width: 100%", "width: 200 %"},
     };
 
     private static final String[][] EQUALS_WITH_SPACE = {


### PR DESCRIPTION
Java CSS where values can be displayed in percent are capped at 100% so  "width: 200%" and "width: 100%" are equal, which is incorrect. 
FIx is made to make sure parsing is not capped at 100%

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318112](https://bugs.openjdk.org/browse/JDK-8318112): CSS percentage values are capped at 100% (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17299/head:pull/17299` \
`$ git checkout pull/17299`

Update a local copy of the PR: \
`$ git checkout pull/17299` \
`$ git pull https://git.openjdk.org/jdk.git pull/17299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17299`

View PR using the GUI difftool: \
`$ git pr show -t 17299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17299.diff">https://git.openjdk.org/jdk/pull/17299.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17299#issuecomment-1880637088)