### PR TITLE
8323552: AbstractMemorySegmentImpl#mismatch returns -1 when comparing distinct areas of the same instance of MemorySegment

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -286,6 +286,17 @@ public abstract sealed class AbstractMemorySegmentImpl
     @Override
     public long mismatch(MemorySegment other) {
         Objects.requireNonNull(other);
+        if (
+            other instanceof AbstractMemorySegmentImpl that &&
+            unsafeGetBase() == that.unsafeGetBase() &&
+            unsafeGetOffset() == that.unsafeGetOffset() &&
+            byteSize() == that.byteSize()
+        ) {
+            this.checkAccess(0, this.byteSize(), true);
+            that.checkAccess(0, that.byteSize(), true);
+            checkValidState();
+            return -1;
+        }
         return MemorySegment.mismatch(this, 0, byteSize(), other, 0, other.byteSize());
     }
 
@@ -681,10 +692,6 @@ public abstract sealed class AbstractMemorySegmentImpl
         long dstBytes = dstToOffset - dstFromOffset;
         srcImpl.checkAccess(srcFromOffset, srcBytes, true);
         dstImpl.checkAccess(dstFromOffset, dstBytes, true);
-        if (dstImpl.equals(srcImpl) && srcFromOffset == dstFromOffset && srcBytes == dstBytes) {
-            srcImpl.checkValidState();
-            return -1;
-        }
 
         long bytes = Math.min(srcBytes, dstBytes);
         long i = 0;

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -681,7 +681,7 @@ public abstract sealed class AbstractMemorySegmentImpl
         long dstBytes = dstToOffset - dstFromOffset;
         srcImpl.checkAccess(srcFromOffset, srcBytes, true);
         dstImpl.checkAccess(dstFromOffset, dstBytes, true);
-        if (dstImpl == srcImpl) {
+        if (dstImpl.equals(srcImpl) && srcFromOffset == dstFromOffset && srcBytes == dstBytes) {
             srcImpl.checkValidState();
             return -1;
         }

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -286,17 +286,6 @@ public abstract sealed class AbstractMemorySegmentImpl
     @Override
     public long mismatch(MemorySegment other) {
         Objects.requireNonNull(other);
-        if (
-            other instanceof AbstractMemorySegmentImpl that &&
-            unsafeGetBase() == that.unsafeGetBase() &&
-            unsafeGetOffset() == that.unsafeGetOffset() &&
-            byteSize() == that.byteSize()
-        ) {
-            this.checkAccess(0, this.byteSize(), true);
-            that.checkAccess(0, that.byteSize(), true);
-            checkValidState();
-            return -1;
-        }
         return MemorySegment.mismatch(this, 0, byteSize(), other, 0, other.byteSize());
     }
 


### PR DESCRIPTION
I belive there is a bug in `AbstractMemorySegmentImpl#mismatch` method. It returns `-1` (meaning that regions are equal) when passing the same instance of MemorySegment as both `srcSegment` and `dstSegment` parameters regardless of whether `srcFromOffset` and `dstFromOffset` as well as `srcToOffset` and `dstToOffset` are also equal.

Am I right?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8323552](https://bugs.openjdk.org/browse/JDK-8323552): AbstractMemorySegmentImpl#mismatch returns -1 when comparing distinct areas of the same instance of MemorySegment (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17354/head:pull/17354` \
`$ git checkout pull/17354`

Update a local copy of the PR: \
`$ git checkout pull/17354` \
`$ git pull https://git.openjdk.org/jdk.git pull/17354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17354`

View PR using the GUI difftool: \
`$ git pr show -t 17354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17354.diff">https://git.openjdk.org/jdk/pull/17354.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17354#issuecomment-1885741232)