### PR TITLE
8323794: Remove unused jimage compressor plugin configuration

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressedResourceHeader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressedResourceHeader.java
@@ -47,8 +47,8 @@ public final class CompressedResourceHeader {
 
     // Standard header offsets
     private static final int MAGIC_OFFSET = 0; // 4 bytes
-    private static final int UNCOMPRESSED_OFFSET = 4; // 8 bytes
-    private static final int COMPRESSED_OFFSET = 12; // 8 bytes
+    private static final int COMPRESSED_OFFSET = 4; // 8 bytes
+    private static final int UNCOMPRESSED_OFFSET = 12; // 8 bytes
     private static final int DECOMPRESSOR_NAME_OFFSET = 20; // 4 bytes, followed by 4 byte gap
     private static final int IS_TERMINAL_OFFSET = 28; // 1 byte
 

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressedResourceHeader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressedResourceHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package jdk.internal.jimage.decompressor;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Objects;
-import jdk.internal.jimage.decompressor.ResourceDecompressor.StringsProvider;
 
 /**
  *
@@ -48,16 +47,14 @@ public final class CompressedResourceHeader {
     private final long uncompressedSize;
     private final long compressedSize;
     private final int decompressorNameOffset;
-    private final int contentOffset;
     private final boolean isTerminal;
 
     public CompressedResourceHeader(long compressedSize,
-            long uncompressedSize, int decompressorNameOffset, int contentOffset,
+            long uncompressedSize, int decompressorNameOffset,
             boolean isTerminal) {
         this.compressedSize = compressedSize;
         this.uncompressedSize = uncompressedSize;
         this.decompressorNameOffset = decompressorNameOffset;
-        this.contentOffset = contentOffset;
         this.isTerminal = isTerminal;
     }
 
@@ -67,18 +64,6 @@ public final class CompressedResourceHeader {
 
     public int getDecompressorNameOffset() {
         return decompressorNameOffset;
-    }
-
-    public int getContentOffset() {
-        return contentOffset;
-    }
-
-    public String getStoredContent(StringsProvider provider) {
-        Objects.requireNonNull(provider);
-        if(contentOffset == -1) {
-            return null;
-        }
-        return provider.getString(contentOffset);
     }
 
     public long getUncompressedSize() {
@@ -97,7 +82,8 @@ public final class CompressedResourceHeader {
         buffer.putLong(compressedSize);
         buffer.putLong(uncompressedSize);
         buffer.putInt(decompressorNameOffset);
-        buffer.putInt(contentOffset);
+        // Compatibility
+        buffer.putInt(-1);
         buffer.put(isTerminal ? (byte)1 : (byte)0);
         return buffer.array();
     }
@@ -115,16 +101,16 @@ public final class CompressedResourceHeader {
         }
         ByteBuffer buffer = ByteBuffer.wrap(resource, 0, SIZE);
         buffer.order(order);
-        int magic = buffer.getInt();
+        int magic = buffer.getInt(0);
         if(magic != MAGIC) {
             return null;
         }
-        long size = buffer.getLong();
-        long uncompressedSize = buffer.getLong();
-        int decompressorNameOffset = buffer.getInt();
-        int contentIndex = buffer.getInt();
-        byte isTerminal = buffer.get();
+        long size = buffer.getLong(4);
+        long uncompressedSize = buffer.getLong(12);
+        int decompressorNameOffset = buffer.getInt(20);
+        // skip unused 'contentOffset' int
+        byte isTerminal = buffer.get(28);
         return new CompressedResourceHeader(size, uncompressedSize,
-                decompressorNameOffset, contentIndex, isTerminal == 1);
+                decompressorNameOffset, isTerminal == 1);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressedResourceHeader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/CompressedResourceHeader.java
@@ -44,6 +44,14 @@ public final class CompressedResourceHeader {
 
     private static final int SIZE = 29;
     public static final int MAGIC = 0xCAFEFAFA;
+
+    // Standard header offsets
+    private static final int MAGIC_OFFSET = 0; // 4 bytes
+    private static final int UNCOMPRESSED_OFFSET = 4; // 8 bytes
+    private static final int COMPRESSED_OFFSET = 12; // 8 bytes
+    private static final int DECOMPRESSOR_NAME_OFFSET = 20; // 4 bytes, followed by 4 byte gap
+    private static final int IS_TERMINAL_OFFSET = 28; // 1 byte
+
     private final long uncompressedSize;
     private final long compressedSize;
     private final int decompressorNameOffset;
@@ -101,15 +109,15 @@ public final class CompressedResourceHeader {
         }
         ByteBuffer buffer = ByteBuffer.wrap(resource, 0, SIZE);
         buffer.order(order);
-        int magic = buffer.getInt(0);
-        if(magic != MAGIC) {
+        int magic = buffer.getInt(MAGIC_OFFSET);
+        if (magic != MAGIC) {
             return null;
         }
-        long size = buffer.getLong(4);
-        long uncompressedSize = buffer.getLong(12);
-        int decompressorNameOffset = buffer.getInt(20);
+        long size = buffer.getLong(COMPRESSED_OFFSET);
+        long uncompressedSize = buffer.getLong(UNCOMPRESSED_OFFSET);
+        int decompressorNameOffset = buffer.getInt(DECOMPRESSOR_NAME_OFFSET);
         // skip unused 'contentOffset' int
-        byte isTerminal = buffer.get(28);
+        byte isTerminal = buffer.get(IS_TERMINAL_OFFSET);
         return new CompressedResourceHeader(size, uncompressedSize,
                 decompressorNameOffset, isTerminal == 1);
     }

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/Decompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/Decompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,14 +24,11 @@
  */
 package jdk.internal.jimage.decompressor;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
 import jdk.internal.jimage.decompressor.ResourceDecompressor.StringsProvider;
 
 /**

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/Decompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/Decompressor.java
@@ -75,17 +75,8 @@ public final class Decompressor {
                     if (pluginName == null) {
                         throw new IOException("Plugin name not found");
                     }
-                    String storedContent = header.getStoredContent(provider);
-                    Properties props = new Properties();
-                    if (storedContent != null) {
-                        try (ByteArrayInputStream stream
-                                = new ByteArrayInputStream(storedContent.
-                                        getBytes(StandardCharsets.UTF_8));) {
-                            props.loadFromXML(stream);
-                        }
-                    }
                     decompressor = ResourceDecompressorRepository.
-                            newResourceDecompressor(props, pluginName);
+                            newResourceDecompressor(pluginName);
                     if (decompressor == null) {
                         throw new IOException("Plugin not found: " + pluginName);
                     }

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressorFactory.java
@@ -25,7 +25,6 @@
 package jdk.internal.jimage.decompressor;
 
 import java.io.IOException;
-import java.util.Properties;
 
 /**
  *
@@ -54,12 +53,10 @@ public abstract class ResourceDecompressorFactory {
 
     /**
      * To build a new decompressor.
-     * @param properties Contains configuration.
      * @return A new decompressor.
      * @throws IOException
      */
-    public abstract ResourceDecompressor newDecompressor(Properties properties)
-            throws IOException;
+    public abstract ResourceDecompressor newDecompressor() throws IOException;
 
 }
 

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressorRepository.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressorRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package jdk.internal.jimage.decompressor;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  *

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressorRepository.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ResourceDecompressorRepository.java
@@ -54,17 +54,15 @@ public final class ResourceDecompressorRepository {
 
     /**
      * Build a new decompressor for the passed name.
-     * @param properties Contains plugin configuration.
      * @param name The plugin name to build.
      * @return A decompressor or null if not found
      * @throws IOException
      */
-    public static ResourceDecompressor newResourceDecompressor(Properties properties,
-            String name) throws IOException {
+    public static ResourceDecompressor newResourceDecompressor(String name) throws IOException {
 
         ResourceDecompressorFactory fact = factories.get(name);
         if (fact != null) {
-            return fact.newDecompressor(properties);
+            return fact.newDecompressor();
         }
         return null;
     }

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressor.java
@@ -33,7 +33,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Properties;
 
 /**
  *
@@ -228,9 +227,7 @@ public class StringSharingDecompressor implements ResourceDecompressor {
         return StringSharingDecompressorFactory.NAME;
     }
 
-    public StringSharingDecompressor(Properties properties) {
-
-    }
+    public StringSharingDecompressor() {}
 
     @Override
     public byte[] decompress(StringsProvider reader, byte[] content,

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/StringSharingDecompressorFactory.java
@@ -25,7 +25,6 @@
 package jdk.internal.jimage.decompressor;
 
 import java.io.IOException;
-import java.util.Properties;
 
 /**
  *
@@ -45,8 +44,8 @@ public class StringSharingDecompressorFactory extends ResourceDecompressorFactor
     }
 
     @Override
-    public ResourceDecompressor newDecompressor(Properties properties)
+    public ResourceDecompressor newDecompressor()
             throws IOException {
-        return new StringSharingDecompressor(properties);
+        return new StringSharingDecompressor();
     }
 }

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressor.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressor.java
@@ -24,7 +24,6 @@
  */
 package jdk.internal.jimage.decompressor;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.zip.Inflater;
 

--- a/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/decompressor/ZipDecompressorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 package jdk.internal.jimage.decompressor;
 
 import java.io.IOException;
-import java.util.Properties;
 
 /**
  *
@@ -44,7 +43,7 @@ public final class ZipDecompressorFactory extends ResourceDecompressorFactory {
     }
 
     @Override
-    public ResourceDecompressor newDecompressor(Properties properties)
+    public ResourceDecompressor newDecompressor()
             throws IOException {
         return new ZipDecompressor();
     }

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/ResourcePoolManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -448,7 +448,8 @@ public class ResourcePoolManager {
 
     public static CompressedModuleData newCompressedResource(ResourcePoolEntry original,
             ByteBuffer compressed,
-            String plugin, String pluginConfig, StringTable strings,
+            String plugin,
+            StringTable strings,
             ByteOrder order) {
         Objects.requireNonNull(original);
         Objects.requireNonNull(compressed);
@@ -461,13 +462,9 @@ public class ResourcePoolManager {
             uncompressed_size = comp.getUncompressedSize();
         }
         int nameOffset = strings.addString(plugin);
-        int configOffset = -1;
-        if (pluginConfig != null) {
-            configOffset = strings.addString(plugin);
-        }
         CompressedResourceHeader rh
                 = new CompressedResourceHeader(compressed.limit(), original.contentLength(),
-                        nameOffset, configOffset, isTerminal);
+                        nameOffset, isTerminal);
         // Merge header with content;
         byte[] h = rh.getBytes(order);
         ByteBuffer bb = ByteBuffer.allocate(compressed.limit() + h.length);

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
@@ -313,7 +313,7 @@ public class StringSharingPlugin extends AbstractPlugin implements ResourcePrevi
                     throw new PluginException(ex);
                 }
                 res = ResourcePoolManager.newCompressedResource(resource,
-                        ByteBuffer.wrap(compressed), getName(), null,
+                        ByteBuffer.wrap(compressed), getName(),
                         ((ResourcePoolImpl)in).getStringTable(), in.byteOrder());
             }
             return res;

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StringSharingPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -306,7 +305,7 @@ public class StringSharingPlugin extends AbstractPlugin implements ResourcePrevi
         in.transformAndCopy((resource) -> {
             ResourcePoolEntry res = resource;
             if (predicate.test(resource.path()) && resource.path().endsWith(".class")) {
-                byte[] compressed = null;
+                byte[] compressed;
                 try {
                     compressed = visit.transform(resource, result, ((ResourcePoolImpl)in).getStringTable());
                 } catch (Exception ex) {

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/ZipPlugin.java
@@ -114,7 +114,7 @@ public final class ZipPlugin extends AbstractPlugin {
                 byte[] compressed;
                 compressed = compress(resource.contentBytes(), this.compressionLevel);
                 res = ResourcePoolManager.newCompressedResource(resource,
-                        ByteBuffer.wrap(compressed), getName(), null,
+                        ByteBuffer.wrap(compressed), getName(),
                         ((ResourcePoolImpl)in).getStringTable(), in.byteOrder());
             }
             return res;

--- a/test/jdk/tools/jlink/ResourcePoolTest.java
+++ b/test/jdk/tools/jlink/ResourcePoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,9 @@
  * @run main ResourcePoolTest
  */
 
-import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -44,7 +42,6 @@ import java.util.function.Function;
 import jdk.tools.jlink.internal.ResourcePoolManager;
 import jdk.tools.jlink.plugin.ResourcePool;
 import jdk.tools.jlink.plugin.ResourcePoolModule;
-import jdk.tools.jlink.plugin.ResourcePool;
 import jdk.tools.jlink.plugin.ResourcePoolEntry;
 
 public class ResourcePoolTest {

--- a/test/jdk/tools/jlink/ResourcePoolTest.java
+++ b/test/jdk/tools/jlink/ResourcePoolTest.java
@@ -139,7 +139,7 @@ public class ResourcePoolTest {
             try {
                 resources.add(ResourcePoolManager.
                         newCompressedResource(ResourcePoolEntry.create(path, new byte[0]),
-                                ByteBuffer.allocate(99), "bitcruncher", null,
+                                ByteBuffer.allocate(99), "bitcruncher",
                                 ((ResourcePoolManager)resources).getStringTable(), ByteOrder.nativeOrder()));
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
@@ -207,7 +207,7 @@ public class ResourcePoolTest {
         ResourcePoolEntry res3 = ResourcePoolEntry.create("/module2/toto1", new byte[7]);
         resources2.add(res3);
         resources2.add(ResourcePoolManager.newCompressedResource(res1,
-                ByteBuffer.allocate(7), "zip", null, resources1.getStringTable(),
+                ByteBuffer.allocate(7), "zip", resources1.getStringTable(),
                 ByteOrder.nativeOrder()));
         checkResources(resources2, res1, res2);
     }

--- a/test/jdk/tools/jlink/plugins/CompressorPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/CompressorPluginTest.java
@@ -370,7 +370,7 @@ public class CompressorPluginTest {
             byte[] decompressed = compressed.contentBytes();
             for (ResourceDecompressorFactory factory : decompressors) {
                 try {
-                    ResourceDecompressor decompressor = factory.newDecompressor(new Properties());
+                    ResourceDecompressor decompressor = factory.newDecompressor();
                     decompressed = decompressor.decompress(
                         strings::get, decompressed,
                         CompressedResourceHeader.getSize(), header.getUncompressedSize());


### PR DESCRIPTION
There's an unused concept of a pluginConfig that is passed into the jlink compress plugins, however we always pass null here and the code seems broken (the pluginConfig wouldn't have been stored properly). This seem to be a left-over from a more generic plugin design that never came to fruition.

This PR cleans out this code from the plugins and decompressors, while keeping the compressed header format intact for backwards compatibility (and in case we want to revisit this in the future)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323794](https://bugs.openjdk.org/browse/JDK-8323794): Remove unused jimage compressor plugin configuration (**Enhancement** - P4)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**) ⚠️ Review applies to [7df80e39](https://git.openjdk.org/jdk/pull/17443/files/7df80e396080a4c6e6cc495c7a74f19e192191c2)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [a65ffbf5](https://git.openjdk.org/jdk/pull/17443/files/a65ffbf5a22d59a56059cd9f022fd147ca692284)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17443/head:pull/17443` \
`$ git checkout pull/17443`

Update a local copy of the PR: \
`$ git checkout pull/17443` \
`$ git pull https://git.openjdk.org/jdk.git pull/17443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17443`

View PR using the GUI difftool: \
`$ git pr show -t 17443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17443.diff">https://git.openjdk.org/jdk/pull/17443.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17443#issuecomment-1893516292)