### PR TITLE
8325505: Fix Javadoc ResourceBundle::getString

### DIFF
--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -508,7 +508,7 @@ public abstract class ResourceBundle {
      * Gets a string for the given key from this resource bundle or one of its parents.
      * Calling this method is equivalent to calling
      * {@snippet lang=java :
-     *     // @link substring="getObject" target="#getObject(java.lang.String)"
+     *     // @link substring="getObject" target="#getObject(java.lang.String)" :
      *     (String) getObject(key);
      * }
      *
@@ -526,7 +526,7 @@ public abstract class ResourceBundle {
      * Gets a string array for the given key from this resource bundle or one of its parents.
      * Calling this method is equivalent to calling
      * {@snippet lang=java :
-     *     // @link substring="getObject" target="#getObject(java.lang.String)"
+     *     // @link substring="getObject" target="#getObject(java.lang.String)" :
      *     (String[]) getObject(key);
      * }
      *

--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -509,7 +509,7 @@ public abstract class ResourceBundle {
      * Calling this method is equivalent to calling
      * {@snippet lang=java :
      *     // @link substring="getObject" target="#getObject(java.lang.String)"
-     *     (String[]) getObject(key);
+     *     (String) getObject(key);
      * }
      *
      * @param key the key for the desired string


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325505](https://bugs.openjdk.org/browse/JDK-8325505): Fix Javadoc ResourceBundle::getString (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17346/head:pull/17346` \
`$ git checkout pull/17346`

Update a local copy of the PR: \
`$ git checkout pull/17346` \
`$ git pull https://git.openjdk.org/jdk.git pull/17346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17346`

View PR using the GUI difftool: \
`$ git pr show -t 17346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17346.diff">https://git.openjdk.org/jdk/pull/17346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17346#issuecomment-1934443556)