### PR TITLE
8323296: java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id1 timed out

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -28,7 +28,7 @@
  * @requires vm.debug != true
  * @modules java.base/java.lang:+open
  * @library /test/lib
- * @run main GetStackTraceALotWhenPinned 500000
+ * @run main/othervm GetStackTraceALotWhenPinned 500000
  */
 
 /*
@@ -36,7 +36,7 @@
  * @requires vm.debug == true
  * @modules java.base/java.lang:+open
  * @library /test/lib
- * @run main/timeout=300 GetStackTraceALotWhenPinned 200000
+ * @run main/othervm/timeout=300 GetStackTraceALotWhenPinned 200000
  */
 
 import java.time.Instant;

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -26,30 +26,44 @@
  * @bug 8322818
  * @summary Stress test Thread.getStackTrace on a virtual thread that is pinned
  * @requires vm.debug != true
- * @run main GetStackTraceALotWhenPinned 25000
+ * @modules java.base/java.lang:+open
+ * @library /test/lib
+ * @run main GetStackTraceALotWhenPinned 500000
  */
 
 /*
  * @test
  * @requires vm.debug == true
- * @run main/timeout=300 GetStackTraceALotWhenPinned 10000
+ * @modules java.base/java.lang:+open
+ * @library /test/lib
+ * @run main/timeout=300 GetStackTraceALotWhenPinned 200000
  */
 
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import jdk.test.lib.thread.VThreadRunner;
 
 public class GetStackTraceALotWhenPinned {
 
     public static void main(String[] args) throws Exception {
-        var counter = new AtomicInteger(Integer.parseInt(args[0]));
+        // need at least two carrier threads when main thread is a virtual thread
+        if (Thread.currentThread().isVirtual()) {
+            VThreadRunner.ensureParallelism(2);
+        }
+
+        int iterations = Integer.parseInt(args[0]);
+        var barrier = new Barrier(2);
 
         // Start a virtual thread that loops doing Thread.yield and parking while pinned.
         // This loop creates the conditions for the main thread to sample the stack trace
         // as it transitions from being unmounted to parking while pinned.
         var thread = Thread.startVirtualThread(() -> {
             boolean timed = false;
-            while (counter.decrementAndGet() > 0) {
+            for (int i = 0; i < iterations; i++) {
+                // wait for main thread to arrive
+                barrier.await();
+
                 Thread.yield();
                 synchronized (GetStackTraceALotWhenPinned.class) {
                     if (timed) {
@@ -63,14 +77,47 @@ public class GetStackTraceALotWhenPinned {
         });
 
         long lastTimestamp = System.currentTimeMillis();
-        while (thread.isAlive()) {
+        for (int i = 0; i < iterations; i++) {
+            // wait for virtual thread to arrive
+            barrier.await();
+
             thread.getStackTrace();
             LockSupport.unpark(thread);
+
             long currentTime = System.currentTimeMillis();
             if ((currentTime - lastTimestamp) > 500) {
-                System.out.format("%s %d remaining ...%n", Instant.now(), counter.get());
+                System.out.format("%s %d remaining ...%n", Instant.now(), (iterations - i));
                 lastTimestamp = currentTime;
             }
         }
+    }
+
+    /**
+     * Alow threads wait for each other to reach a common barrier point. This class does
+     * not park threads that are waiting for the barrier to trip, instead it spins. This
+     * makes it suitable for tests that use LockSupport.park or Thread.yield.
+     */
+    private static class Barrier {
+        private final int parties;
+        private final AtomicInteger count;
+        private volatile int generation;
+
+        Barrier(int parties) {
+            this.parties = parties;
+            this.count = new AtomicInteger(parties);
+        }
+
+        void await() {
+            int g = generation;
+            if (count.decrementAndGet() == 0) {
+                count.set(parties);
+                generation = g + 1;
+            } else {
+                while (generation == g) {
+                    Thread.onSpinWait();
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This test was recently dialled down via JDK-8323002 but it still makes slow progress on some test machines, esp. macox-x64-debug builds. The issue is that the sampling of the target thread is skewed towards the unmounted case so the target thread is disabled from being scheduled and doesn't make progress. The test is re-worked to use a barrier so that the main thread and target virtual thread run in lock step. This allows the virtual thread to make progress at each iteration and also increases the chances of sampling the stack trace at around the time that the target thread transitions from being unmounted (due to the Thread.yield) and parking while pinned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323296](https://bugs.openjdk.org/browse/JDK-8323296): java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java#id1 timed out (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17353/head:pull/17353` \
`$ git checkout pull/17353`

Update a local copy of the PR: \
`$ git checkout pull/17353` \
`$ git pull https://git.openjdk.org/jdk.git pull/17353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17353`

View PR using the GUI difftool: \
`$ git pr show -t 17353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17353.diff">https://git.openjdk.org/jdk/pull/17353.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17353#issuecomment-1886519976)