### PR TITLE
JDK-8323008: filter out harmful -std* flags added by autoconf from CXX

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -389,6 +389,12 @@ AC_DEFUN_ONCE([TOOLCHAIN_POST_DETECTION],
   # This is necessary since AC_PROG_CC defaults CFLAGS to "-g -O2"
   CFLAGS="$ORG_CFLAGS"
   CXXFLAGS="$ORG_CXXFLAGS"
+
+  # filter out some unwanted additions autoconf may add to CXX; we saw this on macOS with autoconf 2.72
+  UTIL_GET_NON_MATCHING_VALUES(cxx_filtered, $CXX, -std=c++11 -std=gnu++11)
+  if test "x$cxx_filtered" != x; then
+    CXX="$cxx_filtered"
+  fi
 ])
 
 # Check if a compiler is of the toolchain type we expect, and save the version

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -392,9 +392,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_POST_DETECTION],
 
   # filter out some unwanted additions autoconf may add to CXX; we saw this on macOS with autoconf 2.72
   UTIL_GET_NON_MATCHING_VALUES(cxx_filtered, $CXX, -std=c++11 -std=gnu++11)
-  if test "x$cxx_filtered" != x; then
-    CXX="$cxx_filtered"
-  fi
+  CXX="$cxx_filtered"
 ])
 
 # Check if a compiler is of the toolchain type we expect, and save the version

--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -199,7 +199,7 @@ AC_DEFUN([UTIL_GET_NON_MATCHING_VALUES],
   if test -z "$legal_values"; then
     $1="$2"
   else
-    result=`$GREP -Fvx "$legal_values" <<< "$values_to_check" | $GREP -v '^$'`
+    result=`$GREP -Fvx -- "$legal_values" <<< "$values_to_check" | $GREP -v '^$'`
     $1=${result//$'\n'/ }
   fi
 ])

--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -226,7 +226,7 @@ AC_DEFUN([UTIL_GET_MATCHING_VALUES],
   if test -z "$illegal_values"; then
     $1=""
   else
-    result=`$GREP -Fx "$illegal_values" <<< "$values_to_check" | $GREP -v '^$'`
+    result=`$GREP -Fx -- "$illegal_values" <<< "$values_to_check" | $GREP -v '^$'`
     $1=${result//$'\n'/ }
   fi
 ])


### PR DESCRIPTION
It was observed, that autoconf 2.72 added on macOS x86_64 the flag -std=gnu++11 by default to CXX in the configure process .
This is not really wanted so better remove / filter out those -std* flags added by autoconf from CXX .

Seems we have something similar for some time for CFLAGS and CXXFLAGS ( see TOOLCHAIN_POST_DETECTION in make/autoconf/toolchain.m4) that
 dates back to JDK 9.

See the discussion about this issue : https://mail.openjdk.org/pipermail/build-dev/2024-January/042551.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323008](https://bugs.openjdk.org/browse/JDK-8323008): filter out harmful -std* flags added by autoconf from CXX (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [ce2ef781](https://git.openjdk.org/jdk/pull/17301/files/ce2ef78196fca4d603ef5307efd9448c6acb3e08)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17301/head:pull/17301` \
`$ git checkout pull/17301`

Update a local copy of the PR: \
`$ git checkout pull/17301` \
`$ git pull https://git.openjdk.org/jdk.git pull/17301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17301`

View PR using the GUI difftool: \
`$ git pr show -t 17301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17301.diff">https://git.openjdk.org/jdk/pull/17301.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17301#issuecomment-1880724511)