### PR TITLE
8324161: validate-source fails after JDK-8275338

### DIFF
--- a/test/jdk/jdk/jfr/event/io/TestSerializationMisdeclarationEvent.java
+++ b/test/jdk/jdk/jfr/event/io/TestSerializationMisdeclarationEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
A trivial fix to the copyright line in test/jdk/jdk/jfr/event/io/TestSerializationMisdeclarationEvent.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324161](https://bugs.openjdk.org/browse/JDK-8324161): validate-source fails after JDK-8275338 (**Bug** - P1)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17490/head:pull/17490` \
`$ git checkout pull/17490`

Update a local copy of the PR: \
`$ git checkout pull/17490` \
`$ git pull https://git.openjdk.org/jdk.git pull/17490/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17490`

View PR using the GUI difftool: \
`$ git pr show -t 17490`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17490.diff">https://git.openjdk.org/jdk/pull/17490.diff</a>

</details>
