### PR TITLE
8323710: (fc) FileChannel.lock creates a FileKey with a poor hashCode after JDK-8321429 (win)

### DIFF
--- a/src/java.base/windows/classes/sun/nio/ch/FileKey.java
+++ b/src/java.base/windows/classes/sun/nio/ch/FileKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,10 +47,7 @@ public class FileKey {
 
     @Override
     public int hashCode() {
-        int h = dwVolumeSerialNumber;
-        h = h << 31 + nFileIndexHigh;
-        h = h << 31 + nFileIndexLow;
-        return h;
+        return dwVolumeSerialNumber + nFileIndexHigh + nFileIndexLow;
     }
 
     @Override


### PR DESCRIPTION
Dispense with the shift operators in calculating the hash code of `FileKey`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323710](https://bugs.openjdk.org/browse/JDK-8323710): (fc) FileChannel.lock creates a FileKey with a poor hashCode after JDK-8321429 (win) (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17452/head:pull/17452` \
`$ git checkout pull/17452`

Update a local copy of the PR: \
`$ git checkout pull/17452` \
`$ git pull https://git.openjdk.org/jdk.git pull/17452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17452`

View PR using the GUI difftool: \
`$ git pr show -t 17452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17452.diff">https://git.openjdk.org/jdk/pull/17452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17452#issuecomment-1894508499)