### PR TITLE
8323621: JDK build should exclude snippet class in java.lang.foreign

### DIFF
--- a/make/modules/java.base/Java.gmk
+++ b/make/modules/java.base/Java.gmk
@@ -37,7 +37,8 @@ EXCLUDE_FILES += \
 
 EXCLUDES += java/lang/doc-files \
     java/lang/classfile/snippet-files \
-    java/lang/classfile/components/snippet-files
+    java/lang/classfile/components/snippet-files \
+    jdk/lang/foreign/snippet-files
 
 # Exclude BreakIterator classes that are just used in compile process to generate
 # data files and shouldn't go in the product

--- a/make/modules/java.base/Java.gmk
+++ b/make/modules/java.base/Java.gmk
@@ -38,7 +38,7 @@ EXCLUDE_FILES += \
 EXCLUDES += java/lang/doc-files \
     java/lang/classfile/snippet-files \
     java/lang/classfile/components/snippet-files \
-    jdk/lang/foreign/snippet-files
+    java/lang/foreign/snippet-files
 
 # Exclude BreakIterator classes that are just used in compile process to generate
 # data files and shouldn't go in the product


### PR DESCRIPTION
This PR proposes to remove the snippet files in `java/lang/foreign/snippet-files` from the build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323621](https://bugs.openjdk.org/browse/JDK-8323621): JDK build should exclude snippet class in java.lang.foreign (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17403/head:pull/17403` \
`$ git checkout pull/17403`

Update a local copy of the PR: \
`$ git checkout pull/17403` \
`$ git pull https://git.openjdk.org/jdk.git pull/17403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17403`

View PR using the GUI difftool: \
`$ git pr show -t 17403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17403.diff">https://git.openjdk.org/jdk/pull/17403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17403#issuecomment-1889506828)