### PR TITLE
8323562: SaslInputStream.read() may return wrong value

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/SaslInputStream.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/sasl/SaslInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2003, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class SaslInputStream extends InputStream {
         byte[] inBuf = new byte[1];
         int count = read(inBuf, 0, 1);
         if (count > 0) {
-            return inBuf[0];
+            return inBuf[0] & 0xff;
         } else {
             return -1;
         }


### PR DESCRIPTION
SaslInputStream.read() should return a value in the range from 0 to 255 per the spec of InputStream.read() but it returns the signed byte from the inBuf as is.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323562](https://bugs.openjdk.org/browse/JDK-8323562): SaslInputStream.read() may return wrong value (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Contributors
 * Aleksey Shipilev `<shade@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17365/head:pull/17365` \
`$ git checkout pull/17365`

Update a local copy of the PR: \
`$ git checkout pull/17365` \
`$ git pull https://git.openjdk.org/jdk.git pull/17365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17365`

View PR using the GUI difftool: \
`$ git pr show -t 17365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17365.diff">https://git.openjdk.org/jdk/pull/17365.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17365#issuecomment-1888225209)