### PR TITLE
8324635: (zipfs) Regression in Files.setPosixFilePermissions called on existing MSDOS entries

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -646,6 +646,8 @@ class ZipFileSystem extends FileSystem {
             }
             if (perms == null) {
                 e.posixPerms = -1;
+            } else if (e.posixPerms == -1) {
+                e.posixPerms = ZipUtils.permsToFlags(perms);
             } else {
                 e.posixPerms = ZipUtils.permsToFlags(perms) |
                         (e.posixPerms & 0xFE00); // Preserve unrelated bits

--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @test
- * @bug 8213031 8273935
+ * @bug 8213031 8273935 8324635
  * @summary Test POSIX ZIP file operations.
  * @modules jdk.zipfs
  *          jdk.jartool
@@ -719,7 +719,7 @@ public class TestPosix {
     }
 
     /**
-     * Verify that calling Files.setPosixPermissions with the current
+     * Verify that calling Files.setPosixFilePermissions with the current
      * permission set does not change the 'external file attributes' field.
      *
      * @throws IOException if an unexpected IOException occurs
@@ -731,6 +731,33 @@ public class TestPosix {
             // Set permissions to their current value
             Files.setPosixFilePermissions(path, Files.getPosixFilePermissions(path));
         });
+    }
+
+    /**
+     * Verify that calling Files.setPosixFilePermissions on an MS-DOS entry
+     * results in only the expected permission bits being set
+     *
+     * @throws IOException if an unexpected IOException occurs
+     */
+    @Test
+    public void setPermissionsShouldConvertToUnix() throws IOException {
+        // The default environment creates MS-DOS entries, with zero 'external file attributes'
+        createEmptyZipFile(ZIP_FILE, ENV_DEFAULT);
+        try (FileSystem fs = FileSystems.newFileSystem(ZIP_FILE, ENV_DEFAULT)) {
+            Path path = fs.getPath("hello.txt");
+            Files.createFile(path);
+        }
+
+        // Sanity check that all 'external file attributes' bits are zero
+        verifyExternalFileAttribute(Files.readAllBytes(ZIP_FILE), "0");
+
+        // Convert to a UNIX entry by calling Files.setPosixFilePermissions
+        try (FileSystem fs = FileSystems.newFileSystem(ZIP_FILE, ENV_POSIX)) {
+            Path path = fs.getPath("hello.txt");
+            Files.setPosixFilePermissions(path, EnumSet.of(OWNER_READ));
+        }
+        // The first of the nine trailing permission bits should be set
+        verifyExternalFileAttribute(Files.readAllBytes(ZIP_FILE), "100000000");
     }
 
     /**

--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -747,8 +747,17 @@ public class TestPosix {
             Path path = fs.getPath("hello.txt");
             Files.createFile(path);
         }
+        // The CEN header is now as follows:
+        //
+        //   004A CENTRAL HEADER #1     02014B50
+        //   004E Created Zip Spec      14 '2.0'
+        //   004F Created OS            00 'MS-DOS'
+        //   0050 Extract Zip Spec      14 '2.0'
+        //   0051 Extract OS            00 'MS-DOS'
+        //   [...]
+        //   0070 Ext File Attributes   00000000
 
-        // Sanity check that all 'external file attributes' bits are zero
+        // Sanity check that all 'external file attributes' bits are all zero
         verifyExternalFileAttribute(Files.readAllBytes(ZIP_FILE), "0");
 
         // Convert to a UNIX entry by calling Files.setPosixFilePermissions
@@ -756,6 +765,17 @@ public class TestPosix {
             Path path = fs.getPath("hello.txt");
             Files.setPosixFilePermissions(path, EnumSet.of(OWNER_READ));
         }
+
+        // The CEN header should now be as follows:
+        //
+        // 004A CENTRAL HEADER #1     02014B50
+        // 004E Created Zip Spec      14 '2.0'
+        // 004F Created OS            03 'Unix'
+        // 0050 Extract Zip Spec      14 '2.0'
+        // 0051 Extract OS            00 'MS-DOS'
+        // [...]
+        // 0070 Ext File Attributes   01000000
+
         // The first of the nine trailing permission bits should be set
         verifyExternalFileAttribute(Files.readAllBytes(ZIP_FILE), "100000000");
     }


### PR DESCRIPTION
Please review this PR to fix to a regression in ZipFileSystem, introduced by JDK-8322565 in PR #17170.

When `Files.setPosixFilePermissions` is called on an existing MSDOS entry, then `Entry.posixPerms` field will be -1 (all 1s in binary). The logic introduced by JDK-8322565 did not account for this and incorrectly sets the leading seven bits to all ones instead of all zeros.

The fix is to introduce a branch for `Entry.posixPerms` being -1 and deal with that case separately.

The PR adds a test case to `TestPosix` which reproduces the regression. While visiting this test, I also fixed an incorrect spelling of `setPosixFilePermissions` (also introduced by #17170).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324635](https://bugs.openjdk.org/browse/JDK-8324635): (zipfs) Regression in Files.setPosixFilePermissions called on existing MSDOS entries (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17556/head:pull/17556` \
`$ git checkout pull/17556`

Update a local copy of the PR: \
`$ git checkout pull/17556` \
`$ git pull https://git.openjdk.org/jdk.git pull/17556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17556`

View PR using the GUI difftool: \
`$ git pr show -t 17556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17556.diff">https://git.openjdk.org/jdk/pull/17556.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17556#issuecomment-1908405760)