### PR TITLE
8324636: Serial: Remove Generation::block_is_obj

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -723,6 +723,12 @@ void DefNewGeneration::adjust_desired_tenuring_threshold() {
   age_table()->print_age_table(_tenuring_threshold);
 }
 
+bool DefNewGeneration::block_is_obj(const HeapWord* addr) const {
+  return eden()->is_in(addr)
+      || from()->is_in(addr)
+      || to()  ->is_in(addr);
+}
+
 void DefNewGeneration::collect(bool   full,
                                bool   clear_all_soft_refs,
                                size_t size,

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -257,6 +257,8 @@ class DefNewGeneration: public Generation {
   // at some additional cost.
   bool collection_attempt_is_safe();
 
+  bool block_is_obj(const HeapWord* addr) const;
+
   virtual void collect(bool   full,
                        bool   clear_all_soft_refs,
                        size_t size,

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -257,6 +257,8 @@ class DefNewGeneration: public Generation {
   // at some additional cost.
   bool collection_attempt_is_safe();
 
+  // Requires "addr" to be the start of a block, and returns "TRUE" iff
+  // the block is an object.
   bool block_is_obj(const HeapWord* addr) const;
 
   virtual void collect(bool   full,

--- a/src/hotspot/share/gc/serial/generation.cpp
+++ b/src/hotspot/share/gc/serial/generation.cpp
@@ -164,22 +164,3 @@ HeapWord* Generation::block_start(const void* p) const {
   ((Generation*)this)->space_iterate(&blk);
   return blk._start;
 }
-
-class GenerationBlockIsObjClosure : public SpaceClosure {
- public:
-  const HeapWord* _p;
-  bool is_obj;
-  virtual void do_space(Space* s) {
-    if (!is_obj && s->is_in_reserved(_p)) {
-      is_obj |= s->block_is_obj(_p);
-    }
-  }
-  GenerationBlockIsObjClosure(const HeapWord* p) { _p = p; is_obj = false; }
-};
-
-bool Generation::block_is_obj(const HeapWord* p) const {
-  GenerationBlockIsObjClosure blk(p);
-  // Cast away const
-  ((Generation*)this)->space_iterate(&blk);
-  return blk.is_obj;
-}

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -234,10 +234,6 @@ class Generation: public CHeapObj<mtGC> {
   // non-object.
   virtual HeapWord* block_start(const void* addr) const;
 
-  // Requires "addr" to be the start of a block, and returns "TRUE" iff
-  // the block is an object.
-  virtual bool block_is_obj(const HeapWord* addr) const;
-
   virtual void print() const;
   virtual void print_on(outputStream* st) const;
 

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -129,6 +129,8 @@ class TenuredGeneration: public Generation {
 
   bool no_allocs_since_save_marks();
 
+  // Requires "addr" to be the start of a block, and returns "TRUE" iff
+  // the block is an object.
   inline bool block_is_obj(const HeapWord* addr) const;
 
   virtual void collect(bool full,

--- a/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
@@ -62,7 +62,7 @@ HeapWord* TenuredGeneration::par_allocate(size_t word_size,
 }
 
 bool TenuredGeneration::block_is_obj(const HeapWord* addr) const {
-  return addr < _the_space  ->top();
+  return addr < _the_space->top();
 }
 
 template <typename OopClosureType>


### PR DESCRIPTION
Trivial moving a method from `Generation` to subclass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324636](https://bugs.openjdk.org/browse/JDK-8324636): Serial: Remove Generation::block_is_obj (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) ⚠️ Review applies to [4f655ef8](https://git.openjdk.org/jdk/pull/17555/files/4f655ef8f773ff834c1599dfd29d97a8b4ca873a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17555/head:pull/17555` \
`$ git checkout pull/17555`

Update a local copy of the PR: \
`$ git checkout pull/17555` \
`$ git pull https://git.openjdk.org/jdk.git pull/17555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17555`

View PR using the GUI difftool: \
`$ git pr show -t 17555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17555.diff">https://git.openjdk.org/jdk/pull/17555.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17555#issuecomment-1908253378)