### PR TITLE
JDK-8323964: runtime/Thread/ThreadCountLimit.java fails intermittently on AIX

### DIFF
--- a/src/hotspot/os/aix/globals_aix.hpp
+++ b/src/hotspot/os/aix/globals_aix.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,11 +49,12 @@
           "Allow VM to run with EXTSHM=ON.")                                        \
                                                                                     \
   /*  Maximum expected size of the data segment. That correlates with the      */   \
-  /*  to the maximum C Heap consumption we expect.                             */   \
-  /*  We need to know this because we need to leave "breathing space" for the  */   \
-  /*  data segment when placing the java heap. If that space is too small, we  */   \
-  /*  reduce our chance of getting a low heap address (needed for compressed   */   \
-  /*  Oops).                                                                   */   \
+  /*  maximum C Heap consumption we expect.                                    */   \
+  /*  We need to leave "breathing space" for the data segment when             */   \
+  /*  placing the java heap. If the MaxExpectedDataSegmentSize setting         */   \
+  /*  is too small, we might run into resource issues creating many native     */   \
+  /*  threads, if it is too large, we reduce our chance of getting a low hea   */   \
+  /*  address (needed for compressed Oops).                                    */   \
   product(uintx, MaxExpectedDataSegmentSize, 8*G,                                   \
           "Maximum expected Data Segment Size.")                                    \
                                                                                     \

--- a/src/hotspot/os/aix/globals_aix.hpp
+++ b/src/hotspot/os/aix/globals_aix.hpp
@@ -53,7 +53,7 @@
   /*  We need to leave "breathing space" for the data segment when             */   \
   /*  placing the java heap. If the MaxExpectedDataSegmentSize setting         */   \
   /*  is too small, we might run into resource issues creating many native     */   \
-  /*  threads, if it is too large, we reduce our chance of getting a low hea   */   \
+  /*  threads, if it is too large, we reduce our chance of getting a low heap  */   \
   /*  address (needed for compressed Oops).                                    */   \
   product(uintx, MaxExpectedDataSegmentSize, 8*G,                                   \
           "Maximum expected Data Segment Size.")                                    \

--- a/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
+++ b/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,17 @@
 /**
  * @test
  * @summary Stress test that reaches the process limit for thread count, or time limit.
+ * @requires os.family != "aix"
  * @key stress
  * @run main/othervm -Xmx1g ThreadCountLimit
+ */
+
+/**
+ * @test
+ * @summary Stress test that reaches the process limit for thread count, or time limit.
+ * @requires os.family == "aix"
+ * @key stress
+ * @run main/othervm -Xmx1g -XX:MaxExpectedDataSegmentSize=16g ThreadCountLimit
  */
 
 import java.util.concurrent.CountDownLatch;


### PR DESCRIPTION
Every 1-2 months we run into into such kind of failures on AIX:

```
[2.498s][warning][os,thread] Failed to start thread "Unknown thread" - pthread_create failed (11=EAGAIN) for attributes: stacksize: 2112k, guardsize: 0k, detached.
[2.498s][warning][os,thread] Number of threads approx. running in the VM: 4223
[2.498s][warning][os,thread] Checking JVM parameter MaxExpectedDataSegmentSize (currently 8388608k) might be helpful
[2.498s][warning][os,thread] Failed to start the native thread for java.lang.Thread "Thread-4213"

[error occurred during error reporting (), id 0xe0000000, Internal Error (/workspace/openjdk-jdk-dev-aix_ppc64-dbg/jdk/src/hotspot/os/aix/os_aix.cpp:2971)]
#
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (malloc) failed to allocate 56 bytes. Error detail: AllocateHeap
[thread 3856 also had an error]
# An error report file with more information is saved as:
# /tmp/hs_err_pid13959464.log
[thread 76331 also had an error]

```
Seems the MaxExpectedDataSegmentSize (Maximum expected size of the data segment, AIX specific flag)
settings in in some cases too low for the test.
We experienced this a few times in scenarios where a lot of threads are created (and even warn about this, see os_aix.cpp).
So we should better run with a higher than default value of MaxExpectedDataSegmentSize for this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323964](https://bugs.openjdk.org/browse/JDK-8323964): runtime/Thread/ThreadCountLimit.java fails intermittently on AIX (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [de4dc68a](https://git.openjdk.org/jdk/pull/17512/files/de4dc68a678600161555e68e2d221ad5da9093b6)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [de4dc68a](https://git.openjdk.org/jdk/pull/17512/files/de4dc68a678600161555e68e2d221ad5da9093b6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17512/head:pull/17512` \
`$ git checkout pull/17512`

Update a local copy of the PR: \
`$ git checkout pull/17512` \
`$ git pull https://git.openjdk.org/jdk.git pull/17512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17512`

View PR using the GUI difftool: \
`$ git pr show -t 17512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17512.diff">https://git.openjdk.org/jdk/pull/17512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17512#issuecomment-1903480762)