### PR TITLE
8323641: Test compiler/loopopts/superword/TestAlignVectorFuzzer.java timed out

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
@@ -558,9 +558,11 @@ public class TestAlignVectorFuzzer {
 
         // Only run for 90% of the time, and subtract some margin. This ensures the shutdown has sufficient time,
         // even for very slow runs.
-        long test_time_allowance = System.currentTimeMillis() +
-                                   (long)(Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.9) -
-                                   20_000;
+        System.out.println("Adjusted Timeout: " + Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT));
+        long test_time_allowance_diff = (long)(Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.6) -
+                                        20_000;
+        System.out.println("Time Allowance:   " + test_time_allowance_diff);
+        long test_time_allowance = System.currentTimeMillis() + test_time_allowance_diff;
         long test_hard_timeout = System.currentTimeMillis() +
                                 Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT);
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
@@ -556,15 +556,15 @@ public class TestAlignVectorFuzzer {
         tests.put("testUU_unsafe_BasIH", () -> { return testUU_unsafe_BasIH(aB.clone(), bB.clone(), cB.clone()); });
 
 
-        // Only run for 90% of the time, and subtract some margin. This ensures the shutdown has sufficient time,
+        // Only run for 40% of the time, and subtract some margin. This ensures the shutdown has sufficient time,
         // even for very slow runs.
         System.out.println("Adjusted Timeout: " + Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT));
-        long test_time_allowance_diff = (long)(Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.6) -
+        long test_time_allowance_diff = (long)(Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.4) -
                                         20_000;
         System.out.println("Time Allowance:   " + test_time_allowance_diff);
         long test_time_allowance = System.currentTimeMillis() + test_time_allowance_diff;
         long test_hard_timeout = System.currentTimeMillis() +
-                                Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT);
+                                 Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT);
 
         for (int i = 1; i <= ITERATIONS_MAX; i++) {
             setRandomConstants();

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
@@ -559,11 +559,11 @@ public class TestAlignVectorFuzzer {
         // Only run for 40% of the time, and subtract some margin. This ensures the shutdown has sufficient time,
         // even for very slow runs.
         System.out.println("Adjusted Timeout: " + Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT));
-        long test_time_allowance_diff = (long)(Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.4) -
-                                        20_000;
-        System.out.println("Time Allowance:   " + test_time_allowance_diff);
-        long test_time_allowance = System.currentTimeMillis() + test_time_allowance_diff;
-        long test_hard_timeout = System.currentTimeMillis() +
+        long testTimeAllowanceDiff = (long)(Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT) * 0.4) -
+                                     20_000;
+        System.out.println("Time Allowance:   " + testTimeAllowanceDiff);
+        long testTimeAllowance = System.currentTimeMillis() + testTimeAllowanceDiff;
+        long testHardTimeout   = System.currentTimeMillis() +
                                  Utils.adjustTimeout(Utils.DEFAULT_TEST_TIMEOUT);
 
         for (int i = 1; i <= ITERATIONS_MAX; i++) {
@@ -571,10 +571,10 @@ public class TestAlignVectorFuzzer {
             for (Map.Entry<String,TestFunction> entry : tests.entrySet()) {
                 String name = entry.getKey();
                 TestFunction test = entry.getValue();
-                long allowance = test_time_allowance - System.currentTimeMillis();
-                long until_timeout = test_hard_timeout - System.currentTimeMillis();
+                long allowance    = testTimeAllowance - System.currentTimeMillis();
+                long untilTimeout = testHardTimeout   - System.currentTimeMillis();
                 System.out.println("ITERATION " + i + " of " + ITERATIONS_MAX + ". Test " + name +
-                                   ", time allowance: " + allowance + ", until timeout: " + until_timeout);
+                                   ", time allowance: " + allowance + ", until timeout: " + untilTimeout);
 
                 // Compute gold value, probably deopt first if constants have changed.
                 Object[] gold = test.run();
@@ -585,18 +585,18 @@ public class TestAlignVectorFuzzer {
                     verify(name, gold, result);
                 }
 
-                if (System.currentTimeMillis() > test_time_allowance) {
-                    allowance = test_time_allowance - System.currentTimeMillis();
-                    until_timeout = test_hard_timeout - System.currentTimeMillis();
+                if (System.currentTimeMillis() > testTimeAllowance) {
+                    allowance    = testTimeAllowance - System.currentTimeMillis();
+                    untilTimeout = testHardTimeout   - System.currentTimeMillis();
                     System.out.println("TEST PASSED: hit maximal time allownance during iteration " + i +
-                                       ", time allowance: " + allowance + ", until timeout: " + until_timeout);
+                                       ", time allowance: " + allowance + ", until timeout: " + untilTimeout);
                     return;
                 }
             }
         }
-        long allowance = test_time_allowance - System.currentTimeMillis();
-        long until_timeout = test_hard_timeout - System.currentTimeMillis();
-        System.out.println("TEST PASSED, time allowance: " + allowance + ", until timeout: " + until_timeout);
+        long allowance    = testTimeAllowance - System.currentTimeMillis();
+        long untilTimeout = testHardTimeout   - System.currentTimeMillis();
+        System.out.println("TEST PASSED, time allowance: " + allowance + ", until timeout: " + untilTimeout);
     }
 
     // Test names:


### PR DESCRIPTION
It seems that allowing `90%` of the timeout-time was cutting it too close. Some individual tests can take more time occasionally, one even took more than `80 sec` (very rare).

Why do these tests take so long?
- Sometimes compilation can take quite a bit of time. `-XX:LoopUnrollLimit=250` already increases the number of nodes allowed in a loop-body, and with unrolling this increases significantly. SuperWord then has to work through all these nodes, and has a lot of quadratic and higher complexity loops.
- The loop bodies are quite large (hand unrolled), and often lead to partial vectorization, with lots of scalar memory ops. This produces quite sub-optimal code, with a bit too many instructions in the loop body. Combined with lots of array copying, this probably takes quite a hit on caches.

I will investigate SuperWord compilation time in the future, and lower the runtime complexity if neccessary/possible, it is part of my autovectorization plans.

I now lowered the allowance down to `40%`, which is hopefully small enough to avoid timeout, while still allowing sufficient many run to get decent test coverage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323641](https://bugs.openjdk.org/browse/JDK-8323641): Test compiler/loopopts/superword/TestAlignVectorFuzzer.java timed out (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [27ba573c](https://git.openjdk.org/jdk/pull/17389/files/27ba573c2d2c4df8a21a5aedf6ea7ba558dbaf9c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17389/head:pull/17389` \
`$ git checkout pull/17389`

Update a local copy of the PR: \
`$ git checkout pull/17389` \
`$ git pull https://git.openjdk.org/jdk.git pull/17389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17389`

View PR using the GUI difftool: \
`$ git pr show -t 17389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17389.diff">https://git.openjdk.org/jdk/pull/17389.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17389#issuecomment-1889592201)