### PR TITLE
8310995: missing @since tags in 36 jdk.dynalink classes

### DIFF
--- a/src/jdk.dynalink/share/classes/jdk/dynalink/CallSiteDescriptor.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/CallSiteDescriptor.java
@@ -88,6 +88,7 @@ import java.util.function.Supplier;
  * the {@code MethodHandles.Lookup} object it carries. This lookup should be used
  * to find method handles to set as targets of the call site described by this
  * descriptor.
+ * @since 9
  */
 public class CallSiteDescriptor extends SecureLookupSupplier {
     private final Operation operation;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/DynamicLinker.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/DynamicLinker.java
@@ -141,6 +141,7 @@ import jdk.dynalink.support.SimpleRelinkableCallSite;
  * in the above example the {@code parseOperation} method is left unimplemented.</li>
  *
  * </ul>
+ * @since 9
  */
 public final class DynamicLinker {
     private static final String CLASS_NAME = DynamicLinker.class.getName();

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/DynamicLinkerFactory.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/DynamicLinkerFactory.java
@@ -105,6 +105,7 @@ import jdk.dynalink.linker.support.TypeUtilities;
  * {@link #setClassLoader(ClassLoader) automatically discovered} ones, and
  * finally the ones configured with {@link #setFallbackLinkers(List)}; this last
  * category usually includes {@link BeansLinker}.
+ * @since 9
  */
 public final class DynamicLinkerFactory {
     @SuppressWarnings("removal")

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/NamedOperation.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/NamedOperation.java
@@ -106,6 +106,7 @@ import java.util.Objects;
  * usually containing the textual representation of the source expression that retrieved the
  * callee, e.g. {@code StandardOperation.CALL.named("window.open")}.
  * </p>
+ * @since 9
  */
 public final class NamedOperation implements Operation {
     private final Operation baseOperation;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/Namespace.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/Namespace.java
@@ -66,6 +66,7 @@ package jdk.dynalink;
  * set of standard namespaces with the {@link StandardNamespace} enum. Operations
  * that need to specify a namespace they operate on can be expressed using
  * {@link NamespaceOperation}.
+ * @since 9
  */
 public interface Namespace {
 }

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/NamespaceOperation.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/NamespaceOperation.java
@@ -134,6 +134,7 @@ import java.util.Objects;
  *         StandardNamespace.PROPERTY)
  *     .named("empty");
  * </pre>
+ * @since 9
  */
 public final class NamespaceOperation implements Operation {
     private final Operation baseOperation;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/NoSuchDynamicMethodException.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/NoSuchDynamicMethodException.java
@@ -64,6 +64,7 @@ import jdk.dynalink.linker.GuardingDynamicLinker;
 
 /**
  * Thrown at the invocation if the call site can not be linked by any available {@link GuardingDynamicLinker}.
+ * @since 9
  */
 public class NoSuchDynamicMethodException extends RuntimeException {
     private static final long serialVersionUID = 1L;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/Operation.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/Operation.java
@@ -74,6 +74,7 @@ package jdk.dynalink;
  * {@code GET:PROPERTY|ELEMENT}), and finally we will refer to named operations
  * by separating the base operation and the name with the colon character (e.g.
  * {@code GET:PROPERTY|ELEMENT:color}).
+ * @since 9
  */
 public interface Operation {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/RelinkableCallSite.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/RelinkableCallSite.java
@@ -76,6 +76,7 @@ import jdk.dynalink.support.SimpleRelinkableCallSite;
  * method handles. A relinkable call site will be managed by a
  * {@link DynamicLinker} object after being associated with it using its
  * {@link DynamicLinker#link(RelinkableCallSite)} method.
+ * @since 9
  */
 public interface RelinkableCallSite {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/SecureLookupSupplier.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/SecureLookupSupplier.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 /**
  * Provides security-checked access to a {@code MethodHandles.Lookup} object.
  * See {@link #getLookup()} for details.
+ * @since 9
  */
 public class SecureLookupSupplier {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/StandardNamespace.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/StandardNamespace.java
@@ -62,6 +62,7 @@ package jdk.dynalink;
 
 /**
  * An enumeration of standard namespaces defined by Dynalink.
+ * @since 9
  */
 public enum StandardNamespace implements Namespace {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/StandardOperation.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/StandardOperation.java
@@ -67,6 +67,7 @@ package jdk.dynalink;
  * disappears from their type signature.
  * {@link NamedOperation} can also be used to decorate {@link #CALL} and {@link #NEW} operations with a
  * diagnostic name, and as such it does not affect their type signature.
+ * @since 9
  */
 public enum StandardOperation implements Operation {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/beans/BeansLinker.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/beans/BeansLinker.java
@@ -135,6 +135,7 @@ import jdk.dynalink.linker.TypeBasedGuardingDynamicLinker;
  * property and method names on classes and class instances, as well as access
  * to per-class linkers using the {@link #getLinkerForClass(Class)}
  * method.</p>
+ * @since 9
  */
 public class BeansLinker implements GuardingDynamicLinker {
     private static final ClassValue<TypeBasedGuardingDynamicLinker> linkers = new ClassValue<>() {

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/beans/MissingMemberHandlerFactory.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/beans/MissingMemberHandlerFactory.java
@@ -67,6 +67,7 @@ import jdk.dynalink.linker.LinkerServices;
  * exception itself, as the linkage for the missing member is often conditional.
  *
  * @see BeansLinker#BeansLinker(MissingMemberHandlerFactory)
+ * @since 9
  */
 @FunctionalInterface
 public interface MissingMemberHandlerFactory {

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/beans/StaticClass.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/beans/StaticClass.java
@@ -102,6 +102,7 @@ import jdk.dynalink.StandardOperation;
  * constructor. You might want to expose a mechanism in your language for
  * selecting a constructor with an explicit signature through
  * {@link BeansLinker#getConstructorMethod(Class, String)}.
+ * @since 9
  */
 public final class StaticClass implements Serializable {
     private static final ClassValue<StaticClass> staticClasses = new ClassValue<>() {

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/ConversionComparator.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/ConversionComparator.java
@@ -70,10 +70,12 @@ package jdk.dynalink.linker;
  * specific method with unrelated signatures. In these cases, language runtimes
  * can be asked to resolve the ambiguity by expressing preferences for one
  * conversion over the other.
+ * @since 9
  */
 public interface ConversionComparator {
     /**
      * Enumeration of possible outcomes of comparing one conversion to another.
+     * @since 9
      */
     enum Comparison {
         /** The conversions cannot be compared. **/

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardedInvocation.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardedInvocation.java
@@ -86,6 +86,7 @@ import jdk.dynalink.linker.support.Guards;
  * throw an exception of the designated type. The guard, the switch points, and
  * the exception type are all optional (a guarded invocation having none of them
  * is unconditionally valid).
+ * @since 9
  */
 public class GuardedInvocation {
     private final MethodHandle invocation;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardedInvocationTransformer.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardedInvocationTransformer.java
@@ -67,6 +67,7 @@ import jdk.dynalink.DynamicLinkerFactory;
  * another one. Typical usage is for implementing
  * {@link DynamicLinkerFactory#setPrelinkTransformer(GuardedInvocationTransformer)
  * pre-link transformers}.
+ * @since 9
  */
 @FunctionalInterface
 public interface GuardedInvocationTransformer {

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardingDynamicLinker.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardingDynamicLinker.java
@@ -87,6 +87,7 @@ import jdk.dynalink.DynamicLinkerFactory;
  * Languages can export linkers to other language runtimes for
  * {@link DynamicLinkerFactory#setClassLoader(ClassLoader) automatic discovery}
  * using a {@link GuardingDynamicLinkerExporter}.
+ * @since 9
  */
 public interface GuardingDynamicLinker {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardingDynamicLinkerExporter.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardingDynamicLinkerExporter.java
@@ -45,6 +45,7 @@ import jdk.dynalink.DynamicLinkerFactory;
  * security manager is present, to ensure that only trusted runtimes can
  * automatically export their linkers into other runtimes.
  * @see DynamicLinkerFactory#setClassLoader(ClassLoader)
+ * @since 9
  */
 public abstract class GuardingDynamicLinkerExporter implements Supplier<List<GuardingDynamicLinker>> {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardingTypeConverterFactory.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/GuardingTypeConverterFactory.java
@@ -75,6 +75,7 @@ import jdk.dynalink.linker.support.TypeUtilities;
  * these conversions, will cause more ambiguity for {@link BeansLinker} in
  * selecting the correct overload when trying to link to an overloaded Java
  * method.
+ * @since 9
  */
 public interface GuardingTypeConverterFactory {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/LinkRequest.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/LinkRequest.java
@@ -69,6 +69,7 @@ import jdk.dynalink.DynamicLinkerFactory;
  * site. Instances of these requests will be constructed and passed to all
  * {@link GuardingDynamicLinker} objects managed by the {@link DynamicLinker}
  * that is trying to link the call site.
+ * @since 9
  */
 public interface LinkRequest {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/LinkerServices.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/LinkerServices.java
@@ -73,6 +73,7 @@ import jdk.dynalink.linker.support.TypeUtilities;
 /**
  * Interface for services provided to {@link GuardingDynamicLinker} instances by
  * the {@link DynamicLinker} that owns them.
+ * @since 9
  */
 public interface LinkerServices {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/MethodHandleTransformer.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/MethodHandleTransformer.java
@@ -68,6 +68,7 @@ import jdk.dynalink.DynamicLinkerFactory;
  * Typical usage is for implementing
  * {@link DynamicLinkerFactory#setInternalObjectsFilter(MethodHandleTransformer)
  * internal objects filters}.
+ * @since 9
  */
 @FunctionalInterface
 public interface MethodHandleTransformer {

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/MethodTypeConversionStrategy.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/MethodTypeConversionStrategy.java
@@ -70,6 +70,7 @@ import jdk.dynalink.DynamicLinkerFactory;
  * of
  * {@link DynamicLinkerFactory#setAutoConversionStrategy(MethodTypeConversionStrategy)
  * method invocation conversions}.
+ * @since 9
  */
 @FunctionalInterface
 public interface MethodTypeConversionStrategy {

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/TypeBasedGuardingDynamicLinker.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/TypeBasedGuardingDynamicLinker.java
@@ -68,6 +68,7 @@ import jdk.dynalink.linker.support.CompositeTypeBasedGuardingDynamicLinker;
  * linkers will fall into this category, as they recognize their native objects as Java objects of classes implementing
  * a specific language-native interface or superclass. The linker mechanism can optimize the dispatch for these linkers,
  * see {@link CompositeTypeBasedGuardingDynamicLinker}.
+ * @since 9
  */
 public interface TypeBasedGuardingDynamicLinker extends GuardingDynamicLinker {
     /**

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/CompositeGuardingDynamicLinker.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/CompositeGuardingDynamicLinker.java
@@ -72,6 +72,7 @@ import jdk.dynalink.linker.LinkerServices;
  * A {@link GuardingDynamicLinker} that delegates sequentially to a list of
  * other guarding dynamic linkers in its
  * {@link #getGuardedInvocation(LinkRequest, LinkerServices)}.
+ * @since 9
  */
 public class CompositeGuardingDynamicLinker implements GuardingDynamicLinker {
 

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/CompositeTypeBasedGuardingDynamicLinker.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/CompositeTypeBasedGuardingDynamicLinker.java
@@ -77,6 +77,7 @@ import jdk.dynalink.linker.TypeBasedGuardingDynamicLinker;
  * returning true are then bound to the class, and next time a receiver of same
  * type is encountered, the linking is delegated to those linkers only, speeding
  * up dispatch.
+ * @since 9
  */
 public class CompositeTypeBasedGuardingDynamicLinker implements TypeBasedGuardingDynamicLinker {
     // Using a separate static class instance so there's no strong reference from the class value back to the composite

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/DefaultInternalObjectFilter.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/DefaultInternalObjectFilter.java
@@ -80,6 +80,7 @@ import jdk.dynalink.linker.MethodHandleTransformer;
  * the parameter filter as being a wrapping method for exposing internal runtime
  * objects wrapped into an adapter with some public interface, and the return
  * value filter as being its inverse unwrapping method.
+ * @since 9
  */
 public class DefaultInternalObjectFilter implements MethodHandleTransformer {
     private static final MethodHandle FILTER_VARARGS = new Lookup(MethodHandles.lookup()).findStatic(

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/Guards.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/Guards.java
@@ -72,6 +72,7 @@ import jdk.dynalink.linker.LinkerServices;
  * Utility methods for creating typical guards for
  * {@link MethodHandles#guardWithTest(MethodHandle, MethodHandle, MethodHandle)}
  * and for adjusting their method types.
+ * @since 9
  */
 public final class Guards {
     private static final Logger LOG = Logger

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/Lookup.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/Lookup.java
@@ -72,6 +72,7 @@ import java.lang.reflect.Method;
  * checked exceptions. It is useful in those cases when you're looking up
  * methods within your own codebase (therefore it is an error if they are not
  * present).
+ * @since 9
  */
 public final class Lookup {
     private final MethodHandles.Lookup lookup;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/SimpleLinkRequest.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/SimpleLinkRequest.java
@@ -66,6 +66,7 @@ import jdk.dynalink.linker.LinkRequest;
 
 /**
  * Default simple implementation of {@link LinkRequest}.
+ * @since 9
  */
 public class SimpleLinkRequest implements LinkRequest {
 

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/TypeUtilities.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/linker/support/TypeUtilities.java
@@ -70,6 +70,7 @@ import jdk.dynalink.linker.MethodTypeConversionStrategy;
 
 /**
  * Various static utility methods for working with Java types.
+ * @since 9
  */
 public final class TypeUtilities {
     private TypeUtilities() {

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/package-info.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/package-info.java
@@ -60,5 +60,6 @@
 
 /**
  * Contains interfaces and classes that are used to link an {@code invokedynamic} call site.
+ * @since 9
  */
 package jdk.dynalink;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/support/AbstractRelinkableCallSite.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/support/AbstractRelinkableCallSite.java
@@ -75,6 +75,7 @@ import jdk.dynalink.linker.GuardedInvocation;
  * {@link #relink(GuardedInvocation, MethodHandle)} and
  * {@link #resetAndRelink(GuardedInvocation, MethodHandle)}
  * methods.
+ * @since 9
  */
 public abstract class AbstractRelinkableCallSite extends MutableCallSite implements RelinkableCallSite {
     private final CallSiteDescriptor descriptor;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/support/ChainedCallSite.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/support/ChainedCallSite.java
@@ -84,6 +84,7 @@ import jdk.dynalink.linker.support.Lookup;
  * Race conditions in linking are resolved by throwing away the
  * {@link GuardedInvocation} produced on the losing thread without incorporating
  * it into the chain, so it can lead to repeated linking for the same arguments.
+ * @since 9
  */
 public class ChainedCallSite extends AbstractRelinkableCallSite {
     private static final MethodHandle PRUNE_CATCHES;

--- a/src/jdk.dynalink/share/classes/jdk/dynalink/support/SimpleRelinkableCallSite.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/support/SimpleRelinkableCallSite.java
@@ -71,6 +71,7 @@ import jdk.dynalink.linker.GuardedInvocation;
  * If the guard of that single invocation fails, or it has an invalidated
  * switch point, or its invalidating exception triggered, then the call site
  * will throw it away and ask its associated {@link DynamicLinker} to relink it.
+ * @since 9
  */
 public class SimpleRelinkableCallSite extends AbstractRelinkableCallSite {
     /**


### PR DESCRIPTION
Adding missing "@ since 9" in javadoc comment of the public classes, interfaces and packages of the jdk.dynalink module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310995](https://bugs.openjdk.org/browse/JDK-8310995): missing @<!---->since tags in 36 jdk.dynalink classes (**Bug** - P4)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Attila Szegedi](https://openjdk.org/census#attila) (@szegedi - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17305/head:pull/17305` \
`$ git checkout pull/17305`

Update a local copy of the PR: \
`$ git checkout pull/17305` \
`$ git pull https://git.openjdk.org/jdk.git pull/17305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17305`

View PR using the GUI difftool: \
`$ git pr show -t 17305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17305.diff">https://git.openjdk.org/jdk/pull/17305.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17305#issuecomment-1881013006)