### PR TITLE
8323700: Add fontconfig requirement to building.md for Alpine Linux

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -753,6 +753,8 @@ macOS.</p>
 <code>sudo apt-get install libfontconfig-dev</code>.</li>
 <li>To install on an rpm-based Linux, try running
 <code>sudo yum install fontconfig-devel</code>.</li>
+<li>To install on Alpine Linux, try running
+<code>sudo apk add fontconfig-dev</code>.</li>
 </ul>
 <p>Use <code>--with-fontconfig-include=&lt;path&gt;</code> and
 <code>--with-fontconfig=&lt;path&gt;</code> if <code>configure</code>

--- a/doc/building.md
+++ b/doc/building.md
@@ -572,6 +572,7 @@ required on all platforms except Windows and macOS.
 libfontconfig-dev`.
 * To install on an rpm-based Linux, try running `sudo yum install
 fontconfig-devel`.
+* To install on Alpine Linux, try running `sudo apk add fontconfig-dev`.
 
 Use `--with-fontconfig-include=<path>` and `--with-fontconfig=<path>` if
 `configure` does not automatically locate the platform Fontconfig files.


### PR DESCRIPTION
Similar to JDK-8309287.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323700](https://bugs.openjdk.org/browse/JDK-8323700): Add fontconfig requirement to building.md for Alpine Linux (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17415/head:pull/17415` \
`$ git checkout pull/17415`

Update a local copy of the PR: \
`$ git checkout pull/17415` \
`$ git pull https://git.openjdk.org/jdk.git pull/17415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17415`

View PR using the GUI difftool: \
`$ git pr show -t 17415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17415.diff">https://git.openjdk.org/jdk/pull/17415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17415#issuecomment-1890840200)