### PR TITLE
8323699: MessageFormat.toPattern() generates non-equivalent MessageFormat pattern

### DIFF
--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -553,6 +553,9 @@ public class MessageFormat extends Format {
      * The string is constructed from internal information and therefore
      * does not necessarily equal the previously applied pattern.
      *
+     * @implNote The string returned by this method can be used to create
+     * an instance that is semantically equivalent to this instance.
+     *
      * @return a pattern representing the current state of the message format
      */
     public String toPattern() {

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -581,12 +581,12 @@ public class MessageFormat extends Format {
                 } else if (fmt.equals(NumberFormat.getIntegerInstance(locale))) {
                     result.append(",number,integer");
                 } else {
-                    if (fmt instanceof DecimalFormat) {
+                    if (fmt instanceof DecimalFormat dfmt) {
                         result.append(",number");
-                        subformatPattern = ((DecimalFormat)fmt).toPattern();
-                    } else if (fmt instanceof ChoiceFormat) {
+                        subformatPattern = dfmt.toPattern();
+                    } else if (fmt instanceof ChoiceFormat cfmt) {
                         result.append(",choice");
-                        subformatPattern = ((ChoiceFormat)fmt).toPattern();
+                        subformatPattern = cfmt.toPattern();
                     } else {
                         // UNKNOWN
                     }
@@ -608,9 +608,9 @@ public class MessageFormat extends Format {
                     }
                 }
                 if (index >= DATE_TIME_MODIFIERS.length) {
-                    if (fmt instanceof SimpleDateFormat) {
+                    if (fmt instanceof SimpleDateFormat sdfmt) {
                         result.append(",date");
-                        subformatPattern = ((SimpleDateFormat)fmt).toPattern();
+                        subformatPattern = sdfmt.toPattern();
                     } else {
                         // UNKNOWN
                     }

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -553,7 +553,7 @@ public class MessageFormat extends Format {
      * The string is constructed from internal information and therefore
      * does not necessarily equal the previously applied pattern.
      *
-     * @implNote The implementation in {@link MessageFormat} returns a string
+     * @implSpec The implementation in {@link MessageFormat} returns a string
      * that can be used to create a new instance that is semantically equivalent
      * to this instance.
      *

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -553,9 +553,10 @@ public class MessageFormat extends Format {
      * The string is constructed from internal information and therefore
      * does not necessarily equal the previously applied pattern.
      *
-     * @implSpec The implementation in {@link MessageFormat} returns a string
-     * that can be used to create a new instance that is semantically equivalent
-     * to this instance.
+     * @implSpec The implementation in {@link MessageFormat} returns a
+     * string that, when passed to a {@code MessageFormat()} constructor
+     * or {@link #applyPattern applyPattern()}, produces an instance that
+     * is semantically equivalent to this instance.
      *
      * @return a pattern representing the current state of the message format
      */

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1671,8 +1671,9 @@ public class MessageFormat extends Format {
                 if (i + 1 < source.length() && source.charAt(i + 1) == '\'') {
                     qchars.add(new Qchar('\'', quoted));
                     i++;
-                } else
+                } else {
                     quoted = !quoted;
+                }
             } else {
                 boolean quotable = ch == '{' || ch == '}';
                 anyChangeNeeded |= quotable && !quoted;
@@ -1690,16 +1691,17 @@ public class MessageFormat extends Format {
         quoted = false;
         for (Qchar qchar : qchars) {
             char ch = qchar.ch;
-            if (ch == '\'')
+            if (ch == '\'') {
                 target.append(ch);          // doubling works whether quoted or not
-            else if (qchar.quoted() != quoted) {
+            } else if (qchar.quoted() != quoted) {
                 target.append('\'');
                 quoted = qchar.quoted();
             }
             target.append(ch);
         }
-        if (quoted)
+        if (quoted) {
             target.append('\'');
+        }
     }
 
     /**

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -553,8 +553,9 @@ public class MessageFormat extends Format {
      * The string is constructed from internal information and therefore
      * does not necessarily equal the previously applied pattern.
      *
-     * @implNote The string returned by this method can be used to create
-     * an instance that is semantically equivalent to this instance.
+     * @implNote The implementation in {@link MessageFormat} returns a string
+     * that can be used to create a new instance that is semantically equivalent
+     * to this instance.
      *
      * @return a pattern representing the current state of the message format
      */

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -1686,7 +1686,7 @@ public class MessageFormat extends Format {
             return;
         }
 
-        // Build new string, automaticaly consolidating adjacent runs of quoted chars
+        // Build new string, automatically consolidating adjacent runs of quoted chars
         quoted = false;
         for (Qchar qchar : qchars) {
             char ch = qchar.ch;

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
@@ -53,6 +53,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MessageFormatToPatternTest {
 
     private static final int NUM_RANDOM_TEST_CASES = 1000;
+
+    // Max levels of nesting of ChoiceFormats inside MessageFormats
     private static final int MAX_FORMAT_NESTING = 3;
 
     private static Locale savedLocale;

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
@@ -23,32 +23,301 @@
 
 /*
  * @test
- * @summary Check MessageFormat.toPattern() is equivalent to original pattern
+ * @summary Verify MessageFormat.toPattern() is equivalent to original pattern
  * @bug 8323699
  * @run junit MessageFormatToPatternTest
  */
 
+import java.text.ChoiceFormat;
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.Format;
 import java.text.MessageFormat;
+import java.text.NumberFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Random;
+import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MessageFormatToPatternTest {
 
-    // Converting from MessageFormat to pattern string and back should give the same result.
-    // For this to work the pattern string needs to quote any "extra" closing brace "}" characters.
+    private static final int NUM_RANDOM_TEST_CASES = 1000;
+    private static final int MAX_FORMAT_NESTING = 3;
+
+    private static Locale savedLocale;
+    private static long randomSeed;             // set this to a non-zero value for reproducibility
+    private static Random random;
+    private static boolean spitSeed;
+    private static int textCount;
+
+// Setup & Teardown
+
+    @BeforeAll
+    public static void setup() {
+        savedLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+        if (randomSeed == 0)
+            randomSeed = new Random().nextLong();
+        random = new Random(randomSeed);
+    }
+
+    @AfterAll
+    public static void teardown() {
+        Locale.setDefault(savedLocale);
+    }
+
+// Tests
+
     @Test
-    public void toPatternTest() {
+    public void testJDK_8323699() {
 
-        String pattern1 = "{0,choice,0.0#option A: {1}|1.0#option B: {1}'}'}";
-        MessageFormat format1 = new MessageFormat(pattern1);
-        String result1 = format1.format(new Object[] { 0, 5 });
+        // This is the test case from JDK-8323699
+        testRoundTrip(new MessageFormat("{2,choice,0.0#option A: {0}|1.0#option B: {0}'}'}"));
 
-        String pattern2 = format1.toPattern();
-        MessageFormat format2 = new MessageFormat(pattern2);
-        String result2 = format2.format(new Object[] { 0, 5 });
+        // A few more test cases from the PR#17416 discussion
+        testRoundTrip(new MessageFormat("Test: {0,number,foo'{'#.00}"));
+        testRoundTrip(new MessageFormat("Test: {0,number,foo'}'#.00}"));
+    }
 
-        assertEquals(result1, result2);
+    // Go roundrip from MessageFormat -> pattern string -> MessageFormat and verify equivalence
+    @ParameterizedTest
+    @MethodSource("testCases")
+    public void testRoundTrip(MessageFormat format1) {
+
+        // Prepare MessageFormat argument
+        Object[] args = new Object[] {
+            8.5,                            // argument for DecimalFormat
+            new Date(1705502102677L),       // argument for SimpleDateFormat
+            random.nextInt(6)               // argument for ChoiceFormat
+        };
+
+        String pattern1 = null;
+        String result1 = null;
+        String pattern2 = null;
+        String result2 = null;
+        try {
+
+            // Format using the given MessageFormat
+            pattern1 = format1.toPattern();
+            result1 = format1.format(args);
+
+            // Round-trip via toPattern() and repeat
+            MessageFormat format2 = new MessageFormat(pattern1);
+            pattern2 = format2.toPattern();
+            result2 = format2.format(args);
+
+            // Check equivalence
+            assertEquals(result1, result2);
+            assertEquals(pattern1, pattern2);
+        } catch (RuntimeException | Error e) {
+            System.out.println(String.format("%n********** FAILURE **********%n"));
+            System.out.println(String.format("%s%n", e));
+            if (!spitSeed) {
+                System.out.println(String.format("*** Random seed was 0x%016xL%n", randomSeed));
+                spitSeed = true;
+            }
+            print(0, format1);
+            System.out.println();
+            if (pattern1 != null)
+                System.out.println(String.format("  pattern1 = %s", javaLiteral(pattern1)));
+            if (result1 != null)
+                System.out.println(String.format("   result1 = %s", javaLiteral(result1)));
+            if (pattern2 != null)
+                System.out.println(String.format("  pattern2 = %s", javaLiteral(pattern2)));
+            if (result2 != null)
+                System.out.println(String.format("   result2 = %s", javaLiteral(result2)));
+            System.out.println();
+            throw e;
+        }
+    }
+
+    public static Stream<Arguments> testCases() {
+        final ArrayList<Arguments> argList = new ArrayList<>();
+        for (int i = 0; i < NUM_RANDOM_TEST_CASES; i++)
+            argList.add(Arguments.of(randomFormat()));
+        return argList.stream();
+    }
+
+    // Generate a "random" MessageFormat. We do this by creating a MessageFormat with "{0}" placeholders
+    // and then substituting in random DecimalFormat, DateFormat, and ChoiceFormat subformats. The goal here
+    // is to avoid using pattern strings to construct formats, because they're what we're trying to check.
+    private static MessageFormat randomFormat() {
+
+        // Create a temporary MessageFormat containing "{0}" placeholders and random text
+        StringBuilder tempPattern = new StringBuilder();
+        int numParts = random.nextInt(3) + 1;
+        for (int i = 0; i < numParts; i++) {
+            if (random.nextBoolean())
+                tempPattern.append("{0}");      // temporary placeholder for a subformat
+            else
+                tempPattern.append(quoteText(randomText()));
+        }
+
+        // Replace all the "{0}" placeholders with random subformats
+        MessageFormat format = new MessageFormat(tempPattern.toString());
+        Format[] formats = format.getFormats();
+        for (int i = 0; i < formats.length; i++) {
+            formats[i] = randomSubFormat(0);
+
+        }
+        format.setFormats(formats);
+
+        // Done
+        return format;
+    }
+
+    // Generate some random text
+    private static String randomText() {
+        StringBuilder buf = new StringBuilder();
+        int length = random.nextInt(6);
+        for (int i = 0; i < length; i++) {
+            char ch = (char)(0x20 + random.nextInt(0x5f));
+            buf.append(ch);
+        }
+        return buf.toString();
+    }
+
+    // Quote non-alphanumeric characters in the given plain text
+    private static String quoteText(String string) {
+        StringBuilder buf = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < string.length(); i++) {
+            char ch = string.charAt(i);
+            if (ch == '\'')
+                buf.append("''");
+            else if (!(ch == ' ' || Character.isLetter(ch) || Character.isDigit(ch))) {
+                if (!quoted) {
+                    buf.append('\'');
+                    quoted = true;
+                }
+                buf.append(ch);
+            } else {
+                if (quoted) {
+                    buf.append('\'');
+                    quoted = false;
+                }
+                buf.append(ch);
+            }
+        }
+        if (quoted)
+            buf.append('\'');
+        return buf.toString();
+    }
+
+    // Create a random subformat
+    private static Format randomSubFormat(int nesting) {
+        int which;
+        if (nesting >= MAX_FORMAT_NESTING)
+            which = random.nextInt(2);          // no more recursion
+        else
+            which = random.nextInt(3);
+        switch (which) {
+        case 0:
+            return new DecimalFormat("#.##");
+        case 1:
+            return new SimpleDateFormat("YYYY-MM-DD");
+        default:
+            int numChoices = random.nextInt(3) + 1;
+            assert numChoices > 0;
+            final double[] limits = new double[numChoices];
+            final String[] formats = new String[numChoices];
+            for (int i = 0; i < limits.length; i++) {
+                limits[i] = (double)i;
+                formats[i] = toChoiceOption(randomSubFormat(nesting + 1));
+            }
+            return new ChoiceFormat(limits, formats);
+        }
+    }
+
+    // Create one ChoiceFormat option containing the given subformat
+    private static String toChoiceOption(Format format) {
+        String beforeText = "";     //quoteText(randomText());
+        String afterText = "";      //quoteText(randomText());
+        String middleText;
+        if (format instanceof DecimalFormat)
+            middleText = String.format("{0,number,%s}", ((DecimalFormat)format).toPattern());
+        else if (format instanceof SimpleDateFormat)
+            middleText = String.format("{1,date,%s}", ((SimpleDateFormat)format).toPattern());
+        else if (format instanceof ChoiceFormat)
+            middleText = String.format("{2,choice,%s}", ((ChoiceFormat)format).toPattern());
+        else
+            throw new RuntimeException("internal error");
+        return String.format("text%d [%s] %s text%d [%s]", ++textCount, beforeText, middleText, ++textCount, afterText);
+    }
+
+// Debug printing
+
+    private static void print(int depth, Object format) {
+        if (format == null)
+            return;
+        if (format instanceof String)
+            System.out.println(String.format("%s- %s", indent(depth), javaLiteral((String)format)));
+        else if (format instanceof MessageFormat)
+            print(depth, (MessageFormat)format);
+        else if (format instanceof DecimalFormat)
+            print(depth, (DecimalFormat)format);
+        else if (format instanceof SimpleDateFormat)
+            print(depth, (SimpleDateFormat)format);
+        else if (format instanceof ChoiceFormat)
+            print(depth, (ChoiceFormat)format);
+        else
+            throw new RuntimeException("internal error: " + format.getClass());
+    }
+
+    private static void print(int depth, MessageFormat format) {
+        System.out.println(String.format("%s- %s: %s", indent(depth), "MessageFormat", javaLiteral(format.toPattern())));
+        for (Format subformat : format.getFormats())
+            print(depth + 1, subformat);
+    }
+
+    private static void print(int depth, DecimalFormat format) {
+        System.out.println(String.format("%s- %s: %s", indent(depth), "DecimalFormat", javaLiteral(format.toPattern())));
+    }
+
+    private static void print(int depth, SimpleDateFormat format) {
+        System.out.println(String.format("%s- %s: %s", indent(depth), "SimpleDateFormat", javaLiteral(format.toPattern())));
+    }
+
+    private static void print(int depth, ChoiceFormat format) {
+        System.out.println(String.format("%s- %s: %s", indent(depth), "ChoiceFormat", javaLiteral(format.toPattern())));
+        for (Object subformat : format.getFormats())
+            print(depth + 1, subformat);
+    }
+
+    private static String indent(int depth) {
+        StringBuilder buf = new StringBuilder();
+        for (int i = 0; i < depth; i++)
+            buf.append("    ");
+        return buf.toString();
+    }
+
+    // Print a Java string in double quotes so it looks like a String literal (for easy pasting into jshell)
+    private static String javaLiteral(String string) {
+        StringBuilder buf = new StringBuilder();
+        buf.append('"');
+        for (int i = 0; i < string.length(); i++) {
+            char ch = string.charAt(i);
+            switch (ch) {
+            case '"':
+            case '\\':
+                buf.append('\\');
+                // FALLTHROUGH
+            default:
+                buf.append(ch);
+                break;
+            }
+        }
+        return buf.append('"').toString();
     }
 }

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
@@ -112,6 +112,10 @@ public class MessageFormatToPatternTest {
             Arguments.of("{0,choice,0.0#''{''curly''}'' braces}", "{curly} braces"),
             Arguments.of("{0,choice,0.0#'{0,choice,0.0#''{0,choice,0.0#''''{0,choice,0.0#foo}''''}''}'}", "foo"),
 
+            // Absurd double quote examples
+            Arguments.of("Foo '}''''''''}' {0,number,bar'}' '}' } baz ", "Foo }''''} bar} } 1 baz "),
+            Arguments.of("'''}''{'''}''''}'", "'}'{'}''}"),
+
             // An absurdly complicated example
             Arguments.of("{0,choice,0.0#text2887 [] '{'1,date,YYYY-MM-DD'}' text2888 [''*'']|1.0#found|2.0#'text2901 [oog'')!''] {2,choice,0.0#''text2897 ['''']''''wq1Q] {2,choice,0.0#''''text2891 [s''''''''&''''''''] {0,number,#0.##} text2892 [8''''''''|$'''''''''''''''''''''''']''''|1.0#''''text2893 [] {0,number,#0.##} text2894 [S'''''''']'''''''']''''|2.0#text2895 [''''''''.''''''''eB] {1,date,YYYY-MM-DD} text2896 [9Y]} text2898 []''|1.0#''text2899 [xk7] {0,number,#0.##} text2900 []''} text2902 [7'':$)''O]'}{0,choice,0.0#'text2903 [] {0,number,#0.##} text2904 [S'':'']'|1.0#'me'}", "foundme")
         );

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
@@ -122,6 +122,9 @@ public class MessageFormatToPatternTest {
             // Check equivalence
             assertEquals(result1, result2);
             assertEquals(pattern1, pattern2);
+
+            // Debug
+            //showRoundTrip(format1, pattern1, result1, pattern2, result2);
         } catch (RuntimeException | Error e) {
             System.out.println(String.format("%n********** FAILURE **********%n"));
             System.out.println(String.format("%s%n", e));
@@ -129,17 +132,7 @@ public class MessageFormatToPatternTest {
                 System.out.println(String.format("*** Random seed was 0x%016xL%n", randomSeed));
                 spitSeed = true;
             }
-            print(0, format1);
-            System.out.println();
-            if (pattern1 != null)
-                System.out.println(String.format("  pattern1 = %s", javaLiteral(pattern1)));
-            if (result1 != null)
-                System.out.println(String.format("   result1 = %s", javaLiteral(result1)));
-            if (pattern2 != null)
-                System.out.println(String.format("  pattern2 = %s", javaLiteral(pattern2)));
-            if (result2 != null)
-                System.out.println(String.format("   result2 = %s", javaLiteral(result2)));
-            System.out.println();
+            showRoundTrip(format1, pattern1, result1, pattern2, result2);
             throw e;
         }
     }
@@ -259,6 +252,20 @@ public class MessageFormatToPatternTest {
     }
 
 // Debug printing
+
+    private void showRoundTrip(MessageFormat format1, String pattern1, String result1, String pattern2, String result2) {
+        print(0, format1);
+        System.out.println();
+        if (pattern1 != null)
+            System.out.println(String.format("  pattern1 = %s", javaLiteral(pattern1)));
+        if (result1 != null)
+            System.out.println(String.format("   result1 = %s", javaLiteral(result1)));
+        if (pattern2 != null)
+            System.out.println(String.format("  pattern2 = %s", javaLiteral(pattern2)));
+        if (result2 != null)
+            System.out.println(String.format("   result2 = %s", javaLiteral(result2)));
+        System.out.println();
+    }
 
     private static void print(int depth, Object format) {
         if (format == null)

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @summary Verify MessageFormat.toPattern() is equivalent to original pattern
+ * @summary Verify that MessageFormat.toPattern() properly escapes special curly braces
  * @bug 8323699
  * @run junit MessageFormatToPatternTest
  */

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
@@ -245,12 +245,12 @@ public class MessageFormatToPatternTest {
         String beforeText = "";     //quoteText(randomText());
         String afterText = "";      //quoteText(randomText());
         String middleText;
-        if (format instanceof DecimalFormat)
-            middleText = String.format("{0,number,%s}", ((DecimalFormat)format).toPattern());
-        else if (format instanceof SimpleDateFormat)
-            middleText = String.format("{1,date,%s}", ((SimpleDateFormat)format).toPattern());
-        else if (format instanceof ChoiceFormat)
-            middleText = String.format("{2,choice,%s}", ((ChoiceFormat)format).toPattern());
+        if (format instanceof DecimalFormat dfmt)
+            middleText = String.format("{0,number,%s}", dfmt.toPattern());
+        else if (format instanceof SimpleDateFormat sdfmt)
+            middleText = String.format("{1,date,%s}", sdfmt.toPattern());
+        else if (format instanceof ChoiceFormat cfmt)
+            middleText = String.format("{2,choice,%s}", cfmt.toPattern());
         else
             throw new RuntimeException("internal error");
         return String.format("text%d [%s] %s text%d [%s]", ++textCount, beforeText, middleText, ++textCount, afterText);

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatToPatternTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Check MessageFormat.toPattern() is equivalent to original pattern
+ * @bug 8323699
+ * @run junit MessageFormatToPatternTest
+ */
+
+import java.text.MessageFormat;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MessageFormatToPatternTest {
+
+    // Converting from MessageFormat to pattern string and back should give the same result.
+    // For this to work the pattern string needs to quote any "extra" closing brace "}" characters.
+    @Test
+    public void toPatternTest() {
+
+        String pattern1 = "{0,choice,0.0#option A: {1}|1.0#option B: {1}'}'}";
+        MessageFormat format1 = new MessageFormat(pattern1);
+        String result1 = format1.format(new Object[] { 0, 5 });
+
+        String pattern2 = format1.toPattern();
+        MessageFormat format2 = new MessageFormat(pattern2);
+        String result2 = format2.format(new Object[] { 0, 5 });
+
+        assertEquals(result1, result2);
+    }
+}

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatsByArgumentIndex.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatsByArgumentIndex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/text/Format/MessageFormat/MessageFormatsByArgumentIndex.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageFormatsByArgumentIndex.java
@@ -35,6 +35,7 @@ import java.text.NumberFormat;
 public class MessageFormatsByArgumentIndex {
 
     private static String choicePattern = "0.0#are no files|1.0#is one file|1.0<are {0,number,integer} files";
+    private static String quotedChoicePattern = choicePattern.replaceAll("([{}])", "'$1'");
 
     public static void main(String[] args) {
         Format[] subformats;
@@ -56,7 +57,7 @@ public class MessageFormatsByArgumentIndex {
 
         format.setFormatByArgumentIndex(0, NumberFormat.getInstance());
 
-        checkPattern(format.toPattern(), "{3,choice," + choicePattern + "}, {2}, {0,number}");
+        checkPattern(format.toPattern(), "{3,choice," + quotedChoicePattern + "}, {2}, {0,number}");
 
         subformats = format.getFormatsByArgumentIndex();
         checkSubformatLength(subformats, 4);
@@ -73,7 +74,8 @@ public class MessageFormatsByArgumentIndex {
 
         format.setFormatsByArgumentIndex(subformats);
 
-        checkPattern(format.toPattern(), "{3,choice," + choicePattern + "}, {2,number}, {0,choice," + choicePattern + "}");
+        checkPattern(format.toPattern(),
+          "{3,choice," + quotedChoicePattern + "}, {2,number}, {0,choice," + quotedChoicePattern + "}");
 
         subformats = format.getFormatsByArgumentIndex();
         checkSubformatLength(subformats, 4);

--- a/test/jdk/java/text/Format/MessageFormat/MessageRegression.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageRegression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/text/Format/MessageFormat/MessageRegression.java
+++ b/test/jdk/java/text/Format/MessageFormat/MessageRegression.java
@@ -114,9 +114,9 @@ public class MessageRegression {
     @Test
     public void Test4058973() {
 
-        MessageFormat fmt = new MessageFormat("{0,choice,0#no files|1#one file|1< {0,number,integer} files}");
+        MessageFormat fmt = new MessageFormat("{0,choice,0.0#no files|1.0#one file|1.0< '{'0,number,integer'}' files}");
         String pat = fmt.toPattern();
-        if (!pat.equals("{0,choice,0.0#no files|1.0#one file|1.0< {0,number,integer} files}")) {
+        if (!pat.equals("{0,choice,0.0#no files|1.0#one file|1.0< '{'0,number,integer'}' files}")) {
             fail("MessageFormat.toPattern failed");
         }
     }


### PR DESCRIPTION
Please consider this fix to ensure that going from `MessageFormat` to pattern string via `toPattern()` and then back via `new MessageFormat()` results in a format that is equivalent to the original.

The quoting and escaping rules for `MessageFormat` pattern strings are really tricky. I admit not completely understanding them. At a high level, they work like this: The normal way one would "nest" strings containing special characters is with straightforward recursive escaping like with the `bash` command line. For example, if you want to echo `a "quoted string" example` then you enter `echo "a \"quoted string\" example"`. With this scheme it's always the "outer" layer's job to (un)escape special characters as needed. That is, the echo command never sees the backslash characters.

In contrast, with `MessageFormat` and friends, nested subformat pattern strings are always provided "pre-escaped". So to build an "outer" string (e.g., for `ChoiceFormat`) the "inner" subformat pattern strings are more or less just concatenated, and then only the `ChoiceFormat` option separator characters (e.g., `<`, `#`, `|`, etc.) are escaped.

The "pre-escape" escaping algorithm escapes `{` characters, because `{` indicates the beginning of a format argument. However, it doesn't escape `}` characters. This is OK because the format string parser treats any "extra" closing braces (where "extra" means not matching an opening brace) as plain characters.

So far, so good... at least, until a format string containing an extra closing brace is nested inside a larger format string, where the extra closing brace, which was previously "extra", can now suddenly match an opening brace in the outer pattern containing it, thus truncating it by "stealing" the match from some subsequent closing brace.

An example is the `MessageFormat` string `"{0,choice,0.0#option A: {1}|1.0#option B: {1}'}'}"`. Note the second option format string has a trailing closing brace in plain text. If you create a `MessageFormat` with this string, you see a trailing `}` only with the second option.

However, if you then invoke `toPattern()`, the result is `"{0,choice,0.0#option A: {1}|1.0#option B: {1}}}"`. Oops, now because the "extra" closing brace is no longer quoted, it matches the opening brace at the beginning of the string, and the following closing  brace, which was the previous match, is now just plain text in the outer `MessageFormat` string.

As a result, invoking `f.format(new Object{} { 0, 5 })` will return `"option A: 5"` using the original `MessageFormat` but `"option A: 5}"` from a new one created with the string from `toPattern()`.

This patch fixes this problem by adding quotes around "extra" closing braces in the subformat pattern strings.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8324172](https://bugs.openjdk.org/browse/JDK-8324172) to be approved

### Issues
 * [JDK-8323699](https://bugs.openjdk.org/browse/JDK-8323699): MessageFormat.toPattern() generates non-equivalent MessageFormat pattern (**Bug** - P4)
 * [JDK-8324172](https://bugs.openjdk.org/browse/JDK-8324172): MessageFormat.toPattern() generates non-equivalent MessageFormat pattern (**CSR**)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17416/head:pull/17416` \
`$ git checkout pull/17416`

Update a local copy of the PR: \
`$ git checkout pull/17416` \
`$ git pull https://git.openjdk.org/jdk.git pull/17416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17416`

View PR using the GUI difftool: \
`$ git pr show -t 17416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17416.diff">https://git.openjdk.org/jdk/pull/17416.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17416#issuecomment-1890985229)