### PR TITLE
8323657: Compilation of snippet results in VerifyError at runtime with --release 9 (and above)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/StringConcat.java
@@ -37,6 +37,7 @@ import com.sun.tools.javac.util.*;
 import static com.sun.tools.javac.code.Kinds.Kind.MTH;
 import static com.sun.tools.javac.code.TypeTag.*;
 import static com.sun.tools.javac.jvm.ByteCodes.*;
+import static com.sun.tools.javac.tree.JCTree.Tag.LITERAL;
 import static com.sun.tools.javac.tree.JCTree.Tag.PLUS;
 import com.sun.tools.javac.jvm.Items.*;
 
@@ -416,7 +417,7 @@ public abstract class StringConcat {
                 for (JCTree arg : t) {
                     Object constVal = arg.type.constValue();
                     if ("".equals(constVal)) continue;
-                    if (arg.type == syms.botType) {
+                    if (arg.type == syms.botType && arg.hasTag(LITERAL)) {
                         // Concat the null into the recipe right away
                         recipe.append((String) null);
                     } else if (constVal != null) {

--- a/test/langtools/tools/javac/StringConcat/StringConcatWithAssignments.java
+++ b/test/langtools/tools/javac/StringConcat/StringConcatWithAssignments.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @compile StringConcatWithAssignments.java
+ * @run main StringConcatWithAssignments
+ * @compile -XDstringConcat=inline StringConcatWithAssignments.java
+ * @run main StringConcatWithAssignments
+ * @compile -XDstringConcat=indy StringConcatWithAssignments.java
+ * @run main StringConcatWithAssignments
+ * @compile -XDstringConcat=indyWithConstants StringConcatWithAssignments.java
+ * @run main StringConcatWithAssignments
+ */
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class StringConcatWithAssignments {
+    public static void main(String[] args) {
+        StringConcatWithAssignments instance = new StringConcatWithAssignments();
+        assertEquals("nulltrue", instance.assignment());
+        assertEquals("nulltrue", instance.invocation());
+    }
+    private String assignment() {
+        boolean b;
+        return ((((b = true) ? null : null) + "") + b);
+    }
+    private String invocation() {
+        StringBuilder sideEffect = new StringBuilder();
+        Supplier<Boolean> provider = () -> {
+            sideEffect.append(true);
+            return true;
+        };
+        return (((provider.get() ? null : null) + "") + sideEffect.toString());
+    }
+    private static void assertEquals(Object o1, Object o2) {
+        if (!Objects.equals(o1, o2)) {
+            throw new AssertionError("Expected that '" + o1 + "' and " +
+                                     "'" + o2 + "' are equal.");
+        }
+    }
+}


### PR DESCRIPTION
Consider code like:
```
public class Test {
    public static void main(String... args) {
        System.err.println((test() ? null : null) + "");
    }
    private static boolean test() {
        System.err.println("test called!");
        return true;
    }
}
```

This should print:
```
test called!
null
```

but it prints:
```
$ java /tmp/Test.java
null
```

The correct semantics can be achieved by using `--source 8`:
```
$ java --source 8 /tmp/Test.java
test called!
null
```

Or `-XDstringConcat=inline` when compiling.

The reason is that when `StringConcat.IndyConstants` converts String concatenation parameters, it will short-circuit any expressions whose type is BOT (i.e. basically the `null` type). But, in this case, the expression that has the BOT type is a complex expression with a side-effect, so short-circuiting it leads to a broken semantics.

My proposal is to "short-circuit" only `null` literals, and generate other expressions normally. There may be some corner cases where we'd generate the expression unnecessarily (if it does not have any side-effect), but looking for side-effects seems unnecessarily complex and fragile given I'd expect non-trivial expressions with the BOT type are very rare. (The only case which comes to mind is exactly the above one - a conditional expressions, whose both result values are `null`.)

Please note that when the expression is incorrectly short-circuited, it may lead to various other effects - the original bug report shows a case where the resulting code does not pass the verification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323657](https://bugs.openjdk.org/browse/JDK-8323657): Compilation of snippet results in VerifyError at runtime with --release 9 (and above) (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17483/head:pull/17483` \
`$ git checkout pull/17483`

Update a local copy of the PR: \
`$ git checkout pull/17483` \
`$ git pull https://git.openjdk.org/jdk.git pull/17483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17483`

View PR using the GUI difftool: \
`$ git pr show -t 17483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17483.diff">https://git.openjdk.org/jdk/pull/17483.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17483#issuecomment-1898272748)