### PR TITLE
8323213: Fix some javadoc broken links in ObjectReference, and other misc javadoc cleanups

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ObjectReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -306,7 +306,7 @@ public interface ObjectReference extends Value {
      * consequently, may result in application behavior under the
      * debugger that differs from its non-debugged behavior.
      * @throws VMCannotBeModifiedException if the VirtualMachine is read-only
-     * -see {@link VirtualMachine#canBeModified()}.
+     * - see {@link VirtualMachine#canBeModified()}.
      */
     void disableCollection();
 
@@ -317,7 +317,7 @@ public interface ObjectReference extends Value {
      * is necessary only if garbage collection was previously disabled
      * with {@link #disableCollection}.
      * @throws VMCannotBeModifiedException if the VirtualMachine is read-only
-     * -see {@link VirtualMachine#canBeModified()}.
+     * - see {@link VirtualMachine#canBeModified()}.
      */
     void enableCollection();
 
@@ -328,7 +328,7 @@ public interface ObjectReference extends Value {
      * @return <code>true</code> if this {@link ObjectReference} has been collected;
      * <code>false</code> otherwise.
      * @throws VMCannotBeModifiedException if the VirtualMachine is read-only
-     * -see {@link VirtualMachine#canBeModified()}.
+     * - see {@link VirtualMachine#canBeModified()}.
      */
     boolean isCollected();
 
@@ -351,7 +351,7 @@ public interface ObjectReference extends Value {
      * for a monitor.
      * <p>
      * Not all target VMs support this operation. See
-     * VirtualMachine#canGetMonitorInfo to determine if the
+     * {@link VirtualMachine#canGetMonitorInfo} to determine if the
      * operation is supported.
      *
      * @return a List of {@link ThreadReference} objects. The list
@@ -372,7 +372,7 @@ public interface ObjectReference extends Value {
      * of ownership.
      * <p>
      * Not all target VMs support this operation. See
-     * VirtualMachine#canGetMonitorInfo to determine if the
+     * {@link VirtualMachine#canGetMonitorInfo} to determine if the
      * operation is supported.
      *
      * @return the {@link ThreadReference} which currently owns the
@@ -392,7 +392,7 @@ public interface ObjectReference extends Value {
      * of ownership.
      * <p>
      * Not all target VMs support this operation. See
-     * VirtualMachine#canGetMonitorInfo to determine if the
+     * {@link VirtualMachine#canGetMonitorInfo} to determine if the
      * operation is supported.
      *
      * @see #owningThread
@@ -422,12 +422,12 @@ public interface ObjectReference extends Value {
      * @param maxReferrers  The maximum number of referring objects to return.
      *                      Must be non-negative.  If zero, all referring
      *                      objects are returned.
-     * @return a of List of {@link ObjectReference} objects. If there are
+     * @return a List of {@link ObjectReference} objects. If there are
      *  no objects that reference this object, a zero-length list is returned..
      * @throws java.lang.UnsupportedOperationException if
      * the target virtual machine does not support this
      * operation - see
-     * {@link VirtualMachine#canGetInstanceInfo() canGetInstanceInfo()}
+     * {@link VirtualMachine#canGetInstanceInfo()}
      * @throws java.lang.IllegalArgumentException if maxReferrers is less
      *         than zero.
      * @since 1.6

--- a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,7 +427,7 @@ public interface VirtualMachine extends Mirror {
      * @return a {@link StringReference} that mirrors the newly created
      * string in the target VM.
      * @throws VMCannotBeModifiedException if the VirtualMachine is read-only
-     * -see {@link VirtualMachine#canBeModified()}.
+     * - see {@link VirtualMachine#canBeModified()}.
      */
     StringReference mirrorOf(String value);
 
@@ -448,7 +448,7 @@ public interface VirtualMachine extends Mirror {
      * @return the {@link java.lang.Process} object for this virtual
      * machine, or null if it was not launched by a {@link LaunchingConnector}.
      * @throws VMCannotBeModifiedException if the VirtualMachine is read-only
-     * -see {@link VirtualMachine#canBeModified()}.
+     * - see {@link VirtualMachine#canBeModified()}.
      */
     Process process();
 
@@ -678,7 +678,8 @@ public interface VirtualMachine extends Mirror {
      * Determines if the target VM supports the filtering of
      * class prepare events by source name.
      *
-     * see {@link ClassPrepareRequest#addSourceNameFilter}.
+     * @see ClassPrepareRequest#addSourceNameFilter
+     *
      * @return <code>true</code> if the feature is supported,
      * <code>false</code> otherwise.
      *


### PR DESCRIPTION
Fix some broken links and other minor cleanups:

 There are a few broken links in the javadoc for ObjectReference.java. For example:

```
     * Not all target VMs support this operation. See
     * VirtualMachine#canGetMonitorInfo to determine if the
     * operation is supported.
```

Which should be:

```
     * Not all target VMs support this operation. See
     * {@link VirtualMachine#canGetMonitorInfo} to determine if the
     * operation is supported.
```


The following does not need to include the link text:

`     * {@link VirtualMachine#canGetInstanceInfo() canGetInstanceInfo()}`

Instead just use:

`     * {@link VirtualMachine#canGetInstanceInfo()}`


There are many places where we embed a "see" rather than use @see. The formatting convention is:

`     * @throws VMCannotBeModifiedException if the VirtualMachine is read-only - see {@link VirtualMachine#canBeModified()}.`

However, there are a few places that are missing a space before the "see":

```
     * @throws VMCannotBeModifiedException if the VirtualMachine is read-only
     * -see {@link VirtualMachine#canBeModified()}. 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323213](https://bugs.openjdk.org/browse/JDK-8323213): Fix some javadoc broken links in ObjectReference, and other misc javadoc cleanups (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17311/head:pull/17311` \
`$ git checkout pull/17311`

Update a local copy of the PR: \
`$ git checkout pull/17311` \
`$ git pull https://git.openjdk.org/jdk.git pull/17311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17311`

View PR using the GUI difftool: \
`$ git pr show -t 17311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17311.diff">https://git.openjdk.org/jdk/pull/17311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17311#issuecomment-1881765368)