### PR TITLE
8322330: JavadocHelperTest.java OOMEs with Parallel GC and ZGC

### DIFF
--- a/test/langtools/jdk/internal/shellsupport/doc/JavadocHelperTest.java
+++ b/test/langtools/jdk/internal/shellsupport/doc/JavadocHelperTest.java
@@ -30,7 +30,7 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/jdk.internal.shellsupport.doc
  * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
- * @run testng/timeout=900/othervm JavadocHelperTest
+ * @run testng/timeout=900/othervm -Xmx1024m JavadocHelperTest
  */
 
 import java.io.IOException;


### PR DESCRIPTION
Hi all,

  please review this small fix to increase max heap size for the test to let it pass with GenZGC and Parallel GC as well.

The test has at least 660m of live data, so the default 768m provided by testng is too small for these collectors.

Testing: local testing

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322330](https://bugs.openjdk.org/browse/JDK-8322330): JavadocHelperTest.java OOMEs with Parallel GC and ZGC (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17304/head:pull/17304` \
`$ git checkout pull/17304`

Update a local copy of the PR: \
`$ git checkout pull/17304` \
`$ git pull https://git.openjdk.org/jdk.git pull/17304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17304`

View PR using the GUI difftool: \
`$ git pr show -t 17304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17304.diff">https://git.openjdk.org/jdk/pull/17304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17304#issuecomment-1881007868)