### PR TITLE
8323540: assert((!((((method)->is_trace_flag_set(((1 << 4) << 8))))))) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -953,7 +953,6 @@ static int write_method(JfrCheckpointWriter* writer, MethodPtr method, bool leak
 int write__method(JfrCheckpointWriter* writer, const void* m) {
   assert(m != nullptr, "invariant");
   MethodPtr method = static_cast<MethodPtr>(m);
-  assert(METHOD_IS_NOT_SERIALIZED(method), "invariant");
   set_serialized(method);
   return write_method(writer, method, false);
 }


### PR DESCRIPTION
The recent integration of [JDK-8316241](https://bugs.openjdk.org/browse/JDK-8316241) is missing a commit.

This is that missing commit.

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323540](https://bugs.openjdk.org/browse/JDK-8323540): assert((!((((method)-&gt;is_trace_flag_set(((1 &lt;&lt; 4) &lt;&lt; 8))))))) failed: invariant (**Bug** - P2)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17351/head:pull/17351` \
`$ git checkout pull/17351`

Update a local copy of the PR: \
`$ git checkout pull/17351` \
`$ git pull https://git.openjdk.org/jdk.git pull/17351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17351`

View PR using the GUI difftool: \
`$ git pr show -t 17351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17351.diff">https://git.openjdk.org/jdk/pull/17351.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17351#issuecomment-1885394027)