### PR TITLE
8323671: DevKit build gcc libraries contain full paths to source location

### DIFF
--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/devkit/Tools.gmk
+++ b/make/devkit/Tools.gmk
@@ -548,6 +548,7 @@ $(BUILDDIR)/$(gcc_ver)/Makefile \
 	  $(PATHPRE) $(ENVS) $(GCC_CFG) $(EXTRA_CFLAGS) \
 	      $(CONFIG) \
 	      --with-sysroot=$(SYSROOT) \
+	      --with-debug-prefix-map=$(OUTPUT_ROOT)=devkit \
 	      --enable-languages=c,c++ \
 	      --enable-shared \
 	      --disable-nls \


### PR DESCRIPTION
This PR adds --with-debug-prefix-map to the building of gcc in the DevKit make file to map the top OUTPUT_ROOT folder to a standard "devkit" path, thus ensuring DevKit builds are reproducible regardless of the folder the DevKit is built within.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323671](https://bugs.openjdk.org/browse/JDK-8323671): DevKit build gcc libraries contain full paths to source location (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [35944221](https://git.openjdk.org/jdk/pull/17400/files/35944221f7692adb456bbff1f59356a0b5a08177)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17400/head:pull/17400` \
`$ git checkout pull/17400`

Update a local copy of the PR: \
`$ git checkout pull/17400` \
`$ git pull https://git.openjdk.org/jdk.git pull/17400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17400`

View PR using the GUI difftool: \
`$ git pr show -t 17400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17400.diff">https://git.openjdk.org/jdk/pull/17400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17400#issuecomment-1889423319)