### PR TITLE
8324123: aarch64: fix prfm literal encoding in assembler

### DIFF
--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -187,6 +187,8 @@ void Address::lea(MacroAssembler *as, Register r) const {
     zrf(Rd, 0);
   }
 
+// This encoding is similar (but not quite identical) to the encoding used
+// by literal ld/st. see JDK-8324123.
 void Assembler::prfm(const Address &adr, prfop pfop) {
   if (adr.getMode() == Address::literal) {
     starti;

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -193,8 +193,7 @@ void Address::lea(MacroAssembler *as, Register r) const {
 void Assembler::prfm(const Address &adr, prfop pfop) {
   Address::mode mode = adr.getMode();
   // PRFM does not support pre/post index
-  guarantee((mode != Address::pre), "prfm does not support pre index");
-  guarantee((mode != Address::post), "prfm does not support post index");
+  guarantee((mode != Address::pre) && (mode != Address::post), "prfm does not support pre/post indexing");
   if (mode == Address::literal) {
     starti;
     f(0b11, 31, 30), f(0b011, 29, 27), f(0b000, 26, 24);

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -189,6 +189,8 @@ void Address::lea(MacroAssembler *as, Register r) const {
 
 // This encoding is similar (but not quite identical) to the encoding used
 // by literal ld/st. see JDK-8324123.
+// FIXME: PRFM should not be used with writeback modes, but the assembler
+// doesn't enfore that.
 void Assembler::prfm(const Address &adr, prfop pfop) {
   if (adr.getMode() == Address::literal) {
     starti;

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -187,6 +187,18 @@ void Address::lea(MacroAssembler *as, Register r) const {
     zrf(Rd, 0);
   }
 
+void Assembler::prfm(const Address &adr, prfop pfop) {
+  if (adr.getMode() == Address::literal) {
+    starti;
+    f(0b11, 31, 30), f(0b011, 29, 27), f(0b000, 26, 24);
+    f(pfop, 4, 0);
+    int64_t offset = (adr.target() - pc()) >> 2;
+    sf(offset, 23, 5);
+  } else {
+    ld_st2(as_Register(pfop), adr, 0b11, 0b10);
+  }
+}
+
 // An "all-purpose" add/subtract immediate, per ARM documentation:
 // A "programmer-friendly" assembler may accept a negative immediate
 // between -(2^24 -1) and -1 inclusive, causing it to convert a

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.cpp
@@ -193,8 +193,6 @@ void Address::lea(MacroAssembler *as, Register r) const {
 void Assembler::prfm(const Address &adr, prfop pfop) {
   Address::mode mode = adr.getMode();
   // PRFM does not support pre/post index
-  // Passing Address with pre/post mode to ld_st2 will generate an undefined instruction.
-  // So use guarantee to avoid pre/post mode Address operand
   guarantee((mode != Address::pre), "prfm does not support pre index");
   guarantee((mode != Address::post), "prfm does not support post index");
   if (mode == Address::literal) {

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -1576,7 +1576,15 @@ public:
 
 #define INSN(NAME, size, op)                                    \
   void NAME(const Address &adr, prfop pfop = PLDL1KEEP) {       \
-    ld_st2(as_Register(pfop), adr, size, op);                   \
+    if (adr.getMode() == Address::literal) {                    \
+      starti;                                                   \
+      f(0b11, 31, 30), f(0b011, 29, 27), f(0b000, 26, 24);      \
+      f(pfop, 4, 0);                                            \
+      int64_t offset = (adr.target() - pc()) >> 2;              \
+      sf(offset, 23, 5);                                        \
+    } else {                                                    \
+      ld_st2(as_Register(pfop), adr, size, op);                 \
+    }                                                           \
   }
 
   INSN(prfm, 0b11, 0b10); // FIXME: PRFM should not be used with

--- a/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/assembler_aarch64.hpp
@@ -797,6 +797,8 @@ public:
 
   void adrp(Register Rd, const Address &dest, uint64_t &offset) = delete;
 
+  void prfm(const Address &adr, prfop pfop = PLDL1KEEP);
+
 #undef INSN
 
   void add_sub_immediate(Instruction_aarch64 &current_insn, Register Rd, Register Rn,
@@ -1571,25 +1573,6 @@ public:
   INSN(ldrsh,  0b01, 0b10);
   INSN(ldrshw, 0b01, 0b11);
   INSN(ldrsw,  0b10, 0b10);
-
-#undef INSN
-
-#define INSN(NAME, size, op)                                    \
-  void NAME(const Address &adr, prfop pfop = PLDL1KEEP) {       \
-    if (adr.getMode() == Address::literal) {                    \
-      starti;                                                   \
-      f(0b11, 31, 30), f(0b011, 29, 27), f(0b000, 26, 24);      \
-      f(pfop, 4, 0);                                            \
-      int64_t offset = (adr.target() - pc()) >> 2;              \
-      sf(offset, 23, 5);                                        \
-    } else {                                                    \
-      ld_st2(as_Register(pfop), adr, size, op);                 \
-    }                                                           \
-  }
-
-  INSN(prfm, 0b11, 0b10); // FIXME: PRFM should not be used with
-                          // writeback modes, but the assembler
-                          // doesn't enfore that.
 
 #undef INSN
 


### PR DESCRIPTION
Current prfm literal mode encoding in aarch64 assembler is not correct.
The prfm_literal instruction requires 31 and 30 bits to be 0x11, while current assembler encodes the two bits to be 0x11, which is a ldr instruction, not prfm.
For example, if adding the following code in stubGenerator
__ prfm(Address(__ pc()))
we get a ldr instruction like
   ldr x0, 0x0000ffff83f8539c
but it should be a prfm instruction like
   prfm pldl1keep, 0x0000ffff8ff8539c

The bug is caused in ld_st2, literal mode, bit 31 and 30 bits are set to (size & 0b01), while for prfm instructions, 31 and 30 bits must be 0b11.
  void ld_st2(Register Rt, const Address &adr, int size, int op, int V = 0) {
    starti;

    f(V, 26); // general reg?
    zrf(Rt, 0);

    // Encoding for literal loads is done here (rather than pushed
    // down into Address::encode) because the encoding of this
    // instruction is too different from all of the other forms to
    // make it worth sharing.
    if (adr.getMode() == Address::literal) {
      assert(size == 0b10 || size == 0b11, "bad operand size in ldr");
      assert(op == 0b01, "literal form can only be used with loads");
      f(**size & 0b01, 31, 30**), f(0b011, 29, 27), f(0b00, 25, 24);
      int64_t offset = (adr.target() - pc()) >> 2;
      sf(offset, 23, 5);
      code_section()->relocate(pc(), adr.rspec());
      return;
    }

    f(size, 31, 30);
    f(op, 23, 22); // str
    adr.encode(&current_insn);
  }

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324123](https://bugs.openjdk.org/browse/JDK-8324123): aarch64: fix prfm literal encoding in assembler (**Bug** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [11d46ff7](https://git.openjdk.org/jdk/pull/17482/files/11d46ff74c1b4e532385a5494a5dc3c6323c7618)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17482/head:pull/17482` \
`$ git checkout pull/17482`

Update a local copy of the PR: \
`$ git checkout pull/17482` \
`$ git pull https://git.openjdk.org/jdk.git pull/17482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17482`

View PR using the GUI difftool: \
`$ git pr show -t 17482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17482.diff">https://git.openjdk.org/jdk/pull/17482.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17482#issuecomment-1898174841)