### PR TITLE
8324050: Issue store-store barrier after re-materializing objects during deoptimization

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1236,11 +1236,15 @@ bool Deoptimization::realloc_objects(JavaThread* thread, frame* fr, RegisterMap*
 
       InstanceKlass* ik = InstanceKlass::cast(k);
       if (obj == nullptr && !cache_init_error) {
+#if COMPILER2_OR_JVMCI
         if (EnableVectorSupport && VectorSupport::is_vector(ik)) {
           obj = VectorSupport::allocate_vector(ik, fr, reg_map, sv, THREAD);
         } else {
           obj = ik->allocate_instance(THREAD);
         }
+#else
+        obj = ik->allocate_instance(THREAD);
+#endif // COMPILER2_OR_JVMCI
       }
     } else if (k->is_typeArray_klass()) {
       TypeArrayKlass* ak = TypeArrayKlass::cast(k);
@@ -1568,6 +1572,7 @@ void Deoptimization::reassign_fields(frame* fr, RegisterMap* reg_map, GrowableAr
       continue;
     }
 #endif // INCLUDE_JVMCI
+#if COMPILER2_OR_JVMCI
     if (EnableVectorSupport && VectorSupport::is_vector(k)) {
       assert(sv->field_size() == 1, "%s not a vector", k->name()->as_C_string());
       ScopeValue* payload = sv->field_at(0);
@@ -1587,6 +1592,7 @@ void Deoptimization::reassign_fields(frame* fr, RegisterMap* reg_map, GrowableAr
       // Else fall-through to do assignment for scalar-replaced boxed vector representation
       // which could be restored after vector object allocation.
     }
+#endif /* !COMPILER2_OR_JVMCI */
     if (k->is_instance_klass()) {
       InstanceKlass* ik = InstanceKlass::cast(k);
       reassign_fields_by_klass(ik, fr, reg_map, sv, 0, obj(), skip_internal);


### PR DESCRIPTION
Added missing store-store barrier when we re-materialize scalar replaced object during deoptimization.

I also removed redundant `#if COMPILER2_OR_JVMCI` guards which were leftover from [JDK-8312579](https://bugs.openjdk.org/browse/JDK-8312579) changes. It added Vector API support to Graal and changed `#ifdef COMPILER2` to these `#if`. But this code is already under these `ifs`.

Tested tier1-3, scope, stress.

No new regression test.  I think it is "almost" impossible to hit this issue because there is a lot of VM's runtime code between the code which rematerialize scalar-replaced objects during deoptimization and a code in Interpreter which is executed after deoptimization and which may execute a store instruction that makes these objects accessible by other threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324050](https://bugs.openjdk.org/browse/JDK-8324050): Issue store-store barrier after re-materializing objects during deoptimization (**Bug** - P3)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [49d44048](https://git.openjdk.org/jdk/pull/17503/files/49d440489225dbdfc0cf9439d47d4df868f87acb)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17503/head:pull/17503` \
`$ git checkout pull/17503`

Update a local copy of the PR: \
`$ git checkout pull/17503` \
`$ git pull https://git.openjdk.org/jdk.git pull/17503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17503`

View PR using the GUI difftool: \
`$ git pr show -t 17503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17503.diff">https://git.openjdk.org/jdk/pull/17503.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17503#issuecomment-1901189153)