### PR TITLE
8324657: Intermittent OOME on exception message create

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -2012,7 +2012,7 @@ public class ObjectInputStream
     }
 
     // Generate an InvalidObjectException for an OutOfMemoryError
-    // Use String.concat() to avoid string formatting code generation
+    // Use String.concat() to avoid string formatting invoke dynamic
     private static InvalidObjectException genInvalidObjectException(OutOfMemoryError oome, String[] ifaces) {
         return new InvalidObjectException("Proxy interface limit exceeded: "
                 .concat(Arrays.toString(ifaces)), oome);

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1987,9 +1987,8 @@ public class ObjectInputStream
             resolveEx = ex;
         } catch (IllegalAccessError aie) {
             throw new InvalidClassException(aie.getMessage(), aie);
-        } catch (OutOfMemoryError memerr) {
-            throw new InvalidObjectException("Proxy interface limit exceeded: " +
-                                             Arrays.toString(ifaces), memerr);
+        } catch (OutOfMemoryError oome) {
+            throw genInvalidObjectException(oome, ifaces);
         }
 
         // Call filterCheck on the class before reading anything else
@@ -2001,9 +2000,8 @@ public class ObjectInputStream
             totalObjectRefs++;
             depth++;
             desc.initProxy(cl, resolveEx, readClassDesc(false));
-        } catch (OutOfMemoryError memerr) {
-            throw new InvalidObjectException("Proxy interface limit exceeded: " +
-                                             Arrays.toString(ifaces), memerr);
+        } catch (OutOfMemoryError oome) {
+            throw genInvalidObjectException(oome, ifaces);
         } finally {
             depth--;
         }
@@ -2011,6 +2009,13 @@ public class ObjectInputStream
         handles.finish(descHandle);
         passHandle = descHandle;
         return desc;
+    }
+
+    // Generate an InvalidObjectException for an OutOfMemoryError
+    // Use String.concat() to avoid string formatting code generation
+    private static InvalidObjectException genInvalidObjectException(OutOfMemoryError oome, String[] ifaces) {
+        return new InvalidObjectException("Proxy interface limit exceeded: "
+                .concat(Arrays.toString(ifaces)), oome);
     }
 
     /**

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -2013,7 +2013,8 @@ public class ObjectInputStream
 
     // Generate an InvalidObjectException for an OutOfMemoryError
     // Use String.concat() to avoid string formatting invoke dynamic
-    private static InvalidObjectException genInvalidObjectException(OutOfMemoryError oome, String[] ifaces) {
+    private static InvalidObjectException genInvalidObjectException(OutOfMemoryError oome,
+                                                                    String[] ifaces) {
         return new InvalidObjectException("Proxy interface limit exceeded: "
                 .concat(Arrays.toString(ifaces)), oome);
     }


### PR DESCRIPTION
When an exception handler for an OutOfMemoryError uses string concatenation to compose an exception message, the invoke dynamic string format implementation may itself exhaust memory, preventing the exception from being handled.
Explicit use of String.concat() call can improve exception handling.

Writing a test of the exact failure condition has proved challenging due to the unpredictable state of memory when OOME occurs. The replacement of "+" with String.concat() is simple and direct.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324657](https://bugs.openjdk.org/browse/JDK-8324657): Intermittent OOME on exception message create (**Bug** - P3)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**) ⚠️ Review applies to [068b9d59](https://git.openjdk.org/jdk/pull/17522/files/068b9d5948e4e4d2762095873d16328cea1953e8)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [bfe60737](https://git.openjdk.org/jdk/pull/17522/files/bfe607379ee60abc64a463e334cfc3350e73b095)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [bfe60737](https://git.openjdk.org/jdk/pull/17522/files/bfe607379ee60abc64a463e334cfc3350e73b095)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17522/head:pull/17522` \
`$ git checkout pull/17522`

Update a local copy of the PR: \
`$ git checkout pull/17522` \
`$ git pull https://git.openjdk.org/jdk.git pull/17522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17522`

View PR using the GUI difftool: \
`$ git pr show -t 17522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17522.diff">https://git.openjdk.org/jdk/pull/17522.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17522#issuecomment-1908851104)