### PR TITLE
8323601: Improve LayoutPath.PathElement::toString

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -864,7 +864,8 @@ public sealed interface MemoryLayout
         static PathElement groupElement(String name) {
             Objects.requireNonNull(name);
             return new LayoutPath.PathElementImpl(PathKind.GROUP_ELEMENT,
-                                                  path -> path.groupElement(name));
+                                                  path -> path.groupElement(name),
+                                                  "\"" + name + "\"");
         }
 
         /**
@@ -879,7 +880,8 @@ public sealed interface MemoryLayout
                 throw new IllegalArgumentException("Index < 0");
             }
             return new LayoutPath.PathElementImpl(PathKind.GROUP_ELEMENT,
-                    path -> path.groupElement(index));
+                                                  path -> path.groupElement(index),
+                                                  Long.toString(index));
         }
 
         /**
@@ -894,7 +896,8 @@ public sealed interface MemoryLayout
                 throw new IllegalArgumentException("Index must be positive: " + index);
             }
             return new LayoutPath.PathElementImpl(PathKind.SEQUENCE_ELEMENT_INDEX,
-                                                  path -> path.sequenceElement(index));
+                                                  path -> path.sequenceElement(index),
+                                                  Long.toString(index));
         }
 
         /**
@@ -927,7 +930,8 @@ public sealed interface MemoryLayout
                 throw new IllegalArgumentException("Step must be != 0: " + step);
             }
             return new LayoutPath.PathElementImpl(PathKind.SEQUENCE_RANGE,
-                                                  path -> path.sequenceElement(start, step));
+                                                  path -> path.sequenceElement(start, step),
+                                                  start + " + N * " + step + ", N >= 0");
         }
 
         /**

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -389,10 +389,19 @@ public class LayoutPath {
 
         final PathKind kind;
         final UnaryOperator<LayoutPath> pathOp;
+        final String additionalInfo;
 
-        public PathElementImpl(PathKind kind, UnaryOperator<LayoutPath> pathOp) {
+        public PathElementImpl(PathKind kind,
+                               UnaryOperator<LayoutPath> pathOp) {
+            this(kind, pathOp, null);
+        }
+
+        public PathElementImpl(PathKind kind,
+                               UnaryOperator<LayoutPath> pathOp,
+                               String additionalInfo) {
             this.kind = kind;
             this.pathOp = pathOp;
+            this.additionalInfo = additionalInfo;
         }
 
         @Override
@@ -402,6 +411,14 @@ public class LayoutPath {
 
         public PathKind kind() {
             return kind;
+        }
+
+        @Override
+        public String toString() {
+            return kind.description() +
+                    (additionalInfo != null
+                            ? " " + additionalInfo
+                            : "");
         }
     }
 }

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -311,6 +311,42 @@ public class TestLayoutPaths {
         assertEquals(actualByteOffset, expectedByteOffset);
     }
 
+    @Test
+    public void testGroupElementIndexToString() {
+        PathElement e = PathElement.groupElement(2);
+        assertEquals(e.toString(), "group element 2");
+    }
+
+    @Test
+    public void testGroupElementNameToString() {
+        PathElement e = PathElement.groupElement("x");
+        assertEquals(e.toString(), "group element \"x\"");
+    }
+
+    @Test
+    public void testSequenceElementToString() {
+        PathElement e = PathElement.sequenceElement();
+        assertEquals(e.toString(), "unbound sequence element");
+    }
+
+    @Test
+    public void testSequenceElementIndexToString() {
+        PathElement e = PathElement.sequenceElement(2);
+        assertEquals(e.toString(), "bound sequence element 2");
+    }
+
+    @Test
+    public void testSequenceElementRangeToString() {
+        PathElement e = PathElement.sequenceElement(2, 4);
+        assertEquals(e.toString(), "sequence range 2 + N * 4, N >= 0");
+    }
+
+    @Test
+    public void testDerefereceElementToString() {
+        PathElement e = PathElement.dereferenceElement();
+        assertEquals(e.toString(), "dereference element");
+    }
+
     @DataProvider
     public static Object[][] testLayouts() {
         List<Object[]> testCases = new ArrayList<>();


### PR DESCRIPTION
This PR proposes to add an improved Improve `LayoutPath.PathElement::toString` method simplifying debugging.

Opinions and suggestions for `static PathElement sequenceElement(long start, long step)` are welcome. 