### PR TITLE
JDK-8324238 : [macOS] java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java fails with the shape has not been applied msg

### DIFF
--- a/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
+++ b/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
@@ -63,7 +63,7 @@ public class ShapeNotSetSometimes {
     public ShapeNotSetSometimes() throws Exception {
         EventQueue.invokeAndWait(this::initializeGUI);
         robot.waitForIdle();
-        robot.delay(1000);
+        robot.delay(500);
     }
 
     private void initializeGUI() {
@@ -172,6 +172,10 @@ public class ShapeNotSetSometimes {
     private void colorCheck(int x, int y, Color expectedColor, boolean mustBeExpectedColor) {
         int screenX = window.getX() + x;
         int screenY = window.getY() + y;
+
+        robot.mouseMove(screenX, screenY);
+        robot.waitForIdle();
+        robot.delay(50);
 
         Color actualColor = robot.getPixelColor(screenX, screenY);
 

--- a/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
+++ b/test/jdk/java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-
-
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.EventQueue;
@@ -44,7 +42,7 @@ import javax.imageio.ImageIO;
  * @key headful
  * @bug 6988428
  * @summary Tests whether shape is always set
- * @run main ShapeNotSetSometimes
+ * @run main/othervm -Dsun.java2d.uiScale=1 ShapeNotSetSometimes
  */
 
 public class ShapeNotSetSometimes {
@@ -55,11 +53,12 @@ public class ShapeNotSetSometimes {
     private Point[] pointsOutsideToCheck;
     private Point[] shadedPointsToCheck;
     private Point innerPoint;
-    private final Rectangle bounds = new Rectangle(220, 400, 300, 300);
 
     private static Robot robot;
     private static final Color BACKGROUND_COLOR = Color.GREEN;
     private static final Color SHAPE_COLOR = Color.WHITE;
+    private static final int DIM = 300;
+    private static final int DELTA = 2;
 
     public ShapeNotSetSometimes() throws Exception {
         EventQueue.invokeAndWait(this::initializeGUI);
@@ -70,7 +69,8 @@ public class ShapeNotSetSometimes {
     private void initializeGUI() {
         backgroundFrame = new BackgroundFrame();
         backgroundFrame.setUndecorated(true);
-        backgroundFrame.setBounds(bounds);
+        backgroundFrame.setSize(DIM, DIM);
+        backgroundFrame.setLocationRelativeTo(null);
         backgroundFrame.setVisible(true);
 
         Area area = new Area();
@@ -81,8 +81,10 @@ public class ShapeNotSetSometimes {
         area.add(new Area(new Ellipse2D.Float(150, 50, 100, 100)));
         area.add(new Area(new Ellipse2D.Float(150, 100, 100, 100)));
 
-
+        // point at the center of white ellipse
         innerPoint = new Point(150, 130);
+
+        // mid points on the 4 sides - on the green background frame
         pointsOutsideToCheck = new Point[] {
                 new Point(150, 20),
                 new Point(280, 120),
@@ -90,6 +92,7 @@ public class ShapeNotSetSometimes {
                 new Point(20, 120)
         };
 
+        // points just outside the ellipse (opposite side of diagonal)
         shadedPointsToCheck = new Point[] {
                 new Point(62, 62),
                 new Point(240, 185)
@@ -97,7 +100,8 @@ public class ShapeNotSetSometimes {
 
         window = new TestFrame();
         window.setUndecorated(true);
-        window.setBounds(bounds);
+        window.setSize(DIM, DIM);
+        window.setLocationRelativeTo(null);
         window.setShape(area);
         window.setVisible(true);
     }
@@ -108,7 +112,7 @@ public class ShapeNotSetSometimes {
         public void paint(Graphics g) {
 
             g.setColor(BACKGROUND_COLOR);
-            g.fillRect(0, 0, 300, 300);
+            g.fillRect(0, 0, DIM, DIM);
 
             super.paint(g);
         }
@@ -120,7 +124,7 @@ public class ShapeNotSetSometimes {
         public void paint(Graphics g) {
 
             g.setColor(SHAPE_COLOR);
-            g.fillRect(0, 0, bounds.width, bounds.height);
+            g.fillRect(0, 0, DIM, DIM);
 
             super.paint(g);
         }
@@ -155,14 +159,17 @@ public class ShapeNotSetSometimes {
             }
         } finally {
             EventQueue.invokeAndWait(() -> {
-                backgroundFrame.dispose();
-                window.dispose();
+                if (backgroundFrame != null) {
+                    backgroundFrame.dispose();
+                }
+                if (window != null) {
+                    window.dispose();
+                }
             });
         }
     }
 
     private void colorCheck(int x, int y, Color expectedColor, boolean mustBeExpectedColor) {
-
         int screenX = window.getX() + x;
         int screenY = window.getY() + y;
 
@@ -176,7 +183,7 @@ public class ShapeNotSetSometimes {
                 expectedColor
         );
 
-        if (mustBeExpectedColor != expectedColor.equals(actualColor)) {
+        if (mustBeExpectedColor != colorCompare(expectedColor, actualColor)) {
             captureScreen();
             System.out.printf("window.getX() = %3d, window.getY() = %3d\n", window.getX(), window.getY());
             System.err.printf(
@@ -188,6 +195,15 @@ public class ShapeNotSetSometimes {
                     expectedColor);
             throw new RuntimeException("Test failed. The shape has not been applied.");
         }
+    }
+
+    private static boolean colorCompare(Color expected, Color actual) {
+        if (Math.abs(expected.getRed() - actual.getRed()) <= DELTA
+                && Math.abs(expected.getGreen() - actual.getGreen()) <= DELTA
+                && Math.abs(expected.getBlue() - actual.getBlue()) <= DELTA) {
+            return true;
+        }
+        return false;
     }
 
     private static void captureScreen() {


### PR DESCRIPTION
ShapeNotSetSometimes.java fails on macOS 11 on a random iteration of `colorCheck()` as shown below. The `colorCheck()` is repeated for about 50 times in the test. It is observed to pass on previous attempts and fail on a random attempt such as Attempt# 29 shown here.

Here the point (150, 20) is well in the green area hence the slight color diff picked up by `robot.getPixelColor()` is not due to sampling of color at the edge (which sometimes causes robot to pick up slightly different color).  

```
Attempt 29
Checking 150, 20, java.awt.Color[r=0,g=255,b=1] should be java.awt.Color[r=0,g=255,b=0]
```

Due to the above, I have kept the color sampling points at the same location as earlier and made the following changes to the test:

- Moved the frame to the center of the screen.
- Instead of comparing exact RGB values, used `colorCompare()` which allows color tolerance of 2 per color component to accommodate slight variations when comparing actual vs expected colors.


```
Attempt 27
Checking 150, 130, java.awt.Color[r=255,g=255,b=255] should be java.awt.Color[r=255,g=255,b=255]
Checking 150, 20, java.awt.Color[r=0,g=255,b=0] should be java.awt.Color[r=0,g=255,b=0]
Checking 280, 120, java.awt.Color[r=0,g=255,b=0] should be java.awt.Color[r=0,g=255,b=0]
Checking 150, 250, java.awt.Color[r=0,g=255,b=0] should be java.awt.Color[r=0,g=255,b=0]
Checking 20, 120, java.awt.Color[r=0,g=255,b=0] should be java.awt.Color[r=0,g=255,b=0]
Checking 62, 62, java.awt.Color[r=0,g=243,b=0] should not be java.awt.Color[r=255,g=255,b=255]
Checking 240, 185, java.awt.Color[r=0,g=229,b=0] should not be java.awt.Color[r=255,g=255,b=255]
Attempt 28
Checking 150, 130, java.awt.Color[r=255,g=255,b=255] should be java.awt.Color[r=255,g=255,b=255]
Checking 150, 20, java.awt.Color[r=0,g=255,b=0] should be java.awt.Color[r=0,g=255,b=0]
Checking 280, 120, java.awt.Color[r=0,g=255,b=0] should be java.awt.Color[r=0,g=255,b=0]
Checking 150, 250, java.awt.Color[r=0,g=255,b=0] should be java.awt.Color[r=0,g=255,b=0]
Checking 20, 120, java.awt.Color[r=0,g=255,b=0] should be java.awt.Color[r=0,g=255,b=0]
Checking 62, 62, java.awt.Color[r=0,g=241,b=0] should not be java.awt.Color[r=255,g=255,b=255]
Checking 240, 185, java.awt.Color[r=0,g=227,b=0] should not be java.awt.Color[r=255,g=255,b=255]
Attempt 29
Checking 150, 130, java.awt.Color[r=255,g=255,b=255] should be java.awt.Color[r=255,g=255,b=255]
Checking 150, 20, java.awt.Color[r=0,g=255,b=1] should be java.awt.Color[r=0,g=255,b=0]
----------System.err:(16/962)----------
Checking for transparency failed: point: 370, 420
actual java.awt.Color[r=0,g=255,b=1]
expected java.awt.Color[r=0,g=255,b=0]
java.lang.RuntimeException: Test failed. The shape has not been applied. 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324238](https://bugs.openjdk.org/browse/JDK-8324238): [macOS] java/awt/Frame/ShapeNotSetSometimes/ShapeNotSetSometimes.java fails with the shape has not been applied msg (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17563/head:pull/17563` \
`$ git checkout pull/17563`

Update a local copy of the PR: \
`$ git checkout pull/17563` \
`$ git pull https://git.openjdk.org/jdk.git pull/17563/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17563`

View PR using the GUI difftool: \
`$ git pr show -t 17563`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17563.diff">https://git.openjdk.org/jdk/pull/17563.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17563#issuecomment-1909183997)