### PR TITLE
8323508: Remove TestGCLockerWithShenandoah.java line from TEST.groups

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -356,7 +356,6 @@ tier2_gc_shenandoah = \
 tier3_gc_shenandoah = \
   gc/stress/gcold/TestGCOldWithShenandoah.java \
   gc/stress/gcbasher/TestGCBasherWithShenandoah.java \
-  gc/stress/gclocker/TestGCLockerWithShenandoah.java \
   gc/stress/systemgc/TestSystemGCWithShenandoah.java \
   gc/shenandoah/TestStringDedupStress.java \
   -:tier2_gc_shenandoah

--- a/test/jdk/java/lang/String/StringRacyConstructor.java
+++ b/test/jdk/java/lang/String/StringRacyConstructor.java
@@ -43,8 +43,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @bug 8311906
  * @modules java.base/java.lang:open
  * @summary check String's racy constructors
- * @run junit/othervm -XX:+CompactStrings test.java.lang.String.StringRacyConstructor
- * @run junit/othervm -XX:-CompactStrings test.java.lang.String.StringRacyConstructor
+ * @run junit test.java.lang.String.StringRacyConstructor
  */
 
 public class StringRacyConstructor {
@@ -154,23 +153,32 @@ public class StringRacyConstructor {
     }
 
     private static List<String> strings() {
-        return List.of("01234", " ");
+        int s = Integer.getInteger("selection", 0);
+        if (s == 0) {
+            return List.of("01234", " ");
+        } else {
+            String[] array = new String[s];
+            for (int i = 0; i < s; i++) {
+                array[i] = " ";
+            }
+			return List.of(array);
+        }
     }
 
-    @ParameterizedTest
     @MethodSource("strings")
     @EnabledIf("test.java.lang.String.StringRacyConstructor#isCompactStrings")
-    public void racyString(String orig) {
+    public void racyString() {
+        String orig = " ";
         String racyString = racyStringConstruction(orig);
         // The contents are indeterminate due to the race
         assertTrue(validCoder(racyString), orig + " string invalid"
                 + ", racyString: " + inspectString(racyString));
     }
 
-    @ParameterizedTest
     @MethodSource("strings")
     @EnabledIf("test.java.lang.String.StringRacyConstructor#isCompactStrings")
-    public void racyCodePoint(String orig) {
+    public void racyCodePoint() {
+        String orig = " ";
         String iffyString = racyStringConstructionCodepoints(orig);
         // The contents are indeterminate due to the race
         assertTrue(validCoder(iffyString), "invalid coder in non-deterministic string"

--- a/test/jdk/java/lang/String/StringRacyConstructor.java
+++ b/test/jdk/java/lang/String/StringRacyConstructor.java
@@ -43,7 +43,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @bug 8311906
  * @modules java.base/java.lang:open
  * @summary check String's racy constructors
- * @run junit test.java.lang.String.StringRacyConstructor
+ * @run junit/othervm -XX:+CompactStrings test.java.lang.String.StringRacyConstructor
+ * @run junit/othervm -XX:-CompactStrings test.java.lang.String.StringRacyConstructor
  */
 
 public class StringRacyConstructor {
@@ -153,32 +154,23 @@ public class StringRacyConstructor {
     }
 
     private static List<String> strings() {
-        int s = Integer.getInteger("selection", 0);
-        if (s == 0) {
-            return List.of("01234", " ");
-        } else {
-            String[] array = new String[s];
-            for (int i = 0; i < s; i++) {
-                array[i] = " ";
-            }
-			return List.of(array);
-        }
+        return List.of("01234", " ");
     }
 
+    @ParameterizedTest
     @MethodSource("strings")
     @EnabledIf("test.java.lang.String.StringRacyConstructor#isCompactStrings")
-    public void racyString() {
-        String orig = " ";
+    public void racyString(String orig) {
         String racyString = racyStringConstruction(orig);
         // The contents are indeterminate due to the race
         assertTrue(validCoder(racyString), orig + " string invalid"
                 + ", racyString: " + inspectString(racyString));
     }
 
+    @ParameterizedTest
     @MethodSource("strings")
     @EnabledIf("test.java.lang.String.StringRacyConstructor#isCompactStrings")
-    public void racyCodePoint() {
-        String orig = " ";
+    public void racyCodePoint(String orig) {
         String iffyString = racyStringConstructionCodepoints(orig);
         // The contents are indeterminate due to the race
         assertTrue(validCoder(iffyString), "invalid coder in non-deterministic string"


### PR DESCRIPTION
TestGCLockerWithShenandoah.java was recently removed, but the TEST.groups file still has a reference to it. This causes problems in our CI pipeline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323508](https://bugs.openjdk.org/browse/JDK-8323508): Remove TestGCLockerWithShenandoah.java line from TEST.groups (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [20eae67d](https://git.openjdk.org/jdk/pull/17344/files/20eae67d4b55f3fb5151927de5e660ecf9c4f347)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17344/head:pull/17344` \
`$ git checkout pull/17344`

Update a local copy of the PR: \
`$ git checkout pull/17344` \
`$ git pull https://git.openjdk.org/jdk.git pull/17344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17344`

View PR using the GUI difftool: \
`$ git pr show -t 17344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17344.diff">https://git.openjdk.org/jdk/pull/17344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17344#issuecomment-1884754618)