### PR TITLE
8323815: Source launcher should find classes with $ in names

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryContext.java
@@ -170,11 +170,22 @@ final class MemoryContext {
      *         if no source file was found for the given name
      */
     byte[] compileJavaFileByName(String name) {
+        // Initially, determine existing directory from class name.
+        // [pack$age . ] na$me [ $ enclo$ed [$ dee$per] ]
+        var lastDot = name.lastIndexOf(".");
+        var packageName = lastDot == -1 ? "" : name.substring(0, lastDot);
+        var packagePath = descriptor.sourceRootPath().resolve(packageName.replace('.', '/'));
+        // Trivial case: no matching directory exists
+        if (!Files.isDirectory(packagePath)) return null;
+
         // Determine source file from class name.
-        var firstDollarSign = name.indexOf('$'); // [package . ] name [ $ enclosed [$ deeper] ]
-        var packageAndClassName = firstDollarSign == -1 ? name : name.substring(0, firstDollarSign);
-        var path = packageAndClassName.replace('.', '/') + ".java";
-        var file = descriptor.sourceRootPath().resolve(path);
+        var candidate = name.substring(lastDot + 1, name.length()); // "na$me$enclo$ed$dee$per"
+        // For each `$` in the name try to find the first matching compilation unit.
+        while (candidate.contains("$")) {
+            if (Files.exists(packagePath.resolve(candidate + ".java"))) break;
+            candidate = candidate.substring(0, candidate.lastIndexOf("$"));
+        }
+        var file = packagePath.resolve(candidate + ".java");
 
         // Trivial case: no matching source file exists
         if (!Files.exists(file)) return null;

--- a/test/langtools/tools/javac/launcher/MultiFileSourceLauncherTests.java
+++ b/test/langtools/tools/javac/launcher/MultiFileSourceLauncherTests.java
@@ -75,7 +75,7 @@ class MultiFileSourceLauncherTests {
                     public class Hello {
                       public static void main(String... args) throws Exception {
                         System.out.println(Class.forName("World$Core"));
-                        System.out.println(Class.forName("p.q.Unit$First$Second"));
+                        System.out.println(Class.forName("p.q.Unit$123$Fir$t$$econd"));
                       }
                     }
                     """);
@@ -86,12 +86,12 @@ class MultiFileSourceLauncherTests {
                     }
                     """);
         var pq = Files.createDirectories(base.resolve("p/q"));
-        Files.writeString(pq.resolve("Unit.java"),
+        Files.writeString(pq.resolve("Unit$123.java"),
                     """
                     package p.q;
-                    record Unit() {
-                      record First() {
-                        record Second() {}
+                    record Unit$123() {
+                      record Fir$t() {
+                        record $econd() {}
                       }
                     }
                     """);
@@ -101,7 +101,7 @@ class MultiFileSourceLauncherTests {
                 () -> assertLinesMatch(
                         """
                         class World$Core
-                        class p.q.Unit$First$Second
+                        class p.q.Unit$123$Fir$t$$econd
                         """.lines(),
                         run.stdOut().lines()),
                 () -> assertTrue(run.stdErr().isEmpty()),

--- a/test/langtools/tools/javac/launcher/MultiFileSourceLauncherTests.java
+++ b/test/langtools/tools/javac/launcher/MultiFileSourceLauncherTests.java
@@ -75,7 +75,9 @@ class MultiFileSourceLauncherTests {
                     public class Hello {
                       public static void main(String... args) throws Exception {
                         System.out.println(Class.forName("World$Core"));
+                        System.out.println(Class.forName("p.q.Unit$Fir$t"));
                         System.out.println(Class.forName("p.q.Unit$123$Fir$t$$econd"));
+                        System.out.println(Class.forName("$.$.$"));
                       }
                     }
                     """);
@@ -86,6 +88,15 @@ class MultiFileSourceLauncherTests {
                     }
                     """);
         var pq = Files.createDirectories(base.resolve("p/q"));
+        Files.writeString(pq.resolve("Unit.java"),
+                    """
+                    package p.q;
+                    record Unit() {
+                      record Fir$t() {
+                        record $econd() {}
+                      }
+                    }
+                    """);
         Files.writeString(pq.resolve("Unit$123.java"),
                     """
                     package p.q;
@@ -95,13 +106,21 @@ class MultiFileSourceLauncherTests {
                       }
                     }
                     """);
+        var $$ = Files.createDirectories(base.resolve("$/$"));
+        Files.writeString($$.resolve("$.java"),
+                    """
+                    package $.$;
+                    record $($ $) {}
+                    """);
 
         var run = Run.of(hello);
         assertAll("Run -> " + run,
                 () -> assertLinesMatch(
                         """
                         class World$Core
+                        class p.q.Unit$Fir$t
                         class p.q.Unit$123$Fir$t$$econd
+                        class $.$.$
                         """.lines(),
                         run.stdOut().lines()),
                 () -> assertTrue(run.stdErr().isEmpty()),


### PR DESCRIPTION
Please review this fix to make the multi-file source-code launcher find classes with `$` in names, including names of packages, names of compliation units, and also names of enclosed types.

Tested tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323815](https://bugs.openjdk.org/browse/JDK-8323815): Source launcher should find classes with $ in names (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**) ⚠️ Review applies to [a8f92b90](https://git.openjdk.org/jdk/pull/17526/files/a8f92b9066fa8028234e56bf15709d19bbd17e02)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17526/head:pull/17526` \
`$ git checkout pull/17526`

Update a local copy of the PR: \
`$ git checkout pull/17526` \
`$ git pull https://git.openjdk.org/jdk.git pull/17526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17526`

View PR using the GUI difftool: \
`$ git pr show -t 17526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17526.diff">https://git.openjdk.org/jdk/pull/17526.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17526#issuecomment-1905425310)