### PR TITLE
JDK-8253438 Add String::encodeEscapes

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4236,6 +4236,7 @@ public final class String
      * @return String with escape sequences translated.
      *
      * @jls 3.10.7 Escape Sequences
+     * @jls 3.3 Unicode Escapes
      *
      * @since 15
      */

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4271,13 +4271,12 @@ public final class String
                     ch = '\t';
                     break;
                 case 'u':
-                    if (from + 4 <= length) {
-                        String hex = substring(from, from + 4);
+                    if (from <= length - 4) {
                         from += 4;
                         try {
-                            ch = (char) Integer.parseInt(hex, 16);
+                            ch = (char) Integer.parseInt(this, from - 4, from, 16);
                         } catch (NumberFormatException ex) {
-                            throw new IllegalArgumentException("Invalid unicode sequence: " + hex);
+                            throw new IllegalArgumentException("Invalid unicode sequence: " + substring(from - 4, from));
                         }
                     } else {
                         throw new IllegalArgumentException("Invalid unicode sequence: " + substring(from));

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4155,7 +4155,7 @@ public final class String
 
     /**
      * Returns a string whose value is this string, with escape sequences
-     * translated as if in a string literal.
+     * and unicode escape sequences translated as if in a string literal.
      * <p>
      * Escape sequences are translated as follows;
      * <table class="striped">

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4223,13 +4223,13 @@ public final class String
      *     <td>continuation</td>
      *     <td>discard</td>
      *   </tr>
+     *   <tr>
+     *     <th scope="row">{@code \u005CuXXXX}</th>
+     *     <td>unicode escape</td>
+     *     <td>unicode equivalent</td>
+     *   </tr>
      *   </tbody>
      * </table>
-     *
-     * @implNote
-     * This method does <em>not</em> translate Unicode escapes such as "{@code \u005cu2022}".
-     * Unicode escapes are translated by the Java compiler when reading input characters and
-     * are not part of the string literal specification.
      *
      * @throws IllegalArgumentException when an escape sequence is malformed.
      *
@@ -4269,6 +4269,19 @@ public final class String
                     break;
                 case 't':
                     ch = '\t';
+                    break;
+                case 'u':
+                    if (from + 4 <= length) {
+                        String hex = substring(from, from + 4);
+                        from += 4;
+                        try {
+                            ch = (char) Integer.parseInt(hex, 16);
+                        } catch (NumberFormatException ex) {
+                            throw new IllegalArgumentException("Invalid unicode sequence: " + hex);
+                        }
+                    } else {
+                        throw new IllegalArgumentException("Invalid unicode sequence: " + substring(from));
+                    }
                     break;
                 case '\'':
                 case '\"':

--- a/test/jdk/java/lang/String/EncodeEscapes.java
+++ b/test/jdk/java/lang/String/EncodeEscapes.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ import java.util.Arrays;
+
+/*
+ * @test
+ * @bug 8253438
+ * @summary This exercises String#encodeEscapes patterns and limits.
+ * @compile EncodeEscapes.java
+ * @run main EncodeEscapes
+ */
+
+public class EncodeEscapes {
+    public static void main(String... arg) {
+        int MAX = 0x10000;
+        char[] allChars = new char[MAX];
+
+        for (int i = 0; i < MAX; i++) {
+            if (Character.isValidCodePoint(i)) {
+                allChars[i] = (char)i;
+            }
+        }
+
+        String allString = new String(allChars);
+
+        String encoded = allString.encodeEscapes();
+        String translated = encoded.translateEscapes();
+
+        isClean(allString, translated);
+
+       isPresent(encoded, "\\b");
+        isPresent(encoded, "\\f");
+        isPresent(encoded, "\\n");
+        isPresent(encoded, "\\r");
+        isPresent(encoded, "\\t");
+        isPresent(encoded, "\\\'");
+        isPresent(encoded, "\\\"");
+        isPresent(encoded, "\\\\");
+        isPresent(encoded, " ");
+        isPresent(encoded, "x");
+        isPresent(encoded, "~");
+        isPresent(encoded, "\\u0000");
+        isPresent(encoded, "\\u2022");
+        isPresent(encoded, "\\ufffe");
+
+        if (errors) {
+            throw new RuntimeException("errors occurred");
+        }
+
+        System.out.println("Done!");
+    }
+
+    static boolean errors = false;
+
+
+    static void isClean(String allString, String translated) {
+        if (allString.equals(translated)) {
+            char[] allChars = allString.toCharArray();
+            char[] translatedChars = translated.toCharArray();
+            int where = 0;
+
+            do {
+                where = Arrays.mismatch(allChars, where, allChars.length, translatedChars, where, translatedChars.length);
+
+                if (where != -1 ) {
+                    System.out.format("Mismatch at %d%n",  where);
+                    where++;
+                    errors = true;
+                }
+            } while (where != -1);
+        }
+    }
+
+    static void isPresent(String string, String substring) {
+        if (string.indexOf(substring) == -1) {
+            System.out.println("Missing " + substring);
+            errors = true;
+        }
+    }
+}

--- a/test/jdk/java/lang/String/TranslateEscapes.java
+++ b/test/jdk/java/lang/String/TranslateEscapes.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8223780
+ * @bug 8223780 8263261
  * @summary This exercises String#translateEscapes patterns and limits.
  * @compile TranslateEscapes.java
  * @run main TranslateEscapes
@@ -35,6 +35,7 @@ public class TranslateEscapes {
         test2();
         test3();
         test4();
+        test5();
     }
 
     /*
@@ -86,11 +87,42 @@ public class TranslateEscapes {
         verifyLineTerminator("\r");
     }
 
+    /*
+     * Unicode escapes.
+     */
+    static void test5() {
+        verifyEscape("\\u0000", "\u0000");
+        verifyEscape("\\u2022", "\u2022");
+        verifyEscape("\\ud83c\\udf09", "\ud83c\udf09");
+
+        verifyUnicodeEscape("\\u000x");
+        verifyUnicodeEscape("\\u000");
+        verifyUnicodeEscape("\\u00");
+        verifyUnicodeEscape("\\u0");
+        verifyUnicodeEscape("\\u");
+    }
+
     static void verifyEscape(String string, char ch) {
         String escapes = "\\" + string;
         if (escapes.translateEscapes().charAt(0) != ch) {
             System.err.format("\"%s\" not escape \"%s\"'%n", string, escapes);
             throw new RuntimeException();
+        }
+    }
+
+    static void verifyEscape(String string1, String string2) {
+        if (!string1.translateEscapes().equals(string2)) {
+            System.err.format("\"%s\" not escaped \"%s\"%n", string1, string2);
+            throw new RuntimeException();
+        }
+    }
+
+    static void verifyUnicodeEscape(String string) {
+        try {
+            string.translateEscapes();
+            System.err.format("\"%s\" should be an error%n", string);
+            throw new RuntimeException();
+        } catch (IllegalArgumentException ex) {
         }
     }
 


### PR DESCRIPTION
Introduce a new method `String::encodeEscapes` which replaces non-ASCII and non-printing characters in the string with escape sequences or unicode escapes.

Note: I've tried various ways of doing this including lookup tables and combos of switch and if statements. This seems the most optimal approach without going intrinsic. On the other hand, I don't see this used in mission critical situations.