### PR TITLE
8324630: C1: Canonicalizer::do_LookupSwitch doesn't break the loop when the successor is found

### DIFF
--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -843,7 +843,11 @@ void Canonicalizer::do_LookupSwitch(LookupSwitch* x) {
     int v = x->tag()->type()->as_IntConstant()->value();
     BlockBegin* sux = x->default_sux();
     for (int i = 0; i < x->length(); i++) {
-      if (v == x->key_at(i)) {
+      int key = x->key_at(i);
+      if (v < key) {
+        break;
+      }
+      if (v == key) {
         sux = x->sux_at(i);
         break;
       }

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -842,14 +842,18 @@ void Canonicalizer::do_LookupSwitch(LookupSwitch* x) {
   if (x->tag()->type()->is_constant()) {
     int v = x->tag()->type()->as_IntConstant()->value();
     BlockBegin* sux = x->default_sux();
-    for (int i = 0; i < x->length(); i++) {
-      int key = x->key_at(i);
-      if (v < key) {
+    int low = 0;
+    int high = x->length() - 1;
+    while (low <= high) {
+      int mid = low + ((high - low) >> 1);
+      int key = x->key_at(mid);
+      if (key == v) {
+        sux = x->sux_at(mid);
         break;
-      }
-      if (v == key) {
-        sux = x->sux_at(i);
-        break;
+      } else if (key > v) {
+        high = mid - 1;
+      } else {
+        low = mid + 1;
       }
     }
     set_canonical(new Goto(sux, x->state_before(), is_safepoint(x, sux)));

--- a/src/hotspot/share/c1/c1_Canonicalizer.cpp
+++ b/src/hotspot/share/c1/c1_Canonicalizer.cpp
@@ -845,6 +845,7 @@ void Canonicalizer::do_LookupSwitch(LookupSwitch* x) {
     for (int i = 0; i < x->length(); i++) {
       if (v == x->key_at(i)) {
         sux = x->sux_at(i);
+        break;
       }
     }
     set_canonical(new Goto(sux, x->state_before(), is_safepoint(x, sux)));


### PR DESCRIPTION
Hi,

Please review the small change that breaks the loop in Canonicalizer::do_LookupSwitch if the successor is found.

The keys of LookupSwitch are sorted, so there is no need to continue the loop once matched.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8324630](https://bugs.openjdk.org/browse/JDK-8324630): C1: Canonicalizer::do_LookupSwitch doesn't break the loop when the successor is found (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17553/head:pull/17553` \
`$ git checkout pull/17553`

Update a local copy of the PR: \
`$ git checkout pull/17553` \
`$ git pull https://git.openjdk.org/jdk.git pull/17553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17553`

View PR using the GUI difftool: \
`$ git pr show -t 17553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17553.diff">https://git.openjdk.org/jdk/pull/17553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17553#issuecomment-1908148565)