### PR TITLE
JDK-8302019: Clarify Elements.overrides

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -694,16 +694,16 @@ public interface Elements {
      * as overriding the corresponding {@code Object} method; for
      * example:
      *
-     * <blockquote><pre>
+     * {@snippet lang=java :
      * interface I {
-     *   &commat;Override
+     *   @Override
      *   String toString();
      * }
      * ...
      * assert elements.overrides(elementForItoString,
      *                           elementForObjecttoString,
      *                           elements.getTypeElement("I"));
-     * </pre></blockquote>
+     * }
      *
      * @param overrider  the first method, possible overrider
      * @param overridden  the second method, possibly being overridden

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -687,14 +687,15 @@ public interface Elements {
      *          elements.getTypeElement("C")); }
      * </blockquote>
      *
-     * Consistent with the usage of the {@code @Override} annotation, if an
+     * Consistent with the usage of the {@link Override @Override} annotation, if an
      * interface declares a method override-equivalent to a {@code
-     * public} method of {@code java.lang.Object}, this method treats
+     * public} method of {@link Object java.lang.Object}, this method treats
      * any such interface methods as overriding the corresponding {@code
-     * Object} method:
+     * Object} method; example:
      *
      * <blockquote><pre>
      * interface I {
+     *   &commat;Override
      *   String toString();
      * }
      * ...

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -688,10 +688,10 @@ public interface Elements {
      * </blockquote>
      *
      * Consistent with the usage of the {@code @Override} annotation, if an
-     * interface declares methods override-equivalent to {@code
-     * public} methods on {@code java.lang.Object}, this method treats
-     * those interface methods as overriding the corresponding {@code
-     * Object} methods:
+     * interface declares a method override-equivalent to a {@code
+     * public} method on {@code java.lang.Object}, this method treats
+     * any such interface methods as overriding the corresponding {@code
+     * Object} method:
      *
      * <blockquote><pre>
      * interface I {

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -687,11 +687,12 @@ public interface Elements {
      *          elements.getTypeElement("C")); }
      * </blockquote>
      *
-     * Consistent with the usage of the {@link Override @Override} annotation, if an
-     * interface declares a method override-equivalent to a {@code
-     * public} method of {@link Object java.lang.Object}, this method treats
-     * any such interface methods as overriding the corresponding {@code
-     * Object} method; example:
+     * Consistent with the usage of the {@link Override @Override}
+     * annotation, if an interface declares a method
+     * override-equivalent to a {@code public} method of {@link Object
+     * java.lang.Object}, such a method of the interface is regarded
+     * as overriding the corresponding {@code Object} method; for
+     * example:
      *
      * <blockquote><pre>
      * interface I {

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -687,6 +687,22 @@ public interface Elements {
      *          elements.getTypeElement("C")); }
      * </blockquote>
      *
+     * Consistent with the usage of the {@code @Override} annotation, if an
+     * interface declares methods override-equivalent to {@code
+     * public} methods on {@code java.lang.Object}, this method treats
+     * those interface methods as overriding the corresponding {@code
+     * Object} methods:
+     *
+     * <blockquote><pre>
+     * interface I {
+     *   String toString();
+     * }
+     * ...
+     * assert elements.overrides(elementForItoString,
+     *                           elementForObjecttoString,
+     *                           elements.getTypeElement("I"));
+     * </pre></blockquote>
+     *
      * @param overrider  the first method, possible overrider
      * @param overridden  the second method, possibly being overridden
      * @param type   the class or interface of which the first method is a member

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -689,7 +689,7 @@ public interface Elements {
      *
      * Consistent with the usage of the {@code @Override} annotation, if an
      * interface declares a method override-equivalent to a {@code
-     * public} method on {@code java.lang.Object}, this method treats
+     * public} method of {@code java.lang.Object}, this method treats
      * any such interface methods as overriding the corresponding {@code
      * Object} method:
      *

--- a/test/langtools/tools/javac/processing/model/util/elements/TestOverrides.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/TestOverrides.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8302019
+ * @summary Test basic operation of Elements.overrides
+ * @library /tools/javac/lib
+ * @build   JavacTestingAbstractProcessor TestOverrides
+ * @compile -processor TestOverrides -proc:only TestOverrides.java
+ */
+
+import java.util.*;
+import java.util.function.*;
+import javax.annotation.processing.*;
+import javax.lang.model.element.*;
+import javax.lang.model.util.*;
+
+/**
+ * Test basic workings of Elements.overrides
+ */
+public class TestOverrides extends JavacTestingAbstractProcessor {
+    public boolean process(Set<? extends TypeElement> annotations,
+                           RoundEnvironment roundEnv) {
+        if (!roundEnv.processingOver()) {
+            checkObjectOverrides();
+        }
+        return true;
+    }
+
+    private void checkObjectOverrides() {
+        boolean elementSeen = false;
+
+        TypeElement objectElt = elements.getTypeElement("java.lang.Object");
+
+        TypeElement objectInterfaceElt = elements.getTypeElement("ObjectInterface");
+        for (var method : ElementFilter.methodsIn(objectInterfaceElt.getEnclosedElements())) {
+            elementSeen = true;
+            Name methodName = method.getSimpleName();
+            boolean expectedOverrideResult = method.getAnnotation(OverrideExpected.class).value();
+            if (expectedOverrideResult !=
+                elements.overrides(method, findMethod(methodName, objectElt), objectInterfaceElt ) ) {
+                throw new RuntimeException("Unexpected overrding relation found for " + method);
+            }
+                 
+            if (!elementSeen) {
+                throw new RuntimeException("No elements seen.");
+            }
+        }
+    }
+
+    ExecutableElement findMethod(Name name, TypeElement typeElt) {
+        for (var method : ElementFilter.methodsIn(typeElt.getEnclosedElements())) {
+            if (method.getSimpleName().equals(name)) {
+                return method;
+            }
+        }
+        return null;
+    }
+        
+}
+
+@interface OverrideExpected {
+    boolean value() default true;
+}
+
+/**
+ * Interface that has methods override-equivalent to methods on
+ * java.lang.Object.
+ */
+interface ObjectInterface {
+    @Override
+    @OverrideExpected
+    boolean equals(Object obj);
+
+    @Override
+    @OverrideExpected
+    int hashCode();
+
+    @Override
+    @OverrideExpected
+    String toString();
+
+    @OverrideExpected(value=false) // protected, not public method
+    Object clone();
+
+    @OverrideExpected(value=false) // protected, not public method
+    void finalize();
+
+    // Final methods on Object (getClass, wait, notify[all]) rejected
+    // if declared in an interface.
+}
+

--- a/test/langtools/tools/javac/processing/model/util/elements/TestOverrides.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/TestOverrides.java
@@ -60,7 +60,7 @@ public class TestOverrides extends JavacTestingAbstractProcessor {
             boolean expectedOverrideResult = method.getAnnotation(OverrideExpected.class).value();
             if (expectedOverrideResult !=
                 elements.overrides(method, findMethod(methodName, objectElt), objectInterfaceElt ) ) {
-                throw new RuntimeException("Unexpected overrding relation found for " + method);
+                throw new RuntimeException("Unexpected overriding relation found for " + method);
             }
 
             if (!elementSeen) {
@@ -85,7 +85,7 @@ public class TestOverrides extends JavacTestingAbstractProcessor {
 }
 
 /**
- * Interface that has methods override-equivalent to methods on
+ * Interface that has methods override-equivalent to methods of
  * java.lang.Object.
  */
 interface ObjectInterface {

--- a/test/langtools/tools/javac/processing/model/util/elements/TestOverrides.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/TestOverrides.java
@@ -62,7 +62,7 @@ public class TestOverrides extends JavacTestingAbstractProcessor {
                 elements.overrides(method, findMethod(methodName, objectElt), objectInterfaceElt ) ) {
                 throw new RuntimeException("Unexpected overrding relation found for " + method);
             }
-                 
+
             if (!elementSeen) {
                 throw new RuntimeException("No elements seen.");
             }
@@ -77,7 +77,7 @@ public class TestOverrides extends JavacTestingAbstractProcessor {
         }
         return null;
     }
-        
+
 }
 
 @interface OverrideExpected {

--- a/test/langtools/tools/javac/processing/model/util/elements/TestOverrides.java
+++ b/test/langtools/tools/javac/processing/model/util/elements/TestOverrides.java
@@ -107,7 +107,7 @@ interface ObjectInterface {
     @OverrideExpected(value=false) // protected, not public method
     void finalize();
 
-    // Final methods on Object (getClass, wait, notify[all]) rejected
+    // Final methods of Object (getClass, wait, notify[all]) rejected
     // if declared in an interface.
 }
 


### PR DESCRIPTION
Explicitly discuss and test handling of an interface declaring methods that "override" public methods on java.lang.Object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8302019](https://bugs.openjdk.org/browse/JDK-8302019): Clarify Elements.overrides (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17564/head:pull/17564` \
`$ git checkout pull/17564`

Update a local copy of the PR: \
`$ git checkout pull/17564` \
`$ git pull https://git.openjdk.org/jdk.git pull/17564/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17564`

View PR using the GUI difftool: \
`$ git pr show -t 17564`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17564.diff">https://git.openjdk.org/jdk/pull/17564.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17564#issuecomment-1909263075)