### PR TITLE
8323210: Update the usage of cmsFLAGS_COPY_ALPHA

### DIFF
--- a/src/java.desktop/share/native/liblcms/LCMS.c
+++ b/src/java.desktop/share/native/liblcms/LCMS.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,8 +177,13 @@ JNIEXPORT jlong JNICALL Java_sun_java2d_cmm_lcms_LCMS_createNativeTransform
         }
     }
 
+    cmsUInt32Number dwFlags = 0;
+    if (T_EXTRA(inFormatter) > 0 && T_EXTRA(outFormatter) > 0) {
+        dwFlags |= cmsFLAGS_COPY_ALPHA;
+    }
+
     sTrans = cmsCreateMultiprofileTransform(iccArray, j,
-        inFormatter, outFormatter, renderingIntent, cmsFLAGS_COPY_ALPHA);
+        inFormatter, outFormatter, renderingIntent, dwFlags);
 
     (*env)->ReleaseLongArrayElements(env, profileIDs, ids, 0);
 

--- a/test/jdk/sun/java2d/cmm/ColorConvertOp/ColCvtAlphaDifferentSrcDst.java
+++ b/test/jdk/sun/java2d/cmm/ColorConvertOp/ColCvtAlphaDifferentSrcDst.java
@@ -52,7 +52,7 @@ import static java.awt.image.BufferedImage.TYPE_USHORT_GRAY;
 
 /*
  * @test
- * @bug 8012229 8300725 8279216
+ * @bug 8012229 8300725 8279216 8323210
  * @summary one more test to check the alpha channel
  */
 public final class ColCvtAlphaDifferentSrcDst {


### PR DESCRIPTION
Implementation of cmsFLAGS_COPY_ALPHA in littlecms 2.16 is changed to throw an exception:
 - if the number of extra channels in src and dst are different.
 - If dst does not have an alpha but src has
 - If src does not have an alpha but dst has

Exception does not occurred if the number of extra channels are the same(even if both are zero)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323210](https://bugs.openjdk.org/browse/JDK-8323210): Update the usage of cmsFLAGS_COPY_ALPHA (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17320/head:pull/17320` \
`$ git checkout pull/17320`

Update a local copy of the PR: \
`$ git checkout pull/17320` \
`$ git pull https://git.openjdk.org/jdk.git pull/17320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17320`

View PR using the GUI difftool: \
`$ git pr show -t 17320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17320.diff">https://git.openjdk.org/jdk/pull/17320.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17320#issuecomment-1882650876)