### PR TITLE
8323651: compiler/c2/irTests/TestPrunedExHandler.java fails with -XX:+DeoptimizeALot

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPrunedExHandler.java
@@ -30,6 +30,7 @@ import compiler.lib.ir_framework.*;
  * @bug 8267532
  * @summary check that uncommon trap is generated for unhandled catch block
  * @library /test/lib /
+ * @requires vm.opt.DeoptimizeALot != true
  * @run driver compiler.c2.irTests.TestPrunedExHandler
  */
 


### PR DESCRIPTION
This test can not work with `-XX:+DeoptimizeALot`. Parts of it depend on a particular sequence of compilation and deoptimization, so if DeoptimizeALot deoptimizes things prematurely, the test can fail.

This PR adds `@requires vm.opt.DeoptimizeALot != true` to the test so that it is skipped when `-XX:+DeoptimizeALot` is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323651](https://bugs.openjdk.org/browse/JDK-8323651): compiler/c2/irTests/TestPrunedExHandler.java fails with -XX:+DeoptimizeALot (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [956a4f78](https://git.openjdk.org/jdk/pull/17432/files/956a4f782253b15bd22b163fd15a2f171fccc99f)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17432/head:pull/17432` \
`$ git checkout pull/17432`

Update a local copy of the PR: \
`$ git checkout pull/17432` \
`$ git pull https://git.openjdk.org/jdk.git pull/17432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17432`

View PR using the GUI difftool: \
`$ git pr show -t 17432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17432.diff">https://git.openjdk.org/jdk/pull/17432.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17432#issuecomment-1892543914)