### PR TITLE
8324580: SIGFPE on THP initialization on kernels < 4.10

### DIFF
--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -311,6 +311,19 @@ StaticHugePageSupport HugePages::_static_hugepage_support;
 THPSupport HugePages::_thp_support;
 ShmemTHPSupport HugePages::_shmem_thp_support;
 
+size_t HugePages::thp_pagesize_fallback() {
+    // Older kernels won't publish the THP page size. Fall back to default static huge page size,
+    // since that is likely to be the THP page size as well. Don't do it if the page size is considered
+    // too large to avoid large alignment waste. If static huge page size is unknown, use educated guess.
+    if (thp_pagesize() != 0) {
+        return thp_pagesize();
+    }
+    if (supports_static_hugepages()) {
+        return MIN2(default_static_hugepage_size(), 16 * M);
+    }
+    return 2 * M;
+}
+
 void HugePages::initialize() {
   _static_hugepage_support.scan_os();
   _thp_support.scan_os();

--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -138,6 +138,7 @@ public:
   static bool supports_thp()                    { return thp_mode() == THPMode::madvise || thp_mode() == THPMode::always; }
   static THPMode thp_mode()                     { return _thp_support.mode(); }
   static size_t thp_pagesize()                  { return _thp_support.pagesize(); }
+  static size_t thp_pagesize_fallback();
 
   static bool supports_shmem_thp()              { return _shmem_thp_support.is_enabled(); }
   static ShmemTHPMode shmem_thp_mode()          { return _shmem_thp_support.mode(); }

--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -135,7 +135,7 @@ public:
   static size_t default_static_hugepage_size()  { return _static_hugepage_support.default_hugepage_size(); }
   static bool supports_static_hugepages()       { return default_static_hugepage_size() > 0 && !_static_hugepage_support.inconsistent(); }
 
-  static bool supports_thp()                    { return thp_mode() == THPMode::madvise || thp_mode() == THPMode::always; }
+  static bool supports_thp()                    { return (thp_mode() == THPMode::madvise || thp_mode() == THPMode::always) && thp_pagesize() != 0; }
   static THPMode thp_mode()                     { return _thp_support.mode(); }
   static size_t thp_pagesize()                  { return _thp_support.pagesize(); }
 

--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -135,7 +135,7 @@ public:
   static size_t default_static_hugepage_size()  { return _static_hugepage_support.default_hugepage_size(); }
   static bool supports_static_hugepages()       { return default_static_hugepage_size() > 0 && !_static_hugepage_support.inconsistent(); }
 
-  static bool supports_thp()                    { return (thp_mode() == THPMode::madvise || thp_mode() == THPMode::always) && thp_pagesize() != 0; }
+  static bool supports_thp()                    { return thp_mode() == THPMode::madvise || thp_mode() == THPMode::always; }
   static THPMode thp_mode()                     { return _thp_support.mode(); }
   static size_t thp_pagesize()                  { return _thp_support.pagesize(); }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3815,6 +3815,20 @@ static bool validate_thps_configured() {
   return true;
 }
 
+static void thp_pagesize_fallback() {
+    // Older kernels won't publish the THP page size. Fall back to default static huge page size,
+    // since that is likely to be the THP page size as well. Don't do it if the page size is considered
+    // too large to avoid large alignment waste. If static huge page size is unknown, use educated guess.
+    log_info(pagesize) ("Cannot determine THP page size (kernel < 4.10 ?)");
+    if (HugePages::supports_static_hugepages()) {
+        log_info(pagesize) ("Assuming THP page size to be same as default static hugepage size (limit 16M)");
+        _large_page_size = MIN2(HugePages::default_static_hugepage_size(), 16 * M);
+        return;
+    }
+    log_info(pagesize) ("Assuming THP page size to be 2M");
+    _large_page_size = 2 * M;
+}
+
 void os::large_page_init() {
   Linux::large_page_init();
 }
@@ -3876,17 +3890,7 @@ void os::Linux::large_page_init() {
     // - os::pagesizes() has two members, the THP page size and the system page size
     _large_page_size = HugePages::thp_pagesize();
     if (_large_page_size == 0) {
-        // Older kernels won't publish the THP page size. Fall back to default static huge page size,
-        // since that is likely to be the THP page size as well. Don't do it if the page size is considered
-        // too large to avoid large alignment waste.
-        log_info(pagesize) ("Cannot determine THP page size (kernel < 4.10 ?)");
-        if (!HugePages::supports_static_hugepages()
-            || HugePages::default_static_hugepage_size() > 16 * M) {
-            warn_no_large_pages_configured();
-            UseLargePages = UseTransparentHugePages = false;
-            return;
-        }
-        _large_page_size = HugePages::default_static_hugepage_size();
+        thp_pagesize_fallback();
     }
     _page_sizes.add(_large_page_size);
     _page_sizes.add(os::vm_page_size());

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3874,8 +3874,16 @@ void os::Linux::large_page_init() {
     // In THP mode:
     // - os::large_page_size() is the *THP page size*
     // - os::pagesizes() has two members, the THP page size and the system page size
-    assert(HugePages::thp_pagesize() > 0, "Missing OS info");
     _large_page_size = HugePages::thp_pagesize();
+    if (_large_page_size == 0) {
+        // Unknown THP page size => falback to default static hugepage size
+        if (!HugePages::supports_static_hugepages()) {
+            warn_no_large_pages_configured();
+            UseLargePages = false;
+            return;
+        }
+        _large_page_size = MIN2(HugePages::default_static_hugepage_size(), 16 * M);
+    }
     _page_sizes.add(_large_page_size);
     _page_sizes.add(os::vm_page_size());
     // +UseTransparentHugePages implies +UseLargePages

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -88,7 +88,7 @@ class HugePageConfiguration {
 
     // Returns true if the THP support is enabled
     public boolean supportsTHP() {
-        return _thpMode == THPMode.always || _thpMode == THPMode.madvise;
+        return (_thpMode == THPMode.always || _thpMode == THPMode.madvise) && _thpPageSize != 0;
     }
 
     public ShmemTHPMode getShmemThpMode() {

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -86,6 +86,18 @@ class HugePageConfiguration {
         return _thpPageSize;
     }
 
+    public long getThpPageSizeFallback() {
+        long pageSize = getThpPageSize();
+        if (pageSize != 0) {
+            return pageSize;
+        }
+        pageSize = getStaticDefaultHugePageSize();
+        if (pageSize != 0) {
+            return Math.min(pageSize, 16 * 1024 * 1024);
+        }
+        return 2 * 1024 * 1024;
+    }
+
     // Returns true if the THP support is enabled
     public boolean supportsTHP() {
         return _thpMode == THPMode.always || _thpMode == THPMode.madvise;

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -86,7 +86,9 @@ class HugePageConfiguration {
         return _thpPageSize;
     }
 
-    public long getThpPageSizeFallback() {
+    // Returns the THP page size (if exposed by the kernel) or a guessed THP page size.
+    // Mimics HugePages::thp_pagesize_fallback() method in hotspot (must be kept in sync with it).
+    public long getThpPageSizeOrFallback() {
         long pageSize = getThpPageSize();
         if (pageSize != 0) {
             return pageSize;

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -88,7 +88,7 @@ class HugePageConfiguration {
 
     // Returns true if the THP support is enabled
     public boolean supportsTHP() {
-        return (_thpMode == THPMode.always || _thpMode == THPMode.madvise) && _thpPageSize != 0;
+        return _thpMode == THPMode.always || _thpMode == THPMode.madvise;
     }
 
     public ShmemTHPMode getShmemThpMode() {

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -128,11 +128,11 @@ public class TestHugePageDecisionsAtVMStartup {
             long thpPageSize = configuration.getThpPageSize();
             if (thpPageSize == 0) {
                 thpPageSize = configuration.getStaticDefaultHugePageSize();
-                if (thpPageSize == 0) {
+                if (thpPageSize == 0 || thpPageSize > 16 * 1024 * 1024) {
                     out.shouldContain("[info][pagesize] Large page support disabled");
                     return;
                 }
-                thpPageSize = Math.min(thpPageSize, 16 * 1024 * 1024);
+                thpPageSize = thpPageSize;
             }
             String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -125,15 +125,7 @@ public class TestHugePageDecisionsAtVMStartup {
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=0");
             out.shouldContain("[info][pagesize] Large page support enabled");
         } else if (useLP && useTHP && configuration.supportsTHP()) {
-            long thpPageSize = configuration.getThpPageSize();
-            if (thpPageSize == 0) {
-                thpPageSize = configuration.getStaticDefaultHugePageSize();
-                if (thpPageSize != 0) {
-                    thpPageSize = Math.min(thpPageSize, 16 * 1024 * 1024);
-                } else {
-                    thpPageSize = 2 * 1024 * 1024;
-                }
-            }
+            long thpPageSize = configuration.getThpPageSizeFallback();
             String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system
             // page size differs, but its always in KB).

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -125,7 +125,7 @@ public class TestHugePageDecisionsAtVMStartup {
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=0");
             out.shouldContain("[info][pagesize] Large page support enabled");
         } else if (useLP && useTHP && configuration.supportsTHP()) {
-            long thpPageSize = configuration.getThpPageSizeFallback();
+            long thpPageSize = configuration.getThpPageSizeOrFallback();
             String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system
             // page size differs, but its always in KB).

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -125,7 +125,16 @@ public class TestHugePageDecisionsAtVMStartup {
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=0");
             out.shouldContain("[info][pagesize] Large page support enabled");
         } else if (useLP && useTHP && configuration.supportsTHP()) {
-            String thpPageSizeString = buildSizeString(configuration.getThpPageSize());
+            long thpPageSize = configuration.getThpPageSize();
+            if (thpPageSize == 0) {
+                thpPageSize = configuration.getStaticDefaultHugePageSize();
+                if (thpPageSize == 0) {
+                    out.shouldContain("[info][pagesize] Large page support disabled");
+                    return;
+                }
+		thpPageSize = Math.min(thpPageSize, 16 * 1024 * 1024);
+            }
+            String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system
             // page size differs, but its always in KB).
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=1");

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -128,11 +128,11 @@ public class TestHugePageDecisionsAtVMStartup {
             long thpPageSize = configuration.getThpPageSize();
             if (thpPageSize == 0) {
                 thpPageSize = configuration.getStaticDefaultHugePageSize();
-                if (thpPageSize == 0 || thpPageSize > 16 * 1024 * 1024) {
-                    out.shouldContain("[info][pagesize] Large page support disabled");
-                    return;
+                if (thpPageSize != 0) {
+                    thpPageSize = Math.min(thpPageSize, 16 * 1024 * 1024);
+                } else {
+                    thpPageSize = 2 * 1024 * 1024;
                 }
-                thpPageSize = thpPageSize;
             }
             String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -132,7 +132,7 @@ public class TestHugePageDecisionsAtVMStartup {
                     out.shouldContain("[info][pagesize] Large page support disabled");
                     return;
                 }
-		thpPageSize = Math.min(thpPageSize, 16 * 1024 * 1024);
+                thpPageSize = Math.min(thpPageSize, 16 * 1024 * 1024);
             }
             String thpPageSizeString = buildSizeString(thpPageSize);
             // We expect to see exactly two "Usable page sizes" :  the system page size and the THP page size. The system


### PR DESCRIPTION
**Problem:**
When THP is enabled, JDK reads `/sys/kernel/mm/transparent_hugepage/hpage_pmd_size` file to [detect](https://github.com/openjdk/jdk/blob/96607df7f055a80d56ea4c19f3f4fcb32838b1f8/src/hotspot/os/linux/hugepages.cpp#L206) large page size. However this file only [appeared](https://github.com/torvalds/linux/commit/49920d28781dcced10cd30cb9a938e7d045a1c94) in kernel 4.10 and does not exist on kernel old kernels (such as 3.10 used by RHEL-7).

This results in detected large page size of 0B and crash, when `-XX:+UseTransparentHugePages` is used on old kernel.
```
gdb --args jdk-23+6/bin/java -XX:+UseTransparentHugePages -Xmx128m -Xlog:pagesize -version
...
[0.005s][info][pagesize] Static hugepage support:
[0.005s][info][pagesize]   hugepage size: 2M
[0.005s][info][pagesize]   hugepage size: 1G
[0.005s][info][pagesize]   default hugepage size: 2M
[0.005s][info][pagesize] Transparent hugepage (THP) support:
[0.005s][info][pagesize]   THP mode: always
[0.005s][info][pagesize]   THP pagesize: 0B
[0.005s][info][pagesize] Shared memory transparent hugepage (THP) support:
[0.005s][info][pagesize]   Shared memory THP mode: unknown
[0.005s][info][pagesize] JVM will attempt to prevent THPs in thread stacks.
[0.005s][info][pagesize] UseLargePages=1, UseTransparentHugePages=1
[0.005s][info][pagesize] Large page support enabled. Usable page sizes: 4k. Default large page size: 0B.

Program received signal SIGFPE, Arithmetic exception.
[Switching to Thread 0x7ffff7fc2700 (LWP 31385)]
0x00007ffff68eeb20 in lcm(unsigned long, unsigned long) () from /home/tester/jdk-23+6/lib/server/libjvm.so
(gdb) bt
#0  0x00007ffff68eeb20 in lcm(unsigned long, unsigned long) () from /home/tester/jdk-23+6/lib/server/libjvm.so
#1  0x00007ffff64a68f2 in Arguments::apply_ergo() () from /home/tester/jdk-23+6/lib/server/libjvm.so
#2  0x00007ffff700458f in Threads::create_vm(JavaVMInitArgs*, bool*) () from /home/tester/jdk-23+6/lib/server/libjvm.so
#3  0x00007ffff6a2373f in JNI_CreateJavaVM () from /home/tester/jdk-23+6/lib/server/libjvm.so
#4  0x00007ffff7fe704b in InitializeJVM (ifn=<synthetic pointer>, penv=0x7ffff7fc1ea8, pvm=0x7ffff7fc1ea0) at src/java.base/share/native/libjli/java.c:1550
#5  JavaMain (_args=<optimized out>) at src/java.base/share/native/libjli/java.c:491
#6  0x00007ffff7feb1c9 in ThreadJavaMain (args=<optimized out>) at src/java.base/unix/native/libjli/java_md.c:650
#7  0x00007ffff7bc6ea5 in start_thread (arg=0x7ffff7fc2700) at pthread_create.c:307
#8  0x00007ffff76ebb0d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324580](https://bugs.openjdk.org/browse/JDK-8324580): SIGFPE on THP initialization on kernels &lt; 4.10 (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [529afb72](https://git.openjdk.org/jdk/pull/17545/files/529afb72271f847790eb424fc8e2fdbfa502a77e)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17545/head:pull/17545` \
`$ git checkout pull/17545`

Update a local copy of the PR: \
`$ git checkout pull/17545` \
`$ git pull https://git.openjdk.org/jdk.git pull/17545/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17545`

View PR using the GUI difftool: \
`$ git pr show -t 17545`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17545.diff">https://git.openjdk.org/jdk/pull/17545.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17545#issuecomment-1907154220)