### PR TITLE
8324613: Serial: Rename GenerationPool to TenuredGenerationPool

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -120,7 +120,7 @@ void SerialHeap::initialize_serviceability() {
                                                    young->max_survivor_size(),
                                                    false /* support_usage_threshold */);
   TenuredGeneration* old = old_gen();
-  _old_pool = new GenerationPool(old, "Tenured Gen", true);
+  _old_pool = new TenuredGenerationPool(old, "Tenured Gen", true);
 
   _young_manager->add_pool(_eden_pool);
   _young_manager->add_pool(_survivor_pool);

--- a/src/hotspot/share/gc/serial/serialMemoryPools.cpp
+++ b/src/hotspot/share/gc/serial/serialMemoryPools.cpp
@@ -24,8 +24,8 @@
 
 #include "precompiled.hpp"
 #include "gc/serial/defNewGeneration.hpp"
-#include "gc/serial/tenuredGeneration.hpp"
 #include "gc/serial/serialMemoryPools.hpp"
+#include "gc/serial/tenuredGeneration.hpp"
 #include "gc/shared/space.hpp"
 
 ContiguousSpacePool::ContiguousSpacePool(ContiguousSpace* space,

--- a/src/hotspot/share/gc/serial/serialMemoryPools.cpp
+++ b/src/hotspot/share/gc/serial/serialMemoryPools.cpp
@@ -24,7 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/serial/defNewGeneration.hpp"
-#include "gc/serial/generation.hpp"
+#include "gc/serial/tenuredGeneration.hpp"
 #include "gc/serial/serialMemoryPools.hpp"
 #include "gc/shared/space.hpp"
 
@@ -72,18 +72,18 @@ MemoryUsage SurvivorContiguousSpacePool::get_memory_usage() {
   return MemoryUsage(initial_size(), used, committed, maxSize);
 }
 
-GenerationPool::GenerationPool(Generation* gen,
-                               const char* name,
-                               bool support_usage_threshold) :
+TenuredGenerationPool::TenuredGenerationPool(TenuredGeneration* gen,
+                                             const char* name,
+                                             bool support_usage_threshold) :
   CollectedMemoryPool(name, gen->capacity(), gen->max_capacity(),
                       support_usage_threshold), _gen(gen) {
 }
 
-size_t GenerationPool::used_in_bytes() {
+size_t TenuredGenerationPool::used_in_bytes() {
   return _gen->used();
 }
 
-MemoryUsage GenerationPool::get_memory_usage() {
+MemoryUsage TenuredGenerationPool::get_memory_usage() {
   size_t used      = used_in_bytes();
   size_t committed = _gen->capacity();
   size_t maxSize   = (available_for_allocation() ? max_size() : 0);

--- a/src/hotspot/share/gc/serial/serialMemoryPools.hpp
+++ b/src/hotspot/share/gc/serial/serialMemoryPools.hpp
@@ -62,11 +62,11 @@ public:
   size_t committed_in_bytes();
 };
 
-class GenerationPool : public CollectedMemoryPool {
+class TenuredGenerationPool : public CollectedMemoryPool {
 private:
-  Generation* _gen;
+  TenuredGeneration* _gen;
 public:
-  GenerationPool(Generation* gen, const char* name, bool support_usage_threshold);
+  TenuredGenerationPool(TenuredGeneration* gen, const char* name, bool support_usage_threshold);
 
   MemoryUsage get_memory_usage();
   size_t used_in_bytes();


### PR DESCRIPTION
Trivial renaming to use concrete subtype.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324613](https://bugs.openjdk.org/browse/JDK-8324613): Serial: Rename GenerationPool to TenuredGenerationPool (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17551/head:pull/17551` \
`$ git checkout pull/17551`

Update a local copy of the PR: \
`$ git checkout pull/17551` \
`$ git pull https://git.openjdk.org/jdk.git pull/17551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17551`

View PR using the GUI difftool: \
`$ git pr show -t 17551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17551.diff">https://git.openjdk.org/jdk/pull/17551.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17551#issuecomment-1907856843)