### PR TITLE
8323066: gc/g1/TestSkipRebuildRemsetPhase.java fails with 'Skipping Remembered Set Rebuild.' missing

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -93,7 +93,6 @@ gc/stress/gclocker/TestGCLockerWithParallel.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithSerial.java 8180622 generic-all
 gc/stress/gclocker/TestGCLockerWithShenandoah.java 8180622 generic-all
 gc/stress/TestStressG1Humongous.java 8286554 windows-x64
-gc/g1/TestSkipRebuildRemsetPhase.java 8323066 linux-aarch64
 
 #############################################################################
 

--- a/test/hotspot/jtreg/gc/g1/TestSkipRebuildRemsetPhase.java
+++ b/test/hotspot/jtreg/gc/g1/TestSkipRebuildRemsetPhase.java
@@ -45,7 +45,7 @@ public class TestSkipRebuildRemsetPhase {
                                                                     "-XX:+UnlockExperimentalVMOptions",
                                                                     "-XX:+UnlockDiagnosticVMOptions",
                                                                     "-XX:+WhiteBoxAPI",
-                                                                    "-XX:G1MixedGCLiveThresholdPercent=20",
+                                                                    "-XX:G1MixedGCLiveThresholdPercent=0",
                                                                     "-Xlog:gc+marking=debug,gc+phases=debug,gc+remset+tracking=trace",
                                                                     "-Xms10M",
                                                                     "-Xmx10M",
@@ -58,24 +58,19 @@ public class TestSkipRebuildRemsetPhase {
     public static class GCTest {
         public static void main(String args[]) throws Exception {
             WhiteBox wb = WhiteBox.getWhiteBox();
-            // Allocate some memory less than region size.
-            Object used = alloc();
+            // Allocate some memory less than region size. Any object is just fine as we set
+            // G1MixedGCLiveThresholdPercent to zero (and no region should be selected).
+            Object used = new byte[2000];
 
-            // Trigger the full GC using the WhiteBox API.
-            wb.fullGC();  // full
+            // Trigger the full GC using the WhiteBox API to make sure that at least "used"
+            // has been promoted to old gen.
+            wb.fullGC();
 
             // Memory objects have been promoted to old by full GC.
-            // Concurrent cycle should not select any regions for rebuilding
+            // Concurrent cycle should not select any regions for rebuilding and print the
+            // appropriate message.
             wb.g1RunConcurrentGC();
             System.out.println(used);
-        }
-
-        private static Object alloc() {
-            // Since G1MixedGCLiveThresholdPercent is 20%, make sure to allocate object larger than that
-            // so that it will not be collected and the expected message printed.
-            final int objectSize = WhiteBox.getWhiteBox().g1RegionSize() / 3;
-            Object ret = new byte[objectSize];
-            return ret;
         }
     }
 }

--- a/test/hotspot/jtreg/gc/g1/TestSkipRebuildRemsetPhase.java
+++ b/test/hotspot/jtreg/gc/g1/TestSkipRebuildRemsetPhase.java
@@ -74,3 +74,4 @@ public class TestSkipRebuildRemsetPhase {
         }
     }
 }
+


### PR DESCRIPTION
Hi all,

  the test is too sensitive to the amount of allocation, using an arbitrary value of `G1MixedGCLiveThresholdPercent`. This caused random test failures depending on how objects were allocated after GC in old gen, and the amount of allocations during startup.

Using a value of 0 should guarantee that no old region will ever be selected for rebuild, resulting in the correct expected message.

Testing: local testing of test case, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323066](https://bugs.openjdk.org/browse/JDK-8323066): gc/g1/TestSkipRebuildRemsetPhase.java fails with 'Skipping Remembered Set Rebuild.' missing (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [4456a0c9](https://git.openjdk.org/jdk/pull/17309/files/4456a0c9fe4530950c6b6f817faec6375cfb4d0b)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) ⚠️ Review applies to [4456a0c9](https://git.openjdk.org/jdk/pull/17309/files/4456a0c9fe4530950c6b6f817faec6375cfb4d0b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17309/head:pull/17309` \
`$ git checkout pull/17309`

Update a local copy of the PR: \
`$ git checkout pull/17309` \
`$ git pull https://git.openjdk.org/jdk.git pull/17309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17309`

View PR using the GUI difftool: \
`$ git pr show -t 17309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17309.diff">https://git.openjdk.org/jdk/pull/17309.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17309#issuecomment-1881402963)