### PR TITLE
8321938: java/foreign/critical/TestCriticalUpcall.java does not need a core file

### DIFF
--- a/test/jdk/java/foreign/critical/TestCriticalUpcall.java
+++ b/test/jdk/java/foreign/critical/TestCriticalUpcall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/critical/TestCriticalUpcall.java
+++ b/test/jdk/java/foreign/critical/TestCriticalUpcall.java
@@ -35,6 +35,7 @@ import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
+import java.util.List;
 
 import static org.testng.Assert.fail;
 
@@ -43,7 +44,7 @@ public class TestCriticalUpcall extends UpcallTestHelper {
     @Test
     public void testUpcallFailure() throws IOException, InterruptedException {
         // test to see if we catch a trivial downcall doing an upcall
-        runInNewProcess(Runner.class, true)
+        runInNewProcess(Runner.class, true, List.of("-XX:-CreateCoredumpOnCrash"), List.of())
             .shouldNotHaveExitValue(0)
             .stdoutShouldContain("wrong thread state for upcall");
     }


### PR DESCRIPTION
A trivial fix to disable core file generation in java/foreign/critical/TestCriticalUpcall.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321938](https://bugs.openjdk.org/browse/JDK-8321938): java/foreign/critical/TestCriticalUpcall.java does not need a core file (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [44ddcbb8](https://git.openjdk.org/jdk/pull/17476/files/44ddcbb89b8b6fb658ac55804e37378bc251bce9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17476/head:pull/17476` \
`$ git checkout pull/17476`

Update a local copy of the PR: \
`$ git checkout pull/17476` \
`$ git pull https://git.openjdk.org/jdk.git pull/17476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17476`

View PR using the GUI difftool: \
`$ git pr show -t 17476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17476.diff">https://git.openjdk.org/jdk/pull/17476.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17476#issuecomment-1897586592)