### PR TITLE
8323122: AArch64: Increase itable stub size estimate

### DIFF
--- a/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vtableStubs_aarch64.cpp
@@ -197,7 +197,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
                                   temp_reg, temp_reg2, itable_index, L_no_such_interface);
 
   // Reduce "estimate" such that "padding" does not drop below 8.
-  const ptrdiff_t estimate = 124;
+  const ptrdiff_t estimate = 144;
   const ptrdiff_t codesize = __ pc() - start_pc;
   slop_delta  = (int)(estimate - codesize);
   slop_bytes += slop_delta;


### PR DESCRIPTION
Since [JDK-8307352](https://bugs.openjdk.org/browse/JDK-8307352), itable stub size has grown by 20 bytes on linux-aarch64. In particular, the "slop-counted" code increases from 100->120 bytes, where the current estimate is 124 bytes. I haven't found a case where it exceeds the estimate. For now this size is stable across the few linux-aarch64 configurations I ran with. It doesn't vary (for example) by different klass decoding schemes. But I think the idea of the estimate is that we can never know. I propose we increase the estimate to be safe.

Passed hotspot/jtreg/:tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323122](https://bugs.openjdk.org/browse/JDK-8323122): AArch64: Increase itable stub size estimate (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17336/head:pull/17336` \
`$ git checkout pull/17336`

Update a local copy of the PR: \
`$ git checkout pull/17336` \
`$ git pull https://git.openjdk.org/jdk.git pull/17336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17336`

View PR using the GUI difftool: \
`$ git pr show -t 17336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17336.diff">https://git.openjdk.org/jdk/pull/17336.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17336#issuecomment-1884077788)