### PR TITLE
8323726: Serial: Remove unused definitions in Generation

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -1104,11 +1104,6 @@ const char* DefNewGeneration::name() const {
   return "def new generation";
 }
 
-// Moved from inline file as they are not called inline
-ContiguousSpace* DefNewGeneration::first_compaction_space() const {
-  return eden();
-}
-
 HeapWord* DefNewGeneration::allocate(size_t word_size, bool is_tlab) {
   // This is the slow-path allocation for the DefNewGeneration.
   // Most allocations are fast-path in compiled code.

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -168,8 +168,6 @@ class DefNewGeneration: public Generation {
   ContiguousSpace* from() const           { return _from_space; }
   ContiguousSpace* to()   const           { return _to_space;   }
 
-  virtual ContiguousSpace* first_compaction_space() const;
-
   // Space enquiries
   size_t capacity() const;
   size_t used() const;

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -55,16 +55,6 @@ class ContiguousSpace;
 class OopClosure;
 class GCStats;
 
-// A "ScratchBlock" represents a block of memory in one generation usable by
-// another.  It represents "num_words" free words, starting at and including
-// the address of "this".
-struct ScratchBlock {
-  ScratchBlock* next;
-  size_t num_words;
-  HeapWord scratch_space[1];  // Actually, of size "num_words-2" (assuming
-                              // first two fields are word-sized.)
-};
-
 class Generation: public CHeapObj<mtGC> {
   friend class VMStructs;
  private:
@@ -174,10 +164,6 @@ class Generation: public CHeapObj<mtGC> {
 
   // Iteration - do not use for time critical operations
   virtual void space_iterate(SpaceClosure* blk, bool usedOnly = false) = 0;
-
-  // Returns the first space, if any, in the generation that can participate
-  // in compaction, or else "null".
-  virtual ContiguousSpace* first_compaction_space() const = 0;
 
   // Returns "true" iff this generation should be used to allocate an
   // object of the given size.  Young generations might

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -101,8 +101,6 @@ class TenuredGeneration: public Generation {
 
   bool is_in(const void* p) const;
 
-  ContiguousSpace* first_compaction_space() const;
-
   TenuredGeneration(ReservedSpace rs,
                     size_t initial_byte_size,
                     size_t min_byte_size,

--- a/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
@@ -49,10 +49,6 @@ inline bool TenuredGeneration::is_in(const void* p) const {
   return space()->is_in(p);
 }
 
-inline ContiguousSpace* TenuredGeneration::first_compaction_space() const {
-  return space();
-}
-
 HeapWord* TenuredGeneration::allocate(size_t word_size,
                                                  bool is_tlab) {
   assert(!is_tlab, "TenuredGeneration does not support TLAB allocation");


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323726](https://bugs.openjdk.org/browse/JDK-8323726): Serial: Remove unused definitions in Generation (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17424/head:pull/17424` \
`$ git checkout pull/17424`

Update a local copy of the PR: \
`$ git checkout pull/17424` \
`$ git pull https://git.openjdk.org/jdk.git pull/17424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17424`

View PR using the GUI difftool: \
`$ git pr show -t 17424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17424.diff">https://git.openjdk.org/jdk/pull/17424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17424#issuecomment-1892147347)