### PR TITLE
8323612: IOVecWrapper should be changed to be TerminatingThreadLocal

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/IOUtil.java
+++ b/src/java.base/share/classes/sun/nio/ch/IOUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,6 +259,7 @@ public final class IOUtil {
                     vec.clearRefs(j);
                 }
             }
+            vec.release();
         }
     }
 
@@ -470,6 +471,7 @@ public final class IOUtil {
                     vec.clearRefs(j);
                 }
             }
+            vec.release();
         }
     }
 


### PR DESCRIPTION
Scatter/gather ops use a native iovec structure that is cached in a thread-local and registered with a Cleaner so it may be freed sometime after the thread has terminated. The change proposed here is to change it to a TerminatingThreadLocal so that it is freed when the thread terminates. In addition, to allow a virtual thread be preempted while it has a reference to iovec structure, IOVecWrapper.get is changed to "remove" the iovec from the cache, a new release method will re-add it to the cache. The changes mean this cache is consistent with the cache of direct buffers. The original plan was to also change IOVecWrapper but it somehow got forgotten.

(The changes proposed here have been in the loom repo for some time. In the loom repo, preemption is possible when doing scatter/gather ops where the array of buffers includes heap buffers. More specifically, the iovec is obtained before substitution of heap buffers so it's possible that direct memory is exhausted and the thread has to wait for reference processing.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323612](https://bugs.openjdk.org/browse/JDK-8323612): IOVecWrapper should be changed to be TerminatingThreadLocal (**Enhancement** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17379/head:pull/17379` \
`$ git checkout pull/17379`

Update a local copy of the PR: \
`$ git checkout pull/17379` \
`$ git pull https://git.openjdk.org/jdk.git pull/17379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17379`

View PR using the GUI difftool: \
`$ git pr show -t 17379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17379.diff">https://git.openjdk.org/jdk/pull/17379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17379#issuecomment-1891617559)