### PR TITLE
8323595: is_aligned(p, alignof(OopT))) assertion fails in Jetty without compressed OOPs

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2181,7 +2181,7 @@ void ThawBase::clear_bitmap_bits(address start, address end) {
   log_develop_trace(continuations)("clearing bitmap for " INTPTR_FORMAT " - " INTPTR_FORMAT, p2i(start), p2i(effective_end));
   stackChunkOop chunk = _cont.tail();
   chunk->bitmap().clear_range(chunk->bit_index_for(start), chunk->bit_index_for(effective_end));
-  assert(chunk->bitmap().count_one_bits(chunk->bit_index_for(effective_end), chunk->bit_index_for(end)) == 0, "bits should not be set");
+  assert(effective_end == end || !chunk->bitmap().at(chunk->bit_index_for(effective_end)), "bit should not be set");
 }
 
 NOINLINE void ThawBase::recurse_thaw_interpreted_frame(const frame& hf, frame& caller, int num_frames) {


### PR DESCRIPTION
This is an oversight in one of the asserts I added as part of the 8320275 fix. Variable `end` cannot be passed to bit_index_for() since it can be unaligned if UseCompressedOops is off. We actually only need `effective_end` in the assert since we only want to check that if `end` was unaligned there is indeed no bit set for that last stack slot of the argument area.
I run the failing test several times with -XX:-UseCompressedOops. I also run the upper loom tiers with that flag since it seems it's not being tested as much. 

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323595](https://bugs.openjdk.org/browse/JDK-8323595): is_aligned(p, alignof(OopT))) assertion fails in Jetty without compressed OOPs (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17465/head:pull/17465` \
`$ git checkout pull/17465`

Update a local copy of the PR: \
`$ git checkout pull/17465` \
`$ git pull https://git.openjdk.org/jdk.git pull/17465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17465`

View PR using the GUI difftool: \
`$ git pr show -t 17465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17465.diff">https://git.openjdk.org/jdk/pull/17465.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17465#issuecomment-1896047379)