### PR TITLE
8324334: Shenandoah: Improve end of process report

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.hpp
@@ -80,9 +80,6 @@ protected:
 
   RegionData* _region_data;
 
-  uint _degenerated_cycles_in_a_row;
-  uint _successful_cycles_in_a_row;
-
   double _cycle_start;
   double _last_cycle_end;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
- * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
@@ -43,13 +43,11 @@ ShenandoahCollectorPolicy::ShenandoahCollectorPolicy() :
   _explicit_concurrent(0),
   _explicit_full(0),
   _implicit_concurrent(0),
-  _implicit_full(0),
-  _cycle_counter(0) {
+  _implicit_full(0) {
 
   Copy::zero_to_bytes(_degen_points, sizeof(size_t) * ShenandoahGC::_DEGENERATED_LIMIT);
 
   _tracer = new ShenandoahTracer();
-
 }
 
 void ShenandoahCollectorPolicy::record_explicit_to_concurrent() {
@@ -102,14 +100,6 @@ void ShenandoahCollectorPolicy::record_success_degenerated(bool is_abbreviated) 
 void ShenandoahCollectorPolicy::record_success_full() {
   _consecutive_degenerated_gcs = 0;
   _success_full_gcs++;
-}
-
-size_t ShenandoahCollectorPolicy::cycle_counter() const {
-  return _cycle_counter;
-}
-
-void ShenandoahCollectorPolicy::record_cycle_start() {
-  _cycle_counter++;
 }
 
 void ShenandoahCollectorPolicy::record_shutdown() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +32,11 @@
 
 ShenandoahCollectorPolicy::ShenandoahCollectorPolicy() :
   _success_concurrent_gcs(0),
+  _abbreviated_concurrent_gcs(0),
   _success_degenerated_gcs(0),
+  _abbreviated_degenerated_gcs(0),
   _success_full_gcs(0),
+  _consecutive_degenerated_gcs(0),
   _alloc_failure_degenerated(0),
   _alloc_failure_degenerated_upgrade_to_full(0),
   _alloc_failure_full(0),
@@ -75,18 +79,28 @@ void ShenandoahCollectorPolicy::record_alloc_failure_to_degenerated(ShenandoahGC
 }
 
 void ShenandoahCollectorPolicy::record_degenerated_upgrade_to_full() {
+  _consecutive_degenerated_gcs = 0;
   _alloc_failure_degenerated_upgrade_to_full++;
 }
 
-void ShenandoahCollectorPolicy::record_success_concurrent() {
+void ShenandoahCollectorPolicy::record_success_concurrent(bool is_abbreviated) {
+  _consecutive_degenerated_gcs = 0;
   _success_concurrent_gcs++;
+  if (is_abbreviated) {
+    _abbreviated_concurrent_gcs++;
+  }
 }
 
-void ShenandoahCollectorPolicy::record_success_degenerated() {
+void ShenandoahCollectorPolicy::record_success_degenerated(bool is_abbreviated) {
   _success_degenerated_gcs++;
+  _consecutive_degenerated_gcs++;
+  if (is_abbreviated) {
+    _abbreviated_degenerated_gcs++;
+  }
 }
 
 void ShenandoahCollectorPolicy::record_success_full() {
+  _consecutive_degenerated_gcs = 0;
   _success_full_gcs++;
 }
 
@@ -110,28 +124,34 @@ void ShenandoahCollectorPolicy::print_gc_stats(outputStream* out) const {
   out->print_cr("Under allocation pressure, concurrent cycles may cancel, and either continue cycle");
   out->print_cr("under stop-the-world pause or result in stop-the-world Full GC. Increase heap size,");
   out->print_cr("tune GC heuristics, set more aggressive pacing delay, or lower allocation rate");
-  out->print_cr("to avoid Degenerated and Full GC cycles.");
+  out->print_cr("to avoid Degenerated and Full GC cycles. Abbreviated cycles are those which found");
+  out->print_cr("enough regions with no live objects to skip evacuation.");
   out->cr();
 
-  out->print_cr(SIZE_FORMAT_W(5) " successful concurrent GCs",         _success_concurrent_gcs);
-  out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly",           _explicit_concurrent);
-  out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly",           _implicit_concurrent);
+  size_t completed_gcs = _success_full_gcs + _success_degenerated_gcs + _success_concurrent_gcs;
+  out->print_cr(SIZE_FORMAT_W(5) " Completed GCs", completed_gcs);
+  out->print_cr(SIZE_FORMAT_W(5) " Successful Concurrent GCs (%.2f%%)",  _success_concurrent_gcs, percent_of(_success_concurrent_gcs, completed_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly (%.2f%%)",    _explicit_concurrent, percent_of(_explicit_concurrent, _success_concurrent_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly (%.2f%%)",    _implicit_concurrent, percent_of(_implicit_concurrent, _success_concurrent_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " abbreviated (%.2f%%)",           _abbreviated_concurrent_gcs, percent_of(_abbreviated_concurrent_gcs, _success_concurrent_gcs));
   out->cr();
 
-  out->print_cr(SIZE_FORMAT_W(5) " Degenerated GCs",                   _success_degenerated_gcs);
-  out->print_cr("  " SIZE_FORMAT_W(5) " caused by allocation failure", _alloc_failure_degenerated);
+  size_t degenerated_gcs = _alloc_failure_degenerated_upgrade_to_full + _success_degenerated_gcs;
+  out->print_cr(SIZE_FORMAT_W(5) " Degenerated GCs (%.2f%%)", degenerated_gcs, percent_of(degenerated_gcs, completed_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " upgraded to Full GC (%.2f%%)",          _alloc_failure_degenerated_upgrade_to_full, percent_of(_alloc_failure_degenerated_upgrade_to_full, degenerated_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " caused by allocation failure (%.2f%%)", _alloc_failure_degenerated, percent_of(_alloc_failure_degenerated, degenerated_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " abbreviated (%.2f%%)",                  _abbreviated_degenerated_gcs, percent_of(_abbreviated_degenerated_gcs, degenerated_gcs));
   for (int c = 0; c < ShenandoahGC::_DEGENERATED_LIMIT; c++) {
     if (_degen_points[c] > 0) {
       const char* desc = ShenandoahGC::degen_point_to_string((ShenandoahGC::ShenandoahDegenPoint)c);
       out->print_cr("    " SIZE_FORMAT_W(5) " happened at %s",         _degen_points[c], desc);
     }
   }
-  out->print_cr("  " SIZE_FORMAT_W(5) " upgraded to Full GC",          _alloc_failure_degenerated_upgrade_to_full);
   out->cr();
 
-  out->print_cr(SIZE_FORMAT_W(5) " Full GCs",                          _success_full_gcs + _alloc_failure_degenerated_upgrade_to_full);
-  out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly",           _explicit_full);
-  out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly",           _implicit_full);
-  out->print_cr("  " SIZE_FORMAT_W(5) " caused by allocation failure", _alloc_failure_full);
-  out->print_cr("  " SIZE_FORMAT_W(5) " upgraded from Degenerated GC", _alloc_failure_degenerated_upgrade_to_full);
+  out->print_cr(SIZE_FORMAT_W(5) " Full GCs (%.2f%%)",                          _success_full_gcs, percent_of(_success_full_gcs, completed_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " invoked explicitly (%.2f%%)",           _explicit_full, percent_of(_explicit_full, _success_full_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " invoked implicitly (%.2f%%)",           _implicit_full, percent_of(_implicit_full, _success_full_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " caused by allocation failure (%.2f%%)", _alloc_failure_full, percent_of(_alloc_failure_full, _success_full_gcs));
+  out->print_cr("  " SIZE_FORMAT_W(5) " upgraded from Degenerated GC (%.2f%%)", _alloc_failure_degenerated_upgrade_to_full, percent_of(_alloc_failure_degenerated_upgrade_to_full, _success_full_gcs));
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -39,9 +39,12 @@ public:
 class ShenandoahCollectorPolicy : public CHeapObj<mtGC> {
 private:
   size_t _success_concurrent_gcs;
+  size_t _abbreviated_concurrent_gcs;
   size_t _success_degenerated_gcs;
+  size_t _abbreviated_degenerated_gcs;
   // Written by control thread, read by mutators
   volatile size_t _success_full_gcs;
+  uint _consecutive_degenerated_gcs;
   size_t _alloc_failure_degenerated;
   size_t _alloc_failure_degenerated_upgrade_to_full;
   size_t _alloc_failure_full;
@@ -49,13 +52,12 @@ private:
   size_t _explicit_full;
   size_t _implicit_concurrent;
   size_t _implicit_full;
+  size_t _cycle_counter;
   size_t _degen_points[ShenandoahGC::_DEGENERATED_LIMIT];
 
   ShenandoahSharedFlag _in_shutdown;
-
   ShenandoahTracer* _tracer;
 
-  size_t _cycle_counter;
 
 public:
   ShenandoahCollectorPolicy();
@@ -64,8 +66,8 @@ public:
   // These two encompass the entire cycle.
   void record_cycle_start();
 
-  void record_success_concurrent();
-  void record_success_degenerated();
+  void record_success_concurrent(bool is_abbreviated);
+  void record_success_degenerated(bool is_abbreviated);
   void record_success_full();
   void record_alloc_failure_to_degenerated(ShenandoahGC::ShenandoahDegenPoint point);
   void record_alloc_failure_to_full();
@@ -86,6 +88,10 @@ public:
 
   size_t full_gc_count() const {
     return _success_full_gcs + _alloc_failure_degenerated_upgrade_to_full;
+  }
+
+  inline size_t consecutive_degenerated_gc_count() const {
+    return _consecutive_degenerated_gcs;
   }
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -52,7 +52,6 @@ private:
   size_t _explicit_full;
   size_t _implicit_concurrent;
   size_t _implicit_full;
-  size_t _cycle_counter;
   size_t _degen_points[ShenandoahGC::_DEGENERATED_LIMIT];
 
   ShenandoahSharedFlag _in_shutdown;
@@ -61,10 +60,6 @@ private:
 
 public:
   ShenandoahCollectorPolicy();
-
-  // TODO: This is different from gc_end: that one encompasses one VM operation.
-  // These two encompass the entire cycle.
-  void record_cycle_start();
 
   void record_success_concurrent(bool is_abbreviated);
   void record_success_degenerated(bool is_abbreviated);
@@ -81,8 +76,6 @@ public:
   bool is_at_shutdown();
 
   ShenandoahTracer* tracer() {return _tracer;}
-
-  size_t cycle_counter() const;
 
   void print_gc_stats(outputStream* out) const;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -61,6 +61,11 @@ private:
 public:
   ShenandoahCollectorPolicy();
 
+  // A collection cycle may be "abbreviated" if Shenandoah finds a sufficient percentage
+  // of regions that contain no live objects (ShenandoahImmediateThreshold). These cycles
+  // end after final mark, skipping the evacuation and reference-updating phases. Such
+  // cycles are very efficient and are worth tracking. Note that both degenerated and
+  // concurrent cycles can be abbreviated.
   void record_success_concurrent(bool is_abbreviated);
   void record_success_degenerated(bool is_abbreviated);
   void record_success_full();
@@ -83,6 +88,9 @@ public:
     return _success_full_gcs + _alloc_failure_degenerated_upgrade_to_full;
   }
 
+  // If the heuristics find that the number of consecutive degenerated cycles is above
+  // ShenandoahFullGCThreshold, then they will initiate a Full GC upon an allocation
+  // failure.
   inline size_t consecutive_degenerated_gc_count() const {
     return _consecutive_degenerated_gcs;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -87,7 +87,8 @@ public:
 
 ShenandoahConcurrentGC::ShenandoahConcurrentGC() :
   _mark(),
-  _degen_point(ShenandoahDegenPoint::_degenerated_unset) {
+  _degen_point(ShenandoahDegenPoint::_degenerated_unset),
+  _abbreviated(false) {
 }
 
 ShenandoahGC::ShenandoahDegenPoint ShenandoahConcurrentGC::degen_point() const {
@@ -188,6 +189,7 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
     entry_cleanup_complete();
   } else {
     vmop_entry_final_roots();
+    _abbreviated = true;
   }
 
   return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -51,6 +51,8 @@ public:
   ShenandoahConcurrentGC();
   bool collect(GCCause::Cause cause);
   ShenandoahDegenPoint degen_point() const;
+
+  // Return true if this cycle found enough immediate garbage to skip evacuation
   bool abbreviated() const { return _abbreviated; }
 
   // Cancel ongoing concurrent GC

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.hpp
@@ -45,11 +45,13 @@ class ShenandoahConcurrentGC : public ShenandoahGC {
 private:
   ShenandoahConcurrentMark  _mark;
   ShenandoahDegenPoint      _degen_point;
+  bool                      _abbreviated;
 
 public:
   ShenandoahConcurrentGC();
   bool collect(GCCause::Cause cause);
   ShenandoahDegenPoint degen_point() const;
+  bool abbreviated() const { return _abbreviated; }
 
   // Cancel ongoing concurrent GC
   static void cancel();

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -396,7 +396,7 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
   if (gc.collect(cause)) {
     // Cycle is complete
     heap->heuristics()->record_success_concurrent();
-    heap->shenandoah_policy()->record_success_concurrent();
+    heap->shenandoah_policy()->record_success_concurrent(gc.abbreviated());
   } else {
     assert(heap->cancelled_gc(), "Must have been cancelled");
     check_cancellation_or_degen(gc.degen_point());
@@ -427,10 +427,6 @@ void ShenandoahControlThread::service_stw_full_cycle(GCCause::Cause cause) {
 
   ShenandoahFullGC gc;
   gc.collect(cause);
-
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  heap->heuristics()->record_success_full();
-  heap->shenandoah_policy()->record_success_full();
 }
 
 void ShenandoahControlThread::service_stw_degenerated_cycle(GCCause::Cause cause, ShenandoahGC::ShenandoahDegenPoint point) {
@@ -441,10 +437,6 @@ void ShenandoahControlThread::service_stw_degenerated_cycle(GCCause::Cause cause
 
   ShenandoahDegenGC gc(point);
   gc.collect(cause);
-
-  ShenandoahHeap* const heap = ShenandoahHeap::heap();
-  heap->heuristics()->record_success_degenerated();
-  heap->shenandoah_policy()->record_success_degenerated();
 }
 
 void ShenandoahControlThread::service_uncommit(double shrink_before, size_t shrink_until) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -60,6 +60,7 @@ private:
   void op_degenerated_futile();
   void op_degenerated_fail();
 
+  // Turns this degenerated cycle into a full gc without leaving the safepoint
   void upgrade_to_full();
 
   const char* degen_event_message(ShenandoahDegenPoint point) const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.hpp
@@ -33,6 +33,7 @@ class ShenandoahDegenGC : public ShenandoahGC {
   friend class VM_ShenandoahDegeneratedGC;
 private:
   const ShenandoahDegenPoint  _degen_point;
+  bool _abbreviated;
 
 public:
   ShenandoahDegenGC(ShenandoahDegenPoint degen_point);
@@ -48,6 +49,7 @@ private:
   void op_finish_mark();
   void op_prepare_evacuation();
   void op_cleanup_early();
+
   void op_evacuate();
   void op_init_updaterefs();
   void op_updaterefs();
@@ -57,6 +59,8 @@ private:
   // Fail handling
   void op_degenerated_futile();
   void op_degenerated_fail();
+
+  void upgrade_to_full();
 
   const char* degen_event_message(ShenandoahDegenPoint point) const;
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -31,6 +31,7 @@
 #include "gc/shared/tlab_globals.hpp"
 #include "gc/shared/workerThread.hpp"
 #include "gc/shenandoah/heuristics/shenandoahHeuristics.hpp"
+#include "gc/shenandoah/shenandoahCollectorPolicy.hpp"
 #include "gc/shenandoah/shenandoahConcurrentGC.hpp"
 #include "gc/shenandoah/shenandoahCollectionSet.hpp"
 #include "gc/shenandoah/shenandoahFreeSet.hpp"
@@ -105,15 +106,21 @@ void ShenandoahFullGC::op_full(GCCause::Cause cause) {
   // Perform full GC
   do_it(cause);
 
+  ShenandoahHeap* const heap = ShenandoahHeap::heap();
+
   metrics.snap_after();
 
   if (metrics.is_good_progress()) {
-    ShenandoahHeap::heap()->notify_gc_progress();
+    heap->notify_gc_progress();
   } else {
     // Nothing to do. Tell the allocation path that we have failed to make
     // progress, and it can finally fail.
-    ShenandoahHeap::heap()->notify_gc_no_progress();
+    heap->notify_gc_no_progress();
   }
+
+  // Regardless if progress was made, we record that we completed a "successful" full GC.
+  heap->heuristics()->record_success_full();
+  heap->shenandoah_policy()->record_success_full();
 }
 
 void ShenandoahFullGC::do_it(GCCause::Cause gc_cause) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -49,7 +49,6 @@ ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause) :
   _tracer->report_gc_start(cause, _timer->gc_start());
   _heap->trace_heap_before_gc(_tracer);
 
-  _heap->shenandoah_policy()->record_cycle_start();
   _heap->heuristics()->record_cycle_start();
   _trace_cycle.initialize(_heap->cycle_memory_manager(), cause,
           "end of GC cycle",


### PR DESCRIPTION
Shenandoah emits a summary of collector statistics when the JVM process exits normally. These statistics do not include the number of cycles which did not require evacuation (we call these abbreviated or short-cut cycles).

The end-of-process report should include these shortcut cycles and also show the outcomes of various cycles as a percentage of the total number of cycles. This change also removes some unused variables/methods and has the heuristic lean on the collector policy for tracking consecutive degenerated cycles (rather than having both the heuristic and the collector policy tracking this).

Here is an example of the improved report:
```
    20 Completed GCs
     5 Successful Concurrent GCs (25.00%)
       2 invoked explicitly (40.00%)
       0 invoked implicitly (0.00%)
       1 abbreviated (20.00%)
    13 Degenerated GCs (65.00%)
       3 upgraded to Full GC (23.08%)
      13 caused by allocation failure (100.00%)
       0 abbreviated (0.00%)
        10 happened at Mark
         3 happened at Update References
     5 Full GCs (25.00%)
       0 invoked explicitly (0.00%)
       0 invoked implicitly (0.00%)
       2 caused by allocation failure (40.00%)
       3 upgraded from Degenerated GC (60.00%)
```

In addition to GHA testing, these changes have been tested on Dacapo, Extremem, SpecJBB2015, SpecJVM2008, Heapothesys and Diluvian.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324334](https://bugs.openjdk.org/browse/JDK-8324334): Shenandoah: Improve end of process report (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role) ⚠️ Review applies to [66bca0f3](https://git.openjdk.org/jdk/pull/17521/files/66bca0f32a1addb28f04b1acb21ddebfcc1cf86e)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) ⚠️ Review applies to [66bca0f3](https://git.openjdk.org/jdk/pull/17521/files/66bca0f32a1addb28f04b1acb21ddebfcc1cf86e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17521/head:pull/17521` \
`$ git checkout pull/17521`

Update a local copy of the PR: \
`$ git checkout pull/17521` \
`$ git pull https://git.openjdk.org/jdk.git pull/17521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17521`

View PR using the GUI difftool: \
`$ git pr show -t 17521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17521.diff">https://git.openjdk.org/jdk/pull/17521.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17521#issuecomment-1904781501)