### PR TITLE
8322692: ZGC: avoid over-unrolling due to hidden barrier size

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -278,6 +278,9 @@ public:
   virtual bool optimize_loops(PhaseIdealLoop* phase, LoopOptsMode mode, VectorSet& visited, Node_Stack& nstack, Node_List& worklist) const { return false; }
   virtual bool strip_mined_loops_expanded(LoopOptsMode mode) const { return false; }
   virtual bool is_gc_specific_loop_opts_pass(LoopOptsMode mode) const { return false; }
+  // Estimated size of the node barrier in number of C2 Ideal nodes.
+  // This is used to guide heuristics in C2, e.g. whether to unroll a loop.
+  virtual uint estimated_barrier_size(const Node* node) const { return 0; }
 
   enum CompilePhase {
     BeforeOptimize,

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -327,11 +327,11 @@ uint ZBarrierSetC2::estimated_barrier_size(const Node* node) const {
   if ((barrier_data & ZBarrierElided) != 0) {
     return uncolor_or_color_size;
   }
-  // A compare and branch corresponds to approximately five Ideal nodes (Cmp,
-  // Bool, If, IfTrue, IfFalse). The runtime call corresponds to approximately
-  // seven more nodes (CallLeaf, control Proj, memory Proj, data Proj, Region,
-  // memory Phi, data Phi).
-  return uncolor_or_color_size + 12;
+  // A compare and branch corresponds to approximately four fast-path Ideal
+  // nodes (Cmp, Bool, If, If projection). The slow path (If projection and
+  // runtime call) is excluded since the corresponding code is laid out
+  // separately and does not directly affect performance.
+  return uncolor_or_color_size + 4;
 }
 
 void* ZBarrierSetC2::create_barrier_state(Arena* comp_arena) const {

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -128,6 +128,7 @@ protected:
                                         const Type* val_type) const;
 
 public:
+  virtual uint estimated_barrier_size(const Node* node) const;
   virtual void* create_barrier_state(Arena* comp_arena) const;
   virtual bool array_copy_requires_gc_barriers(bool tightly_coupled_alloc,
                                                BasicType type,

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -839,6 +839,15 @@ const TypePtr* MemNode::calculate_adr_type(const Type* t, const TypePtr* cross_c
   }
 }
 
+uint8_t MemNode::barrier_data(const Node* n) {
+  if (n->is_LoadStore()) {
+    return n->as_LoadStore()->barrier_data();
+  } else if (n->is_Mem()) {
+    return n->as_Mem()->barrier_data();
+  }
+  return 0;
+}
+
 //=============================================================================
 // Should LoadNode::Ideal() attempt to remove control edges?
 bool LoadNode::can_remove_control() const {

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -126,6 +126,9 @@ public:
 #endif
   }
 
+  // Return the barrier data of n, if available, or 0 otherwise.
+  static uint8_t barrier_data(const Node* n);
+
   // Map a load or store opcode to its corresponding store opcode.
   // (Return -1 if unknown.)
   virtual int store_Opcode() const { return -1; }

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.gcbarriers;
+
+import compiler.lib.ir_framework.*;
+import java.lang.invoke.VarHandle;
+import java.lang.invoke.MethodHandles;
+
+/**
+ * @test
+ * @summary Test that the expanded size of ZGC barriers is taken into account in
+ *          C2's loop unrolling heuristics so that over-unrolling is avoided.
+ *          The tests use volatile memory accesses to prevent C2 from simply
+ *          optimizing them away.
+ * @library /test/lib /
+ * @requires vm.gc.ZGenerational
+ * @run driver compiler.gcbarriers.TestZGCUnrolling
+ */
+
+public class TestZGCUnrolling {
+
+    static class Outer {
+        Object f;
+    }
+
+    static final VarHandle fVarHandle;
+    static {
+        MethodHandles.Lookup l = MethodHandles.lookup();
+        try {
+            fVarHandle = l.findVarHandle(Outer.class, "f", Object.class);
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:+UseZGC", "-XX:+ZGenerational",
+                                   "-XX:LoopUnrollLimit=32");
+    }
+
+    @Test
+    @IR(counts = {IRNode.STORE_P, "1"})
+    public static void testNoUnrolling(Outer o, Object o1) {
+        for (int i = 0; i < 64; i++) {
+            fVarHandle.setVolatile(o, o1);
+        }
+    }
+
+    @Run(test = {"testNoUnrolling"})
+    void run() {
+        testNoUnrolling(new Outer(), new Object());
+    }
+}

--- a/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
+++ b/test/hotspot/jtreg/compiler/gcbarriers/TestZGCUnrolling.java
@@ -56,7 +56,7 @@ public class TestZGCUnrolling {
 
     public static void main(String[] args) {
         TestFramework.runWithFlags("-XX:+UseZGC", "-XX:+ZGenerational",
-                                   "-XX:LoopUnrollLimit=32");
+                                   "-XX:LoopUnrollLimit=24");
     }
 
     @Test


### PR DESCRIPTION
This changeset refines the C2 loop unrolling heuristic by including an estimation of the final size of (Generational) ZGC barriers in the loop size computation. These are not exposed in C2's intermediate representation and thus currently ignored by the heuristic, which can lead to over-unrolling.

#### Testing

- tier1-5, stress test, fuzzing (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64).
- tier6-9 (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64, ZGC-specific tests only).

#### Performance and code size evaluation

- DaCapo, SPECjvm2008, SPECjbb2015 (linux-x64 with `-XX:+UseZGC -XX:+ZGenerational`). The changeset reduces slightly the size of the C2-generated code (around 0.3% fewer bytes per compiled bytecode for the DaCapo `fop` benchmark) and speeds up SPECjvm2008's `Serial` by around 4%.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322692](https://bugs.openjdk.org/browse/JDK-8322692): ZGC: avoid over-unrolling due to hidden barrier size (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17367/head:pull/17367` \
`$ git checkout pull/17367`

Update a local copy of the PR: \
`$ git checkout pull/17367` \
`$ git pull https://git.openjdk.org/jdk.git pull/17367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17367`

View PR using the GUI difftool: \
`$ git pr show -t 17367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17367.diff">https://git.openjdk.org/jdk/pull/17367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17367#issuecomment-1888878964)