### PR TITLE
enhance compressed streams, prompted by the observations of JDK-8293170

### DIFF
--- a/src/hotspot/share/code/compressedStream.hpp
+++ b/src/hotspot/share/code/compressedStream.hpp
@@ -26,88 +26,287 @@
 #define SHARE_CODE_COMPRESSEDSTREAM_HPP
 
 #include "memory/allocation.hpp"
-#include "utilities/unsigned5.hpp"
+#include "utilities/unsigned5.inline.hpp"
 
 // Simple interface for filing out and filing in basic types
 // Used for writing out and reading in debugging information.
+// It uses the UNSIGNED5 type uniformly.
 
 class CompressedStream : public ResourceObj {
   friend class VMStructs;
  protected:
-  u_char* _buffer;
-  int     _position;
+#ifdef ASSERT
+  size_t _reported_data_size;
+#endif //ASSERT
+
+  CompressedStream() {
+#ifdef ASSERT
+    _reported_data_size = (size_t)-1;
+#endif //ASSERT
+  }
+
+  size_t report_data_size(size_t data_size) {
+    assert(_reported_data_size == (size_t)-1 || _reported_data_size == data_size,
+           "data size reported twice with intervening side effects");
+    DEBUG_ONLY(_reported_data_size = data_size);
+    return data_size;
+  }
+
+  static bool in_bounds(size_t position, size_t limit,
+                        bool inclusive_end = false) {
+    // This is only useful for assertions, since not all streams
+    // have known limit pointers.
+    return (limit == 0 || (position >= 0 &&
+                           (inclusive_end
+                            ? position <= limit
+                            : position <  limit)));
+  }
 
  public:
-  CompressedStream(u_char* buffer, int position = 0) {
-    _buffer   = buffer;
-    _position = position;
-  }
+  /// Canned routines for handling float/long/double.
 
-  u_char* buffer() const               { return _buffer; }
+  // write_int(reverse_bits(jint_cast(v)))
+  static juint encode_float(jfloat value);
+  // write_int(reverse_bits(<low,high>))
+  static void encode_double(jdouble value, juint& first, juint& second);
+  // write_signed_int(<low,high>)
+  static void encode_long(jlong value, juint& first, juint& second);
 
-  // Positioning
-  int position() const                 { return _position; }
-  void set_position(int position)      { _position = position; }
+  // jfloat_cast(reverse_bits(read_int()))
+  static jfloat decode_float(juint encoding);
+  // jdouble_cast(2*reverse_bits(read_int))
+  static jdouble decode_double(juint first, juint second);
+  // jlong_from(2*read_signed_int())
+  static jlong decode_long(juint first, juint second);
 };
 
+/// This intermediate read/write layer deals with only unsigned ints.
 
-class CompressedReadStream : public CompressedStream {
- private:
-  inline u_char read()                 { return _buffer[_position++]; }
+#define DO_CZ DO_CZ
 
- public:
-  CompressedReadStream(u_char* buffer, int position = 0)
-  : CompressedStream(buffer, position) {}
-
-  jboolean read_bool()                 { return (jboolean) read();      }
-  jbyte    read_byte()                 { return (jbyte   ) read();      }
-  jchar    read_char()                 { return (jchar   ) read_int();  }
-  jshort   read_short()                { return (jshort  ) read_signed_int(); }
-  jint     read_signed_int();
-  jfloat   read_float();               // jfloat_cast(reverse_bits(read_int()))
-  jdouble  read_double();              // jdouble_cast(2*reverse_bits(read_int))
-  jlong    read_long();                // jlong_from(2*read_signed_int())
-
-  jint     read_int() {
-    return UNSIGNED5::read_uint(_buffer, _position, 0);
-  }
-};
-
-
-class CompressedWriteStream : public CompressedStream {
- private:
-  bool full() {
-    return _position >= _size;
-  }
-  void store(u_char b) {
-    _buffer[_position++] = b;
-  }
-  void write(u_char b) {
-    if (full()) grow();
-    store(b);
-  }
-  void grow();
+class CompressedIntReadStream : public CompressedStream {
+#ifdef DO_CZ
+  using Reader = ZeroSuppressingU5::ZSReader<u_char*,size_t>;
+#else
+  using Reader = UNSIGNED5::Reader<u_char*,size_t>;
+#endif
+  Reader _r;
 
  protected:
-  int _size;
+  size_t position() {
+    return _r.position();
+  }
+  void reset() {
+    reset_at(0);
+  }
+  void reset_at(size_t pos) {
+#ifdef DO_CZ
+    _r.reset_at_position(pos);
+#else
+    _r.set_position(pos);
+#endif
+  }
 
  public:
-  CompressedWriteStream(int initial_size);
-  CompressedWriteStream(u_char* buffer, int initial_size, int position = 0)
-  : CompressedStream(buffer, position) { _size = initial_size; }
+  CompressedIntReadStream(u_char* buffer, size_t limit = 0) {
+    setup(buffer, limit);
+  }
 
-  void write_bool(jboolean value)      { write(value);      }
-  void write_byte(jbyte value)         { write(value);      }
+  CompressedIntReadStream(u_char* buffer, size_t limit, bool suppress_zeroes) {
+    setup(buffer, limit, suppress_zeroes);
+  }
+
+  void setup(address initial_buffer, size_t initial_size,
+             bool suppress_zeroes = false);
+
+  juint read_int() {
+    return _r.next_uint();
+  }
+
+  juint read_int_pair(int first_width, juint* second) {
+    juint first = 0;
+    _r.next_uint_pair(first_width, first, *second);
+    return first;
+  }
+
+  size_t data_size() {
+    return report_data_size(_r.position());
+  }
+
+  // Use this predicate only if the stream is known to use end-bytes.
+  // Simpler streams do not have end-bytes because their size is known
+  // by consulting external information.
+  bool has_next() {
+    return _r.has_next();
+  }
+
+  bool at_start() {
+#ifdef DO_CZ
+    return _r.at_start();
+#else
+    return _r.position() == 0;
+#endif
+  }
+};
+
+class CompressedIntWriteStream : public CompressedStream {
+#ifdef DO_CZ
+  using Writer = ZeroSuppressingU5::ZSWriter<u_char*,size_t>;
+  using Checkpoint = ZeroSuppressingU5::ZSWriterCheckpoint<size_t,Writer>;
+#else
+  using Writer = UNSIGNED5::Writer<u_char*,size_t>;
+  using Checkpoint = size_t;
+#endif
+  Writer _w;
+  Checkpoint _w_checkpoint;
+
+  void grow();
+
+  void reset() {
+    _w.reset();
+  }
+
+ public:
+  CompressedIntWriteStream(size_t initial_size) {
+    setup(nullptr, initial_size);
+  }
+  CompressedIntWriteStream(address initial_buffer, size_t initial_size,
+                           bool suppress_zeroes = false) {
+    setup(initial_buffer, initial_size, suppress_zeroes);
+  }
+  // If you use this one, make a call to setup before storing any data:
+  CompressedIntWriteStream() {
+  }
+  void setup(address initial_buffer, size_t initial_size,
+             bool suppress_zeroes = false);
+
+  bool at_start() {
+#ifdef DO_CZ
+    return _w.at_start();
+#else
+    return _w.position() == 0;
+#endif
+  }
+
+  void write_int(juint value) {
+    _w.accept_uint_grow(value, [&](int){ grow(); });
+  }
+
+  void write_int_pair(int first_width, juint first, juint second) {
+    _w.accept_uint_pair_grow(first_width, first, second, [&](int){ grow(); });
+  }
+
+  // Flush the compressor and get ready for another run of data.
+  // Return the offset where a reader can start reading the data.
+  size_t checkpoint();
+
+  // After making a checkpoint and then writing some data, flush the
+  // compressor and return the number of bytes output.
+  size_t data_size_after_checkpoint(size_t checkpoint_pos);
+
+  // Undo all writes since a previous checkpoint.
+  void restore(size_t checkpoint_pos);
+
+  // Use this method only if the stream reader will need to call
+  // has_next to sense the end of a variable sequence of items.
+  // Otherwise, just rely on dead reckoning.
+  void write_end_byte() {
+    _w.accept_end_byte();
+  }
+
+  // Add end bytes to round up the size to a given multiple,
+  // such as sizeof(HeapWord).
+  void round_up_size_to_multiple(size_t size_unit) {
+    assert(is_power_of_2(size_unit) && size_unit <= 4*sizeof(HeapWord), "");
+    while ((_w.position() & (size_unit-1)) != 0) {
+      _w.accept_end_byte();
+    }
+  }
+
+  u_char* data_address_at(size_t position, size_t length = 0);
+
+  // At end of a successful life cycle, we can copy out the data.
+  // But we must not ask for conflicting data sizes.
+  // The data_size query must happen at the end, just before copying.
+  size_t data_size() {
+#ifdef DO_CZ
+    _w.flush();
+#endif
+    return report_data_size(_w.position());
+  }
+
+  void copy_bytes_to(address data, size_t data_size, UNSIGNED5::Statistics::Kind kind) {
+    assert(this->data_size() == data_size, "incorrect data size argument");
+    memcpy(data, _w.array(), data_size);
+    _w.collect_stats(kind);
+  }
+};
+
+/// This layer supports all the types.
+
+class CompressedReadStream : public CompressedIntReadStream {
+ public:
+  template<typename... Arg>
+  CompressedReadStream(Arg... arg)
+    : CompressedIntReadStream(arg...)
+  { }
+
+  jboolean read_bool()                 { return (jboolean) read_int();  }
+  jbyte    read_byte()                 { return (jbyte   ) read_int();  }
+  jchar    read_char()                 { return (jchar   ) read_int();  }
+  jshort   read_short()                { return (jshort  ) read_signed_int(); }
+  jint     read_signed_int()           { return UNSIGNED5::decode_sign(read_int()); }
+  jint     read_signed_int(int sign_bits) {
+    juint x = read_int();
+    return UNSIGNED5::decode_multi_sign(sign_bits, x);
+  }
+  jfloat   read_float() {
+    int x = read_int();
+    return decode_float(x);
+  }
+  jdouble  read_double() {
+    int x = read_int();
+    int y = read_int();
+    return decode_double(x, y);
+  }
+  jlong    read_long() {
+    int x = read_int();
+    int y = read_int();
+    return decode_long(x, y);
+  }
+};
+
+class CompressedWriteStream : public CompressedIntWriteStream {
+ public:
+  template<typename... Arg>
+  CompressedWriteStream(Arg... arg)
+    : CompressedIntWriteStream(arg...)
+  { }
+
+  void write_byte(jbyte value)         { write_int(value & 0xFF); }
+  void write_bool(jboolean value)      { write_int(value ? 1 : 0); }
   void write_char(jchar value)         { write_int(value); }
   void write_short(jshort value)       { write_signed_int(value);  }
   void write_signed_int(jint value)    { write_int(UNSIGNED5::encode_sign(value)); }
-  void write_float(jfloat value);      // write_int(reverse_bits(jint_cast(v)))
-  void write_double(jdouble value);    // write_int(reverse_bits(<low,high>))
-  void write_long(jlong value);        // write_signed_int(<low,high>)
-
-  void write_int(juint value) {
-    UNSIGNED5::write_uint_grow(value, _buffer, _position, _size,
-                               [&](int){ grow(); });
+  void write_signed_int(jint value, int sign_bits) {
+    juint x = UNSIGNED5::encode_multi_sign(sign_bits, value);
+    write_int(x);
+  }
+  void write_float(jfloat value) {
+    juint x = encode_float(value);
+    write_int(x);
+  }
+  void write_double(jdouble value) {
+    juint x, y;
+    encode_double(value, x, y);
+    write_int(x);
+    write_int(y);
+  }
+  void write_long(jlong value) {
+    juint x, y;
+    encode_long(value, x, y);
+    write_int(x);
+    write_int(y);
   }
 };
 

--- a/src/hotspot/share/code/dependencies.hpp
+++ b/src/hotspot/share/code/dependencies.hpp
@@ -302,11 +302,11 @@ class Dependencies: public ResourceObj {
   // State for making a new set of dependencies:
   OopRecorder* _oop_recorder;
 
+  // State for encoding everything other than the oop reference:
+  CompressedWriteStream _non_oop_data;
+
   // Logging support
   CompileLog* _log;
-
-  address  _content_bytes;  // everything but the oop references, encoded
-  size_t   _size_in_bytes;
 
  public:
   // Make a new empty dependencies set.
@@ -452,12 +452,11 @@ class Dependencies: public ResourceObj {
   void encode_content_bytes();
 
   address content_bytes() {
-    assert(_content_bytes != nullptr, "encode it first");
-    return _content_bytes;
+    assert(size_in_bytes() != 0, "encode it first");
+    return _non_oop_data.data_address_at(0);
   }
   size_t size_in_bytes() {
-    assert(_content_bytes != nullptr, "encode it first");
-    return _size_in_bytes;
+    return _non_oop_data.data_size();
   }
 
   OopRecorder* oop_recorder() { return _oop_recorder; }

--- a/src/hotspot/share/code/location.cpp
+++ b/src/hotspot/share/code/location.cpp
@@ -56,13 +56,16 @@ void Location::print_on(outputStream* st) const {
 }
 
 
-Location::Location(DebugInfoReadStream* stream) {
-  _value = (juint) stream->read_int();
+Location::Location(bool tagged, DebugInfoReadStream* stream) {
+  _value = tagged ? stream->read_post_tag() : stream->read_int();
 }
 
 
-void Location::write_on(DebugInfoWriteStream* stream) {
-  stream->write_int(_value);
+void Location::write_on(bool tagged, DebugInfoWriteStream* stream) {
+  if (tagged)
+    stream->write_post_tag(_value);
+  else
+    stream->write_int(_value);
 }
 
 

--- a/src/hotspot/share/code/location.hpp
+++ b/src/hotspot/share/code/location.hpp
@@ -117,8 +117,8 @@ class Location {
   void print_on(outputStream* st) const;
 
   // Serialization of debugging information
-  Location(DebugInfoReadStream* stream);
-  void write_on(DebugInfoWriteStream* stream);
+  Location(bool tagged, DebugInfoReadStream* stream);
+  void write_on(bool tagged, DebugInfoWriteStream* stream);
 
   // check
   static bool legal_offset_in_bytes(int offset_in_bytes);

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2037,9 +2037,10 @@ void nmethod::copy_scopes_pcs(PcDesc* pcs, int count) {
   assert(last_pc + 1 == scopes_pcs_end(), "must match exactly");
 }
 
-void nmethod::copy_scopes_data(u_char* buffer, int size) {
-  assert(scopes_data_size() >= size, "oob");
-  memcpy(scopes_data_begin(), buffer, size);
+void nmethod::copy_scopes_data(CompressedIntWriteStream* stream) {
+  assert((size_t)scopes_data_size() >= stream->data_size(), "oob");
+  stream->copy_bytes_to(scopes_data_begin(), stream->data_size(),
+                        UNSIGNED5::Statistics::DI);
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -591,7 +591,7 @@ public:
  public:
   // copying of debugging information
   void copy_scopes_pcs(PcDesc* pcs, int count);
-  void copy_scopes_data(address buffer, int size);
+  void copy_scopes_data(CompressedIntWriteStream* stream);
 
   int orig_pc_offset() { return _orig_pc_offset; }
 

--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -185,8 +185,10 @@ class OopMap: public ResourceObj {
   int offset() const     { return _pc_offset; }
   void set_offset(int o) { _pc_offset = o; }
   int count() const { return _omv_count; }
-  int data_size() const  { return write_stream()->position(); }
-  address data() const { return write_stream()->buffer(); }
+  int data_size() const  { return write_stream()->data_size(); }
+  void copy_bytes_to(address data, size_t data_size) {
+    write_stream()->copy_bytes_to(data, data_size, UNSIGNED5::Statistics::OM);
+  }
   int num_oops() const { return _num_oops; }
   bool has_derived_oops() const { return _has_derived_oops; }
   int index() const { return _index; }
@@ -200,7 +202,6 @@ class OopMap: public ResourceObj {
   void set_derived_oop ( VMReg local, VMReg derived_from_local_register );
 
   int heap_size() const;
-  void copy_data_to(address addr) const;
   void copy_and_sort_data_to(address addr) const;
   OopMap* deep_copy();
 
@@ -378,9 +379,7 @@ class OopMapStream : public StackObj {
   bool is_done()                        { if(!_valid_omv) { find_next(); } return !_valid_omv; }
   void next()                           { find_next(); }
   OopMapValue current()                 { return _omv; }
-#ifdef ASSERT
-  int stream_position() const           { return _stream.position(); }
-#endif
+  CompressedReadStream& data()          { return _stream; }
 };
 
 class ImmutableOopMapBuilder {

--- a/src/hotspot/share/oops/array.hpp
+++ b/src/hotspot/share/oops/array.hpp
@@ -143,6 +143,17 @@ protected:
     return size(_length);
   }
 
+  // Helper class for access to an Array<u1>, comparable to
+  // UNSIGNED5::ArrayGetSet, but applied to Array types.
+  // Used to access compressed streams of FieldInfo.
+  struct GetSetHelper {
+    uint8_t operator()(Array<T>* a, int i) const { return a->at(i); };
+    void operator()(Array<T>* a, int i, uint8_t b) const { a->at_put(i,b); };
+    // So, an expression ArrayWriterHelper() acts like these lambdas:
+    // auto get = [&](ARR a, OFF i){ return a[i]; };
+    // auto set = [&](ARR a, OFF i, uint8_t x){ a[i] = x; };
+  };
+
   static int length_offset_in_bytes() { return (int) (offset_of(Array<T>, _length)); }
   // Note, this offset don't have to be wordSize aligned.
   static int base_offset_in_bytes() { return (int) (offset_of(Array<T>, _data)); };

--- a/src/hotspot/share/oops/constMethod.cpp
+++ b/src/hotspot/share/oops/constMethod.cpp
@@ -488,7 +488,7 @@ void ConstMethod::verify_on(outputStream* st) {
     while (stream.read_pair()) {
       guarantee(stream.bci() >= 0 && stream.bci() <= code_size(), "invalid bci in line number table");
     }
-    compressed_table_end += stream.position();
+    compressed_table_end += stream.data_size();
   }
   guarantee(compressed_table_end <= m_end, "invalid method layout");
   // Verify checked exceptions, exception table and local variable tables

--- a/src/hotspot/share/oops/fieldInfo.cpp
+++ b/src/hotspot/share/oops/fieldInfo.cpp
@@ -59,7 +59,7 @@ Array<u1>* FieldInfoStream::create_FieldInfoStream(GrowableArray<FieldInfo>* fie
   //   End = 0
 
   using StreamSizer = UNSIGNED5::Sizer<>;
-  using StreamFieldSizer = Mapper<StreamSizer>;
+  using StreamFieldSizer = FieldInfoMapper<StreamSizer>;
   StreamSizer s;
   StreamFieldSizer sizer(&s);
 
@@ -72,8 +72,8 @@ Array<u1>* FieldInfoStream::create_FieldInfoStream(GrowableArray<FieldInfo>* fie
   int storage_size = sizer.consumer()->position() + 1;
   Array<u1>* const fis = MetadataFactory::new_array<u1>(loader_data, storage_size, CHECK_NULL);
 
-  using StreamWriter = UNSIGNED5::Writer<Array<u1>*, int, ArrayHelper<Array<u1>*, int>>;
-  using StreamFieldWriter = Mapper<StreamWriter>;
+  using StreamWriter = UNSIGNED5::Writer<Array<u1>*, int, Array<u1>::GetSetHelper>;
+  using StreamFieldWriter = FieldInfoMapper<StreamWriter>;
   StreamWriter w(fis);
   StreamFieldWriter writer(&w);
 
@@ -83,6 +83,8 @@ Array<u1>* FieldInfoStream::create_FieldInfoStream(GrowableArray<FieldInfo>* fie
     FieldInfo* fi = fields->adr_at(i);
     writer.map_field_info(*fi);
   }
+
+  w.collect_stats(UNSIGNED5::Statistics::FI);
 
 #ifdef ASSERT
   FieldInfoReader r(fis);

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -874,36 +874,30 @@ public:
 
 // Utility class for compressing line number tables
 
-class CompressedLineNumberWriteStream: public CompressedWriteStream {
+class CompressedLineNumberWriteStream: public CompressedIntWriteStream {
  private:
-  int _bci;
-  int _line;
+  uint32_t _bci;
+  uint32_t _line;
+  DEBUG_ONLY(CompressedWriteStream _check_data;)
  public:
   // Constructor
-  CompressedLineNumberWriteStream(int initial_size) : CompressedWriteStream(initial_size), _bci(0), _line(0) {}
-  CompressedLineNumberWriteStream(u_char* buffer, int initial_size) : CompressedWriteStream(buffer, initial_size), _bci(0), _line(0) {}
+  CompressedLineNumberWriteStream(u_char* initial_buffer,
+                                  int initial_size);
 
   // Write (bci, line number) pair to stream
-  void write_pair_regular(int bci_delta, int line_delta);
-
-  // If (bci delta, line delta) fits in (5-bit unsigned, 3-bit unsigned)
-  // we save it as one byte, otherwise we write a 0xFF escape character
-  // and use regular compression. 0x0 is used as end-of-stream terminator.
-  void write_pair_inline(int bci, int line);
-
   void write_pair(int bci, int line);
 
   // Write end-of-stream marker
-  void write_terminator()                        { write_byte(0); }
+  void write_terminator();
 };
 
 
 // Utility class for decompressing line number tables
 
-class CompressedLineNumberReadStream: public CompressedReadStream {
+class CompressedLineNumberReadStream: public CompressedIntReadStream {
  private:
-  int _bci;
-  int _line;
+  uint32_t _bci;
+  uint32_t _line;
  public:
   // Constructor
   CompressedLineNumberReadStream(u_char* buffer);

--- a/src/hotspot/share/oops/method.inline.hpp
+++ b/src/hotspot/share/oops/method.inline.hpp
@@ -44,39 +44,6 @@ inline CompiledMethod* Method::code() const {
   return Atomic::load_acquire(&_code);
 }
 
-// Write (bci, line number) pair to stream
-inline void CompressedLineNumberWriteStream::write_pair_regular(int bci_delta, int line_delta) {
-  // bci and line number does not compress into single byte.
-  // Write out escape character and use regular compression for bci and line number.
-  write_byte((jubyte)0xFF);
-  write_signed_int(bci_delta);
-  write_signed_int(line_delta);
-}
-
-inline void CompressedLineNumberWriteStream::write_pair_inline(int bci, int line) {
-  int bci_delta = bci - _bci;
-  int line_delta = line - _line;
-  _bci = bci;
-  _line = line;
-  // Skip (0,0) deltas - they do not add information and conflict with terminator.
-  if (bci_delta == 0 && line_delta == 0) return;
-  // Check if bci is 5-bit and line number 3-bit unsigned.
-  if (((bci_delta & ~0x1F) == 0) && ((line_delta & ~0x7) == 0)) {
-    // Compress into single byte.
-    jubyte value = (jubyte)((bci_delta << 3) | line_delta);
-    // Check that value doesn't match escape character.
-    if (value != 0xFF) {
-      write_byte(value);
-      return;
-    }
-  }
-  write_pair_regular(bci_delta, line_delta);
-}
-
-inline void CompressedLineNumberWriteStream::write_pair(int bci, int line) {
-  write_pair_inline(bci, line);
-}
-
 inline bool Method::has_compiled_code() const { return code() != nullptr; }
 
 inline bool Method::is_empty_method() const {

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -621,6 +621,26 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, PrintDebugInfo, false,                                      \
           "Print debug information for all nmethods when generated")        \
                                                                             \
+  product(bool, PrintCompressionStatistics, false, DIAGNOSTIC,              \
+          "Print summary information about data stored using UNSIGNED5")    \
+                                                                            \
+  product(int, DisableMetadataCompression, true, DIAGNOSTIC,                \
+          "Disable extra compression transformations on top "               \
+          "of metadata streams, using a bit mask indexed "                  \
+          "by values of UNSIGNED5::Statistics::Kind")                       \
+                                                                            \
+  develop(int, FICompressionOptions, 2,                                     \
+          "Parameter for compressing debug information")                    \
+                                                                            \
+  develop(int, LTCompressionOptions, 5 + 6*64,                              \
+          "Parameter for compressing LineNumberTable attributes")           \
+                                                                            \
+  develop(int, DICompressionOptions, 4 + 32,                                \
+          "Parameter for compressing debug information")                    \
+                                                                            \
+  develop(bool, VerifyLNTCompression, trueInDebug,                          \
+          "Verify that LineNumberTable data is encoded accurately")         \
+                                                                            \
   develop(bool, PrintRelocations, false,                                    \
           "Print relocation information for all nmethods when generated")   \
                                                                             \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -258,6 +258,11 @@ void print_statistics() {
 #endif //COMPILER1
   }
 
+  if (PrintCompressionStatistics || LogVMOutput || LogCompilation) {
+    FlagSetting fs(DisplayVMOutput, DisplayVMOutput && PrintCompressionStatistics);
+    UNSIGNED5::Statistics::print_statistics();
+  }
+
   if (PrintLockStatistics || PrintPreciseRTMLockingStatistics) {
     OptoRuntime::print_named_counters();
   }

--- a/src/hotspot/share/runtime/relocator.cpp
+++ b/src/hotspot/share/runtime/relocator.cpp
@@ -426,14 +426,14 @@ void Relocator::adjust_line_no_table(int bci, int delta) {
       table = method()->compressed_linenumber_table();
     }
     CompressedLineNumberReadStream  reader(table);
-    CompressedLineNumberWriteStream writer(64);  // plenty big for most line number tables
+    CompressedLineNumberWriteStream writer(nullptr, 64);  // plenty big for most line number tables
     while (reader.read_pair()) {
       int adjustment = (reader.bci() > bci) ? delta : 0;
       writer.write_pair(reader.bci() + adjustment, reader.line());
     }
     writer.write_terminator();
-    set_compressed_line_number_table(writer.buffer());
-    set_compressed_line_number_table_size(writer.position());
+    set_compressed_line_number_table(writer.data_address_at(0));
+    set_compressed_line_number_table_size(writer.data_size());
     if (TraceRelocator) {
       tty->print_cr("Adjusted line number table");
       print_linenumber_table(compressed_line_number_table());

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -706,13 +706,6 @@
   nonstatic_field(JNIHandleBlock,              _top,                                          int)                                   \
   nonstatic_field(JNIHandleBlock,              _next,                                         JNIHandleBlock*)                       \
                                                                                                                                      \
-  /********************/                                                                                                             \
-  /* CompressedStream */                                                                                                             \
-  /********************/                                                                                                             \
-                                                                                                                                     \
-  nonstatic_field(CompressedStream,            _buffer,                                       u_char*)                               \
-  nonstatic_field(CompressedStream,            _position,                                     int)                                   \
-                                                                                                                                     \
   /*********************************/                                                                                                \
   /* VMRegImpl (NOTE: incomplete) */                                                                                                 \
   /*********************************/                                                                                                \

--- a/src/hotspot/share/utilities/unsigned5.cpp
+++ b/src/hotspot/share/utilities/unsigned5.cpp
@@ -24,15 +24,792 @@
 
 #include "precompiled.hpp"
 #include "memory/allocation.hpp"
-#include "utilities/unsigned5.hpp"
-
-// Most of UNSIGNED5 is in the header file.
-// Let's put a few debug functions out-of-line here.
+#include "oops/array.hpp"
+#include "utilities/unsigned5.inline.hpp"
+#include "utilities/xmlstream.hpp"
 
 // For the record, UNSIGNED5 was defined around 2001 and was first
 // published in the initial Pack200 spec.  See:
 // https://docs.oracle.com/en/java/javase/11/docs/specs/pack-spec.html
 // in Section 6.1, "Encoding of Small Whole Numbers".
+
+// Zero suppression logic (mainly useful for DebugInfo, which is zero-rich)
+
+#define APPLY_ArrayGetSet(ARR,OFF) \
+  UNSIGNED5::ArrayGetSet<ARR,OFF>
+
+#define FOR_EACH_TEMPLATE_INSTANCE(FN) \
+  FN(char*,int,APPLY_ArrayGetSet(char*,int)) \
+  FN(u1*,int,APPLY_ArrayGetSet(u1*,int)) \
+  FN(address,size_t,APPLY_ArrayGetSet(address,size_t)) \
+  FN(Array<u1>*,int,Array<u1>::GetSetHelper) \
+  /*end*/
+
+template<typename ARR, typename OFF, typename GET>
+using ZSReader = ZeroSuppressingU5::ZSReader<ARR,OFF,GET>;
+
+template<typename ARR, typename OFF, typename SET>
+using ZSWriter = ZeroSuppressingU5::ZSWriter<ARR,OFF,SET>;
+
+template<typename ARR, typename OFF, typename GET>
+uint32_t ZeroSuppressingU5::ZSReader<ARR,OFF,GET>::next_uint_uncompressing() {
+  uint32_t zm = _zero_mask;
+  uint32_t bc = _block_count;
+  if (is_clean()) {
+    uint32_t cmd = _r.next_uint();
+    if (is_block_count_code(cmd)) {
+      bc = decode_block_count(cmd);
+      assert(bc <= MAX_BLOCK_COUNT && MAX_BLOCK_COUNT < PASSTHROUGH_BLOCK_COUNT, "");
+      if (bc == 0)  bc = PASSTHROUGH_BLOCK_COUNT;
+      _block_count = bc;
+    } else {
+      zm = decode_zero_mask(cmd);
+      assert(zm != 0, "");
+      _zero_mask = zm;
+    }
+  }
+  // Execute the next step of the current command.
+  assert(!is_clean(), "");
+  if (zm != 0) {
+    _zero_mask = zm >> 1;
+    if ((zm & 1) != 0) {
+      return 0;
+    }
+    // else fall through
+  } else {
+    assert(bc != 0, "");
+    if ((bc + 1) > 1) {   // decrement if not passthrough
+      assert(bc > 0 && bc != PASSTHROUGH_BLOCK_COUNT, "");
+      _block_count = bc - 1;
+    }
+    // and fall through
+  }
+  return _r.next_uint();
+}
+
+template<typename ARR, typename OFF, typename GET>
+void ZeroSuppressingU5::ZSReader<ARR,OFF,GET>::setup(ARR array, OFF limit) {
+  _sticky_passthrough = false;
+  _r.setup(array, limit);
+  reset();
+}
+template<typename ARR, typename OFF, typename GET>
+void ZeroSuppressingU5::ZSReader<ARR,OFF,GET>::reset() {
+  _r.reset();
+  set_clean_or_passthrough();
+}
+
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::setup(ARR array, OFF limit) {
+  _sticky_passthrough = false;
+  _w.setup(array, limit);
+  reset();
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::reset() {
+  _w.reset();
+  _suppressed_zeroes = 0;
+  _zero_mask_length = 0;
+  _zero_mask_start = 0;
+  _zero_mask = 0;
+  _block_length = 0;
+  _block_start = 0;
+  assert(is_clean(), "");
+  set_clean_or_passthrough();
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::grow_array(ARR array, OFF limit) {
+  _w.grow_array(array, limit);
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::accept_end_byte() {
+  commit(false, false);
+  _w.accept_end_byte();
+  set_clean_or_passthrough();
+}
+
+template<typename ARR, typename OFF, typename SET>
+
+OFF ZSWriter<ARR,OFF,SET>::advance_position(OFF start, int count) {
+  ARR arr = array();
+  OFF pos = start;
+  int rem = count;
+  while (rem > 0) {
+    int len = UNSIGNED5::check_length(arr, pos, (OFF)0, SET());
+    assert(len > 0, "");
+    pos += len;
+    rem -= 1;
+  }
+  return pos;
+}
+
+// extra slots beyond 32, in the uint64_t _zero_mask
+#define MASK_SLOP 2
+
+int ZSWriter_extra_sanity_checks = 1000;
+
+template<typename ARR, typename OFF, typename SET>
+bool ZSWriter<ARR,OFF,SET>::sanity_checks() {
+  const int zmlen = _zero_mask_length;
+  const int bklen = _block_length;
+  if (is_passthrough()) {
+    assert(bklen == (int)PASSTHROUGH_BLOCK_COUNT, "");
+    assert(zmlen == 0, "");
+    const OFF bks = _block_start;
+    assert(bks >= 0 && bks <= _w.position(), "");
+    return true;
+  }
+  assert(zmlen >= 0 && zmlen <= (int)MAX_MASK_WIDTH+MASK_SLOP, "");
+  assert((bklen >= 0 && bklen <= (int)MAX_BLOCK_COUNT), "");
+  // the advance_position logic is extremely expensive
+  if (ZSWriter_extra_sanity_checks == 0) {
+    return true;
+  } else if (ZSWriter_extra_sanity_checks > 0) {
+    --ZSWriter_extra_sanity_checks;
+  }
+  const OFF zms = (zmlen != 0) ? _zero_mask_start : _w.position();
+  const OFF zme = advance_position(zms, zmlen);
+  const OFF bks = (bklen != 0) ? _block_start : zms;
+  const OFF bke = advance_position(bks, bklen);
+  assert(zme == _w.position(), "");
+  assert(bke == zms, "");
+  // The writer stores three consecutive areas, always: The committed
+  // part (already done), the current block being accumulated, and the
+  // zero mask area.  The compression process shifts items from the
+  // third area into the second, and from both latter areas into the
+  // first.
+  //
+  //  ... X Y Z | A B C D ... | P 0 Q 0 0 R S 0 T ... |
+  // (...done) bs (block...) zs                      w.pos
+  //             \__ blen ___/ \_ zm(010110010...) __/
+  return true;
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::digest_multiple_uints(OFF start_pos, int count) {
+  assert(count >= 1 && count <= 3, "");
+  uint32_t zm = 0;
+  OFF pos = start_pos;
+  for (int i = 0; i < count; i++) {
+    if (SET()(array(), pos) == UNSIGNED5::MIN_ENCODING_BYTE) {
+      zm += 1 << i;
+      ++pos;
+      continue;
+    }
+    if (i+1 == count)  break;  // no more work to do
+    // compute next pos, based on data in the array:
+    auto len = UNSIGNED5::check_length(array(), pos, (OFF)0, SET());
+    if (len == 0)  break;
+    pos += len;
+  }
+  digest_uint_mask(zm, count, start_pos);
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::digest_uint_mask(uint32_t more_zm, int more_zm_len, OFF start_pos) {
+  if (is_passthrough()) {
+    return;  // no more compression, but it's OK to keep accumulating
+  }
+  int blen = _block_length;
+  if (blen > (int)GIVE_UP_AFTER) {
+    commit(false, true);
+    return;
+  }
+  int zml = _zero_mask_length;
+  assert(zml >= 0 && zml < (int)MAX_MASK_WIDTH+MASK_SLOP, "");
+  if (zml == 0) {
+    assert(_zero_mask == 0, "");
+    if (blen != 0) {
+      if (more_zm == 0) {
+        _block_length = blen + more_zm_len;
+        assert(sanity_checks(), "");
+        return;  // do not start a mask here
+      }
+      while ((more_zm & 1) == 0) {
+        // transfer any leading non-zero values into the block
+        more_zm >>= 1;
+        more_zm_len -= 1;
+        blen++;
+      }
+      _block_length = blen;
+    }
+    _zero_mask_start = start_pos;
+    _zero_mask = 0;  // initialize the mask
+  }
+  // add to zero mask (or maybe start a new one)
+  _zero_mask |= (uint64_t)more_zm << zml;
+  _zero_mask_length = (zml += more_zm_len);
+  assert(sanity_checks(), "");
+  if (zml >= (int)MAX_MASK_WIDTH) {
+    // A full mask means that we can finalize some decisions, with the
+    // result of removing some items from the zero mask area.
+    drain_zero_mask(MAX_MASK_WIDTH-1);
+  }
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::expand_current_block(int trim) {
+  // current block (middle area) takes leading items from zero mask area
+  assert(trim > 0 && trim <= _zero_mask_length, "");
+  assert(have_zero_mask(), "");
+  if (_block_length == 0) {
+    _block_start = _zero_mask_start;
+  }
+  _block_length += trim;
+  _zero_mask_length -= trim; // remove trimmed items from zero mask
+  _zero_mask_start = advance_position(_zero_mask_start, trim);
+  assert(trim < BitsPerLong && sizeof(_zero_mask) == BitsPerLong/BitsPerByte, "");
+  _zero_mask >>= trim;       // shift out the zero-tracking data also
+  assert(sanity_checks(), "");
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::drain_zero_mask(int target_zero_mask_length) {
+  // Drain the zero mask area until it is at most the target size.
+  const int zml = _zero_mask_length;
+  if (zml <= target_zero_mask_length)  return;
+  const int blen = _block_length;
+  const uint32_t bcmd = encode_block_count(blen);
+  const int bcmd_size = UNSIGNED5::encoded_length(bcmd);
+  uint32_t zm = (uint32_t) _zero_mask;
+  uint32_t best_zm = 0;
+  if (is_valid_zero_mask(zm)) {
+    const int RESTART_BLOCK_MODE = 1;
+    int min_profit = (blen == 0) ? 0 : RESTART_BLOCK_MODE + bcmd_size;
+    // If we are not in block mode, even a mask with zero profit
+    // (that is, a wash) is enough to keep us in mask mode.  In
+    // any given run of multiple masks, the first mask has enough
+    // profit to pay for breaking out of block mode, plus the
+    // eventual one byte required to start a new block mode after
+    // a run of masks.  Therefore, all subsequent masks can
+    // tolerate zero profit, as long as there is no loss.  A more
+    // subtle algorithm would track the profit across a series of
+    // mask commands, and trade off the total size of the masks
+    // against the total profit.  The benefit would be small in
+    // many cases, so it's probably not worth extra complexity.
+    best_zm = best_zero_mask(zm, min_profit);
+  }
+
+  if (best_zm == 0) {
+    // There are too many leading non-zero items, or a zero mask
+    // that is not dense enough to be profitable.  The remedy is
+    // to skip to the next zero, if any, in the mask.  Because we
+    // must skip at least one mask position, be sure to count the
+    // LSB as unset (hence the <=1 and &~1).
+    int trim = (zm <= 1) ? zml : count_trailing_zeros(zm & ~1);
+    expand_current_block(trim);  // absorb trimmed items into current block
+    assert(_zero_mask_length == zml - trim, "");
+  } else {
+    do_compression(best_zm);
+  }
+  assert(sanity_checks(), "");
+
+  assert(_zero_mask_length < zml, "");  // must make progress
+  if (_zero_mask_length > target_zero_mask_length) {
+    // go around again if that is needed to hit the target 
+    drain_zero_mask(target_zero_mask_length);
+  }
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::do_compression(uint32_t best_zm) {
+  // Act on the chosen zero mask.
+  assert(best_zm != 0, "");  // must have something to compress
+  assert((best_zm & _zero_mask) == best_zm, "subset mask");
+  assert(sanity_checks(), "");
+
+  // Split _zero_mask right away:
+  const int best_zm_length = zero_mask_length(best_zm);
+  const int rest_zm_length = _zero_mask_length - best_zm_length;
+  const uint64_t rest_zm = _zero_mask >> best_zm_length;
+  assert(best_zm_length >  0 && best_zm_length <= (int)MAX_MASK_WIDTH, "");
+  assert(rest_zm_length >= 0 && rest_zm_length < (int)MAX_MASK_WIDTH+MASK_SLOP, "");
+
+  // Old contents of _w:
+  //  ... X Y Z | A B C D ... | P 0 Q 0 0 R S 0 T ... |
+  // (...done) bs (block...) zs                      w.pos
+  //             \__ blen ___/ \_ zm(010110010...) __/
+  //
+  // New contents of _w:
+  //  ... X Y Z | bh(blen) : A B C D ... | zm(01011) : P Q | &
+  //  (...done  ...done   ...done       ...done     ...done)
+  //          & | R S 0 T ... |
+  // (...done) zs            w.pos
+  //     blen=0  \_zm(0010...)_/
+  //
+  // This complicated transformation is the only way that zeroes
+  // are eliminated.  It only takes place if there is a profit.
+  // That is, the number of bytes stored in _w.array() must not
+  // increase.  A side benefit of the profitability condition is
+  // that the transformation does not require growing the array.
+  //
+  // The zero mask is encoded and placed in the buffer, and it must
+  // not be too long.  Any increases in length must be "paid for" by
+  // removing zero items from between the PQRST, in effect shrinking
+  // them to single bits in the zero mask command zm(01011).  The
+  // other bits in the zero mask command are a "steering tax" required
+  // to place the zeroes correctly between the non-zero items.
+  //
+  // The bh(blen), which also must not be too long, is inserted before
+  // the ABCD.  But if ABCD is empty (blen=0) then the whole block
+  // command |bh(blen):ABCD| is suppressed.  If ABCD is a one or two
+  // items A or AB, then the block command is |bh(1):A| or |bh(2):AB|,
+  // and so on.  Blocks up to length 11 require only one byte for a
+  // header, followed immediately by the encoded items of the block.
+  // That may be immediately followed by a mask command with its data
+  // PQ, or else a null marker, or the end of the data.
+
+  // Buffer for the bytes of the zero mask area (e.g., P0Q00RS0T...).
+  uint8_t buffer[(MAX_MASK_WIDTH+MASK_SLOP+1) * UNSIGNED5::MAX_LENGTH];
+
+  // Copy out all items covered in the zero mask window (and beyond).
+  // We absolutely need to do this if bcmd_size>1 later on.
+  const OFF zms = _zero_mask_start;
+  const OFF zme = _w.position();  // could include 1-2 items beyond the zm
+  const ARR array  = _w.array();
+  const OFF alimit = _w.limit();
+  OFF zmp = zms;  // source scan pointer
+  OFF bufp = 0;   // destination fill pointer
+  int zm1_count = 0, zm1_zero_count = 0;
+  for (uint32_t zm = best_zm; zm != 0; zm >>= 1) {
+    if ((zm & 1) != 0) {
+      // this is the only compression, the point of all the bookkeeping
+      assert(SET()(array, zmp) == ZERO_ENCODING, "");
+      zm1_zero_count++;
+      zmp++;
+    } else {
+      // where is Copy::disjoint_bytes?
+      const int len = UNSIGNED5::check_length(array, zmp, alimit, SET());
+      Copy::conjoint_jbytes(&array[zmp], &buffer[bufp], len);
+      zmp += len;
+      bufp += len;
+    }
+    assert(bufp < (OFF) sizeof(buffer), "");
+    zm1_count += 1;
+  }
+  assert(zm1_count == best_zm_length, "");
+  _suppressed_zeroes += zm1_zero_count;
+  const OFF buffer_zm1_size = bufp;         // size of payload for best_zm
+  const OFF buffer_zm2_size = (zme - zmp);  // size of payload for rest_zm
+  if (buffer_zm2_size != 0) {
+    assert(zme > zmp, "");
+    Copy::conjoint_jbytes(&array[zmp], &buffer[buffer_zm1_size], buffer_zm2_size);
+  }
+  assert(buffer_zm1_size + buffer_zm2_size < (OFF) sizeof(buffer), "");
+
+  // Temporarily remove the buffered data, while we close the block:
+  _w.set_position(zms);
+  _zero_mask_length = 0;
+
+  // Close off the current block (if any) with a definite size.
+  if (have_current_block()) {
+    emit_block_command(false);
+  }
+
+  emit_zero_mask_command(best_zm);
+  assert(_w.array() == array, "no growth please");
+
+  const OFF w_zm1_start = _w.position();
+  Copy::conjoint_jbytes(&buffer[0], &array[w_zm1_start], buffer_zm1_size + buffer_zm2_size);
+  _w.set_position(w_zm1_start + buffer_zm1_size + buffer_zm2_size);
+  // The copy also pasted, directly after the zero-mask command, any
+  // unused zero mask area bytes (buffer_zm2_size).  At this point,
+  // the executed zero mask command (zmcmd) is committed, there is
+  // no current block area, and the new zero mask area might have
+  // something in it (if buffer_zm2_size>0).
+  _zero_mask_start = w_zm1_start + buffer_zm1_size;
+  _zero_mask_length = rest_zm_length;
+  _zero_mask = rest_zm;
+  assert(sanity_checks(), "");
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::emit_block_command(bool use_indefinite_length) {
+  assert(!have_zero_mask(), "");
+  assert(have_current_block(), "");
+  assert(sanity_checks(), "");
+  // Insert non-empty block command, after shifting the payloads.
+  const uint32_t bcmd = encode_block_count(use_indefinite_length ? 0 : _block_length);
+  const int bcmd_size = UNSIGNED5::encoded_length(bcmd);
+  // Note: Block copy bypasses the GET functor, so it fails for
+  // Array<u1>.  To fix this, the GET functor should return a
+  // reference, so we can take an address.
+  const OFF bs = _block_start;
+  const OFF be = _w.position();
+  const ARR a = _w.array();
+  Copy::conjoint_jbytes(&a[bs], &a[bs + bcmd_size], be - bs);
+  _w.set_position(be + bcmd_size);
+  OFF wp = bs;
+  UNSIGNED5::write_uint(bcmd, a, wp, (OFF)0, SET());
+  assert(wp == bs + bcmd_size, "");
+  _block_start = 0;
+  _block_length = 0;
+  assert(is_clean(), "");
+  if (use_indefinite_length) {
+    // After an indefinite header, the only thing we can do after this
+    // is pass through additional items uncompressed.  We could also
+    // issue a null byte and restart everything.  But for now, we are
+    // committed to passthrough mode.  This can be a temporary
+    // condition.  It is a choice made by the compressor, not the user.
+    // Therefore, we do not set the sticky bit.
+    _block_length = PASSTHROUGH_BLOCK_COUNT;  // not set_passthrough
+    assert(!_sticky_passthrough, "");  // this is not a sticky state
+  }
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::emit_zero_mask_command(uint32_t best_zm) {
+  assert(is_clean(), "");
+  assert(sanity_checks(), "");
+  // Emit the zero mask command, including its buffered payload data.
+  uint32_t zmcmd = encode_zero_mask(best_zm);
+  _w.accept_uint(zmcmd);
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::commit(bool require_clean,
+                                   bool require_passthrough) {
+  assert(!require_clean || !require_passthrough, "");  // not both
+  if (is_passthrough()) {   // already passing through uncompressed
+    assert(!require_clean, "");
+    return;
+  }
+  if (is_clean()) {   // already clean
+    if (require_passthrough) {   // need an explicit command
+      _w.accept_uint(encode_block_count(0));
+      _block_length = PASSTHROUGH_BLOCK_COUNT;  // not set_passthrough
+      assert(!_sticky_passthrough, "");  // this is not a sticky state
+    }
+    return;
+  }
+  // finalize compression decisions
+  drain_zero_mask(0);
+  assert(!have_zero_mask(), "");
+  if (have_current_block()) {
+    bool use_indefinite_length = !require_clean;
+    emit_block_command(use_indefinite_length);
+  }
+  assert(!require_clean || is_clean(), "");
+  assert(!require_passthrough || is_passthrough(), "");
+}
+
+template<typename ARR, typename OFF, typename GET>
+void ZSReader<ARR,OFF,GET>::print_on(outputStream* st) {
+  UNSIGNED5::Reader<ARR,OFF,GET> r(_r.array(), _r.limit());
+  OFF pos = _r.position();
+  st->print("CR");
+  if (is_passthrough()) {
+    st->print("(PT)");
+    r.print_on(st);
+    return;
+  }
+  st->print("[");
+  int command_count = 0, payload_count = 0, null_count = 0;
+  for (;;) {
+    if (try_skip_end_byte()) {
+      null_count++;
+      st->print(" null");
+      if (_r.limit() == 0)  break;
+      continue;
+    }
+    if (!r.has_next())  break;
+    command_count++;
+    uint32_t cmd = r.next_uint();
+    int cmdlen = UNSIGNED5::encoded_length(cmd);
+    uint32_t bc = 0, zm = 0;
+    if (is_block_count_code(cmd)) {
+      bc = decode_block_count(cmd);
+      assert(bc <= MAX_BLOCK_COUNT && MAX_BLOCK_COUNT < PASSTHROUGH_BLOCK_COUNT, "");
+      if (bc == 0) {
+        bc = PASSTHROUGH_BLOCK_COUNT;
+        st->print(" [END]");
+      } else {
+        st->print(" [B%d]", bc);
+      }
+    } else {
+      zm = decode_zero_mask(cmd);
+      st->print(" [ZM%x%s]", zm, is_valid_zero_mask(cmd) ? "" : "*");
+    }
+    st->print("%x", cmd);
+    if (cmdlen > 1)  st->print(":%d", cmdlen);
+    while (bc != 0) {
+      if (!r.has_next())  break;
+      st->print(" %d", r.next_uint());
+      ++payload_count;
+      --bc;
+    }
+    while (zm != 0) {
+      if ((zm & 1) != 0) {
+        st->print(" .");
+      } else if (!r.has_next()) {
+        break;
+      } else {
+        st->print(" %d", r.next_uint());
+        ++payload_count;
+      }
+      zm >>= 1;
+    }
+  }
+  st->print(" ] (commands=%d/payloads=%d/length=%d/nulls=%d)",
+            command_count,
+            payload_count,
+            (int)r.position(),
+            null_count);
+  if (is_passthrough()) {
+    st->print(" (state=PT)");
+  } else {
+    st->print(" (state=BC%d,ZM%x)", (int)_block_count, (int)_zero_mask);
+  }
+  st->cr();
+}
+
+template<typename ARR, typename OFF, typename SET>
+void ZSWriter<ARR,OFF,SET>::print_on(outputStream* st) {
+  ZSReader<ARR,OFF,SET> r(_w.array(), _w.position());
+  if (is_passthrough())  r.set_passthrough();
+  st->print("CW[");
+  if (is_clean())  st->print("clean");
+  if (is_passthrough())  st->print("passthrough");
+  if (have_current_block() && !is_passthrough()) {
+    st->print("bk=@%d[%d]", (int)_block_start, (int)_block_length);
+  }
+  if (have_zero_mask()) {
+    if (have_current_block())  st->print(";");
+    st->print("zm=@%d[%d]%x", (int)_zero_mask_start, (int)_zero_mask_length, (int)_zero_mask);
+  }
+  st->print("]:");
+  r.print_on(st);
+}
+
+#define READER_WRITER_INSTANCES(ARR,OFF,GET) \
+  template class UNSIGNED5::Reader<ARR,OFF,GET>; \
+  template class UNSIGNED5::Writer<ARR,OFF,GET>; \
+  template class ZeroSuppressingU5::ZSReader<ARR,OFF,GET>; \
+  template class ZeroSuppressingU5::ZSWriter<ARR,OFF,GET>; \
+  /*end*/
+
+FOR_EACH_TEMPLATE_INSTANCE(READER_WRITER_INSTANCES)
+#undef READER_WRITER_INSTANCES
+
+
+template void UNSIGNED5::Reader<char*,int>::
+print_on(outputStream* st, int count, const char* left, const char* right);
+template void UNSIGNED5::Reader<u1*,int>::
+print_on(outputStream* st, int count, const char* left, const char* right);
+template void UNSIGNED5::Reader<address,size_t>::
+print_on(outputStream* st, int count, const char* left, const char* right);
+
+template<typename ARR, typename OFF, typename GET>
+void UNSIGNED5::Statistics::
+record_one_stream(ARR array, OFF limit, GET get,
+                  size_t original_size,
+                  size_t* pair_counts,
+                  size_t suppressed_zeroes) {
+  size_t csize = limit;
+  _stream_count += 1;
+  _compressed_size += csize;
+  _suppressed_zeroes += suppressed_zeroes;
+  if (pair_counts != nullptr) {
+    for (int pc = 1; pc <= 3; pc++) {
+      _pair_counts[pc-1] += pair_counts[pc-1];
+    }
+  }
+  if (original_size != 0) {
+    _original_size_count += 1;
+    _original_size += original_size;
+  }
+  auto r = Reader<ARR,OFF,GET>(array, limit);
+  size_t lastp = 0;
+  while (r.position() < limit) {
+    if (r.try_skip_end_byte()) {
+      _null_count += 1;
+      lastp = r.position();
+    } else if (r.try_skip(1)) {
+      size_t nextp = r.position();
+      int len = nextp - lastp;
+      assert(len >= 1 && len <= MAX_LENGTH, "");
+      lastp = nextp;
+      uint8_t lastb = GET()(array, lastp-1);
+      assert(lastb >= 0 && (lastb < X+L || len == MAX_LENGTH), "");
+      unsigned int bits = lastb - X;  // unbias the byte to more accurately assess its width
+      size_t sigi = BitsPerByte * (len-1);
+      while (bits != 0) { bits >>= 1; sigi += 1; }
+      assert(sigi >= 0 && sigi < sizeof(_bit_width_counts)/sizeof(_bit_width_counts[0]), "");
+      _bit_width_counts[sigi] += 1;
+      _uint_count += 1;
+    } else {
+      assert(false, "");
+      break;
+    }
+  }
+}
+
+template void UNSIGNED5::Statistics::
+record_one_stream(char* array, int limit,
+                  UNSIGNED5::ArrayGetSet<char*,int> get,
+                  size_t original_size,
+                  size_t* pair_counts,
+                  size_t suppressed_zeroes);
+template void UNSIGNED5::Statistics::
+record_one_stream(u1* array, int limit,
+                  UNSIGNED5::ArrayGetSet<u1*,int> get,
+                  size_t original_size,
+                  size_t* pair_counts,
+                  size_t suppressed_zeroes);
+template void UNSIGNED5::Statistics::
+record_one_stream(address array, size_t limit,
+                  UNSIGNED5::ArrayGetSet<address,size_t> get,
+                  size_t original_size,
+                  size_t* pair_counts,
+                  size_t suppressed_zeroes);
+template void UNSIGNED5::Statistics::
+record_one_stream(Array<u1>* array, int limit,
+                  Array<u1>::GetSetHelper get,
+                  size_t original_size,
+                  size_t* pair_counts,
+                  size_t suppressed_zeroes);
+
+
+UNSIGNED5::Statistics UNSIGNED5::Statistics::_table[UNSIGNED5::Statistics::LIMIT];
+
+void UNSIGNED5::Statistics::print_statistics() {
+  assert(tty != nullptr, "");
+  if (xtty != nullptr)  xtty->head("compression_statistics");
+  for (int i = 0; i < LIMIT; i++) {
+    if (_table[i]._stream_count == 0)  continue;
+    _table[i].print_on(tty);
+  }
+  if (xtty != nullptr)  xtty->tail("compression_statistics");
+}
+
+void UNSIGNED5::Statistics::print_on(outputStream* st) {
+  Kind kind = Kind(this - &_table[0]);
+  static const char* KS_TAB[LIMIT*2] = {
+    #define DECLARE_KS(AB,CD) #AB, #CD,
+    FOR_EACH_Statistics_Kind(DECLARE_KS)
+    #undef DECLARE_KS
+  };
+  const char* *kdescs = &KS_TAB[kind >= UK && kind < LIMIT ? 2*kind : 0];
+  const char* kd = kdescs[0];
+  const bool have_pairs = ((_pair_counts[0] | _pair_counts[1] | _pair_counts[2]) != 0);
+  const bool have_zsupp = (_suppressed_zeroes != 0);
+  const double num_strm = _stream_count;
+  const double num_byte = _compressed_size;
+  const double num_uint = _uint_count;
+  const double num_item = _uint_count + _null_count;
+  const double num_uint_pre_transform = (num_uint + _suppressed_zeroes * 0.80 +
+                                         (_pair_counts[0] - _pair_counts[2]));
+  // Zero suppression replaces zero bytes by zero bits, so 1 zero byte
+  // input is replaced by a bitmask bit (1/8 of a byte) output.
+  // Sadly, steering information is required to recover bit positions.
+  // Adding that back in 1 zero byte input is replaced by about 1/5
+  // byte of bitmask plus steering information; so 1 in => 0.20 out.
+  st->print_cr("%s: stream %s %d count, "
+               "average size/uint/nulls %.2f / %.2f / %.2f",
+               kd, kdescs[1], (int)_stream_count,
+               _compressed_size/num_strm, _uint_count/num_strm, _null_count/num_strm);
+  st->print_cr("%s: total size/uint/nulls " SIZE_FORMAT " / %d / %d",
+               kd, (size_t)_compressed_size, (int)_uint_count, (int)_null_count);
+  if (have_pairs | have_zsupp) {
+    st->print_cr("%s: efficiency %.2f bytes/uint in, %.2f bytes/uint out (%s%s%s)",
+                 kd,
+                 (_compressed_size - _null_count)/num_uint_pre_transform,
+                 (_compressed_size - _null_count)/num_uint,
+                 have_pairs ? "uint pairing" : "",
+                 (have_pairs & have_zsupp) ? ", " : "",
+                 have_zsupp ? "zero suppression" : "");
+  } else {
+    st->print_cr("%s: efficiency %.2f bytes/uint (no uint transforms)",
+                 kd, (_compressed_size - _null_count)/num_uint);
+  }
+  switch (kind) {
+  case FI:
+    st->print_cr("%s: -XX:FICompressionOptions=%d", kd, FICompressionOptions);
+    break;
+  case LT:
+    st->print_cr("%s: -XX:LTCompressionOptions=%d", kd, LTCompressionOptions);
+    break;
+  case DI:
+    st->print_cr("%s: -XX:DICompressionOptions=%d", kd, DICompressionOptions);
+    st->print("%s: code counts", kd);
+    {
+      extern size_t* report_di_code_counts(int& length);
+      int num_code_counts = 0;
+      size_t* code_counts = report_di_code_counts(num_code_counts);
+      for (int i = 0; i < num_code_counts; i++) {
+        st->print(" %d", (int)code_counts[i]);
+      }
+    }
+    st->cr();
+    break;
+  default: break;
+  }
+  if (_null_count != 0) {
+    st->print_cr("%s: nulls %.2f per stream, %d total, %.2f%% of bytes",
+                 kd, _null_count / num_strm, (int)_null_count, 
+                 100.0 * _null_count / num_byte);
+  }
+  const size_t zero_count = _bit_width_counts[0];  // only zero is zero bits wide
+  st->print_cr("%s: zeroes %.2f per stream, %d bytes total, %.2f%% / %.2f%% of ints/bytes",
+               kd, zero_count / num_strm, (int)zero_count,
+               100.0 * zero_count / num_uint,
+               100.0 * zero_count / num_byte);
+  if (have_pairs != 0) {
+    st->print_cr("%s: pairs in 1/2/3 words, %d / %d / %d total,"
+                 " %.2f%% / %.2f%% / %.2f%% of ints",
+                 kd,
+                 (int)_pair_counts[0], (int)_pair_counts[1], (int)_pair_counts[2],
+                 100.0*_pair_counts[0]/num_uint,
+                 200.0*_pair_counts[1]/num_uint,
+                 300.0*_pair_counts[2]/num_uint);
+  }
+  if (_suppressed_zeroes != 0) {
+    st->print_cr("%s: suppressed zeroes %d", kd, (int)_suppressed_zeroes);
+  }
+  if (_original_size_count != 0) {
+    st->print_cr("%s: original size average %.2f total %d", kd,
+                 (double)_original_size / _original_size_count, (int)_original_size);
+  }
+
+  const int NBWC = sizeof(_bit_width_counts)/sizeof(_bit_width_counts[0]);
+  int max_bwc = 0;
+  size_t sum_count = 0, sum_size = 0;
+  int i;
+  for (i = 0; i < NBWC; i++) {
+    double est_bytes = ((i == 0 ? 1 : i) + 7) / 8 + ((i & 7) == 7 && i < 32 ? 0.5 : 0);
+    size_t bwc = _bit_width_counts[i];
+    if (bwc == 0)  continue;
+    sum_count += bwc;
+    sum_size += bwc * est_bytes;  // this is an estimate
+    max_bwc = i;
+  }
+  tty->print_cr("%s: bw MDF/CDF/CSZ   count bit-width histogram "
+                "count/size %d / ~~%d",
+                kd, (int)sum_count, (int)sum_size);
+  const double total_count = sum_count;
+  const double total_size  = sum_size;
+  sum_count = sum_size = 0;  // reset for another go-around
+  for (i = 0; i <= max_bwc; i++) {
+    double est_bytes = ((i == 0 ? 1 : i) + 7) / 8 + ((i & 7) == 7 && i < 32 ? 0.5 : 0);
+    size_t bwc = _bit_width_counts[i];
+    sum_count += bwc;
+    double mdf = bwc       / total_count; // mass density function (of counts)
+    double cdf = sum_count / total_count; // cumulative density function
+    sum_size += bwc * est_bytes;          // this is an estimate
+    double csz = sum_size / total_size;   // CDF of estimated byte-size
+    const char STARS[] = "**************************************************";
+    tty->print_cr("%s: %-2d%5.2f%3.0f%3.0f %8d %.*s",
+                  kd, i,
+                  100*mdf, 100*cdf, 100*csz,
+                  (int)bwc,
+                  (int)(cdf*(sizeof(STARS)-1)+0.5), STARS);
+  }
+}
+
 
 PRAGMA_DIAG_PUSH
 PRAGMA_FORMAT_NONLITERAL_IGNORED
@@ -44,32 +821,61 @@ print_on(outputStream* st, int count,
          const char* left,   // "U5: ["
          const char* right   // "] (values=%d/length=%d)\n"
          ) {
+  OFF original_position = _position;  // save for restore at end
   if (left == nullptr)   left = "U5: [";
   if (right == nullptr)  right = "] (values=%d/length=%d)\n";
-  int printed = 0;
   st->print("%s", left);
+  OFF window_start = 0;   // where we will start printing in the stream
+  if (original_position > 0 && count > 0) {
+    // Advance left_part to skip stuff we don't want to print.
+    int window_size = 0;
+    int window_skip = 0;
+    Reader pr(array(), original_position);
+    while (pr.try_skip(1) || pr.try_skip_end_byte()) {
+      if (window_size > count) {
+        window_skip += 1;
+      } else {
+        window_size += 1;
+      }
+    }
+    pr.set_position(0);
+    while (window_skip > 0 && (pr.try_skip(1) || pr.try_skip_end_byte())) {
+      --window_skip;
+    }
+    window_start = pr.position();
+  }
+  bool is_first = true;
+  if (window_start != 0 && window_start != original_position) {
+    st->print("...[@%d]", (int)window_start);
+    _position = window_start;
+    is_first = false;
+  }
+  uint32_t null_count = 0, uint_count = 0;
   for (;;) {
-    if (count >= 0 && printed >= count)  break;
+    if (count >= 0 && uint_count + null_count >= (uint32_t)count)  break;
+    if (is_first) { is_first = false; } else { st->print(" "); }
+    if (_position == original_position && _position != 0) {
+      st->print("[pos@%d] ", (int)_position);
+    }
     if (!has_next()) {
-      if ((_limit == 0 || _position < _limit) && _array[_position] == 0) {
-        st->print(" null");
+      if ((_limit == 0 || _position < _limit) && GET()(_array, _position) == 0) {
+        st->print("null");
         ++_position;  // skip null byte
-        ++printed;
+        ++null_count;
         if (_limit != 0)  continue;  // keep going to explicit limit
+        if (_position < original_position)  continue;
       }
       break;
     }
-    u4 value = next_uint();
-    if (printed == 0)
-      st->print("%d", value);
-    else
-      st->print(" %d", value);
-    ++printed;
+    ++uint_count;
+    uint32_t value = next_uint();
+    st->print("%d", value);
   }
   st->print(right,
             // these arguments may or may not be used in the format string:
-            printed,
-            (int)_position);
+            (int)uint_count,
+            (int)position());
+  _position = original_position;  // restore at end
 }
 
 PRAGMA_DIAG_POP

--- a/src/hotspot/share/utilities/unsigned5.hpp
+++ b/src/hotspot/share/utilities/unsigned5.hpp
@@ -26,8 +26,12 @@
 #define SHARE_UTILITIES_UNSIGNED5_HPP
 
 #include "memory/allStatic.hpp"
+#include "utilities/copy.hpp"
+#include "utilities/count_trailing_zeros.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/ostream.hpp"
+#include "utilities/population_count.hpp"
+#include "utilities/powerOfTwo.hpp"
 
 // Low-level interface for [de-]coding compressed uint32_t (u4) values.
 
@@ -89,10 +93,13 @@ class UNSIGNED5 : AllStatic {
   static const int X     = 1  ;      // there is one excluded byte ('\0')
   static const int MAX_b = (1<<BitsPerByte)-1;  // largest byte value
   static const int L     = (MAX_b+1)-X-H;       // number of "low" bytes (191)
+  static const int flg_L = 7;        // log2i(L) = ctz(hob(L))
 
  public:
   static const int MAX_LENGTH = 5;   // lengths are in [1..5]
   static const uint32_t MAX_VALUE = (uint32_t)-1;  // 2^^32-1
+  static const int END_BYTE = X-1;   // null byte not used by encodings
+  static const int MIN_ENCODING_BYTE = X;   // encoding skips end-byte
 
   // The default method for reading and writing bytes is simply
   // b=a[i] and a[i]=b, as defined by this helpful functor.
@@ -144,6 +151,7 @@ class UNSIGNED5 : AllStatic {
   template<typename ARR, typename OFF, typename SET = ArrayGetSet<ARR,OFF>>
   static void write_uint(uint32_t value, ARR array, OFF& offset_rw, OFF limit, SET set = SET()) {
     const OFF pos = offset_rw;
+    assert(limit == 0 || fits_in_limit(value, pos, limit), "");
     if (value < L) {
       const uint32_t b_0 = X + value;
       assert(b_0 == (uint8_t)b_0, "valid byte");
@@ -187,25 +195,42 @@ class UNSIGNED5 : AllStatic {
 
   // reports the largest uint32_t value that can be encoded using len bytes
   // len must be in the range [1..5]
-  static constexpr uint32_t max_encoded_in_length(uint32_t len) {
+  static constexpr uint32_t max_encoded_in_length(int len) {
     assert(len >= 1 && len <= MAX_LENGTH, "invalid length");
     if (len >= MAX_LENGTH)  return MAX_VALUE;  // largest non-overflow value
     // Be careful:  the constexpr magic evaporates if undefined behavior
     // results from any of these expressions.  Beware of signed overflow!
     uint32_t all_combinations = 0;
     uint32_t combinations_i = L;  // L * H^i
-    for (uint32_t i = 0; i < len; i++) {
+    for (uint32_t i = 0; i < (uint32_t)len; i++) {
       // count combinations of <H*L> that end at byte i
       all_combinations += combinations_i;
       combinations_i <<= lg_H;
     }
     return all_combinations - 1;
   }
+  // reports the smallest value that encodes in *exactly* len bytes
+  // len must be in the range [1..5]
+  static constexpr uint32_t min_encoded_in_length(int len) {
+    return (len == 1) ? 0 : max_encoded_in_length(len-1)+1;
+  }
+
+  // Returns the floor of the base-two logarithm of the largest
+  // (unsigned) value that requires len bytes to represent.
+  // Thus there are 5 possible results:  7, 13, 19, 25, 31.
+  // For five-byte encodings, which support negative values,
+  // this is the number 31.
+  static constexpr int log2i_max_encoded_in_length(int len) {
+    // This is a simple linear formula over integers.
+    // This works because H is an exact power of 2.
+    int log2i_max = flg_L + (len - 1) * lg_H;
+    assert(log2i_max == log2i(max_encoded_in_length(len)), "");
+    return log2i_max;
+  }
 
   // tells if a value, when encoded, would fit between the offset and limit
   template<typename OFF>
   static constexpr bool fits_in_limit(uint32_t value, OFF offset, OFF limit) {
-    assert(limit != 0, "");
     return (offset + MAX_LENGTH <= limit ||
             offset + encoded_length(value) <= limit);
   }
@@ -216,6 +241,8 @@ class UNSIGNED5 : AllStatic {
   template<typename ARR, typename OFF, typename GET = ArrayGetSet<ARR,OFF>>
   static int check_length(ARR array, OFF offset, OFF limit = 0,
                           GET get = GET()) {
+    if ((limit != 0 && offset >= limit) || array == nullptr)
+      return 0;                 // limit failure or unset array
     const OFF pos = offset;
     STATIC_ASSERT(sizeof(get(array, pos)) == 1);  // must be a byte-getter
     const uint32_t b_0 = (uint8_t) get(array, pos);  //b_0 = a[0]
@@ -238,14 +265,158 @@ class UNSIGNED5 : AllStatic {
   static void write_uint_grow(uint32_t value,
                               ARR& array, OFF& offset, OFF& limit,
                               GFN grow, SET set = SET()) {
-    assert(limit != 0, "limit required");
     const OFF pos = offset;
     if (!fits_in_limit(value, pos, limit)) {
-      grow(MAX_LENGTH);  // caller must ensure it somehow fixes array/limit span
-      assert(pos + MAX_LENGTH <= limit, "should have grown");
+      grow(encoded_length(value));  // caller must ensure it somehow fixes array/limit span
+      assert(fits_in_limit(value, pos, limit), "should have grown");
     }
     write_uint(value, array, offset, limit, set);
   }
+
+  /// Encoding of pairs
+  //
+  // When two ints X,Y have small enough entropy (or "bandwidth") to
+  // fit in one byte, then it is worth thinking about using a packed
+  // representation like (Y<<S)+X.  For wider applicability and better
+  // safety, we provide an escape hatch for when Y is too large
+  // (1<<32-S or larger) or X is too large (1<<S or larger).
+  //
+  // Generally speaking, X and Y are independently packed into
+  // bitfields of size S and 32-S, and numbers (X or Y) which are "too
+  // big" for their bitfields are saturated to the maximum (all 1s).
+  // Specifically, X can saturate individually, which leads to an
+  // extra int emitted to carry the full X value.  And, if Y
+  // saturates, then X is forced to saturate as well, and both X and Y
+  // are passed as two extra ints.  Finally, if X saturates, the Y
+  // bitfield (saturated or not) is incremented.  This last touch
+  // minimizes the overhead of the worst case (3 ints).
+  //
+  // Here are the specific rules for encoding in 1, 2, or 3 tokens:
+  //  - If Y<(1<<32-S) AND X<(1<<S)-1, then use < (Y<<S)+X >.
+  //  - If X is "big" and Y<(1<<32-S)-1, then use < ((Y+1)<<S)+M, X >
+  //  - Otherwise, Y is "big"; use < M, Y, X >.
+  // Here, M is (1<<S)-1, the mask for the X bitfield.
+  //
+  // Examples of Y:X codes in these three cases, for S==3 (1<<S is 8):
+  //  - 0:0 => <0>, 0:1 => <1>, 1:0 => <8>, x:y => <8y+x> (small x, y)
+  //  - 0:X => <15,X>, 1:X => <8+15,X>, y:X => <8y+15,X> (small y, big X)
+  //  - Y:0 => <7,0,Y>, Y:x => <7,x,Y>  (big Y, any X)
+  // In the worst case, the overhead is an extra byte (the leading M=7),
+  // compared to sending the two values separately (i.e., unpaired).
+
+  // decode a pair of unsigned 32-bit ints from an array-like base address
+  // returns both decoded values by reference, updates offset_rw
+  // that is, offset_rw is both read and written
+  // Returns the number of words written (1, 2, or 3).
+  //
+  // The expected bit-width of the first value X is specified (S in (Y<<S)+X).
+  // If S=0, two individual 32-bit values are read, unconditionally,
+  // just as if two separate calls of read_uint are used to pick up X and Y.
+  //
+  // Treatment of limit is the same as with read_uint.
+  template<typename READ_UINT>
+  inline static int read_uint_pair(int first_width,
+                                   uint32_t& first_result,
+                                   uint32_t& second_result,
+                                   READ_UINT read_uint);
+
+  // write a pair of values, preferably in one uint, if they can fit in it
+  template<typename WRITE_UINT>
+  inline static int write_uint_pair(int first_width, uint32_t first, uint32_t second,
+                                    WRITE_UINT write_uint);
+
+  // Returns the leading "YX" word used to encode a pair of ints, as
+  // read by read_uint_pair.  See definition for more details.
+  // This is public for the sake of ZSReader.
+  static int encoded_pair_lead(int first_width, uint32_t first, uint32_t second);
+
+  // returns the minimum number of words (1, 2, or 3) required to
+  // encode a pair of ints, as read by read_uint_pair.
+  static inline int encoded_pair_count(int first_width, uint32_t first, uint32_t second) {
+    return encoded_pair_count(first_width, encoded_pair_lead(first_width, first, second));
+  }
+
+  // returns the number of encoding a pair of ints, as being read by
+  // read_uint_pair, given the first word (the input XY word)
+  static inline int encoded_pair_count(int first_width, uint32_t pair_lead_yx);
+
+  // returns the encoded byte length of a pair of ints as read by read_uint_pair
+  static inline int encoded_pair_length(int first_width, uint32_t first, uint32_t second);
+
+  // implementation of -XX:+PrintCompressionStatistics and option control
+  class Statistics {
+   public:
+    #define FOR_EACH_Statistics_Kind(FN) \
+      FN(UK,Unknown) \
+      FN(FI,FieldInfo) \
+      FN(LT,LineNumberTable) \
+      FN(DI,DebugInfo) \
+      FN(OM,OopMap) \
+      FN(DP,Dependencies) \
+    /*end*/
+    enum Kind {
+      #define DECLARE_Statistics_Kind(AB,ignore) AB,
+      FOR_EACH_Statistics_Kind(DECLARE_Statistics_Kind)
+      #undef DECLARE_Statistics_Kind
+      LIMIT
+    };
+    /*END*/
+
+    // command line switch control routes through here, per kind
+    // these settings are useful for evaluating the effects of compression
+    static int compression_mode_setting(Kind kind) {
+      if ((DisableMetadataCompression & (1 << (int)kind)) != 0) {
+        return 0;  // zero means "no extra compression"
+      }
+      switch (kind) {
+      case FI: return FICompressionOptions;
+      case LT: return LTCompressionOptions;
+      case DI: return DICompressionOptions;
+      default: return 0;  // zero means "no extra compression"
+      }
+    }
+    static bool compression_enabled(Kind kind) {
+      return compression_mode_setting(kind) != 0;
+    }
+    static int int_pair_setting(Kind kind) {
+      return compression_mode_setting(kind) & 31;
+    }
+    static bool zero_suppress_setting(Kind kind) {
+      return (compression_mode_setting(kind) & 32) != 0;
+    }
+    static bool extra_setting(Kind kind) {
+      return compression_mode_setting(kind) >> 6;
+    }
+
+   private:
+    Kind   _kind;
+    size_t _stream_count;       // number of streams observed (zero-order moment)
+    // various summed totals:
+    size_t _compressed_size;    // sum of sizes of all observed streams
+    size_t _null_count;         // number of null end-bytes
+    size_t _uint_count;         // number of encoded uints (after transforms)
+    size_t _suppressed_zeroes;  // if zero suppression, # of zeroes elided
+    size_t _pair_counts[3];     // if pair transforms, the 1/2/3-item counts
+    size_t _bit_width_counts[BitsPerByte*MAX_LENGTH + 1];
+    size_t _original_size;
+    size_t _original_size_count;
+
+    static Statistics _table[LIMIT];
+
+   public:
+    static Statistics& for_kind(Kind kind) {
+      assert((int)kind >= 0 && kind < LIMIT, "");
+      return _table[kind];
+    }
+
+    template<typename ARR, typename OFF, typename GET>
+    void record_one_stream(ARR array, OFF limit, GET get,
+                           size_t original_size = 0,
+                           size_t* pair_counts = nullptr,
+                           size_t suppressed_zeroes = 0);
+    static void print_statistics();
+    void print_on(outputStream* st);
+  };
 
   /// Handy state machines for that will help you with reading,
   /// sizing, and writing (with optional growth).
@@ -258,34 +429,57 @@ class UNSIGNED5 : AllStatic {
   //  MyReader r(array); while (r.has_next())  print(r.next_uint());
   template<typename ARR, typename OFF, typename GET = ArrayGetSet<ARR,OFF>>
   class Reader {
-    ARR _array;
-    OFF _limit;
-    OFF _position;
+    ARR _array;     // base address of byte array
+    OFF _limit;     // limit position in array, or zero if unknown
+    OFF _position;  // current position in array, index of next byte to read
     int next_length() {
       return UNSIGNED5::check_length(_array, _position, _limit, GET());
     }
   public:
-    Reader(ARR array, OFF limit = 0)
-      : _array(array), _limit(limit) { _position = 0; }
+    Reader(ARR array = nullptr, OFF limit = 0) { setup(array, limit); }
+    void setup(ARR array, OFF limit = 0) {
+      _array = array;
+      _limit = limit;
+      reset();
+    }
+    void reset() {
+      _position = 0;
+    }
+
     uint32_t next_uint() {
       return UNSIGNED5::read_uint(_array, _position, _limit, GET());
     }
     bool has_next() {
       return next_length() != 0;
     }
+    void next_uint_pair(int first_width, uint32_t& first, uint32_t& second) {
+      auto reader = [&]{ return read_uint(_array, _position, _limit, GET()); };
+      UNSIGNED5::read_uint_pair(first_width, first, second, reader);
+    }
     // tries to skip count logical entries; returns actual number skipped
     int try_skip(int count) {
       int actual = 0;
       while (actual < count && has_next()) {
+        ++actual;
         int len = next_length();  // 0 or length in [1..5]
-        if (len == 0)  break;
+        assert(len > 0, "");
         _position += len;
       }
       return actual;
     }
+    // tries to skip a single null (out of band) byte
+    bool try_skip_end_byte() {
+      if ((_limit == 0 || _position < _limit)
+          && GET()(_array, _position) == END_BYTE) {
+        ++_position;
+        return 1;
+      } else {
+        return 0;
+      }
+    }
     ARR array() { return _array; }
     OFF limit() { return _limit; }
-    OFF position() { return _position; }
+    OFF position() { return _position; }  // number of bytes scanned
     void set_position(OFF position) { _position = position; }
 
     // For debugging, even in product builds (see debug.cpp).
@@ -297,7 +491,8 @@ class UNSIGNED5 : AllStatic {
     // count items (uint32_t values or "null").
     // A negative count means we stop only at the limit or null,
     // kind of like strlen.
-    void print(int count = -1) { print_on(tty, count); }
+    void print(int count) { print_on(tty, count); }
+    void print()          { print(-1); }
 
     // The character strings are printed before and after the
     // series of values (which are separated only by spaces).
@@ -318,66 +513,121 @@ class UNSIGNED5 : AllStatic {
   //  for (auto i = ...)  w.accept_uint(i);
   template<typename ARR, typename OFF, typename SET = ArrayGetSet<ARR,OFF>>
   class Writer {
-    ARR& _array;
-    OFF* const _limit_ptr;
+    ARR _array;
+    OFF _limit;
     OFF _position;
-  public:
-    Writer(const ARR& array)
-      : _array(const_cast<ARR&>(array)), _limit_ptr(nullptr), _position(0) {
-      // Note: if _limit_ptr is null, the ARR& is never reassigned,
-      // because has_limit is false.  So the const_cast here is safe.
-      assert(!has_limit(), "this writer cannot be growable");
+    size_t _pair_counts[3];  // used only by -XX:+PrintCompressionStatistics
+    void add_tidy_null() {
+#ifdef ASSERT
+      // For debugger displays, add '\0' after every token, if there's room.
+      if (_limit != 0 && _position < _limit) {
+        SET()(_array, _position, (u_char)0);
+      }
+#endif //ASSERT
     }
-    Writer(ARR& array, OFF& limit)
-      : _array(array), _limit_ptr(&limit), _position(0) {
-      // Writable array argument can be rewritten by accept_grow.
-      // So we need a legitimate (non-zero) limit to work with.
-      // As a result, a writer's initial buffer must not be empty.
-      assert(this->limit() != 0, "limit required");
+  public:
+    Writer(ARR array = nullptr, OFF limit = 0) { setup(array, limit); }
+    void setup(ARR array, OFF limit) {
+      _array = array;
+      _limit = limit;
+      reset();
+    }
+    void reset() {
+      _position = 0;
+      _pair_counts[0] = _pair_counts[1] = _pair_counts[2] = 0;
+    }
+    // this is called by a grow-function, after it finds a bigger array:
+    void grow_array(ARR array, OFF limit) {
+      assert(_limit == 0 || (_position <= _limit && _limit <= limit), "");
+      assert(_position <= limit, "");
+      _limit = limit;
+      if (_array != array) {
+        memcpy(array, _array, _position);
+        _array = array;
+      }
     }
     void accept_uint(uint32_t value) {
-      const OFF lim = has_limit() ? limit() : 0;
-      UNSIGNED5::write_uint(value, _array, _position, lim, SET());
+      UNSIGNED5::write_uint(value, _array, _position, _limit, SET());
+      add_tidy_null();
     }
     template<typename GFN>
-    void accept_grow(uint32_t value, GFN grow) {
-      assert(has_limit(), "must track growing limit");
-      UNSIGNED5::write_uint_grow(value, _array, _position, *_limit_ptr,
+    void accept_uint_grow(uint32_t value, GFN grow) {
+      UNSIGNED5::write_uint_grow(value, _array, _position, _limit,
                                  grow, SET());
+      add_tidy_null();
     }
+    int accept_uint_pair(int first_width, uint32_t first, uint32_t second) {
+      auto writer = [&](uint32_t value) { accept_uint(value); };
+      int nw = UNSIGNED5::write_uint_pair(first_width, first, second, writer);
+      collect_pair_count_stat(nw);
+      add_tidy_null();
+      return nw;
+    }
+    template<typename GFN>
+    int accept_uint_pair_grow(int first_width, uint32_t first, uint32_t second,
+                              GFN grow) {
+      const int MAX_PAIR_LENGTH = 2*MAX_LENGTH + encoded_length(right_n_bits(first_width & 31));
+      ensure_remaining_grow(MAX_PAIR_LENGTH, grow);
+      return accept_uint_pair(first_width, first, second);
+    }
+
     // Ensure that remaining() >= r, grow if needed.  Suggested
     // expression for r is (n*MAX_LENGTH)+1, where n is the number of
     // values you are about to write.
     template<typename GFN>
     void ensure_remaining_grow(int request_remaining, GFN grow) {
       const OFF have = remaining();
-      if (have < request_remaining) {
+      if (have < (OFF)request_remaining) {
         grow(have - request_remaining);  // caller must fix array/limit span
-        assert(remaining() >= request_remaining, "should have grown");
+        assert(remaining() >= (OFF)request_remaining, "should have grown");
       }
     }
     // use to add a terminating null or other data
-    void end_byte(uint8_t extra_byte = 0) {
+    void accept_end_byte(uint8_t extra_byte = END_BYTE) {
+      // do not increment _count here
       SET()(_array, _position++, extra_byte);
     }
     ARR array() { return _array; }
-    OFF position() { return _position; }
+    OFF position() { return _position; }  // number of bytes emitted
     void set_position(OFF position) { _position = position; }
-    bool has_limit() { return _limit_ptr != nullptr; }
-    OFF limit() { assert(has_limit(), "needs limit"); return *_limit_ptr; }
-    OFF remaining() { return limit() - position(); }
+    OFF limit() { return _limit; }
+    OFF remaining() {
+      assert(_position <= _limit, "");
+      return _limit - _position;
+    }
+    void collect_stats(UNSIGNED5::Statistics::Kind kind,
+                       size_t original_size = 0,
+                       size_t suppressed_zeroes = 0,
+                       SET get = SET()) {
+      UNSIGNED5::Statistics::for_kind(kind)
+        .record_one_stream(array(), position(), get,
+                           original_size, _pair_counts, suppressed_zeroes);
+    }
+    void collect_pair_count_stat(int nw) {
+      if (PrintCompressionStatistics) {
+        assert(nw >= 1 && nw <= 3, "");
+        _pair_counts[nw-1]++;
+      }
+    }
+    // ugly hole in abstraction for ZSWriter checkpoints:
+    size_t* pair_count_stats() {
+      return &_pair_counts[0];
+    }
+
+    void print(int count) { Reader<ARR,OFF,SET>(array(),position()).print(count); }
+    void print()          { print(-1); }
   };
 
   // Sizer example use
   //  UNSIGNED5::Sizer s;
   //  for (auto i = ...)  s.accept_uint(i);
-  //  printf("%d items occupying %d bytes", s.count(), s.position());
+  //  printf("%d items occupying %d bytes", (int)s.count(), (int)s.position());
   //  auto buf = new char[s.position() + 1];
   //  UNSIGNED5::Writer<char*, int> w(buf);
   //  for (auto i = ...)  w.accept_uint(i);
   //  w.add_byte();
   //  assert(w.position() == s.position(), "s and w agree");
-  template<typename OFF = int>
+  template<typename OFF = size_t>
   class Sizer {
     OFF _position;
     int _count;
@@ -391,15 +641,42 @@ class UNSIGNED5 : AllStatic {
       _position += encoded_length(value);
       _count++;
     }
+    void accept_uint_pair(int first_width, uint32_t first, uint32_t second) {
+      _position += encoded_pair_length(first_width, first, second);
+      _count    += encoded_pair_count(first_width, first, second);
+    }
     OFF position() { return _position; }
     int count() { return _count; }
   };
 
-  // 32-bit one-to-one sign encoding taken from Pack200
-  // converts leading sign bits into leading zeroes with trailing sign bit
-  // use this to better compress 32-bit values that might be negative
+  // 32-bit one-to-one sign encoding taken from Pack200, which
+  // converts leading sign bits into leading zeroes with trailing sign bit.
+  // Use this to better compress 32-bit values that might be negative.
+  // It works best when positives and negatives are equally likely.
+  // There is never data loss, because it is a 1-1 function.
   static uint32_t encode_sign(int32_t value) { return ((uint32_t)value << 1) ^ (value >> 31); }
   static int32_t decode_sign(uint32_t value) { return (value >> 1) ^ -(int32_t)(value & 1); }
+
+  // An option to encode signs asymmetrically.  Use joint sign bits
+  // when we expect positive numbers more often than negatives.  For
+  // example, use 3 bits when the ratio is 7-to-1.  This makes sense
+  // for delta encodings, when differences are mostly small positive
+  // numbers.
+  //
+  // Sign bit count is in the range [0..15].  For any sign bit count,
+  // the transcoding is 1-1 (a bijection) across the whole 32-bit
+  // range, so you never lose data.  If the count is 0 or 1, there is
+  // no transcoding or the normal single-sign encoding, respectively.
+  // All transcodings leave zero unchanged.
+  //
+  // The encodings run like this:
+  // S=0 0 1 2 3 .. -3 -2 -1 => 0 1 2 3 .. FF**FD FF**FE FF**FF (uint32_t(x))
+  // S=1 0 1 2 3 .. -3 -2 -1 => 0 2 4 6 .. -5 -3 -1  (encode_sign(x))
+  // S=2 0 ..  9 .. -3 -2 -1 => 0 1 2   4 5 6  8 9 10 12 .. 11  7 3
+  // S=3 0 .. 10 .. -3 -2 -1 => 0 1 2 3 4 5 6  8 9 10 11 .. 23 15 7
+  // S=10 0..1022 => 0..1022; 1023..2045 => 1024..2046; -2 -1 => 2047 1023
+  static inline int32_t decode_multi_sign(int sign_bits, uint32_t value);
+  static inline uint32_t encode_multi_sign(int sign_bits, int32_t value);
 
   template<typename ARR, typename OFF, typename GET = ArrayGetSet<ARR,OFF>>
   static OFF print(ARR array, OFF offset = 0, OFF limit = 0,
@@ -415,5 +692,628 @@ class UNSIGNED5 : AllStatic {
     r.print_on(tty, count);
     return r.position();
   }
+};
+
+class ZeroSuppressingU5 : AllStatic {
+ public:
+  // Some streams have a disproportionate number of zero values.
+  // These widgets read and write such streams in such a way that less
+  // storage is used, if the proportion of zero values is more than
+  // about 15%.  As the proportion of zeroes increases beyond 15%, the
+  // stored compressed data decreases in size gradually, down to a
+  // lower limit of about 19% of the original (about 5.25x compression
+  // for nearly all zero values).  As a rule of thumb, expect zeroes
+  // to decrease 5x in size and non-zeroes to stay the same size.
+  //
+  // The compression technique is very simple and specific to zero
+  // values.  If you are passing patterned data or data with many
+  // values of (say) 1, this will not help.  But it might help to
+  // encode your data slightly differently, so that discrete values or
+  // patterns are encoded in such a way that zeroes become more
+  // likely.  For example, correlated values (even if they are mixed
+  // in with non-correlated values) can be delta-encoded relative to
+  // each other.  This could have two benefits: First, the deltas
+  // (even if signed) might be of shorter average byte-lengths (using
+  // UNSIGNED5) than the absolute numbers themselves, and second,
+  // repetitions will delta-encode as zeroes, which will be picked up
+  // by the zero-supressing widget.
+  //
+  // Since there is no free lunch, if you apply one of these widgets
+  // to a stream with 10% or fewer zero values, you will use slightly
+  // more memory.  The good news is that the memory overhead is at
+  // most one extra byte per sequence of values, of any length.  The
+  // alert reader will deduce that there is a one-byte compression
+  // command that says, "pass the rest of this data uncompressed".
+  //
+  // The compressed encoding uses UNSIGNED5 itself, rather than
+  // something more general-purpose or complex.  The compressed stream
+  // consists of a series of 32-bit commands, possibly followed by
+  // 32-bit payload values (usually but not always non-zero).  All
+  // these values (commands and payloads) are uniformly encoded as
+  // UNSIGNED5.  This means that null bytes can be used to terminate
+  // compressed streams just as with regular UNSIGNED5 streams.
+  //
+  // There are only two commands, a zero mask and a block copy.  The
+  // zero mask encodes a 32-bit bitmask, where one-bits denote zeroes,
+  // and zero-bits denote payload values (following the command
+  // immediately in order).  The MSB of the mask denotes the final
+  // zero emitted by the command, and payload values correspond only
+  // to lower-order bits in the bitmask.  The block copy command
+  // encodes a length, which counts the number of payloads that
+  // followed immediately.  If the length decodes as zero, the payload
+  // count is treated as infinite, which is the command to stop
+  // compressing.
+  //
+  // The encoding details are a little fiddly, in order to get
+  // (significantly) better compression.  Since the commands are
+  // themselves 32-bit UNSIGNED5 values, some attention has been paid
+  // to ensuring that common commands use fewer bytes than rare
+  // commands.  Specifically, some 8-bit bitmasks are useful when zero
+  // values appear more than 80% frequency.  These "special" bitmasks
+  // have been reassigned UNSIGNED5 values that fit in one byte, when
+  // that byte is not already useful as a mask.
+  //
+  template<typename ARR, typename OFF,
+           typename GET = UNSIGNED5::ArrayGetSet<ARR,OFF>>
+  class ZSReader {
+    UNSIGNED5::Reader<ARR,OFF,GET> _r;  // stored compression commands and payloads
+    // Besides the backing reader, the decompressor state is just 64 bits:
+    uint32_t _zero_mask;   // if non-zero, the current bitmask for zeroes
+    uint32_t _block_count; // if non-zero, remaining items in current block
+    bool _sticky_passthrough;
+    void set_clean_or_passthrough() {
+      _zero_mask = 0;
+      _block_count = (_sticky_passthrough ? PASSTHROUGH_BLOCK_COUNT : 0);
+    }
+    bool is_clean_or_passthrough() {
+      return is_clean() || is_passthrough();
+    }
+    uint32_t next_uint_uncompressing();
+
+  public:
+    ZSReader(ARR array = nullptr, OFF limit = 0) { setup(array, limit); }
+    void setup(ARR array, OFF limit = 0);
+    void reset();
+
+    bool at_start() {
+      return _r.position() == 0;
+    }
+
+    bool is_clean() {   // true if there we have no un-executed commands
+      return (_zero_mask | _block_count) == 0;
+    }
+
+    bool is_passthrough() {
+      return (_block_count == PASSTHROUGH_BLOCK_COUNT);
+    }
+
+    // set this stream to pass-through mode (stop expanding)
+    // must be done immediately after reset
+    // this condition, requested by the user, is sticky; it cannot be reversed
+    void set_passthrough() {
+      assert(is_clean_or_passthrough(), "");
+      _sticky_passthrough = true;
+      _block_count = PASSTHROUGH_BLOCK_COUNT;
+    }
+
+    bool has_next() {
+      return !is_clean_or_passthrough() || _r.has_next();
+    }
+
+    uint32_t next_uint() {
+      return is_passthrough() ? _r.next_uint() : next_uint_uncompressing();
+    }
+
+    void next_uint_pair(int first_width, uint32_t& first, uint32_t& second) {
+      auto reader = [&]{ return next_uint(); };
+      UNSIGNED5::read_uint_pair(first_width, first, second, reader);
+    }
+
+    // tries to skip count logical entries; returns actual number skipped
+    int try_skip(int count) {
+      int actual = 0;
+      while (actual < count && has_next()) {
+        ++actual;
+        next_uint();
+        // We could make this faster but it's not worth it.
+      }
+      return actual;
+    }
+    // tries to skip a single null (out of band) byte
+    bool try_skip_end_byte() {
+      if (!has_next() && _r.try_skip_end_byte()) {
+        set_clean_or_passthrough();
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    ARR array() { return _r.array(); }
+    OFF position() {
+      assert(is_clean_or_passthrough(), "");  // no active decompressor state
+      return _r.position();
+    }
+    void reset_at_position(OFF position) {
+      set_clean_or_passthrough();
+      _r.set_position(position);
+    }
+
+    // Dump all compression codes in this reader.
+    void print() { print_on(tty); }
+    void print_on(outputStream* st);
+  };
+
+ private:
+  // templates for the checkpointer
+  struct CopyIn {
+    template<typename T> void operator()(T& ours, T& theirs) { ours = theirs; }
+  };
+  struct CopyOut {
+    template<typename T> void operator()(T& ours, T& theirs) { theirs = ours; }
+  };
+
+ public:
+  template<typename OFF, typename ZSWriter>
+  class ZSWriterCheckpoint {
+    bool _is_active;
+    OFF _position;
+    int _block_length;   // represents passthrough, only
+    // save the statistics
+    size_t _suppressed_zeroes;
+    size_t _pair_counts[3];
+    template<typename FN> void mapper(ZSWriter& zw, FN fn) {
+      auto& uw = zw._w;
+      fn(_block_length, zw._block_length);
+      fn(_suppressed_zeroes, zw._suppressed_zeroes);
+      fn(_pair_counts[0], uw.pair_count_stats()[0]);
+      fn(_pair_counts[1], uw.pair_count_stats()[1]);
+      fn(_pair_counts[2], uw.pair_count_stats()[2]);
+    }
+  public:
+    bool is_active() { return _is_active; }
+    OFF position() {
+      assert(is_active(), "");
+      return _position;
+    }
+    ZSWriterCheckpoint() {
+      _is_active = false;
+      // rest of fields are garbage
+    }
+    ZSWriterCheckpoint(ZSWriter& zw) {
+      _is_active = true;
+      assert(zw.is_clean_or_passthrough(), "");
+      _position = zw._w.position();
+      mapper(zw, CopyIn());
+    }
+    void restore(ZSWriter& zw) {
+      assert(is_active(), "");  // it is a one-shot checkpoint
+      assert(zw._w.position() >= _position, "");  // must restore backwards
+      zw.set_clean_or_passthrough();
+      zw._w.set_position(_position);
+      mapper(zw, CopyOut());
+      _is_active = false;
+    }
+  };
+
+  template<typename ARR, typename OFF,
+           typename SET = UNSIGNED5::ArrayGetSet<ARR,OFF>>
+  class ZSWriter {
+    friend class ZSWriterCheckpoint<OFF,ZSWriter<ARR,OFF,SET>>;
+
+    UNSIGNED5::Writer<ARR,OFF,SET> _w;
+    size_t _suppressed_zeroes;
+
+    // The compressor requires a window of up to 34 items.  We store
+    // the window in the backing writer _w, but also summarize the
+    // positions of zeroes in a bitmask.
+    //
+    // There are three distinct areas in the writer:
+    //  - a committed area:  compression commands that are already done
+    //  - a block area:  items which are destined for a block command
+    //  - a zero mask area:  items being considered for a zero mask command
+    //
+    // Any or all of these three areas can be empty.  They are all
+    // disjoint and contiguous, in the order of committed, then block,
+    // then zero mask.  If the block area is non-empty, then it begins
+    // with a zero word, which stands for an indefinite block copy
+    // command.  It may be left as-is (if no further commands are
+    // committed) or it may be updated to a definite block copy
+    // command.  If updated, it may be expanded in size requiring some
+    // shifting of bytes in the array of the writer _w.
+    //
+    // Typical contents of _w:
+    //
+    // ... X Y Z | bh(0) | A B C D ... | P 0 Q 0 0 R S 0 T ... |
+    //  (...done)       bs (block...) zs (mask area...)       w.pos
+    //                   \___ blen ___/ \_ zm(010110010...) __/
+    //
+    // The bh(0) item is present only if blen>0, which means we are
+    // certain we want a block-copy command, whether or not we will
+    // follow it with a zero-mask command.  New items are added on the
+    // right, to the zero-mask area.  If the zero-mask area grows to
+    // 32 bits (or larger) then a decision is made to group older
+    // items into a zero-mask command, if that is profitable, or else
+    // spill the oldest items down to the block area.  The possibility
+    // of repeated spilling into the same block area is why we don't
+    // commit to blocks quickly; we wait until a zero-mask command is
+    // decided upon, and then all the pending block items are combined
+    // into a single block-copy command.
+
+    int _zero_mask_length; // number of valid z.m. bits, in 0..34
+    OFF _zero_mask_start;  // starting position for zero mask area (if zml>0)
+    uint64_t _zero_mask;   // map of all zeroes in the zero mask area (if zml>0)
+
+    int _block_length;     // number of items in current block area
+    OFF _block_start;      // position of start of current block area (if bl>0)
+
+    bool _sticky_passthrough;
+
+    void set_clean_or_passthrough() {
+      _zero_mask_length = 0;
+      _block_length = (_sticky_passthrough ? PASSTHROUGH_BLOCK_COUNT : 0);
+    }
+    bool is_clean_or_passthrough() {
+      return is_clean() || is_passthrough();
+    }
+    bool have_zero_mask() {
+      return _zero_mask_length != 0;
+    }
+    bool have_current_block() {
+      return _block_length != 0;
+    }
+
+  public:
+    ZSWriter(ARR array = nullptr, OFF limit = 0) { setup(array, limit); }
+    void setup(ARR array, OFF limit);
+    void reset();
+    void grow_array(ARR array, OFF limit);
+
+    bool at_start() {
+      return is_clean_or_passthrough() && _w.position() == 0;
+    }
+
+    bool is_clean() {   // true if there we have no un-committed state
+      return (_zero_mask_length | _block_length) == 0;
+    }
+
+    bool is_passthrough() {
+      return (_block_length == (int)PASSTHROUGH_BLOCK_COUNT);
+    }
+
+    // set this stream to pass-through mode (stop compressing)
+    // must be done immediately after reset
+    // this condition, requested by the user, is sticky; it cannot be reversed
+    void set_passthrough() {
+      assert(is_clean_or_passthrough(), "");
+      _sticky_passthrough = true;
+      _block_length = PASSTHROUGH_BLOCK_COUNT;
+    }
+
+    // Flush pending compressor state, if any.  After this function,
+    // additional inputs will be accepted, but they might not be
+    // compressed, because the compressor may choose to end up
+    // in pass-through mode, if that gets the best compression of
+    // the input so far.
+    //
+    // If the argument is true, then compression will be attempted on
+    // future inputs as well.  However, this comes at a cost: The
+    // compression of the input so far is NOT going to be optimal.  In
+    // particular, if the input has been incompressible so far, then a
+    // definite block header will be inserted, which can raise the
+    // compression overhead above its guaranteed maximum of one byte.
+    // If you need to make pointers into the middle of the compression
+    // stream, this is what you need to do.  Alternatively, you can
+    // ensure that every directly addressible substream starts fresh
+    // after an end-byte.
+    void flush(bool continue_compressing = false) {
+      if (!is_clean_or_passthrough()) {
+        commit(continue_compressing, false);
+      }
+    }
+
+    // similar to UNSIGNED5::Writer::accept_uint
+    void accept_uint(uint32_t value) {
+      const OFF start_pos = accept_uint_setup();
+      _w.accept_uint(value);
+      if (!is_passthrough()) {
+        digest_uint(start_pos, value);
+      }
+    }
+
+    // similar to UNSIGNED5::Writer::accept_uint_grow
+    template<typename GFN>
+    void accept_uint_grow(uint32_t value, GFN grow) {
+      const OFF start_pos = accept_uint_setup();
+        _w.accept_uint_grow(value, [&](int n){ grow(1+n); });
+      if (!is_passthrough()) {
+        digest_uint(start_pos, value);
+      }
+    }
+
+    void accept_uint_pair(int first_width, uint32_t first, uint32_t second) {
+      const OFF start_pos = accept_uint_setup();
+      int nw = _w.accept_uint_pair(first_width, first, second);
+      if (!is_passthrough()) {
+        digest_multiple_uints(start_pos, nw);
+      }
+    }
+
+    template<typename GFN>
+    void accept_uint_pair_grow(int first_width, uint32_t first, uint32_t second,
+                               GFN grow) {
+      const OFF start_pos = accept_uint_setup();
+      int nw = _w.accept_uint_pair_grow(first_width, first, second,
+                                        [&](int n){ grow(1+n); });
+      if (!is_passthrough()) {
+        digest_multiple_uints(start_pos, nw);
+      }
+    }
+
+    // similar to UNSIGNED5::Writer::ensuring_remaining_grow
+    template<typename GFN>
+    void ensure_remaining_grow(int request_remaining, GFN grow) {
+      _w.ensure_remaining_grow(1 + request_remaining, grow);
+    }
+
+    // Finish compression and add a terminating null byte as a fence.
+    // This is one of the few operations that ends up with a clean state.
+    void accept_end_byte();
+
+    ARR array() { return _w.array(); }
+    OFF position() {
+      assert(is_clean_or_passthrough(), "");  // no active decompressor state
+      return _w.position();
+    }
+    OFF limit() { return _w.limit(); }
+    OFF remaining() { return _w.remaining(); }
+
+    ZSWriterCheckpoint<OFF,ZSWriter<ARR,OFF,SET>> checkpoint() {
+      return ZSWriterCheckpoint<OFF,ZSWriter<ARR,OFF,SET>>(*this);
+    }
+    void restore(ZSWriterCheckpoint<OFF,ZSWriter<ARR,OFF,SET>>& ckpt) {
+      ckpt.restore(*this);
+    }
+
+    // There is a lot of machinery inside this black box...
+   private:
+    // advance in the output buffer of _w (must already have been written!)
+    OFF advance_position(OFF start, int count);
+
+    bool sanity_checks();
+
+    // Get ready to push a single uint to the Writer _w.
+    OFF accept_uint_setup() {
+      assert(sanity_checks(), "");
+      return _w.position();
+    }
+
+    // After pushing a uint (or maybe a few) to the Writer _w, update
+    // the bookkeeping for compression.
+    void digest_uint_mask(uint32_t more_zm, int more_zm_len, OFF start_pos);
+    void digest_multiple_uints(OFF start_pos, int nw);
+    void digest_uint(OFF start_pos, uint32_t value) {
+      digest_uint_mask(value == 0 ? 1 : 0, 1, start_pos);
+    }
+
+    // Remove items from the zero mask area until it is no more than
+    // the target size.  If they can be placed profitably into a zero
+    // mask command, do so, else transfer them into the block area.
+    void drain_zero_mask(int target_zero_mask_length);
+
+    // Remove items from the zero mask and assign them to the current
+    // block.  This is an alternative to do_compression; both
+    // functions finalize decisions about zero suppression (in the
+    // current zero mask region).  But this one just passes the
+    // UNSIGNED5 encodings unchanged, even if they are zeroes.
+    // Sometimes that's the right decision, even for zeroes.
+    void expand_current_block(int trim);
+
+    // This is where the payoff happens.
+    void do_compression(uint32_t best_zm);
+
+    // commit the current block to a real command
+    // use an indefinite length (works like passthrough) or a more
+    // expensive definite length, according to the selected option
+    void emit_block_command(bool use_indefinite_length);
+
+    // commit a zero mask command (caller must marshal the payloads)
+    void emit_zero_mask_command(uint32_t best_zm);
+
+    // Commit any pending commands to the backing store and get to a
+    // clean state ready to compress further data, or else to a
+    // passthrough state to which any amount of further data can be
+    // appended to the backing store.
+    void commit(bool require_clean,
+                bool require_passthrough);
+
+   public:
+    void collect_stats(UNSIGNED5::Statistics::Kind kind,
+                       size_t original_size = 0, SET get = SET()) {
+      _w.collect_stats(kind, original_size, _suppressed_zeroes, get);
+    }
+
+    // ugly hole in abstraction for testing:
+    UNSIGNED5::Writer<ARR,OFF,SET>& writer_for_testing() {
+      return _w;
+    }
+
+    void print() { print_on(tty); }
+    void print_on(outputStream* st);
+  };
+
+ private:
+  // Implementation details.
+  static const uint32_t BLOCK_TAG_WIDTH = 4;  // tunable
+  static const uint32_t BLOCK_TAG_MASK = (1<<BLOCK_TAG_WIDTH)-1;
+  static const uint32_t MAX_BLOCK_COUNT = (uint32_t)-1 >> BLOCK_TAG_WIDTH;
+  static const uint32_t PASSTHROUGH_BLOCK_COUNT = (uint32_t)-1;  //sentinel
+  static const uint32_t MAX_MASK_WIDTH = 8 * sizeof(uint32_t);
+  static const uint32_t SPECIAL_MASK_KNOCKOUTS = 1 | ((-0x80 >> (BLOCK_TAG_WIDTH-2)) & 0x7F);
+  static const uint32_t GIVE_UP_AFTER = 1 << 10;  // must be less than 2^28
+  static const uint32_t ZERO_ENCODING = UNSIGNED5::MIN_ENCODING_BYTE;
+  static const bool SPLIT_MASKS = true;
+  static const bool SHORTER_MASKS = true;
+ 
+  static bool is_block_count_code(uint32_t cmd) {
+    return (cmd & BLOCK_TAG_MASK) == 0;
+  }
+  static uint32_t decode_block_count(uint32_t cmd) {
+    assert(is_block_count_code(cmd), "");
+    // Any block count must be less than 2^28.  If you haven't found
+    // zeroes by then, it's time to stop compressing.
+    return cmd >> BLOCK_TAG_WIDTH;
+  }
+  static uint32_t encode_block_count(uint32_t count) {
+    assert(count >= 0 && count <= MAX_BLOCK_COUNT, "");
+    int cmd = count << BLOCK_TAG_WIDTH;
+    assert(decode_block_count(cmd) == count, "");
+    return cmd;
+  }
+  static bool is_valid_zero_mask(uint32_t mask) {
+    // It must not look like a block copy command, so it must have at
+    // least one bit set in the lower part (4 bits).  On the other
+    // hand, it must not be a singleton bitmask.  A single zero,
+    // encoded in a bitmask, is never a profitable command to issue.
+    return (mask & BLOCK_TAG_MASK) != 0 && !is_power_of_2(mask);
+  }
+  static uint32_t decode_zero_mask(uint32_t cmd) {
+    assert(!is_block_count_code(cmd), "");
+    // usually, the encoding IS the mask, but sometimes it is special
+    return (is_valid_zero_mask(cmd)
+            ? cmd
+            : decode_special_mask(cmd));
+  }
+  static uint32_t encode_zero_mask(uint32_t mask) {
+    assert(is_valid_zero_mask(mask), "");
+    int cmd = (!is_special_mask(mask)
+               ? mask
+               : encode_special_mask(mask));
+    assert(decode_zero_mask(cmd) == mask, "");
+    return cmd;
+  }
+
+  // Very sparse workloads, having many consecutive zeroes, call for
+  // zero masks with high bit weights.  In particular, a sequence of
+  // the form {@code <0**N|1|0**M>} has a good encoding as runs of
+  // {@code N=8} zeroes until a final run of {@code N<8}, using the
+  // following patterns:
+  //
+  //   - N=8: 0xFF* (8 zeroes, then another of these cases)
+  //   - N=0: 0x02 0x06 0x0E 0x1E 0x3E 0x7E 0xFE* (0<M<8)
+  //   - N=1:      0x05 0x0D 0x1D 0x3D 0x7D 0xFD* (0<M<7)
+  //   - N=2:           0x0B 0x1B 0x3B 0x7B 0xFB* (0<M<6)
+  //   - N=3:                0x17 0x37 0x77 0xF7* (0<M<5)
+  //   - N=4:                     0x2F 0x6F 0xEF* (0<M<4)
+  //   - N=5:                          0x5F 0xDF* (0<M<3)
+  //   - N=6:                               0xBF* (M=1)
+  //   - N=7: 0x7F  (7 zeroes, then one of the N=0 cases)
+  //
+  // The starred masks demand two bytes in UNSIGNED5 notation, so they
+  // must either be encoded in one byte by the special replacement
+  // convention, or else expanded somehow.  The correct way to expand
+  // in these sparse cases is not to use a two-byte UNSIGNED5
+  // encoding, which burns an extra byte that normally should encode
+  // up to 8 zeroes.  Instead, as single zero mask bit is transferred
+  // from the MSB of the over-sized mask to the LSB of the next mask.
+  // So, for masks other than the important 0xFF*, 0xFE*, 0xBF*:
+  //
+  //   - N=1:  0xFD* => 0x7D (M=5) + 0x01|mask (N>0)
+  //   - N=2:  0xFB* => 0x7B (M=4) + (same)
+  //   - N=3:  0xF7* => 0x77 (M=3) + (same)
+  //   - N=4:  0xEF* => 0x6F (M=2) + (same)
+  //   - N=5:  0xDF* => 0x5F (M=1) + (same)
+  //
+  // Here are encodings (singleton mask to high bit-weight):
+  //   0x01 => 0xFF* (8 zeroes in a row)
+  //   0x02 => 0xFE* (one non-zero plus 7 zeroes)
+  //   0x04 => 0xDF* (6 zeros, one non-zero, 2 more zeroes)
+  //   0x08 => 0xBF* (7 zeros, one non-zero, 1 more zero)
+  //
+  // Each of these is a full 8-bit mask (0xFF) with at most one bit
+  // "knocked out".  Higher codes correspond to higher bits knocked
+  // out.
+  //
+  // Thus, every special mask fits into an 8-bit byte, has its top bit
+  // set, and has at most one bit clear.  As such is useful for
+  // compressing streams with more than 80% zeroes.
+  static bool is_special_mask(uint32_t mask) {
+    assert(is_valid_zero_mask(mask), "");
+    return ((mask | SPECIAL_MASK_KNOCKOUTS) == 0xFF
+            && population_count(mask) >= 7);
+  }
+  static uint32_t decode_special_mask(uint32_t cmd) {
+    assert(is_power_of_2(cmd), "");
+    // Compute at most one bit to "knock out" of 0xFF:
+    int ko = (cmd <= 2) ? cmd - 1 : cmd << (7-BLOCK_TAG_WIDTH);
+    assert((ko == 0 || is_power_of_2(ko)) && (ko & 0x7F) == ko, "");
+    return 0xFF & ~ko;
+  }
+  static uint32_t encode_special_mask(uint32_t mask) {
+    assert(is_special_mask(mask), "");
+    uint32_t ko = ~mask & SPECIAL_MASK_KNOCKOUTS;
+    assert(mask + ko == 0xFF && population_count(ko) <= 1, "");
+    uint32_t cmd = (ko <= 1) ? ko + 1 : ko >> (7 - BLOCK_TAG_WIDTH);
+    assert(decode_special_mask(cmd) == mask, "");
+    return cmd;
+  }
+
+  // This function is the heart of the compression policy.  It starts
+  // with a 32-element window of zero/non-zero observations, and
+  // decides what initial sequence of them to turn into a zero mask
+  // command.  But if the profit from doing so is less than min_profit
+  // (or if there is negative profit), return a zero bitmask, meaning
+  // no zero mask command should be emitted at this point.
+  static uint32_t best_zero_mask(uint32_t zm, int min_profit) {
+    // If zm is a valid mask we can use it, as long as profit is big enough.
+    if (!is_valid_zero_mask(zm))  return 0;
+    const int zml = UNSIGNED5::encoded_length(encode_zero_mask(zm));
+    int best_mask = 0, best_profit = 0;
+    // Maybe see if there is a shorter mask that gives us a better profit.
+    for (int zm1len = SPLIT_MASKS ? 1 : zml; zm1len <= zml; zm1len++) {
+      // Split the mask in two, and see if the earlier one is nice enough.
+      const uint32_t zm1 = (zm1len == zml) ? zm : split_zero_mask(zm, zm1len);
+      assert(zm1len == zml || zm1 != zm, "");  // it should be a real split
+      // zero masks must have at least 2 bits set:
+      if (zm1 == 0 || is_power_of_2(zm1))  continue;
+      assert(UNSIGNED5::encoded_length(encode_zero_mask(zm1)) == zm1len, "");
+      const int zm1_profit = population_count(zm1) - zm1len;
+      if (SHORTER_MASKS && zm1len < zml && zm1_profit >= min_profit &&
+          is_valid_zero_mask(zm >> zero_mask_length(zm1))) {
+        // Split as soon as we can see a second complete mask ready to emit.
+        return zm1;
+      }
+      if (best_profit <= zm1_profit) {
+        // '<=' instead of '<' favors longer tokens, for slightly better scores
+        best_profit = zm1_profit;
+        best_mask = zm1;
+      }
+    }
+    return (best_profit >= min_profit) ? best_mask : 0;
+  }
+
+  static int zero_mask_length(uint32_t zm) {
+    // The elements represented by a zero mask correspond to lower bit
+    // positions in the mask, from the MSB, up to and including the
+    // highest 1-bit (which denotes a zero).  So return 32-clz(zm).
+    return (zm == 0) ? 0 : 32 - count_leading_zeros(zm);
+  }
+
+  static uint32_t split_zero_mask(uint32_t zm, int zm1len) {
+    assert(zm1len < UNSIGNED5::encoded_length(encode_zero_mask(zm)), "");
+    const uint32_t minv = UNSIGNED5::min_encoded_in_length(zm1len);
+    const uint32_t maxv = UNSIGNED5::max_encoded_in_length(zm1len);
+    const int flg = UNSIGNED5::log2i_max_encoded_in_length(zm1len);
+    const uint32_t flg_mask = ((((uint32_t)2) << flg) - 1);
+    const uint32_t zm1 = zm & flg_mask; // split off earlier part of zm
+    if (zm1 < minv) {
+      return 0;  // split part is under-sized, so return empty result
+    } else if (zm1 > maxv && !is_special_mask(zm1)) {
+      return zm1 & (flg_mask >> 1);  // shave off the top bit also
+    } else {
+      return zm1;
+    }
+  }
+
 };
 #endif // SHARE_UTILITIES_UNSIGNED5_HPP

--- a/src/hotspot/share/utilities/unsigned5.inline.hpp
+++ b/src/hotspot/share/utilities/unsigned5.inline.hpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_UNSIGNED5_INLINE_HPP
+#define SHARE_UTILITIES_UNSIGNED5_INLINE_HPP
+
+#include "utilities/unsigned5.hpp"
+
+/// Extra-complicated implementation details.  Moved here to reduce clutter.
+
+// The functions are inline to encourage constant folding.
+
+// Returns the leading "YX" word used to encode a pair of ints, as
+// read by read_uint_pair.  If X is big, the Y field is biased by +1
+// so that in the worst case (big X, big Y), where all bits are
+// saturated to 1, the stored value ((Y+1)<<(32-S))+X will be close
+// to zero, probably requiring only a single byte.  Note also that
+// if Y is big, the X field is forced to be all 1-bits, so that the
+// transmission of a separate Y is always preceded by a separate X.
+inline int UNSIGNED5::encoded_pair_lead(int first_width, uint32_t first, uint32_t second) {
+  assert(first_width >= 0 && first_width <= 31, "");
+  const uint32_t xmask = right_n_bits(first_width &= 31);
+  const bool badx = (first >= xmask);
+  const bool bady = (second > right_n_bits(32-first_width));
+  const uint32_t yx = bady ? xmask : ((second << first_width)
+                                      + (badx ? xmask*2+1 : first));
+  // (If second = -1, bady is false but yx will make bady appear to
+  // be true.  That is by design.  Doing it this way allows us to
+  // compare first against a bound that does not depend on badx.)
+  return yx;
+}
+
+inline int UNSIGNED5::encoded_pair_count(int first_width, uint32_t pair_lead_xy) {
+  const uint32_t xmask = right_n_bits(first_width &= 31);
+  const uint32_t testyx = xmask ^ pair_lead_xy;
+  return (testyx == 0 && first_width != 0 ? 3 : (testyx & xmask) == 0 ? 2 : 1);
+}
+
+inline int UNSIGNED5::encoded_pair_length(int first_width, uint32_t first, uint32_t second) {
+  const uint32_t yx = encoded_pair_lead(first_width, first, second);
+  const int      n  = encoded_pair_count(first_width, first, second);
+  return (encoded_length(yx)
+          + (n < 2 ? 0 : encoded_length(first)
+             + ( n < 3 ? 0 : encoded_length(second))));
+}
+
+inline uint32_t UNSIGNED5::encode_multi_sign(int sign_bits, int32_t value) {
+  assert(sign_bits >= 0 && sign_bits < 16, "");
+  const uint32_t sign_mask = right_n_bits(sign_bits &= 15);
+  switch (sign_bits) {
+  case 0: return value;                // straight cast to unsigned
+  case 1: return encode_sign(value);   // symmetric sign encoding
+  }
+  const uint32_t v = value;
+  const bool has_negative_code = (v >= ((uint32_t)-1 << (32-sign_bits)));
+  // check alternative formula:
+  assert(has_negative_code ==
+         (value < 0 && value >= (int32_t)INT32_MIN / (1<<(sign_bits-1))), "");
+  uint32_t r;
+  if (has_negative_code) {
+    r = (~v << sign_bits) + sign_mask;
+    assert(r == v * (-1<<sign_bits) - 1, "");  // check alternate formula
+  } else {
+    r = value;
+    r += v / sign_mask;
+    // Division by a non-constant sign mask is going to the most expensive step.
+    // But most callers supply a constant argument, which allows this inline function
+    // to strength-reduce the division to a multiplication.
+  }
+  // Test for a bijection at this point:
+  DEBUG_ONLY(uint32_t v2 = decode_multi_sign(sign_bits, r));
+  assert(v == v2, "round trip failed: %x => %x => %x", value, r, v2);
+  return r;
+}
+
+int32_t UNSIGNED5::decode_multi_sign(int sign_bits, uint32_t value) {
+  switch (sign_bits) {
+  case 0: return value;       // straight cast to unsigned
+  case 1: return decode_sign(value);  // symmetric sign encoding
+  }
+  const uint32_t v = value;
+  uint32_t sign_mask = right_n_bits(sign_bits);
+  int32_t r;
+  if ((v & sign_mask) == sign_mask) {
+    r = ~(v >> sign_bits);
+  } else {
+    r = v;
+    r -= v >> sign_bits;
+  }
+  return r;
+}
+
+template<typename READ_UINT>
+inline int UNSIGNED5::read_uint_pair(int first_width,
+                                     uint32_t& first_result,
+                                     uint32_t& second_result,
+                                     READ_UINT read_uint) {
+  assert(first_width >= 0 && first_width <= 31, "");
+  first_width &= 31;
+  const uint32_t yx = read_uint();  // get the pair lead, then decide n
+  const int      n  = encoded_pair_count(first_width, yx);
+  uint32_t x = yx & right_n_bits(first_width);
+  uint32_t y = yx >> first_width;
+  // X and Y usually fit in YX, if the workload cooperates
+  if (n > 1) {   // oops, X did not fit
+    // second most common case: Y fits in YX but not X (or X=0)
+    x = read_uint();
+    y -= 1;  // when x was big, y bitfield was incremented mod 2^(32-S)
+    if (n > 2) {
+      // third case: Y does not fit in YX (or X=Y=0)
+      y = read_uint();
+    }
+  }
+  first_result = x;
+  second_result = y;
+  return n;
+}
+
+template<typename WRITE_UINT>
+inline int UNSIGNED5::write_uint_pair(int first_width,
+                                      uint32_t first,
+                                      uint32_t second,
+                                      WRITE_UINT write_uint) {
+  assert(first_width >= 0 && first_width <= 31, "");
+  first_width &= 31;
+  const uint32_t yx = encoded_pair_lead(first_width, first, second);
+  const int      n  = encoded_pair_count(first_width, first, second);
+  write_uint(yx);
+  if (n > 1) {
+    write_uint(first);
+    if (n > 2) {
+      write_uint(second);
+    }
+  }
+  return n;
+}
+
+#endif // SHARE_UTILITIES_UNSIGNED5_INLINE_HPP


### PR DESCRIPTION
Over the break, when other folks were doing Advent of Code and other cool competitions, I thought about zero-suppression, prompted by last year’s PR 12387 to introduce run-length encoding of repeated zeroes.

https://github.com/openjdk/jdk/pull/12387

I came up with a scheme that seems competitive with run-length encoding, for cases where RLE wins, but also wins in other scenarios.  Basically, if you have more than 20% zeroes (by uint count) in your workload, you can suppress the excess above 20%.  (This is a rough number, but it is an empirically sharp  bound, verified by the unit test.)

No matter how irregularly distributed the zeroes are, the excess over 20% disappears, by re-coding the stream of uint tokens to pass a mix of zero-mask and block-copy commands, that “steer” the remaining uint tokens (which are mostly non-zero).  The commands themselves are encoded using UNSIGNED5, so both the input and output of the compressing transform are the same format, readable with the same tools.

As I looked for opportunities to use this mechanism, I found lots of other “slack” in the metadata streams, so I introduced another transform, also one that converts U5 streams to U5 streams (usually smaller ones).  This is a pairing transform that takes two uints that usually can pack into one 32-bit int, tries to pack and encode them as one, and if there is a problem deals with it.  This generalizes the usual technique of encoding some tag bits in the LSB of a word.  It turns out to improve several kinds of metadata.

I also brushed up the delta-encoding of the LineNumberTable attribute, after checking the statistics.

See the patch for details…

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/SE1.gif)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17474/head:pull/17474` \
`$ git checkout pull/17474`

Update a local copy of the PR: \
`$ git checkout pull/17474` \
`$ git pull https://git.openjdk.org/jdk.git pull/17474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17474`

View PR using the GUI difftool: \
`$ git pr show -t 17474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17474.diff">https://git.openjdk.org/jdk/pull/17474.diff</a>

</details>
