### PR TITLE
8300088: [IMPROVE] OPEN_MAX is no longer the max limit on macOS >= 10.6 for RLIMIT_NOFILE

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2039,15 +2039,13 @@ jint os::init_2(void) {
     if (status != 0) {
       log_info(os)("os::init_2 getrlimit failed: %s", os::strerror(errno));
     } else {
-      rlim_t rlim_org = nbr_files.rlim_cur;
+      rlim_t rlim_original = nbr_files.rlim_cur;
 
       // on macOS according to setrlimit(2), OPEN_MAX must be used instead
       // of RLIM_INFINITY, but testing on macOS >= 10.6, reveals that
       // we can, in fact, use even RLIM_INFINITY, so try the max value
       // that the system claims can be used first, same as other BSD OSes.
-      nbr_files.rlim_cur = nbr_files.rlim_max;
-
-      // WORKAROUND: some terminals (ksh) will internally use "int" type
+      // However, some terminals (ksh) will internally use "int" type
       // to store this value and since RLIM_INFINITY overflows an "int"
       // we might end up with a negative value, so cap the system limit max
       // at INT_MAX instead, just in case, for everyone.
@@ -2057,7 +2055,7 @@ jint os::init_2(void) {
       if (status != 0) {
         // if that fails then try lowering the limit to either OPEN_MAX
         // (which is safe) or the original limit, whichever was greater.
-        nbr_files.rlim_cur = MAX(OPEN_MAX, rlim_org);
+        nbr_files.rlim_cur = MAX(OPEN_MAX, rlim_original);
         status = setrlimit(RLIMIT_NOFILE, &nbr_files);
       }
       if (status != 0) {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2009,7 +2009,7 @@ extern "C" {
   }
 }
 
-// this is called _after_ the global arguments have been parsed
+// This is called _after_ the global arguments have been parsed
 jint os::init_2(void) {
 
   // This could be set after os::Posix::init() but all platforms
@@ -2032,7 +2032,7 @@ jint os::init_2(void) {
   FLAG_SET_ERGO(UseNUMAInterleaving, false);
 
   if (MaxFDLimit) {
-    // set the number of file descriptors to max. print out error
+    // Set the number of file descriptors to max. Print out error
     // if getrlimit/setrlimit fails but continue regardless.
     struct rlimit nbr_files;
     int status = getrlimit(RLIMIT_NOFILE, &nbr_files);
@@ -2041,7 +2041,7 @@ jint os::init_2(void) {
     } else {
       rlim_t rlim_original = nbr_files.rlim_cur;
 
-      // on macOS according to setrlimit(2), OPEN_MAX must be used instead
+      // On macOS according to setrlimit(2), OPEN_MAX must be used instead
       // of RLIM_INFINITY, but testing on macOS >= 10.6, reveals that
       // we can, in fact, use even RLIM_INFINITY, so try the max value
       // that the system claims can be used first, same as other BSD OSes.
@@ -2053,7 +2053,7 @@ jint os::init_2(void) {
 
       status = setrlimit(RLIMIT_NOFILE, &nbr_files);
       if (status != 0) {
-        // if that fails then try lowering the limit to either OPEN_MAX
+        // If that fails then try lowering the limit to either OPEN_MAX
         // (which is safe) or the original limit, whichever was greater.
         nbr_files.rlim_cur = MAX(OPEN_MAX, rlim_original);
         status = setrlimit(RLIMIT_NOFILE, &nbr_files);
@@ -2064,18 +2064,18 @@ jint os::init_2(void) {
     }
   }
 
-  // at-exit methods are called in the reverse order of their registration.
+  // At-exit methods are called in the reverse order of their registration.
   // atexit functions are called on return from main or as a result of a
   // call to exit(3C). There can be only 32 of these functions registered
   // and atexit() does not set errno.
 
   if (PerfAllowAtExitRegistration) {
-    // only register atexit functions if PerfAllowAtExitRegistration is set.
+    // Only register atexit functions if PerfAllowAtExitRegistration is set.
     // atexit functions can be delayed until process exit time, which
     // can be problematic for embedded VM situations. Embedded VMs should
     // call DestroyJavaVM() to assure that VM resources are released.
 
-    // note: perfMemory_exit_helper atexit function may be removed in
+    // Note: perfMemory_exit_helper atexit function may be removed in
     // the future if the appropriate cleanup code can be added to the
     // VM_Exit VMOperation's doit method.
     if (atexit(perfMemory_exit_helper) != 0) {
@@ -2083,11 +2083,11 @@ jint os::init_2(void) {
     }
   }
 
-  // initialize thread priority policy
+  // Initialize thread priority policy
   prio_init();
 
 #ifdef __APPLE__
-  // dynamically link to objective c gc registration
+  // Dynamically link to objective c gc registration
   void *handleLibObjc = dlopen(OBJC_LIB, RTLD_LAZY);
   if (handleLibObjc != nullptr) {
     objc_registerThreadWithCollectorFunction = (objc_registerThreadWithCollector_t) dlsym(handleLibObjc, OBJC_GCREGISTER);

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2053,13 +2053,11 @@ jint os::init_2(void) {
       // at INT_MAX instead, just in case, for everyone.
       nbr_files.rlim_cur = MIN(INT_MAX, nbr_files.rlim_max);
 
-      if (rlim_org < nbr_files.rlim_cur) {
-        status = setrlimit(RLIMIT_NOFILE, &nbr_files);
-        if (status != 0) {
-          // if that fails then try lowering the limit to either OPEN_MAX
-          // (which is safe) or the original limit, whichever was greater.
-          nbr_files.rlim_cur = MAX(OPEN_MAX, rlim_org);
-        }
+      status = setrlimit(RLIMIT_NOFILE, &nbr_files);
+      if (status != 0) {
+        // if that fails then try lowering the limit to either OPEN_MAX
+        // (which is safe) or the original limit, whichever was greater.
+        nbr_files.rlim_cur = MAX(OPEN_MAX, rlim_org);
       }
 #else
       nbr_files.rlim_cur = nbr_files.rlim_max;

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2039,13 +2039,30 @@ jint os::init_2(void) {
     if (status != 0) {
       log_info(os)("os::init_2 getrlimit failed: %s", os::strerror(errno));
     } else {
+#ifdef __APPLE__
+      rlim_t rlim_org = nbr_files.rlim_cur;
+      // according to setrlimit(2), OPEN_MAX must be used instead
+      // of RLIM_INFINITY, but testing on macOS >= 10.6, reveals that
+      // we can, in fact, use even RLIM_INFINITY, so try the max value
+      // that the system claims can be used first.
       nbr_files.rlim_cur = nbr_files.rlim_max;
 
-#ifdef __APPLE__
-      // Darwin returns RLIM_INFINITY for rlim_max, but fails with EINVAL if
-      // you attempt to use RLIM_INFINITY. As per setrlimit(2), OPEN_MAX must
-      // be used instead
-      nbr_files.rlim_cur = MIN(OPEN_MAX, nbr_files.rlim_cur);
+      // WORKAROUND: some terminals (ksh) will internally use "int" type
+      // to store this value and since RLIM_INFINITY overflows an "int"
+      // we might end up with a negative value, so cap the system limit max
+      // at INT_MAX instead, just in case, for everyone.
+      nbr_files.rlim_cur = MIN(INT_MAX, nbr_files.rlim_max);
+
+      if (rlim_org < nbr_files.rlim_cur) {
+        status = setrlimit(RLIMIT_NOFILE, &nbr_files);
+        if (status != 0) {
+          // if that fails then try lowering the limit to either OPEN_MAX
+          // (which is safe) or the original limit, whichever was greater.
+          nbr_files.rlim_cur = MAX(OPEN_MAX, rlim_org);
+        }
+      }
+#else
+      nbr_files.rlim_cur = nbr_files.rlim_max;
 #endif
 
       status = setrlimit(RLIMIT_NOFILE, &nbr_files);

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1994,7 +1994,7 @@ void os::init(void) {
 
   Bsd::initialize_system_info();
 
-  // _main_thread points to the thread that created/loaded the JVM.
+  // _main_thread points to the thread that created/loaded the JVM
   Bsd::_main_thread = pthread_self();
 
   Bsd::clock_init();
@@ -2002,14 +2002,14 @@ void os::init(void) {
   os::Posix::init();
 }
 
-// To install functions for atexit system call
+// to install functions for atexit system call
 extern "C" {
   static void perfMemory_exit_helper() {
     perfMemory_exit();
   }
 }
 
-// This is called _after_ the global arguments have been parsed
+// this is called _after_ the global arguments have been parsed
 jint os::init_2(void) {
 
   // This could be set after os::Posix::init() but all platforms
@@ -2022,12 +2022,12 @@ jint os::init_2(void) {
     return JNI_ERR;
   }
 
-  // Check and sets minimum stack sizes against command line options
+  // check and sets minimum stack sizes against command line options
   if (set_minimum_stack_sizes() == JNI_ERR) {
     return JNI_ERR;
   }
 
-  // Not supported.
+  // not supported
   FLAG_SET_ERGO(UseNUMA, false);
   FLAG_SET_ERGO(UseNUMAInterleaving, false);
 
@@ -2083,11 +2083,11 @@ jint os::init_2(void) {
     }
   }
 
-  // Initialize thread priority policy
+  // initialize thread priority policy
   prio_init();
 
 #ifdef __APPLE__
-  // Dynamically link to objective c gc registration
+  // dynamically link to objective c gc registration
   void *handleLibObjc = dlopen(OBJC_LIB, RTLD_LAZY);
   if (handleLibObjc != nullptr) {
     objc_registerThreadWithCollectorFunction = (objc_registerThreadWithCollector_t) dlsym(handleLibObjc, OBJC_GCREGISTER);
@@ -2098,7 +2098,7 @@ jint os::init_2(void) {
 }
 
 int os::active_processor_count() {
-  // User has overridden the number of active processors
+  // user has overridden the number of active processors
   if (ActiveProcessorCount > 0) {
     log_trace(os)("active_processor_count: "
                   "active processor count set by user : %d",
@@ -2151,9 +2151,9 @@ uint os::processor_id() {
 
 void os::set_native_thread_name(const char *name) {
 #if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_5
-  // This is only supported in Snow Leopard and beyond
+  // this is only supported in Snow Leopard and beyond
   if (name != nullptr) {
-    // Add a "Java: " prefix to the name
+    // add a "Java: " prefix to the name
     char buf[MAXTHREADNAMESIZE];
     snprintf(buf, sizeof(buf), "Java: %s", name);
     pthread_setname_np(buf);


### PR DESCRIPTION
On current macOS (> 10.6) we can use `RLIM_INFINITY` for `setrlimit(RLIMIT_NOFILE)`, even though the man page for setrlimit(2) claims otherwise.

The only wrinkle here is that some terminals (ksh) will crash with `RLIM_INFINITY`, because that value overflows `int` type, which they use internally, causing crash, so we work around that by using `INT_MAX` instead of `RLIM_INFINITY`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300088](https://bugs.openjdk.org/browse/JDK-8300088): [IMPROVE] OPEN_MAX is no longer the max limit on macOS &gt;= 10.6 for RLIMIT_NOFILE (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) ⚠️ Review applies to [926a50eb](https://git.openjdk.org/jdk/pull/17361/files/926a50eb6a9fdcc1ae7b64fa20eba631763fb612)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17361/head:pull/17361` \
`$ git checkout pull/17361`

Update a local copy of the PR: \
`$ git checkout pull/17361` \
`$ git pull https://git.openjdk.org/jdk.git pull/17361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17361`

View PR using the GUI difftool: \
`$ git pr show -t 17361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17361.diff">https://git.openjdk.org/jdk/pull/17361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17361#issuecomment-1885811436)