### PR TITLE
4760025: sRGB conversions to and from CIE XYZ incorrect

### DIFF
--- a/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBToFromCIEXYZ.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBToFromCIEXYZ.java
@@ -1,5 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBToFromCIEXYZ.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBToFromCIEXYZ.java
@@ -23,6 +23,7 @@
  */
 
 import java.awt.color.ColorSpace;
+import java.util.Arrays;
 
 /**
  * @test
@@ -39,20 +40,11 @@ public final class SimpleSRGBToFromCIEXYZ {
             float[] inv = cs.fromCIEXYZ(xyz);
 
             if (inv[0] != 0 || Math.abs(inv[1] - g) > 0.0001f || inv[2] != 0) {
-                System.err.println("Expected color:\t" + toString(rgb));
-                System.err.println("XYZ color:\t\t" + toString(xyz));
-                System.err.println("Actual color:\t" + toString(inv));
-                throw new Error("Wrong color");
+                System.err.println("Expected color:\t" + Arrays.toString(rgb));
+                System.err.println("XYZ color:\t\t" + Arrays.toString(xyz));
+                System.err.println("Actual color:\t" + Arrays.toString(inv));
+                throw new java.lang.Error("Wrong color");
             }
         }
-    }
-
-    private static String toString(float[] color) {
-        StringBuilder buffer = new StringBuilder();
-        for (int i = 0; i < color.length; i++) {
-            if (i > 0) buffer.append(' ');
-            buffer.append(color[i]);
-        }
-        return buffer.toString();
     }
 }

--- a/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBToFromCIEXYZ.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBToFromCIEXYZ.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.color.ColorSpace;
+
+/**
+ * @test
+ * @bug 4760025
+ * @summary Verifies sRGB conversions to and from CIE XYZ
+ */
+public final class SimpleSRGBToFromCIEXYZ {
+
+    public static void main(String[] args) {
+        ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+        for (float g : new float[]{1.0f, 0.8f, 0.6f}) {
+            float[] rgb = {0, g, 0};
+            float[] xyz = cs.toCIEXYZ(rgb);
+            float[] inv = cs.fromCIEXYZ(xyz);
+
+            if (inv[0] != 0 || Math.abs(inv[1] - g) > 0.0001f || inv[2] != 0) {
+                System.err.println("Expected color:\t" + toString(rgb));
+                System.err.println("XYZ color:\t\t" + toString(xyz));
+                System.err.println("Actual color:\t" + toString(inv));
+                throw new Error("Wrong color");
+            }
+        }
+    }
+
+    private static String toString(float[] color) {
+        StringBuilder buffer = new StringBuilder();
+        for (int i = 0; i < color.length; i++) {
+            if (i > 0) buffer.append(' ');
+            buffer.append(color[i]);
+        }
+        return buffer.toString();
+    }
+}

--- a/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBToFromCIEXYZ.java
+++ b/test/jdk/java/awt/color/ICC_ColorSpace/SimpleSRGBToFromCIEXYZ.java
@@ -43,7 +43,7 @@ public final class SimpleSRGBToFromCIEXYZ {
                 System.err.println("Expected color:\t" + Arrays.toString(rgb));
                 System.err.println("XYZ color:\t\t" + Arrays.toString(xyz));
                 System.err.println("Actual color:\t" + Arrays.toString(inv));
-                throw new java.lang.Error("Wrong color");
+                throw new Error("Wrong color");
             }
         }
     }


### PR DESCRIPTION
Since the time the bug was reported color conversion accuracy for the sRGB profile and specific values from the report increased by x100. This is a request to add the code from the report as a test case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4760025](https://bugs.openjdk.org/browse/JDK-4760025): sRGB conversions to and from CIE XYZ incorrect (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [8925fbd5](https://git.openjdk.org/jdk/pull/17388/files/8925fbd5342738407373bcf6abe5a330f7f81269)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17388/head:pull/17388` \
`$ git checkout pull/17388`

Update a local copy of the PR: \
`$ git checkout pull/17388` \
`$ git pull https://git.openjdk.org/jdk.git pull/17388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17388`

View PR using the GUI difftool: \
`$ git pr show -t 17388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17388.diff">https://git.openjdk.org/jdk/pull/17388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17388#issuecomment-1889855724)