### PR TITLE
8324543: Remove Space::object_iterate

### DIFF
--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -135,11 +135,6 @@ class Space: public CHeapObj<mtGC> {
   virtual size_t used() const = 0;
   virtual size_t free() const = 0;
 
-  // Iterate over all objects in the space, calling "cl.do_object" on
-  // each.  Objects allocated by applications of the closure are not
-  // included in the iteration.
-  virtual void object_iterate(ObjectClosure* blk) = 0;
-
   // If "p" is in the space, returns the address of the start of the
   // "block" that contains "p".  We say "block" instead of "object" since
   // some heaps may not pack objects densely; a chunk may either be an
@@ -271,7 +266,7 @@ protected:
   HeapWord* par_allocate(size_t word_size) override;
 
   // Iteration
-  void object_iterate(ObjectClosure* blk) override;
+  void object_iterate(ObjectClosure* blk);
 
   // Apply "blk->do_oop" to the addresses of all reference fields in objects
   // starting with the _saved_mark_word, which was noted during a generation's


### PR DESCRIPTION
Trivial removing effectively dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324543](https://bugs.openjdk.org/browse/JDK-8324543): Remove Space::object_iterate (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17539/head:pull/17539` \
`$ git checkout pull/17539`

Update a local copy of the PR: \
`$ git checkout pull/17539` \
`$ git pull https://git.openjdk.org/jdk.git pull/17539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17539`

View PR using the GUI difftool: \
`$ git pr show -t 17539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17539.diff">https://git.openjdk.org/jdk/pull/17539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17539#issuecomment-1906401190)