### PR TITLE
8324129: C2: Remove some ttyLocker usages in preparation for JDK-8306767

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,9 +236,9 @@ const ImmutableOopMap* CodeBlob::oop_map_for_return_address(address return_addre
   return _oop_maps->find_map_at_offset((intptr_t) return_address - (intptr_t) code_begin());
 }
 
-void CodeBlob::print_code() {
+void CodeBlob::print_code_on(outputStream* st) {
   ResourceMark m;
-  Disassembler::decode(this, tty);
+  Disassembler::decode(this, st);
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,7 @@ public:
   virtual void print_on(outputStream* st) const;
   virtual void print_value_on(outputStream* st) const;
   void dump_for_addr(address addr, outputStream* st, bool verbose) const;
-  void print_code();
+  void print_code_on(outputStream* st);
 
   // Print to stream, any comments associated with offset.
   virtual void print_block_comment(outputStream* stream, address block_begin) const {

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -687,12 +687,15 @@ address CompiledMethod::continuation_for_implicit_exception(address pc, bool for
     ResourceMark rm(thread);
     CodeBlob* cb = CodeCache::find_blob(pc);
     assert(cb != nullptr && cb == this, "");
-    ttyLocker ttyl;
-    tty->print_cr("implicit exception happened at " INTPTR_FORMAT, p2i(pc));
-    print();
-    method()->print_codes();
-    print_code();
-    print_pcs();
+
+    // Keep tty output consistent. To avoid ttyLocker, we buffer in stream, and print all at once.
+    stringStream ss;
+    ss.print_cr("implicit exception happened at " INTPTR_FORMAT, p2i(pc));
+    print_on(&ss);
+    method()->print_codes_on(&ss);
+    print_code_on(&ss);
+    print_pcs_on(&ss);
+    tty->print("%s", ss.as_string()); // print all at once
   }
 #endif
   if (cont_offset == 0) {

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,7 +227,7 @@ public:
   virtual bool is_osr_method() const = 0;
   virtual int osr_entry_bci() const = 0;
   Method* method() const                          { return _method; }
-  virtual void print_pcs() = 0;
+  virtual void print_pcs_on(outputStream* st) = 0;
   bool is_native_method() const { return _method != nullptr && _method->is_native(); }
   bool is_java_method() const { return _method != nullptr && !_method->is_native(); }
 

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1021,7 +1021,7 @@ void nmethod::print_nmethod(bool printmethod) {
       tty->print_cr("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
       print_metadata(tty);
       tty->print_cr("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
-      print_pcs();
+      print_pcs_on(tty);
       tty->print_cr("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ");
       if (oop_maps() != nullptr) {
         tty->print("oop maps:"); // oop_maps()->print_on(tty) outputs a cr() at the beginning

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -621,7 +621,6 @@ public:
 #if defined(SUPPORT_DATA_STRUCTS)
   // print output in opt build for disassembler library
   void print_relocations()                        PRODUCT_RETURN;
-  void print_pcs() { print_pcs_on(tty); }
   void print_pcs_on(outputStream* st);
   void print_scopes() { print_scopes_on(tty); }
   void print_scopes_on(outputStream* st)          PRODUCT_RETURN;
@@ -635,8 +634,7 @@ public:
   void print_oops(outputStream* st);     // oops from the underlying CodeBlob.
   void print_metadata(outputStream* st); // metadata in metadata pool.
 #else
-  // void print_pcs()                             PRODUCT_RETURN;
-  void print_pcs()                                { return; }
+  void print_pcs_on(outputStream* st) { return; }
 #endif
 
   void print_calls(outputStream* st)              PRODUCT_RETURN;

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -192,10 +192,13 @@ void BytecodeTracer::print_method_codes(const methodHandle& method, int from, in
   BytecodeStream s(method);
   s.set_interval(from, to);
 
-  ttyLocker ttyl;  // keep the following output coherent
+  // Keep output to st coherent: collect all lines and print at once.
+  ResourceMark rm;
+  stringStream ss;
   while (s.next() >= 0) {
-    method_printer.trace(method, s.bcp(), st);
+    method_printer.trace(method, s.bcp(), &ss);
   }
+  st->print("%s", ss.as_string());
 }
 
 void BytecodePrinter::print_constant(int cp_index, outputStream* st) {

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -540,38 +540,38 @@ bool Method::was_executed_more_than(int n) {
   }
 }
 
-void Method::print_invocation_count() {
+void Method::print_invocation_count(outputStream* st) {
   //---<  compose+print method return type, klass, name, and signature  >---
-  if (is_static()) tty->print("static ");
-  if (is_final()) tty->print("final ");
-  if (is_synchronized()) tty->print("synchronized ");
-  if (is_native()) tty->print("native ");
-  tty->print("%s::", method_holder()->external_name());
-  name()->print_symbol_on(tty);
-  signature()->print_symbol_on(tty);
+  if (is_static())       { st->print("static "); }
+  if (is_final())        { st->print("final "); }
+  if (is_synchronized()) { st->print("synchronized "); }
+  if (is_native())       { st->print("native "); }
+  st->print("%s::", method_holder()->external_name());
+  name()->print_symbol_on(st);
+  signature()->print_symbol_on(st);
 
   if (WizardMode) {
     // dump the size of the byte codes
-    tty->print(" {%d}", code_size());
+    st->print(" {%d}", code_size());
   }
-  tty->cr();
+  st->cr();
 
   // Counting based on signed int counters tends to overflow with
   // longer-running workloads on fast machines. The counters under
   // consideration here, however, are limited in range by counting
   // logic. See InvocationCounter:count_limit for example.
   // No "overflow precautions" need to be implemented here.
-  tty->print_cr ("  interpreter_invocation_count: " INT32_FORMAT_W(11), interpreter_invocation_count());
-  tty->print_cr ("  invocation_counter:           " INT32_FORMAT_W(11), invocation_count());
-  tty->print_cr ("  backedge_counter:             " INT32_FORMAT_W(11), backedge_count());
+  st->print_cr ("  interpreter_invocation_count: " INT32_FORMAT_W(11), interpreter_invocation_count());
+  st->print_cr ("  invocation_counter:           " INT32_FORMAT_W(11), invocation_count());
+  st->print_cr ("  backedge_counter:             " INT32_FORMAT_W(11), backedge_count());
 
   if (method_data() != nullptr) {
-    tty->print_cr ("  decompile_count:              " UINT32_FORMAT_W(11), method_data()->decompile_count());
+    st->print_cr ("  decompile_count:              " UINT32_FORMAT_W(11), method_data()->decompile_count());
   }
 
 #ifndef PRODUCT
   if (CountCompiledCalls) {
-    tty->print_cr ("  compiled_invocation_count:    " INT64_FORMAT_W(11), compiled_invocation_count());
+    st->print_cr ("  compiled_invocation_count:    " INT64_FORMAT_W(11), compiled_invocation_count());
   }
 #endif
 }

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -454,7 +454,7 @@ public:
   void mask_for(int bci, InterpreterOopMap* mask);
 
   // operations on invocation counter
-  void print_invocation_count();
+  void print_invocation_count(outputStream* st);
 
   // byte codes
   void    set_code(address code)      { return constMethod()->set_code(code); }

--- a/src/hotspot/share/runtime/vframe.inline.hpp
+++ b/src/hotspot/share/runtime/vframe.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,14 +159,16 @@ inline void vframeStreamCommon::fill_from_compiled_frame(int decode_offset) {
     // as it were a native compiled frame (no Java-level assumptions).
 #ifdef ASSERT
     if (WizardMode) {
-      ttyLocker ttyl;
-      tty->print_cr("Error in fill_from_frame: pc_desc for "
-                    INTPTR_FORMAT " not found or invalid at %d",
-                    p2i(_frame.pc()), decode_offset);
-      nm()->print();
-      nm()->method()->print_codes();
-      nm()->print_code();
-      nm()->print_pcs();
+      // Keep tty output consistent. To avoid ttyLocker, we buffer in stream, and print all at once.
+      stringStream ss;
+      ss.print_cr("Error in fill_from_frame: pc_desc for "
+                  INTPTR_FORMAT " not found or invalid at %d",
+                  p2i(_frame.pc()), decode_offset);
+      nm()->print_on(&ss);
+      nm()->method()->print_codes_on(&ss);
+      nm()->print_code_on(&ss);
+      nm()->print_pcs_on(&ss);
+      tty->print("%s", ss.as_string()); // print all at once
     }
     found_bad_method_frame();
 #endif


### PR DESCRIPTION
I'm removing some instances of `ttyLocker`. Instead of locking, I first put all the output on a `stringStream`, and then print this stream all at once, which is atomic.

Removing the `ttyLocker` is nice, because it means we have less interference with other locking mechanisms, such as the `extra_data_lock` cases I have to introduce with [JDK-8306767](https://bugs.openjdk.org/browse/JDK-8306767).

@coleenp wished that I do this separately, so I filed this RFE here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324129](https://bugs.openjdk.org/browse/JDK-8324129): C2: Remove some ttyLocker usages in preparation for JDK-8306767 (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17486/head:pull/17486` \
`$ git checkout pull/17486`

Update a local copy of the PR: \
`$ git checkout pull/17486` \
`$ git pull https://git.openjdk.org/jdk.git pull/17486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17486`

View PR using the GUI difftool: \
`$ git pr show -t 17486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17486.diff">https://git.openjdk.org/jdk/pull/17486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17486#issuecomment-1898704106)