### PR TITLE
8324648: Avoid NoSuchMethodError when instantiating NativePRNG

### DIFF
--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -204,7 +204,6 @@ public final class NativePRNG extends SecureRandomSpi {
 
     // constructor, called by the JCA framework
     public NativePRNG(SecureRandomParameters params) {
-        super();
         if (INSTANCE == null) {
             throw new AssertionError("NativePRNG not available");
         }
@@ -255,7 +254,6 @@ public final class NativePRNG extends SecureRandomSpi {
 
         // constructor, called by the JCA framework
         public Blocking(SecureRandomParameters params) {
-            super();
             if (INSTANCE == null) {
                 throw new AssertionError("NativePRNG$Blocking not available");
             }
@@ -307,7 +305,6 @@ public final class NativePRNG extends SecureRandomSpi {
 
         // constructor, called by the JCA framework
         public NonBlocking(SecureRandomParameters params) {
-            super();
             if (INSTANCE == null) {
                 throw new AssertionError(
                     "NativePRNG$NonBlocking not available");

--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -202,16 +202,14 @@ public final class NativePRNG extends SecureRandomSpi {
         return INSTANCE != null;
     }
 
-    // constructor, unused argument to speed up lookups from Provider
-    public NativePRNG(SecureRandomParameters ignored) {
-        this();
-    }
-
     // constructor, called by the JCA framework
-    public NativePRNG() {
+    public NativePRNG(SecureRandomParameters params) {
         super();
         if (INSTANCE == null) {
             throw new AssertionError("NativePRNG not available");
+        }
+        if (params != null) {
+            throw new IllegalArgumentException("Unsupported params: " + params.getClass());
         }
     }
 
@@ -255,16 +253,14 @@ public final class NativePRNG extends SecureRandomSpi {
             return INSTANCE != null;
         }
 
-        // constructor, unused argument to speed up lookups from Provider
-        public Blocking(SecureRandomParameters ignored) {
-            this();
-        }
-
         // constructor, called by the JCA framework
-        public Blocking() {
+        public Blocking(SecureRandomParameters params) {
             super();
             if (INSTANCE == null) {
                 throw new AssertionError("NativePRNG$Blocking not available");
+            }
+            if (params != null) {
+                throw new IllegalArgumentException("Unsupported params: " + params.getClass());
             }
         }
 
@@ -309,17 +305,15 @@ public final class NativePRNG extends SecureRandomSpi {
             return INSTANCE != null;
         }
 
-        // constructor, unused argument to speed up lookups from Provider
-        public NonBlocking(SecureRandomParameters ignored) {
-            this();
-        }
-
         // constructor, called by the JCA framework
-        public NonBlocking() {
+        public NonBlocking(SecureRandomParameters params) {
             super();
             if (INSTANCE == null) {
                 throw new AssertionError(
                     "NativePRNG$NonBlocking not available");
+            }
+            if (params != null) {
+                throw new IllegalArgumentException("Unsupported params: " + params.getClass());
             }
         }
 

--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -202,6 +202,11 @@ public final class NativePRNG extends SecureRandomSpi {
         return INSTANCE != null;
     }
 
+    // constructor, unused argument to speed up lookups from Provider
+    public NativePRNG(SecureRandomParameters ignored) {
+        this();
+    }
+
     // constructor, called by the JCA framework
     public NativePRNG() {
         super();
@@ -248,6 +253,11 @@ public final class NativePRNG extends SecureRandomSpi {
         // return whether this is available
         static boolean isAvailable() {
             return INSTANCE != null;
+        }
+
+        // constructor, unused argument to speed up lookups from Provider
+        public Blocking(SecureRandomParameters ignored) {
+            this();
         }
 
         // constructor, called by the JCA framework
@@ -297,6 +307,11 @@ public final class NativePRNG extends SecureRandomSpi {
         // return whether this is available
         static boolean isAvailable() {
             return INSTANCE != null;
+        }
+
+        // constructor, unused argument to speed up lookups from Provider
+        public NonBlocking(SecureRandomParameters ignored) {
+            this();
         }
 
         // constructor, called by the JCA framework


### PR DESCRIPTION
A typical call to `new SecureRandom()` is slowed down by looking for a constructor in NativePRNG which takes `java.security.SecureRandomParameters`. NativePRNG does not have such a constructor, so the search fails [here](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/security/Provider.java#L1951-L1957), incurring all the cost of the lookup and creating a subsequent exception.

Creating a dummy constructor which takes and ignores this parameter will speed up `new SecureRandom()` calls significantly. 

The benchmark from https://github.com/openjdk/jdk/pull/17559 shows around 80% reduction in time taken to create a new SecureRandom with NativePRNG (default on my machine).

```
Before
SecureRandomBench.newSecureRandom  avgt  2930 ± 50 ns/op

After
SecureRandomBench.newSecureRandom  avgt  510 ± 16 ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8324648](https://bugs.openjdk.org/browse/JDK-8324648): Avoid NoSuchMethodError when instantiating NativePRNG (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [d537b80c](https://git.openjdk.org/jdk/pull/17560/files/d537b80c2dceb652786a4cc26f3062bec9d85c0f)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**) ⚠️ Review applies to [de4d83ac](https://git.openjdk.org/jdk/pull/17560/files/de4d83ace566cb0ef093e24186b2114bed578651)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author) ⚠️ Review applies to [44958eff](https://git.openjdk.org/jdk/pull/17560/files/44958eff4ed52b9adb751d5ba6c4349e33214e8a)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17560/head:pull/17560` \
`$ git checkout pull/17560`

Update a local copy of the PR: \
`$ git checkout pull/17560` \
`$ git pull https://git.openjdk.org/jdk.git pull/17560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17560`

View PR using the GUI difftool: \
`$ git pr show -t 17560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17560.diff">https://git.openjdk.org/jdk/pull/17560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17560#issuecomment-1908398984)