### PR TITLE
8323745: Missing comma in copyright header in TestScope

### DIFF
--- a/test/jdk/java/foreign/TestScope.java
+++ b/test/jdk/java/foreign/TestScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This PR proposed to fix a missing comma in the header of TestScope