### PR TITLE
8324582: Replace -Djava.util.concurrent.ForkJoinPool.common.parallelism to -Djdk.virtualThreadScheduler.maxPoolSize in jvmti vthread tests

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/allthr01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/allthr01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@
  * @requires vm.continuations
  * @library /test/lib
  * @compile allthr01.java
- * @run main/othervm/native -Djava.util.concurrent.ForkJoinPool.common.parallelism=1 -agentlib:allthr01 allthr01
+ * @run main/othervm/native -Djdk.virtualThreadScheduler.parallelism=1 -agentlib:allthr01 allthr01
  */
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/allthr01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/allthr01.java
@@ -39,7 +39,7 @@
  * @requires vm.continuations
  * @library /test/lib
  * @compile allthr01.java
- * @run main/othervm/native -Djdk.virtualThreadScheduler.parallelism=1 -agentlib:allthr01 allthr01
+ * @run main/othervm/native -Djdk.virtualThreadScheduler.maxPoolSize=1 -agentlib:allthr01 allthr01
  */
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/liballthr01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/liballthr01.cpp
@@ -46,7 +46,7 @@ static jrawMonitorID stopping_agent_thread_lock;
 static const char main_name[] = "main";
 static const char thread1_name[] = "thread1";
 static const char sys_thread_name[] = "SysThread";
-// Tes uses -Djdk.virtualThreadScheduler.parallelism=1
+// Test uses -Djdk.virtualThreadScheduler.maxPoolSize=1
 // to make name of carrier thread deterministic
 static const char fj_thread_name[] = "ForkJoinPool-1-worker-1";
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/liballthr01.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetAllThreads/allthr01/liballthr01.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ static jrawMonitorID stopping_agent_thread_lock;
 static const char main_name[] = "main";
 static const char thread1_name[] = "thread1";
 static const char sys_thread_name[] = "SysThread";
-// Tes uses -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
+// Tes uses -Djdk.virtualThreadScheduler.parallelism=1
 // to make name of carrier thread deterministic
 static const char fj_thread_name[] = "ForkJoinPool-1-worker-1";
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/FollowReferences/VThreadStackRefTest.java
@@ -26,7 +26,7 @@
  * @requires vm.jvmti
  * @requires vm.continuations
  * @run main/othervm/native
- *      -Djdk.virtualThreadScheduler.parallelism=1
+ *      -Djdk.virtualThreadScheduler.maxPoolSize=1
  *      -agentlib:VThreadStackRefTest
  *      VThreadStackRefTest
  */

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/HeapDump/VThreadInHeapDump.java
@@ -184,7 +184,7 @@ public class VThreadInHeapDump {
             theApp = new VThreadInHeapDumpTarg();
 
             List<String> extraVMArgs = new ArrayList<>();
-            extraVMArgs.add("-Djdk.virtualThreadScheduler.parallelism=1");
+            extraVMArgs.add("-Djdk.virtualThreadScheduler.maxPoolSize=1");
             extraVMArgs.add("-Xlog:heapdump");
             extraVMArgs.addAll(Arrays.asList(extraOptions));
             LingeredApp.startApp(theApp, extraVMArgs.toArray(new String[0]));

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @compile SuspendResume1.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native/timeout=600
- *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
+ *      -Djdk.virtualThreadScheduler.parallelism=1
  *      -agentlib:SuspendResume1
  *      SuspendResume1
  */
@@ -41,7 +41,6 @@
  * @compile SuspendResume1.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native/timeout=600
- *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -agentlib:SuspendResume1
  *      -XX:+UnlockExperimentalVMOptions
  *      -XX:-VMContinuations

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/SuspendResume1.java
@@ -29,7 +29,7 @@
  * @compile SuspendResume1.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native/timeout=600
- *      -Djdk.virtualThreadScheduler.parallelism=1
+ *      -Djdk.virtualThreadScheduler.maxPoolSize=1
  *      -agentlib:SuspendResume1
  *      SuspendResume1
  */

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume2/SuspendResume2.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume2/SuspendResume2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @compile SuspendResume2.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native
- *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
+ *      -Djdk.virtualThreadScheduler.parallelism=1
  *      -agentlib:SuspendResume2
  *      SuspendResume2
  */
@@ -40,7 +40,6 @@
  * @compile SuspendResume2.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native
- *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -agentlib:SuspendResume2
  *      -XX:+UnlockExperimentalVMOptions
  *      -XX:-VMContinuations

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume2/SuspendResume2.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume2/SuspendResume2.java
@@ -28,7 +28,7 @@
  * @compile SuspendResume2.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native
- *      -Djdk.virtualThreadScheduler.parallelism=1
+ *      -Djdk.virtualThreadScheduler.maxPoolSize=1
  *      -agentlib:SuspendResume2
  *      SuspendResume2
  */

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java
@@ -28,7 +28,7 @@
  * @compile SuspendResumeAll.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native
- *      -Djdk.virtualThreadScheduler.parallelism=1
+ *      -Djdk.virtualThreadScheduler.maxPoolSize=1
  *      -agentlib:SuspendResumeAll
  *      SuspendResumeAll
  */

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/SuspendResumeAll.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @compile SuspendResumeAll.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native
- *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
+ *      -Djdk.virtualThreadScheduler.parallelism=1
  *      -agentlib:SuspendResumeAll
  *      SuspendResumeAll
  */
@@ -40,7 +40,6 @@
  * @compile SuspendResumeAll.java
  * @run driver jdk.test.lib.FileInstaller . .
  * @run main/othervm/native
- *      -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
  *      -agentlib:SuspendResumeAll
  *      -XX:+UnlockExperimentalVMOptions
  *      -XX:-VMContinuations

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadEventTest/VThreadEventTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadEventTest/VThreadEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,4 +207,3 @@ public class VThreadEventTest {
     }
 
 }
-

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadEventTest/VThreadEventTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadEventTest/VThreadEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,3 +207,4 @@ public class VThreadEventTest {
     }
 
 }
+

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
  * @library /test/lib
  * @compile WaitNotifySuspendedVThreadTest.java
  * @run main/othervm/native
- *     -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
+ *     -Djdk.virtualThreadScheduler.parallelism=1
  *     -agentlib:WaitNotifySuspendedVThread WaitNotifySuspendedVThreadTest
  */
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/WaitNotifySuspendedVThreadTest/WaitNotifySuspendedVThreadTest.java
@@ -31,7 +31,7 @@
  * @library /test/lib
  * @compile WaitNotifySuspendedVThreadTest.java
  * @run main/othervm/native
- *     -Djdk.virtualThreadScheduler.parallelism=1
+ *     -Djdk.virtualThreadScheduler.maxPoolSize=1
  *     -agentlib:WaitNotifySuspendedVThread WaitNotifySuspendedVThreadTest
  */
 


### PR DESCRIPTION
Some jvmti tests use
-Djava.util.concurrent.ForkJoinPool.common.parallelism
to control the pool of virtual threads. However, it is controlled by
jdk.virtualThreadScheduler.parallelism property.

The non-continuations implementation doesn't use any of these properties and it was just deleted.

I verified the fix using jcmd Thread.dump and ran all jvmti tests in the default configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324582](https://bugs.openjdk.org/browse/JDK-8324582): Replace -Djava.util.concurrent.ForkJoinPool.common.parallelism to -Djdk.virtualThreadScheduler.maxPoolSize in jvmti vthread tests (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [af0ceb3f](https://git.openjdk.org/jdk/pull/17547/files/af0ceb3f64cdb4854b8713537aa2bf3dfa2176ed)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [0f608fe5](https://git.openjdk.org/jdk/pull/17547/files/0f608fe5cd19d028db00313fef1460fd39a1fdda)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17547/head:pull/17547` \
`$ git checkout pull/17547`

Update a local copy of the PR: \
`$ git checkout pull/17547` \
`$ git pull https://git.openjdk.org/jdk.git pull/17547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17547`

View PR using the GUI difftool: \
`$ git pr show -t 17547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17547.diff">https://git.openjdk.org/jdk/pull/17547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17547#issuecomment-1907260345)