### PR TITLE
8320328: Restore interrupted flag in ImageIcon.loadImage

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ImageIcon.java
+++ b/src/java.desktop/share/classes/javax/swing/ImageIcon.java
@@ -330,6 +330,7 @@ public class ImageIcon implements Icon, Serializable, Accessible {
                 mTracker.waitForID(id, 0);
             } catch (InterruptedException e) {
                 interrupted = true;
+                Thread.currentThread().interrupt();
             }
 
             loadStatus = mTracker.statusID(id, false);


### PR DESCRIPTION
ImageIcon.loadImage used to handle InterruptedException only by printing a message to the console. JDK-8236987 handled the interrupted state more gracefully, but it didn't restore the interrupted flag.
This change restores the interrupted flag that will allow the following code to handle interruption and exit the thread; otherwise, the thread will continue to run.