### PR TITLE
8323627: Shenandoah: Refactor init logger

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,37 +30,26 @@
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
 #include "gc/shenandoah/mode/shenandoahMode.hpp"
 #include "logging/log.hpp"
-#include "runtime/globals.hpp"
 #include "utilities/globalDefinitions.hpp"
-
-void ShenandoahInitLogger::print_heap() {
-  GCInitLogger::print_heap();
-
-  ShenandoahHeap* heap = ShenandoahHeap::heap();
-
-  log_info(gc, init)("Mode: %s",
-                     heap->mode()->name());
-
-  log_info(gc, init)("Heuristics: %s",
-                     heap->heuristics()->name());
-
-  log_info(gc, init)("Heap Region Count: " SIZE_FORMAT,
-                     ShenandoahHeapRegion::region_count());
-
-  log_info(gc, init)("Heap Region Size: " SIZE_FORMAT "%s",
-                     byte_size_in_exact_unit(ShenandoahHeapRegion::region_size_bytes()),
-                     exact_unit_for_byte_size(ShenandoahHeapRegion::region_size_bytes()));
-
-  log_info(gc, init)("TLAB Size Max: " SIZE_FORMAT "%s",
-                     byte_size_in_exact_unit(ShenandoahHeapRegion::max_tlab_size_bytes()),
-                     exact_unit_for_byte_size(ShenandoahHeapRegion::max_tlab_size_bytes()));
-
-  log_info(gc, init)("Humongous Object Threshold: " SIZE_FORMAT "%s",
-          byte_size_in_exact_unit(ShenandoahHeapRegion::humongous_threshold_bytes()),
-          exact_unit_for_byte_size(ShenandoahHeapRegion::humongous_threshold_bytes()));
-}
 
 void ShenandoahInitLogger::print() {
   ShenandoahInitLogger init_log;
   init_log.print_all();
+}
+
+void ShenandoahInitLogger::print_heap() {
+  GCInitLogger::print_heap();
+
+  log_info(gc, init)("Heap Region Count: " SIZE_FORMAT, ShenandoahHeapRegion::region_count());
+  log_info(gc, init)("Heap Region Size: " EXACTFMT, EXACTFMTARGS(ShenandoahHeapRegion::region_size_bytes()));
+  log_info(gc, init)("TLAB Size Max: " EXACTFMT, EXACTFMTARGS(ShenandoahHeapRegion::max_tlab_size_bytes()));
+  log_info(gc, init)("Humongous Object Threshold: " EXACTFMT, EXACTFMTARGS(ShenandoahHeapRegion::humongous_threshold_bytes()));
+}
+
+void ShenandoahInitLogger::print_gc_specific() {
+  GCInitLogger::print_gc_specific();
+
+  ShenandoahHeap* heap = ShenandoahHeap::heap();
+  log_info(gc, init)("Mode: %s", heap->mode()->name());
+  log_info(gc, init)("Heuristics: %s", heap->heuristics()->name());
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahInitLogger.hpp
@@ -29,7 +29,8 @@
 
 class ShenandoahInitLogger : public GCInitLogger {
 protected:
-  virtual void print_heap();
+  void print_heap() override;
+  void print_gc_specific() override;
 
 public:
   static void print();


### PR DESCRIPTION
Use format macros and override keyword to improvement readability.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323627](https://bugs.openjdk.org/browse/JDK-8323627): Shenandoah: Refactor init logger (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17383/head:pull/17383` \
`$ git checkout pull/17383`

Update a local copy of the PR: \
`$ git checkout pull/17383` \
`$ git pull https://git.openjdk.org/jdk.git pull/17383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17383`

View PR using the GUI difftool: \
`$ git pr show -t 17383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17383.diff">https://git.openjdk.org/jdk/pull/17383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17383#issuecomment-1888112692)