### PR TITLE
8323637: Capture hotspot replay files in GHA

### DIFF
--- a/.github/scripts/gen-test-results.sh
+++ b/.github/scripts/gen-test-results.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ for test in $failures $errors; do
   base_path="$(echo "$test" | tr '#' '_')"
   report_file="$report_dir/$base_path.jtr"
   hs_err_files=$(ls $report_dir/$base_path/hs_err*.log 2> /dev/null || true)
+  replay_files=$(ls $report_dir/$base_path/replay*.log 2> /dev/null || true)
   echo "####  <a id="$anchor">$test"
-
   echo '<details><summary>View test results</summary>'
   echo ''
   echo '```'
@@ -73,6 +73,20 @@ for test in $failures $errors; do
     echo ''
   fi
 
+  if [[ "$replay_files" != "" ]]; then
+    echo '<details><summary>View HotSpot replay file</summary>'
+    echo ''
+    for replay in $replay_files; do
+      echo '```'
+      echo "$replay:"
+      echo ''
+      cat "$replay"
+      echo '```'
+    done
+
+    echo '</details>'
+    echo ''
+  fi
 done >> $GITHUB_STEP_SUMMARY
 
 # With many failures, the summary can easily exceed 1024 kB, the limit set by Github


### PR DESCRIPTION
From the bug report:

jdk/.github/scripts/gen-test-results.sh is capable of capture hs_err_* file for erroneous and failed tests. They are also exposed under tag `<details><summary>View HotSpot error log</summary>`.

I think we can do the same thing for replay files. A replay file is automatically generated when compiler threads encounter a fatal error. sometimes, we can only trigger the compilation error on GHA. attached replay file is invaluable. 

---

I have not figured out how to provoke a replay file on GHA, so this is untested, but since it is based on the hs_err logic I'm pretty confident that it works. If it turns out to be problematic, let's fix it in a follow up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323637](https://bugs.openjdk.org/browse/JDK-8323637): Capture hotspot replay files in GHA (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17392/head:pull/17392` \
`$ git checkout pull/17392`

Update a local copy of the PR: \
`$ git checkout pull/17392` \
`$ git pull https://git.openjdk.org/jdk.git pull/17392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17392`

View PR using the GUI difftool: \
`$ git pr show -t 17392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17392.diff">https://git.openjdk.org/jdk/pull/17392.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17392#issuecomment-1888810498)