### PR TITLE
8324647: Invalid test group of lib-test after JDK-8323515

### DIFF
--- a/test/lib-test/TEST.groups
+++ b/test/lib-test/TEST.groups
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 # All tests
 
 all = \
-    :all
+    :libtest_all
 
 libtest_all = \
     /


### PR DESCRIPTION
This patch tries to fix the invalid test group definition of lib-test.
Please review.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324647](https://bugs.openjdk.org/browse/JDK-8324647): Invalid test group of lib-test after JDK-8323515 (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17558/head:pull/17558` \
`$ git checkout pull/17558`

Update a local copy of the PR: \
`$ git checkout pull/17558` \
`$ git pull https://git.openjdk.org/jdk.git pull/17558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17558`

View PR using the GUI difftool: \
`$ git pr show -t 17558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17558.diff">https://git.openjdk.org/jdk/pull/17558.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17558#issuecomment-1908357788)