### PR TITLE
6507038: Memory Leak in JTree / BasicTreeUI

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -3280,8 +3280,10 @@ public class BasicTreeUI extends TreeUI
                      expanded, treeModel.isLeaf(value), row,
                      false);
                 if(tree != null) {
+                    // Remove previously added components to prevent leak
+                    // and add the current component returned by cellrenderer for
+                    // painting and other measurements
                     rendererPane.removeAll();
-                    // Only ever removed when UI changes, this is OK!
                     rendererPane.add(aComponent);
                     aComponent.validate();
                 }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -3280,9 +3280,7 @@ public class BasicTreeUI extends TreeUI
                      expanded, treeModel.isLeaf(value), row,
                      false);
                 if(tree != null) {
-                    for (int i = 0; i < rendererPane.getComponentCount(); i++) {
-                        rendererPane.remove(i);
-                    }
+                    rendererPane.removeAll();
                     // Only ever removed when UI changes, this is OK!
                     rendererPane.add(aComponent);
                     aComponent.validate();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -1334,6 +1334,9 @@ public class BasicTreeUI extends TreeUI
      */
     protected void uninstallComponents() {
         if(rendererPane != null) {
+            if (!tree.isVisible()) {
+                rendererPane.removeAll();
+            }
             tree.remove(rendererPane);
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java
@@ -1334,9 +1334,6 @@ public class BasicTreeUI extends TreeUI
      */
     protected void uninstallComponents() {
         if(rendererPane != null) {
-            if (!tree.isVisible()) {
-                rendererPane.removeAll();
-            }
             tree.remove(rendererPane);
         }
     }
@@ -3283,6 +3280,9 @@ public class BasicTreeUI extends TreeUI
                      expanded, treeModel.isLeaf(value), row,
                      false);
                 if(tree != null) {
+                    for (int i = 0; i < rendererPane.getComponentCount(); i++) {
+                        rendererPane.remove(i);
+                    }
                     // Only ever removed when UI changes, this is OK!
                     rendererPane.add(aComponent);
                     aComponent.validate();

--- a/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
@@ -72,6 +72,7 @@ public final class TreeCellRendererLeakTest {
         public TreeCellRenderer() {}
 
         // Create a new JLabel every time
+        @Override
         public Component getTreeCellRendererComponent(
                 JTree tree,
                 Object value,

--- a/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 6507038
- * @summary Verifies memory leak in BasicTreeUI TreeCellRenderer 
+ * @summary Verifies memory leak in BasicTreeUI TreeCellRenderer
  * @run main TreeCellRendererLeakTest
  */
 
@@ -42,9 +42,9 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
 
 public class TreeCellRendererLeakTest {
-    
+
     static long smCount = 0;
-    static boolean done;    
+    static boolean done;
 
     private static JFrame frame;
     private JPanel jPanel1;
@@ -52,25 +52,24 @@ public class TreeCellRendererLeakTest {
     private JScrollPane jScrollPane1;
     private JTabbedPane jTabbedPane1;
     private JTree jTree1;
-    // End of variables declaration
-    
+
     // JLabel with an instance counter
     public class TestLabel extends JLabel {
         public TestLabel() {
             smCount++;
         }
-        
+
         public void finalize( ) {
             smCount--;
         }
     }
-    
+
     // Custom TreeCellRenderer
     public class TreeCellRenderer extends DefaultTreeCellRenderer {
-        
+
         public TreeCellRenderer( ) {
         }
-        
+
         // Create a new JLabel every time
         public Component getTreeCellRendererComponent(
                 JTree tree,
@@ -87,11 +86,11 @@ public class TreeCellRendererLeakTest {
             } else {
                 label.setBackground(getBackgroundNonSelectionColor());
             }
-            
+
             return label;
         }
     }
-    
+
     public TreeCellRendererLeakTest() {
         initComponents();
         jTree1.setCellRenderer(new TreeCellRenderer());
@@ -110,7 +109,7 @@ public class TreeCellRendererLeakTest {
         infoThread.setDaemon(true);
         infoThread.start();
     }
-    
+
     // <editor-fold defaultstate="collapsed" desc=" Generated Code ">
     private void initComponents() {
         jTabbedPane1 = new javax.swing.JTabbedPane();
@@ -140,7 +139,7 @@ public class TreeCellRendererLeakTest {
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }// </editor-fold>
-    
+
     public static void main(String args[]) throws Exception {
         try {
             SwingUtilities.invokeAndWait(() -> {
@@ -155,9 +154,9 @@ public class TreeCellRendererLeakTest {
                     frame.dispose();
                 }
             });
-        } 
+        }
     }
-    
+
     // Periodically cause a nodeChanged() for one of the nodes
     public void runChanges() {
         long count = 0;
@@ -185,7 +184,7 @@ public class TreeCellRendererLeakTest {
         }
         done = true;
     }
-    
+
     // Print number of uncollected TestLabels
     public void runInfo( ) {
         long time = System.currentTimeMillis();
@@ -203,5 +202,5 @@ public class TreeCellRendererLeakTest {
             throw new RuntimeException("TreeCellRenderer component leaked");
         }
     }
-    
+
 }

--- a/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
@@ -29,6 +29,7 @@
  * @run main TreeCellRendererLeakTest
  */
 
+import java.awt.BorderLayout;
 import java.awt.Component;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.Reference;
@@ -108,23 +109,22 @@ public final class TreeCellRendererLeakTest {
         infoThread.start();
     }
 
-    // <editor-fold defaultstate="collapsed" desc=" Generated Code ">
     private void initComponents() {
-        jTabbedPane1 = new javax.swing.JTabbedPane();
-        jPanel1 = new javax.swing.JPanel();
-        jScrollPane1 = new javax.swing.JScrollPane();
-        jTree1 = new javax.swing.JTree();
-        jPanel2 = new javax.swing.JPanel();
+        jTabbedPane1 = new JTabbedPane();
+        jPanel1 = new JPanel();
+        jScrollPane1 = new JScrollPane();
+        jTree1 = new JTree();
+        jPanel2 = new JPanel();
 
-        jPanel1.setLayout(new java.awt.BorderLayout());
+        jPanel1.setLayout(new BorderLayout());
 
         jScrollPane1.setViewportView(jTree1);
 
-        jPanel1.add(jScrollPane1, java.awt.BorderLayout.CENTER);
+        jPanel1.add(jScrollPane1, BorderLayout.CENTER);
 
         jTabbedPane1.addTab("tab1", jPanel1);
 
-        jPanel2.setLayout(new java.awt.BorderLayout());
+        jPanel2.setLayout(new BorderLayout());
 
         jTabbedPane1.addTab("tab2", jPanel2);
 
@@ -137,7 +137,7 @@ public final class TreeCellRendererLeakTest {
         frame = new JFrame();
         frame.getContentPane().add(jTabbedPane1, java.awt.BorderLayout.CENTER);
 
-        frame.pack();
+        frame.setSize(200, 200);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }// </editor-fold>

--- a/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 6507038
+ * @key headful
  * @summary Verifies memory leak in BasicTreeUI TreeCellRenderer
  * @run main TreeCellRendererLeakTest
  */

--- a/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
@@ -56,6 +56,8 @@ public final class TreeCellRendererLeakTest {
     private JScrollPane jScrollPane1;
     private JTabbedPane jTabbedPane1;
     private JTree jTree1;
+    private DefaultMutableTreeNode defTreeNode;
+    private DefaultTreeModel model;
 
     private static final CountDownLatch testDone = new CountDownLatch(1);
 
@@ -126,6 +128,10 @@ public final class TreeCellRendererLeakTest {
 
         jTabbedPane1.setSelectedIndex(1);
 
+        model = (DefaultTreeModel) jTree1.getModel();
+        TreeNode root = (TreeNode) model.getRoot();
+        defTreeNode = (DefaultMutableTreeNode) model.getChild(root, 0);
+
         frame = new JFrame();
         frame.getContentPane().add(jTabbedPane1, java.awt.BorderLayout.CENTER);
 
@@ -137,7 +143,7 @@ public final class TreeCellRendererLeakTest {
     public static void main(String[] args) throws Exception {
         try {
             SwingUtilities.invokeAndWait(() -> {
-                TreeCellRendererLeakTest tf = new TreeCellRendererLeakTest();
+                new TreeCellRendererLeakTest();
             });
             testDone.await();
         } finally {
@@ -157,14 +163,9 @@ public final class TreeCellRendererLeakTest {
         while ((tm - time) < (15 * 1000)) {
             final long currentCount = count;
             try {
-                SwingUtilities.invokeAndWait(new Runnable( ) {
-                    public void run( ) {
-                        DefaultTreeModel model = (DefaultTreeModel) jTree1.getModel();
-                        TreeNode root = (TreeNode) model.getRoot();
-                        DefaultMutableTreeNode n = (DefaultMutableTreeNode) model.getChild(root, 0);
-                        n.setUserObject("runcount " + currentCount);
-                        model.nodeChanged(n);
-                    }
+                SwingUtilities.invokeAndWait(() -> {
+                    defTreeNode.setUserObject("runcount " + currentCount);
+                    model.nodeChanged(defTreeNode);
                 });
                 count++;
                 Thread.sleep(1000);

--- a/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
@@ -219,4 +219,3 @@ public final class TreeCellRendererLeakTest {
         }
     }
 }
-

--- a/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTreeUI/TreeCellRendererLeakTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6507038
+ * @summary Verifies memory leak in BasicTreeUI TreeCellRenderer 
+ * @run main TreeCellRendererLeakTest
+ */
+
+import java.awt.Component;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTree;
+import javax.swing.SwingUtilities;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
+
+public class TreeCellRendererLeakTest {
+    
+    static long smCount = 0;
+    static boolean done;    
+
+    private static JFrame frame;
+    private JPanel jPanel1;
+    private JPanel jPanel2;
+    private JScrollPane jScrollPane1;
+    private JTabbedPane jTabbedPane1;
+    private JTree jTree1;
+    // End of variables declaration
+    
+    // JLabel with an instance counter
+    public class TestLabel extends JLabel {
+        public TestLabel() {
+            smCount++;
+        }
+        
+        public void finalize( ) {
+            smCount--;
+        }
+    }
+    
+    // Custom TreeCellRenderer
+    public class TreeCellRenderer extends DefaultTreeCellRenderer {
+        
+        public TreeCellRenderer( ) {
+        }
+        
+        // Create a new JLabel every time
+        public Component getTreeCellRendererComponent(
+                JTree tree,
+                Object value,
+                boolean sel,
+                boolean expanded,
+                boolean leaf,
+                int row,
+                boolean hasFocus) {
+            JLabel label = new TestLabel( );
+            label.setText("TreeNode: " + value.toString());
+            if (sel) {
+                label.setBackground(getBackgroundSelectionColor());
+            } else {
+                label.setBackground(getBackgroundNonSelectionColor());
+            }
+            
+            return label;
+        }
+    }
+    
+    public TreeCellRendererLeakTest() {
+        initComponents();
+        jTree1.setCellRenderer(new TreeCellRenderer());
+        Thread updateThread = new Thread(new Runnable( ) {
+            public void run( ) {
+                runChanges( );
+            }
+        });
+        updateThread.setDaemon(true);
+        updateThread.start();
+        Thread infoThread = new Thread(new Runnable( ) {
+            public void run( ) {
+                runInfo( );
+            }
+        });
+        infoThread.setDaemon(true);
+        infoThread.start();
+    }
+    
+    // <editor-fold defaultstate="collapsed" desc=" Generated Code ">
+    private void initComponents() {
+        jTabbedPane1 = new javax.swing.JTabbedPane();
+        jPanel1 = new javax.swing.JPanel();
+        jScrollPane1 = new javax.swing.JScrollPane();
+        jTree1 = new javax.swing.JTree();
+        jPanel2 = new javax.swing.JPanel();
+
+        jPanel1.setLayout(new java.awt.BorderLayout());
+
+        jScrollPane1.setViewportView(jTree1);
+
+        jPanel1.add(jScrollPane1, java.awt.BorderLayout.CENTER);
+
+        jTabbedPane1.addTab("tab1", jPanel1);
+
+        jPanel2.setLayout(new java.awt.BorderLayout());
+
+        jTabbedPane1.addTab("tab2", jPanel2);
+
+        jTabbedPane1.setSelectedIndex(1);
+
+        frame = new JFrame();
+        frame.getContentPane().add(jTabbedPane1, java.awt.BorderLayout.CENTER);
+
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }// </editor-fold>
+    
+    public static void main(String args[]) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                TreeCellRendererLeakTest tf = new TreeCellRendererLeakTest();
+            });
+            while (!done) {
+                Thread.sleep(100);
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        } 
+    }
+    
+    // Periodically cause a nodeChanged() for one of the nodes
+    public void runChanges() {
+        long count = 0;
+        long time = System.currentTimeMillis();
+        long tm = System.currentTimeMillis();
+        while ((tm - time) < (30 * 1000)) {
+            final long currentCount = count;
+            try {
+                SwingUtilities.invokeAndWait(new Runnable( ) {
+                    public void run( ) {
+                        DefaultTreeModel model = (DefaultTreeModel) jTree1.getModel();
+                        TreeNode root = (TreeNode) model.getRoot();
+                        DefaultMutableTreeNode n = (DefaultMutableTreeNode) model.getChild(root, 0);
+                        n.setUserObject("runcount " + currentCount);
+                        model.nodeChanged(n);
+                    }
+                });
+                count++;
+                Thread.sleep(1000);
+                tm = System.currentTimeMillis();
+                System.out.println("time elapsed " + (tm - time));
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
+        done = true;
+    }
+    
+    // Print number of uncollected TestLabels
+    public void runInfo( ) {
+        long time = System.currentTimeMillis();
+        long initialCnt = smCount;
+        while ((System.currentTimeMillis() - time) < (30 * 1000)) {
+            System.gc();
+            System.err.println("Live TestLabels:" + smCount);
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ex) {
+                ex.printStackTrace();
+            }
+        }
+        if (smCount - initialCnt > 50) {
+            throw new RuntimeException("TreeCellRenderer component leaked");
+        }
+    }
+    
+}


### PR DESCRIPTION
When using a TreeCellRenterer which creates new components in getTreeCellRendererComponent() in a JTree that is not visible, changes to the nodes cause a memory leak.
When a node is changed, the Method getNodeDimensions() is called to calculate the new dimensions for the node. In this method, getTreeCellRendererComponent() is called to obtain the renderer component (what else...) and [this component is added to rendererPane](https://github.com/openjdk/jdk/blob/36f4b34f1953af736706ec67192204727808bc6c/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java#L3283-L3284). It is not removed from the rendererPane afterwards. 
Only when the tree is painted, the paint() method does a removeAll on the rendererPane [in this code](https://github.com/openjdk/jdk/blob/36f4b34f1953af736706ec67192204727808bc6c/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTreeUI.java#L1500)

FIx is added to remove the components from rendererPane when the JTree UI is changed/uninstalled only when tree is not visible since they are already removed when tree is painted in paint() method..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6507038](https://bugs.openjdk.org/browse/JDK-6507038): Memory Leak in JTree / BasicTreeUI (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [970955a1](https://git.openjdk.org/jdk/pull/17458/files/970955a1ec2049bd0154d04a6154f49bd0d8dd5b)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Contributors
 * Alexey Ivanov `<aivanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17458/head:pull/17458` \
`$ git checkout pull/17458`

Update a local copy of the PR: \
`$ git checkout pull/17458` \
`$ git pull https://git.openjdk.org/jdk.git pull/17458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17458`

View PR using the GUI difftool: \
`$ git pr show -t 17458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17458.diff">https://git.openjdk.org/jdk/pull/17458.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17458#issuecomment-1895229403)