### PR TITLE
8324229: JFR: Temporarily disable assertion for missing object reference

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantMap.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/ConstantMap.java
@@ -77,7 +77,8 @@ final class ConstantMap {
             if (id != 0) {
                 String msg = "Missing object ID " + id + " in pool " + getName() + ". All IDs should reference an object";
                 Logger.log(LogTag.JFR_SYSTEM_PARSER, LogLevel.INFO, msg);
-                assert false : msg;
+                // Disable assertion until JDK-8323883 is fixed
+                // assert false : msg;
             }
             return null;
         }


### PR DESCRIPTION
Could I have a review of a change that temporarily disables an assertion.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324229](https://bugs.openjdk.org/browse/JDK-8324229): JFR: Temporarily disable assertion for missing object reference (**Sub-task** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17504/head:pull/17504` \
`$ git checkout pull/17504`

Update a local copy of the PR: \
`$ git checkout pull/17504` \
`$ git pull https://git.openjdk.org/jdk.git pull/17504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17504`

View PR using the GUI difftool: \
`$ git pr show -t 17504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17504.diff">https://git.openjdk.org/jdk/pull/17504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17504#issuecomment-1901286019)