### PR TITLE
8323800: Serial: Fix include guard macro in generation.hpp

### DIFF
--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef SHARE_GC_SHARED_GENERATION_HPP
-#define SHARE_GC_SHARED_GENERATION_HPP
+#ifndef SHARE_GC_SERIAL_GENERATION_HPP
+#define SHARE_GC_SERIAL_GENERATION_HPP
 
 #include "gc/shared/collectorCounters.hpp"
 #include "gc/shared/referenceProcessor.hpp"


### PR DESCRIPTION
Trivial fix of macro name.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323800](https://bugs.openjdk.org/browse/JDK-8323800): Serial: Fix include guard macro in generation.hpp (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17446/head:pull/17446` \
`$ git checkout pull/17446`

Update a local copy of the PR: \
`$ git checkout pull/17446` \
`$ git pull https://git.openjdk.org/jdk.git pull/17446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17446`

View PR using the GUI difftool: \
`$ git pr show -t 17446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17446.diff">https://git.openjdk.org/jdk/pull/17446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17446#issuecomment-1893623016)