### PR TITLE
8323554: The typos in Javadoc: "@return if "

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/eawt/event/GestureEvent.java
+++ b/src/java.desktop/macosx/classes/com/apple/eawt/event/GestureEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,8 @@ public abstract class GestureEvent {
     }
 
     /**
-     * @return if the event has been consumed
+     * @return {@code true} if the event has been consumed, otherwise
+     *         {@code false}
      */
     protected boolean isConsumed() {
         return consumed;

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,14 +230,12 @@ public class DragSource implements Serializable {
     }
 
     /**
-     * Reports
-     * whether or not drag
-     * {@code Image} support
-     * is available on the underlying platform.
+     * Reports whether or not drag {@code Image} support is available on the
+     * underlying platform.
      *
-     * @return if the Drag Image support is available on this platform
+     * @return {@code true} if the Drag Image support is available on this
+     *         platform, otherwise {@code false}
      */
-
     public static boolean isDragImageSupported() {
         Toolkit t = Toolkit.getDefaultToolkit();
 

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetContext.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -242,15 +242,13 @@ public final class DropTargetContext implements Serializable {
     }
 
     /**
-     * This method returns a {@code boolean}
-     * indicating if the given {@code DataFlavor} is
-     * supported by this {@code DropTargetContext}.
+     * This method returns a {@code boolean} indicating if the given
+     * {@code DataFlavor} is supported by this {@code DropTargetContext}.
      *
-     * @param df the {@code DataFlavor}
-     *
-     * @return if the {@code DataFlavor} specified is supported
+     * @param  df the {@code DataFlavor} to test
+     * @return {@code true} if the {@code DataFlavor} specified is supported,
+     *         otherwise {@code false}
      */
-
     protected boolean isDataFlavorSupported(DataFlavor df) {
         return getCurrentDataFlavorsAsList().contains(df);
     }

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetDragEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetDragEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,14 +154,13 @@ public class DropTargetDragEvent extends DropTargetEvent {
     }
 
     /**
-     * This method returns a {@code boolean} indicating
-     * if the specified {@code DataFlavor} is supported.
+     * This method returns a {@code boolean} indicating if the specified
+     * {@code DataFlavor} is supported.
      *
-     * @param df the {@code DataFlavor} to test
-     *
-     * @return if a particular DataFlavor is supported
+     * @param  df the {@code DataFlavor} to test
+     * @return {@code true} if a particular {@code DataFlavor} is supported,
+     *         otherwise {@code false}
      */
-
     public boolean isDataFlavorSupported(DataFlavor df) {
         return getDropTargetContext().isDataFlavorSupported(df);
     }

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetDropEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetDropEvent.java
@@ -254,7 +254,7 @@ public class DropTargetDropEvent extends DropTargetEvent {
     }
 
     /**
-     * This method returns an {@code int} indicating if the source is in the
+     * This method returns an {@code boolean} indicating if the source is in the
      * same JVM as the target.
      *
      * @return {@code true} if the Source is in the same JVM, otherwise

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetDropEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetDropEvent.java
@@ -254,7 +254,7 @@ public class DropTargetDropEvent extends DropTargetEvent {
     }
 
     /**
-     * This method returns an {@code boolean} indicating if the source is in the
+     * This method returns a {@code boolean} indicating if the source is in the
      * same JVM as the target.
      *
      * @return {@code true} if the Source is in the same JVM, otherwise

--- a/src/java.desktop/share/classes/java/awt/dnd/DropTargetDropEvent.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DropTargetDropEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,15 +188,13 @@ public class DropTargetDropEvent extends DropTargetEvent {
     }
 
     /**
-     * This method returns a {@code boolean} indicating if the
-     * specified {@code DataFlavor} is available
-     * from the source.
+     * This method returns a {@code boolean} indicating if the specified
+     * {@code DataFlavor} is available from the source.
      *
-     * @param df the {@code DataFlavor} to test
-     *
-     * @return if the DataFlavor specified is available from the source
+     * @param  df the {@code DataFlavor} to test
+     * @return {@code true} if the {@code DataFlavor} specified is available
+     *         from the source, otherwise {@code false}
      */
-
     public boolean isDataFlavorSupported(DataFlavor df) {
         return getDropTargetContext().isDataFlavorSupported(df);
     }
@@ -256,12 +254,12 @@ public class DropTargetDropEvent extends DropTargetEvent {
     }
 
     /**
-     * This method returns an {@code int} indicating if
-     * the source is in the same JVM as the target.
+     * This method returns an {@code int} indicating if the source is in the
+     * same JVM as the target.
      *
-     * @return if the Source is in the same JVM
+     * @return {@code true} if the Source is in the same JVM, otherwise
+     *         {@code false}
      */
-
     public boolean isLocalTransfer() {
         return isLocalTx;
     }

--- a/src/java.desktop/share/classes/java/awt/dnd/peer/DropTargetContextPeer.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/peer/DropTargetContextPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,11 +78,12 @@ public interface DropTargetContextPeer {
     Transferable getTransferable() throws InvalidDnDOperationException;
 
     /**
-     * Return whether or not the DragSource Transferable is in the
-     * same JVM as the Target.
-     * @return if the DragSource Transferable is in the same JVM as the Target
+     * Return whether or not the DragSource Transferable is in the same JVM as
+     * the Target.
+     *
+     * @return {@code true} if the DragSource Transferable is in the same JVM as
+     *         the Target, otherwise {@code false}
      */
-
     boolean isTransferableJVMLocal();
 
     /**

--- a/src/java.desktop/share/classes/java/awt/peer/ComponentPeer.java
+++ b/src/java.desktop/share/classes/java/awt/peer/ComponentPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -497,8 +497,10 @@ public interface ComponentPeer {
 
     /**
      * Updates internal data structures related to the component's GC.
-     * @param gc the reference graphics configuration
-     * @return if the peer needs to be recreated for the changes to take effect
+     *
+     * @param  gc the reference graphics configuration
+     * @return {@code true} if the peer needs to be recreated for the changes to
+     *         take effect, otherwise {@code false}
      * @since 1.7
      */
     boolean updateGraphicsData(GraphicsConfiguration gc);

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -203,12 +203,11 @@ public class      BeanContextSupport extends BeanContextChildSupport
     }
 
     /**
-     * Reports whether or not this
-     * {@code BeanContext} is empty.
-     * A {@code BeanContext} is considered
-     * empty when it contains zero
-     * nested children.
-     * @return if there are not children
+     * Reports whether or not this {@code BeanContext} is empty. A
+     * {@code BeanContext} is considered empty when it contains zero nested
+     * children.
+     *
+     * @return {@code true} if there are no children, otherwise {@code false}
      */
     public boolean isEmpty() {
         synchronized(children) {
@@ -217,10 +216,11 @@ public class      BeanContextSupport extends BeanContextChildSupport
     }
 
     /**
-     * Determines whether or not the specified object
-     * is currently a child of this {@code BeanContext}.
-     * @param o the Object in question
-     * @return if this object is a child
+     * Determines whether or not the specified object is currently a child of
+     * this {@code BeanContext}.
+     *
+     * @param  o the Object in question
+     * @return {@code true} if this object is a child, otherwise {@code false}
      */
     public boolean contains(Object o) {
         synchronized(children) {
@@ -229,10 +229,11 @@ public class      BeanContextSupport extends BeanContextChildSupport
     }
 
     /**
-     * Determines whether or not the specified object
-     * is currently a child of this {@code BeanContext}.
-     * @param o the Object in question
-     * @return if this object is a child
+     * Determines whether or not the specified object is currently a child of
+     * this {@code BeanContext}.
+     *
+     * @param  o the Object in question
+     * @return {@code true} if this object is a child, otherwise {@code false}
      */
     public boolean containsKey(Object o) {
         synchronized(children) {
@@ -839,10 +840,10 @@ public class      BeanContextSupport extends BeanContextChildSupport
     }
 
     /**
-     * Is this {@code BeanContext} in the
-     * process of being serialized?
-     * @return if this {@code BeanContext} is
-     * currently being serialized
+     * Is this {@code BeanContext} in the process of being serialized?
+     *
+     * @return {@code true} if this {@code BeanContext} is currently being
+     *         serialized, otherwise {@code false}
      */
     public boolean isSerializing() { return serializing; }
 

--- a/src/java.desktop/share/classes/javax/swing/JTextArea.java
+++ b/src/java.desktop/share/classes/javax/swing/JTextArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -318,12 +318,12 @@ public class JTextArea extends JTextComponent {
     }
 
     /**
-     * Gets the line-wrapping policy of the text area.  If set
-     * to true the lines will be wrapped if they are too long
-     * to fit within the allocated width.  If set to false,
-     * the lines will always be unwrapped.
+     * Gets the line-wrapping policy of the text area. If set to {@code true}
+     * the lines will be wrapped if they are too long to fit within the
+     * allocated width. If set to {@code false}, the lines will always be
+     * unwrapped.
      *
-     * @return if lines will be wrapped
+     * @return {@code true} if lines will be wrapped, otherwise {@code false}
      */
     public boolean getLineWrap() {
         return wrap;
@@ -350,14 +350,13 @@ public class JTextArea extends JTextComponent {
     }
 
     /**
-     * Gets the style of wrapping used if the text area is wrapping
-     * lines.  If set to true the lines will be wrapped at word
-     * boundaries (ie whitespace) if they are too long
-     * to fit within the allocated width.  If set to false,
-     * the lines will be wrapped at character boundaries.
+     * Gets the style of wrapping used if the text area is wrapping lines. If
+     * set to {@code true} the lines will be wrapped at word boundaries (ie
+     * whitespace) if they are too long to fit within the allocated width. If
+     * set to {@code false}, the lines will be wrapped at character boundaries.
      *
-     * @return if the wrap style should be word boundaries
-     *  instead of character boundaries
+     * @return {@code true} if the wrap style should be word boundaries instead
+     *         of character boundaries, otherwise {@code false}
      * @see #setWrapStyleWord
      */
     public boolean getWrapStyleWord() {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicOptionPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1101,7 +1101,8 @@ public class BasicOptionPaneUI extends OptionPaneUI {
         /**
          * Returns if the width of children should be synchronized.
          *
-         * @return if the width of children should be synchronized
+         * @return {@code true} if the width of children should be synchronized,
+         *         otherwise {@code false}
          */
         public boolean getSyncAllWidths() {
             return syncAllWidths;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2075,9 +2075,11 @@ public class BasicSliderUI extends SliderUI{
         }
 
         /**
-         * Returns if scrolling should occur
-         * @param direction the direction.
-         * @return if scrolling should occur
+         * Returns if scrolling should occur.
+         *
+         * @param  direction the direction
+         * @return {@code true} if scrolling should occur, otherwise
+         *         {@code false}
          */
         public boolean shouldScroll(int direction) {
             Rectangle r = thumbRect;

--- a/src/java.desktop/share/classes/javax/swing/text/BoxView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/BoxView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,10 +134,10 @@ public class BoxView extends CompositeView {
 
     /**
      * Determines if the layout is valid along the given axis.
-     * @return if the layout is valid along the given axis
      *
-     * @param axis either <code>View.X_AXIS</code> or <code>View.Y_AXIS</code>
-     *
+     * @param  axis either {@code View.X_AXIS} or {@code View.Y_AXIS}
+     * @return {@code true} if the layout is valid along the given axis,
+     *         otherwise {@code false}
      * @since 1.4
      */
     protected boolean isLayoutValid(int axis) {

--- a/src/java.desktop/share/classes/javax/swing/text/GlyphView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/GlyphView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,9 +207,11 @@ public class GlyphView extends View implements TabableView, Cloneable {
     }
 
     /**
-     * Determine if the glyphs should be underlined.  If true,
-     * an underline should be drawn through the baseline.
-     * @return if the glyphs should be underlined
+     * Determine if the glyphs should be underlined. If {@code true}, an
+     * underline should be drawn through the baseline.
+     *
+     * @return {@code true} if the glyphs should be underlined, otherwise
+     *         {@code false}
      */
     public boolean isUnderline() {
         AttributeSet attr = getAttributes();
@@ -217,10 +219,11 @@ public class GlyphView extends View implements TabableView, Cloneable {
     }
 
     /**
-     * Determine if the glyphs should have a strikethrough
-     * line.  If true, a line should be drawn through the center
-     * of the glyphs.
-     * @return if the glyphs should have a strikethrough line
+     * Determine if the glyphs should have a strikethrough line. If
+     * {@code true}, a line should be drawn through the center of the glyphs.
+     *
+     * @return {@code true} if the glyphs should have a strikethrough line,
+     *         otherwise {@code false}
      */
     public boolean isStrikeThrough() {
         AttributeSet attr = getAttributes();
@@ -229,7 +232,9 @@ public class GlyphView extends View implements TabableView, Cloneable {
 
     /**
      * Determine if the glyphs should be rendered as superscript.
-     * @return if the glyphs should be rendered as superscript
+     *
+     * @return {@code true} if the glyphs should be rendered as superscript,
+     *         otherwise {@code false}
      */
     public boolean isSubscript() {
         AttributeSet attr = getAttributes();
@@ -238,7 +243,9 @@ public class GlyphView extends View implements TabableView, Cloneable {
 
     /**
      * Determine if the glyphs should be rendered as subscript.
-     * @return if the glyphs should be rendered as subscript
+     *
+     * @return {@code true} if the glyphs should be rendered as subscript,
+     *         otherwise {@code false}
      */
     public boolean isSuperscript() {
         AttributeSet attr = getAttributes();

--- a/src/java.desktop/share/classes/sun/awt/dnd/SunDropTargetContextPeer.java
+++ b/src/java.desktop/share/classes/sun/awt/dnd/SunDropTargetContextPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,9 +200,8 @@ public abstract class SunDropTargetContextPeer implements DropTargetContextPeer,
     }
 
     /**
-     * @return if the flavor is supported
+     * @return {@code true} if the flavor is supported, otherwise {@code false}
      */
-
     public boolean isDataFlavorSupported(DataFlavor df) {
         Transferable localTransferable = local;
 
@@ -289,7 +288,8 @@ public abstract class SunDropTargetContextPeer implements DropTargetContextPeer,
       throws IOException;
 
     /**
-     * @return if the transfer is a local one
+     * @return {@code true} if the transfer is a local one, otherwise
+     *         {@code false}
      */
     public boolean isTransferableJVMLocal() {
         return local != null || getJVMLocalSourceTransferable() != null;


### PR DESCRIPTION
The docs for the boolean methods are updated from this style:
```
@return if the event has been consumed
```
to this one
```
@return {@code true} if the event has been consumed, otherwise
{@code false}
```
plus small cleanups here and there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323554](https://bugs.openjdk.org/browse/JDK-8323554): The typos in Javadoc: "@<!---->return if " (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17357/head:pull/17357` \
`$ git checkout pull/17357`

Update a local copy of the PR: \
`$ git checkout pull/17357` \
`$ git pull https://git.openjdk.org/jdk.git pull/17357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17357`

View PR using the GUI difftool: \
`$ git pr show -t 17357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17357.diff">https://git.openjdk.org/jdk/pull/17357.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17357#issuecomment-1885965490)