### PR TITLE
JDK-8312518 : [macos13] setFullScreenWindow() shows black screen on macOS 13 & above

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1697,6 +1697,7 @@ JNI_COCOA_ENTER(env);
             int shieldLevel = CGShieldingWindowLevel();
             window.preFullScreenLevel = [nsWindow level];
             [nsWindow setLevel: shieldLevel];
+            [nsWindow makeKeyAndOrderFront: nil];
 
             NSRect screenRect = [[nsWindow screen] frame];
             [nsWindow setFrame:screenRect display:YES];

--- a/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
+++ b/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
@@ -33,8 +33,8 @@ import static java.awt.EventQueue.invokeAndWait;
  * @test
  * @key headful
  * @bug 8312518
- * @summary Setting a fullscreen window using setFullScreenWindow()
- *          shows up as black screen on newer macOS versions (13 & 14).
+ * @summary Setting fullscreen window using setFullScreenWindow() shows up
+ *          as black screen on newer macOS versions (13 & 14).
  */
 
 public class SetFullScreenTest {

--- a/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
+++ b/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
@@ -38,7 +38,7 @@ import static java.awt.EventQueue.invokeAndWait;
  */
 
 public class SetFullScreenTest {
-    private static Frame f;
+    private static Frame frame;
     private static GraphicsDevice gd;
     private static volatile int width;
     private static volatile int height;
@@ -47,18 +47,18 @@ public class SetFullScreenTest {
         try {
             Robot robot = new Robot();
             invokeAndWait(() -> {
-                f = new Frame();
-                f.setBackground(Color.RED);
-                f.setSize(100, 100);
-                f.setLocation(10, 10);
-                f.setVisible(true);
+                frame = new Frame();
+                frame.setBackground(Color.RED);
+                frame.setSize(100, 100);
+                frame.setLocation(10, 10);
+                frame.setVisible(true);
             });
             robot.delay(1000);
 
             invokeAndWait(() -> {
                 gd = GraphicsEnvironment.getLocalGraphicsEnvironment().
                                 getDefaultScreenDevice();
-                gd.setFullScreenWindow(f);
+                gd.setFullScreenWindow(frame);
             });
             robot.delay(300);
 
@@ -71,8 +71,8 @@ public class SetFullScreenTest {
                 throw new RuntimeException("Test Failed! Window not in full screen mode");
             }
         } finally {
-            if (f != null) {
-                f.dispose();
+            if (frame != null) {
+                frame.dispose();
             }
         }
     }

--- a/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
+++ b/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Robot;
+
+import static java.awt.EventQueue.invokeAndWait;
+
+/*
+ * @test
+ * @key headful
+ * @bug 8312518
+ * @summary Setting a fullscreen window using setFullScreenWindow()
+ *          shows up as black screen on newer macOS versions (13 & 14).
+ */
+
+public class SetFullScreenTest {
+    private static Frame f;
+    private static GraphicsDevice gd;
+    private static volatile int width;
+    private static volatile int height;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            invokeAndWait(() -> {
+                f = new Frame();
+                f.setBackground(Color.RED);
+                f.setSize(100, 100);
+                f.setLocation(10, 10);
+                f.setVisible(true);
+            });
+            robot.delay(1000);
+
+            invokeAndWait(() -> {
+                gd = GraphicsEnvironment.getLocalGraphicsEnvironment().
+                                getDefaultScreenDevice();
+                gd.setFullScreenWindow(f);
+            });
+            robot.delay(300);
+
+            invokeAndWait(() -> {
+                width = gd.getFullScreenWindow().getWidth();
+                height = gd.getFullScreenWindow().getHeight();
+            });
+
+            if (!robot.getPixelColor(width / 2, height / 2).equals(Color.RED)) {
+                throw new RuntimeException("Test Failed! Window not in full screen mode");
+            }
+        } finally {
+            if (f != null) {
+                f.dispose();
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
+++ b/test/jdk/java/awt/FullScreen/SetFullScreenTest.java
@@ -26,7 +26,6 @@ import java.awt.Frame;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Robot;
-
 import jtreg.SkippedException;
 
 import static java.awt.EventQueue.invokeAndWait;


### PR DESCRIPTION
A black screen is seen on newer versions of macOS (13.3 & above) when a window is set to full-screen using `setFullScreenWindow()`. The root cause was narrowed down to the shield level of the full-screen window vs the shield level of the captured display.

Following solutions were explored -

1. Setting `kCGMaximumWindowLevelKey` as the shield level for the full screen window. But setting the fullscreen window to maximum available window level might cause z-order issues when other popup/screen savers are involved.

          int shieldLevel = CGWindowLevelForKey(kCGMaximumWindowLevelKey);
          window.preFullScreenLevel = [nsWindow level];
          [nsWindow setLevel: shieldLevel];

2. Raise the window's level slightly (shieldLevel + 1) above the system shield window. 

            int shieldLevel = CGShieldingWindowLevel();
            window.preFullScreenLevel = [nsWindow level];
            [nsWindow setLevel: (shieldLevel + 1)]; 

3. Keeping the shielding level as-is and bringing the window to the foreground after display is captured. The 3rd approach **(also the one Apple recommends)** ensures that the full screen window has focus as well as being visible and also maintains the correct z-order. This solution works as expected on older (< 13.3) and newer versions (13.3 & above) of macOS.

          if (CGDisplayCapture(aID) == kCGErrorSuccess) {
                ...
                ...
                int shieldLevel = CGShieldingWindowLevel();
                window.preFullScreenLevel = [nsWindow level];
                [nsWindow setLevel: shieldLevel];
                [nsWindow makeKeyAndOrderFront: nil];
            }

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312518](https://bugs.openjdk.org/browse/JDK-8312518): [macos13] setFullScreenWindow() shows black screen on macOS 13 &amp; above (**Bug** - P3)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17358/head:pull/17358` \
`$ git checkout pull/17358`

Update a local copy of the PR: \
`$ git checkout pull/17358` \
`$ git pull https://git.openjdk.org/jdk.git pull/17358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17358`

View PR using the GUI difftool: \
`$ git pr show -t 17358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17358.diff">https://git.openjdk.org/jdk/pull/17358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17358#issuecomment-1885785037)