### PR TITLE
JDK-8222719: libperfstat on AIX - cleanup old API versions

### DIFF
--- a/src/hotspot/os/aix/libperfstat_aix.cpp
+++ b/src/hotspot/os/aix/libperfstat_aix.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 SAP SE. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -213,12 +213,8 @@ bool libperfstat::get_cpuinfo(cpuinfo_t* pci) {
 
   if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(PERFSTAT_CPU_TOTAL_T_LATEST), 1)) {
     if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(perfstat_cpu_total_t_71), 1)) {
-      if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(perfstat_cpu_total_t_61), 1)) {
-        if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(perfstat_cpu_total_t_53), 1)) {
-          trcVerbose("perfstat_cpu_total() failed (errno=%d)", errno);
-          return false;
-        }
-      }
+      trcVerbose("perfstat_cpu_total() failed (errno=%d)", errno);
+      return false;
     }
   }
 
@@ -252,14 +248,8 @@ bool libperfstat::get_partitioninfo(partitioninfo_t* ppi) {
   if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(PERFSTAT_PARTITON_TOTAL_T_LATEST), 1)) {
     if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_71), 1)) {
       ame_details = false;
-      if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_61), 1)) {
-        if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_53), 1)) {
-          if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_53_5), 1)) {
-            trcVerbose("perfstat_partition_total() failed (errno=%d)", errno);
-            return false;
-          }
-        }
-      }
+      trcVerbose("perfstat_partition_total() failed (errno=%d)", errno);
+      return false;
     }
   }
 
@@ -324,10 +314,8 @@ bool libperfstat::get_wparinfo(wparinfo_t* pwi) {
   memset (&pswt, '\0', sizeof(pswt));
 
   if (-1 == libperfstat::perfstat_wpar_total(nullptr, &pswt, sizeof(PERFSTAT_WPAR_TOTAL_T_LATEST), 1)) {
-    if (-1 == libperfstat::perfstat_wpar_total(nullptr, &pswt, sizeof(perfstat_wpar_total_t_61), 1)) {
-      trcVerbose("perfstat_wpar_total() failed (errno=%d)", errno);
-      return false;
-    }
+    trcVerbose("perfstat_wpar_total() failed (errno=%d)", errno);
+    return false;
   }
 
   // WPAR type info.

--- a/src/hotspot/os/aix/libperfstat_aix.hpp
+++ b/src/hotspot/os/aix/libperfstat_aix.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 SAP SE. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -38,16 +38,8 @@
 #include <stdlib.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
-// These are excerpts from the AIX 5.3, 6.1, 7.1 libperfstat.h -
+// These are excerpts from the AIX 7.1 libperfstat.h -
 // this is all we need from libperfstat.h and I want to avoid having to include <libperfstat.h>
-//
-// Note: I define all structures as if I were to include libperfstat.h on an AIX 5.2
-// build machine.
-//
-// The ratio behind that is that if I would build on an AIX 5.2 build machine,
-// include libperfstat.h and hard-link against libperfstat.a, the program should
-// work without recompilation on all newer AIX versions.
-//
 
 #define IDENTIFIER_LENGTH  64    /* length of strings included in the structures */
 #define FIRST_CPU          ""    /* pseudo-name for fist CPU */
@@ -93,169 +85,6 @@ typedef struct { /* Virtual memory utilization */
   u_longlong_t virt_active;   /* Active virtual pages. Virtual pages are considered active if they have been accessed */
 
 } perfstat_memory_total_t;
-
-typedef struct { /* global cpu information AIX 5.3 < TL10 */
-  int ncpus;                            /* number of active logical processors */
-  int ncpus_cfg;                        /* number of configured processors */
-  char description[IDENTIFIER_LENGTH];  /* processor description (type/official name) */
-  u_longlong_t processorHZ;             /* processor speed in Hz */
-  u_longlong_t user;                    /* raw total number of clock ticks spent in user mode */
-  u_longlong_t sys;                     /* raw total number of clock ticks spent in system mode */
-  u_longlong_t idle;                    /* raw total number of clock ticks spent idle */
-  u_longlong_t wait;                    /* raw total number of clock ticks spent waiting for I/O */
-  u_longlong_t pswitch;                 /* number of process switches (change in currently running process) */
-  u_longlong_t syscall;                 /* number of system calls executed */
-  u_longlong_t sysread;                 /* number of read system calls executed */
-  u_longlong_t syswrite;                /* number of write system calls executed */
-  u_longlong_t sysfork;                 /* number of forks system calls executed */
-  u_longlong_t sysexec;                 /* number of execs system calls executed */
-  u_longlong_t readch;                  /* number of characters transferred with read system call */
-  u_longlong_t writech;                 /* number of characters transferred with write system call */
-  u_longlong_t devintrs;                /* number of device interrupts */
-  u_longlong_t softintrs;               /* number of software interrupts */
-  time_t lbolt;                         /* number of ticks since last reboot */
-  u_longlong_t loadavg[3];              /* (1<<SBITS) times the average number of runnables processes during the last 1, 5 and 15 minutes.
-                                               * To calculate the load average, divide the numbers by (1<<SBITS). SBITS is defined in <sys/proc.h>. */
-  u_longlong_t runque;                  /* length of the run queue (processes ready) */
-  u_longlong_t swpque;                  /* ength of the swap queue (processes waiting to be paged in) */
-  u_longlong_t bread;                   /* number of blocks read */
-  u_longlong_t bwrite;                  /* number of blocks written */
-  u_longlong_t lread;                   /* number of logical read requests */
-  u_longlong_t lwrite;                  /* number of logical write requests */
-  u_longlong_t phread;                  /* number of physical reads (reads on raw devices) */
-  u_longlong_t phwrite;                 /* number of physical writes (writes on raw devices) */
-  u_longlong_t runocc;                  /* updated whenever runque is updated, i.e. the runqueue is occupied.
-                                               * This can be used to compute the simple average of ready processes  */
-  u_longlong_t swpocc;                  /* updated whenever swpque is updated. i.e. the swpqueue is occupied.
-                                               * This can be used to compute the simple average processes waiting to be paged in */
-  u_longlong_t iget;                    /* number of inode lookups */
-  u_longlong_t namei;                   /* number of vnode lookup from a path name */
-  u_longlong_t dirblk;                  /* number of 512-byte block reads by the directory search routine to locate an entry for a file */
-  u_longlong_t msg;                     /* number of IPC message operations */
-  u_longlong_t sema;                    /* number of IPC semaphore operations */
-  u_longlong_t rcvint;                  /* number of tty receive interrupts */
-  u_longlong_t xmtint;                  /* number of tyy transmit interrupts */
-  u_longlong_t mdmint;                  /* number of modem interrupts */
-  u_longlong_t tty_rawinch;             /* number of raw input characters  */
-  u_longlong_t tty_caninch;             /* number of canonical input characters (always zero) */
-  u_longlong_t tty_rawoutch;            /* number of raw output characters */
-  u_longlong_t ksched;                  /* number of kernel processes created */
-  u_longlong_t koverf;                  /* kernel process creation attempts where:
-                                               * -the user has forked to their maximum limit
-                                               * -the configuration limit of processes has been reached */
-  u_longlong_t kexit;                   /* number of kernel processes that became zombies */
-  u_longlong_t rbread;                  /* number of remote read requests */
-  u_longlong_t rcread;                  /* number of cached remote reads */
-  u_longlong_t rbwrt;                   /* number of remote writes */
-  u_longlong_t rcwrt;                   /* number of cached remote writes */
-  u_longlong_t traps;                   /* number of traps */
-  int ncpus_high;                       /* index of highest processor online */
-  u_longlong_t puser;                   /* raw number of physical processor tics in user mode */
-  u_longlong_t psys;                    /* raw number of physical processor tics in system mode */
-  u_longlong_t pidle;                   /* raw number of physical processor tics idle */
-  u_longlong_t pwait;                   /* raw number of physical processor tics waiting for I/O */
-  u_longlong_t decrintrs;               /* number of decrementer tics interrupts */
-  u_longlong_t mpcrintrs;               /* number of mpc's received interrupts */
-  u_longlong_t mpcsintrs;               /* number of mpc's sent interrupts */
-  u_longlong_t phantintrs;              /* number of phantom interrupts */
-  u_longlong_t idle_donated_purr;       /* number of idle cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t idle_donated_spurr;      /* number of idle spurr cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t busy_donated_purr;       /* number of busy cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t busy_donated_spurr;      /* number of busy spurr cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t idle_stolen_purr;        /* number of idle cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t idle_stolen_spurr;       /* number of idle spurr cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t busy_stolen_purr;        /* number of busy cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t busy_stolen_spurr;       /* number of busy spurr cycles stolen by the hypervisor from a dedicated partition */
-  short iowait;                         /* number of processes that are asleep waiting for buffered I/O */
-  short physio;                         /* number of processes waiting for raw I/O */
-  longlong_t twait;                     /* number of threads that are waiting for filesystem direct(cio) */
-  u_longlong_t hpi;                     /* number of hypervisor page-ins */
-  u_longlong_t hpit;                    /* Time spent in hypervisor page-ins (in nanoseconds) */
-} perfstat_cpu_total_t_53;
-
-typedef struct { /* global cpu information AIX 6.1|5.3 > TL09 */
-  int ncpus;                            /* number of active logical processors */
-  int ncpus_cfg;                        /* number of configured processors */
-  char description[IDENTIFIER_LENGTH];  /* processor description (type/official name) */
-  u_longlong_t processorHZ;             /* processor speed in Hz */
-  u_longlong_t user;                    /* raw total number of clock ticks spent in user mode */
-  u_longlong_t sys;                     /* raw total number of clock ticks spent in system mode */
-  u_longlong_t idle;                    /* raw total number of clock ticks spent idle */
-  u_longlong_t wait;                    /* raw total number of clock ticks spent waiting for I/O */
-  u_longlong_t pswitch;                 /* number of process switches (change in currently running process) */
-  u_longlong_t syscall;                 /* number of system calls executed */
-  u_longlong_t sysread;                 /* number of read system calls executed */
-  u_longlong_t syswrite;                /* number of write system calls executed */
-  u_longlong_t sysfork;                 /* number of forks system calls executed */
-  u_longlong_t sysexec;                 /* number of execs system calls executed */
-  u_longlong_t readch;                  /* number of characters transferred with read system call */
-  u_longlong_t writech;                 /* number of characters transferred with write system call */
-  u_longlong_t devintrs;                /* number of device interrupts */
-  u_longlong_t softintrs;               /* number of software interrupts */
-  time_t lbolt;                         /* number of ticks since last reboot */
-  u_longlong_t loadavg[3];              /* (1<<SBITS) times the average number of runnables processes during the last 1, 5 and 15 minutes.
-                                               * To calculate the load average, divide the numbers by (1<<SBITS). SBITS is defined in <sys/proc.h>. */
-  u_longlong_t runque;                  /* length of the run queue (processes ready) */
-  u_longlong_t swpque;                  /* length of the swap queue (processes waiting to be paged in) */
-  u_longlong_t bread;                   /* number of blocks read */
-  u_longlong_t bwrite;                  /* number of blocks written */
-  u_longlong_t lread;                   /* number of logical read requests */
-  u_longlong_t lwrite;                  /* number of logical write requests */
-  u_longlong_t phread;                  /* number of physical reads (reads on raw devices) */
-  u_longlong_t phwrite;                 /* number of physical writes (writes on raw devices) */
-  u_longlong_t runocc;                  /* updated whenever runque is updated, i.e. the runqueue is occupied.
-                                               * This can be used to compute the simple average of ready processes  */
-  u_longlong_t swpocc;                  /* updated whenever swpque is updated. i.e. the swpqueue is occupied.
-                                               * This can be used to compute the simple average processes waiting to be paged in */
-  u_longlong_t iget;                    /* number of inode lookups */
-  u_longlong_t namei;                   /* number of vnode lookup from a path name */
-  u_longlong_t dirblk;                  /* number of 512-byte block reads by the directory search routine to locate an entry for a file */
-  u_longlong_t msg;                     /* number of IPC message operations */
-  u_longlong_t sema;                    /* number of IPC semaphore operations */
-  u_longlong_t rcvint;                  /* number of tty receive interrupts */
-  u_longlong_t xmtint;                  /* number of tyy transmit interrupts */
-  u_longlong_t mdmint;                  /* number of modem interrupts */
-  u_longlong_t tty_rawinch;             /* number of raw input characters  */
-  u_longlong_t tty_caninch;             /* number of canonical input characters (always zero) */
-  u_longlong_t tty_rawoutch;            /* number of raw output characters */
-  u_longlong_t ksched;                  /* number of kernel processes created */
-  u_longlong_t koverf;                  /* kernel process creation attempts where:
-                                               * -the user has forked to their maximum limit
-                                               * -the configuration limit of processes has been reached */
-  u_longlong_t kexit;                   /* number of kernel processes that became zombies */
-  u_longlong_t rbread;                  /* number of remote read requests */
-  u_longlong_t rcread;                  /* number of cached remote reads */
-  u_longlong_t rbwrt;                   /* number of remote writes */
-  u_longlong_t rcwrt;                   /* number of cached remote writes */
-  u_longlong_t traps;                   /* number of traps */
-  int ncpus_high;                       /* index of highest processor online */
-  u_longlong_t puser;                   /* raw number of physical processor tics in user mode */
-  u_longlong_t psys;                    /* raw number of physical processor tics in system mode */
-  u_longlong_t pidle;                   /* raw number of physical processor tics idle */
-  u_longlong_t pwait;                   /* raw number of physical processor tics waiting for I/O */
-  u_longlong_t decrintrs;               /* number of decrementer tics interrupts */
-  u_longlong_t mpcrintrs;               /* number of mpc's received interrupts */
-  u_longlong_t mpcsintrs;               /* number of mpc's sent interrupts */
-  u_longlong_t phantintrs;              /* number of phantom interrupts */
-  u_longlong_t idle_donated_purr;       /* number of idle cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t idle_donated_spurr;      /* number of idle spurr cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t busy_donated_purr;       /* number of busy cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t busy_donated_spurr;      /* number of busy spurr cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t idle_stolen_purr;        /* number of idle cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t idle_stolen_spurr;       /* number of idle spurr cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t busy_stolen_purr;        /* number of busy cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t busy_stolen_spurr;       /* number of busy spurr cycles stolen by the hypervisor from a dedicated partition */
-  short iowait;                         /* number of processes that are asleep waiting for buffered I/O */
-  short physio;                         /* number of processes waiting for raw I/O */
-  longlong_t twait;                     /* number of threads that are waiting for filesystem direct(cio) */
-  u_longlong_t hpi;                     /* number of hypervisor page-ins */
-  u_longlong_t hpit;                    /* Time spent in hypervisor page-ins (in nanoseconds) */
-  u_longlong_t puser_spurr;             /* number of spurr cycles spent in user mode */
-  u_longlong_t psys_spurr;              /* number of spurr cycles spent in kernel mode */
-  u_longlong_t pidle_spurr;             /* number of spurr cycles spent in idle mode */
-  u_longlong_t pwait_spurr;             /* number of spurr cycles spent in wait mode */
-  int spurrflag;                        /* set if running in spurr mode */
-} perfstat_cpu_total_t_61;
 
 typedef struct { /* global cpu information AIX 7.1 */
   int ncpus;                            /* number of active logical processors */
@@ -564,166 +393,6 @@ typedef union {
   } b;
 } perfstat_partition_type_t;
 
-typedef struct { /* partition total information AIX 5.3 < TL6 */
-  char name[IDENTIFIER_LENGTH];         /* name of the logical partition */
-  perfstat_partition_type_t type;       /* set of bits describing the partition */
-  int lpar_id;                          /* logical partition identifier */
-  int group_id;                         /* identifier of the LPAR group this partition is a member of */
-  int pool_id;                          /* identifier of the shared pool of physical processors this partition is a member of */
-  int online_cpus;                      /* number of virtual CPUs currently online on the partition */
-  int max_cpus;                         /* maximum number of virtual CPUs this partition can ever have */
-  int min_cpus;                         /* minimum number of virtual CPUs this partition must have */
-  u_longlong_t online_memory;           /* amount of memory currently online */
-  u_longlong_t max_memory;              /* maximum amount of memory this partition can ever have */
-  u_longlong_t min_memory;              /* minimum amount of memory this partition must have */
-  int entitled_proc_capacity;           /* number of processor units this partition is entitled to receive */
-  int max_proc_capacity;                /* maximum number of processor units this partition can ever have */
-  int min_proc_capacity;                /* minimum number of processor units this partition must have */
-  int proc_capacity_increment;          /* increment value to the entitled capacity */
-  int unalloc_proc_capacity;            /* number of processor units currently unallocated in the shared processor pool this partition belongs to */
-  int var_proc_capacity_weight;         /* partition priority weight to receive extra capacity */
-  int unalloc_var_proc_capacity_weight; /* number of variable processor capacity weight units currently unallocated  in the shared processor pool this partition belongs to */
-  int online_phys_cpus_sys;             /* number of physical CPUs currently active in the system containing this partition */
-  int max_phys_cpus_sys;                /* maximum possible number of physical CPUs in the system containing this partition */
-  int phys_cpus_pool;                   /* number of the physical CPUs currently in the shared processor pool this partition belong to */
-  u_longlong_t puser;                   /* raw number of physical processor tics in user mode */
-  u_longlong_t psys;                    /* raw number of physical processor tics in system mode */
-  u_longlong_t pidle;                   /* raw number of physical processor tics idle */
-  u_longlong_t pwait;                   /* raw number of physical processor tics waiting for I/O */
-  u_longlong_t pool_idle_time;          /* number of clock tics a processor in the shared pool was idle */
-  u_longlong_t phantintrs;              /* number of phantom interrupts received by the partition */
-  u_longlong_t invol_virt_cswitch;      /* number involuntary virtual CPU context switches */
-  u_longlong_t vol_virt_cswitch;        /* number voluntary virtual CPU context switches */
-  u_longlong_t timebase_last;           /* most recently cpu time base */
-  u_longlong_t reserved_pages;          /* Currently number of 16GB pages. Cannot participate in DR operations */
-  u_longlong_t reserved_pagesize;       /* Currently 16GB pagesize Cannot participate in DR operations */
-} perfstat_partition_total_t_53_5;
-
-typedef struct { /* partition total information AIX 5.3 < TL10 */
-  char name[IDENTIFIER_LENGTH];         /* name of the logical partition */
-  perfstat_partition_type_t type;       /* set of bits describing the partition */
-  int lpar_id;                          /* logical partition identifier */
-  int group_id;                         /* identifier of the LPAR group this partition is a member of */
-  int pool_id;                          /* identifier of the shared pool of physical processors this partition is a member of */
-  int online_cpus;                      /* number of virtual CPUs currently online on the partition */
-  int max_cpus;                         /* maximum number of virtual CPUs this partition can ever have */
-  int min_cpus;                         /* minimum number of virtual CPUs this partition must have */
-  u_longlong_t online_memory;           /* amount of memory currently online */
-  u_longlong_t max_memory;              /* maximum amount of memory this partition can ever have */
-  u_longlong_t min_memory;              /* minimum amount of memory this partition must have */
-  int entitled_proc_capacity;           /* number of processor units this partition is entitled to receive */
-  int max_proc_capacity;                /* maximum number of processor units this partition can ever have */
-  int min_proc_capacity;                /* minimum number of processor units this partition must have */
-  int proc_capacity_increment;          /* increment value to the entitled capacity */
-  int unalloc_proc_capacity;            /* number of processor units currently unallocated in the shared processor pool this partition belongs to */
-  int var_proc_capacity_weight;         /* partition priority weight to receive extra capacity */
-  int unalloc_var_proc_capacity_weight; /* number of variable processor capacity weight units currently unallocated  in the shared processor pool this partition belongs to */
-  int online_phys_cpus_sys;             /* number of physical CPUs currently active in the system containing this partition */
-  int max_phys_cpus_sys;                /* maximum possible number of physical CPUs in the system containing this partition */
-  int phys_cpus_pool;                   /* number of the physical CPUs currently in the shared processor pool this partition belong to */
-  u_longlong_t puser;                   /* raw number of physical processor tics in user mode */
-  u_longlong_t psys;                    /* raw number of physical processor tics in system mode */
-  u_longlong_t pidle;                   /* raw number of physical processor tics idle */
-  u_longlong_t pwait;                   /* raw number of physical processor tics waiting for I/O */
-  u_longlong_t pool_idle_time;          /* number of clock tics a processor in the shared pool was idle */
-  u_longlong_t phantintrs;              /* number of phantom interrupts received by the partition */
-  u_longlong_t invol_virt_cswitch;      /* number involuntary virtual CPU context switches */
-  u_longlong_t vol_virt_cswitch;        /* number voluntary virtual CPU context switches */
-  u_longlong_t timebase_last;           /* most recently cpu time base */
-  u_longlong_t reserved_pages;          /* Currently number of 16GB pages. Cannot participate in DR operations */
-  u_longlong_t reserved_pagesize;       /* Currently 16GB pagesize Cannot participate in DR operations */
-  u_longlong_t idle_donated_purr;       /* number of idle cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t idle_donated_spurr;      /* number of idle spurr cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t busy_donated_purr;       /* number of busy cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t busy_donated_spurr;      /* number of busy spurr cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t idle_stolen_purr;        /* number of idle cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t idle_stolen_spurr;       /* number of idle spurr cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t busy_stolen_purr;        /* number of busy cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t busy_stolen_spurr;       /* number of busy spurr cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t shcpus_in_sys;           /* Number of physical processors allocated for shared processor use */
-  u_longlong_t max_pool_capacity;       /* Maximum processor capacity of partitions pool */
-  u_longlong_t entitled_pool_capacity;  /* Entitled processor capacity of partitions pool */
-  u_longlong_t pool_max_time;           /* Summation of maximum time that could be consumed by the pool (nano seconds) */
-  u_longlong_t pool_busy_time;          /* Summation of busy (non-idle) time accumulated across all partitions in the pool (nano seconds) */
-  u_longlong_t pool_scaled_busy_time;   /* Scaled summation of busy (non-idle) time accumulated across all partitions in the pool (nano seconds) */
-  u_longlong_t shcpu_tot_time;          /* Summation of total time across all physical processors allocated for shared processor use (nano seconds) */
-  u_longlong_t shcpu_busy_time;         /* Summation of busy (non-idle) time accumulated across all shared processor partitions (nano seconds) */
-  u_longlong_t shcpu_scaled_busy_time;  /* Scaled summation of busy time accumulated across all shared processor partitions (nano seconds) */
-  int ams_pool_id;                      /* AMS pool id of the pool the LPAR belongs to */
-  int var_mem_weight;                   /* variable memory capacity weight */
-  u_longlong_t iome;                    /* I/O memory entitlement of the partition in bytes*/
-  u_longlong_t pmem;                    /* Physical memory currently backing the partition's logical memory in bytes*/
-  u_longlong_t hpi;                     /* number of hypervisor page-ins */
-  u_longlong_t hpit;                    /* Time spent in hypervisor page-ins (in nanoseconds)*/
-  u_longlong_t hypv_pagesize;           /* Hypervisor page size in KB*/
-} perfstat_partition_total_t_53;
-
-typedef struct { /* partition total information AIX 6.1|5.3 > TL09 */
-  char name[IDENTIFIER_LENGTH];         /* name of the logical partition */
-  perfstat_partition_type_t type;       /* set of bits describing the partition */
-  int lpar_id;                          /* logical partition identifier */
-  int group_id;                         /* identifier of the LPAR group this partition is a member of */
-  int pool_id;                          /* identifier of the shared pool of physical processors this partition is a member of */
-  int online_cpus;                      /* number of virtual CPUs currently online on the partition */
-  int max_cpus;                         /* maximum number of virtual CPUs this partition can ever have */
-  int min_cpus;                         /* minimum number of virtual CPUs this partition must have */
-  u_longlong_t online_memory;           /* amount of memory currently online */
-  u_longlong_t max_memory;              /* maximum amount of memory this partition can ever have */
-  u_longlong_t min_memory;              /* minimum amount of memory this partition must have */
-  int entitled_proc_capacity;           /* number of processor units this partition is entitled to receive */
-  int max_proc_capacity;                /* maximum number of processor units this partition can ever have */
-  int min_proc_capacity;                /* minimum number of processor units this partition must have */
-  int proc_capacity_increment;          /* increment value to the entitled capacity */
-  int unalloc_proc_capacity;            /* number of processor units currently unallocated in the shared processor pool this partition belongs to */
-  int var_proc_capacity_weight;         /* partition priority weight to receive extra capacity */
-  int unalloc_var_proc_capacity_weight; /* number of variable processor capacity weight units currently unallocated  in the shared processor pool this partition belongs to */
-  int online_phys_cpus_sys;             /* number of physical CPUs currently active in the system containing this partition */
-  int max_phys_cpus_sys;                /* maximum possible number of physical CPUs in the system containing this partition */
-  int phys_cpus_pool;                   /* number of the physical CPUs currently in the shared processor pool this partition belong to */
-  u_longlong_t puser;                   /* raw number of physical processor tics in user mode */
-  u_longlong_t psys;                    /* raw number of physical processor tics in system mode */
-  u_longlong_t pidle;                   /* raw number of physical processor tics idle */
-  u_longlong_t pwait;                   /* raw number of physical processor tics waiting for I/O */
-  u_longlong_t pool_idle_time;          /* number of clock tics a processor in the shared pool was idle */
-  u_longlong_t phantintrs;              /* number of phantom interrupts received by the partition */
-  u_longlong_t invol_virt_cswitch;      /* number involuntary virtual CPU context switches */
-  u_longlong_t vol_virt_cswitch;        /* number voluntary virtual CPU context switches */
-  u_longlong_t timebase_last;           /* most recently cpu time base */
-  u_longlong_t reserved_pages;          /* Currently number of 16GB pages. Cannot participate in DR operations */
-  u_longlong_t reserved_pagesize;       /* Currently 16GB pagesize Cannot participate in DR operations */
-  u_longlong_t idle_donated_purr;       /* number of idle cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t idle_donated_spurr;      /* number of idle spurr cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t busy_donated_purr;       /* number of busy cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t busy_donated_spurr;      /* number of busy spurr cycles donated by a dedicated partition enabled for donation */
-  u_longlong_t idle_stolen_purr;        /* number of idle cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t idle_stolen_spurr;       /* number of idle spurr cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t busy_stolen_purr;        /* number of busy cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t busy_stolen_spurr;       /* number of busy spurr cycles stolen by the hypervisor from a dedicated partition */
-  u_longlong_t shcpus_in_sys;           /* Number of physical processors allocated for shared processor use */
-  u_longlong_t max_pool_capacity;       /* Maximum processor capacity of partitions pool */
-  u_longlong_t entitled_pool_capacity;  /* Entitled processor capacity of partitions pool */
-  u_longlong_t pool_max_time;           /* Summation of maximum time that could be consumed by the pool (nano seconds) */
-  u_longlong_t pool_busy_time;          /* Summation of busy (non-idle) time accumulated across all partitions in the pool (nano seconds) */
-  u_longlong_t pool_scaled_busy_time;   /* Scaled summation of busy (non-idle) time accumulated across all partitions in the pool (nano seconds) */
-  u_longlong_t shcpu_tot_time;          /* Summation of total time across all physical processors allocated for shared processor use (nano seconds) */
-  u_longlong_t shcpu_busy_time;         /* Summation of busy (non-idle) time accumulated across all shared processor partitions (nano seconds) */
-  u_longlong_t shcpu_scaled_busy_time;  /* Scaled summation of busy time accumulated across all shared processor partitions (nano seconds) */
-  int ams_pool_id;                      /* AMS pool id of the pool the LPAR belongs to */
-  int var_mem_weight;                   /* variable memory capacity weight */
-  u_longlong_t iome;                    /* I/O memory entitlement of the partition in bytes*/
-  u_longlong_t pmem;                    /* Physical memory currently backing the partition's logical memory in bytes*/
-  u_longlong_t hpi;                     /* number of hypervisor page-ins */
-  u_longlong_t hpit;                    /* Time spent in hypervisor page-ins (in nanoseconds)*/
-  u_longlong_t hypv_pagesize;           /* Hypervisor page size in KB*/
-  uint online_lcpus;                    /* number of online logical cpus */
-  uint smt_thrds;                       /* number of hardware threads that are running */
-  u_longlong_t puser_spurr;             /* number of spurr cycles spent in user mode */
-  u_longlong_t psys_spurr;              /* number of spurr cycles spent in kernel mode */
-  u_longlong_t pidle_spurr;             /* number of spurr cycles spent in idle mode */
-  u_longlong_t pwait_spurr;             /* number of spurr cycles spent in wait mode */
-  int spurrflag;                        /* set if running in spurr mode */
-} perfstat_partition_total_t_61;
-
 typedef struct { /* partition total information AIX 7.1 */
   char name[IDENTIFIER_LENGTH];         /* name of the logical partition */
   perfstat_partition_type_t type;       /* set of bits describing the partition */
@@ -941,17 +610,6 @@ typedef union { /* WPAR Type & Flags */
         } b;
 } perfstat_wpar_type_t;
 
-typedef struct { /* Workload partition Information AIX 5.3 & 6.1*/
-       char name[MAXCORRALNAMELEN+1]; /* name of the Workload Partition */
-       perfstat_wpar_type_t type;     /* set of bits describing the wpar */
-       cid_t wpar_id;                 /* workload partition identifier */
-       uint  online_cpus;             /* Number of Virtual CPUs in partition rset or  number of virtual CPUs currently online on the Global partition*/
-       int   cpu_limit;               /* CPU limit in 100ths of % - 1..10000 */
-       int   mem_limit;               /* Memory limit in 100ths of % - 1..10000 */
-       u_longlong_t online_memory;    /* amount of memory currently online in Global Partition */
-       int entitled_proc_capacity;    /* number of processor units this partition is entitled to receive */
-} perfstat_wpar_total_t_61;
-
 typedef struct { /* Workload partition Information AIX 7.1*/
        char name[MAXCORRALNAMELEN+1]; /* name of the Workload Partition */
        perfstat_wpar_type_t type;     /* set of bits describing the wpar */
@@ -983,7 +641,7 @@ typedef struct { /* WPAR identifier */
 
 
 
-// end: libperfstat.h (AIX 5.2, 5.3, 6.1, 7.1)
+// end: libperfstat.h (AIX 7.1)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #define PERFSTAT_PARTITON_TOTAL_T_LATEST perfstat_partition_total_t_71_1 /* latest perfstat_partition_total_t structure */


### PR DESCRIPTION
Currently we use libperfstat with dlopen/dladdr, see src/hotspot/os/aix/libperfstat_aix.hpp (+cpp) .
For compatibility reason we have support for  different versions of this API.
However the AIX 5.3 / 6.1  support is outdated now, AIX versions older than 7.X are not supported any more by the current OpenJDK . So remove support for those old API versions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8222719](https://bugs.openjdk.org/browse/JDK-8222719): libperfstat on AIX - cleanup old API versions (**Bug** - P4)


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17460/head:pull/17460` \
`$ git checkout pull/17460`

Update a local copy of the PR: \
`$ git checkout pull/17460` \
`$ git pull https://git.openjdk.org/jdk.git pull/17460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17460`

View PR using the GUI difftool: \
`$ git pr show -t 17460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17460.diff">https://git.openjdk.org/jdk/pull/17460.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17460#issuecomment-1895319709)