### PR TITLE
8323994: gtest runner repeats test name for every single gtest assertion

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestResultParser.java
+++ b/test/hotspot/jtreg/gtest/GTestResultParser.java
@@ -57,7 +57,10 @@ public class GTestResultParser {
                             testCase = xmlReader.getAttributeValue("", "name");
                             break;
                         case "failure":
-                            failedTests.add(testSuite + "::" + testCase);
+                            String failedStr = testSuite + "::" + testCase;
+                            if (! failedTests.contains(failedStr)) {
+                                failedTests.add(failedStr);
+                            }
                             break;
                         default:
                             // ignore


### PR DESCRIPTION
If GTest fails multiple times within the same test (for example when EXPECT or ASSERT are used in a subroutine), `GTestResultParser` repeats the failing test multiple times in its report. 

Please refer to the existing issue for an example. 

We only need to see the failing test reported once, so this patch fixes that. 

Let me know your thoughts. 
Cheers, 
Sonia