### PR TITLE
8323584: AArch64: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe

### DIFF
--- a/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
@@ -28,7 +28,6 @@
 #include "code/codeCache.hpp"
 #include "code/compiledIC.hpp"
 #include "gc/shared/collectedHeap.hpp"
-#include "memory/resourceArea.hpp"
 #include "nativeInst_aarch64.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.hpp"
@@ -189,8 +188,6 @@ void NativeCall::set_destination_mt_safe(address dest, bool assert_lock) {
          CompiledICLocker::is_safe(addr_at(0)),
          "concurrent code patching");
 
-  ResourceMark rm;
-  int code_size = NativeInstruction::instruction_size;
   address addr_call = addr_at(0);
   bool reachable = Assembler::reachable_from_branch_at(addr_call, dest);
   assert(NativeCall::is_call_at(addr_call), "unexpected code at call site");


### PR DESCRIPTION
Was looking at `ICBuffer` cleaning paths that run at safepoint. In `NativeCall::set_destination_mt_safe`, there is a `ResourceMark` that does not seem to have any purpose: no code in its scope uses resource allocation. There is adjacent dead code too. Looks like a development/debugging leftover.

Additional testing:
 - [x] Linux x86_64 AArch64 server fastdebug, `tier{1,2,3}`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323584](https://bugs.openjdk.org/browse/JDK-8323584): AArch64: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe (**Enhancement** - P4)


### Reviewers
 * [Tobias Holenstein](https://openjdk.org/census#tholenstein) (@tobiasholenstein - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17372/head:pull/17372` \
`$ git checkout pull/17372`

Update a local copy of the PR: \
`$ git checkout pull/17372` \
`$ git pull https://git.openjdk.org/jdk.git pull/17372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17372`

View PR using the GUI difftool: \
`$ git pr show -t 17372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17372.diff">https://git.openjdk.org/jdk/pull/17372.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17372#issuecomment-1887049860)