### PR TITLE
8321512: runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java fails on 32-bit platforms

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -143,11 +143,6 @@ void G1Arguments::initialize_card_set_configuration() {
                                                     G1RemSetArrayOfCardsEntriesBase << region_size_log_mb));
   }
 
-  // Round to next 8 byte boundary for array to maximize space usage.
-  size_t const cur_size = G1CardSetArray::size_in_bytes(G1RemSetArrayOfCardsEntries);
-  FLAG_SET_ERGO(G1RemSetArrayOfCardsEntries,
-                G1RemSetArrayOfCardsEntries + (uint)(align_up(cur_size, G1CardSetAllocOptions::SlotAlignment) - cur_size) / sizeof(G1CardSetArray::EntryDataType));
-
   // Howl card set container globals.
   if (FLAG_IS_DEFAULT(G1RemSetHowlNumBuckets)) {
     FLAG_SET_ERGO(G1RemSetHowlNumBuckets, G1CardSetHowl::num_buckets(HeapRegion::CardsPerRegion,


### PR DESCRIPTION
Hi all,

  please review this fix for a failing test on 32 bit platforms. In particular, for the `G1CardSetArray` card set container the existing code tries to optimize memory usage by changing the number of entries (`G1RemSetArrayOfCardsEntries`, each entry taking 2 bytes) so that the resulting memory usage is 8 bytes aligned (because the allocator used aligns to 8 bytes anyway, so why not use that space).

On 32 bit platforms, the calculation results in an invalid size (> 2^16).

The suggested fix removes this automatic container size optimization: it is only used for the rare case when the knowledgeable user modifies the defaults; in that case I propose to have the user worry about optimal usage of the memory too, and simplify the code.

Testing: failing test passes

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321512](https://bugs.openjdk.org/browse/JDK-8321512): runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java fails on 32-bit platforms (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17532/head:pull/17532` \
`$ git checkout pull/17532`

Update a local copy of the PR: \
`$ git checkout pull/17532` \
`$ git pull https://git.openjdk.org/jdk.git pull/17532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17532`

View PR using the GUI difftool: \
`$ git pr show -t 17532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17532.diff">https://git.openjdk.org/jdk/pull/17532.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17532#issuecomment-1905783859)