### PR TITLE
8323675: Race in jdk.javadoc-gendata

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -969,12 +969,16 @@ else
 
   jdk.jdeps-gendata: java
 
-  # The ct.sym generation is done in both jdk.compiler and jdk.javadoc gendata.
-  # It needs all generated java code present.
+  # jdk.compiler gendata generates ct.sym, which requires all generated
+  # java source and compiled classes present.
   jdk.compiler-gendata: $(JAVA_TARGETS)
-  jdk.javadoc-gendata: $(JAVA_TARGETS)
-  # ct.sym generation also needs the BUILD_JDK. If the BUILD_JDK was supplied
-  # externally, no extra prerequisites are needed.
+
+  # jdk.javadoc gendata generates element-list, which requires all java sources
+  # but not compiled classes.
+  jdk.javadoc-gendata: $(GENSRC_TARGETS)
+
+  # ct.sym and element-list generation also needs the BUILD_JDK. If the
+  # BUILD_JDK was supplied externally, no extra prerequisites are needed.
   ifeq ($(CREATE_BUILDJDK), true)
     ifneq ($(CREATING_BUILDJDK), true)
       # When cross compiling and an external BUILD_JDK wasn't supplied, it's

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -969,20 +969,24 @@ else
 
   jdk.jdeps-gendata: java
 
-  # The ct.sym generation uses all the moduleinfos as input
-  jdk.compiler-gendata: $(GENSRC_MODULEINFO_TARGETS) $(JAVA_TARGETS)
-  # jdk.compiler-gendata needs the BUILD_JDK. If the BUILD_JDK was supplied
+  # The ct.sym generation is done in both jdk.compiler and jdk.javadoc gendata.
+  # It needs all generated java code present.
+  jdk.compiler-gendata: $(JAVA_TARGETS)
+  jdk.javadoc-gendata: $(JAVA_TARGETS)
+  # ct.sym generation also needs the BUILD_JDK. If the BUILD_JDK was supplied
   # externally, no extra prerequisites are needed.
   ifeq ($(CREATE_BUILDJDK), true)
     ifneq ($(CREATING_BUILDJDK), true)
       # When cross compiling and an external BUILD_JDK wasn't supplied, it's
       # produced by the create-buildjdk target.
       jdk.compiler-gendata: create-buildjdk
+      jdk.javadoc-gendata: create-buildjdk
     endif
   else ifeq ($(EXTERNAL_BUILDJDK), false)
     # When not cross compiling, the BUILD_JDK is the interim jdk image, and
     # the javac launcher is needed.
     jdk.compiler-gendata: jdk.compiler-launchers
+    jdk.javadoc-gendata: jdk.compiler-launchers
   endif
 
   # Declare dependencies between jmod targets.


### PR DESCRIPTION
In [JDK-8318913](https://bugs.openjdk.org/browse/JDK-8318913), the symbolgenerator started to look at current sources as well. This means that the gensrc stage needs to be completed before this is run. A dependency was added for jdk.compiler-gendata, but unfortunately the same tool is run also in jdk.javadoc-gendata, where no such safeguard was created.

The result is that the build can fail intermittently with:
```
.../module-info.java:77: error: module not found on module source path
module java.base {
^
error: cannot access module-info
  cannot resolve modules
Exception in thread "main" java.lang.AssertionError
at jdk.compiler.interim/com.sun.tools.javac.util.Assert.error(Assert.java:155)
at jdk.compiler.interim/com.sun.tools.javac.util.Assert.checkNonNull(Assert.java:62)
at jdk.compiler.interim/com.sun.tools.javac.comp.Modules.allModules(Modules.java:1225)
at jdk.compiler.interim/com.sun.tools.javac.comp.Modules.getObservableModule(Modules.java:1450)
at jdk.compiler.interim/com.sun.tools.javac.model.JavacElements.getModuleElement(JavacElements.java:144)
at jdk.compiler.interim/com.sun.tools.javac.model.JavacElements.getModuleElement(JavacElements.java:89)
at build.tools.symbolgenerator.JavadocElementList.main(JavadocElementList.java:98)
Compiling up to 2 files for BUILD_BREAKITERATOR_BASE
Compiling up to 2 files for BUILD_BREAKITERATOR_LD
make[3]: *** [.../_element_lists.marker] Error 1
Gendata.gmk:74: recipe for target '.../_element_lists.marker' failed
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323675](https://bugs.openjdk.org/browse/JDK-8323675): Race in jdk.javadoc-gendata (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17402/head:pull/17402` \
`$ git checkout pull/17402`

Update a local copy of the PR: \
`$ git checkout pull/17402` \
`$ git pull https://git.openjdk.org/jdk.git pull/17402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17402`

View PR using the GUI difftool: \
`$ git pr show -t 17402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17402.diff">https://git.openjdk.org/jdk/pull/17402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17402#issuecomment-1889565610)