### PR TITLE
8323101: C2: assert(n->in(0) == nullptr) failed: divisions with zero check should already have bailed out earlier in split-if

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -287,7 +287,11 @@ bool PhaseIdealLoop::cannot_split_division(const Node* n, const Node* region) co
       return false;
   }
 
-  assert(n->in(0) == nullptr, "divisions with zero check should already have bailed out earlier in split-if");
+  if (n->in(0) != nullptr) {
+    // Cannot split through phi if Div or Mod node has a control dependency to a zero check.
+    return true;
+  }
+
   Node* divisor = n->in(2);
   return is_divisor_counted_loop_phi(divisor, region) &&
          loop_phi_backedge_type_contains_zero(divisor, zero);

--- a/test/hotspot/jtreg/compiler/splitif/TestSplitDivThroughPhiWithControl.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestSplitDivThroughPhiWithControl.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=normal
+ * @bug 8323101
+ * @summary Test split_thru_phi with pinned divisions/modulo that have phi as inputs.
+ * @run main/othervm -Xbatch
+ *                   -XX:CompileCommand=compileonly,compiler.splitif.TestSplitDivThroughPhiWithControl::*
+ *                   compiler.splitif.TestSplitDivThroughPhiWithControl
+ */
+
+/*
+ * @test id=fuzzer
+ * @bug 8323101
+ * @summary Test split_thru_phi with pinned divisions/modulo that have phi as inputs.
+ * @run main/othervm -Xbatch -XX:PerMethodTrapLimit=0
+ *                   -XX:CompileCommand=compileonly,compiler.splitif.TestSplitDivThroughPhiWithControl::*
+ *                   compiler.splitif.TestSplitDivThroughPhiWithControl
+ */
+
+package compiler.splitif;
+
+public class TestSplitDivThroughPhiWithControl {
+    static int divisorInt = 34;
+    static int iFld;
+    static int x;
+    static int y;
+    static long divisorLong = 34L;
+    static long lFld;
+    static long lFld2;
+    static long lFld3;
+    static boolean flag;
+
+    static int[] iArr = new int[400];
+
+    public static void main(String[] strArr) {
+        iArr[0] = 52329;
+        for (int i = 0; i < 10000; i++) {
+            flag = i % 3 == 0;                 // Avoid unstable if trap
+            divisorInt = i % 2 == 0 ? 0 : 23;  // Avoid div by zero trap
+            divisorLong = divisorInt;          // Avoid div by zero trap
+            try {
+                testIntDiv();
+            } catch (ArithmeticException e) {
+                // Expected.
+            }
+
+            try {
+                testIntMod();
+            } catch (ArithmeticException e) {
+                // Expected.
+            }
+
+            try {
+                testLongDiv(); // Currently does not trigger due to JDK-8323652
+            } catch (ArithmeticException e) {
+                // Expected.
+            }
+
+            try {
+                testLongMod(); // Currently does not trigger due to JDK-8323652
+            } catch (ArithmeticException e) {
+                // Expected.
+            }
+
+            testFuzzer();
+        }
+    }
+
+    static void testIntDiv() {
+        int a;
+
+        for (int j = 0; j < 100; j++) {
+            y += 5;
+            int sub = j - 3; // AddI
+            int div = (sub / divisorInt); // DivI with AddI input
+
+            if (flag) {
+                a = y;
+            } else {
+                a = 2;
+            }
+            // Region
+
+            // Use StoreI with AddI input. Store needs to be split through Region in Split-If which is done together
+            // with AddI.
+            iFld = sub;
+
+            if (a < 3) { // If that's split in Split-If
+                // Use of DivI -> after Split-If, DivI gets a Phi input that merges the split AddI nodes.
+                // -> triggers assert that we should not find pinned div nodes in cannot_split_division().
+                x = div;
+            }
+        }
+    }
+
+    // Same as testIntDiv() but with ModI
+    static void testIntMod() {
+        int a;
+
+        for (int j = 0; j < 100; j++) {
+            y += 5;
+            int sub = j - 3;
+            int mod = (sub % divisorInt);
+
+            if (flag) {
+                a = y;
+            } else {
+                a = 2;
+            }
+
+            iFld = sub;
+
+            if (a < 3) {
+                x = mod; // Only StoreI visited first but not mod since it's an input
+            }
+        }
+    }
+
+    // Same as testIntDiv() but with DivL
+    static void testLongDiv() {
+        long a;
+
+        for (int j = 0; j < 100; j++) {
+            y += 5;
+            long sub = j - 3;
+            long div = (sub / divisorLong);
+
+            if (flag) {
+                a = lFld2;
+            } else {
+                a = 2;
+            }
+
+            lFld = sub;
+
+            if (a < 3) {
+                lFld3 = div;
+            }
+        }
+    }
+
+
+    // Same as testIntDiv() but with ModL
+    static void testLongMod() {
+        long a;
+
+        for (long j = 0; j < 100; j++) {
+            lFld2 += 5;
+            long sub = j - 3;
+            long mod = (sub % divisorLong);
+
+            if (flag) {
+                a = lFld2;
+            } else {
+                a = 2;
+            }
+
+            lFld = sub;
+
+            if (a < 3) {
+                lFld3 = mod; // Only StoreI visited first but not mod since it's an input
+            }
+        }
+    }
+
+    // Original fuzzer crash
+    static void testFuzzer() {
+        int i19, i21 = 4928, i23 = 14;
+        for (int i = 5; i < 100; i++) {
+            i19 = i23;
+            int j = 1;
+            while (true) {
+                try {
+                    i21 = (iArr[0] / 34);
+                    i23 = (j % i21);
+                } catch (ArithmeticException a_e) {
+                }
+                iArr = iArr;
+                iFld = i21;
+                iArr[1] += 5;
+                if (j == 1000) {
+                    break;
+                }
+                j++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The assertion added by [JDK-8299259](https://bugs.openjdk.org/browse/JDK-8299259) is wrong. I've originally assumed that at this point, there are no pinned `Div/Mod` nodes anymore that we possibly want to split through a phi due to bailing out earlier here:
https://github.com/openjdk/jdk/blob/3e19bf88d5b51fe10c183f930b99bce961a368c1/src/hotspot/share/opto/loopopts.cpp#L1137-L1140

The assumption was that a `Div/Mod` node with a control input to the zero-check `IfProj` could only have a `Phi` input with a `Region` that is further up in the graph. This is normally true. However, in `testIntDiv()`, we split an `If` with `do_split_if()` and need to empty the basic block. We split the store `iFld = sub` up. This includes the `StoreI` as well as the `AddI` which also has the `Region` as current `ctrl` (i.e. returned with `get_ctrl()`).

The `AddI` also has the `DivI` as output which, however, is not pushed up since it's not part of the same basic block. We end up with the following graph after the completion of `do_split_if()`:

![image](https://github.com/openjdk/jdk/assets/17833009/b76293e1-a593-4319-b026-254be3c098fc)

The `DivI` now has `252 Phi` as input which merges the split `AddI` nodes. `246 Region` of the `252 Phi` is further down than the control input `83 IfTrue` of the `DivI`.This is rather unusual and thus was missed when the assert was added in JDK-8299259. When finally processing the `DivI` node in the DFS walk of Split-If, we fail with the assertion.

The fix is straight forward to turn this assert into a simple bailout: We should not split a `Div/Mod` node that is pinned (i.e. has a zero check).

While working on this bug, I've also tried to trigger the assert with `DivL/ModL` nodes. However, this did not work because `split_up()` does not split the `Add` node up. The reason is that we set late ctrl to early ctrl for the `DivL/ModL` node (and thus also set the same late ctrl for the `Add` node) while we do not do that for `DivI/ModI` nodes. It seems that we miss to treat `DivL/ModL` nodes as unpinned here which would allow us to set a later ctrl:
https://github.com/openjdk/jdk/blob/82a63a03c0155288e8e43b9f766c8be70be50b6a/src/hotspot/share/opto/loopnode.cpp#L6091-L6101

I've done some digging and found that `DivL/ModL` nodes were added after this switch statment. So, I assume we simply forgot to also treat them as unpinned here. It's not wrong but I think just an unnecessary limitation. I filed [JDK-8323652](https://bugs.openjdk.org/browse/JDK-8323652) to fix this. 

Either way, I left the code for the long cases in even though they do not trigger. They should once JDK-8323652 is fixed.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323101](https://bugs.openjdk.org/browse/JDK-8323101): C2: assert(n-&gt;in(0) == nullptr) failed: divisions with zero check should already have bailed out earlier in split-if (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17394/head:pull/17394` \
`$ git checkout pull/17394`

Update a local copy of the PR: \
`$ git checkout pull/17394` \
`$ git pull https://git.openjdk.org/jdk.git pull/17394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17394`

View PR using the GUI difftool: \
`$ git pr show -t 17394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17394.diff">https://git.openjdk.org/jdk/pull/17394.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17394#issuecomment-1888887887)