### PR TITLE
8323502: javac crash with wrongly typed method block in Flow

### DIFF
--- a/test/langtools/tools/javac/T8323502.java
+++ b/test/langtools/tools/javac/T8323502.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8323502
+ * @summary javac crash with wrongly typed method block in Flow
+ * @compile/fail/ref=T8323502.out -XDrawDiagnostics --should-stop=at=FLOW -XDdev T8323502.java
+ */
+public class T8323502 {
+    public void m(Object o) {
+        return switch(o) {
+            default -> System.out.println("boom");
+        };
+    }
+}

--- a/test/langtools/tools/javac/T8323502.out
+++ b/test/langtools/tools/javac/T8323502.out
@@ -1,0 +1,2 @@
+T8323502.java:31:16: compiler.err.prob.found.req: (compiler.misc.unexpected.ret.val)
+1 error


### PR DESCRIPTION
The observation is that the `tree.target` of the RHS's `yield` was not set properly to point at the outer switch. As a result, the assertion was hit in `clearPendingExits` with a wrong set of pending exits.

The cause was that the `tree` was not attributed since `visitSwitchExpression` was short-circuited to `return;` and `visitYield` was never setting the `target`. As a result, `resolveJump` was not actually resolving the jump correctly.

thx @lahodaj for the help!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323502](https://bugs.openjdk.org/browse/JDK-8323502): javac crash with wrongly typed method block in Flow (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Contributors
 * Jan Lahoda `<jlahoda@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17466/head:pull/17466` \
`$ git checkout pull/17466`

Update a local copy of the PR: \
`$ git checkout pull/17466` \
`$ git pull https://git.openjdk.org/jdk.git pull/17466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17466`

View PR using the GUI difftool: \
`$ git pr show -t 17466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17466.diff">https://git.openjdk.org/jdk/pull/17466.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17466#issuecomment-1896102433)