### PR TITLE
8314186: runtime/8176717/TestInheritFD.java failed with "Log file was leaked"

### DIFF
--- a/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
+++ b/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
@@ -308,8 +308,9 @@ public class TestInheritFD {
                 if (e instanceof TimeoutException) {
                     TimeoutException te = (TimeoutException)e;
                     System.out.println("(Third VM) Timed out waiting for second VM: " + te.toString());
+                } else {
+                    System.out.println("(Third VM) Exception was thrown: " + e.toString());
                 }
-                System.out.println("(Third VM) Exception was thrown: " + e.toString());
                 throw e;
             } finally {
                 System.out.println(EXIT);

--- a/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
+++ b/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -255,7 +256,7 @@ public class TestInheritFD {
         } else if (result == Result.FOUND_LEAKS_FD) {
             throw new RuntimeException("Log file was leaked to the third VM.");
         } else {
-            throw new RuntimeException("Found neither message, I am confused!");
+            throw new RuntimeException("Found neither message, test failed to run correctly");
         }
         System.out.println("First VM ends.");
     }
@@ -304,13 +305,11 @@ public class TestInheritFD {
                 if (false) {  // Enable to simulate a timeout in the third VM.
                     Thread.sleep(300 * 1000);
                 }
+            } catch (CompletionException e) {
+                System.out.println("(Third VM) Timed out waiting for second VM: " + e.toString());
+                throw e;
             } catch (Exception e) {
-                if (e instanceof TimeoutException) {
-                    TimeoutException te = (TimeoutException)e;
-                    System.out.println("(Third VM) Timed out waiting for second VM: " + te.toString());
-                } else {
-                    System.out.println("(Third VM) Exception was thrown: " + e.toString());
-                }
+                System.out.println("(Third VM) Exception was thrown: " + e.toString());
                 throw e;
             } finally {
                 System.out.println(EXIT);

--- a/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
+++ b/test/hotspot/jtreg/runtime/8176717/TestInheritFD.java
@@ -306,7 +306,11 @@ public class TestInheritFD {
                     Thread.sleep(300 * 1000);
                 }
             } catch (CompletionException e) {
-                System.out.println("(Third VM) Timed out waiting for second VM: " + e.toString());
+                if (e.getCause() instanceof TimeoutException) {
+                    System.out.println("(Third VM) Timed out waiting for second VM: " + e.toString());
+                } else {
+                    System.out.println("(Third VM) Exception was thrown: " + e.toString());
+                }
                 throw e;
             } catch (Exception e) {
                 System.out.println("(Third VM) Exception was thrown: " + e.toString());


### PR DESCRIPTION
Hi,

This PR intends to make the test a bit more sturdy by looking for both the success string and the failure string, reporting that the test messed up if neither are found. I also removed the extra newline at the end of the file and did some special reporting in case of a `TimeoutException`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314186](https://bugs.openjdk.org/browse/JDK-8314186): runtime/8176717/TestInheritFD.java failed with "Log file was leaked" (**Bug** - P4)


### Reviewers
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**) ⚠️ Review applies to [f1ae2575](https://git.openjdk.org/jdk/pull/17325/files/f1ae257542f2826781eeb10cda069de8379762b8)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17325/head:pull/17325` \
`$ git checkout pull/17325`

Update a local copy of the PR: \
`$ git checkout pull/17325` \
`$ git pull https://git.openjdk.org/jdk.git pull/17325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17325`

View PR using the GUI difftool: \
`$ git pr show -t 17325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17325.diff">https://git.openjdk.org/jdk/pull/17325.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17325#issuecomment-1883203747)