### PR TITLE
8323519: Add applications/ctw/modules to Hotspot tiered testing

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -151,7 +151,6 @@ hotspot_not_fast_compiler = \
   -:hotspot_slow_compiler
 
 hotspot_slow_compiler = \
-  applications/ctw/modules \
   compiler/codegen/aes \
   compiler/codecache/stress \
   compiler/gcbarriers/PreserveFPRegistersTest.java \
@@ -247,6 +246,7 @@ tier2_compiler = \
   -:hotspot_slow_compiler
 
 tier3_compiler = \
+  applications/ctw/modules \
   compiler/c2/ \
   compiler/ciReplay/ \
   compiler/compilercontrol/ \

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -151,6 +151,7 @@ hotspot_not_fast_compiler = \
   -:hotspot_slow_compiler
 
 hotspot_slow_compiler = \
+  applications/ctw/modules \
   compiler/codegen/aes \
   compiler/codecache/stress \
   compiler/gcbarriers/PreserveFPRegistersTest.java \


### PR DESCRIPTION
Noticed that `applications/ctw/modules` is missing from current `tier{1,2,3,4}` hotspot definitions, since tier4 specifically excludes all applications. That exclusion was due to potentially unprepared dependencies that are needed for testing: for example jcstress tests would fail with the default configuration. But CTW for JDK modules works well out of the box, so we can add it somewhere in high tier, for example tier3. It should be useful to catch compiler bugs early, before running `hotspot:all`.

These tests take quite a bit of time (~15 mins on my M1), so I opted to add them to relevant "slow" group that is run in tier3.

Additional testing:
 - [x] Checked that `tier3_compiler` runs CTW tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323519](https://bugs.openjdk.org/browse/JDK-8323519): Add applications/ctw/modules to Hotspot tiered testing (**Enhancement** - P4)


### Reviewers
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer) ⚠️ Review applies to [b2694c10](https://git.openjdk.org/jdk/pull/17348/files/b2694c10bee3c9e75fd788492db446f389611de4)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17348/head:pull/17348` \
`$ git checkout pull/17348`

Update a local copy of the PR: \
`$ git checkout pull/17348` \
`$ git pull https://git.openjdk.org/jdk.git pull/17348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17348`

View PR using the GUI difftool: \
`$ git pr show -t 17348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17348.diff">https://git.openjdk.org/jdk/pull/17348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17348#issuecomment-1884885793)