### PR TITLE
JDK-8322366: Add IEEE rounding mode corruption check to JNI checks

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -985,6 +985,9 @@ void *os::Bsd::dlopen_helper(const char *filename, int mode, char *ebuf, int ebu
   if (!ieee_handling) {
     Events::log_dll_message(nullptr, "IEEE subnormal handling check failed before loading %s", filename);
     log_info(os)("IEEE subnormal handling check failed before loading %s", filename);
+    if (CheckJNICalls) {
+      tty->print_cr("WARNING: IEEE subnormal handling check failed before loading %s", filename);
+    }
   }
 
   // Save and restore the floating-point environment around dlopen().
@@ -1038,6 +1041,9 @@ void *os::Bsd::dlopen_helper(const char *filename, int mode, char *ebuf, int ebu
       } else {
         Events::log_dll_message(nullptr, "IEEE subnormal handling could not be corrected after loading %s", filename);
         log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
+        if (CheckJNICalls) {
+          tty->print_cr("WARNING: IEEE subnormal handling could not be corrected after loading %s", filename);
+        }
         assert(false, "fesetenv didn't work");
       }
     }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -987,6 +987,10 @@ void *os::Bsd::dlopen_helper(const char *filename, int mode, char *ebuf, int ebu
     log_info(os)("IEEE subnormal handling check failed before loading %s", filename);
     if (CheckJNICalls) {
       tty->print_cr("WARNING: IEEE subnormal handling check failed before loading %s", filename);
+      Thread* current = Thread::current();
+      if (current->is_Java_thread()) {
+        JavaThread::cast(current)->print_jni_stack();
+      }
     }
   }
 
@@ -1043,6 +1047,10 @@ void *os::Bsd::dlopen_helper(const char *filename, int mode, char *ebuf, int ebu
         log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
         if (CheckJNICalls) {
           tty->print_cr("WARNING: IEEE subnormal handling could not be corrected after loading %s", filename);
+          Thread* current = Thread::current();
+          if (current->is_Java_thread()) {
+            JavaThread::cast(current)->print_jni_stack();
+          }
         }
         assert(false, "fesetenv didn't work");
       }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1813,6 +1813,9 @@ void * os::Linux::dlopen_helper(const char *filename, char *ebuf, int ebuflen) {
   if (!ieee_handling) {
     Events::log_dll_message(nullptr, "IEEE subnormal handling check failed before loading %s", filename);
     log_info(os)("IEEE subnormal handling check failed before loading %s", filename);
+    if (CheckJNICalls) {
+      tty->print_cr("WARNING: IEEE subnormal handling check failed before loading %s", filename);
+    }
   }
 
   // Save and restore the floating-point environment around dlopen().
@@ -1867,6 +1870,9 @@ void * os::Linux::dlopen_helper(const char *filename, char *ebuf, int ebuflen) {
       } else {
         Events::log_dll_message(nullptr, "IEEE subnormal handling could not be corrected after loading %s", filename);
         log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
+        if (CheckJNICalls) {
+          tty->print_cr("WARNING: IEEE subnormal handling could not be corrected after loading %s", filename);
+        }
         assert(false, "fesetenv didn't work");
       }
     }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1815,6 +1815,10 @@ void * os::Linux::dlopen_helper(const char *filename, char *ebuf, int ebuflen) {
     log_info(os)("IEEE subnormal handling check failed before loading %s", filename);
     if (CheckJNICalls) {
       tty->print_cr("WARNING: IEEE subnormal handling check failed before loading %s", filename);
+      Thread* current = Thread::current();
+      if (current->is_Java_thread()) {
+        JavaThread::cast(current)->print_jni_stack();
+      }
     }
   }
 
@@ -1872,6 +1876,10 @@ void * os::Linux::dlopen_helper(const char *filename, char *ebuf, int ebuflen) {
         log_info(os)("IEEE subnormal handling could not be corrected after loading %s", filename);
         if (CheckJNICalls) {
           tty->print_cr("WARNING: IEEE subnormal handling could not be corrected after loading %s", filename);
+          Thread* current = Thread::current();
+          if (current->is_Java_thread()) {
+            JavaThread::cast(current)->print_jni_stack();
+          }
         }
         assert(false, "fesetenv didn't work");
       }


### PR DESCRIPTION
In the review of [JDK-8321017](https://bugs.openjdk.org/browse/JDK-8321017) the idea was introduced to enhance the JNI checker (-Xcheck:jni) by adding IEEE rounding mode corruption checks.
See also https://bugs.openjdk.org/browse/JDK-8295159 for more details on these issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322366](https://bugs.openjdk.org/browse/JDK-8322366): Add IEEE rounding mode corruption check to JNI checks (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17391/head:pull/17391` \
`$ git checkout pull/17391`

Update a local copy of the PR: \
`$ git checkout pull/17391` \
`$ git pull https://git.openjdk.org/jdk.git pull/17391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17391`

View PR using the GUI difftool: \
`$ git pr show -t 17391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17391.diff">https://git.openjdk.org/jdk/pull/17391.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17391#issuecomment-1888709008)