### PR TITLE
8323318: Remove unused Space::is_free_block

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -74,10 +74,6 @@ void ContiguousSpace::clear(bool mangle_space) {
   }
 }
 
-bool ContiguousSpace::is_free_block(const HeapWord* p) const {
-  return p >= _top;
-}
-
 #ifndef PRODUCT
 
 void ContiguousSpace::set_top_for_allocations(HeapWord* v) {

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -133,9 +133,6 @@ class Space: public CHeapObj<mtGC> {
   // given address.
   bool is_in_reserved(const void* p) const { return _bottom <= p && p < _end; }
 
-  // Returns true iff the given block is not allocated.
-  virtual bool is_free_block(const HeapWord* p) const = 0;
-
   // Test whether p is double-aligned
   static bool is_aligned(void* p) {
     return ::is_aligned(p, sizeof(double));
@@ -272,8 +269,6 @@ protected:
   // Size computations: sizes in bytes.
   size_t used() const override   { return byte_size(bottom(), top()); }
   size_t free() const override   { return byte_size(top(),    end()); }
-
-  bool is_free_block(const HeapWord* p) const override;
 
   // In a contiguous space we have a more obvious bound on what parts
   // contain objects.


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323318](https://bugs.openjdk.org/browse/JDK-8323318): Remove unused Space::is_free_block (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17327/head:pull/17327` \
`$ git checkout pull/17327`

Update a local copy of the PR: \
`$ git checkout pull/17327` \
`$ git pull https://git.openjdk.org/jdk.git pull/17327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17327`

View PR using the GUI difftool: \
`$ git pr show -t 17327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17327.diff">https://git.openjdk.org/jdk/pull/17327.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17327#issuecomment-1883327813)