### PR TITLE
8314329: AgeTable: add is_clear() & allocation spec, and relax assert to allow use of 0-index slot

### DIFF
--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -71,6 +71,16 @@ void AgeTable::clear() {
   }
 }
 
+#ifndef PRODUCT
+bool AgeTable::is_clear() {
+  size_t total = 0;
+  for (size_t* p = sizes; p < sizes + table_size; ++p) {
+    total += *p;
+  }
+  return total == 0;
+}
+#endif // !PRODUCT
+
 void AgeTable::merge(const AgeTable* subTable) {
   for (int i = 0; i < table_size; i++) {
     sizes[i]+= subTable->sizes[i];

--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -72,8 +72,8 @@ void AgeTable::clear() {
 }
 
 #ifndef PRODUCT
-bool AgeTable::is_clear() {
-  for (size_t* p = sizes; p < sizes + table_size; ++p) {
+bool AgeTable::is_clear() const {
+  for (const size_t* p = sizes; p < sizes + table_size; ++p) {
     if (*p != 0) return false;
   }
   return true;

--- a/src/hotspot/share/gc/shared/ageTable.cpp
+++ b/src/hotspot/share/gc/shared/ageTable.cpp
@@ -73,11 +73,10 @@ void AgeTable::clear() {
 
 #ifndef PRODUCT
 bool AgeTable::is_clear() {
-  size_t total = 0;
   for (size_t* p = sizes; p < sizes + table_size; ++p) {
-    total += *p;
+    if (*p != 0) return false;
   }
-  return total == 0;
+  return true;
 }
 #endif // !PRODUCT
 

--- a/src/hotspot/share/gc/shared/ageTable.hpp
+++ b/src/hotspot/share/gc/shared/ageTable.hpp
@@ -25,6 +25,7 @@
 #ifndef SHARE_GC_SHARED_AGETABLE_HPP
 #define SHARE_GC_SHARED_AGETABLE_HPP
 
+#include "memory/allocation.hpp"
 #include "oops/markWord.hpp"
 #include "oops/oop.hpp"
 #include "runtime/perfDataTypes.hpp"
@@ -36,7 +37,7 @@
 //
 // Note: all sizes are in oops
 
-class AgeTable {
+class AgeTable: public CHeapObj<mtGC> {
   friend class VMStructs;
 
  public:
@@ -52,17 +53,18 @@ class AgeTable {
 
   // clear table
   void clear();
+  // check whether it's clear
+  bool is_clear() PRODUCT_RETURN0;
 
   // add entry
   inline void add(oop p, size_t oop_size);
 
   void add(uint age, size_t oop_size) {
-    assert(age > 0 && age < table_size, "invalid age of object");
+    assert(age < table_size, "invalid age of object");
     sizes[age] += oop_size;
   }
 
-  // Merge another age table with the current one.  Used
-  // for parallel young generation gc.
+  // Merge another age table with the current one.
   void merge(const AgeTable* subTable);
 
   // Calculate new tenuring threshold based on age information.

--- a/src/hotspot/share/gc/shared/ageTable.hpp
+++ b/src/hotspot/share/gc/shared/ageTable.hpp
@@ -56,7 +56,7 @@ class AgeTable: public CHeapObj<mtGC> {
 
 #ifndef PRODUCT
   // check whether it's clear
-  bool is_clear();
+  bool is_clear() const;
 #endif // !PRODUCT
 
   // add entry

--- a/src/hotspot/share/gc/shared/ageTable.hpp
+++ b/src/hotspot/share/gc/shared/ageTable.hpp
@@ -53,8 +53,11 @@ class AgeTable: public CHeapObj<mtGC> {
 
   // clear table
   void clear();
+
+#ifndef PRODUCT
   // check whether it's clear
-  bool is_clear() PRODUCT_RETURN0;
+  bool is_clear();
+#endif // !PRODUCT
 
   // add entry
   inline void add(oop p, size_t oop_size);


### PR DESCRIPTION
/issue JDK-8314329

I'd like to propose the following changes to the AgeTable (motivated by the uses in generational shenandoah):

/summary

1. add an allocation spec so the AgeTable can be allocated on the C-heap, and tracked
2. add an `is_clear()` method that checks whether the age table has only zero entries
3. relax the assertion that the 0th index of the age table is never used, so specific collectors may make use of the slot

Testing:
- [x] the code has been active in the generational shenandoah repository for several months
- [x] tested in the jdk repository with hotspot_gc tests
- [x] code pipeline stress tests
- [x] github actions (tier1) testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314329](https://bugs.openjdk.org/browse/JDK-8314329): AgeTable: add is_clear() &amp; allocation spec, and relax assert to allow use of 0-index slot (**Task** - P5)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Author) ⚠️ Review applies to [ede84ca2](https://git.openjdk.org/jdk/pull/17470/files/ede84ca20b621601b1639ad94085aa5d581d4ca3)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role) ⚠️ Review applies to [ede84ca2](https://git.openjdk.org/jdk/pull/17470/files/ede84ca20b621601b1639ad94085aa5d581d4ca3)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [3572babf](https://git.openjdk.org/jdk/pull/17470/files/3572babfb8ee94f4a027f473ad1989d9ce873cba)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [3572babf](https://git.openjdk.org/jdk/pull/17470/files/3572babfb8ee94f4a027f473ad1989d9ce873cba)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17470/head:pull/17470` \
`$ git checkout pull/17470`

Update a local copy of the PR: \
`$ git checkout pull/17470` \
`$ git pull https://git.openjdk.org/jdk.git pull/17470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17470`

View PR using the GUI difftool: \
`$ git pr show -t 17470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17470.diff">https://git.openjdk.org/jdk/pull/17470.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17470#issuecomment-1897041905)