### PR TITLE
8323634: Shenandoah: Document behavior of EvacOOM protocol

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
@@ -46,6 +46,10 @@ void ShenandoahEvacOOMCounter::clear() {
   Atomic::release_store_fence(&_bits, (jint)0);
 }
 
+// This sets the OOM bit for a single counter.  If decrement is true, it also decrements the count of evacuating threads
+// associated with this counter.  After all _num_counters OOM bits have been set, all threads newly attempting to enter_evacuation
+// will be informed that they cannot allocate for evacation.  Threads that entered evacuation before the OOM bit was set may
+// continue to allocate for evacuation until they exit_evacuation.
 void ShenandoahEvacOOMCounter::set_oom_bit(bool decrement) {
   jint threads_in_evac = Atomic::load_acquire(&_bits);
   while (true) {
@@ -55,7 +59,7 @@ void ShenandoahEvacOOMCounter::set_oom_bit(bool decrement) {
 
     jint other = Atomic::cmpxchg(&_bits, threads_in_evac, newval);
     if (other == threads_in_evac) {
-      // Success: wait for other threads to get out of the protocol and return.
+      // Success: return so we can wait for other threads to stop allocating.
       break;
     } else {
       // Failure: try again with updated new value.
@@ -121,20 +125,23 @@ ShenandoahEvacOOMCounter* ShenandoahEvacOOMHandler::counter_for_thread(Thread* t
   return &_threads_in_evac[key & (_num_counters - 1)];
 }
 
-void ShenandoahEvacOOMHandler::wait_for_one_counter(ShenandoahEvacOOMCounter* ptr) {
+// Wait until this counter's OOM bit is set and there are no more evacuating threads associated with the counter.
+void ShenandoahEvacOOMHandler::wait_for_no_evac_threads_on_counter(ShenandoahEvacOOMCounter* counter) {
   // We might be racing against handle_out_of_memory_during_evacuation()
   // setting the OOM_MARKER_MASK bit so we must make sure it is set here
   // *and* the counter is zero.
-  while (ptr->load_acquire() != ShenandoahEvacOOMCounter::OOM_MARKER_MASK) {
+  while (counter->load_acquire() != ShenandoahEvacOOMCounter::OOM_MARKER_MASK) {
     os::naked_short_sleep(1);
   }
 }
 
+// Wait until every counter's OOM bit is set and the number of evacuating threads associated with every counter is zero.
+// Then disable further allocations by the current thread by setting its thread-local oom_during_evag flag to true.
 void ShenandoahEvacOOMHandler::wait_for_no_evac_threads() {
   // Once the OOM_MARKER_MASK bit is set the counter can only decrease
   // so it's safe to check each bucket in turn.
   for (int i = 0; i < _num_counters; i++) {
-    wait_for_one_counter(&_threads_in_evac[i]);
+    wait_for_no_evac_threads_on_counter(&_threads_in_evac[i]);
   }
   // At this point we are sure that no threads can evacuate anything. Raise
   // the thread-local oom_during_evac flag to indicate that any attempt
@@ -142,6 +149,16 @@ void ShenandoahEvacOOMHandler::wait_for_no_evac_threads() {
   ShenandoahThreadLocalData::set_oom_during_evac(Thread::current(), true);
 }
 
+// Increment the count of evacuating threads if this thread is authorized to allocate and no other allocating thread
+// has experienced out-of-memory when attempting an evacuation allocation.
+//
+// Upon return:
+//
+//  1. The thread is authorized to allocate for evacuation and the count of allocating threads has been incremented to
+//     include this thread, or
+//  2. The thread is not authorized to allocate for evacuation and the count of allocating thread does not include this thread.
+//
+// Thread-local flag is_oom_during_evac(thr) is false iff thread thr is authorized to allocate for evacuation.
 void ShenandoahEvacOOMHandler::register_thread(Thread* thr) {
   assert(!ShenandoahThreadLocalData::is_oom_during_evac(Thread::current()), "TL oom-during-evac must not be set");
 
@@ -152,6 +169,17 @@ void ShenandoahEvacOOMHandler::register_thread(Thread* thr) {
   }
 }
 
+// Decrement the count of evacuating threads if this thread is still authorized to allocate for evacuation.
+//
+// Upon return:
+//
+//  1. The thread is authorized to allocate for evacuation.
+//  2. The count of threads that are authorized to allocate for evacuations does not include this thread.
+//
+// Note: Authorizing the thread to allocate for evacuation has "no effect".  This is simply the "presumed" default state
+//       of every thread.  When/if this thread subsequently attempts to re-register, we will check whether further
+//       allocations are authorized by this thread and we will adjust the thread-local authorization flag (is_oom_during_evac)
+//       if necessary.  The thread will not attempt to allocate for evacuation without first re-registering.
 void ShenandoahEvacOOMHandler::unregister_thread(Thread* thr) {
   if (!ShenandoahThreadLocalData::is_oom_during_evac(thr)) {
     counter_for_thread(thr)->decrement();
@@ -164,6 +192,27 @@ void ShenandoahEvacOOMHandler::unregister_thread(Thread* thr) {
   assert(!ShenandoahThreadLocalData::is_oom_during_evac(thr), "TL oom-during-evac must be turned off");
 }
 
+// The current thread failed to allocate memory required by evacuation.  Perform the following:
+//
+// Upon entry:
+//
+//  1. The current thread is known to be authorized to allocate for evacuation.
+//
+// Upon return:
+//
+//  1. The OOM bit is set for every counter.
+//  2. This thread's thread-local is_oom_during_evac flag is true, denoting that this thread is no longer authorized
+//     to perform evacuation allocations.
+//  3. The count of threads authorized to evacuate for allocation has been decremented, because this thread is no
+//     longer authorized.
+//  4. We have waited for all evacuating threads to stop allocating, after which it is safe for this thread to resolve
+//     remaining objects as either forwarded or not forwarded.  Hereafter, the status of these objects will not
+//     change until we STW to perform full GC.
+//
+// Note: Multiple threads may handle_out_of_memory_during_evacuation() at the same time.  Setting the OOM bit on every
+//       counter is idempotent.  Any particular thread will execute handle_out_of_memory_during_evacuation() only once
+//       per GC cycle.
+//
 void ShenandoahEvacOOMHandler::handle_out_of_memory_during_evacuation() {
   assert(ShenandoahThreadLocalData::is_evac_allowed(Thread::current()), "sanity");
   assert(!ShenandoahThreadLocalData::is_oom_during_evac(Thread::current()), "TL oom-during-evac must not be set");
@@ -179,6 +228,8 @@ void ShenandoahEvacOOMHandler::handle_out_of_memory_during_evacuation() {
   wait_for_no_evac_threads();
 }
 
+// This method resets the count of evacuating threads to zero and clears the OOM bit for each counter.
+// We call this at the start of each GC cycle.
 void ShenandoahEvacOOMHandler::clear() {
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at a safepoint");
   for (int i = 0; i < _num_counters; i++) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
@@ -136,7 +136,7 @@ void ShenandoahEvacOOMHandler::wait_for_no_evac_threads_on_counter(ShenandoahEva
 }
 
 // Wait until every counter's OOM bit is set and the number of evacuating threads associated with every counter is zero.
-// Then disable further allocations by the current thread by setting its thread-local oom_during_evag flag to true.
+// Then disable further allocations by the current thread by setting its thread-local oom_during_evac flag to true.
 void ShenandoahEvacOOMHandler::wait_for_no_evac_threads() {
   // Once the OOM_MARKER_MASK bit is set the counter can only decrease
   // so it's safe to check each bucket in turn.

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
@@ -139,6 +139,9 @@ void ShenandoahEvacOOMHandler::wait_for_no_evac_threads_on_counter(ShenandoahEva
 }
 
 // Wait until every counter's OOM bit is set and the number of evacuating threads associated with every counter is zero.
+// This assures that this thread waits for some other thread's handle_out_of_memory_during_evacuation() call to finish
+// setting the OOM bit in all counters before this thread proceeds.
+//
 // Then disable further allocations by the current thread by setting its thread-local oom_during_evac flag to true.
 void ShenandoahEvacOOMHandler::wait_for_no_evac_threads() {
   // Once the OOM_MARKER_MASK bit is set the counter can only decrease

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
@@ -98,6 +98,9 @@ ShenandoahEvacOOMHandler::ShenandoahEvacOOMHandler() :
   for (int i = 0; i < _num_counters; i++) {
     new (&_threads_in_evac[i]) ShenandoahEvacOOMCounter();
   }
+#ifdef ASSERT
+  Atomic::store(&_evacuation_state, _evacuating);
+#endif
 }
 
 int ShenandoahEvacOOMHandler::calc_num_counters() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.cpp
@@ -147,6 +147,9 @@ void ShenandoahEvacOOMHandler::wait_for_no_evac_threads() {
   // the thread-local oom_during_evac flag to indicate that any attempt
   // to evacuate should simply return the forwarding pointer instead (which is safe now).
   ShenandoahThreadLocalData::set_oom_during_evac(Thread::current(), true);
+#ifdef ASSERT
+  Atomic::store(&_evacuation_state, _oom_not_evacuating);
+#endif
 }
 
 // Increment the count of evacuating threads if this thread is authorized to allocate and no other allocating thread
@@ -235,4 +238,7 @@ void ShenandoahEvacOOMHandler::clear() {
   for (int i = 0; i < _num_counters; i++) {
     _threads_in_evac[i].clear();
   }
+#ifdef ASSERT
+  Atomic::store(&_evacuation_state, _evacuating);
+#endif
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.hpp
@@ -68,11 +68,11 @@ public:
  *
  *  1. If we fail to evacuate the entirety of live memory from all cset regions,
  *     we will transition first to degenerated GC and if that fails, to full GC at
- *     the end of this canceeled concurrent evacuation phase.  To heal heap invariants
+ *     the end of this cancelled concurrent evacuation phase.  To heal heap invariants
  *     that may be violated temporarily during the Evac-OOM protocol, degenerated GC
  *     overwrites the update_watermark field of every heap region with its current top
  *     (because a pointer to the cset may have been leaked through a failed LRB and
- *     written into the heap above the original value of update_watermark.  Furthermore,
+ *     written into the heap above the original value of update_watermark).  Furthermore,
  *     the degenerated GC restarts the evacuation effort, revisiting every region in
  *     the cset (because we have no assurance that cset regions already evacuated during
  *     the concurrent evacuation were fully evacuated; at least one object failed to

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.hpp
@@ -181,6 +181,14 @@ public:
  *     evacuating.
  */
 class ShenandoahEvacOOMHandler {
+#ifdef ASSERT
+public:
+  enum ShenandoahEvacuationState {
+    _evacuating,
+    _oom_not_evacuating
+  };
+  volatile ShenandoahEvacuationState _evacuation_state;
+#endif
 private:
   const int _num_counters;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.hpp
@@ -59,34 +59,60 @@ public:
  * Provides safe handling of out-of-memory situations during evacuation.
  *
  * When a Java thread encounters out-of-memory while evacuating an object in a
- * load-reference-barrier (i.e. it cannot copy the object to to-space), it does not
- * necessarily follow we can return immediately from the LRB (and store to from-space).
+ * load-reference-barrier (i.e. it cannot copy the object to to-space), a special
+ * protocol is required to assure that all threads see the same version of every
+ * object.
  *
- * In very basic case, on such failure we may wait until the evacuation is over,
- * and then resolve the forwarded copy, and to the store there. This is possible
- * because other threads might still have space in their GCLABs, and successfully
- * evacuate the object.
+ * This file and its accompanying .cpp and .inline.hpp files hold the implementation
+ * of this protocol.  The general idea is as follows:
  *
- * But, there is a race due to non-atomic evac_in_progress transition. Consider
- * thread A is stuck waiting for the evacuation to be over -- it cannot leave with
- * from-space copy yet. Control thread drops evacuation_in_progress preparing for
- * next STW phase that has to recover from OOME. Thread B misses that update, and
- * successfully evacuates the object, does the write to to-copy. But, before
- * Thread B is able to install the fwdptr, thread A discovers evac_in_progress is
- * down, exits from here, reads the fwdptr, discovers old from-copy, and stores there.
- * Thread B then wakes up and installs to-copy. This breaks to-space invariant, and
- * silently corrupts the heap: we accepted two writes to separate copies of the object.
+ *  1. If we fail to evacuate the entirety of live memory from all cset regions,
+ *     we will transition to STW full gc at the end of the evacuation cycle.  Full GC
+ *     marks and compacts the entire heap.  If we fail to evacuate a single cset object,
+ *     we will pay the price of a full GC.
  *
- * The way it is solved here is to maintain a counter of threads inside the
- * 'evacuation path'. The 'evacuation path' is the part of evacuation that does the actual
- * allocation, copying and CASing of the copy object, and is protected by this
- * OOM-during-evac-handler. The handler allows multiple threads to enter and exit
- * evacuation path, but on OOME it requires all threads that experienced OOME to wait
- * for current threads to leave, and blocks other threads from entering. The counter state
- * is striped across multiple cache lines to reduce contention when many threads attempt
- * to enter or leave the protocol at the same time.
+ *  2. If any thread A fails to evacuate object X, it will wait to see if some
+ *     other mutator or GC worker thread can successfully evacuate object X.  At the
+ *     thread A fails to allocate, it launches the OOM-during-evacuation protocol.  There
+ *     is no going back (even though some other thread may successfully evacuate object X).
+ *
+ *  3. The protocol consists of:
+ *
+ *     a) Thread A sets internal state to indicate that OOM-during-evac has been
+ *        encountered.
+ *     b) Thread A now waits for all other threads to finish any ongoing allocations
+ *        for evacuation that might be in process.
+ *     c) Other threads that announce intent to allocate for evacuation are informed
+ *        that the OOM-during-evac protocol has been initated.  As with thread A,
+ *        these threads also wait for all other threads to finish any ongoing allocations
+ *        for evacuation that might be in process.
+ *     d) After all threads have finished whatever allocations for evacuation they
+ *        were in the process of performing, the evacution state of the heap is considered
+ *        to be "frozen".  At this point, some cset objects may have been successfully
+ *        evacuated and some cset objects may have failed to evacuate.  There will be
+ *        no more evaucations until we STW and perform Full GC.
+ *     e) Now, all of the threads that were waiting for evacuating threads to finish
+ *        allocations that were in progress are allowed to run, but they are not allowed
+ *        to allocate for evacuation.  Additional threads that newly announce intent to
+ *        allocate for evacuation are immediately allowed to continue running, but without
+ *        authorization to allocate.
+ *     f) Threads that desire to allocate for evacuation but are not authorized to do so
+ *        simply consult the head of each cset object.  If the header denotes that the
+ *        object has been evacuated by a different thread, then this thread will replace
+ *        its pointer to the object with a pointer to the new location.  If the header
+ *        denotes that this object has not yet been copied, this thread will continue to
+ *        use the original cset location as the official version of the object.  Since
+ *        no threads are allowed to allocate for evacuation in this phase, all threads
+ *        accessing this same object will agree to refer to this object at its original
+ *        location within the cset.
+ *     g) Evacuation is cancelled and all threads will eventually reach a Full GC
+ *        safepoint.  Marking by Full GC will finish updating references that might
+ *        be inconsistent within the heap, and will then compact all live memory within
+ *        the heap.
  *
  * Detailed state change:
+ *
+ * Maintain a count of how many threads are on an evac-path (which is allocating for evacuation)
  *
  * Upon entry of the evac-path, entering thread will attempt to increase the counter,
  * using a CAS. Depending on the result of the CAS:
@@ -94,17 +120,64 @@ public:
  * - failure:
  *   - if offending value is a valid counter, then try again
  *   - if offending value is OOM-during-evac special value: loop until
- *     counter drops to 0, then exit with resolving the ptr
+ *     counter drops to 0, then continue without authorization to allocate.
+ *     As such, the thread will treat unforwarded cset objects as residing
+ *     permanently at their original location.
+ *
  *
  * Upon exit, exiting thread will decrease the counter using atomic dec.
  *
  * Upon OOM-during-evac, any thread will attempt to CAS OOM-during-evac
  * special value into the counter. Depending on result:
- *   - success: busy-loop until counter drops to zero, then exit with resolve
+ *   - success: busy-loop until counter drops to zero, Then continue
+ *     to execute without authnorization to allocate.  Any unforwarded
+ *     cset objects will be treated as residing permanently at their original
+ *     location.
  *   - failure:
  *     - offender is valid counter update: try again
  *     - offender is OOM-during-evac: busy loop until counter drops to
- *       zero, then exit with resolve
+ *       zero, then continue to execute without autnorization to allocate,
+ *       as above.
+ */
+
+/*
+ * For most service workloads, OOM-during-evac will be very rare.  Most services are provisioned
+ * with enough memory and CPU cores to avoid experiencing OOM during evac.  The typical cause for
+ * OOM during evac is a spike in client requests, possibly related to a DOS attack.  When OOM during
+ * evac does occur, there are opportunities to make the protocol more efficient.  In some cases,
+ * OOM during evac can also occur because the heap becomes fragmented.  For example, it may not be
+ * possible to find contiguous memory to evacuate an object that is 50% of the heap region size, even
+ * though there is an abundance of "fragmented" memory available to support evacuation of thousands of
+ * smaller (more normal-sized) objects.
+ *
+ * TODO: make refinements to the OOM-during-evac protocol so that it is less disruptive and more efficient.
+ *
+ *  1. Allow a mutator or GC worker thread that fails to allocate for evacuation to mark a single
+ *     cset object as frozen-in-from-space and then continue to evacuate other objects while other
+ *     threads continue to evacuate other objects.  A draft solution is described here, along with discussion
+ *     of prerequisites required for full implementation:  https://github.com/openjdk/jdk/pull/12881
+ *     This allows all threads, including the one that failed to evacuate a single object, to fully utilize
+ *     all of the memory available within their existing GCLABs.  This allows more of evacuation to be
+ *     performed concurrently rather than requiring STW operation.
+ *
+ *  2. At the end of evacuation, if there were any failures to evacuate, fixup the cset before
+ *     we go to update-refs.  This can be done concurrently.  Fixup consists of:
+ *
+ *     a. Take region out of cset if it contains objects that failed to evacuate.
+ *
+ *     b. For each such region, set top to be address following last object that failed to evacuate.
+ *
+ *     c. For each such region, make the garbage found below and between uncopied objects parseable:
+ *        overwrite each run of garbage with array-of-integer object of appropriate size.  Generational
+ *        Shenandoah calls this coalesce-and-fill.
+ *
+ *  3. Do not automatically upgrade to Full GC.  Continue with concurrent GC as long as possible.
+ *     There is already a mechanism in place to escalate to Full GC if the mutator experiences out-of-memory
+ *     and/or if concurrent GC is not "productive".  Transitions to Full GC are very costly because (i) this
+ *     results in a very long STW pause during which mutator threads are unresponsive, and (ii) Full GC
+ *     redundantly repeats work that was already successfully performed concurrently.  When OOM-during-evac
+ *     transitions to Full GC, we throw away and repeat all of the previously completed work of marking and
+ *     evacuating.
  */
 class ShenandoahEvacOOMHandler {
 private:
@@ -116,7 +189,7 @@ private:
   ShenandoahEvacOOMCounter* counter_for_thread(Thread* t);
 
   void wait_for_no_evac_threads();
-  void wait_for_one_counter(ShenandoahEvacOOMCounter* ptr);
+  void wait_for_no_evac_threads_on_counter(ShenandoahEvacOOMCounter* counter);
 
   static uint64_t hash_pointer(const void* p);
   static int calc_num_counters();
@@ -124,23 +197,37 @@ public:
   ShenandoahEvacOOMHandler();
 
   /**
-   * Attempt to enter the protected evacuation path.
+   * Enter a protected evacuation path.
    *
-   * When this returns true, it is safe to continue with normal evacuation.
-   * When this method returns false, evacuation must not be entered, and caller
-   * may safely continue with a simple resolve (if Java thread).
+   * Upon return: 
+   *
+   *  1. Thread t has authorization to allocate for evacuation and the count of evacuating threads includes thread t, or
+   *
+   *  2. Thread t has no authorization to allocate for evacuation and the count of evacuating threads does not include
+   *     thread t.
+   *
+   * This function may pause while it waits for coordination with other allocating threads.
+   *
+   * Authority to allocate for evacuation is represented by thread-local flag is_oom_during_evac(t) equal to false.
+   * If this thread is not authorized to allocate and it encounters an object residing within the cset, it uses
+   * the most current location of the object, as represented by the object's header.  If the object was not previously
+   * allocated, the evac-OOM protocol assures that the object will not be subsequently evacuated during the remainder
+   * of the concurrent evacuation phase.
    */
   inline void enter_evacuation(Thread* t);
 
   /**
-   * Leave evacuation path.
+   * Leave a protected evacuation path.
    */
   inline void leave_evacuation(Thread* t);
 
   /**
-   * Signal out-of-memory during evacuation. It will prevent any other threads
+   * Signal out-of-memory during evacuation. This will prevent any other threads
    * from entering the evacuation path, then wait until all threads have left the
-   * evacuation path, and then return. It is then safe to continue with a simple resolve.
+   * evacuation path, and then return. Following this, it is safe to assume that
+   * any object residing in the cset and not previously forwarded will remain in
+   * the cset throughout the remainder of the concurrent evacuation phase.  It will
+   * not be subsequently evacuated.
    */
   void handle_out_of_memory_during_evacuation();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.inline.hpp
@@ -39,7 +39,7 @@ jint ShenandoahEvacOOMCounter::unmasked_count() {
   return Atomic::load_acquire(&_bits) & ~OOM_MARKER_MASK;
 }
 
-// Announce the intent by thread thr to perform allocations for evacuation.  
+// Announce the intent by thread thr to perform allocations for evacuation.
 //
 // Upon return:
 //
@@ -49,7 +49,7 @@ jint ShenandoahEvacOOMCounter::unmasked_count() {
 //
 // Thread-local flag is_oom_during_evac(thr) is false iff thread thr is authorized to allocate for evacuation.
 //
-// Notes: If this thread subsequently encounters a "need" to allocate memory for evacuation but it is not authorized to 
+// Notes: If this thread subsequently encounters a "need" to allocate memory for evacuation but it is not authorized to
 //        allocate for evacuation, this thread will simply treat the relevant cset object as "frozen within from-space".
 //        If this thread is forbidden to allocate, then all threads are forbidden to allocate.  As soon as a first thread
 //        begins to execute within an "evacuation region" without authorization to allocate, the evac-OOM protocol requires
@@ -82,7 +82,7 @@ void ShenandoahEvacOOMHandler::enter_evacuation(Thread* thr) {
 //    b. This thread is authorized to allocate for evacuation.
 //
 // Notes: A thread that has already entered evacuation and not left may make a nested re-entry into evacuation.  Each nested
-// invocation of enter_evacuation should be matched by invocation of leave_evacuation.
+//        invocation of enter_evacuation should be matched by invocation of leave_evacuation.
 
 void ShenandoahEvacOOMHandler::leave_evacuation(Thread* thr) {
   uint8_t level = ShenandoahThreadLocalData::pop_evac_oom_scope(thr);

--- a/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahEvacOOMHandler.inline.hpp
@@ -39,6 +39,23 @@ jint ShenandoahEvacOOMCounter::unmasked_count() {
   return Atomic::load_acquire(&_bits) & ~OOM_MARKER_MASK;
 }
 
+// Announce the intent by thread thr to perform allocations for evacuation.  
+//
+// Upon return:
+//
+//  1. The count of nested allocate-for-evacuation scopes for this thread has been incremented.
+//  2. Thread thr is authorized to allocate for evacuation and the count of allocating threads represents this thread, or
+//  3. Thread thr is not authorized to allocate for evacuation and the count of allocating thread does not include this thread.
+//
+// Thread-local flag is_oom_during_evac(thr) is false iff thread thr is authorized to allocate for evacuation.
+//
+// Notes: If this thread subsequently encounters a "need" to allocate memory for evacuation but it is not authorized to 
+//        allocate for evacuation, this thread will simply treat the relevant cset object as "frozen within from-space".
+//        If this thread is forbidden to allocate, then all threads are forbidden to allocate.  As soon as a first thread
+//        begins to execute within an "evacuation region" without authorization to allocate, the evac-OOM protocol requires
+//        that no additional objects be evacuated.  Normally, this phase of executing without authorization to evacuate is
+//        immediately followed by a Full GC which compacts all of heap memory in STW mode.
+
 void ShenandoahEvacOOMHandler::enter_evacuation(Thread* thr) {
   uint8_t level = ShenandoahThreadLocalData::push_evac_oom_scope(thr);
  if (level == 0) {
@@ -54,6 +71,18 @@ void ShenandoahEvacOOMHandler::enter_evacuation(Thread* thr) {
    }
  }
 }
+
+// Announce intent to leave a control scope that performs allocation for evacuation.
+//
+// Upon return:
+//
+// 1. The thread-local count of nested allocation-for-evacuation scopes for this thread has been decremented.
+// 2. If we have left the outer-most allocation-for-evacuation scope for this thread:
+//    a. The count of threads that are allocating for evacuation does not represent this thread
+//    b. This thread is authorized to allocate for evacuation.
+//
+// Notes: A thread that has already entered evacuation and not left may make a nested re-entry into evacuation.  Each nested
+// invocation of enter_evacuation should be matched by invocation of leave_evacuation.
 
 void ShenandoahEvacOOMHandler::leave_evacuation(Thread* thr) {
   uint8_t level = ShenandoahThreadLocalData::pop_evac_oom_scope(thr);


### PR DESCRIPTION
The protocol for handling OOM during evacuation is subtle and critical for correct operation.  This PR does NOT change behavior.  It provides improved documentation of existing behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323634](https://bugs.openjdk.org/browse/JDK-8323634): Shenandoah: Document behavior of EvacOOM protocol (**Bug** - P5)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [d1d1c1c6](https://git.openjdk.org/jdk/pull/17385/files/d1d1c1c6afa8dd73039ffb8c8f3f3061ee524684)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17385/head:pull/17385` \
`$ git checkout pull/17385`

Update a local copy of the PR: \
`$ git checkout pull/17385` \
`$ git pull https://git.openjdk.org/jdk.git pull/17385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17385`

View PR using the GUI difftool: \
`$ git pr show -t 17385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17385.diff">https://git.openjdk.org/jdk/pull/17385.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17385#issuecomment-1889373240)