### PR TITLE
JDK-8323330: [BACKOUT] JDK-8276809: java/awt/font/JNICheck/FreeTypeScalerJNICheck.java shows JNI warning on Windows

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Win32GraphicsEnv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,15 +126,9 @@ BOOL DWMIsCompositionEnabled() {
     dwmIsCompositionEnabled = bRes;
 
     JNIEnv *env = (JNIEnv *)JNU_GetEnv(jvm, JNI_VERSION_1_2);
-    jboolean hasException;
-    JNU_CallStaticMethodByName(env, &hasException,
+    JNU_CallStaticMethodByName(env, NULL,
                               "sun/awt/Win32GraphicsEnvironment",
                               "dwmCompositionChanged", "(Z)V", (jboolean)bRes);
-    if (hasException) {
-        J2dTraceLn(J2D_TRACE_INFO, "Exception occurred in DWMIsCompositionEnabled");
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-    }
     return bRes;
 }
 


### PR DESCRIPTION
There have been concerns raised about [JDK-8276809](https://bugs.openjdk.org/browse/JDK-8276809) , so bring back the old behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323330](https://bugs.openjdk.org/browse/JDK-8323330): [BACKOUT] JDK-8276809: java/awt/font/JNICheck/FreeTypeScalerJNICheck.java shows JNI warning on Windows (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17341/head:pull/17341` \
`$ git checkout pull/17341`

Update a local copy of the PR: \
`$ git checkout pull/17341` \
`$ git pull https://git.openjdk.org/jdk.git pull/17341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17341`

View PR using the GUI difftool: \
`$ git pr show -t 17341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17341.diff">https://git.openjdk.org/jdk/pull/17341.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17341#issuecomment-1884475333)