### PR TITLE
8323529: Relativize test image dependencies in microbenchmarks

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -620,11 +620,16 @@ define SetupRunMicroTestBody
     $1_MICRO_WARMUP_TIME := -w $$(MICRO_WARMUP_TIME)
   endif
 
+# Microbenchmarks are executed from the root of the test image directory.
+# This enables JMH tests to add dependencies using relative paths such as
+# -Djava.library.path=micro/native
+
   run-test-$1: pre-run-test
 	$$(call LogWarn)
 	$$(call LogWarn, Running test '$$($1_TEST)')
 	$$(call MakeDir, $$($1_TEST_RESULTS_DIR) $$($1_TEST_SUPPORT_DIR))
 	$$(call ExecuteWithLog, $$($1_TEST_SUPPORT_DIR)/micro, ( \
+	    $$(CD) $$(TEST_IMAGE_DIR) && \
 	    $$(FIXPATH) $$($1_MICRO_TEST_JDK)/bin/java $$($1_MICRO_JAVA_OPTIONS) \
 	        -jar $$($1_MICRO_BENCHMARKS_JAR) \
 	        $$($1_MICRO_ITER) $$($1_MICRO_FORK) $$($1_MICRO_TIME) \

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadConstant.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.foreign.CallOverheadHelper.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class CallOverheadConstant {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadVirtual.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadVirtual.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.foreign.CallOverheadHelper.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class CallOverheadVirtual {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CriticalCalls.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CriticalCalls.java
@@ -51,7 +51,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class CriticalCalls {
 
     static final MethodHandle PINNED;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(3)
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class LoopOverOfAddress extends JavaLayouts {
 
     static final int ITERATIONS = 1_000_000;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointerInvoke extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
@@ -46,7 +46,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class QSort extends CLayouts {
 
     static final Linker abi = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class StrLenTest extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
@@ -51,7 +51,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class ToCStringTest extends CLayouts {
 
     @Param({"5", "20", "100", "200"})

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED", "--enable-preview"})
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-Djava.library.path=micro/native" })
 public class ToJavaStringTest {
 
     private MemorySegment strSegment;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
@@ -45,7 +45,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class Upcalls extends CLayouts {
 
     static final Linker abi = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(3)
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 @State(Scope.Benchmark)
 public class PointerBench {
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAccess.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAccess.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointsAccess {
 
     BBPoint BBPoint;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAlloc.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAlloc.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointsAlloc {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsDistance.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsDistance.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointsDistance {
 
     BBPoint jniP1;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsFree.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsFree.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointsFree {
 
     JNIPoint jniPoint;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/xor/XorTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/xor/XorTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 
 public class XorTest {
 


### PR DESCRIPTION
JMH microbenchmarks may have dependencies on artifacts in the test image outside of the benchmarks.jar. This includes native libraries (built into `$TEST_IMAGE/micro/native`) and may soon include other test libraries like wb.jar (built into `$TEST_IMAGE/lib-test/`)

By moving execution to the test image root (currently we run out of the `make` directory) we can make do with relative paths, which means benchmark can supply a build-time constant flag themselves rather than have the test runner provide it for you. And needing to be explicit about external dependencies is good, I think.

Taken together this makes the benchmarks.jar more self-contained and simpler to run: all you need is to run `java -jar micro/benchmarks.jar` from the test image root.

This patch also drive-by fixes some lang.foreign tests that were printing warnings due to a missing `--enable-native-access=ALL-UNNAMED` flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323529](https://bugs.openjdk.org/browse/JDK-8323529): Relativize test image dependencies in microbenchmarks (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17349/head:pull/17349` \
`$ git checkout pull/17349`

Update a local copy of the PR: \
`$ git checkout pull/17349` \
`$ git pull https://git.openjdk.org/jdk.git pull/17349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17349`

View PR using the GUI difftool: \
`$ git pr show -t 17349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17349.diff">https://git.openjdk.org/jdk/pull/17349.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17349#issuecomment-1885052773)