### PR TITLE
8322324: java/foreign/TestStubAllocFailure.java times out while waiting for forked process

### DIFF
--- a/test/jdk/java/foreign/UpcallTestHelper.java
+++ b/test/jdk/java/foreign/UpcallTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/UpcallTestHelper.java
+++ b/test/jdk/java/foreign/UpcallTestHelper.java
@@ -29,8 +29,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class UpcallTestHelper extends NativeTestHelper {
 
@@ -50,16 +51,18 @@ public class UpcallTestHelper extends NativeTestHelper {
         command.add(target.getName());
         command.addAll(programArgs);
 
-        Process process = ProcessTools.createTestJavaProcessBuilder(command).start();
-
-        long timeOut = (long) (Utils.TIMEOUT_FACTOR * 1L);
-        boolean completed = process.waitFor(timeOut, TimeUnit.MINUTES);
-        assertTrue(completed, "Time out while waiting for process");
-
-        OutputAnalyzer output = new OutputAnalyzer(process);
-        output.outputTo(System.out);
-        output.errorTo(System.err);
-
-        return output;
+        try {
+            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(command);
+            // note that it's important to use ProcessTools.startProcess here since this makes sure output streams of the
+            // fork don't fill up, which could make the process stall while writing to stdout/stderr
+            Process process = ProcessTools.startProcess(target.getName(), pb, null, null, 1L, TimeUnit.MINUTES);
+            OutputAnalyzer output = new OutputAnalyzer(process);
+            output.outputTo(System.out);
+            output.errorTo(System.err);
+            return output;
+        } catch (TimeoutException e) {
+            fail("Timeout while waiting for forked process");
+            return null;
+        }
     }
 }


### PR DESCRIPTION
The issue with this test, and the test of JDK-8322324, seems to be that the forked processes write to stderr/stdout, without this output being read before the process terminates. The buffer might fill up if the output is not being read, which means that the process will stall when writing (see stack trace in JBS issue).

`OutputAnalyzer` has ways to prevent this by continuously reading from the output streams in separate threads, but because the current code calls `Process::waitFor` before creating the `OutputAnalyzer`, we never actually read the written output of the fork, which occasionally results in a stall and subsequent timeout.

The fix proposed by this patch is to use `ProcessTools::startProcess`, instead of `ProcessBuilder::start`, which will also start the necessary reader threads, preventing a stall. Incidentally, `startProcess` also has built-in timeout handling which we can use.

Testing:
-  500 runs of both java/foreign/TestStubAllocFailure.java and java/foreign/critical/TestCriticalUpcall on various Windows x64 hosts (100 iterations was enough to observe the failure twice).
-  `jdk_foreign` suite.

/solves JDK-8322637

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8322324](https://bugs.openjdk.org/browse/JDK-8322324): java/foreign/TestStubAllocFailure.java times out while waiting for forked process (**Bug** - P2)
 * [JDK-8322637](https://bugs.openjdk.org/browse/JDK-8322637): java/foreign/critical/TestCriticalUpcall.java timed out (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [2ba2851c](https://git.openjdk.org/jdk/pull/17324/files/2ba2851cf39312f5faf6cdda6c65ab9d9a989e48)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17324/head:pull/17324` \
`$ git checkout pull/17324`

Update a local copy of the PR: \
`$ git checkout pull/17324` \
`$ git pull https://git.openjdk.org/jdk.git pull/17324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17324`

View PR using the GUI difftool: \
`$ git pr show -t 17324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17324.diff">https://git.openjdk.org/jdk/pull/17324.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17324#issuecomment-1883297984)