### PR TITLE
JDK-8322854: Incorrect rematerialization of scalar replaced objects in C2

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,7 +167,7 @@ void PhaseMacroExpand::eliminate_gc_barrier(Node* p2x) {
 // Search for a memory operation for the specified memory slice.
 static Node *scan_mem_chain(Node *mem, int alias_idx, int offset, Node *start_mem, Node *alloc, PhaseGVN *phase) {
   Node *orig_mem = mem;
-  Node *alloc_mem = alloc->in(TypeFunc::Memory);
+  Node *alloc_mem = alloc->as_Allocate()->proj_out_or_null(TypeFunc::Memory);
   const TypeOopPtr *tinst = phase->C->get_adr_type(alias_idx)->isa_oopptr();
   while (true) {
     if (mem == alloc_mem || mem == start_mem ) {
@@ -371,7 +371,7 @@ Node *PhaseMacroExpand::value_from_mem_phi(Node *mem, BasicType ft, const Type *
     return nullptr; // Give up: phi tree too deep
   }
   Node *start_mem = C->start()->proj_out_or_null(TypeFunc::Memory);
-  Node *alloc_mem = alloc->in(TypeFunc::Memory);
+  Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory);
 
   uint length = mem->req();
   GrowableArray <Node *> values(length, length, nullptr);
@@ -456,7 +456,7 @@ Node *PhaseMacroExpand::value_from_mem(Node *sfpt_mem, Node *sfpt_ctl, BasicType
   int offset = adr_t->offset();
   Node *start_mem = C->start()->proj_out_or_null(TypeFunc::Memory);
   Node *alloc_ctrl = alloc->in(TypeFunc::Control);
-  Node *alloc_mem = alloc->in(TypeFunc::Memory);
+  Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory);
   VectorSet visited;
 
   bool done = sfpt_mem == alloc_mem;

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -168,6 +168,7 @@ void PhaseMacroExpand::eliminate_gc_barrier(Node* p2x) {
 static Node *scan_mem_chain(Node *mem, int alias_idx, int offset, Node *start_mem, Node *alloc, PhaseGVN *phase) {
   Node *orig_mem = mem;
   Node *alloc_mem = alloc->as_Allocate()->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
+  assert(alloc_mem != nullptr, "Allocation without a memory projection.");
   const TypeOopPtr *tinst = phase->C->get_adr_type(alias_idx)->isa_oopptr();
   while (true) {
     if (mem == alloc_mem || mem == start_mem ) {
@@ -372,6 +373,7 @@ Node *PhaseMacroExpand::value_from_mem_phi(Node *mem, BasicType ft, const Type *
   }
   Node *start_mem = C->start()->proj_out_or_null(TypeFunc::Memory);
   Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
+  assert(alloc_mem != nullptr, "Allocation without a memory projection.");
 
   uint length = mem->req();
   GrowableArray <Node *> values(length, length, nullptr);
@@ -457,6 +459,7 @@ Node *PhaseMacroExpand::value_from_mem(Node *sfpt_mem, Node *sfpt_ctl, BasicType
   Node *start_mem = C->start()->proj_out_or_null(TypeFunc::Memory);
   Node *alloc_ctrl = alloc->in(TypeFunc::Control);
   Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
+  assert(alloc_mem != nullptr, "Allocation without a memory projection.");
   VectorSet visited;
 
   bool done = sfpt_mem == alloc_mem;

--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -167,7 +167,7 @@ void PhaseMacroExpand::eliminate_gc_barrier(Node* p2x) {
 // Search for a memory operation for the specified memory slice.
 static Node *scan_mem_chain(Node *mem, int alias_idx, int offset, Node *start_mem, Node *alloc, PhaseGVN *phase) {
   Node *orig_mem = mem;
-  Node *alloc_mem = alloc->as_Allocate()->proj_out_or_null(TypeFunc::Memory);
+  Node *alloc_mem = alloc->as_Allocate()->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
   const TypeOopPtr *tinst = phase->C->get_adr_type(alias_idx)->isa_oopptr();
   while (true) {
     if (mem == alloc_mem || mem == start_mem ) {
@@ -371,7 +371,7 @@ Node *PhaseMacroExpand::value_from_mem_phi(Node *mem, BasicType ft, const Type *
     return nullptr; // Give up: phi tree too deep
   }
   Node *start_mem = C->start()->proj_out_or_null(TypeFunc::Memory);
-  Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory);
+  Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
 
   uint length = mem->req();
   GrowableArray <Node *> values(length, length, nullptr);
@@ -456,7 +456,7 @@ Node *PhaseMacroExpand::value_from_mem(Node *sfpt_mem, Node *sfpt_ctl, BasicType
   int offset = adr_t->offset();
   Node *start_mem = C->start()->proj_out_or_null(TypeFunc::Memory);
   Node *alloc_ctrl = alloc->in(TypeFunc::Control);
-  Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory);
+  Node *alloc_mem = alloc->proj_out_or_null(TypeFunc::Memory, /*io_use:*/false);
   VectorSet visited;
 
   bool done = sfpt_mem == alloc_mem;

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndMemoryLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndMemoryLoop.java
@@ -28,7 +28,6 @@
  * @library /test/lib /
  * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndMemoryLoop*::test*
  *                   -XX:-TieredCompilation -Xbatch
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+TraceReduceAllocationMerges
  *                   compiler.c2.TestReduceAllocationAndMemoryLoop
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndMemoryLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndMemoryLoop.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8322854
+ * @summary Check that the RAM optimization works when there is a memory loop.
+ * @library /test/lib /
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndMemoryLoop*::test*
+ *                   -XX:-TieredCompilation -Xbatch
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+TraceReduceAllocationMerges
+ *                   compiler.c2.TestReduceAllocationAndMemoryLoop
+ */
+
+package compiler.c2;
+
+public class TestReduceAllocationAndMemoryLoop {
+    public static void main(String[] args) throws Exception {
+        // Warmup
+        for (int i = 0; i < 50_000; ++i) {
+            test(false, 10);
+        }
+
+        // Trigger deoptimization
+        MyClass obj = test(false, 11);
+        if (obj.val != 42) {
+            throw new RuntimeException("Test failed, val = " + obj.val);
+        }
+    }
+
+    static class MyClass {
+        final int val;
+
+        public MyClass(int val) {
+            this.val = val;
+        }
+    }
+
+    public static MyClass test(boolean alwaysFalse, int limit) {
+        for (int i = 0; ; ++i) {
+            MyClass obj = new MyClass(42);
+            if (alwaysFalse || i > 10) {
+                return obj;
+            }
+            if (i == limit) {
+              return null;
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndMemoryLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndMemoryLoop.java
@@ -26,6 +26,7 @@
  * @bug 8322854
  * @summary Check that the RAM optimization works when there is a memory loop.
  * @library /test/lib /
+ * @requires vm.compiler2.enabled
  * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndMemoryLoop*::test*
  *                   -XX:-TieredCompilation -Xbatch
  *                   compiler.c2.TestReduceAllocationAndMemoryLoop


### PR DESCRIPTION
Current implementation of `PhaseMacroExpand::value_from_mem` returns `return _igvn.zerocon(ft);` when it hits a sentinel while searching for a memory operation on a given slice. One of the sentinels is the memory input of the allocate node origin of the memory slice. Therefore, `value_from_mem` may return `zeroconf(ft)` if `sfpt_mem` is the same memory edge used by the Allocate node origin of the memory slice being traversed.

The scalar replacement implementation uses `value_from_mem` during creation of metadata describing object scalar replaced (see `PhaseMacroExpand::create_scalarized_object_description`). The `create_scalarized_object_description` method is also used as part of RAM optimization implementation. The RAM optimization targets Phi nodes and therefore a memory graph loop created by a _memory phi_ node is possible to seen as part of the transformation. See image below:

<img src="https://github.com/openjdk/jdk/assets/2249648/288681b7-4461-41ea-8dab-bbaebac4727f" height="500" />

This pattern doesn't show up when scalarizing objects that don't participate in allocation merges. 

To fix the issue I changed the code in `value_from_mem` to instead of using the _input_ memory edge of the Allocate as a stop condition, it will now use the projection memory edge of the Allocate.

Tested locally on windows, mac and linux x86_64 with JTREG tier1-3 and didn't observe any regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322854](https://bugs.openjdk.org/browse/JDK-8322854): Incorrect rematerialization of scalar replaced objects in C2 (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17562/head:pull/17562` \
`$ git checkout pull/17562`

Update a local copy of the PR: \
`$ git checkout pull/17562` \
`$ git pull https://git.openjdk.org/jdk.git pull/17562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17562`

View PR using the GUI difftool: \
`$ git pr show -t 17562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17562.diff">https://git.openjdk.org/jdk/pull/17562.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17562#issuecomment-1909089270)