### PR TITLE
8309460: JScrollBar leaves behind clutter for non-integer UI scales

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1179,7 +1179,6 @@ public class BasicScrollBarUI
                 }
             }
             scrollbar.setValue(newValue);
-
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1179,6 +1179,7 @@ public class BasicScrollBarUI
                 }
             }
             scrollbar.setValue(newValue);
+
         }
     }
 
@@ -1188,6 +1189,8 @@ public class BasicScrollBarUI
      */
     protected void scrollByUnit(int direction)  {
         scrollByUnits(scrollbar, direction, 1, false);
+        Rectangle r = getTrackBounds();
+        scrollbar.repaint(r.x, r.y, r.width, r.height);
     }
 
     /**
@@ -1376,6 +1379,8 @@ public class BasicScrollBarUI
                 updateThumbState(currentMouseX, currentMouseY);
                 startScrollTimerIfNecessary();
             }
+            Rectangle r = getTrackBounds();
+            scrollbar.repaint(r.x, r.y, r.width, r.height);
         }
 
         private void setValueFrom(MouseEvent e) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicScrollBarUI.java
@@ -1188,8 +1188,7 @@ public class BasicScrollBarUI
      */
     protected void scrollByUnit(int direction)  {
         scrollByUnits(scrollbar, direction, 1, false);
-        Rectangle r = getTrackBounds();
-        scrollbar.repaint(r.x, r.y, r.width, r.height);
+        scrollbar.repaint(getTrackBounds());
     }
 
     /**
@@ -1378,8 +1377,7 @@ public class BasicScrollBarUI
                 updateThumbState(currentMouseX, currentMouseY);
                 startScrollTimerIfNecessary();
             }
-            Rectangle r = getTrackBounds();
-            scrollbar.repaint(r.x, r.y, r.width, r.height);
+            scrollbar.repaint(getTrackBounds());
         }
 
         private void setValueFrom(MouseEvent e) {

--- a/test/jdk/javax/swing/JScrollBar/JScrollBarArtifactTest.java
+++ b/test/jdk/javax/swing/JScrollBar/JScrollBarArtifactTest.java
@@ -30,7 +30,8 @@ import javax.swing.SwingUtilities;
 /*
  * @test
  * @bug 8309460
- * @summary Verifies clicking JComboBox during frame closure causes Exception
+ * @summary Verifies JScrollBar doesn't leaves behind clutter when dragged
+            or clicked on right arrow button
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual JScrollBarArtifactTest
@@ -39,7 +40,7 @@ import javax.swing.SwingUtilities;
 public class JScrollBarArtifactTest {
     private static final String instructionsText = """
             This test is used to verify that dragging scrollbar or clicking
-            on right scrollbar thumb does nto leave behing lines or artifacts.
+            on right scrollbar thumb does not leave behing lines or artifacts.
 
             A horizontal JScrollBar is shown.
             Drag the scrollbar without releasing mouse.

--- a/test/jdk/javax/swing/JScrollBar/JScrollBarArtifactTest.java
+++ b/test/jdk/javax/swing/JScrollBar/JScrollBarArtifactTest.java
@@ -44,7 +44,7 @@ public class JScrollBarArtifactTest {
             A horizontal JScrollBar is shown.
             Drag the scrollbar without releasing mouse.
             Additionally, keep right arrow button pressed to move the scrollbar.
-            If lines are left behind in both cases, please click Fail 
+            If lines are left behind in both cases, please click Fail
             otherwise click Pass.  """;
 
     public static void main(String[] args) throws Exception {

--- a/test/jdk/javax/swing/JScrollBar/JScrollBarArtifactTest.java
+++ b/test/jdk/javax/swing/JScrollBar/JScrollBarArtifactTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JScrollBar;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 8309460
+ * @summary Verifies clicking JComboBox during frame closure causes Exception
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual JScrollBarArtifactTest
+ */
+
+public class JScrollBarArtifactTest {
+    private static final String instructionsText = """
+            This test is used to verify that dragging scrollbar or clicking
+            on right scrollbar thumb does nto leave behing lines or artifacts.
+
+            A horizontal JScrollBar is shown.
+            Drag the scrollbar without releasing mouse.
+            Additionally, keep right arrow button pressed to move the scrollbar.
+            If lines are left behind in both cases, please click Fail 
+            otherwise click Pass.  """;
+
+    public static void main(String[] args) throws Exception {
+        System.setProperty("sun.java2d.uiScale", "2.3");
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("ComboPopup Instructions")
+                .instructions(instructionsText)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(35)
+                .build();
+
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame();
+            JPanel panel = new JPanel(new BorderLayout());
+            JScrollBar sb = new JScrollBar(JScrollBar.HORIZONTAL);
+            panel.add(sb, "South");
+            frame.setContentPane(panel);
+            frame.setSize(500, 200);
+
+            PassFailJFrame.addTestWindow(frame);
+            PassFailJFrame.positionTestWindow(frame,
+                    PassFailJFrame.Position.VERTICAL);
+
+            frame.setVisible(true);
+        });
+
+        passFailJFrame.awaitAndCheck();
+    }
+}
+


### PR DESCRIPTION
Lines  are left behind when moving the scrollbar in the positive direction. but are cleaned up on mouse release. 
Additonally, with right arrow clicks too, the lines are left behind.
Seems like for mouseDragged and scrollByUnit, the dirty region of the scrollbar is not repainted leading to artifacts
which is being done in this fix..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309460](https://bugs.openjdk.org/browse/JDK-8309460): JScrollBar leaves behind clutter for non-integer UI scales (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17484/head:pull/17484` \
`$ git checkout pull/17484`

Update a local copy of the PR: \
`$ git checkout pull/17484` \
`$ git pull https://git.openjdk.org/jdk.git pull/17484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17484`

View PR using the GUI difftool: \
`$ git pr show -t 17484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17484.diff">https://git.openjdk.org/jdk/pull/17484.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17484#issuecomment-1898298219)