### PR TITLE
8323577: C2 SuperWord: remove AlignVector restrictions on IR tests added in JDK-8305055

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeTypeConversion.java
@@ -58,10 +58,7 @@ public class TestVectorizeTypeConversion {
     // Mixing types of different sizes has the effect that some vectors are shorter than the type allows.
     @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0",
                   IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0",
-                  IRNode.STORE_VECTOR, ">0"},
-        // The vectorization of some conversions may fail when `+AlignVector`.
-        // We can remove the condition after JDK-8303827.
-        applyIf = {"AlignVector", "false"})
+                  IRNode.STORE_VECTOR, ">0"})
     private static void testConvI2D(double[] d, int[] a) {
         for(int i = 0; i < d.length; i++) {
             d[i] = (double) (a[i]);

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayTypeConvertTest.java
@@ -143,9 +143,6 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        // The vectorization of some conversions may fail when `+AlignVector`.
-        // We can remove the condition after JDK-8303827.
-        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_I2D, IRNode.VECTOR_SIZE + "min(max_int, max_double)", ">0"})
     public double[] convertIntToDouble() {
         double[] res = new double[SIZE];
@@ -233,9 +230,6 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx512dq", "true"},
-        // The vectorization of some conversions may fail when `+AlignVector`.
-        // We can remove the condition after JDK-8303827.
-        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_F2L, IRNode.VECTOR_SIZE + "min(max_float, max_long)", ">0"})
     public long[] convertFloatToLong() {
         long[] res = new long[SIZE];
@@ -317,9 +311,6 @@ public class ArrayTypeConvertTest extends VectorizationTestRunner {
     // ---------------- Convert Between F & D ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        // The vectorization of some conversions may fail when `+AlignVector`.
-        // We can remove the condition after JDK-8303827.
-        applyIf = {"AlignVector", "false"},
         counts = {IRNode.VECTOR_CAST_F2D, IRNode.VECTOR_SIZE + "min(max_float, max_double)", ">0"})
     public double[] convertFloatToDouble() {
         double[] res = new double[SIZE];


### PR DESCRIPTION
These IR rules were restricted in [JDK-8305055](https://bugs.openjdk.org/browse/JDK-8305055), [PR for comparison](https://git.openjdk.org/jdk/pull/13236).

This had to be done because those cases were no longer vectorized with `AlignVector` after my bugfix [JDK-8298935](https://bugs.openjdk.org/browse/JDK-8298935), they were "collateral damage". Before this bugfix, we would vectorize, even though the alignment constraints had rejected some memops, but then they were re-intriduced during pair extension. This re-introduction led to this bug for other reasons. I proposed to restore vectorization (i.e. fix the "collateral damage") by improving alignment-constraints ([JDK-8303827](https://bugs.openjdk.org/browse/JDK-8303827)).

Since I had to already completely rework the alignment constraints because of a bug, I relaxed the constraints:
[JDK-8310190](https://bugs.openjdk.org/browse/JDK-8310190)

Now I can remove the restrictions on those rules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323577](https://bugs.openjdk.org/browse/JDK-8323577): C2 SuperWord: remove AlignVector restrictions on IR tests added in JDK-8305055 (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17369/head:pull/17369` \
`$ git checkout pull/17369`

Update a local copy of the PR: \
`$ git checkout pull/17369` \
`$ git pull https://git.openjdk.org/jdk.git pull/17369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17369`

View PR using the GUI difftool: \
`$ git pr show -t 17369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17369.diff">https://git.openjdk.org/jdk/pull/17369.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17369#issuecomment-1887073994)