### PR TITLE
JDK-8253438 Add String::encodeEscapes

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -4235,6 +4235,8 @@ public final class String
      *
      * @return String with escape sequences translated.
      *
+     * @see String#encodeEscapes()
+     *
      * @jls 3.10.7 Escape Sequences
      *
      * @since 15
@@ -4309,6 +4311,76 @@ public final class String
         }
 
         return new String(chars, 0, to);
+    }
+
+    /**
+     * Translate characters to their escaped equivalents, if necessary, such that the
+     * resulting string, when embedded in double quotes, can be parsed by the compiler
+     * to reproduce this string.
+     * <p>
+     * The characters in the range {@code '\u005Cu0000'} through {@code '\u005Cu001F'}
+     * inclusive will be translated to unicode escapes, except for {@code '\u005Cb'}
+     * (backspace), {@code '\u005Ct'} (tab), {@code '\u005Cn'} (newline), {@code '\u005Cf'}
+     * (formfeed) and {@code '\u005Cr'} (return) which will be translated to
+     * their corresponding escape sequences. The characters in the range {@code '\u005Cu0020'}
+     * through {@code '\u005Cu007E'} will be left untranslated, except
+     * for {@code "} (double quote), {@code '} (quote) and {@code \u005C} (backslash)
+     * which will be translated to their corresponding escaped sequences. All other
+     * characters will be translated to unicode escapes. Example:
+     * {@snippet lang=JAVA :
+     * String encoded = "\u2022This is a line.\n\t followed by this line.".encodeEscapes();
+     * System.out.println(encoded.equals("\\u2022This is a line.\\n\\t followed by this line."
+     * }
+     * will print out {@code true}.
+     * <p>
+     * The result of this method is lossless and as such the original string can always be
+     * reproduced using {@link String#translateEscapes()}. Also because of losslessness,
+     * specific characters that don't require escaping can be reverted by simply using a
+     * replace method. For example: if newlines need to be maintained in the resulting
+     * string then just apply {@code replace("\\n", "\n")} to the result.
+     *
+     * @return string with characters encoded using escape sequences
+     *
+     * @since 23
+     *
+     * @implNote If no characters were translated then the original string will be returned.
+     *
+     * @implSpec {@code string.encodeEscapes().translateEscapes().equals(string)} will
+     * always be {@code true}. However, this method is not the reciprocal to
+     * {@link String#translateEscapes()} as any string yielded by
+     * {@link String#translateEscapes()} may have many variations of original string.
+     *
+     * @see String#translateEscapes()
+     *
+     * @jls 3.10.7 Escape Sequences
+     * @jls 3.3 Unicode Escapes
+     */
+    public String encodeEscapes() {
+        int length = length();
+        StringBuilder sb = new StringBuilder(length + (length >> 2));
+        for (int i = 0; i < length; i++) {
+            char ch = charAt(i);
+            switch (ch) {
+                case '\b': sb.append('\\'); sb.append('b'); break;
+                case '\t': sb.append('\\'); sb.append('t'); break;
+                case '\n': sb.append('\\'); sb.append('n'); break;
+                case '\f': sb.append('\\'); sb.append('f'); break;
+                case '\r': sb.append('\\'); sb.append('r'); break;
+                case '\"': sb.append('\\'); sb.append('\"'); break;
+                case '\'': sb.append('\\'); sb.append('\''); break;
+                case '\\': sb.append('\\'); sb.append('\\'); break;
+                default: if (' ' <= ch && ch <= '~') {
+                    sb.append(ch);
+                } else {
+                    String hex = Integer.toHexString(ch);
+                    sb.append('\\');
+                    sb.append('u');
+                    sb.repeat('0', 4 - hex.length());
+                    sb.append(hex);
+                }
+            }
+        }
+        return sb.length() != length ? sb.toString() : this;
     }
 
     /**

--- a/test/jdk/java/lang/String/EncodeEscapes.java
+++ b/test/jdk/java/lang/String/EncodeEscapes.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ import java.util.Arrays;
+
+/*
+ * @test
+ * @bug 8253438
+ * @summary This exercises String#encodeEscapes patterns and limits.
+ * @compile EncodeEscapes.java
+ * @run main EncodeEscapes
+ */
+
+public class EncodeEscapes {
+    public static void main(String... arg) {
+        int MAX = 0x10000;
+        char[] allChars = new char[MAX];
+
+        for (int i = 0; i < MAX; i++) {
+            if (Character.isValidCodePoint(i)) {
+                allChars[i] = (char)i;
+            }
+        }
+
+        String allString = new String(allChars);
+
+        String encoded = allString.encodeEscapes();
+        String translated = encoded.translateEscapes();
+
+        isClean(allString, translated);
+
+       isPresent(encoded, "\\b");
+        isPresent(encoded, "\\f");
+        isPresent(encoded, "\\n");
+        isPresent(encoded, "\\r");
+        isPresent(encoded, "\\t");
+        isPresent(encoded, "\\\'");
+        isPresent(encoded, "\\\"");
+        isPresent(encoded, "\\\\");
+        isPresent(encoded, " ");
+        isPresent(encoded, "x");
+        isPresent(encoded, "~");
+        isPresent(encoded, "\\u0000");
+        isPresent(encoded, "\\u2022");
+        isPresent(encoded, "\\ufffe");
+
+        if (errors) {
+            throw new RuntimeException("errors occurred");
+        }
+
+        System.out.println("Done!");
+    }
+
+    static boolean errors = false;
+
+
+    static void isClean(String allString, String translated) {
+        if (allString.equals(translated)) {
+            char[] allChars = allString.toCharArray();
+            char[] translatedChars = translated.toCharArray();
+            int where = 0;
+
+            do {
+                where = Arrays.mismatch(allChars, where, allChars.length,
+                                        translatedChars, where, translatedChars.length);
+
+                if (where != -1 ) {
+                    System.out.format("Mismatch at %d%n",  where);
+                    where++;
+                    errors = true;
+                }
+            } while (where != -1);
+        }
+    }
+
+    static void isPresent(String string, String substring) {
+        if (string.indexOf(substring) == -1) {
+            System.out.println("Missing " + substring);
+            errors = true;
+        }
+    }
+}
+


### PR DESCRIPTION
Introduce a new method String::encodeEscapes which replaces non-ASCII and non-printing characters in the string with escape sequences or unicode escapes.

Note: I've tried various ways of doing this including lookup tables and combos of switch and if statements. This seems the most optimal approach without going intrinsic. On the other hand, I don't see this used in mission critical situations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change requires CSR request [JDK-8263253](https://bugs.openjdk.org/browse/JDK-8263253) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8253438](https://bugs.openjdk.org/browse/JDK-8253438): Add String::encodeEscapes (**Enhancement** - P3)
 * [JDK-8263253](https://bugs.openjdk.org/browse/JDK-8263253): Add String::encodeEscapes (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17502/head:pull/17502` \
`$ git checkout pull/17502`

Update a local copy of the PR: \
`$ git checkout pull/17502` \
`$ git pull https://git.openjdk.org/jdk.git pull/17502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17502`

View PR using the GUI difftool: \
`$ git pr show -t 17502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17502.diff">https://git.openjdk.org/jdk/pull/17502.diff</a>

</details>
