### PR TITLE
8323820: [MacOS] build failure: non-void function does not return a value

### DIFF
--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -467,7 +467,7 @@ Node* ConstraintCastNode::make_cast_for_type(Node* c, Node* in, const Type* type
   } else if (type->isa_ptr()) {
     return new CastPPNode(c, in, type, dependency, types);
   }
-  ShouldNotReachHere();
+  fatal("unreachable. Invalid cast type.");
   return nullptr;
 }
 

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -467,7 +467,8 @@ Node* ConstraintCastNode::make_cast_for_type(Node* c, Node* in, const Type* type
   } else if (type->isa_ptr()) {
     return new CastPPNode(c, in, type, dependency, types);
   }
-  fatal("unreachable. Invalid cast type.");
+  ShouldNotReachHere();
+  return nullptr;
 }
 
 Node* ConstraintCastNode::optimize_integer_cast(PhaseGVN* phase, BasicType bt) {


### PR DESCRIPTION
I can't reproduce the issue since I don't have the right build setup. But hopefully this change is trivial enough to fix the error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323820](https://bugs.openjdk.org/browse/JDK-8323820): [MacOS] build failure: non-void function does not return a value (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17449/head:pull/17449` \
`$ git checkout pull/17449`

Update a local copy of the PR: \
`$ git checkout pull/17449` \
`$ git pull https://git.openjdk.org/jdk.git pull/17449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17449`

View PR using the GUI difftool: \
`$ git pr show -t 17449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17449.diff">https://git.openjdk.org/jdk/pull/17449.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17449#issuecomment-1894232240)