### PR TITLE
8324065: Daylight saving information for `Africa/Casablanca` are incorrect

### DIFF
--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfo.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,14 +45,14 @@ import java.util.TimeZone;
  * for the {@link #getOffset(int,int,int,int,int,int) getOffset}
  * method that takes Gregorian calendar date fields.
  * <p>
- * This table covers transitions from 1900 until 2037 (as of version
- * 1.4), Before 1900, it assumes that there was no daylight saving
+ * This table covers transitions from 1900 until 2100 (as of version
+ * 23), Before 1900, it assumes that there was no daylight saving
  * time and the <code>getOffset</code> methods always return the
  * {@link #getRawOffset} value. No Local Mean Time is supported. If a
  * specified date is beyond the transition table and this time zone is
- * supposed to observe daylight saving time in 2037, it delegates
+ * supposed to observe daylight saving time in 2100, it delegates
  * operations to a {@link java.util.SimpleTimeZone SimpleTimeZone}
- * object created using the daylight saving time schedule as of 2037.
+ * object created using the daylight saving time schedule as of 2100.
  * <p>
  * The date items, transitions, GMT offset(s), etc. are read from a database
  * file. See {@link ZoneInfoFile} for details.

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -814,6 +814,8 @@ public final class ZoneInfoFile {
     private static final long DST_MASK = 0xf0L;
     private static final int  DST_NSHIFT = 4;
     private static final int  TRANSITION_NSHIFT = 12;
+    // The `last` year that transitions are accounted for. If there are
+    // rules that go beyond this LASTYEAR, the value needs to be expanded.
     private static final int  LASTYEAR = 2100;
 
     // from: 0 for offset lookup, 1 for dstsvings lookup

--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -406,16 +406,16 @@ public final class ZoneInfoFile {
     // ZoneInfo starts with UTC1900
     private static final long UTC1900 = -2208988800L;
 
-    // ZoneInfo ends with   UTC2037
-    // LocalDateTime.of(2038, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) - 1;
-    private static final long UTC2037 = 2145916799L;
+    // ZoneInfo ends with   UTC2100
+    // LocalDateTime.of(2101, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) - 1;
+    private static final long UTC2100 = 4133980799L;
 
-    // ZoneInfo has an ending entry for 2037, this need to be offset by
+    // ZoneInfo has an ending entry for 2100, this need to be offset by
     // a "rawOffset"
-    // LocalDateTime.of(2037, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC));
-    private static final long LDT2037 = 2114380800L;
+    // LocalDateTime.of(2100, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC);
+    private static final long LDT2100 = 4102444800L;
 
-    //Current time. Used to determine future GMToffset transitions
+    //Current time. Used to determine future GMT offset transitions
     private static final long CURRT = System.currentTimeMillis()/1000;
 
     /**
@@ -482,7 +482,7 @@ public final class ZoneInfoFile {
 
             for (; i < savingsInstantTransitions.length; i++) {
                 long trans = savingsInstantTransitions[i];
-                if (trans > UTC2037) {
+                if (trans > UTC2100) {
                     // no trans beyond LASTYEAR
                     lastyear = LASTYEAR;
                     break;
@@ -629,11 +629,11 @@ public final class ZoneInfoFile {
                 }
             } else if (nTrans > 0) {  // only do this if there is something in table already
                 if (lastyear < LASTYEAR) {
-                    // ZoneInfo has an ending entry for 2037
+                    // ZoneInfo has an ending entry for 2100
                     //long trans = OffsetDateTime.of(LASTYEAR, 1, 1, 0, 0, 0, 0,
                     //                               ZoneOffset.ofTotalSeconds(rawOffset/1000))
                     //                           .toEpochSecond();
-                    long trans = LDT2037 - rawOffset/1000;
+                    long trans = LDT2100 - rawOffset/1000;
 
                     int offsetIndex = indexOf(offsets, 0, nOffsets, rawOffset/1000);
                     if (offsetIndex == nOffsets)
@@ -814,7 +814,7 @@ public final class ZoneInfoFile {
     private static final long DST_MASK = 0xf0L;
     private static final int  DST_NSHIFT = 4;
     private static final int  TRANSITION_NSHIFT = 12;
-    private static final int  LASTYEAR = 2037;
+    private static final int  LASTYEAR = 2100;
 
     // from: 0 for offset lookup, 1 for dstsvings lookup
     private static int indexOf(int[] offsets, int from, int nOffsets, int offset) {

--- a/test/jdk/java/util/TimeZone/NegativeDSTTest.java
+++ b/test/jdk/java/util/TimeZone/NegativeDSTTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/TimeZone/NegativeDSTTest.java
+++ b/test/jdk/java/util/TimeZone/NegativeDSTTest.java
@@ -37,7 +37,7 @@ import static org.testng.Assert.assertEquals;
 
 /**
  * @test
- * @bug 8212970
+ * @bug 8212970 8324065
  * @summary Test whether the savings are positive in time zones that have
  *      negative savings in the source TZ files.
  * @run testng NegativeDSTTest
@@ -81,7 +81,10 @@ public class NegativeDSTTest {
             {CASABLANCA, LocalDate.of(2019, 5, 6), 0, false},
             {CASABLANCA, LocalDate.of(2037, 10, 5), 0, false},
             {CASABLANCA, LocalDate.of(2037, 11, 16), ONE_HOUR, true},
+            {CASABLANCA, LocalDate.of(2038, 9, 27), 0, false},
             {CASABLANCA, LocalDate.of(2038, 11, 1), ONE_HOUR, true},
+            {CASABLANCA, LocalDate.of(2087, 3, 31), 0, false},
+            {CASABLANCA, LocalDate.of(2087, 5, 12), ONE_HOUR, true},
         };
     }
 

--- a/test/jdk/sun/util/calendar/zi/TestZoneInfo310.java
+++ b/test/jdk/sun/util/calendar/zi/TestZoneInfo310.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8007572 8008161 8157792 8212970 8224560
+ * @bug 8007572 8008161 8157792 8212970 8224560 8324065
  * @summary Test whether the TimeZone generated from JSR310 tzdb is the same
  * as the one from the tz data from javazic
  * @modules java.base/sun.util.calendar:+open
@@ -171,9 +171,9 @@ public class TestZoneInfo310 {
             ZoneInfoOld zi = toZoneInfoOld(TimeZone.getTimeZone(zid));
             ZoneInfoOld ziOLD = (ZoneInfoOld)ZoneInfoOld.getTimeZone(zid);
             /*
-             * Temporary ignoring the failing TimeZones which are having zone
-             * rules defined till year 2037 and/or above and have negative DST
-             * save time in IANA tzdata. This bug is tracked via JDK-8223388.
+             * Ignoring the failing TimeZones which have negative DST
+             * save time in IANA tzdata, as javazic/ZoneInfoOld cannot
+             * handle the negative DST.
              *
              * These are the zones/rules that employ negative DST in vanguard
              * format (as of 2019a), Palestine added in 2022d:
@@ -183,11 +183,6 @@ public class TestZoneInfo310 {
              *  - Rule "Namibia"
              *  - Rule "Palestine"
              *  - Zone "Europe/Prague"
-             *
-             * Tehran/Iran rule has rules beyond 2037, in which javazic assumes
-             * to be the last year. Thus javazic's rule is based on year 2037
-             * (Mar 20th/Sep 20th are the cutover dates), while the real rule
-             * has year 2087 where Mar 21st/Sep 21st are the cutover dates.
              */
             if (zid.equals("Africa/Casablanca") || // uses "Morocco" rule
                 zid.equals("Africa/El_Aaiun") || // uses "Morocco" rule
@@ -196,10 +191,8 @@ public class TestZoneInfo310 {
                 zid.equals("Europe/Bratislava") || // link to "Europe/Prague"
                 zid.equals("Europe/Dublin") || // uses "Eire" rule
                 zid.equals("Europe/Prague") ||
-                zid.equals("Asia/Tehran") || // last rule mismatch
                 zid.equals("Asia/Gaza") || // uses "Palestine" rule
-                zid.equals("Asia/Hebron") || // uses "Palestine" rule
-                zid.equals("Iran")) { // last rule mismatch
+                zid.equals("Asia/Hebron")) { // uses "Palestine" rule
                     continue;
             }
             if (! zi.equalsTo(ziOLD)) {

--- a/test/jdk/sun/util/calendar/zi/ZoneInfoOld.java
+++ b/test/jdk/sun/util/calendar/zi/ZoneInfoOld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,14 +51,14 @@ import sun.util.calendar.CalendarDate;
  * for the {@link #getOffset(int,int,int,int,int,int) getOffset}
  * method that takes Gregorian calendar date fields.
  * <p>
- * This table covers transitions from 1900 until 2037 (as of version
- * 1.4), Before 1900, it assumes that there was no daylight saving
+ * This table covers transitions from 1900 until 2100 (as of version
+ * 23), Before 1900, it assumes that there was no daylight saving
  * time and the <code>getOffset</code> methods always return the
  * {@link #getRawOffset} value. No Local Mean Time is supported. If a
  * specified date is beyond the transition table and this time zone is
- * supposed to observe daylight saving time in 2037, it delegates
+ * supposed to observe daylight saving time in 2100, it delegates
  * operations to a {@link java.util.SimpleTimeZone SimpleTimeZone}
- * object created using the daylight saving time schedule as of 2037.
+ * object created using the daylight saving time schedule as of 2100.
  * <p>
  * The date items, transitions, GMT offset(s), etc. are read from a database
  * file. See {@link ZoneInfoFile} for details.

--- a/test/jdk/sun/util/calendar/zi/Zoneinfo.java
+++ b/test/jdk/sun/util/calendar/zi/Zoneinfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.util.StringTokenizer;
 class Zoneinfo {
 
     private static final int minYear = 1900;
-    private static final int maxYear = 2037;
+    private static final int maxYear = 2100;
     private static final long minTime = Time.getLocalTime(minYear, Month.JANUARY, 1, 0);
     private static int startYear = minYear;
     private static int endYear = maxYear;


### PR DESCRIPTION
Fixing incorrect std/dst transitions for time zones that have rules beyond 2037. The year 2037 restriction seems to come from the old `zic` command implementation and thus can be expanded in the JDK. Arbitrary I chose 2100 which is greater than the year 2087 which is the farthest rule at the moment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324065](https://bugs.openjdk.org/browse/JDK-8324065): Daylight saving information for `Africa/Casablanca` are incorrect (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [9ce8f35b](https://git.openjdk.org/jdk/pull/17492/files/9ce8f35b7fb4cd693c7a5ca479232f54429200e1)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [9ce8f35b](https://git.openjdk.org/jdk/pull/17492/files/9ce8f35b7fb4cd693c7a5ca479232f54429200e1)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [9ce8f35b](https://git.openjdk.org/jdk/pull/17492/files/9ce8f35b7fb4cd693c7a5ca479232f54429200e1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17492/head:pull/17492` \
`$ git checkout pull/17492`

Update a local copy of the PR: \
`$ git checkout pull/17492` \
`$ git pull https://git.openjdk.org/jdk.git pull/17492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17492`

View PR using the GUI difftool: \
`$ git pr show -t 17492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17492.diff">https://git.openjdk.org/jdk/pull/17492.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17492#issuecomment-1899100702)