### PR TITLE
8323273: AArch64: Strengthen CompressedClassPointers initialization check for base

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -914,6 +914,9 @@ public:
   void encode_klass_not_null(Register dst, Register src);
   void decode_klass_not_null(Register dst, Register src);
 
+  static int eor_compatible_klass_encoding(uint64_t base);
+  static bool movk_compatible_klass_encoding(uint64_t shifted_base);
+
   void set_narrow_klass(Register dst, Klass* k);
 
   // if heap base register is used - reinit it with the correct value

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -42,6 +42,7 @@ size_t CompressedKlassPointers::_range = 0;
 void CompressedKlassPointers::assert_is_valid_encoding(address addr, size_t len, address base, int shift) {
   assert(base + nth_bit(32 + shift) >= addr + len, "Encoding (base=" PTR_FORMAT ", shift=%d) does not "
          "fully cover the class range " PTR_FORMAT "-" PTR_FORMAT, p2i(base), shift, p2i(addr), p2i(addr + len));
+  assert(pd_is_valid_encoding(addr, len, base, shift), "Must satisfy");
 }
 #endif
 
@@ -114,6 +115,10 @@ void CompressedKlassPointers::initialize(address addr, size_t len) {
   _range = end - _base;
 
   DEBUG_ONLY(assert_is_valid_encoding(addr, len, _base, _shift);)
+}
+
+bool CompressedKlassPointers::pd_is_valid_encoding(address addr, size_t len, address base, int shift) {
+  return true;
 }
 #endif // !AARCH64 || ZERO
 

--- a/src/hotspot/share/oops/compressedKlass.hpp
+++ b/src/hotspot/share/oops/compressedKlass.hpp
@@ -83,6 +83,8 @@ public:
   //  structures outside this range).
   static void initialize(address addr, size_t len);
 
+  static bool pd_is_valid_encoding(address addr, size_t len, address base, int shift);
+
   static void     print_mode(outputStream* st);
 
   static address  base()               { return  _base; }


### PR DESCRIPTION
Summary:
Add a platform-dependent check for CompressedClassSpaceBaseAddress;
Remove the "reserve anywhere" attempt after the initial mapping attempt failed---this is rarely used and will likely fail anyway, because the accepted mapping is very restricted on aarch64;
Additional assertions after initialization.

Passed hotspot/jtreg/:tier1 on fastdebug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323273](https://bugs.openjdk.org/browse/JDK-8323273): AArch64: Strengthen CompressedClassPointers initialization check for base (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17437/head:pull/17437` \
`$ git checkout pull/17437`

Update a local copy of the PR: \
`$ git checkout pull/17437` \
`$ git pull https://git.openjdk.org/jdk.git pull/17437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17437`

View PR using the GUI difftool: \
`$ git pr show -t 17437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17437.diff">https://git.openjdk.org/jdk/pull/17437.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17437#issuecomment-1892991533)