### PR TITLE
JDK-8322648: Improve class initialization barrier in TemplateTable::_new for PPC

### DIFF
--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3805,16 +3805,15 @@ void TemplateTable::_new() {
 
     // Make sure klass is initialized.
     assert(VM_Version::supports_fast_class_init_checks(), "Optimization requires support for fast class initialization checks");
-    __ clinit_barrier(Rcpool, R16_thread, nullptr /*L_fast_path*/, &Lslow_case);
+    __ clinit_barrier(RinstanceKlass, R16_thread, nullptr /*L_fast_path*/, &Lslow_case);
 
     // get instance_size.
     __ lwz(Rinstance_size, in_bytes(Klass::layout_helper_offset()), RinstanceKlass);
 
-    __ cmpdi(CCR1, Rscratch, InstanceKlass::fully_initialized);
     // Make sure klass does not have has_finalizer, or is abstract, or interface or java/lang/Class.
     __ andi_(R0, Rinstance_size, Klass::_lh_instance_slow_path_bit); // slow path bit equals 0?
 
-    __ cmpdi(CCR0, Rscratch, InstanceKlass::fully_initialized); // slow path bit set or not fully initialized?
+    __ crnand(CCR0, Assembler::equal, CCR1, Assembler::equal); // slow path bit set or not fully initialized?
     __ beq(CCR0, Lslow_case);
 
     // --------------------------------------------------------------------------

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2013, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3805,7 +3805,7 @@ void TemplateTable::_new() {
 
     // Make sure klass is initialized.
     assert(VM_Version::supports_fast_class_init_checks(), "Optimization requires support for fast class initialization checks");
-    __ clinit_barrier(Rcpool,R16_thread, nullptr /*L_fast_path*/, &Lslow_case);
+    __ clinit_barrier(Rcpool, R16_thread, nullptr /*L_fast_path*/, &Lslow_case);
 
     // get instance_size.
     __ lwz(Rinstance_size, in_bytes(Klass::layout_helper_offset()), RinstanceKlass);

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3807,14 +3807,11 @@ void TemplateTable::_new() {
     assert(VM_Version::supports_fast_class_init_checks(), "Optimization requires support for fast class initialization checks");
     __ clinit_barrier(RinstanceKlass, R16_thread, nullptr /*L_fast_path*/, &Lslow_case);
 
-    // get instance_size.
     __ lwz(Rinstance_size, in_bytes(Klass::layout_helper_offset()), RinstanceKlass);
 
     // Make sure klass does not have has_finalizer, or is abstract, or interface or java/lang/Class.
     __ andi_(R0, Rinstance_size, Klass::_lh_instance_slow_path_bit); // slow path bit equals 0?
-
-    __ crnand(CCR0, Assembler::equal, CCR1, Assembler::equal); // slow path bit set or not fully initialized?
-    __ beq(CCR0, Lslow_case);
+    __ bne(CCR0, Lslow_case);
 
     // --------------------------------------------------------------------------
     // Fast case:

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3803,8 +3803,11 @@ void TemplateTable::_new() {
     __ sldi(Roffset, Rindex, LogBytesPerWord);
     __ load_resolved_klass_at_offset(Rcpool, Roffset, RinstanceKlass);
 
-    // Make sure klass is fully initialized and get instance_size.
-    __ lbz(Rscratch, in_bytes(InstanceKlass::init_state_offset()), RinstanceKlass);
+    // Make sure klass is initialized.
+    assert(VM_Version::supports_fast_class_init_checks(), "Optimization requires support for fast class initialization checks");
+    __ clinit_barrier(Rcpool,R16_thread, nullptr /*L_fast_path*/, &Lslow_case);
+
+    // get instance_size.
     __ lwz(Rinstance_size, in_bytes(Klass::layout_helper_offset()), RinstanceKlass);
 
     __ cmpdi(CCR1, Rscratch, InstanceKlass::fully_initialized);

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3814,7 +3814,7 @@ void TemplateTable::_new() {
     // Make sure klass does not have has_finalizer, or is abstract, or interface or java/lang/Class.
     __ andi_(R0, Rinstance_size, Klass::_lh_instance_slow_path_bit); // slow path bit equals 0?
 
-    __ crnand(CCR0, Assembler::equal, CCR1, Assembler::equal); // slow path bit set or not fully initialized?
+    __ cmpdi(CCR0, Rscratch, InstanceKlass::fully_initialized); // slow path bit set or not fully initialized?
     __ beq(CCR0, Lslow_case);
 
     // --------------------------------------------------------------------------


### PR DESCRIPTION
ppc port implementation of https://github.com/openjdk/jdk/pull/17006

Fastdebug and Release : build and tier1 testing successful.

JBS Issue : [JDK-8322648](https://bugs.openjdk.org/browse/JDK-8322648)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322648](https://bugs.openjdk.org/browse/JDK-8322648): Improve class initialization barrier in TemplateTable::_new for PPC (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17518/head:pull/17518` \
`$ git checkout pull/17518`

Update a local copy of the PR: \
`$ git checkout pull/17518` \
`$ git pull https://git.openjdk.org/jdk.git pull/17518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17518`

View PR using the GUI difftool: \
`$ git pr show -t 17518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17518.diff">https://git.openjdk.org/jdk/pull/17518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17518#issuecomment-1903909025)