### PR TITLE
JDK-8323276: StressDirListings.java fails on AIX

### DIFF
--- a/test/jdk/com/sun/net/httpserver/simpleserver/StressDirListings.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/StressDirListings.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Test to stress directory listings
  * @library /test/lib
- * @run testng/othervm/timeout=180 StressDirListings
+ * @run testng/othervm/timeout=180 -Dsun.net.httpserver.nodelay=true StressDirListings
  */
 
 import java.io.IOException;


### PR DESCRIPTION
The delay in response has caused an incomplete test and timeout error. Setting the TCP_NODELAY socket option to 1 by the property sun.net.httpserver.nodelay solves the issue.

JBS Issue : [JDK-8323276](https://bugs.openjdk.org/browse/JDK-8323276)