### PR TITLE
8323284: Remove unused FilteringClosure declaration

### DIFF
--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -51,7 +51,6 @@ class Generation;
 class ContiguousSpace;
 class CardTableRS;
 class DirtyCardToOopClosure;
-class FilteringClosure;
 
 // A Space describes a heap area. Class Space is an abstract
 // base class.

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -45,8 +45,6 @@
 
 // Forward declarations.
 class OopClosure;
-class FilteringClosure;
-
 class PSPromotionManager;
 class ParCompactionManager;
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323284](https://bugs.openjdk.org/browse/JDK-8323284): Remove unused FilteringClosure declaration (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17323/head:pull/17323` \
`$ git checkout pull/17323`

Update a local copy of the PR: \
`$ git checkout pull/17323` \
`$ git pull https://git.openjdk.org/jdk.git pull/17323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17323`

View PR using the GUI difftool: \
`$ git pr show -t 17323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17323.diff">https://git.openjdk.org/jdk/pull/17323.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17323#issuecomment-1883032688)