### PR TITLE
8324240: Remove unused GrowableArrayView::EMPTY

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -124,8 +124,6 @@ protected:
   ~GrowableArrayView() {}
 
 public:
-  const static GrowableArrayView EMPTY;
-
   bool operator==(const GrowableArrayView<E>& rhs) const {
     if (_len != rhs._len)
       return false;
@@ -349,9 +347,6 @@ public:
     tty->print("}\n");
   }
 };
-
-template<typename E>
-const GrowableArrayView<E> GrowableArrayView<E>::EMPTY(nullptr, 0, 0);
 
 template <typename E>
 class GrowableArrayFromArray : public GrowableArrayView<E> {


### PR DESCRIPTION
Please review this trivial change to remove an unused variable.

The variable was introduced by [JDK-8254231](https://bugs.openjdk.org/browse/JDK-8254231). All uses were removed by [JDK-8283689](https://bugs.openjdk.org/browse/JDK-8283689).

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324240](https://bugs.openjdk.org/browse/JDK-8324240): Remove unused GrowableArrayView::EMPTY (**Enhancement** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17507/head:pull/17507` \
`$ git checkout pull/17507`

Update a local copy of the PR: \
`$ git checkout pull/17507` \
`$ git pull https://git.openjdk.org/jdk.git pull/17507/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17507`

View PR using the GUI difftool: \
`$ git pr show -t 17507`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17507.diff">https://git.openjdk.org/jdk/pull/17507.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17507#issuecomment-1902213370)