### PR TITLE
JDK-8323839: Expand use of Messager convenience methods in langtools regression tests

### DIFF
--- a/test/langtools/tools/javac/modules/AnnotationProcessing.java
+++ b/test/langtools/tools/javac/modules/AnnotationProcessing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1781,7 +1781,7 @@ public class AnnotationProcessing extends ModuleTestBase {
                     if (type == null) {
                         throw new AssertionError("Did not find the expected type.");
                     } else {
-                        processingEnv.getMessager().printMessage(Kind.NOTE, name + " found in module: " + processingEnv.getElementUtils().getModuleOf(type));
+                        processingEnv.getMessager().printNote(name + " found in module: " + processingEnv.getElementUtils().getModuleOf(type));
                     }
                 } else {
                     if (type != null) {

--- a/test/langtools/tools/javac/processing/8268575/Processor.java
+++ b/test/langtools/tools/javac/processing/8268575/Processor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class Processor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    processingEnv.getMessager().printMessage(Kind.NOTE, "round " + round);
+    processingEnv.getMessager().printNote("round " + round);
     Element t = processingEnv.getElementUtils().getTypeElement("T8268575");
     for (Element e : t.getEnclosedElements()) {
       if (e instanceof ExecutableElement) {

--- a/test/langtools/tools/javac/processing/TestMultipleErrors.java
+++ b/test/langtools/tools/javac/processing/TestMultipleErrors.java
@@ -19,8 +19,8 @@ public class TestMultipleErrors extends JavacTestingAbstractProcessor {
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         for (Element root : roundEnv.getRootElements()) {
-            processingEnv.getMessager().printMessage(Kind.ERROR, "error1", root);
-            processingEnv.getMessager().printMessage(Kind.ERROR, "error2", root);
+            processingEnv.getMessager().printError("error1", root);
+            processingEnv.getMessager().printError("error2", root);
 
             Trees trees = Trees.instance(processingEnv);
             TreePath path = trees.getPath(root);

--- a/test/langtools/tools/javac/processing/messager/6362067/T6362067.java
+++ b/test/langtools/tools/javac/processing/messager/6362067/T6362067.java
@@ -21,7 +21,7 @@ public class T6362067 extends JavacTestingAbstractProcessor {
                            RoundEnvironment roundEnv) {
 
         for (Element e: roundEnv.getRootElements()) {
-            messager.printMessage(NOTE, "note:elem", e);
+            messager.printNote("note:elem", e);
             for (AnnotationMirror a: e.getAnnotationMirrors()) {
                 messager.printMessage(NOTE, "note:anno", e, a);
                 for (AnnotationValue v: a.getElementValues().values()) {

--- a/test/langtools/tools/javac/processing/model/element/TestMissingElement/TestMissingElement.java
+++ b/test/langtools/tools/javac/processing/model/element/TestMissingElement/TestMissingElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ public class TestMissingElement extends JavacTestingAbstractProcessor {
 
     private void checkEqual(String label, TypeElement te, String found, String expect) {
         if (found.equals(expect)) {
-//            messager.printMessage(NOTE, "expected " + label + " found: " + expect, te);
+//            messager.printNote("expected " + label + " found: " + expect, te);
         } else {
             out.println("unexpected " + label + ": " + te + "\n"
                     + " found: " + found + "\n"


### PR DESCRIPTION
Simple refactoring. Remaining uses of "printMessage" are against Trees (where there are no corresponding convenience methods) or for calls to printMessage where there is not an appropriate convenience method overload, etc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323839](https://bugs.openjdk.org/browse/JDK-8323839): Expand use of Messager convenience methods in langtools regression tests (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17454/head:pull/17454` \
`$ git checkout pull/17454`

Update a local copy of the PR: \
`$ git checkout pull/17454` \
`$ git pull https://git.openjdk.org/jdk.git pull/17454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17454`

View PR using the GUI difftool: \
`$ git pr show -t 17454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17454.diff">https://git.openjdk.org/jdk/pull/17454.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17454#issuecomment-1894588102)