### PR TITLE
8323716: Only print ZGC Phase Switch events in hs_err files when running with ZGC

### DIFF
--- a/src/hotspot/share/utilities/events.cpp
+++ b/src/hotspot/share/utilities/events.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shared/gc_globals.hpp"
 #include "memory/allocation.inline.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/symbol.hpp"
@@ -97,7 +98,9 @@ void Events::init() {
   if (LogEvents) {
     _messages = new StringEventLog("Events", "events");
     _vm_operations = new StringEventLog("VM Operations", "vmops");
-    _zgc_phase_switch = new StringEventLog("ZGC Phase Switch", "zgcps");
+    if (UseZGC) {
+      _zgc_phase_switch = new StringEventLog("ZGC Phase Switch", "zgcps");
+    }
     _exceptions = new ExceptionsEventLog("Internal exceptions", "exc");
     _redefinitions = new StringEventLog("Classes redefined", "redef");
     _class_unloading = new UnloadingEventLog("Classes unloaded", "unload");


### PR DESCRIPTION
Don't print the ZGC Phase Switch hs_err section when the JVM is run with other GCs than ZGC.

I've tested this manually with `-XX:ErrorHandlerTest=3 -version` and verified that the section is logged when ZGC is used, and that it is not logged when G1 is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323716](https://bugs.openjdk.org/browse/JDK-8323716): Only print ZGC Phase Switch events in hs_err files when running with ZGC (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17420/head:pull/17420` \
`$ git checkout pull/17420`

Update a local copy of the PR: \
`$ git checkout pull/17420` \
`$ git pull https://git.openjdk.org/jdk.git pull/17420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17420`

View PR using the GUI difftool: \
`$ git pr show -t 17420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17420.diff">https://git.openjdk.org/jdk/pull/17420.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17420#issuecomment-1891811782)