### PR TITLE
8324132: G1: Remove unimplemented G1MonitoringSupport::recalculate_eden_size

### DIFF
--- a/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
+++ b/src/hotspot/share/gc/g1/g1MonitoringSupport.hpp
@@ -180,8 +180,6 @@ class G1MonitoringSupport : public CHeapObj<mtGC> {
   // Recalculate all the sizes.
   void recalculate_sizes();
 
-  void recalculate_eden_size();
-
 public:
   G1MonitoringSupport(G1CollectedHeap* g1h);
   ~G1MonitoringSupport();


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324132](https://bugs.openjdk.org/browse/JDK-8324132): G1: Remove unimplemented G1MonitoringSupport::recalculate_eden_size (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17485/head:pull/17485` \
`$ git checkout pull/17485`

Update a local copy of the PR: \
`$ git checkout pull/17485` \
`$ git pull https://git.openjdk.org/jdk.git pull/17485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17485`

View PR using the GUI difftool: \
`$ git pr show -t 17485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17485.diff">https://git.openjdk.org/jdk/pull/17485.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17485#issuecomment-1898504734)