### PR TITLE
8324241: Always record evol_method deps to avoid excessive method flushing

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -149,7 +149,15 @@ class JvmtiExport : public AllStatic {
     JVMTI_ONLY(_can_access_local_variables = (on != 0);)
   }
   inline static void set_can_hotswap_or_post_breakpoint(bool on) {
-    JVMTI_ONLY(_can_hotswap_or_post_breakpoint = (on != 0);)
+#if INCLUDE_JVMTI
+    // Check that _can_hotswap_or_post_breakpoint is not reset once it
+    // was set to true. When _can_hotswap_or_post_breakpoint is set to true
+    // _all_dependencies_are_recorded is also set to true and never
+    // reset so we have to ensure that evol dependencies are always
+    // recorded from that point on.
+    assert(!_can_hotswap_or_post_breakpoint || on, "sanity check");
+    _can_hotswap_or_post_breakpoint = (on != 0);
+#endif
   }
   inline static void set_can_walk_any_space(bool on) {
     JVMTI_ONLY(_can_walk_any_space = (on != 0);)

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4060,21 +4060,22 @@ void VM_RedefineClasses::transfer_old_native_function_registrations(InstanceKlas
 // Deoptimize all compiled code that depends on the classes redefined.
 //
 // If the can_redefine_classes capability is obtained in the onload
-// phase then the compiler has recorded all dependencies from startup.
-// In that case we need only deoptimize and throw away all compiled code
-// that depends on the class.
+// phase or 'AlwaysRecordEvolDependencies' is true, then the compiler has
+// recorded all dependencies from startup. In that case we need only
+// deoptimize and throw away all compiled code that depends on the class.
 //
-// If can_redefine_classes is obtained sometime after the onload
-// phase then the dependency information may be incomplete. In that case
-// the first call to RedefineClasses causes all compiled code to be
-// thrown away. As can_redefine_classes has been obtained then
-// all future compilations will record dependencies so second and
-// subsequent calls to RedefineClasses need only throw away code
-// that depends on the class.
+// If can_redefine_classes is obtained sometime after the onload phase
+// (and 'AlwaysRecordEvolDependencies' is false) then the dependency
+// information may be incomplete. In that case the first call to
+// RedefineClasses causes all compiled code to be thrown away. As
+// can_redefine_classes has been obtained then all future compilations will
+// record dependencies so second and subsequent calls to RedefineClasses
+// need only throw away code that depends on the class.
 //
 
 void VM_RedefineClasses::flush_dependent_code() {
   assert(SafepointSynchronize::is_at_safepoint(), "sanity check");
+  assert(AlwaysRecordEvolDependencies ? JvmtiExport::all_dependencies_are_recorded() : true, "sanity check");
 
   DeoptimizationScope deopt_scope;
 

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4075,7 +4075,7 @@ void VM_RedefineClasses::transfer_old_native_function_registrations(InstanceKlas
 
 void VM_RedefineClasses::flush_dependent_code() {
   assert(SafepointSynchronize::is_at_safepoint(), "sanity check");
-  assert(AlwaysRecordEvolDependencies ? JvmtiExport::all_dependencies_are_recorded() : true, "sanity check");
+  assert(JvmtiExport::all_dependencies_are_recorded() || !AlwaysRecordEvolDependencies, "sanity check");
 
   DeoptimizationScope deopt_scope;
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2010,7 +2010,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, ProfileExceptionHandlers, true,                             \
           "Profile exception handlers")                                     \
                                                                             \
-  product(bool, AlwaysRecordEvolDependencies, true, DIAGNOSTIC,             \
+  product(bool, AlwaysRecordEvolDependencies, true, EXPERIMENTAL,           \
                 "Unconditionally record nmethod dependencies on class "     \
                 "rewriting/transformation independently of the JVMTI "      \
                 " can_{retransform/redefine}_classes capabilities.")        \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2013,7 +2013,7 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, AlwaysRecordEvolDependencies, true, EXPERIMENTAL,           \
                 "Unconditionally record nmethod dependencies on class "     \
                 "rewriting/transformation independently of the JVMTI "      \
-                " can_{retransform/redefine}_classes capabilities.")        \
+                "can_{retransform/redefine}_classes capabilities.")         \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2009,6 +2009,11 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(bool, ProfileExceptionHandlers, true,                             \
           "Profile exception handlers")                                     \
+                                                                            \
+  product(bool, AlwaysRecordEvolDependencies, true, DIAGNOSTIC,             \
+                "Unconditionally record method dependencies on class "      \
+                "rewriting/transformation independently of the JVMTI "      \
+                " can_{retransform/redefine}_classes capabilities.")        \
 
 // end of RUNTIME_FLAGS
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2011,7 +2011,7 @@ const int ObjectAlignmentInBytes = 8;
           "Profile exception handlers")                                     \
                                                                             \
   product(bool, AlwaysRecordEvolDependencies, true, DIAGNOSTIC,             \
-                "Unconditionally record method dependencies on class "      \
+                "Unconditionally record nmethod dependencies on class "     \
                 "rewriting/transformation independently of the JVMTI "      \
                 " can_{retransform/redefine}_classes capabilities.")        \
 

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -116,8 +116,10 @@ jint init_globals() {
   management_init();
   JvmtiExport::initialize_oop_storage();
 #if INCLUDE_JVMTI
-  JvmtiExport::set_can_hotswap_or_post_breakpoint(true);
-  JvmtiExport::set_all_dependencies_are_recorded(true);
+  if (AlwaysRecordEvolDependencies) {
+    JvmtiExport::set_can_hotswap_or_post_breakpoint(true);
+    JvmtiExport::set_all_dependencies_are_recorded(true);
+  }
 #endif
   bytecodes_init();
   classLoader_init1();

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -115,6 +115,10 @@ void vm_init_globals() {
 jint init_globals() {
   management_init();
   JvmtiExport::initialize_oop_storage();
+#if INCLUDE_JVMTI
+  JvmtiExport::set_can_hotswap_or_post_breakpoint(true);
+  JvmtiExport::set_all_dependencies_are_recorded(true);
+#endif
   bytecodes_init();
   classLoader_init1();
   compilationPolicy_init();


### PR DESCRIPTION
Currently we don't record dependencies on redefined methods (i.e. `evol_method` dependencies) in JIT compiled methods if none of the `can_redefine_classes`, `can_retransform_classes` or `can_generate_breakpoint_events` JVMTI capabalities is set. This means that if a JVMTI agent which requests one of these capabilities is dynamically attached, all the methods which have been JIT compiled until that point, will be marked for deoptimization and flushed from the code cache. For large, warmed-up applications this mean deoptimization and instant recompilation of thousands if not then-thousands of methods, which can lead to dramatic performance/latency drop-downs for several minutes.

One could argue that dynamic agent attach is now deprecated anyway (see [JEP 451: Prepare to Disallow the Dynamic Loading of Agents](https://openjdk.org/jeps/451)) and this problem could be solved by making the recording of `evol_method` dependencies dependent on the new `-XX:+EnableDynamicAgentLoading` flag isntead of the concrete JVMTI capabilities (because the presence of the flag indicates that an agent will be loaded eventually).

But there a single, however important exception to this rule and that's JFR. JFR is advertised as low overhead profiler which can be enabled in production at any time. However, when JFR is started dynamically (e.g. through JCMD or JMX) it will silently load a HotSpot internl JVMTI agent which requests the `can_retransform_classes` and retransforms some classes. This will inevitably trigger the deoptimization of all compiled methods as described above.

I'd therefor like to propose to *always* and unconditionally record `evol_method` dependencies in JIT compiled code by exporting the relevant properties right at startup in `init_globals()`:
```c++
 jint init_globals() {
   management_init();
   JvmtiExport::initialize_oop_storage();
+#if INCLUDE_JVMTI
+  JvmtiExport::set_can_hotswap_or_post_breakpoint(true);
+  JvmtiExport::set_all_dependencies_are_recorded(true);
+#endif
```

My measurements indicate that the overhead of doing so is minimal (around 1% increase of nmethod size) and justifies the benefit. E.g. a Spring Petclinic application started with `-Xbatch -XX:+UnlockDiagnosticVMOptions -XX:+LogCompilation` compiles about ~11500 methods (~9000 with C1 and ~2500 with C2) resulting in an aggregated nmethod size of around ~40bm. Additionally recording `evol_method` dependencies only increases this size be about 400kb. The ration remains about the same if we run the same experiment with only C1 or only C2.

Instead of unconditionally recording `evol_method` dependencies we could guard the recording by a new flag. But this would only make sense if that flag would be on by default and I don't know if such a flag is justified just for the rare (or non-existent?) cases where somebody wants to disable the recording of the dependencies.

Another alternative would be to remove the `set_can_hotswap_or_post_breakpoint()`/`set_all_dependencies_are_recorded()` from `JvmtiExport` altogether (and always record the dependencies). It is currently only used at a few call sites in the C1/C2 compiler (`set_can_hotswap_or_post_breakpoint()`) and once when redefining classes (`set_all_dependencies_are_recorded()`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324241](https://bugs.openjdk.org/browse/JDK-8324241): Always record evol_method deps to avoid excessive method flushing (**Enhancement** - P4)


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer) ⚠️ Review applies to [7b750da5](https://git.openjdk.org/jdk/pull/17509/files/7b750da5bad05573151c80f7e81ceeaab456bb4d)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**) ⚠️ Review applies to [95db4a72](https://git.openjdk.org/jdk/pull/17509/files/95db4a7218be14212d11d12f59f1d0c847fa48ea)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [6d3e24ab](https://git.openjdk.org/jdk/pull/17509/files/6d3e24ab152b3f7b2e906f9e7f0b883a99b45147)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [29966635](https://git.openjdk.org/jdk/pull/17509/files/2996663532733d90e949afae431a093923845b1f)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [29966635](https://git.openjdk.org/jdk/pull/17509/files/2996663532733d90e949afae431a093923845b1f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17509/head:pull/17509` \
`$ git checkout pull/17509`

Update a local copy of the PR: \
`$ git checkout pull/17509` \
`$ git pull https://git.openjdk.org/jdk.git pull/17509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17509`

View PR using the GUI difftool: \
`$ git pr show -t 17509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17509.diff">https://git.openjdk.org/jdk/pull/17509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17509#issuecomment-1902251150)