### PR TITLE
8301994: Remove unused code from awt_List.cpp

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_List.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_List.cpp
@@ -170,7 +170,6 @@ void AwtList::ReleaseDragCapture(UINT flags)
 void AwtList::Reshape(int x, int y, int w, int h)
 {
     AwtComponent::Reshape(x, y, w, h);
-
 }
 
 //Netscape : Override the AwtComponent method so we can set the item height

--- a/src/java.desktop/windows/native/libawt/windows/awt_List.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_List.cpp
@@ -171,16 +171,6 @@ void AwtList::Reshape(int x, int y, int w, int h)
 {
     AwtComponent::Reshape(x, y, w, h);
 
-/*
-    HWND hList = GetListHandle();
-    if (hList != NULL) {
-        long flags = SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOCOPYBITS;
-        /*
-         * Fix for bug 4046446.
-         * /
-        SetWindowPos(hList, 0, 0, 0, w, h, flags);
-    }
-*/
 }
 
 //Netscape : Override the AwtComponent method so we can set the item height


### PR DESCRIPTION
Remove commented out/ unused code from awt_List.cpp, which has been commented out since 2007, when the code was moved to Mercurial.
The test ScrollPaneLimitation.java has been opened under [JDK-8306137](https://bugs.openjdk.org/browse/JDK-8306137), and it should be safe to remove this code now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301994](https://bugs.openjdk.org/browse/JDK-8301994): Remove unused code from awt_List.cpp (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) ⚠️ Review applies to [6d1045d0](https://git.openjdk.org/jdk/pull/17378/files/6d1045d0d2114100b03e76badfe39bd0e843982c)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [6d1045d0](https://git.openjdk.org/jdk/pull/17378/files/6d1045d0d2114100b03e76badfe39bd0e843982c)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17378/head:pull/17378` \
`$ git checkout pull/17378`

Update a local copy of the PR: \
`$ git checkout pull/17378` \
`$ git pull https://git.openjdk.org/jdk.git pull/17378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17378`

View PR using the GUI difftool: \
`$ git pr show -t 17378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17378.diff">https://git.openjdk.org/jdk/pull/17378.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17378#issuecomment-1887760152)