### PR TITLE
JDK-8324169 : Remove macOS from ProblemList for CycleDMIMage.java when fix is available for JDK-8312518

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -433,7 +433,7 @@ java/awt/xembed/server/RunTestXEmbed.java 7034201 linux-all
 java/awt/Modal/ModalFocusTransferTests/FocusTransferDialogsDocModalTest.java 8164473 linux-all
 java/awt/Frame/DisposeParentGC/DisposeParentGC.java 8079786 macosx-all
 
-java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223,8274106 macosx-all,linux-all,windows-all
+java/awt/GraphicsDevice/DisplayModes/CycleDMImage.java 7099223,8274106 linux-all,windows-all
 java/awt/keyboard/AllKeyCode/AllKeyCode.java 8242930 macosx-all
 java/awt/FullScreen/8013581/bug8013581.java 8169471 macosx-all
 java/awt/event/MouseEvent/RobotLWTest/RobotLWTest.java 8233568 macosx-all


### PR DESCRIPTION
CycleDMIMage.java passes on macOS after [JDK-8312518](https://bugs.openjdk.org/browse/JDK-8312518), [PR#17358](https://github.com/openjdk/jdk/pull/17358). It is de-problemlisted for macOS only.


CI testing looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324169](https://bugs.openjdk.org/browse/JDK-8324169): Remove macOS from ProblemList for CycleDMIMage.java when fix is available for JDK-8312518 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17493/head:pull/17493` \
`$ git checkout pull/17493`

Update a local copy of the PR: \
`$ git checkout pull/17493` \
`$ git pull https://git.openjdk.org/jdk.git pull/17493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17493`

View PR using the GUI difftool: \
`$ git pr show -t 17493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17493.diff">https://git.openjdk.org/jdk/pull/17493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17493#issuecomment-1899154144)