### PR TITLE
8323730: Tweak TestZAllocationStallEvent.java to allocate smaller objects

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestZAllocationStallEvent.java
@@ -56,7 +56,7 @@ public class TestZAllocationStallEvent {
 
             // Allocate many large objects quickly, to outrun the GC
             for (int i = 0; i < 100; i++) {
-                blackHole(new byte[16 * 1024 * 1024]);
+                blackHole(new byte[4 * 1024 * 1024]);
             }
 
             recording.stop();


### PR DESCRIPTION
This is a minor tweak to TestZAllocationStallEvent.java in an attempt to lower the risk of hitting OOME while provoking allocation stalls.

Tested by running tier5, where the test has been found to very intermittently cause problems.