### PR TITLE
8324186: Use "dmb.ishst+dmb.ishld" for release barrier

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -8289,7 +8289,7 @@ instruct membar_acquire() %{
   ins_cost(VOLATILE_REF_COST);
 
   format %{ "membar_acquire\n\t"
-            "dmb ish" %}
+            "dmb ishld" %}
 
   ins_encode %{
     __ block_comment("membar_acquire");
@@ -8343,11 +8343,12 @@ instruct membar_release() %{
   ins_cost(VOLATILE_REF_COST);
 
   format %{ "membar_release\n\t"
-            "dmb ish" %}
+            "dmb ishst\n\tdmb ishld" %}
 
   ins_encode %{
     __ block_comment("membar_release");
-    __ membar(Assembler::LoadStore|Assembler::StoreStore);
+    __ membar(Assembler::StoreStore);
+    __ membar(Assembler::LoadStore);
   %}
   ins_pipe(pipe_serial);
 %}

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -127,7 +127,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           range(1, 99)                                                  \
   product(ccstr, UseBranchProtection, "none",                           \
           "Branch Protection to use: none, standard, pac-ret")          \
-  product(bool, AlwaysMergeDMB, false,                                  \
+  product(bool, AlwaysMergeDMB, false, DIAGNOSTIC,                      \
           "Always merge DMB instructions in code emission")             \
 
 // end of ARCH_FLAGS

--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -127,6 +127,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
           range(1, 99)                                                  \
   product(ccstr, UseBranchProtection, "none",                           \
           "Branch Protection to use: none, standard, pac-ret")          \
+  product(bool, AlwaysMergeDMB, false,                                  \
+          "Always merge DMB instructions in code emission")             \
 
 // end of ARCH_FLAGS
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2066,8 +2066,9 @@ void MacroAssembler::membar(Membar_mask_bits order_constraint) {
   address last = code()->last_insn();
   if (last != nullptr && nativeInstruction_at(last)->is_Membar() && prev == last) {
     NativeMembar *bar = NativeMembar_at(prev);
-    // We need avoid promoting barrier to dmb.ish,
-    // Only merge same type or any one with ish type
+    // Don't promote DMB ST|DMB LD to DMB (a full barrier) because
+    // doing so would introduce  a StoreLoad which  the caller did not
+    // intend
     if (bar->get_kind() == order_constraint
         || bar->get_kind() == AnyAny
         || order_constraint == AnyAny) {

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2067,9 +2067,9 @@ void MacroAssembler::membar(Membar_mask_bits order_constraint) {
   if (last != nullptr && nativeInstruction_at(last)->is_Membar() && prev == last) {
     NativeMembar *bar = NativeMembar_at(prev);
     // Don't promote DMB ST|DMB LD to DMB (a full barrier) because
-    // doing so would introduce  a StoreLoad which  the caller did not
+    // doing so would introduce a StoreLoad which the caller did not
     // intend
-    if (bar->get_kind() == order_constraint
+    if (AlwaysMergeDMB || bar->get_kind() == order_constraint
         || bar->get_kind() == AnyAny
         || order_constraint == AnyAny) {
       // We are merging two memory barrier instructions.  On AArch64 we

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2066,14 +2066,20 @@ void MacroAssembler::membar(Membar_mask_bits order_constraint) {
   address last = code()->last_insn();
   if (last != nullptr && nativeInstruction_at(last)->is_Membar() && prev == last) {
     NativeMembar *bar = NativeMembar_at(prev);
-    // We are merging two memory barrier instructions.  On AArch64 we
-    // can do this simply by ORing them together.
-    bar->set_kind(bar->get_kind() | order_constraint);
-    BLOCK_COMMENT("merged membar");
-  } else {
-    code()->set_last_insn(pc());
-    dmb(Assembler::barrier(order_constraint));
+    // We need avoid promoting barrier to dmb.ish,
+    // Only merge same type or any one with ish type
+    if (bar->get_kind() == order_constraint
+        || bar->get_kind() == AnyAny
+        || order_constraint == AnyAny) {
+      // We are merging two memory barrier instructions.  On AArch64 we
+      // can do this simply by ORing them together.
+      bar->set_kind(bar->get_kind() | order_constraint);
+      BLOCK_COMMENT("merged membar");
+      return;
+    }
   }
+  code()->set_last_insn(pc());
+  dmb(Assembler::barrier(order_constraint));
 }
 
 bool MacroAssembler::try_merge_ldst(Register rt, const Address &adr, size_t size_in_bytes, bool is_store) {

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -183,6 +183,9 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }
+    if (FLAG_IS_DEFAULT(AlwaysMergeDMB)) {
+      FLAG_SET_DEFAULT(AlwaysMergeDMB, true);
+    }
   }
 
   // Cortex A53

--- a/test/micro/org/openjdk/bench/vm/compiler/FinalFieldInitialize.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/FinalFieldInitialize.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024, Alibaba Group Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.infra.Blackhole;
+
+/* test allocation speed of object with final field */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+public class FinalFieldInitialize {
+  final static int LEN = 100_000;
+  Object arr[] = null;
+  @Setup
+  public void setup(){
+    arr = new Object[LEN];
+  }
+
+  @Benchmark
+  public void testAlloc(Blackhole bh) {
+    for (int i=0; i<LEN; i++) {
+      arr[i] = new TObj();
+    }
+    bh.consume(arr);
+  }
+
+  @Benchmark
+  public void testAllocWithFinal(Blackhole bh) {
+    for (int i=0; i<LEN; i++) {
+      arr[i] = new TObjWithFinal();
+    }
+    bh.consume(arr);
+  }
+}
+
+class TObj {
+  private int i;
+  private long l;
+  private boolean b;
+
+  public TObj() {
+    i = 10;
+    l = 100l;
+    b = true;
+  }
+}
+
+class TObjWithFinal {
+  private int i;
+  private long l;
+  private final boolean b;
+
+  public TObjWithFinal() {
+    i = 10;
+    l = 100l;
+    b = true;
+  }
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/FinalFieldInitialize.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/FinalFieldInitialize.java
@@ -67,7 +67,7 @@ class TObj {
 
   public TObj() {
     i = 10;
-    l = 100l;
+    l = 100L;
     b = true;
   }
 }
@@ -79,7 +79,7 @@ class TObjWithFinal {
 
   public TObjWithFinal() {
     i = 10;
-    l = 100l;
+    l = 100L;
     b = true;
   }
 }


### PR DESCRIPTION
Details is https://mail.openjdk.org/pipermail/hotspot-compiler-dev/2024-January/071921.html.
Using a combined dmb.ish for release barrier will introduce a heavy storeload barrier. Use "dmb.ishst+dmb.ishld" pair instead, we can gain performance improvement on N1 and N2 architecture. The benchmark is test/micro/org/openjdk/bench/vm/compiler/FinalFieldInitialize.java
Run with ParallelGC to minimalize impact of gc barrier.
```bash
make test TEST="micro:org.openjdk.bench.vm.compiler.FinalFieldInitialize" MICRO="VM_OPTIONS=-XX:+UseParallelGC"
...
FinalFieldInitialize.testAllocWithFinal  thrpt    9  1411.601 ?  6.546  ops/s
```
Without the patch
```bash
FinalFieldInitialize.testAllocWithFinal  thrpt    9  1214.575 ? 14.217  ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324186](https://bugs.openjdk.org/browse/JDK-8324186): use "dmb.ishst+dmb.ishld" for release barrier (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [f817bb25](https://git.openjdk.org/jdk/pull/17511/files/f817bb25384f9e0acb5ba621b6417489f8f4b96f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17511/head:pull/17511` \
`$ git checkout pull/17511`

Update a local copy of the PR: \
`$ git checkout pull/17511` \
`$ git pull https://git.openjdk.org/jdk.git pull/17511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17511`

View PR using the GUI difftool: \
`$ git pr show -t 17511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17511.diff">https://git.openjdk.org/jdk/pull/17511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17511#issuecomment-1902885701)