### PR TITLE
8323635: Test gc/g1/TestHumongousAllocConcurrentStart.java fails with -XX:TieredStopAtLevel=3

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestHumongousAllocConcurrentStart.java
+++ b/test/hotspot/jtreg/gc/g1/TestHumongousAllocConcurrentStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package gc.g1;
  * @bug 7168848
  * @summary G1: humongous object allocations should initiate marking cycles when necessary
  * @requires vm.gc.G1
+ * @requires vm.flagless
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
@@ -45,7 +46,7 @@ public class TestHumongousAllocConcurrentStart {
     private static final int initiatingHeapOccupancyPercent = 50;  // %
 
     public static void main(String[] args) throws Exception {
-        OutputAnalyzer output = ProcessTools.executeTestJava(
+        OutputAnalyzer output = ProcessTools.executeLimitedTestJava(
             "-XX:+UseG1GC",
             "-Xms" + heapSize + "m",
             "-Xmx" + heapSize + "m",


### PR DESCRIPTION
Hi all,

  please review this fix to the TestHumongousConcurrentStart test that changes execution so that additional test options are _not_ passed on to the test as it is sensitive to the type of gcs that occur. An alternative would be just excluding -Xcomp to fix this particular occurrence, but I wanted to avoid having to revisit this issue again.

Testing: that test on aarch64 does not fail any more

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323635](https://bugs.openjdk.org/browse/JDK-8323635): Test gc/g1/TestHumongousAllocConcurrentStart.java fails with -XX:TieredStopAtLevel=3 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17419/head:pull/17419` \
`$ git checkout pull/17419`

Update a local copy of the PR: \
`$ git checkout pull/17419` \
`$ git pull https://git.openjdk.org/jdk.git pull/17419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17419`

View PR using the GUI difftool: \
`$ git pr show -t 17419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17419.diff">https://git.openjdk.org/jdk/pull/17419.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17419#issuecomment-1891777149)