### PR TITLE
8323995: Suppress notes generated on incremental microbenchmark builds

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -107,6 +107,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
         --add-exports java.base/sun.invoke.util=ALL-UNNAMED \
         --add-exports java.base/sun.security.util=ALL-UNNAMED \
         --enable-preview \
+        -XDsuppressNotes \
         -processor org.openjdk.jmh.generators.BenchmarkProcessor, \
     JAVA_FLAGS := \
         --add-exports java.base/jdk.internal.vm=ALL-UNNAMED \


### PR DESCRIPTION
Incrementally building the OpenJDK microbenchmarks emit a "Note: Benchmark entries for <class>already exists, overwriting" for each microbenchmark class. This is generated by the JMH BenchmarkProcessor annotation processor via the javac messager framework.

To carefully disable this informative message without disabling all linters and warnings we can supply the undocumented `-XDsuppressNotes` flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323995](https://bugs.openjdk.org/browse/JDK-8323995): Suppress notes generated on incremental microbenchmark builds (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17464/head:pull/17464` \
`$ git checkout pull/17464`

Update a local copy of the PR: \
`$ git checkout pull/17464` \
`$ git pull https://git.openjdk.org/jdk.git pull/17464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17464`

View PR using the GUI difftool: \
`$ git pr show -t 17464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17464.diff">https://git.openjdk.org/jdk/pull/17464.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17464#issuecomment-1895837008)