### PR TITLE
8323779: Serial: Remove Generation::promotion_attempt_is_safe

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -54,6 +54,7 @@ class DefNewGeneration: public Generation {
   friend class VMStructs;
 
   TenuredGeneration* _old_gen;
+
   uint        _tenuring_threshold;   // Tenuring threshold for next collection.
   AgeTable    _age_table;
   // Size of object to pretenure in words; command line provides bytes

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/serial/cSpaceCounters.hpp"
 #include "gc/serial/generation.hpp"
+#include "gc/serial/tenuredGeneration.hpp"
 #include "gc/shared/ageTable.hpp"
 #include "gc/shared/copyFailedInfo.hpp"
 #include "gc/shared/gc_globals.hpp"
@@ -52,7 +53,7 @@ class STWGCTimer;
 class DefNewGeneration: public Generation {
   friend class VMStructs;
 
-  Generation* _old_gen;
+  TenuredGeneration* _old_gen;
   uint        _tenuring_threshold;   // Tenuring threshold for next collection.
   AgeTable    _age_table;
   // Size of object to pretenure in words; command line provides bytes

--- a/src/hotspot/share/gc/serial/generation.cpp
+++ b/src/hotspot/share/gc/serial/generation.cpp
@@ -113,14 +113,6 @@ size_t Generation::max_contiguous_available() const {
   return MAX2(avail, old_avail);
 }
 
-bool Generation::promotion_attempt_is_safe(size_t max_promotion_in_bytes) const {
-  size_t available = max_contiguous_available();
-  bool   res = (available >= max_promotion_in_bytes);
-  log_trace(gc)("Generation: promo attempt is%s safe: available(" SIZE_FORMAT ") %s max_promo(" SIZE_FORMAT ")",
-                res? "":" not", available, res? ">=":"<", max_promotion_in_bytes);
-  return res;
-}
-
 // Ignores "ref" and calls allocate().
 oop Generation::promote(oop obj, size_t obj_size) {
   assert(obj_size == obj->size(), "bad obj_size passed in");

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -122,12 +122,6 @@ class Generation: public CHeapObj<mtGC> {
   // The largest number of contiguous free bytes in this or any higher generation.
   virtual size_t max_contiguous_available() const;
 
-  // Returns true if promotions of the specified amount are
-  // likely to succeed without a promotion failure.
-  // Promotion of the full amount is not guaranteed but
-  // might be attempted in the worst case.
-  virtual bool promotion_attempt_is_safe(size_t max_promotion_in_bytes) const;
-
   // Return an estimate of the maximum allocation that could be performed
   // in the generation without triggering any collection or expansion
   // activity.  It is "unsafe" because no locks are taken; the result

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -156,7 +156,11 @@ class TenuredGeneration: public Generation {
 
   virtual void update_gc_stats(Generation* current_generation, bool full);
 
-  virtual bool promotion_attempt_is_safe(size_t max_promoted_in_bytes) const;
+  // Returns true if promotions of the specified amount are
+  // likely to succeed without a promotion failure.
+  // Promotion of the full amount is not guaranteed but
+  // might be attempted in the worst case.
+  bool promotion_attempt_is_safe(size_t max_promoted_in_bytes) const;
 
   virtual void verify();
   virtual void print_on(outputStream* st) const;

--- a/src/hotspot/share/gc/serial/vmStructs_serial.hpp
+++ b/src/hotspot/share/gc/serial/vmStructs_serial.hpp
@@ -40,7 +40,7 @@
   nonstatic_field(TenuredGeneration,                 _min_heap_delta_bytes,  size_t)                        \
   nonstatic_field(TenuredGeneration,                 _the_space,             TenuredSpace*)                 \
                                                                                                             \
-  nonstatic_field(DefNewGeneration,                  _old_gen,               Generation*)                   \
+  nonstatic_field(DefNewGeneration,                  _old_gen,               TenuredGeneration*)            \
   nonstatic_field(DefNewGeneration,                  _tenuring_threshold,    uint)                          \
   nonstatic_field(DefNewGeneration,                  _age_table,             AgeTable)                      \
   nonstatic_field(DefNewGeneration,                  _eden_space,            ContiguousSpace*)              \


### PR DESCRIPTION
Simple updating a field type to use more concrete type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323779](https://bugs.openjdk.org/browse/JDK-8323779): Serial: Remove Generation::promotion_attempt_is_safe (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17439/head:pull/17439` \
`$ git checkout pull/17439`

Update a local copy of the PR: \
`$ git checkout pull/17439` \
`$ git pull https://git.openjdk.org/jdk.git pull/17439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17439`

View PR using the GUI difftool: \
`$ git pr show -t 17439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17439.diff">https://git.openjdk.org/jdk/pull/17439.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17439#issuecomment-1893355071)