### PR TITLE
8323795: jcmd Compiler.codecache should print total size of code cache

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1790,16 +1790,15 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
                   total_size, total_used, total_max_used, total_free);
     }
     st->print_cr(" total_blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
-                       ", adapters=" UINT32_FORMAT,
-                       blob_count(), nmethod_count(), adapter_count());
-    st->print_cr(" stopped_count=%d, restarted_count=%d, full_count=%d",
-                 CompileBroker::get_total_compiler_stopped_count(),
-                 CompileBroker::get_total_compiler_restarted_count(),
-                 full_count);
-    st->print_cr(" compilation=%s", CompileBroker::should_compile_new_jobs() ?
-              "enabled" : Arguments::mode() == Arguments::_int ?
-              "disabled (interpreter mode)" :
-              "disabled (not enough contiguous free space left)");
+                 ", adapters=" UINT32_FORMAT ", full_count=" UINT32_FORMAT,
+                 blob_count(), nmethod_count(), adapter_count(), full_count);
+    st->print_cr("Compilation:%s, stopped_count=%d, restarted_count=%d",
+                CompileBroker::should_compile_new_jobs() ?
+                "enabled" : Arguments::mode() == Arguments::_int ?
+                "disabled (interpreter mode)" :
+                "disabled (not enough contiguous free space left)",
+                CompileBroker::get_total_compiler_stopped_count(),
+                CompileBroker::get_total_compiler_restarted_count());
   }
 }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1786,19 +1786,19 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
     if (SegmentedCodeCache) {
       st->print("CodeCache:");
       st->print_cr(" size=" JULONG_FORMAT "Kb, used=" JULONG_FORMAT
-                  "Kb, max_used=" JULONG_FORMAT "Kb, free=" JULONG_FORMAT "Kb",
-                  total_size, total_used, total_max_used, total_free);
+                   "Kb, max_used=" JULONG_FORMAT "Kb, free=" JULONG_FORMAT "Kb",
+                   total_size, total_used, total_max_used, total_free);
     }
     st->print_cr(" total_blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
                  ", adapters=" UINT32_FORMAT ", full_count=" UINT32_FORMAT,
                  blob_count(), nmethod_count(), adapter_count(), full_count);
     st->print_cr("Compilation: %s, stopped_count=%d, restarted_count=%d",
-                CompileBroker::should_compile_new_jobs() ?
-                "enabled" : Arguments::mode() == Arguments::_int ?
-                "disabled (interpreter mode)" :
-                "disabled (not enough contiguous free space left)",
-                CompileBroker::get_total_compiler_stopped_count(),
-                CompileBroker::get_total_compiler_restarted_count());
+                 CompileBroker::should_compile_new_jobs() ?
+                 "enabled" : Arguments::mode() == Arguments::_int ?
+                 "disabled (interpreter mode)" :
+                 "disabled (not enough contiguous free space left)",
+                 CompileBroker::get_total_compiler_stopped_count(),
+                 CompileBroker::get_total_compiler_restarted_count());
   }
 }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1792,7 +1792,7 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
     st->print_cr(" total_blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
                  ", adapters=" UINT32_FORMAT ", full_count=" UINT32_FORMAT,
                  blob_count(), nmethod_count(), adapter_count(), full_count);
-    st->print_cr("Compilation:%s, stopped_count=%d, restarted_count=%d",
+    st->print_cr("Compilation: %s, stopped_count=%d, restarted_count=%d",
                 CompileBroker::should_compile_new_jobs() ?
                 "enabled" : Arguments::mode() == Arguments::_int ?
                 "disabled (interpreter mode)" :

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1783,22 +1783,24 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
   }
 
   if (detailed) {
-    st->print_cr(" total_blobs=" UINT32_FORMAT " nmethods=" UINT32_FORMAT
-                       " adapters=" UINT32_FORMAT,
+    if (SegmentedCodeCache) {
+      st->print("CodeCache:");
+      st->print_cr(" size=" JULONG_FORMAT "Kb, used=" JULONG_FORMAT
+                  "Kb, max_used=" JULONG_FORMAT "Kb, free=" JULONG_FORMAT "Kb",
+                  total_size, total_used, total_max_used, total_free);
+    }
+    st->print_cr(" total_blobs=" UINT32_FORMAT ", nmethods=" UINT32_FORMAT
+                       ", adapters=" UINT32_FORMAT,
                        blob_count(), nmethod_count(), adapter_count());
-    st->print_cr(" compilation: %s", CompileBroker::should_compile_new_jobs() ?
-                 "enabled" : Arguments::mode() == Arguments::_int ?
-                 "disabled (interpreter mode)" :
-                 "disabled (not enough contiguous free space left)");
-    st->print_cr("              stopped_count=%d, restarted_count=%d",
+    st->print_cr(" stopped_count=%d, restarted_count=%d, full_count=%d",
                  CompileBroker::get_total_compiler_stopped_count(),
-                 CompileBroker::get_total_compiler_restarted_count());
-    st->print_cr(" full_count=%d", full_count);
+                 CompileBroker::get_total_compiler_restarted_count(),
+                 full_count);
+    st->print_cr(" compilation=%s", CompileBroker::should_compile_new_jobs() ?
+              "enabled" : Arguments::mode() == Arguments::_int ?
+              "disabled (interpreter mode)" :
+              "disabled (not enough contiguous free space left)");
   }
-  st->print_cr("Total CodeHeap:");
-  st->print_cr(" size=" SIZE_FORMAT "Kb, used=" SIZE_FORMAT
-               "Kb, max used=" SIZE_FORMAT "Kb, free=" SIZE_FORMAT "Kb",
-               total_size, total_used, total_max_used, total_free);
 }
 
 void CodeCache::print_codelist(outputStream* st) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1748,6 +1748,10 @@ void CodeCache::print() {
 
 void CodeCache::print_summary(outputStream* st, bool detailed) {
   int full_count = 0;
+  julong total_used = 0;
+  julong total_max_used = 0;
+  julong total_free = 0;
+  julong total_size = 0;
   FOR_ALL_HEAPS(heap_iterator) {
     CodeHeap* heap = (*heap_iterator);
     size_t total = (heap->high_boundary() - heap->low_boundary());
@@ -1756,10 +1760,17 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
     } else {
       st->print("CodeCache:");
     }
+    size_t size = total/K;
+    size_t used = (total - heap->unallocated_capacity())/K;
+    size_t max_used = heap->max_allocated_capacity()/K;
+    size_t free = heap->unallocated_capacity()/K;
+    total_size += size;
+    total_used += used;
+    total_max_used += max_used;
+    total_free += free;
     st->print_cr(" size=" SIZE_FORMAT "Kb used=" SIZE_FORMAT
                  "Kb max_used=" SIZE_FORMAT "Kb free=" SIZE_FORMAT "Kb",
-                 total/K, (total - heap->unallocated_capacity())/K,
-                 heap->max_allocated_capacity()/K, heap->unallocated_capacity()/K);
+                 size, used, max_used, free);
 
     if (detailed) {
       st->print_cr(" bounds [" INTPTR_FORMAT ", " INTPTR_FORMAT ", " INTPTR_FORMAT "]",
@@ -1784,6 +1795,10 @@ void CodeCache::print_summary(outputStream* st, bool detailed) {
                  CompileBroker::get_total_compiler_restarted_count());
     st->print_cr(" full_count=%d", full_count);
   }
+  st->print_cr("Total CodeHeap:");
+  st->print_cr(" size=" SIZE_FORMAT "Kb, used=" SIZE_FORMAT
+               "Kb, max used=" SIZE_FORMAT "Kb, free=" SIZE_FORMAT "Kb",
+               total_size, total_used, total_max_used, total_free);
 }
 
 void CodeCache::print_codelist(outputStream* st) {

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
@@ -76,7 +76,7 @@ public class CodeCacheTest {
     static Pattern line1 = Pattern.compile("(CodeCache|CodeHeap.*): size=(\\p{Digit}*)Kb used=(\\p{Digit}*)Kb max_used=(\\p{Digit}*)Kb free=(\\p{Digit}*)Kb");
     static Pattern line2 = Pattern.compile(" bounds \\[0x(\\p{XDigit}*), 0x(\\p{XDigit}*), 0x(\\p{XDigit}*)\\]");
     static Pattern line3 = Pattern.compile(" total_blobs=(\\p{Digit}*), nmethods=(\\p{Digit}*), adapters=(\\p{Digit}*), full_count=(\\p{Digit}*)");
-    static Pattern line4 = Pattern.compile("Compilation:(.*?), stopped_count=(\\p{Digit}*), restarted_count=(\\p{Digit}*)");
+    static Pattern line4 = Pattern.compile("Compilation: (.*?), stopped_count=(\\p{Digit}*), restarted_count=(\\p{Digit}*)");
 
     private static boolean getFlagBool(String flag, String where) {
       Matcher m = Pattern.compile(flag + "\\s+:?= (true|false)").matcher(where);

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CodeCacheTest.java
@@ -58,7 +58,7 @@ public class CodeCacheTest {
      * CodeCache: size=245760Kb used=1366Kb max_used=1935Kb free=244393Kb
      *  bounds [0x00007ff4d89f2000, 0x00007ff4d8c62000, 0x00007ff4e79f2000]
      *  total_blobs=474, nmethods=87, adapters=293, full_count=0
-     * Compilation:enabled, stopped_count=0, restarted_count=0
+     * Compilation: enabled, stopped_count=0, restarted_count=0
      *
      * Expected output with code cache segmentation (number of segments may change):
      *
@@ -70,7 +70,7 @@ public class CodeCacheTest {
      *  bounds [0x00007f09f7dc1000, 0x00007f09f8031000, 0x00007f09f8622000]
      * CodeCache: size=245760Kb, used=1366Kb, max_used=1942Kb, free=244392Kb
      *  total_blobs=474, nmethods=87, adapters=293, full_count=0
-     * Compilation:enabled, stopped_count=0, restarted_count=0
+     * Compilation: enabled, stopped_count=0, restarted_count=0
      */
 
     static Pattern line1 = Pattern.compile("(CodeCache|CodeHeap.*): size=(\\p{Digit}*)Kb used=(\\p{Digit}*)Kb max_used=(\\p{Digit}*)Kb free=(\\p{Digit}*)Kb");

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfo/Test.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/CodeCacheInfo/Test.java
@@ -56,14 +56,15 @@ public class Test {
     static {
         String p1 = " size=\\d+Kb used=\\d+Kb max_used=\\d+Kb free=\\d+Kb\\n";
         String p2 = " bounds \\[0x[0-9a-f]+, 0x[0-9a-f]+, 0x[0-9a-f]+\\]\\n";
-        String p3 = " total_blobs=\\d+ nmethods=\\d+ adapters=\\d+\\n";
-        String p4 = " compilation: enabled\\n";
+        String p3 = "CodeCache:.*\\n";
+        String p4 = " total_blobs=\\d+, nmethods=\\d+, adapters=\\d+, full_count=\\d+\\n";
+        String p5 = "Compilation: enabled.*\\n";
 
         String segPrefix = "^(CodeHeap '[^']+':" + p1 + p2 + ")+";
         String nosegPrefix = "^CodeCache:" + p1 + p2;
 
-        SEG_REGEXP = segPrefix + p3 + p4;
-        NOSEG_REGEXP = nosegPrefix + p3 + p4;
+        SEG_REGEXP = segPrefix + p3 + p4 + p5;
+        NOSEG_REGEXP = nosegPrefix + p4 + p5;
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
```
CodeHeap 'non-profiled nmethods': size=118592Kb used=29Kb max_used=29Kb free=118562Kb
 bounds [0x00007fbe84622000, 0x00007fbe84892000, 0x00007fbe8b9f2000]
CodeHeap 'profiled nmethods': size=118588Kb used=80Kb max_used=80Kb free=118507Kb
 bounds [0x00007fbe7c9f2000, 0x00007fbe7cc62000, 0x00007fbe83dc1000]
CodeHeap 'non-nmethods': size=8580Kb used=1258Kb max_used=1834Kb free=7321Kb
 bounds [0x00007fbe83dc1000, 0x00007fbe84031000, 0x00007fbe84622000]
 total_blobs=474 nmethods=87 adapters=293
 compilation: enabled
              stopped_count=0, restarted_count=0
 full_count=0
```

It's better to accumulates total size of used/free/size, for example
```
-SegmentedCodeCache
CodeCache: size=245760Kb used=1366Kb max_used=1943Kb free=244393Kb
 bounds [0x00007fdcc89f2000, 0x00007fdcc8c62000, 0x00007fdcd79f2000]
 total_blobs=474, nmethods=87, adapters=293
 stopped_count=0, restarted_count=0, full_count=0 
 compilation=enabled
```

```
+SegmentedCodeCache
CodeHeap 'non-profiled nmethods': size=118592Kb used=29Kb max_used=29Kb free=118562Kb
 bounds [0x00007f89c8622000, 0x00007f89c8892000, 0x00007f89cf9f2000]
CodeHeap 'profiled nmethods': size=118588Kb used=80Kb max_used=80Kb free=118507Kb
 bounds [0x00007f89c09f2000, 0x00007f89c0c62000, 0x00007f89c7dc1000]
CodeHeap 'non-nmethods': size=8580Kb used=1258Kb max_used=1834Kb free=7321Kb
 bounds [0x00007f89c7dc1000, 0x00007f89c8031000, 0x00007f89c8622000]
CodeCache: size=245760Kb, used=1367Kb, max_used=1943Kb, free=244390Kb
 total_blobs=474, nmethods=87, adapters=293
 stopped_count=0, restarted_count=0, full_count=0 
 compilation=enabled
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8323795](https://bugs.openjdk.org/browse/JDK-8323795): jcmd Compiler.codecache should print total size of code cache (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17445/head:pull/17445` \
`$ git checkout pull/17445`

Update a local copy of the PR: \
`$ git checkout pull/17445` \
`$ git pull https://git.openjdk.org/jdk.git pull/17445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17445`

View PR using the GUI difftool: \
`$ git pr show -t 17445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17445.diff">https://git.openjdk.org/jdk/pull/17445.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17445#issuecomment-1893537680)