### PR TITLE
8324280: RISC-V: Incorrect implementation in VM_Version::parse_satp_mode

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -169,13 +169,13 @@ void VM_Version::os_aux_features() {
 }
 
 VM_Version::VM_MODE VM_Version::parse_satp_mode(const char* vm_mode) {
-  if (!strcmp(vm_mode, "sv39")) {
+  if (!strcmp(vm_mode, "sv39\n")) {
     return VM_SV39;
-  } else if (!strcmp(vm_mode, "sv48")) {
+  } else if (!strcmp(vm_mode, "sv48\n")) {
     return VM_SV48;
-  } else if (!strcmp(vm_mode, "sv57")) {
+  } else if (!strcmp(vm_mode, "sv57\n")) {
     return VM_SV57;
-  } else if (!strcmp(vm_mode, "sv64")) {
+  } else if (!strcmp(vm_mode, "sv64\n")) {
     return VM_SV64;
   } else {
     return VM_MBARE;
@@ -197,7 +197,7 @@ char* VM_Version::os_uarch_additional_features() {
     if ((p = strchr(buf, ':')) != nullptr) {
       if (mode == VM_NOTSET) {
         if (strncmp(buf, "mmu", sizeof "mmu" - 1) == 0) {
-          mode = VM_Version::parse_satp_mode(p);
+          mode = VM_Version::parse_satp_mode(p + 2);
         }
       }
       if (ret == nullptr) {

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -169,13 +169,13 @@ void VM_Version::os_aux_features() {
 }
 
 VM_Version::VM_MODE VM_Version::parse_satp_mode(const char* vm_mode) {
-  if (!strcmp(vm_mode, "sv39\n")) {
+  if (!strncmp(vm_mode, "sv39", sizeof "sv39" - 1)) {
     return VM_SV39;
-  } else if (!strcmp(vm_mode, "sv48\n")) {
+  } else if (!strncmp(vm_mode, "sv48", sizeof "sv48" - 1)) {
     return VM_SV48;
-  } else if (!strcmp(vm_mode, "sv57\n")) {
+  } else if (!strncmp(vm_mode, "sv57", sizeof "sv57" - 1)) {
     return VM_SV57;
-  } else if (!strcmp(vm_mode, "sv64\n")) {
+  } else if (!strncmp(vm_mode, "sv64", sizeof "sv64" - 1)) {
     return VM_SV64;
   } else {
     return VM_MBARE;


### PR DESCRIPTION
Currently, method `VM_Version::os_uarch_additional_features` uses `fgets` to read the contents of `/proc/cpuinfo`, then calls `parse_satp_mode` with a string with the leading "mmu" and whitespaces removed, like ": sv39\n". However, `parse_satp_mode` compares this string directly to "sv39", which always fails and returns `VM_MBARE`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324280](https://bugs.openjdk.org/browse/JDK-8324280): RISC-V: Incorrect implementation in VM_Version::parse_satp_mode (**Bug** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [5d1a8f27](https://git.openjdk.org/jdk/pull/17513/files/5d1a8f2771ad80f5022c36f4c9e71a41a9084100)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17513/head:pull/17513` \
`$ git checkout pull/17513`

Update a local copy of the PR: \
`$ git checkout pull/17513` \
`$ git pull https://git.openjdk.org/jdk.git pull/17513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17513`

View PR using the GUI difftool: \
`$ git pr show -t 17513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17513.diff">https://git.openjdk.org/jdk/pull/17513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17513#issuecomment-1909117348)