### PR TITLE
JDK-8316756: C2 EA fails with "missing memory path" when encountering unsafe_arraycopy stub call

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -4006,6 +4006,13 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
       if (n == nullptr) {
         continue;
       }
+    } else if (n->is_CallLeaf()) {
+      // Runtime calls with narrow memory input (no MergeMem node)
+      // get the memory projection
+      n = n->as_Call()->proj_out_or_null(TypeFunc::Memory);
+      if (n == nullptr) {
+        continue;
+      }
     } else if (n->Opcode() == Op_StrCompressedCopy ||
                n->Opcode() == Op_EncodeISOArray) {
       // get the memory projection
@@ -4048,7 +4055,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
           continue;
         }
         memnode_worklist.append_if_missing(use);
-      } else if (use->is_MemBar()) {
+      } else if (use->is_MemBar() || use->is_CallLeaf()) {
         if (use->in(TypeFunc::Memory) == n) { // Ignore precedent edge
           memnode_worklist.append_if_missing(use);
         }

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4861,6 +4861,28 @@ bool LibraryCallKit::inline_fp_range_check(vmIntrinsics::ID id) {
 //----------------------inline_unsafe_copyMemory-------------------------
 // public native void Unsafe.copyMemory0(Object srcBase, long srcOffset, Object destBase, long destOffset, long bytes);
 
+static bool has_wide_mem(PhaseGVN& gvn, Node* addr, Node* base) {
+  const TypeAryPtr* addr_t = gvn.type(addr)->isa_aryptr();
+  const Type*       base_t = gvn.type(base);
+
+  bool in_native = (base_t == TypePtr::NULL_PTR);
+  bool in_heap   = !TypePtr::NULL_PTR->higher_equal(base_t);
+  bool is_mixed  = !in_heap && !in_native;
+
+  if (is_mixed) {
+    return true; // mixed accesses can touch both on-heap and off-heap memory
+  }
+  if (in_heap) {
+    bool is_prim_array = (addr_t != nullptr) && (addr_t->elem() != Type::BOTTOM);
+    if (!is_prim_array) {
+      // Though Unsafe.copyMemory() ensures at runtime for on-heap accesses that base is a primitive array,
+      // there's not enough type information available to determine proper memory slice for it.
+      return true;
+    }
+  }
+  return false;
+}
+
 bool LibraryCallKit::inline_unsafe_copyMemory() {
   if (callee()->is_static())  return false;  // caller must have the capability!
   null_check_receiver();  // null-check receiver
@@ -4888,12 +4910,27 @@ bool LibraryCallKit::inline_unsafe_copyMemory() {
   // update volatile field
   store_to_memory(control(), doing_unsafe_access_addr, intcon(1), doing_unsafe_access_bt, Compile::AliasIdxRaw, MemNode::unordered);
 
+  int flags = RC_LEAF | RC_NO_FP;
+
+  const TypePtr* dst_type = TypePtr::BOTTOM;
+
+  // Adjust memory effects of the runtime call based on input values.
+  if (!has_wide_mem(_gvn, src_addr, src_base) &&
+      !has_wide_mem(_gvn, dst_addr, dst_base)) {
+    dst_type = _gvn.type(dst_addr)->is_ptr(); // narrow out memory
+
+    const TypePtr* src_type = _gvn.type(src_addr)->is_ptr();
+    if (C->get_alias_index(src_type) == C->get_alias_index(dst_type)) {
+      flags |= RC_NARROW_MEM; // narrow in memory
+    }
+  }
+
   // Call it.  Note that the length argument is not scaled.
-  make_runtime_call(RC_LEAF | RC_NO_FP,
+  make_runtime_call(flags,
                     OptoRuntime::fast_arraycopy_Type(),
                     StubRoutines::unsafe_arraycopy(),
                     "unsafe_arraycopy",
-                    TypePtr::BOTTOM,
+                    dst_type,
                     src_addr, dst_addr, size XTOP);
 
   store_to_memory(control(), doing_unsafe_access_addr, intcon(0), doing_unsafe_access_bt, Compile::AliasIdxRaw, MemNode::unordered);

--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeArrayCopy.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8316756
+ * @summary Test UNSAFE.copyMemory in combination with Escape Analysis
+ * @library /test/lib
+ *
+ * @modules java.base/jdk.internal.misc
+ *
+ * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,compiler.unsafe.UnsafeArrayCopy::test
+ *                   compiler.unsafe.UnsafeArrayCopy
+ */
+
+package compiler.unsafe;
+
+import java.lang.reflect.*;
+import java.util.*;
+
+import jdk.internal.misc.Unsafe;
+
+
+public class UnsafeArrayCopy {
+
+    private static Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    static long SRC_BASE = UNSAFE.allocateMemory(4);
+    static long DST_BASE = UNSAFE.allocateMemory(4);
+
+    static class MyClass {
+        int x;
+    }
+
+    static int test() {
+        MyClass obj = new MyClass(); // Non-escaping to trigger Escape Analysis
+        UNSAFE.copyMemory(null, SRC_BASE, null, DST_BASE, 4);
+        obj.x = 42;
+        return obj.x;
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; ++i) {
+            test();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeArrayCopy.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeArrayCopy.java
@@ -29,7 +29,7 @@
  *
  * @modules java.base/jdk.internal.misc
  *
- * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,compiler.unsafe.UnsafeArrayCopy::test
+ * @run main/othervm -XX:-TieredCompilation -Xbatch -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,compiler.unsafe.UnsafeArrayCopy::test*
  *                   compiler.unsafe.UnsafeArrayCopy
  */
 
@@ -59,9 +59,20 @@ public class UnsafeArrayCopy {
         return obj.x;
     }
 
+    static int[] test2() {
+         int[] src = new int[4];
+         int[] dst = new int[4];
+         MyClass obj = new MyClass();
+         UNSAFE.copyMemory(src, 0, dst, 0, 4);
+         obj.x = 42;
+         dst[1] = obj.x;
+         return dst;
+    }
+
     public static void main(String[] args) {
         for (int i = 0; i < 50_000; ++i) {
             test();
+            test2();
         }
     }
 }


### PR DESCRIPTION
Before https://github.com/openjdk/jdk/pull/5259 the graph of the following program looked like this during Escape Analysis:

```java
static int test() {
    MyClass obj = new MyClass(); // Non-escaping to trigger Escape Analysis
    UNSAFE.copyMemory(null, SRC_BASE, null, DST_BASE, 4);
    obj.x = 42;
    return obj.x;
}
```
With MemBarCPUOrder:
<img width="395" alt="working" src="https://github.com/openjdk/jdk/assets/71546117/63a82554-49ff-4373-8567-4457b094093f">

Setting `RC_NARROW_MEM` flag in `LibraryCallKit::inline_unsafe_copyMemory()` removes the `428 MergeMem` node. Without a `MergeMem` node after `432 StoreB` EA failes in Phase 2 of `ConnectionGraph::split_unique_types(...)` when trying to push the allocation's users on the appropriate worklist - `429 CallLeafNoFP` is not an expected user of `428 StoreB`. Therefore the assert `"EA: missing memory path"` is hit. 
Without MemBarCPUOrdera and after setting `RC_NARROW_MEM`:
<img width="370" alt="failing" src="https://github.com/openjdk/jdk/assets/71546117/5d98c38c-d404-4ac4-bd11-bc1e1b7b481f">


### Proposed Fix
Dropping the `RC_NARROW_MEM` flag in `LibraryCallKit::inline_unsafe_copyMemory()` causes the introduction of a `MergeMem` between `StoreB` and `CallLeafNoFP`, so the corresponding code in EA doesn't encounter a `CallLeafNoFP` anymore:
<img width="336" alt="fixed" src="https://github.com/openjdk/jdk/assets/71546117/c538c199-6676-49a4-aaac-a2b3b8f11694">

Testing: Tier1-4 passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316756](https://bugs.openjdk.org/browse/JDK-8316756): C2 EA fails with "missing memory path" when encountering unsafe_arraycopy stub call (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Contributors
 * Vladimir Kozlov `<kvn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17347/head:pull/17347` \
`$ git checkout pull/17347`

Update a local copy of the PR: \
`$ git checkout pull/17347` \
`$ git pull https://git.openjdk.org/jdk.git pull/17347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17347`

View PR using the GUI difftool: \
`$ git pr show -t 17347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17347.diff">https://git.openjdk.org/jdk/pull/17347.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17347#issuecomment-1887500493)