### PR TITLE
8323616: [JVMCI] TestInvalidJVMCIOption.java fails intermittently with NPE

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3040,8 +3040,8 @@ C2V_VMENTRY(void, callSystemExit, (JNIEnv* env, jobject, jint status))
   if (!JVMCIENV->is_hotspot()) {
     // It's generally not safe to call Java code before the module system is initialized
     if (!Universe::is_module_initialized()) {
-      JVMCI_event_1("callSystemExit before Universe::is_module_initialized() -> direct VM exit");
-      vm_exit(status);
+      JVMCI_event_1("callSystemExit(%d) before Universe::is_module_initialized() -> direct VM exit", status);
+      vm_exit_during_initialization();
     }
   }
   CompilerThreadCanCallJava canCallJava(thread, true);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3037,6 +3037,13 @@ C2V_VMENTRY_0(jboolean, addFailedSpeculation, (JNIEnv* env, jobject, jlong faile
 C2V_END
 
 C2V_VMENTRY(void, callSystemExit, (JNIEnv* env, jobject, jint status))
+  if (!JVMCIENV->is_hotspot()) {
+    // It's generally not safe to call Java code before the module system is initialized
+    if (!Universe::is_module_initialized()) {
+      JVMCI_event_1("callSystemExit before Universe::is_module_initialized() -> direct VM exit");
+      vm_exit(status);
+    }
+  }
   CompilerThreadCanCallJava canCallJava(thread, true);
   JavaValue result(T_VOID);
   JavaCallArguments jargs(1);

--- a/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
@@ -48,9 +48,13 @@ public class TestInvalidJVMCIOption {
             "Error parsing JVMCI options: Could not find option jvmci.XXXXXXXXX%n" +
             "Error: A fatal exception has occurred. Program will exit.%n");
 
-        Asserts.assertEQ(expectStdout, output.getStdout());
-        output.stderrShouldBeEmpty();
+        // Test for containment instead of equality as -XX:+EagerJVMCI means
+        // the main thread and one or more libjvmci compiler threads
+        // may initialize libjvmci at the same time and thus the error
+        // message can appear multiple times.
+        output.stdoutShouldContain(expectStdout);
 
+        output.stderrShouldBeEmpty();
         output.shouldHaveExitValue(1);
     }
 }

--- a/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
@@ -49,7 +49,6 @@ public class TestInvalidJVMCIOption {
             "Error: A fatal exception has occurred. Program will exit.%n");
 
         Asserts.assertEQ(expectStdout, output.getStdout());
-        output.stderrShouldBeEmpty();
 
         output.shouldHaveExitValue(1);
     }

--- a/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestInvalidJVMCIOption.java
@@ -49,6 +49,7 @@ public class TestInvalidJVMCIOption {
             "Error: A fatal exception has occurred. Program will exit.%n");
 
         Asserts.assertEQ(expectStdout, output.getStdout());
+        output.stderrShouldBeEmpty();
 
         output.shouldHaveExitValue(1);
     }


### PR DESCRIPTION
This PR changes callSystemExit to call `vm_exit_during_initialization()` instead of `System.exit` if the module system has not been initialized. This avoids an NPE in the `System.exit` code path where it is assumed that the `Class.module` field is non-null for `java.lang.Shutdown`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323616](https://bugs.openjdk.org/browse/JDK-8323616): [JVMCI] TestInvalidJVMCIOption.java fails intermittently with NPE (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [91be4c2d](https://git.openjdk.org/jdk/pull/17397/files/91be4c2d8036c5ee50e48ee4523a76bad448c6f4)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17397/head:pull/17397` \
`$ git checkout pull/17397`

Update a local copy of the PR: \
`$ git checkout pull/17397` \
`$ git pull https://git.openjdk.org/jdk.git pull/17397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17397`

View PR using the GUI difftool: \
`$ git pr show -t 17397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17397.diff">https://git.openjdk.org/jdk/pull/17397.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17397#issuecomment-1889373707)