### PR TITLE
8323556: CDS archive space addresses should be randomized with ArchiveRelocationMode=1

### DIFF
--- a/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
@@ -25,9 +25,6 @@
 
 #include "precompiled.hpp"
 #include "asm/assembler.hpp"
-#if INCLUDE_CDS
-#include "cds/cdsConfig.hpp"
-#endif
 #include "logging/log.hpp"
 #include "oops/compressedKlass.hpp"
 #include "memory/metaspace.hpp"
@@ -61,20 +58,7 @@ static char* reserve_at_eor_compatible_address(size_t size, bool aslr) {
       0x7ffc, 0x7ffe, 0x7fff
   };
   static constexpr int num_immediates = sizeof(immediates) / sizeof(immediates[0]);
-  if (aslr) {
-    // With aslr enabled, call os::init_random so that we get a different start_index
-    // in each run.
-#if INCLUDE_CDS
-    if (!CDSConfig::is_dumping_static_archive()) {
-      // To ensure we have a deterministic static archive on aarch64 platform, call
-      // os::init_random when not dumping static archive.
-#endif
-      os::init_random((int)os::javaTimeNanos());
-#if INCLUDE_CDS
-    }
-#endif
-  }
-  const int start_index = aslr ? os::random() : 0;
+  const int start_index = aslr ? os::next_random((int)os::javaTimeNanos()) : 0;
   constexpr int max_tries = 64;
   for (int ntry = 0; result == nullptr && ntry < max_tries; ntry ++) {
     // As in os::attempt_reserve_memory_between, we alternate between higher and lower


### PR DESCRIPTION
Please review this small fix for ensuring the reserved archive space addresses are different from run to run. The bug is only on the aarch64 platforms. The fix is to call `os::init_random()` if aslr is `true` and not dumping CDS static archive.

Tested manually on linux-aarch64 and macosx-aarch64 platforms.
```
% ./jdk-23/fastdebug/bin/java -Xlog:cds --version | grep archive_space_rs | tail -1
[0.015s][info][cds] Reserved archive_space_rs [0x0000200000000000 - 0x0000200001000000] (16777216) bytes
% ./jdk-23/fastdebug/bin/java -Xlog:cds --version | grep archive_space_rs | tail -1
[0.014s][info][cds] Reserved archive_space_rs [0x0000080000000000 - 0x0000080001000000] (16777216) bytes
```
The fix also passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323556](https://bugs.openjdk.org/browse/JDK-8323556): CDS archive space addresses should be randomized with ArchiveRelocationMode=1 (**Bug** - P2)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17409/head:pull/17409` \
`$ git checkout pull/17409`

Update a local copy of the PR: \
`$ git checkout pull/17409` \
`$ git pull https://git.openjdk.org/jdk.git pull/17409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17409`

View PR using the GUI difftool: \
`$ git pr show -t 17409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17409.diff">https://git.openjdk.org/jdk/pull/17409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17409#issuecomment-1890047527)