### PR TITLE
8324066: "clhsdb jstack" should not by default scan for j.u.c locks because it can be very slow

### DIFF
--- a/src/jdk.hotspot.agent/doc/clhsdb.html
+++ b/src/jdk.hotspot.agent/doc/clhsdb.html
@@ -53,7 +53,7 @@ Available commands:
   intConstant [ name [ value ] ] <font color="red">print out hotspot integer constant(s)</font>
   jdis address <font color="red">show bytecode disassembly of a given Method*</font>
   jhisto <font color="red">show Java heap histogram</font>
-  jstack [-v] <font color="red">show Java stack trace of all Java threads. -v is verbose mode</font>
+  jstack [-v] [-l] <font color="red">show Java stack trace of all Java threads. -v is verbose mode. -l includes info on owned java.util.concurrent locks.</font>
   livenmethods <font color="red">show all live nmethods</font>
   longConstant [ name [ value ] ] <font color="red">print out hotspot long constant(s)s</font>
   mem [ -v ] { address[/count] | address,address } <font color="red">show contents of memory range. -v adds "findpc" info for addresses</font>
@@ -62,7 +62,7 @@ Available commands:
   printas type expression <font color="red">print given address as given HotSpot type. eg. print JavaThread &lt;address&gt;</font>
   printmdo -a | expression <font color="red">print method data oop</font>
   printstatics [ type ] <font color="red">print static fields of given HotSpot type (or all types if none specified)</font>
-  pstack [-v] <font color="red">show mixed mode stack trace for all Java, non-Java threads. -v is verbose mode</font>
+  pstack [-v] <font color="red">show mixed mode stack trace for all Java, non-Java threads. -v is verbose mode. -l includes info on owned java.util.concurrent locks.</font>
   quit <font color="red">quit CLHSDB tool</font>
   reattach <font color="red">detach and re-attach SA to current target</font>
   revptrs  <font color="red">find liveness of oops</font>

--- a/src/jdk.hotspot.agent/doc/clhsdb.html
+++ b/src/jdk.hotspot.agent/doc/clhsdb.html
@@ -62,7 +62,7 @@ Available commands:
   printas type expression <font color="red">print given address as given HotSpot type. eg. print JavaThread &lt;address&gt;</font>
   printmdo -a | expression <font color="red">print method data oop</font>
   printstatics [ type ] <font color="red">print static fields of given HotSpot type (or all types if none specified)</font>
-  pstack [-v] <font color="red">show mixed mode stack trace for all Java, non-Java threads. -v is verbose mode. -l includes info on owned java.util.concurrent locks.</font>
+  pstack [-v] [-l] <font color="red">show mixed mode stack trace for all Java, non-Java threads. -v is verbose mode. -l includes info on owned java.util.concurrent locks.</font>
   quit <font color="red">quit CLHSDB tool</font>
   reattach <font color="red">detach and re-attach SA to current target</font>
   revptrs  <font color="red">find liveness of oops</font>

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/CommandProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1143,13 +1143,22 @@ public class CommandProcessor {
                  histo.run(out, err);
             }
         },
-        new Command("jstack", "jstack [-v]", false) {
+        new Command("jstack", "jstack [-v] [-l]", false) {
             public void doit(Tokens t) {
                 boolean verbose = false;
-                if (t.countTokens() > 0 && t.nextToken().equals("-v")) {
-                    verbose = true;
+                boolean concurrentLocks = false;
+                while (t.countTokens() > 0) {
+                    String arg = t.nextToken();
+                    if (arg.equals("-v")) {
+                        verbose = true;
+                    } else if (arg.equals("-l")) {
+                        concurrentLocks = true;
+                    } else {
+                        usage();
+                        return;
+                    }
                 }
-                StackTrace jstack = new StackTrace(verbose, true);
+                StackTrace jstack = new StackTrace(verbose, concurrentLocks);
                 jstack.run(out);
             }
         },
@@ -1201,13 +1210,22 @@ public class CommandProcessor {
                 pmap.run(out, debugger.getAgent().getDebugger());
             }
         },
-        new Command("pstack", "pstack [-v]", false) {
+        new Command("pstack", "pstack [-v] [-l]", false) {
             public void doit(Tokens t) {
                 boolean verbose = false;
-                if (t.countTokens() > 0 && t.nextToken().equals("-v")) {
-                    verbose = true;
+                boolean concurrentLocks = false;
+                while (t.countTokens() > 0) {
+                    String arg = t.nextToken();
+                    if (arg.equals("-v")) {
+                        verbose = true;
+                    } else if (arg.equals("-l")) {
+                        concurrentLocks = true;
+                    } else {
+                        usage();
+                        return;
+                    }
                 }
-                PStack pstack = new PStack(verbose, true, debugger.getAgent());
+                PStack pstack = new PStack(verbose, concurrentLocks, debugger.getAgent());
                 pstack.run(out, debugger.getAgent().getDebugger());
             }
         },

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ConcurrentLocksPrinter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ConcurrentLocksPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,12 +31,14 @@ import sun.jvm.hotspot.oops.*;
 
 public class ConcurrentLocksPrinter {
     private final Map<JavaThread, List<Oop>> locksMap = new HashMap<>();
+    private PrintStream tty;
 
-    public ConcurrentLocksPrinter() {
+    public ConcurrentLocksPrinter(PrintStream tty) {
+        this.tty = tty;
         fillLocks();
     }
 
-    public void print(JavaThread jthread, PrintStream tty) {
+    public void print(JavaThread jthread) {
         List<Oop> locks = locksMap.get(jthread);
         tty.println("Locked ownable synchronizers:");
         if (locks == null || locks.isEmpty()) {
@@ -66,6 +68,7 @@ public class ConcurrentLocksPrinter {
         ObjectHeap heap = vm.getObjectHeap();
         // may be not loaded at all
         if (absOwnSyncKlass != null) {
+            tty.println("Finding concurrent locks. This might take a while...");
             heap.iterateObjectsOfKlass(new DefaultHeapVisitor() {
                     public boolean doObj(Oop oop) {
                         JavaThread thread = getOwnerThread(oop);
@@ -77,6 +80,7 @@ public class ConcurrentLocksPrinter {
                     }
 
                 }, absOwnSyncKlass, true);
+            tty.println();
         }
     }
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -72,7 +72,7 @@ public class PStack extends Tool {
          // compute and cache java Vframes.
          initJFrameCache();
          if (concurrentLocks) {
-            concLocksPrinter = new ConcurrentLocksPrinter();
+            concLocksPrinter = new ConcurrentLocksPrinter(out);
          }
          // print Java level deadlocks
          try {
@@ -192,7 +192,7 @@ public class PStack extends Tool {
             if (concurrentLocks) {
                JavaThread jthread = proxyToThread.get(th);
                if (jthread != null) {
-                   concLocksPrinter.print(jthread, out);
+                   concLocksPrinter.print(jthread);
                }
             }
          } // for threads

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/StackTrace.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/StackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class StackTrace extends Tool {
         try {
             ConcurrentLocksPrinter concLocksPrinter = null;
             if (concurrentLocks) {
-                concLocksPrinter = new ConcurrentLocksPrinter();
+                concLocksPrinter = new ConcurrentLocksPrinter(tty);
             }
             Threads threads = VM.getVM().getThreads();
             for (int i = 0; i < threads.getNumberOfThreads(); i++) {
@@ -123,9 +123,9 @@ public class StackTrace extends Tool {
                     }
                     tty.println();
                     if (concurrentLocks) {
-                        concLocksPrinter.print(cur, tty);
+                        concLocksPrinter.print(cur);
+                        tty.println();
                     }
-                    tty.println();
               }
           }
       }

--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,7 @@ serviceability/sa/ClhsdbJdis.java                             8307393   generic-
 serviceability/sa/ClhsdbJhisto.java                           8307393   generic-all
 serviceability/sa/ClhsdbJstack.java#id0                       8307393   generic-all
 serviceability/sa/ClhsdbJstack.java#id1                       8307393   generic-all
+serviceability/sa/ClhsdbJstackWithConcurrentLock.java         8307393   generic-all
 serviceability/sa/ClhsdbJstackXcompStress.java                8307393   generic-all
 serviceability/sa/ClhsdbLauncher.java                         8307393   generic-all
 serviceability/sa/ClhsdbLongConstant.java                     8307393   generic-all

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 resourcehogs/serviceability/sa/TestHeapDumpForLargeArray.java 8276539   generic-all
 serviceability/sa/CDSJMapClstats.java                         8276539   generic-all
 serviceability/sa/ClhsdbJhisto.java                           8276539   generic-all
+serviceability/sa/ClhsdbJstackWithConcurrentLock.java         8276539   generic-all
 serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java      8276539   generic-all
 
 serviceability/sa/ClhsdbFindPC.java#xcomp-core                8284045   generic-all

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
@@ -62,7 +62,7 @@ public class ClhsdbJstackWithConcurrentLock {
             String addressString = null;
             for (String line : lines) {
                 if (line.contains(key)) {
-                    String[] words = line.split(key + "|[, ]");
+                    String[] words = line.split("[, ]");
                     for (String word : words) {
                         word = word.replace("<", "").replace(">", "");
                         if (word.startsWith("0x")) {

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
@@ -64,7 +64,7 @@ public class ClhsdbJstackWithConcurrentLock {
                 if (line.contains(key)) {
                     String[] words = line.split(key + "|[, ]");
                     for (String word : words) {
-                        word = word.replace("<","").replace(">","");
+                        word = word.replace("<", "").replace(">", "");
                         if (word.startsWith("0x")) {
                             addressString = word;
                             break;

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbJstackWithConcurrentLock.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8192985
+ * @summary Test the clhsdb 'jstack -l' command
+ * @requires vm.hasSA
+ * @library /test/lib
+ * @run main/othervm/timeout=480 ClhsdbJstackWithConcurrentLock
+ */
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import jdk.test.lib.apps.LingeredApp;
+import jtreg.SkippedException;
+
+public class ClhsdbJstackWithConcurrentLock {
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Starting the ClhsdbJstackWithConcurrentLock test");
+
+        LingeredApp theApp = null;
+        try {
+            ClhsdbLauncher test = new ClhsdbLauncher();
+
+            theApp = new LingeredAppWithConcurrentLock();
+            LingeredApp.startApp(theApp, "-Xmx4m");
+            System.out.println("Started LingeredApp with pid " + theApp.getPid());
+
+            // Run the 'jstack -v -l' command to get the 
+            List<String> cmds = List.of("jstack -v -l");
+            String jstackOutput = test.run(theApp.getPid(), cmds, null, null);
+
+            // We are looking for:
+            //   Locked ownable synchronizers:
+            //    - <0x00000000ffc2ed70>, (a java/util/concurrent/locks/ReentrantLock$NonfairSync)
+            // We want to fetch the address from this line.
+            String key = ", (a java/util/concurrent/locks/ReentrantLock$NonfairSync)";
+            String[] lines = jstackOutput.split("\\R");
+            String addressString = null;
+            for (String line : lines) {
+                if (line.contains(key)) {
+                    String[] words = line.split(key + "|[, ]");
+                    for (String word : words) {
+                        word = word.replace("<","").replace(">","");
+                        if (word.startsWith("0x")) {
+                            addressString = word;
+                            break;
+                        }
+                    }
+                    if (addressString != null)
+                        break;
+                }
+            }
+            if (addressString == null) {
+                throw new RuntimeException("Token '" + key + "' not found in jstack output");
+            }
+
+            // We are looking for:
+            //  - jdk.internal.misc.Unsafe.park(boolean, long)...
+            //      - parking to wait for <0x00000000ffc2ed70> (a java/util/concurrent/locks/ReentrantLock$NonfairSync)
+            // Note the address matches the one we found above.
+            key = "- parking to wait for <" + addressString +
+                "> (a java/util/concurrent/locks/ReentrantLock$NonfairSync)";
+            boolean found = false;
+            for (String line : lines) {
+                if (line.contains(key)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                throw new RuntimeException("Token '" + key + "' not found in jstack output");
+            }
+        } catch (SkippedException e) {
+            throw e;
+        } catch (Exception ex) {
+            throw new RuntimeException("Test ERROR " + ex, ex);
+        } finally {
+            LingeredApp.stopApp(theApp);
+            System.out.println("OUTPUT: " + theApp.getOutput());
+        }
+        System.out.println("Test PASSED");
+    }
+}

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithConcurrentLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithConcurrentLock.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.apps.LingeredApp;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+public class LingeredAppWithConcurrentLock extends LingeredApp {
+
+    private static final Lock lock = new ReentrantLock();
+
+    public static void lockMethod(Lock lock) {
+        lock.lock();
+        synchronized (lock) {
+            try {
+                Thread.sleep(300000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static void main(String args[]) {
+        Thread classLock1 = new Thread(() -> lockMethod(lock));
+        Thread classLock2 = new Thread(() -> lockMethod(lock));
+        Thread classLock3 = new Thread(() -> lockMethod(lock));
+
+        classLock1.start();
+        classLock2.start();
+        classLock3.start();
+
+        // Wait until all threads have reached their blocked or timed wait state
+        while ((classLock1.getState() != Thread.State.WAITING &&
+                classLock1.getState() != Thread.State.TIMED_WAITING) ||
+               (classLock2.getState() != Thread.State.WAITING &&
+                classLock2.getState() != Thread.State.TIMED_WAITING) ||
+               (classLock3.getState() != Thread.State.WAITING &&
+                classLock3.getState() != Thread.State.TIMED_WAITING)) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ex) {
+            }
+        }
+        System.out.println("classLock1 state: " + classLock1.getState());
+        System.out.println("classLock2 state: " + classLock2.getState());
+        System.out.println("classLock3 state: " + classLock3.getState());
+        
+        LingeredApp.main(args);
+    }
+ }

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithConcurrentLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithConcurrentLock.java
@@ -66,7 +66,7 @@ public class LingeredAppWithConcurrentLock extends LingeredApp {
         System.out.println("classLock1 state: " + classLock1.getState());
         System.out.println("classLock2 state: " + classLock2.getState());
         System.out.println("classLock3 state: " + classLock3.getState());
-        
+
         LingeredApp.main(args);
     }
  }

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ import jdk.test.lib.util.CoreUtils;
  *
  *  After app termination (stopApp/waitAppTermination) its output is available
  *
- *   output = a.getAppOutput();
+ *   output = a.getOutput();
  *
  */
 public class LingeredApp {


### PR DESCRIPTION
I noticed that "clhsdb jstack" seemed to hang when I attached to process with a somewhat large heap. It had taken over 10 minutes when I finally decided to have a look at the SA process (using bin/jstack), which came up with the following in the stack:

```
at sun.jvm.hotspot.oops.ObjectHeap.iterateObjectsOfKlass([jdk.hotspot.agent@23-internal](jdk.hotspot.agent@23-internal)/ObjectHeap.java:117)
at sun.jvm.hotspot.runtime.ConcurrentLocksPrinter.fillLocks([jdk.hotspot.agent@23-internal](jdk.hotspot.agent@23-internal)/ConcurrentLocksPrinter.java:70)
at sun.jvm.hotspot.runtime.ConcurrentLocksPrinter.<init>([jdk.hotspot.agent@23-internal](jdk.hotspot.agent@23-internal)/ConcurrentLocksPrinter.java:36)
at sun.jvm.hotspot.tools.StackTrace.run([jdk.hotspot.agent@23-internal](jdk.hotspot.agent@23-internal)/StackTrace.java:71)
```

This code is meant to print information about j.u.c. locks. It it works by searching the entire java heap for instances of AbstractOwnableSynchronizer. This is a very expensive operation because it means not only does SA need to read in the entire java heap, but it needs to create a Klass mirror for every heap object so it can determine its type.

Our testing doesn't seem to run into this slowness problem because "clhsdb jstack" only iterates over the heap if AbstractOwnableSynchronizer has been loaded, which it won't be if no j.u.c. locks have been created. This seems to be the case wherever we use "clhsdb jstack" in testing. We do have some tests that likely result in j.u.c locks, but they all use "jhsdb jstack", which doesn't have this issue (it requires use of the --locks argument to enable printing of j.u.c locks).

This issue was already called out in [JDK-8262098](https://bugs.openjdk.org/browse/JDK-8262098). For this CR I am proposing that "clhsdb jstack" not include j.u.c lock scanning by default, and add the -l argument to enable it. This will make it similar to bin/jstack, which also has a -l argument, and to "clhsdb jstack", which has a --locks argument (which maps internally to the Jstack.java -l argument).

The same changes are also being made to "clhsdb pstack".

Tested with all tier1, tier2, and tier5 svc tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324066](https://bugs.openjdk.org/browse/JDK-8324066): "clhsdb jstack" should not by default scan for j.u.c locks because it can be very slow (**Enhancement** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) ⚠️ Review applies to [814739bb](https://git.openjdk.org/jdk/pull/17479/files/814739bb72cd4332c7e33d98a092b3cdad452713)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17479/head:pull/17479` \
`$ git checkout pull/17479`

Update a local copy of the PR: \
`$ git checkout pull/17479` \
`$ git pull https://git.openjdk.org/jdk.git pull/17479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17479`

View PR using the GUI difftool: \
`$ git pr show -t 17479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17479.diff">https://git.openjdk.org/jdk/pull/17479.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17479#issuecomment-1897686092)