### PR TITLE
8323680: SA PointerFinder code can do a better job of leveraging existing code to determine if an address is in the TLAB

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -85,9 +85,27 @@ public class PointerFinder {
 
     // Check if address is in the java heap.
     CollectedHeap heap = VM.getVM().getUniverse().heap();
-    if (heap instanceof SerialHeap) {
-      SerialHeap sh = (SerialHeap) heap;
-      if (sh.isIn(a)) {
+    if (heap.isIn(a)) {
+      loc.heap = heap;
+
+      // See if the address is in a TLAB
+      if (VM.getVM().getUseTLAB()) {
+        // Try to find thread containing it
+        for (int i = 0; i < threads.getNumberOfThreads(); i++) {
+          JavaThread t = threads.getJavaThreadAt(i);
+          ThreadLocalAllocBuffer tlab = t.tlab();
+          if (tlab.contains(a)) {
+            loc.inTLAB = true;
+            loc.tlabThread = t;
+            loc.tlab = tlab;
+            break;
+          }
+        }
+      }
+
+      // If we are using the SerialHeap, find out which generation the address is in
+      if (heap instanceof SerialHeap) {
+        SerialHeap sh = (SerialHeap) heap;
         loc.heap = heap;
         for (int i = 0; i < sh.nGens(); i++) {
           Generation g = sh.getGen(i);
@@ -98,30 +116,11 @@ public class PointerFinder {
         }
 
         if (Assert.ASSERTS_ENABLED) {
-          Assert.that(loc.gen != null, "Should have found this in a generation");
+          Assert.that(loc.gen != null, "Should have found this address in a generation");
         }
-
-        if (VM.getVM().getUseTLAB()) {
-          // Try to find thread containing it
-          for (int i = 0; i < threads.getNumberOfThreads(); i++) {
-            JavaThread t = threads.getJavaThreadAt(i);
-            ThreadLocalAllocBuffer tlab = t.tlab();
-            if (tlab.contains(a)) {
-              loc.inTLAB = true;
-              loc.tlabThread = t;
-              loc.tlab = tlab;
-              break;
-            }
-          }
-        }
-
-        return loc;
       }
-    } else {
-      if (heap.isIn(a)) {
-        loc.heap = heap;
-        return loc;
-      }
+
+      return loc;
     }
 
     // Check if address is in the interpreter

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -95,7 +95,6 @@ public class PointerFinder {
           JavaThread t = threads.getJavaThreadAt(i);
           ThreadLocalAllocBuffer tlab = t.tlab();
           if (tlab.contains(a)) {
-            loc.inTLAB = true;
             loc.tlabThread = t;
             loc.tlab = tlab;
             break;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -269,10 +269,16 @@ public class PointerLocation {
         tty.println();
     } else if (isInHeap()) {
       if (isInTLAB()) {
-        tty.print("In thread-local allocation buffer for thread (");
-        getTLABThread().printThreadInfoOn(tty);
-        tty.print(") ");
-        getTLAB().printOn(tty); // includes "\n"
+        tty.print("In TLAB for thread ");
+        JavaThread thread = getTLABThread();
+        if (verbose) {
+          tty.print("(");
+          thread.printThreadInfoOn(tty);
+          tty.print(") ");
+          getTLAB().printOn(tty); // includes "\n"
+        } else {
+          tty.format("\"%s\" %s\n", thread.getThreadName(), thread);
+        }
       } else {
         if (isInNewGen()) {
           tty.print("In new generation ");

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -61,7 +61,6 @@ public class PointerLocation {
 
   // If UseTLAB was enabled and the pointer was found in a
   // currently-active TLAB, these will be set
-  boolean inTLAB;
   JavaThread tlabThread;
   ThreadLocalAllocBuffer tlab;
 
@@ -129,7 +128,7 @@ public class PointerLocation {
 
   /** This may be true if isInNewGen is also true */
   public boolean isInTLAB() {
-    return inTLAB;
+    return (tlab != null);
   }
 
   /** Only valid if isInTLAB() returns true */


### PR DESCRIPTION
In PointerFinder.java we have some code to determine if a pointer is in a TLAB, but it only executes for the SerialGC. It should work for all GCs, so I moved the code out of the SerialGC block.

I also cleaned up the printing in PointerLocation. java a bit so when not using verbose mode not as much info about the tlab address is printed. This is consistent with other addresses, such as java stack addresses, which is what I modeled this change on.

It's hard to test this change since it is hard to consistently get an address to be in the tlab. I wrote a little test program that just sits in a loop doing allocations. I attached to it with clhsdb and ran the threadcontext command, which does a fincpc on each register. About half the time the main thread was suspended in a frame where some registers where pointing into the tlab, and I confirmed this was the case for both SerialGC and G1. Here's an example of one register with verbose off and verbose on:

rsi: 0x000000008a5d4448: In TLAB for thread "main" sun.jvm.hotspot.runtime.JavaThread@0x00007ffa24029000

rsi: 0x000000008a5d4448: In TLAB for thread ("main" #1 prio=5 tid=0x00007ffa24029000 nid=25392 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
   JavaThread state: _thread_in_java
)  [0x000000008a5d4448,0x000000008ab724b8,0x000000008b0c0250,{0x000000008b0c0490})

For testing I ran all tier1, tier2, and tier5 svc tests (still in progress)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323680](https://bugs.openjdk.org/browse/JDK-8323680): SA PointerFinder code can do a better job of leveraging existing code to determine if an address is in the TLAB (**Enhancement** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) ⚠️ Review applies to [ed620194](https://git.openjdk.org/jdk/pull/17494/files/ed6201942007f7c319caa343ba078fdc841d2bb0)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17494/head:pull/17494` \
`$ git checkout pull/17494`

Update a local copy of the PR: \
`$ git checkout pull/17494` \
`$ git pull https://git.openjdk.org/jdk.git pull/17494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17494`

View PR using the GUI difftool: \
`$ git pr show -t 17494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17494.diff">https://git.openjdk.org/jdk/pull/17494.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17494#issuecomment-1899352779)