### PR TITLE
8323614: Enhance OutputAnalyzer APIs

### DIFF
--- a/test/lib-test/jdk/test/lib/process/OutputAnalyzerTest.java
+++ b/test/lib-test/jdk/test/lib/process/OutputAnalyzerTest.java
@@ -242,6 +242,108 @@ public class OutputAnalyzerTest {
                 }
             }
         }
+
+        String stdOut = "aaaaa\nbbbbb\n";
+        String stdErr = "cccc\nddddd\n";
+        OutputAnalyzer ot = new OutputAnalyzer(stdOut, stdErr);
+        try {
+            String[] needles = {"aa", "bb"};
+            ot.shouldContainMultiLinePattern(needles);
+        } catch (RuntimeException e) {
+            throw new Exception("shouldContainMultiLinePattern failed", e);
+        }
+
+        try {
+            String[] needles = {"aaaa", "cccc", "bbbbb"};
+            ot.shouldContainMultiLinePattern(needles);
+            throw new Exception("shouldContainMultiLinePattern failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        try {
+            String[] regex = {"a.", "b.", "c.", "d."};
+            ot.shouldMatchMultiLinePattern(regex);
+        } catch (RuntimeException e) {
+            throw new Exception("shouldMatchMultiLinePattern failed", e);
+        }
+
+        try {
+            String[] regex = {"a.", "c."};
+            ot.shouldMatchMultiLinePattern(regex);
+            throw new Exception("shouldMatchMultiLinePattern failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        try {
+            String[] needles = {"aa", "cc"};
+            ot.shouldContainTrivialOrder(needles);
+        } catch (RuntimeException e) {
+            throw new Exception("shouldContainTrivialOrder failed", e);
+        }
+
+        try {
+            String[] needles = {"aa", "zzzz"};
+            ot.shouldContainTrivialOrder(needles);
+            throw new Exception("shouldContainTrivialOrder failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        try {
+            String[] needles = {"d.", ".a", ".b"};
+            ot.shouldMatchTrivialOrder(needles);
+        } catch (RuntimeException e) {
+            throw new Exception("shouldMatchTrivialOrder failed", e);
+        }
+
+        try {
+            String[] needles = {"a.", "\\d"};
+            ot.shouldMatchTrivialOrder(needles);
+            throw new Exception("shouldMatchTrivialOrder failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        try {
+            String[] needles = {"a.", "c."};
+            ot.shouldMatchOrderedPatternsInterleavedLines(needles);
+        } catch (RuntimeException e) {
+            throw new Exception("shouldMatchOrderedPatternsInterleavedLines failed");
+        }
+
+        try {
+            String[] needles = {"a.", "z.", "d."};
+            ot.shouldMatchOrderedPatternsInterleavedLines(needles);
+            throw new Exception("shouldMatchOrderedPatternsInterleavedLines failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        try {
+            String[] needles = {"d.", "a."};
+            ot.shouldMatchOrderedPatternsInterleavedLines(needles);
+            throw new Exception("shouldMatchOrderedPatternsInterleavedLines failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
+        try {
+            String[] needles = {"aa", "dd"};
+            ot.shouldContainOrderedPatternsInterleavedLines(needles);
+        } catch (RuntimeException e) {
+            throw new Exception("shouldContainOrderedPatternsInterleavedLines failed");
+        }
+
+        try {
+            String[] needles = {"dd", "aa"};
+            ot.shouldContainOrderedPatternsInterleavedLines(needles);
+            throw new Exception("shouldContainOrderedPatternsInterleavedLines failed");
+        } catch (RuntimeException e) {
+            // expected
+        }
+
     }
 
 }


### PR DESCRIPTION
In this PR, I enhance the OutputAnalyzer APIs to make writing tests a bit simpler. The proposed enhancements implement the following for shouldMatch and shouldContain: 

1) Match a bunch of patterns in the output buffer, but only if the patterns follow each other directly in subsequent lines.
2) Match a bunch of patterns in the output buffer, pattern must appear in order but lines can interleave.
3) Match a bunch of patterns in the output buffer, order does not matter, just match them all.

Testing: I added tests for the additional functionality in ```OutputAnalyzerTest```. 

Let me know your thoughts. 
Cheers, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323614](https://bugs.openjdk.org/browse/JDK-8323614): Enhance OutputAnalyzer APIs (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17451/head:pull/17451` \
`$ git checkout pull/17451`

Update a local copy of the PR: \
`$ git checkout pull/17451` \
`$ git pull https://git.openjdk.org/jdk.git pull/17451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17451`

View PR using the GUI difftool: \
`$ git pr show -t 17451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17451.diff">https://git.openjdk.org/jdk/pull/17451.diff</a>

</details>
