### PR TITLE
8323694: RISC-V: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -27,7 +27,6 @@
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
 #include "code/compiledIC.hpp"
-#include "memory/resourceArea.hpp"
 #include "nativeInst_riscv.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.hpp"
@@ -157,7 +156,6 @@ void NativeCall::set_destination_mt_safe(address dest, bool assert_lock) {
          CompiledICLocker::is_safe(addr_at(0)),
          "concurrent code patching");
 
-  ResourceMark rm;
   address addr_call = addr_at(0);
   assert(NativeCall::is_call_at(addr_call), "unexpected code at call site");
 


### PR DESCRIPTION
Hi, We noticed that RISC-V bears a similar issue as: https://bugs.openjdk.org/browse/JDK-8323584.
In `NativeCall::set_destination_mt_safe`, there is a `ResourceMark` that does not seem to have any purpose: no code in its scope uses resource allocation.

### Testing:

- [x]  Run tier1 tests on qemu 8.1.0 with UseRVV (fastdebug)
- [x]  Run tier1-3 tests on qemu 8.1.0 with UseRVV (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323694](https://bugs.openjdk.org/browse/JDK-8323694): RISC-V: Unnecessary ResourceMark in NativeCall::set_destination_mt_safe (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17436/head:pull/17436` \
`$ git checkout pull/17436`

Update a local copy of the PR: \
`$ git checkout pull/17436` \
`$ git pull https://git.openjdk.org/jdk.git pull/17436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17436`

View PR using the GUI difftool: \
`$ git pr show -t 17436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17436.diff">https://git.openjdk.org/jdk/pull/17436.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17436#issuecomment-1892978853)