### PR TITLE
JDK-8324231: bad command-line option in make/Docs.gmk

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -642,7 +642,7 @@ ifeq ($(ENABLE_PANDOC), true)
   GLOBAL_SPECS_DEFAULT_CSS_FILE := $(DOCS_OUTPUTDIR)/resources/jdk-default.css
   # Unset the following to suppress the link to the tool guides
   NAV_LINK_GUIDES := --nav-link-guides
-  HEADER_RIGHT_SIDE_INFO := <strong>$(subst &amp;,&,$(JDK_SHORT_NAME))$(DRAFT_MARKER_STR)</strong>
+  HEADER_RIGHT_SIDE_INFO := <strong>$(subst &amp;,&,$(JDK_SHORT_NAME))</strong>$(DRAFT_MARKER_STR)
 
   $(foreach m, $(ALL_MODULES), \
     $(eval SPECS_$m := $(call FindModuleSpecsDirs, $m)) \


### PR DESCRIPTION
Please review an almost trivial change to move the position of an HTML end tag to avoid nested use of the tag.

There is no change to the visual presentation, because the macro `$(DRAFT_MARKER_STR)` itself uses `<strong>` (that was the cause of the nested tags).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324231](https://bugs.openjdk.org/browse/JDK-8324231): bad command-line option in make/Docs.gmk (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17505/head:pull/17505` \
`$ git checkout pull/17505`

Update a local copy of the PR: \
`$ git checkout pull/17505` \
`$ git pull https://git.openjdk.org/jdk.git pull/17505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17505`

View PR using the GUI difftool: \
`$ git pr show -t 17505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17505.diff">https://git.openjdk.org/jdk/pull/17505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17505#issuecomment-1901257355)