### PR TITLE
JDK-8319382: com/sun/jdi/JdwpAllowTest.java shows failures on AIX if prefixLen of mask is larger than 32 in IPv6 case

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -395,9 +395,6 @@ parseAddress(const char *address, struct addrinfo **result) {
     return getAddrInfo(address, hostnameLen, port, &hints, result);
 }
 
-/*
- * Input is in_addr just because all clients have it.
- */
 static void convertIPv4ToIPv6(const struct in_addr *addr4, struct in6_addr *addr6) {
     // Implement in a platform-independent way.
     // Spec requires in_addr has s_addr member, in6_addr has s6_addr[16] member.

--- a/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
+++ b/src/jdk.jdwp.agent/share/native/libdt_socket/socketTransport.c
@@ -425,8 +425,9 @@ parseAllowedAddr(const char *buffer, struct in6_addr *result, int *isIPv4) {
         memcpy(&(((struct sockaddr_in*)&sa)->sin_addr), &addr, 4);
         convertIPv4ToIPv6(&sa, &addr6);
         *isIPv4 = 1;
-    } else
-         return JDWPTRANSPORT_ERROR_IO_ERROR;
+    } else {
+        return JDWPTRANSPORT_ERROR_IO_ERROR;
+    }
 
     memcpy(result, &addr6, sizeof(*result));
 


### PR DESCRIPTION
In parseAllowedMask in socketTransport.c, prefixLen of mask is compared with a maxValue (32 for IPv4, 128 otherwise).  This fails if it is larger than 32, because getaddrinfo seems to detect IPv4 family, if IPv6 address has set only some of the last 32 Bits. So we take the wrong maxValue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319382](https://bugs.openjdk.org/browse/JDK-8319382): com/sun/jdi/JdwpAllowTest.java shows failures on AIX if prefixLen of mask is larger than 32 in IPv6 case (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17374/head:pull/17374` \
`$ git checkout pull/17374`

Update a local copy of the PR: \
`$ git checkout pull/17374` \
`$ git pull https://git.openjdk.org/jdk.git pull/17374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17374`

View PR using the GUI difftool: \
`$ git pr show -t 17374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17374.diff">https://git.openjdk.org/jdk/pull/17374.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17374#issuecomment-1887462405)