### PR TITLE
JDK-8317804: com/sun/jdi/JdwpAllowTest.java fails on Alpine 3.17 / 3.18

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -752,7 +752,7 @@ socketTransport_startListening(jdwpTransportEnv* env, const char* address,
 
         if (isEqualIPv6Addr(listenAddr, mappedAny)) {
             for (ai = addrInfo; ai != NULL; ai = ai->ai_next) {
-                if (isEqualIPv6Addr(listenAddr, in6addr_any)) {
+                if (isEqualIPv6Addr(ai, in6addr_any)) {
                     listenAddr = ai;
                     break;
                 }


### PR DESCRIPTION
The change fixes workaround introduced by [[JDK-8250630]](https://bugs.openjdk.org/browse/JDK-8250630).
The root cause of the test failure was identified by JDK-8250630:
On Apline Linux getaddrinfo function returns 2 entries for "any" address - mapped IPv4 (`::ffff:0.0.0.0`) and IPv6 (`::`) and IPv4 is returned first.
When JDWP agent listens on mapped IPv4, it accepts only connections from IPv4 addresses, connections from IPv6 addresses fail with "connection refused" error.
Fix for JDK-8250630 introduced workaround for the case - if we get `::ffff:0.0.0.0` (`mappedAny`) and `::` (`in6addr_any`) is also returned by getaddrinfo, agent uses `in6addr_any` for listening.

But the fix had a typo - the loop goes through returned addresses (`ai` variable), but checks if `listenAddr` equals `in6addr_any`. This is always false (because `listenAddr` equals `mappedAny`), so the workaround does not work.

Submitter confirmed that the fix resolves the issue.

Testing: tier1, all JDI-related tests (test/hotspot/jtreg/vmTestbase/nsk/jdwp, test/hotspot/jtreg/vmTestbase/nsk/jdi, test/hotspot/jtreg/vmTestbase/nsk/jdb, test/jdk/com/sun/jdi)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317804](https://bugs.openjdk.org/browse/JDK-8317804): com/sun/jdi/JdwpAllowTest.java fails on Alpine 3.17 / 3.18 (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17334/head:pull/17334` \
`$ git checkout pull/17334`

Update a local copy of the PR: \
`$ git checkout pull/17334` \
`$ git pull https://git.openjdk.org/jdk.git pull/17334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17334`

View PR using the GUI difftool: \
`$ git pr show -t 17334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17334.diff">https://git.openjdk.org/jdk/pull/17334.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17334#issuecomment-1884070460)