### PR TITLE
JDK-8323617 : Add missing null checks to GetMousePositionWithPopup.java test

### DIFF
--- a/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
+++ b/test/jdk/java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,9 +94,13 @@ public class GetMousePositionWithPopup {
             robot.mouseMove(MOUSE_POS3, MOUSE_POS3);
             syncLocationToWindowManager();
         } finally {
-            SwingUtilities.invokeLater(() -> {
-                frame1.dispose();
-                frame2.dispose();
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame1 != null) {
+                    frame1.dispose();
+                }
+                if (frame2 != null) {
+                    frame2.dispose();
+                }
             });
         }
     }


### PR DESCRIPTION
While investigating a macOS 14 issue noticed missing null checks in java/awt/Mouse/GetMousePositionTest/GetMousePositionWithPopup.java

The missing null check will cause an NPE in finally block when frame2 is not created in the event that mouse move is not received.

PS: This test passes on the latest version of macOS (14.2)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323617](https://bugs.openjdk.org/browse/JDK-8323617): Add missing null checks to GetMousePositionWithPopup.java test (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17380/head:pull/17380` \
`$ git checkout pull/17380`

Update a local copy of the PR: \
`$ git checkout pull/17380` \
`$ git pull https://git.openjdk.org/jdk.git pull/17380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17380`

View PR using the GUI difftool: \
`$ git pr show -t 17380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17380.diff">https://git.openjdk.org/jdk/pull/17380.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17380#issuecomment-1887915331)