### PR TITLE
8323188: JFR: Needless RESOURCE_ARRAY when sending EventOSInformation

### DIFF
--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -115,10 +115,10 @@ TRACE_REQUEST_FUNC(JVMInformation) {
 
 TRACE_REQUEST_FUNC(OSInformation) {
   ResourceMark rm;
-  char* os_name = NEW_RESOURCE_ARRAY(char, 2048);
-  JfrOSInterface::os_version(&os_name);
+  char* os_version = nullptr;
+  JfrOSInterface::os_version(&os_version);
   EventOSInformation event;
-  event.set_osVersion(os_name);
+  event.set_osVersion(os_version);
   event.commit();
 }
 


### PR DESCRIPTION
Hi,

Please help review this fix that removes a needless resource array in TRACE_REQUEST_FUNC(OSInformation).

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323188](https://bugs.openjdk.org/browse/JDK-8323188): JFR: Needless RESOURCE_ARRAY when sending EventOSInformation (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17307/head:pull/17307` \
`$ git checkout pull/17307`

Update a local copy of the PR: \
`$ git checkout pull/17307` \
`$ git pull https://git.openjdk.org/jdk.git pull/17307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17307`

View PR using the GUI difftool: \
`$ git pr show -t 17307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17307.diff">https://git.openjdk.org/jdk/pull/17307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17307#issuecomment-1881198876)