### PR TITLE
8324646: Avoid Class.forName in SecureRandom constructor

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -27,7 +27,9 @@ package java.security;
 
 import jdk.internal.event.SecurityProviderServiceEvent;
 
+import javax.security.auth.login.Configuration;
 import java.io.*;
+import java.security.cert.CertStoreParameters;
 import java.util.*;
 import static java.util.Locale.ENGLISH;
 import java.lang.ref.*;
@@ -1556,30 +1558,20 @@ public abstract class Provider extends Properties {
     private static class EngineDescription {
         final String name;
         final boolean supportsParameter;
-        final String constructorParameterClassName;
-        private volatile Class<?> constructorParameterClass;
+        final Class<?> constructorParameterClass;
 
-        EngineDescription(String name, boolean sp, String paramName) {
+        EngineDescription(String name, boolean sp, Class<?> constructorParameterClass) {
             this.name = name;
             this.supportsParameter = sp;
-            this.constructorParameterClassName = paramName;
-        }
-
-        Class<?> getConstructorParameterClass() throws ClassNotFoundException {
-            Class<?> clazz = constructorParameterClass;
-            if (clazz == null) {
-                clazz = Class.forName(constructorParameterClassName);
-                constructorParameterClass = clazz;
-            }
-            return clazz;
+            this.constructorParameterClass = constructorParameterClass;
         }
     }
 
     // built in knowledge of the engine types shipped as part of the JDK
     private static final Map<String,EngineDescription> knownEngines;
 
-    private static void addEngine(String name, boolean sp, String paramName) {
-        EngineDescription ed = new EngineDescription(name, sp, paramName);
+    private static void addEngine(String name, boolean sp, Class<?> constructorParameterClass) {
+        EngineDescription ed = new EngineDescription(name, sp, constructorParameterClass);
         // also index by canonical name to avoid toLowerCase() for some lookups
         knownEngines.put(name.toLowerCase(ENGLISH), ed);
         knownEngines.put(name, ed);
@@ -1595,13 +1587,13 @@ public abstract class Provider extends Properties {
         addEngine("KeyStore",                           false, null);
         addEngine("MessageDigest",                      false, null);
         addEngine("SecureRandom",                       false,
-                "java.security.SecureRandomParameters");
+                SecureRandomParameters.class);
         addEngine("Signature",                          true,  null);
         addEngine("CertificateFactory",                 false, null);
         addEngine("CertPathBuilder",                    false, null);
         addEngine("CertPathValidator",                  false, null);
         addEngine("CertStore",                          false,
-                            "java.security.cert.CertStoreParameters");
+                CertStoreParameters.class);
         // JCE
         addEngine("Cipher",                             true,  null);
         addEngine("ExemptionMechanism",                 false, null);
@@ -1620,18 +1612,20 @@ public abstract class Provider extends Properties {
         addEngine("SaslClientFactory",                  false, null);
         addEngine("SaslServerFactory",                  false, null);
         // POLICY
+        @SuppressWarnings("removal")
+        Class<Policy.Parameters> policyParams = Policy.Parameters.class;
         addEngine("Policy",                             false,
-                            "java.security.Policy$Parameters");
+                policyParams);
         // CONFIGURATION
         addEngine("Configuration",                      false,
-                            "javax.security.auth.login.Configuration$Parameters");
+                Configuration.Parameters.class);
         // XML DSig
         addEngine("XMLSignatureFactory",                false, null);
         addEngine("KeyInfoFactory",                     false, null);
         addEngine("TransformService",                   false, null);
         // Smart Card I/O
         addEngine("TerminalFactory",                    false,
-                            "java.lang.Object");
+                            Object.class);
     }
 
     // get the "standard" (mixed-case) engine name for arbitrary case engine name
@@ -1905,8 +1899,7 @@ public abstract class Provider extends Properties {
                     ctrParamClz = constructorParameter == null?
                         null : constructorParameter.getClass();
                 } else {
-                    ctrParamClz = cap.constructorParameterClassName == null?
-                        null : cap.getConstructorParameterClass();
+                    ctrParamClz = cap.constructorParameterClass;
                     if (constructorParameter != null) {
                         if (ctrParamClz == null) {
                             throw new InvalidParameterException
@@ -1917,7 +1910,7 @@ public abstract class Provider extends Properties {
                             if (!ctrParamClz.isAssignableFrom(argClass)) {
                                 throw new InvalidParameterException
                                     ("constructorParameter must be instanceof "
-                                    + cap.constructorParameterClassName.replace('$', '.')
+                                    + cap.constructorParameterClass.getName().replace('$', '.')
                                     + " for engine type " + type);
                             }
                         }

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1557,11 +1557,21 @@ public abstract class Provider extends Properties {
         final String name;
         final boolean supportsParameter;
         final String constructorParameterClassName;
+        private volatile Class<?> constructorParameterClass;
 
         EngineDescription(String name, boolean sp, String paramName) {
             this.name = name;
             this.supportsParameter = sp;
             this.constructorParameterClassName = paramName;
+        }
+
+        Class<?> getConstructorParameterClass() throws ClassNotFoundException {
+            Class<?> clazz = constructorParameterClass;
+            if (clazz == null) {
+                clazz = Class.forName(constructorParameterClassName);
+                constructorParameterClass = clazz;
+            }
+            return clazz;
         }
     }
 
@@ -1896,7 +1906,7 @@ public abstract class Provider extends Properties {
                         null : constructorParameter.getClass();
                 } else {
                     ctrParamClz = cap.constructorParameterClassName == null?
-                        null : Class.forName(cap.constructorParameterClassName);
+                        null : cap.getConstructorParameterClass();
                     if (constructorParameter != null) {
                         if (ctrParamClz == null) {
                             throw new InvalidParameterException

--- a/test/micro/org/openjdk/bench/java/security/SecureRandomBench.java
+++ b/test/micro/org/openjdk/bench/java/security/SecureRandomBench.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 public class SecureRandomBench {
 
     @Benchmark
-    public SecureRandom newSecureRandom() throws Exception {
+    public SecureRandom create() throws Exception {
         return new SecureRandom();
     }
 }

--- a/test/micro/org/openjdk/bench/java/security/SecureRandomBench.java
+++ b/test/micro/org/openjdk/bench/java/security/SecureRandomBench.java
@@ -1,0 +1,19 @@
+package org.openjdk.bench.java.security;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 3)
+public class SecureRandomBench {
+
+    @Benchmark
+    public SecureRandom newSecureRandom() throws Exception {
+        return new SecureRandom();
+    }
+}

--- a/test/micro/org/openjdk/bench/java/security/SecureRandomBench.java
+++ b/test/micro/org/openjdk/bench/java/security/SecureRandomBench.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
 package org.openjdk.bench.java.security;
 
 import org.openjdk.jmh.annotations.*;


### PR DESCRIPTION
Avoid expensive `Class.forName` call when constructing Providers such as `SecureRandom` which take constructor parameters. This can easily be cached in EngineDescription (this cache already existed before, it was removed in [JDK-8280970](https://bugs.openjdk.org/browse/JDK-8280970) as unused, I'm bringing it back unchanged to support this new usage).

Benchmark results on my Linux x86 host show around a 20% reduction in time to create a new `SecureRandom` instance. Most of the remaining overhead is due to a failing constructor lookup - see [JDK-8324648](https://bugs.openjdk.org/browse/JDK-8324648).

```
Before
newSecureRandom  avgt  2930 ± 50  ns/op

After
newSecureRandom  avgt  2400 ± 33  ns/op
```

I have seen multiple real-world applications which call `new SecureRandom()` on the hot path, so I believe efficiency here is important.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8324646](https://bugs.openjdk.org/browse/JDK-8324646): Avoid Class.forName in SecureRandom constructor (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [45da78f9](https://git.openjdk.org/jdk/pull/17559/files/45da78f924c0890bde36c95a09e95dce25c5f965)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to [45da78f9](https://git.openjdk.org/jdk/pull/17559/files/45da78f924c0890bde36c95a09e95dce25c5f965)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17559/head:pull/17559` \
`$ git checkout pull/17559`

Update a local copy of the PR: \
`$ git checkout pull/17559` \
`$ git pull https://git.openjdk.org/jdk.git pull/17559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17559`

View PR using the GUI difftool: \
`$ git pr show -t 17559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17559.diff">https://git.openjdk.org/jdk/pull/17559.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17559#issuecomment-1908368998)