### PR TITLE
8323170 - j2dbench is using outdated javac source/target to be able to build by itself

### DIFF
--- a/src/demo/share/java2d/J2DBench/Makefile
+++ b/src/demo/share/java2d/J2DBench/Makefile
@@ -120,7 +120,7 @@ $(CLASSES):
 mkdirs: $(DIST) $(CLASSES)
 
 $(CLASSES)/j2dbench/%.class: $(SOURCEPATH)/j2dbench/%.java
-	javac -g:none -source 1.7 -target 1.7 -d $(CLASSES) -sourcepath $(SOURCEPATH) $<
+	javac -g:none -source 9 -target 9 -d $(CLASSES) -sourcepath $(SOURCEPATH) $<
 
 clean:
 	rm -rf $(CLASSES)

--- a/src/demo/share/java2d/J2DBench/README
+++ b/src/demo/share/java2d/J2DBench/README
@@ -20,8 +20,8 @@ Minimum requirements
 -----------------------------------------------------------------------
 
 The benchmark requires at least jdk1.4 to compile and run. Note that
-source/target is set to 1.7 in the makefile and build.xml, because of
-support in jdk 14 compiler. To check compatibility with jdk1.4 you can
+source/target is set to 9 in the makefile and build.xml, because of
+support in jdk 22 compiler. To check compatibility with jdk1.4 you can
 use "-source 1.4 -target 1.4" options and jdk1.7.
 
 -----------------------------------------------------------------------

--- a/src/demo/share/java2d/J2DBench/build.xml
+++ b/src/demo/share/java2d/J2DBench/build.xml
@@ -49,7 +49,7 @@
   <target name="compile" depends="init"
         description="compile the source " >
     <!-- Compile the java code from ${src} into ${build} -->
-    <javac debug="off" source="1.7" target="1.7" srcdir="${src}" destdir="${build}"/>
+    <javac debug="off" source="9" target="9" srcdir="${src}" destdir="${build}"/>
   </target>
 
   <target name="run" depends="dist"


### PR DESCRIPTION
This PR is fixig to-old values of javac source/target for jdk22.
Note, that jdk21 suffers the same, only the target values have to be 8. I will be happy to backport this cange to jdk17 later.

Note, that considering the rolling release of jdk and the reached threshold of bytecode compatibility, we will be forced to do this bump every STS, so best would be to drop this hardcoded limitation. As it obtains a bit more coding, I had filled the [JDK-8323169](https://bugs.openjdk.org/browse/JDK-8323169) - [ j2dbench need constant updating of javac source/target ](https://bugs.openjdk.org/browse/JDK-8323169)  and will be happy to fit it for jdk asap once this direct fix bubbles to jdk21

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with updated jcheck configuration in pull request)

### Issue
 * [JDK-8323170](https://bugs.openjdk.org/browse/JDK-8323170): j2dbench is using outdated  javac source/target to be able to build by itself (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17303/head:pull/17303` \
`$ git checkout pull/17303`

Update a local copy of the PR: \
`$ git checkout pull/17303` \
`$ git pull https://git.openjdk.org/jdk.git pull/17303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17303`

View PR using the GUI difftool: \
`$ git pr show -t 17303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17303.diff">https://git.openjdk.org/jdk/pull/17303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17303#issuecomment-1880976312)