### PR TITLE
8324213: C1: There is no need for Canonicalizer to handle IfOp

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -469,9 +469,6 @@ void Canonicalizer::do_CompareOp      (CompareOp*       x) {
 
 
 void Canonicalizer::do_IfOp(IfOp* x) {
-  // Caution: do not use do_Op2(x) here for now since
-  //          we map the condition to the op for now!
-  move_const_to_right(x);
 }
 
 

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -472,7 +472,7 @@ void Canonicalizer::do_IfOp(IfOp* x) {
   // Currently, Canonicalizer is only used by GraphBuilder,
   // and IfOp is not created by GraphBuilder but only later
   // when eliminating conditional expressions with CE_Eliminator,
-  // therefor this method will not be called.
+  // so this method will not be called.
   ShouldNotReachHere();
 }
 

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -469,6 +469,7 @@ void Canonicalizer::do_CompareOp      (CompareOp*       x) {
 
 
 void Canonicalizer::do_IfOp(IfOp* x) {
+  ShouldNotReachHere();
 }
 
 

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -469,6 +469,10 @@ void Canonicalizer::do_CompareOp      (CompareOp*       x) {
 
 
 void Canonicalizer::do_IfOp(IfOp* x) {
+  // Currently, Canonicalizer is only used by GraphBuilder,
+  // and IfOp is not created by GraphBuilder but only later
+  // when eliminating conditional expressions with CE_Eliminator,
+  // therefor this method will not be called.
   ShouldNotReachHere();
 }
 


### PR DESCRIPTION
IfOp will not be created when building the graph, so there is no need for Canonicalizer to handle IfOp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324213](https://bugs.openjdk.org/browse/JDK-8324213): C1: There is no need for Canonicalizer to handle IfOp (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [e156cd0c](https://git.openjdk.org/jdk/pull/17499/files/e156cd0cf9ee5ad7594c9e33564e56b158f4202d)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17499/head:pull/17499` \
`$ git checkout pull/17499`

Update a local copy of the PR: \
`$ git checkout pull/17499` \
`$ git pull https://git.openjdk.org/jdk.git pull/17499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17499`

View PR using the GUI difftool: \
`$ git pr show -t 17499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17499.diff">https://git.openjdk.org/jdk/pull/17499.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17499#issuecomment-1900632753)