### PR TITLE
8324053: Use the blessed modifier order for sealed in java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/BaseVirtualThread.java
+++ b/src/java.base/share/classes/java/lang/BaseVirtualThread.java
@@ -27,7 +27,7 @@ package java.lang;
 /**
  * Base class for virtual thread implementations.
  */
-sealed abstract class BaseVirtualThread extends Thread
+abstract sealed class BaseVirtualThread extends Thread
         permits VirtualThread, ThreadBuilders.BoundVirtualThread {
 
     /**

--- a/src/java.base/share/classes/sun/net/dns/ResolverConfiguration.java
+++ b/src/java.base/share/classes/sun/net/dns/ResolverConfiguration.java
@@ -37,7 +37,7 @@ import java.util.List;
  * @since 1.4
  */
 
-public sealed abstract class ResolverConfiguration permits ResolverConfigurationImpl {
+public abstract sealed class ResolverConfiguration permits ResolverConfigurationImpl {
 
     private static final Object lock = new Object();
 

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1153,7 +1153,7 @@ public class FileChannelImpl
 
     // -- Memory-mapped buffers --
 
-    private sealed abstract static class Unmapper
+    private abstract static sealed class Unmapper
         implements Runnable, UnmapperProxy
     {
         private final long address;

--- a/src/java.base/share/classes/sun/util/calendar/AbstractCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/AbstractCalendar.java
@@ -44,7 +44,7 @@ import java.util.TimeZone;
  * @since 1.5
  */
 
-public sealed abstract class AbstractCalendar extends CalendarSystem
+public abstract sealed class AbstractCalendar extends CalendarSystem
         permits BaseCalendar {
 
     // The constants assume no leap seconds support.

--- a/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
+++ b/src/java.base/share/classes/sun/util/calendar/BaseCalendar.java
@@ -36,7 +36,7 @@ import java.util.TimeZone;
  * @since 1.5
  */
 
-public sealed abstract class BaseCalendar extends AbstractCalendar
+public abstract sealed class BaseCalendar extends AbstractCalendar
         permits Gregorian, JulianCalendar, LocalGregorianCalendar {
 
     public static final int JANUARY = 1;
@@ -141,7 +141,7 @@ public sealed abstract class BaseCalendar extends AbstractCalendar
         744365, // 2039
     };
 
-    public sealed abstract static class Date extends CalendarDate
+    public abstract static sealed class Date extends CalendarDate
             permits Gregorian.Date, ImmutableGregorianDate, JulianCalendar.Date, LocalGregorianCalendar.Date {
         protected Date() {
             super();

--- a/src/java.base/share/classes/sun/util/calendar/CalendarDate.java
+++ b/src/java.base/share/classes/sun/util/calendar/CalendarDate.java
@@ -59,7 +59,7 @@ import java.util.TimeZone;
  * @author Masayoshi Okutsu
  * @since 1.5
  */
-public sealed abstract class CalendarDate implements Cloneable
+public abstract sealed class CalendarDate implements Cloneable
         permits BaseCalendar.Date {
     public static final int FIELD_UNDEFINED = Integer.MIN_VALUE;
     public static final long TIME_UNDEFINED = Long.MIN_VALUE;

--- a/src/java.base/share/classes/sun/util/calendar/CalendarSystem.java
+++ b/src/java.base/share/classes/sun/util/calendar/CalendarSystem.java
@@ -65,7 +65,7 @@ import java.util.concurrent.ConcurrentMap;
  * @since 1.5
  */
 
-public sealed abstract class CalendarSystem permits AbstractCalendar {
+public abstract sealed class CalendarSystem permits AbstractCalendar {
 
     /////////////////////// Calendar Factory Methods /////////////////////////
 


### PR DESCRIPTION
Please review this trivial PR to reorder the `sealed` class or interface modifier. For context of this change see: https://github.com/openjdk/jdk/pull/17242#issuecomment-1887338396.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324053](https://bugs.openjdk.org/browse/JDK-8324053): Use the blessed modifier order for sealed in java.base (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17468/head:pull/17468` \
`$ git checkout pull/17468`

Update a local copy of the PR: \
`$ git checkout pull/17468` \
`$ git pull https://git.openjdk.org/jdk.git pull/17468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17468`

View PR using the GUI difftool: \
`$ git pr show -t 17468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17468.diff">https://git.openjdk.org/jdk/pull/17468.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17468#issuecomment-1896807435)