### PR TITLE
8323576: [Windows] Fallthrough to ::abort instead of os::infinite_sleep for noreturn methods

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4235,11 +4235,11 @@ static void exit_process_or_thread(Ept what, int exit_code) {
   } else if (what == EPT_PROCESS) {
     ALLOW_C_FUNCTION(::exit, ::exit(exit_code);)
   } else { // EPT_PROCESS_DIE
-    std::_Exit(exit_code);
+    ::_Exit(exit_code);
   }
 
   // Should not reach here
-  std::abort();
+  ::abort();
 }
 
 #undef EXIT_TIMEOUT

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4235,7 +4235,7 @@ static void exit_process_or_thread(Ept what, int exit_code) {
   } else if (what == EPT_PROCESS) {
     ALLOW_C_FUNCTION(::exit, ::exit(exit_code);)
   } else { // EPT_PROCESS_DIE
-    ::_Exit(exit_code);
+    ALLOW_C_FUNCTION(::_exit, ::_exit(exit_code);)
   }
 
   // Should not reach here

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4235,11 +4235,11 @@ static void exit_process_or_thread(Ept what, int exit_code) {
   } else if (what == EPT_PROCESS) {
     ALLOW_C_FUNCTION(::exit, ::exit(exit_code);)
   } else { // EPT_PROCESS_DIE
-    ALLOW_C_FUNCTION(::_exit, ::_exit(exit_code);)
+    std::_Exit(exit_code);
   }
 
   // Should not reach here
-  os::infinite_sleep();
+  std::abort();
 }
 
 #undef EXIT_TIMEOUT

--- a/src/hotspot/os/windows/vmError_windows.cpp
+++ b/src/hotspot/os/windows/vmError_windows.cpp
@@ -71,5 +71,5 @@ void VMError::raise_fail_fast(void* exrecord, void* context) {
   RaiseFailFastException(static_cast<PEXCEPTION_RECORD>(exrecord),
                          static_cast<PCONTEXT>(context),
                          flags);
-  std::abort();
+  ::abort();
 }

--- a/src/hotspot/os/windows/vmError_windows.cpp
+++ b/src/hotspot/os/windows/vmError_windows.cpp
@@ -71,5 +71,5 @@ void VMError::raise_fail_fast(void* exrecord, void* context) {
   RaiseFailFastException(static_cast<PEXCEPTION_RECORD>(exrecord),
                          static_cast<PCONTEXT>(context),
                          flags);
-  os::infinite_sleep();
+  std::abort();
 }


### PR DESCRIPTION
os::infinite_sleep should only be used in very specific scenarios, and using it to satisfy compiler requirements for [[noreturn]] marked methods is a bad idea, since in the impossible case this will cause HotSpot to hang for a seemingly unknown reason. Fallthrough to ::abort instead, like other platforms do, to align Windows with them

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323576](https://bugs.openjdk.org/browse/JDK-8323576): [Windows] Fallthrough to ::abort instead of os::infinite_sleep for noreturn methods (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17366/head:pull/17366` \
`$ git checkout pull/17366`

Update a local copy of the PR: \
`$ git checkout pull/17366` \
`$ git pull https://git.openjdk.org/jdk.git pull/17366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17366`

View PR using the GUI difftool: \
`$ git pr show -t 17366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17366.diff">https://git.openjdk.org/jdk/pull/17366.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17366#issuecomment-1886620973)