### PR TITLE
8323791: Parallel: Using non-atomic for live bytes update during Full GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -308,8 +308,9 @@ public:
     inline void set_completed();
     inline bool claim_unsafe();
 
-    // These are atomic.
     inline void add_live_obj(size_t words);
+
+    // These are atomic.
     inline void decrement_destination_count();
     inline bool claim();
 
@@ -408,7 +409,6 @@ public:
   inline size_t     block(const BlockData* block_ptr) const;
 
   void add_obj(HeapWord* addr, size_t len);
-  void add_obj(oop p, size_t len) { add_obj(cast_from_oop<HeapWord*>(p), len); }
 
   // Fill in the regions covering [beg, end) so that no data moves; i.e., the
   // destination of region n is simply the start of region n.  Both arguments
@@ -573,7 +573,7 @@ inline bool ParallelCompactData::RegionData::claim_unsafe()
 inline void ParallelCompactData::RegionData::add_live_obj(size_t words)
 {
   assert(words <= (size_t)los_mask - live_obj_size(), "overflow");
-  Atomic::add(&_dc_and_los, static_cast<region_sz_t>(words));
+  _dc_and_los += static_cast<region_sz_t>(words);
 }
 
 inline bool ParallelCompactData::RegionData::claim()

--- a/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
@@ -100,7 +100,6 @@ inline void PSParallelCompact::check_new_location(HeapWord* old_addr, HeapWord* 
 inline bool PSParallelCompact::mark_obj(oop obj) {
   const size_t obj_size = obj->size();
   if (mark_bitmap()->mark_obj(obj, obj_size)) {
-    _summary_data.add_obj(obj, obj_size);
     ContinuationGCSupport::transform_stack_chunk(obj);
     return true;
   } else {


### PR DESCRIPTION
Simple optimization to avoid atomic-operation during Full GC marking.

Test: Full GC pause length shows ~1% regresion when using single gc-thread and ~20% improvement when using multiple gc-threads using the attached program.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323791](https://bugs.openjdk.org/browse/JDK-8323791): Parallel: Using non-atomic for live bytes update during Full GC (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17442/head:pull/17442` \
`$ git checkout pull/17442`

Update a local copy of the PR: \
`$ git checkout pull/17442` \
`$ git pull https://git.openjdk.org/jdk.git pull/17442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17442`

View PR using the GUI difftool: \
`$ git pr show -t 17442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17442.diff">https://git.openjdk.org/jdk/pull/17442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17442#issuecomment-1893493886)