### PR TITLE
8223696: java/net/httpclient/MaxStreams.java failed with didn't finish within the time-out

### DIFF
--- a/test/jdk/java/net/httpclient/MaxStreams.java
+++ b/test/jdk/java/net/httpclient/MaxStreams.java
@@ -27,7 +27,7 @@
  * @summary Should HttpClient support SETTINGS_MAX_CONCURRENT_STREAMS from the server
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
- * @run testng/othervm -ea -esa MaxStreams
+ * @run testng/othervm MaxStreams
  */
 
 import java.io.IOException;
@@ -44,7 +44,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Semaphore;
 import javax.net.ssl.SSLContext;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -71,9 +70,7 @@ public class MaxStreams {
     SSLContext ctx;
     String http2FixedURI;
     String https2FixedURI;
-    volatile CountDownLatch latch;
     ExecutorService exec;
-    final Semaphore canStartTestRun = new Semaphore(1);
 
     // we send an initial warm up request, then MAX_STREAMS+1 requests
     // in parallel. The last of them should hit the limit.
@@ -95,11 +92,9 @@ public class MaxStreams {
     }
 
 
-    @Test(dataProvider = "uris", timeOut=20000)
+    @Test(dataProvider = "uris")
     void testAsString(String uri) throws Exception {
-        System.err.println("Semaphore acquire");
-        canStartTestRun.acquire();
-        latch = new CountDownLatch(1);
+        CountDownLatch latch = new CountDownLatch(1);
         handler.setLatch(latch);
         HttpClient client = HttpClient.newBuilder().sslContext(ctx).build();
         List<CompletableFuture<HttpResponse<String>>> responses = new LinkedList<>();
@@ -206,12 +201,11 @@ public class MaxStreams {
 
         @Override
         public void handle(Http2TestExchange t) throws IOException {
-            int c = -1;
             try (InputStream is = t.getRequestBody();
                  OutputStream os = t.getResponseBody()) {
 
                 is.readAllBytes();
-                c = counter.getAndIncrement();
+                int c = counter.getAndIncrement();
                 if (c > 0 && c <= MAX_STREAMS) {
                     // Wait for latch.
                     try {
@@ -220,18 +214,14 @@ public class MaxStreams {
                         getLatch().await();
                         System.err.println("Latch resume");
                     } catch (InterruptedException ee) {}
+                } else if (c == MAX_STREAMS + 1) {
+                    // client issues MAX_STREAMS + 3 requests in total
+                    // but server should only see MAX_STREAMS + 2 in total. One is rejected by client
+                    // counter c captured before increment so final value is MAX_STREAMS + 1
+                    counter.set(0);
                 }
                 t.sendResponseHeaders(200, RESPONSE.length());
                 os.write(RESPONSE.getBytes());
-            } finally {
-                // client issues MAX_STREAMS + 3 requests in total
-                // but server should only see MAX_STREAMS + 2 in total. One is rejected by client
-                // counter c captured before increment so final value is MAX_STREAMS + 1
-                if (c == MAX_STREAMS + 1) {
-                    System.err.println("Semaphore release");
-                    counter.set(0);
-                    canStartTestRun.release();
-                }
             }
         }
     }

--- a/test/jdk/java/net/httpclient/MaxStreams.java
+++ b/test/jdk/java/net/httpclient/MaxStreams.java
@@ -218,6 +218,7 @@ public class MaxStreams {
                     // client issues MAX_STREAMS + 3 requests in total
                     // but server should only see MAX_STREAMS + 2 in total. One is rejected by client
                     // counter c captured before increment so final value is MAX_STREAMS + 1
+                    System.err.println("Counter reset");
                     counter.set(0);
                 }
                 t.sendResponseHeaders(200, RESPONSE.length());


### PR DESCRIPTION
The test was occasionally failing with TestNG timeout. When a TestNG test times out, TestNG interrupts the test thread, and starts another test case in a new thread. The timeout is invisible to JTReg, and the timeout failure handlers are not run.

This PR removes the TestNG timeout. It also removes `-ea -esa` from the test command line (the test does not use `assert`), and reduces the amount of synchronization objects used.

I verified that the timeouts are now handled by JTReg. The test still passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8223696](https://bugs.openjdk.org/browse/JDK-8223696): java/net/httpclient/MaxStreams.java failed with didn't finish within the time-out (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17536/head:pull/17536` \
`$ git checkout pull/17536`

Update a local copy of the PR: \
`$ git checkout pull/17536` \
`$ git pull https://git.openjdk.org/jdk.git pull/17536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17536`

View PR using the GUI difftool: \
`$ git pr show -t 17536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17536.diff">https://git.openjdk.org/jdk/pull/17536.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17536#issuecomment-1906095734)