### PR TITLE
8323264: Serial: Remove unused GenerationBlockSizeClosure

### DIFF
--- a/src/hotspot/share/gc/serial/generation.cpp
+++ b/src/hotspot/share/gc/serial/generation.cpp
@@ -173,18 +173,6 @@ HeapWord* Generation::block_start(const void* p) const {
   return blk._start;
 }
 
-class GenerationBlockSizeClosure : public SpaceClosure {
- public:
-  const HeapWord* _p;
-  size_t size;
-  virtual void do_space(Space* s) {
-    if (size == 0 && s->is_in_reserved(_p)) {
-      size = s->block_size(_p);
-    }
-  }
-  GenerationBlockSizeClosure(const HeapWord* p) { _p = p; size = 0; }
-};
-
 class GenerationBlockIsObjClosure : public SpaceClosure {
  public:
   const HeapWord* _p;


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323264](https://bugs.openjdk.org/browse/JDK-8323264): Serial: Remove unused GenerationBlockSizeClosure (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17321/head:pull/17321` \
`$ git checkout pull/17321`

Update a local copy of the PR: \
`$ git checkout pull/17321` \
`$ git pull https://git.openjdk.org/jdk.git pull/17321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17321`

View PR using the GUI difftool: \
`$ git pr show -t 17321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17321.diff">https://git.openjdk.org/jdk/pull/17321.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17321#issuecomment-1882658928)