### PR TITLE
8324513: Inline ContiguousSpace::object_iterate_from

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -147,13 +147,11 @@ bool Space::obj_is_alive(const HeapWord* p) const {
 
 void ContiguousSpace::object_iterate(ObjectClosure* blk) {
   if (is_empty()) return;
-  object_iterate_from(bottom(), blk);
-}
-
-void ContiguousSpace::object_iterate_from(HeapWord* mark, ObjectClosure* blk) {
-  while (mark < top()) {
-    blk->do_object(cast_to_oop(mark));
-    mark += cast_to_oop(mark)->size();
+  HeapWord* addr = bottom();
+  while (addr < top()) {
+    oop obj = cast_to_oop(addr);
+    blk->do_object(obj);
+    addr += obj->size();
   }
 }
 

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -146,7 +146,6 @@ bool Space::obj_is_alive(const HeapWord* p) const {
 }
 
 void ContiguousSpace::object_iterate(ObjectClosure* blk) {
-  if (is_empty()) return;
   HeapWord* addr = bottom();
   while (addr < top()) {
     oop obj = cast_to_oop(addr);

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -283,11 +283,6 @@ protected:
   template <typename OopClosureType>
   void oop_since_save_marks_iterate(OopClosureType* blk);
 
-  // Same as object_iterate, but starting from "mark", which is required
-  // to denote the start of an object.  Objects allocated by
-  // applications of the closure *are* included in the iteration.
-  virtual void object_iterate_from(HeapWord* mark, ObjectClosure* blk);
-
   // Very inefficient implementation.
   HeapWord* block_start_const(const void* p) const override;
   size_t block_size(const HeapWord* p) const override;


### PR DESCRIPTION
Trivial refactoring of inlining a method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324513](https://bugs.openjdk.org/browse/JDK-8324513): Inline ContiguousSpace::object_iterate_from (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17531/head:pull/17531` \
`$ git checkout pull/17531`

Update a local copy of the PR: \
`$ git checkout pull/17531` \
`$ git pull https://git.openjdk.org/jdk.git pull/17531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17531`

View PR using the GUI difftool: \
`$ git pr show -t 17531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17531.diff">https://git.openjdk.org/jdk/pull/17531.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17531#issuecomment-1905763874)