### PR TITLE
8323760: clarify specification of Map::putIfAbsent return value

### DIFF
--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -818,7 +818,7 @@ public interface Map<K, V> {
      * @param key key with which the specified value is to be associated
      * @param value value to be associated with the specified key
      * @return {@code null} if the specified key was absent or had a {@code null}
-     *         value, else returns the value currently associated with the key. (A
+     *         value, else returns the value currently associated with {@code key}. (A
      *         {@code null} return can also indicate that the map previously
      *         associated {@code null} with the key, if the implementation supports
      *         null values.)

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -817,10 +817,10 @@ public interface Map<K, V> {
      *
      * @param key key with which the specified value is to be associated
      * @param value value to be associated with the specified key
-     * @return {@code null} if the specified key was considered absent, else returns
-     *         the current value. (A {@code null} return can also indicate that
-     *         the map previously associated {@code null} with the key,
-     *         if the implementation supports null values.)
+     * @return {@code null} if the specified key was absent or had a {@code null}
+     *         value, else returns the current value. (A {@code null} return can 
+     *         also indicate that the map previously associated {@code null} with 
+     *         the key, if the implementation supports null values.)
      * @throws UnsupportedOperationException if the {@code putIfAbsent} operation
      *         is not supported by this map
      *         ({@linkplain Collection##optional-restrictions optional})

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -817,10 +817,9 @@ public interface Map<K, V> {
      *
      * @param key key with which the specified value is to be associated
      * @param value value to be associated with the specified key
-     * @return the previous value associated with the specified key, or
-     *         {@code null} if there was no mapping for the key.
-     *         (A {@code null} return can also indicate that the map
-     *         previously associated {@code null} with the key,
+     * @return {@code null} if the specified key was considered absent, else returns
+     *         the current value. (A {@code null} return can also indicate that
+     *         the map previously associated {@code null} with the key,
      *         if the implementation supports null values.)
      * @throws UnsupportedOperationException if the {@code putIfAbsent} operation
      *         is not supported by this map

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -817,11 +817,8 @@ public interface Map<K, V> {
      *
      * @param key key with which the specified value is to be associated
      * @param value value to be associated with the specified key
-     * @return {@code null} if the specified key was absent or had a {@code null}
-     *         value, else returns the value currently associated with {@code key}. (A
-     *         {@code null} return can also indicate that the map previously
-     *         associated {@code null} with the key, if the implementation supports
-     *         null values.)
+     * @return {@code null} if the specified key was absent or was associated with
+     *         {@code null}, otherwise the value currently associated with the key
      * @throws UnsupportedOperationException if the {@code putIfAbsent} operation
      *         is not supported by this map
      *         ({@linkplain Collection##optional-restrictions optional})

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -818,9 +818,10 @@ public interface Map<K, V> {
      * @param key key with which the specified value is to be associated
      * @param value value to be associated with the specified key
      * @return {@code null} if the specified key was absent or had a {@code null}
-     *         value, else returns the current value. (A {@code null} return can 
-     *         also indicate that the map previously associated {@code null} with 
-     *         the key, if the implementation supports null values.)
+     *         value, else returns the previous value associated with the key. (A
+     *         {@code null} return can also indicate that the map previously
+     *         associated {@code null} with the key, if the implementation supports
+     *         null values.)
      * @throws UnsupportedOperationException if the {@code putIfAbsent} operation
      *         is not supported by this map
      *         ({@linkplain Collection##optional-restrictions optional})

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -818,7 +818,7 @@ public interface Map<K, V> {
      * @param key key with which the specified value is to be associated
      * @param value value to be associated with the specified key
      * @return {@code null} if the specified key was absent or had a {@code null}
-     *         value, else returns the previous value associated with the key. (A
+     *         value, else returns the value currently associated with the key. (A
      *         {@code null} return can also indicate that the map previously
      *         associated {@code null} with the key, if the implementation supports
      *         null values.)


### PR DESCRIPTION
Update the documentation for `@return` tag of `putIfAbsent` to match the main description. `putIfAbsent` uses the same wording as `put` for its `@return` tag, but that is incorrect.  `putIfAbsent` never returns the **previous** value, as the whole point of the method is not the replace the value if it was present.  As such, if it returns a value, it is the **current** value, and in all other cases it will return `null`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8325811](https://bugs.openjdk.org/browse/JDK-8325811) to be approved

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8323760: clarify specification of Map::putIfAbsent return value`

### Issues
 * [JDK-8323760](https://bugs.openjdk.org/browse/JDK-8323760): clarify specification of Map::putIfAbsent return value (**Bug** - P4)
 * [JDK-8325811](https://bugs.openjdk.org/browse/JDK-8325811): clarify specification of Map::putIfAbsent return value (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17438/head:pull/17438` \
`$ git checkout pull/17438`

Update a local copy of the PR: \
`$ git checkout pull/17438` \
`$ git pull https://git.openjdk.org/jdk.git pull/17438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17438`

View PR using the GUI difftool: \
`$ git pr show -t 17438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17438.diff">https://git.openjdk.org/jdk/pull/17438.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17438#issuecomment-1893216794)