### PR TITLE
JDK-8322572: AllocationMergesTests.java fails with "IRViolationException: There were one or multiple IR rule failures."

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
@@ -117,11 +117,11 @@ public class AllocationMergesTests {
         Asserts.assertEQ(testMergedAccessAfterCallWithWrite_Interp(cond1, x, y),    testMergedAccessAfterCallWithWrite_C2(cond1, x, y));
         Asserts.assertEQ(testLoadAfterTrap_Interp(cond1, x, y),                     testLoadAfterTrap_C2(cond1, x, y));
         Asserts.assertEQ(testCondAfterMergeWithNull_Interp(cond1, cond2, x, y),     testCondAfterMergeWithNull_C2(cond1, cond2, x, y));
-        Asserts.assertEQ(testLoadAfterLoopAlias_Interp(cond1, x, y),                testLoadAfterLoopAlias_C2(cond1, x, y));
+        Asserts.assertEQ(testLoadAfterLoopAlias_Interp(x, y),                       testLoadAfterLoopAlias_C2(x, y));
         Asserts.assertEQ(testCallTwoSide_Interp(cond1, x, y),                       testCallTwoSide_C2(cond1, x, y));
         Asserts.assertEQ(testMergedAccessAfterCallNoWrite_Interp(cond1, x, y),      testMergedAccessAfterCallNoWrite_C2(cond1, x, y));
         Asserts.assertEQ(testCmpMergeWithNull_Second_Interp(cond1, x, y),           testCmpMergeWithNull_Second_C2(cond1, x, y));
-        Asserts.assertEQ(testObjectIdentity_Interp(cond1, 42, y),                   testObjectIdentity_C2(cond1, 42, y));
+        Asserts.assertEQ(testObjectIdentity_Interp(cond1, 42, y),                 testObjectIdentity_C2(cond1, 42, y));
         Asserts.assertEQ(testSubclassesTrapping_Interp(cond1, cond2, x, y, w, z),   testSubclassesTrapping_C2(cond1, cond2, x, y, w, z));
         Asserts.assertEQ(testCmpMergeWithNull_Interp(cond1, x, y),                  testCmpMergeWithNull_C2(cond1, x, y));
         Asserts.assertEQ(testSubclasses_Interp(cond1, cond2, x, y, w, z),           testSubclasses_C2(cond1, cond2, x, y, w, z));
@@ -414,27 +414,26 @@ public class AllocationMergesTests {
     // -------------------------------------------------------------------------
 
     @ForceInline
-    int testLoadAfterLoopAlias(boolean cond, int x, int y) {
+    int testLoadAfterLoopAlias(int x, int y) {
         Point a = new Point(x, y);
         Point b = new Point(y, x);
-        Point c = a;
+        int acc = 0;
 
         for (int i=10; i<232; i++) {
-            if (i == x) {
-                c = b;
-            }
+            Point c = (i % 2 == 0) ? a : b;
+            acc += c.x + c.y;
         }
 
-        return cond ? c.x : c.y;
+        return acc;
     }
 
     @Test
     @IR(failOn = { IRNode.ALLOC })
     // Both allocations should be removed
-    int testLoadAfterLoopAlias_C2(boolean cond, int x, int y) { return testLoadAfterLoopAlias(cond, x, y); }
+    int testLoadAfterLoopAlias_C2(int x, int y) { return testLoadAfterLoopAlias(x, y); }
 
     @DontCompile
-    int testLoadAfterLoopAlias_Interp(boolean cond, int x, int y) { return testLoadAfterLoopAlias(cond, x, y); }
+    int testLoadAfterLoopAlias_Interp(int x, int y) { return testLoadAfterLoopAlias(x, y); }
 
     // -------------------------------------------------------------------------
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesTests.java
@@ -121,7 +121,7 @@ public class AllocationMergesTests {
         Asserts.assertEQ(testCallTwoSide_Interp(cond1, x, y),                       testCallTwoSide_C2(cond1, x, y));
         Asserts.assertEQ(testMergedAccessAfterCallNoWrite_Interp(cond1, x, y),      testMergedAccessAfterCallNoWrite_C2(cond1, x, y));
         Asserts.assertEQ(testCmpMergeWithNull_Second_Interp(cond1, x, y),           testCmpMergeWithNull_Second_C2(cond1, x, y));
-        Asserts.assertEQ(testObjectIdentity_Interp(cond1, 42, y),                 testObjectIdentity_C2(cond1, 42, y));
+        Asserts.assertEQ(testObjectIdentity_Interp(cond1, 42, y),                   testObjectIdentity_C2(cond1, 42, y));
         Asserts.assertEQ(testSubclassesTrapping_Interp(cond1, cond2, x, y, w, z),   testSubclassesTrapping_C2(cond1, cond2, x, y, w, z));
         Asserts.assertEQ(testCmpMergeWithNull_Interp(cond1, x, y),                  testCmpMergeWithNull_C2(cond1, x, y));
         Asserts.assertEQ(testSubclasses_Interp(cond1, cond2, x, y, w, z),           testSubclasses_C2(cond1, cond2, x, y, w, z));


### PR DESCRIPTION
Please review this PR to fix a test in `AllocationMergesTest.java`. The test was failing intermittently because of a random value used as parameter was causing some randomization in the shape method's IR graph and consequently the optimization tested wasn't happening.

Tested this locally on Mac, Win and Linux x86_64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322572](https://bugs.openjdk.org/browse/JDK-8322572): AllocationMergesTests.java fails with "IRViolationException: There were one or multiple IR rule failures." (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17469/head:pull/17469` \
`$ git checkout pull/17469`

Update a local copy of the PR: \
`$ git checkout pull/17469` \
`$ git pull https://git.openjdk.org/jdk.git pull/17469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17469`

View PR using the GUI difftool: \
`$ git pr show -t 17469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17469.diff">https://git.openjdk.org/jdk/pull/17469.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17469#issuecomment-1897154036)