### PR TITLE
8324147: Serial: Remove generation::compute_new_size

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -250,7 +250,7 @@ class DefNewGeneration: public Generation {
   void reset_scratch();
 
   // GC support
-  virtual void compute_new_size();
+  void compute_new_size();
 
   // Returns true if the collection is likely to be safely
   // completed. Even if this method returns true, a collection

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -248,11 +248,6 @@ class Generation: public CHeapObj<mtGC> {
   // generation since the last call to "save_marks".
   virtual bool no_allocs_since_save_marks() = 0;
 
-  // When an older generation has been collected, and perhaps resized,
-  // this method will be invoked on all younger generations (from older to
-  // younger), allowing them to resize themselves as appropriate.
-  virtual void compute_new_size() = 0;
-
   // Printing
   virtual const char* name() const = 0;
   virtual const char* short_name() const = 0;

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -81,7 +81,7 @@ class TenuredGeneration: public Generation {
 
   void compute_new_size_inner();
  public:
-  virtual void compute_new_size();
+  void compute_new_size();
 
   TenuredSpace* space() const { return _the_space; }
 


### PR DESCRIPTION
Trivial removing effectively dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324147](https://bugs.openjdk.org/browse/JDK-8324147): Serial: Remove generation::compute_new_size (**Enhancement** - P4)


### Reviewers
 * [Erik Duveblad](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17487/head:pull/17487` \
`$ git checkout pull/17487`

Update a local copy of the PR: \
`$ git checkout pull/17487` \
`$ git pull https://git.openjdk.org/jdk.git pull/17487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17487`

View PR using the GUI difftool: \
`$ git pr show -t 17487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17487.diff">https://git.openjdk.org/jdk/pull/17487.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17487#issuecomment-1898736634)