### PR TITLE
JDK-8301466: [AIX] Revisit CommittedVirtualMemoryTest

### DIFF
--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -32,7 +32,6 @@
 class CommittedVirtualMemoryTest {
 public:
   static void test() {
-    // See JDK-8202772: temporarily disabled.
     Thread* thr = Thread::current();
     address stack_end = thr->stack_end();
     size_t  stack_size = thr->stack_size();

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -32,7 +32,6 @@
 class CommittedVirtualMemoryTest {
 public:
   static void test() {
-#ifndef _AIX
     // See JDK-8202772: temporarily disabled.
     Thread* thr = Thread::current();
     address stack_end = thr->stack_end();
@@ -77,7 +76,6 @@ public:
     ASSERT_TRUE(i >= 1);
     ASSERT_TRUE(found_stack_top);
     ASSERT_TRUE(found_i_addr);
-#endif // !_AIX
   }
 
   static void check_covered_pages(address addr, size_t size, address base, size_t touch_pages, int* page_num) {


### PR DESCRIPTION
We can now enable AIX on [CommitedVirtualMemoryTest](https://github.com/openjdk/jdk/blob/master/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp#L35)  

JBS Issue : [JDK-8301466](https://bugs.openjdk.org/browse/JDK-8301466)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301466](https://bugs.openjdk.org/browse/JDK-8301466): [AIX] Revisit CommittedVirtualMemoryTest (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17371/head:pull/17371` \
`$ git checkout pull/17371`

Update a local copy of the PR: \
`$ git checkout pull/17371` \
`$ git pull https://git.openjdk.org/jdk.git pull/17371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17371`

View PR using the GUI difftool: \
`$ git pr show -t 17371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17371.diff">https://git.openjdk.org/jdk/pull/17371.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17371#issuecomment-1887050062)