### PR TITLE
8323159: Consider adding some text re. memory zeroing in Arena::allocate

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -265,10 +265,10 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * aligned according the provided alignment constraint.
      *
      * @implSpec
-     * Implementations of this method must return a native segment featuring the
-     * requested size, and that is compatible with the provided alignment constraint.
-     * Furthermore, for any two segments {@code S1, S2} returned by this method, the
-     * following invariant must hold:
+     * Implementations of this method must return a native, zero-initialized segment
+     * featuring the requested size, and that is compatible with the provided alignment
+     * constraint. Furthermore, for any two segments {@code S1, S2} returned by
+     * this method, the following invariant must hold:
      *
      * {@snippet lang = java:
      *     S1.asOverlappingSlice(S2).isEmpty() == true

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -208,11 +208,6 @@ import java.util.function.Consumer;
  * @implSpec
  * Implementations of this interface are thread-safe.
  *
- * @implSpec
- * Arenas obtained from the factory methods {@linkplain #ofAuto()}, {@linkplain #global()}
- * {@linkplain #ofConfined()} and, {@linkplain #ofShared()} will return segments
- * that are zeroed out when invoking {@linkplain Arena#allocate(long, long) allocate()}.
- *
  * @see MemorySegment
  *
  * @since 22
@@ -224,6 +219,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * Segments allocated with the returned arena can be
      * {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by any thread.
      * Calling {@link #close()} on the returned arena will result in an {@link UnsupportedOperationException}.
+     * <p>
+     * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
+     * are zero initialized.
      *
      * @return a new arena that is managed, automatically, by the garbage collector
      */
@@ -236,6 +234,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by any thread.
      *          Calling {@link #close()} on the returned arena will result in
      *          an {@link UnsupportedOperationException}.
+     * <p>
+     * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
+     * are zero initialized.
      */
     static Arena global() {
         class Holder {
@@ -248,6 +249,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * {@return a new confined arena} Segments allocated with the confined arena can be
      *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by the thread
      *          that created the arena, the arena's <em>owner thread</em>.
+     * <p>
+     * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
+     * are zero initialized.
      */
     static Arena ofConfined() {
         return MemorySessionImpl.createConfined(Thread.currentThread()).asArena();
@@ -256,6 +260,9 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
     /**
      * {@return a new shared arena} Segments allocated with the global arena can be
      *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by any thread.
+     * <p>
+     * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
+     * are zero initialized.
      */
     static Arena ofShared() {
         return MemorySessionImpl.createShared().asArena();

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -208,6 +208,11 @@ import java.util.function.Consumer;
  * @implSpec
  * Implementations of this interface are thread-safe.
  *
+ * @implSpec
+ * Arenas obtained from the factory methods {@linkplain #ofAuto()}, {@linkplain #global()}
+ * {@linkplain #ofConfined()} and, {@linkplain #ofShared()} will return segments
+ * that are zeroed out when invoking {@linkplain Arena#allocate(long, long) allocate()}.
+ *
  * @see MemorySegment
  *
  * @since 22
@@ -265,10 +270,10 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * aligned according the provided alignment constraint.
      *
      * @implSpec
-     * Implementations of this method must return a native, zero-initialized segment
-     * featuring the requested size, and that is compatible with the provided alignment
-     * constraint. Furthermore, for any two segments {@code S1, S2} returned by
-     * this method, the following invariant must hold:
+     * Implementations of this method must return a native segment featuring the
+     * requested size, and that is compatible with the provided alignment constraint.
+     * Furthermore, for any two segments {@code S1, S2} returned by this method, the
+     * following invariant must hold:
      *
      * {@snippet lang = java:
      *     S1.asOverlappingSlice(S2).isEmpty() == true

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -221,7 +221,7 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      * Calling {@link #close()} on the returned arena will result in an {@link UnsupportedOperationException}.
      * <p>
      * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
-     * are zero initialized.
+     * are zero-initialized.
      *
      * @return a new arena that is managed, automatically, by the garbage collector
      */
@@ -236,7 +236,7 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      *          an {@link UnsupportedOperationException}.
      * <p>
      * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
-     * are zero initialized.
+     * are zero-initialized.
      */
     static Arena global() {
         class Holder {
@@ -251,7 +251,7 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      *          that created the arena, the arena's <em>owner thread</em>.
      * <p>
      * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
-     * are zero initialized.
+     * are zero-initialized.
      */
     static Arena ofConfined() {
         return MemorySessionImpl.createConfined(Thread.currentThread()).asArena();
@@ -262,7 +262,7 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
      *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by any thread.
      * <p>
      * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena
-     * are zero initialized.
+     * are zero-initialized.
      */
     static Arena ofShared() {
         return MemorySessionImpl.createShared().asArena();

--- a/test/jdk/java/foreign/TestScope.java
+++ b/test/jdk/java/foreign/TestScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,11 @@ import org.testng.annotations.*;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.util.HexFormat;
+import java.util.stream.LongStream;
 
 import static org.testng.Assert.*;
 
@@ -108,6 +111,30 @@ public class TestScope {
         testDerivedBufferScope(segment1.reinterpret(10));
     }
 
+    @Test
+    public void testZeroedOfAuto() {
+        testZeroed(Arena.ofAuto());
+    }
+
+    @Test
+    public void testZeroedGlobal() {
+        testZeroed(Arena.global());
+    }
+
+    @Test
+    public void testZeroedOfConfined() {
+        try (Arena arena = Arena.ofConfined()) {
+            testZeroed(arena);
+        }
+    }
+
+    @Test
+    public void testZeroedOfShared() {
+        try (Arena arena = Arena.ofShared()) {
+            testZeroed(arena);
+        }
+    }
+
     void testDerivedBufferScope(MemorySegment segment) {
         ByteBuffer buffer = segment.asByteBuffer();
         MemorySegment.Scope expectedScope = segment.scope();
@@ -119,4 +146,14 @@ public class TestScope {
         IntBuffer view = buffer.asIntBuffer();
         assertEquals(expectedScope, MemorySegment.ofBuffer(view).scope());
     }
+
+    private static final MemorySegment ZEROED_MEMORY = MemorySegment.ofArray(new byte[8102]);
+
+    void testZeroed(Arena arena) {
+        long byteSize = ZEROED_MEMORY.byteSize();
+        var segment = arena.allocate(byteSize, Long.BYTES);
+        long mismatch = ZEROED_MEMORY.mismatch(segment);
+        assertEquals(mismatch, -1);
+    }
+
 }


### PR DESCRIPTION
This PR proposes to add a clarification that an `Arena` always returns zeroed-out segments for `Arena::allocate` methods.

Note that other overloaded methods refer to the abstract `Arena::allocate` method via implementation notes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8323526](https://bugs.openjdk.org/browse/JDK-8323526) to be approved

### Issues
 * [JDK-8323159](https://bugs.openjdk.org/browse/JDK-8323159): Consider adding some text re. memory zeroing in Arena::allocate (**Bug** - P4)(⚠️ The fixVersion in this issue is [22] but the fixVersion in .jcheck/conf is 23, a new backport will be created when this pr is integrated.)
 * [JDK-8323526](https://bugs.openjdk.org/browse/JDK-8323526): Consider adding some text re. memory zeroing in Arena::allocate (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [878cbcae](https://git.openjdk.org/jdk/pull/17308/files/878cbcaebf19ffd6fbe81c4c00d837f7bcc8ac1c)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [878cbcae](https://git.openjdk.org/jdk/pull/17308/files/878cbcaebf19ffd6fbe81c4c00d837f7bcc8ac1c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17308/head:pull/17308` \
`$ git checkout pull/17308`

Update a local copy of the PR: \
`$ git checkout pull/17308` \
`$ git pull https://git.openjdk.org/jdk.git pull/17308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17308`

View PR using the GUI difftool: \
`$ git pr show -t 17308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17308.diff">https://git.openjdk.org/jdk/pull/17308.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17308#issuecomment-1881403329)