### PR TITLE
8159927: Add a test to verify JMOD files created in the images do not have debug symbols

### DIFF
--- a/test/jdk/jdk/modules/etc/JmodExcludedFiles.java
+++ b/test/jdk/jdk/modules/etc/JmodExcludedFiles.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8159927
+ * @modules java.base/jdk.internal.util
+ * @run main JmodExcludedFiles
+ * @summary Test that JDK JMOD files do not include native debug symbols
+ */
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import jdk.internal.util.OperatingSystem;
+
+public class JmodExcludedFiles {
+    public static void main(String[] args) throws Exception {
+        String javaHome = System.getProperty("java.home");
+        Path jmods = Path.of(javaHome, "jmods");
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(jmods, "*.jmod")) {
+            for (Path jmodFile : stream) {
+                try (ZipFile zip = new ZipFile(jmodFile.toFile())) {
+                    if (zip.stream().map(ZipEntry::getName)
+                                    .anyMatch(JmodExcludedFiles::isNativeDebugSymbol)) {
+                        throw new RuntimeException(jmodFile + " is expected not to include native debug symbols");
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean isNativeDebugSymbol(String name) {
+        int index = name.indexOf("/");
+        if (index < 0) {
+            throw new RuntimeException("unexpected entry name: " + name);
+        }
+        String section = name.substring(0, index);
+        if (section.equals("lib") || section.equals("bin")) {
+            if (OperatingSystem.isMacOS()) {
+                String n = name.substring(index+1);
+                int i = n.indexOf("/");
+                if (i != -1) {
+                    return n.substring(0, i).endsWith(".dSYM");
+                }
+            }
+            return name.endsWith(".diz")
+                    || name.endsWith(".debuginfo")
+                    || name.endsWith(".map")
+                    || name.endsWith(".pdb");
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
The build excludes the native debug symbols in JMOD files created for JDK modules (see make/CreateJmods.gmk).   This PR adds a test to verify that native debug symbols are excluded as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8159927](https://bugs.openjdk.org/browse/JDK-8159927): Add a test to verify JMOD files created in the images do not have debug symbols (**Enhancement** - P4)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17467/head:pull/17467` \
`$ git checkout pull/17467`

Update a local copy of the PR: \
`$ git checkout pull/17467` \
`$ git pull https://git.openjdk.org/jdk.git pull/17467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17467`

View PR using the GUI difftool: \
`$ git pr show -t 17467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17467.diff">https://git.openjdk.org/jdk/pull/17467.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17467#issuecomment-1896673209)