### PR TITLE
8323241: jcmd manpage should use lists for argument lists

### DIFF
--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -172,11 +172,11 @@ Impact: Low: Depends on code heap size and content.
 Holds CodeCache_lock during analysis step, usually sub-second duration.
 .PP
 \f[I]arguments\f[R]:
-.PP
+.IP \[bu] 2
 \f[I]function\f[R]: (Optional) Function to be performed (aggregate,
 UsedSpace, FreeSpace, MethodCount, MethodSpace, MethodAge, MethodNames,
 discard (STRING, all)
-.PP
+.IP \[bu] 2
 \f[I]granularity\f[R]: (Optional) Detail level - smaller value -> more
 detail (INT, 4096)
 .RE
@@ -202,7 +202,7 @@ Adds compiler directives from a file.
 Impact: Low
 .PP
 \f[I]arguments\f[R]:
-.PP
+.IP \[bu] 2
 \f[I]filename\f[R]: The name of the directives file (STRING, no default
 value)
 .RE
@@ -253,7 +253,7 @@ Write map file for Linux perf tool.
 Impact: Low
 .PP
 \f[I]arguments\f[R]:
-.PP
+.IP \[bu] 2
 \f[I]filename\f[R]: (Optional) The name of the map file (STRING, no
 default value)
 .RE


### PR DESCRIPTION
Trivial fix to the formatting of "argument" lists for a few sub-commands.
Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323241](https://bugs.openjdk.org/browse/JDK-8323241): jcmd manpage should use lists for argument lists (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17318/head:pull/17318` \
`$ git checkout pull/17318`

Update a local copy of the PR: \
`$ git checkout pull/17318` \
`$ git pull https://git.openjdk.org/jdk.git pull/17318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17318`

View PR using the GUI difftool: \
`$ git pr show -t 17318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17318.diff">https://git.openjdk.org/jdk/pull/17318.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17318#issuecomment-1882231135)