### PR TITLE
JDK-8323190: Segfault during deoptimization of C2-compiled code

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1085,6 +1085,30 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
           }
           scval = sv;
         }
+      } else if (obj_node->is_SafePointScalarMerge()) {
+        SafePointScalarMergeNode* smerge = obj_node->as_SafePointScalarMerge();
+        ObjectMergeValue* mv = (ObjectMergeValue*) sv_for_node_id(objs, smerge->_idx);
+
+        if (mv == NULL) {
+          GrowableArray<ScopeValue*> deps;
+
+          int merge_pointer_idx = smerge->merge_pointer_idx(youngest_jvms);
+          (void)FillLocArray(0, sfn, sfn->in(merge_pointer_idx), &deps, objs);
+          assert(deps.length() == 1, "missing value");
+
+          int selector_idx = smerge->selector_idx(youngest_jvms);
+          (void)FillLocArray(1, NULL, sfn->in(selector_idx), &deps, NULL);
+          assert(deps.length() == 2, "missing value");
+
+          mv = new ObjectMergeValue(smerge->_idx, deps.at(0), deps.at(1));
+          set_sv_for_object_node(objs, mv);
+
+          for (uint i = 1; i < smerge->req(); i++) {
+            Node* obj_node = smerge->in(i);
+            (void)FillLocArray(mv->possible_objects()->length(), sfn, obj_node, mv->possible_objects(), objs);
+          }
+        }
+        scval = mv;
       } else if (!obj_node->is_Con()) {
         OptoReg::Name obj_reg = C->regalloc()->get_reg_first(obj_node);
         if( obj_node->bottom_type()->base() == Type::NarrowOop ) {

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -775,7 +775,7 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
     SafePointScalarMergeNode* smerge = local->as_SafePointScalarMerge();
     ObjectMergeValue* mv = (ObjectMergeValue*) sv_for_node_id(objs, smerge->_idx);
 
-    if (mv == NULL) {
+    if (mv == nullptr) {
       GrowableArray<ScopeValue*> deps;
 
       int merge_pointer_idx = smerge->merge_pointer_idx(sfpt->jvms());
@@ -783,7 +783,7 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
       assert(deps.length() == 1, "missing value");
 
       int selector_idx = smerge->selector_idx(sfpt->jvms());
-      (void)FillLocArray(1, NULL, sfpt->in(selector_idx), &deps, NULL);
+      (void)FillLocArray(1, nullptr, sfpt->in(selector_idx), &deps, nullptr);
       assert(deps.length() == 2, "missing value");
 
       mv = new ObjectMergeValue(smerge->_idx, deps.at(0), deps.at(1));
@@ -1089,7 +1089,7 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
         SafePointScalarMergeNode* smerge = obj_node->as_SafePointScalarMerge();
         ObjectMergeValue* mv = (ObjectMergeValue*) sv_for_node_id(objs, smerge->_idx);
 
-        if (mv == NULL) {
+        if (mv == nullptr) {
           GrowableArray<ScopeValue*> deps;
 
           int merge_pointer_idx = smerge->merge_pointer_idx(youngest_jvms);
@@ -1097,7 +1097,7 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
           assert(deps.length() == 1, "missing value");
 
           int selector_idx = smerge->selector_idx(youngest_jvms);
-          (void)FillLocArray(1, NULL, sfn->in(selector_idx), &deps, NULL);
+          FillLocArray(1, nullptr, sfn->in(selector_idx), &deps, nullptr);
           assert(deps.length() == 2, "missing value");
 
           mv = new ObjectMergeValue(smerge->_idx, deps.at(0), deps.at(1));
@@ -1105,7 +1105,7 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
 
           for (uint i = 1; i < smerge->req(); i++) {
             Node* obj_node = smerge->in(i);
-            (void)FillLocArray(mv->possible_objects()->length(), sfn, obj_node, mv->possible_objects(), objs);
+            FillLocArray(mv->possible_objects()->length(), sfn, obj_node, mv->possible_objects(), objs);
           }
         }
         scval = mv;

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1093,7 +1093,7 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
           GrowableArray<ScopeValue*> deps;
 
           int merge_pointer_idx = smerge->merge_pointer_idx(youngest_jvms);
-          (void)FillLocArray(0, sfn, sfn->in(merge_pointer_idx), &deps, objs);
+          FillLocArray(0, sfn, sfn->in(merge_pointer_idx), &deps, objs);
           assert(deps.length() == 1, "missing value");
 
           int selector_idx = smerge->selector_idx(youngest_jvms);

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
@@ -1,0 +1,64 @@
+/* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8323190
+ * @summary C2 Segfaults during code generation because of unhandled SafePointScalarMerge monitor debug info.
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xcomp -Xbatch -XX:+ReduceAllocationMerges TestInvalidLocation
+ */
+
+public class TestInvalidLocation {
+    static boolean var2 = true;
+    static double[] var4 = new double[1];
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10; i++) {
+            System.out.println(test());
+        }
+    }
+
+    static Class0 test() {
+        double[] var14;
+        double var3;
+        StringBuilder var1 = new StringBuilder();
+        Class0 var0 = Class1.Class1_sfield0;
+        synchronized (var2 ? new StringBuilder() : var1) {
+            var14 = var4;
+            for (int i0 = 0; i0 < var0.Class0_field0.length && i0 < var14.length; i0 = 1) {
+                var3 = var14[i0];
+            }
+        }
+        return var0;
+    }
+
+    static class Class0 {
+        double[] Class0_field0;
+        Class0() {
+            Class0_field0 = new double[] { 85.42200639495138 };
+        }
+    }
+
+    class Class1 {
+        static Class0 Class1_sfield0 = new Class0();
+    }
+}

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
@@ -24,7 +24,7 @@
  * @test
  * @bug 8323190
  * @summary C2 Segfaults during code generation because of unhandled SafePointScalarMerge monitor debug info.
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xcomp -Xbatch -XX:+ReduceAllocationMerges TestInvalidLocation
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xcomp -XX:+ReduceAllocationMerges TestInvalidLocation
  */
 
 public class TestInvalidLocation {

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestInvalidLocation.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+/* 
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Currently, if `ReduceAllocationMerges` reduces an allocation merge that is used as a monitor C2 will SIGFAULT in `Process_OopMap_Node` because it's missing code to handle that case.  This patch fixes C2 to properly handle reduced allocation merges that are used as monitors. 

Tested with Linux x86_64 hotspot_all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323190](https://bugs.openjdk.org/browse/JDK-8323190): Segfault during deoptimization of C2-compiled code (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17333/head:pull/17333` \
`$ git checkout pull/17333`

Update a local copy of the PR: \
`$ git checkout pull/17333` \
`$ git pull https://git.openjdk.org/jdk.git pull/17333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17333`

View PR using the GUI difftool: \
`$ git pr show -t 17333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17333.diff">https://git.openjdk.org/jdk/pull/17333.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17333#issuecomment-1884049242)