### PR TITLE
8324207: Serial: Remove Space::set_saved_mark_word

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.inline.hpp
@@ -41,7 +41,6 @@ void DefNewGeneration::oop_since_save_marks_iterate(OopClosureType* cl) {
   assert(from()->saved_mark_at_top(), "inv");
 
   to()->oop_since_save_marks_iterate(cl);
-  to()->set_saved_mark();
 }
 
 #endif // SHARE_GC_SERIAL_DEFNEWGENERATION_INLINE_HPP

--- a/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
@@ -68,8 +68,6 @@ bool TenuredGeneration::block_is_obj(const HeapWord* addr) const {
 template <typename OopClosureType>
 void TenuredGeneration::oop_since_save_marks_iterate(OopClosureType* blk) {
   _the_space->oop_since_save_marks_iterate(blk);
-
-  save_marks();
 }
 
 #endif // SHARE_GC_SERIAL_TENUREDGENERATION_INLINE_HPP

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -82,8 +82,6 @@ class Space: public CHeapObj<mtGC> {
 
   HeapWord* saved_mark_word() const  { return _saved_mark_word; }
 
-  void set_saved_mark_word(HeapWord* p) { _saved_mark_word = p; }
-
   // Returns a subregion of the space containing only the allocated objects in
   // the space.
   virtual MemRegion used_region() const = 0;

--- a/src/hotspot/share/gc/shared/space.inline.hpp
+++ b/src/hotspot/share/gc/shared/space.inline.hpp
@@ -71,13 +71,12 @@ void ContiguousSpace::oop_since_save_marks_iterate(OopClosureType* blk) {
     t = top();
     while (p < t) {
       Prefetch::write(p, interval);
-      debug_only(HeapWord* prev = p);
       oop m = cast_to_oop(p);
       p += m->oop_iterate_size(blk);
     }
   } while (t < top());
 
-  set_saved_mark_word(p);
+  set_saved_mark();
 }
 
 #endif // SHARE_GC_SHARED_SPACE_INLINE_HPP


### PR DESCRIPTION
Simple refactoring to remove redundant save-mark-word calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324207](https://bugs.openjdk.org/browse/JDK-8324207): Serial: Remove Space::set_saved_mark_word (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17496/head:pull/17496` \
`$ git checkout pull/17496`

Update a local copy of the PR: \
`$ git checkout pull/17496` \
`$ git pull https://git.openjdk.org/jdk.git pull/17496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17496`

View PR using the GUI difftool: \
`$ git pr show -t 17496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17496.diff">https://git.openjdk.org/jdk/pull/17496.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17496#issuecomment-1900343230)