### PR TITLE
8323738: Serial: Remove unreachable methods in Generation

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -254,8 +254,8 @@ class DefNewGeneration: public Generation {
   // completed. Even if this method returns true, a collection
   // may not be guaranteed to succeed, and the system should be
   // able to safely unwind and recover from that failure, albeit
-  // at some additional cost. Override superclass's implementation.
-  virtual bool collection_attempt_is_safe();
+  // at some additional cost.
+  bool collection_attempt_is_safe();
 
   virtual void collect(bool   full,
                        bool   clear_all_soft_refs,

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -188,18 +188,6 @@ class Generation: public CHeapObj<mtGC> {
 
   // Thread-local allocation buffers
   virtual bool supports_tlab_allocation() const { return false; }
-  virtual size_t tlab_capacity() const {
-    guarantee(false, "Generation doesn't support thread local allocation buffers");
-    return 0;
-  }
-  virtual size_t tlab_used() const {
-    guarantee(false, "Generation doesn't support thread local allocation buffers");
-    return 0;
-  }
-  virtual size_t unsafe_max_tlab_alloc() const {
-    guarantee(false, "Generation doesn't support thread local allocation buffers");
-    return 0;
-  }
 
   // "obj" is the address of an object in a younger generation.  Allocate space
   // for "obj" in the current (or some higher) generation, and copy "obj" into
@@ -224,16 +212,6 @@ class Generation: public CHeapObj<mtGC> {
                               size_t word_size,
                               bool   is_tlab) {
     return (full || should_allocate(word_size, is_tlab));
-  }
-
-  // Returns true if the collection is likely to be safely
-  // completed. Even if this method returns true, a collection
-  // may not be guaranteed to succeed, and the system should be
-  // able to safely unwind and recover from that failure, albeit
-  // at some additional cost.
-  virtual bool collection_attempt_is_safe() {
-    guarantee(false, "Are you sure you want to call this method?");
-    return true;
   }
 
   // Perform a garbage collection.


### PR DESCRIPTION
Trivial removing effectively dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323738](https://bugs.openjdk.org/browse/JDK-8323738): Serial: Remove unreachable methods in Generation (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17429/head:pull/17429` \
`$ git checkout pull/17429`

Update a local copy of the PR: \
`$ git checkout pull/17429` \
`$ git pull https://git.openjdk.org/jdk.git pull/17429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17429`

View PR using the GUI difftool: \
`$ git pr show -t 17429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17429.diff">https://git.openjdk.org/jdk/pull/17429.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17429#issuecomment-1892385549)