### PR TITLE
8324125: Improve class initialization barrier in TemplateTable::_new for RISC-V

### DIFF
--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3548,7 +3548,8 @@ void TemplateTable::_new() {
   __ load_resolved_klass_at_offset(x14, x13, x14, t0);
 
   // make sure klass is initialized
-  assert(VM_Version::supports_fast_class_init_checks(), "Optimization requires support for fast class initialization checks");
+  assert(VM_Version::supports_fast_class_init_checks(),
+         "Optimization requires support for fast class initialization checks");
   __ clinit_barrier(x14, t0, nullptr /*L_fast_path*/, &slow_case);
 
   // get instance_size in InstanceKlass (scaled to a count of bytes)

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3547,11 +3547,9 @@ void TemplateTable::_new() {
   // get InstanceKlass
   __ load_resolved_klass_at_offset(x14, x13, x14, t0);
 
-  // make sure klass is initialized & doesn't have finalizer
-  // make sure klass is fully initialized
-  __ lbu(t0, Address(x14, InstanceKlass::init_state_offset()));
-  __ sub(t1, t0, (u1)InstanceKlass::fully_initialized);
-  __ bnez(t1, slow_case);
+  // make sure klass is initialized
+  assert(VM_Version::supports_fast_class_init_checks(), "Optimization requires support for fast class initialization checks");
+  __ clinit_barrier(x14, t0, nullptr /*L_fast_path*/, &slow_case);
 
   // get instance_size in InstanceKlass (scaled to a count of bytes)
   __ lwu(x13, Address(x14, Klass::layout_helper_offset()));


### PR DESCRIPTION
Hi, This RISC-V Port implementation for https://github.com/openjdk/jdk/pull/17006,

### Testing:

- [x]  Run tier1-3 tests on qemu 8.1.0 with UseRVV (fastdebug)
- [x]  Run tier1-3 tests with SiFive unmatched (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324125](https://bugs.openjdk.org/browse/JDK-8324125): Improve class initialization barrier in TemplateTable::_new for RISC-V (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [ae736225](https://git.openjdk.org/jdk/pull/17548/files/ae73622551cc71d059960105e05467b5bd6902d0)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17548/head:pull/17548` \
`$ git checkout pull/17548`

Update a local copy of the PR: \
`$ git checkout pull/17548` \
`$ git pull https://git.openjdk.org/jdk.git pull/17548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17548`

View PR using the GUI difftool: \
`$ git pr show -t 17548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17548.diff">https://git.openjdk.org/jdk/pull/17548.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17548#issuecomment-1909557274)