### PR TITLE
8320676 : Manual printer tests have no Pass/Fail buttons, instructions close

### DIFF
--- a/test/jdk/java/awt/print/PageFormat/PageSetupDialog.java
+++ b/test/jdk/java/awt/print/PageFormat/PageSetupDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,333 +21,240 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Checkbox;
+import java.awt.Color;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Paper;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4197377
  * @bug 4299145
  * @bug 6358747
  * @bug 6574633
- * @summary Page setup dialog settings
  * @key printer
+ * @summary Page setup dialog settings
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual PageSetupDialog
  */
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-
 public class PageSetupDialog extends Frame implements Printable {
 
-  PrinterJob myPrinterJob;
-  PageFormat myPageFormat;
-  Label pw, ph, pglm, pgiw, pgrm, pgtm, pgih, pgbm;
-  Label myWidthLabel;
-  Label myHeightLabel;
-  Label myImageableXLabel;
-  Label myImageableYLabel;
-  Label myImageableRightLabel;
-  Label myImageableBottomLabel;
-  Label myImageableWidthLabel;
-  Label myImageableHeightLabel;
-  Label myOrientationLabel;
-  Checkbox reverseCB;
-  boolean alpha = false;
-  boolean reverse = false;
+    PrinterJob myPrinterJob;
+    PageFormat myPageFormat;
+    Label pw, ph, pglm, pgiw, pgrm, pgtm, pgih, pgbm;
+    Label myWidthLabel;
+    Label myHeightLabel;
+    Label myImageableXLabel;
+    Label myImageableYLabel;
+    Label myImageableRightLabel;
+    Label myImageableBottomLabel;
+    Label myImageableWidthLabel;
+    Label myImageableHeightLabel;
+    Label myOrientationLabel;
+    Checkbox reverseCB;
+    boolean alpha = false;
+    boolean reverse = false;
 
-  protected void displayPageFormatAttributes() {
+    private static final String instructions =
+             " You must have a printer available to perform this test\n" +
+             "\n" +
+             " This test is very flexible and requires much interaction.\n" +
+             " If the platform print dialog supports it, adjust orientation\n" +
+             " and margins and print pages and compare the results with the request.";
 
-    myWidthLabel.setText("Format Width = " + (float)myPageFormat.getWidth());
-    myHeightLabel.setText("Format Height = " + (float)myPageFormat.getHeight());
-    myImageableXLabel.setText
-        ("Format Left Margin = " + (float)myPageFormat.getImageableX());
-    myImageableRightLabel.setText
-        ("Format Right Margin = " + (float)(myPageFormat.getWidth() -
-        (myPageFormat.getImageableX() + myPageFormat.getImageableWidth())));
-    myImageableWidthLabel.setText
-        ("Format ImageableWidth = " + (float)myPageFormat.getImageableWidth());
-    myImageableYLabel.setText
-        ("Format Top Margin = " + (float)myPageFormat.getImageableY());
-    myImageableBottomLabel.setText
-        ("Format Bottom Margin = " + (float)(myPageFormat.getHeight() -
-        (myPageFormat.getImageableY() + myPageFormat.getImageableHeight())));
-    myImageableHeightLabel.setText
-        ("Format ImageableHeight = " + (float)myPageFormat.getImageableHeight());
-    int o = myPageFormat.getOrientation();
-    if (o == PageFormat.LANDSCAPE && reverse) {
-        o = PageFormat.REVERSE_LANDSCAPE;
-        myPageFormat.setOrientation(PageFormat.REVERSE_LANDSCAPE);
-    } else if (o == PageFormat.REVERSE_LANDSCAPE && !reverse) {
-        o = PageFormat.LANDSCAPE;
-        myPageFormat.setOrientation(PageFormat.LANDSCAPE);
+    protected void displayPageFormatAttributes() {
+
+        myWidthLabel.setText("Format Width = " + (float) myPageFormat.getWidth());
+        myHeightLabel.setText("Format Height = " + (float) myPageFormat.getHeight());
+        myImageableXLabel.setText
+                ("Format Left Margin = " + (float) myPageFormat.getImageableX());
+        myImageableRightLabel.setText
+                ("Format Right Margin = " + (float) (myPageFormat.getWidth() -
+                        (myPageFormat.getImageableX() + myPageFormat.getImageableWidth())));
+        myImageableWidthLabel.setText
+                ("Format ImageableWidth = " + (float) myPageFormat.getImageableWidth());
+        myImageableYLabel.setText
+                ("Format Top Margin = " + (float) myPageFormat.getImageableY());
+        myImageableBottomLabel.setText
+                ("Format Bottom Margin = " + (float) (myPageFormat.getHeight() -
+                        (myPageFormat.getImageableY() + myPageFormat.getImageableHeight())));
+        myImageableHeightLabel.setText
+                ("Format ImageableHeight = " + (float) myPageFormat.getImageableHeight());
+        int o = myPageFormat.getOrientation();
+        if (o == PageFormat.LANDSCAPE && reverse) {
+            o = PageFormat.REVERSE_LANDSCAPE;
+            myPageFormat.setOrientation(PageFormat.REVERSE_LANDSCAPE);
+        } else if (o == PageFormat.REVERSE_LANDSCAPE && !reverse) {
+            o = PageFormat.LANDSCAPE;
+            myPageFormat.setOrientation(PageFormat.LANDSCAPE);
+        }
+        myOrientationLabel.setText
+                ("Format Orientation = " +
+                        (o == PageFormat.PORTRAIT ? "PORTRAIT" :
+                                o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
+                                        o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
+                                                "<invalid>"));
+        Paper p = myPageFormat.getPaper();
+        pw.setText("Paper Width = " + (float) p.getWidth());
+        ph.setText("Paper Height = " + (float) p.getHeight());
+        pglm.setText("Paper Left Margin = " + (float) p.getImageableX());
+        pgiw.setText("Paper Imageable Width = " + (float) p.getImageableWidth());
+        pgrm.setText("Paper Right Margin = " +
+                (float) (p.getWidth() - (p.getImageableX() + p.getImageableWidth())));
+        pgtm.setText("Paper Top Margin = " + (float) p.getImageableY());
+        pgih.setText("Paper Imageable Height = " + (float) p.getImageableHeight());
+        pgbm.setText("Paper Bottom Margin = " +
+                (float) (p.getHeight() - (p.getImageableY() + p.getImageableHeight())));
     }
-    myOrientationLabel.setText
-        ("Format Orientation = " +
-                (o == PageFormat.PORTRAIT ? "PORTRAIT" :
-                 o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
-                 o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
-                 "<invalid>"));
-    Paper p = myPageFormat.getPaper();
-    pw.setText("Paper Width = " + (float)p.getWidth());
-    ph.setText("Paper Height = " + (float)p.getHeight());
-    pglm.setText("Paper Left Margin = " + (float)p.getImageableX());
-    pgiw.setText("Paper Imageable Width = " + (float)p.getImageableWidth());
-    pgrm.setText("Paper Right Margin = " +
-         (float)(p.getWidth() - (p.getImageableX()+p.getImageableWidth())));
-    pgtm.setText("Paper Top Margin = " + (float)p.getImageableY());
-    pgih.setText("Paper Imageable Height = " + (float)p.getImageableHeight());
-    pgbm.setText("Paper Bottom Margin = " +
-       (float)(p.getHeight() - (p.getImageableY()+p.getImageableHeight())));
-  }
 
-  public PageSetupDialog() {
-    super ("Page Dialog Test");
-    myPrinterJob = PrinterJob.getPrinterJob();
-    myPageFormat = new PageFormat();
-    Paper p = new Paper();
-    double margin = 1.5*72;
-    p.setImageableArea(margin, margin,
-                       p.getWidth()-2*margin, p.getHeight()-2*margin);
-    myPageFormat.setPaper(p);
-    Panel c = new Panel();
-    c.setLayout (new GridLayout (9, 2, 0, 0));
-    c.add (reverseCB = new Checkbox("reverse if landscape"));
-    c.add (myOrientationLabel = new Label());
-    c.add (myWidthLabel = new Label());
-    c.add (pw = new Label());
-    c.add (myImageableXLabel = new Label());
-    c.add (pglm = new Label());
-    c.add (myImageableRightLabel = new Label());
-    c.add (pgrm = new Label());
-    c.add (myImageableWidthLabel = new Label());
-    c.add (pgiw = new Label());
-    c.add (myHeightLabel = new Label());
-    c.add (ph = new Label());
-    c.add (myImageableYLabel = new Label());
-    c.add (pgtm = new Label());
-    c.add (myImageableHeightLabel = new Label());
-    c.add (pgih = new Label());
-    c.add (myImageableBottomLabel = new Label());
-    c.add (pgbm = new Label());
+    public PageSetupDialog() {
+        super("Page Dialog Test");
+        myPrinterJob = PrinterJob.getPrinterJob();
+        myPageFormat = new PageFormat();
+        Paper p = new Paper();
+        double margin = 1.5 * 72;
+        p.setImageableArea(margin, margin,
+                p.getWidth() - 2 * margin, p.getHeight() - 2 * margin);
+        myPageFormat.setPaper(p);
+        Panel c = new Panel();
+        c.setLayout(new GridLayout(9, 2, 0, 0));
+        c.add(reverseCB = new Checkbox("reverse if landscape"));
+        c.add(myOrientationLabel = new Label());
+        c.add(myWidthLabel = new Label());
+        c.add(pw = new Label());
+        c.add(myImageableXLabel = new Label());
+        c.add(pglm = new Label());
+        c.add(myImageableRightLabel = new Label());
+        c.add(pgrm = new Label());
+        c.add(myImageableWidthLabel = new Label());
+        c.add(pgiw = new Label());
+        c.add(myHeightLabel = new Label());
+        c.add(ph = new Label());
+        c.add(myImageableYLabel = new Label());
+        c.add(pgtm = new Label());
+        c.add(myImageableHeightLabel = new Label());
+        c.add(pgih = new Label());
+        c.add(myImageableBottomLabel = new Label());
+        c.add(pgbm = new Label());
 
-    reverseCB.addItemListener(new ItemListener() {
-                public void itemStateChanged(ItemEvent e) {
-                       reverse = e.getStateChange() == ItemEvent.SELECTED;
-                       int o = myPageFormat.getOrientation();
-                       if (o == PageFormat.LANDSCAPE ||
-                           o == PageFormat.REVERSE_LANDSCAPE) {
-                           displayPageFormatAttributes();
-                       }
+        reverseCB.addItemListener(new ItemListener() {
+            public void itemStateChanged(ItemEvent e) {
+                reverse = e.getStateChange() == ItemEvent.SELECTED;
+                int o = myPageFormat.getOrientation();
+                if (o == PageFormat.LANDSCAPE ||
+                        o == PageFormat.REVERSE_LANDSCAPE) {
+                    displayPageFormatAttributes();
                 }
-    });
+            }
+        });
 
-    add("Center", c);
-    displayPageFormatAttributes();
-    Panel panel = new Panel();
-    Button pageButton = new Button ("Page Setup...");
-    pageButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                        myPageFormat = myPrinterJob.pageDialog (myPageFormat);
-                        displayPageFormatAttributes();
+        add("Center", c);
+        displayPageFormatAttributes();
+        Panel panel = new Panel();
+        Button pageButton = new Button("Page Setup...");
+        pageButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                myPageFormat = myPrinterJob.pageDialog(myPageFormat);
+                displayPageFormatAttributes();
+            }
+        });
+        Button printButton = new Button("Print ...");
+        printButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    if (myPrinterJob.printDialog()) {
+                        myPrinterJob.setPrintable(PageSetupDialog.this,
+                                myPageFormat);
+                        alpha = false;
+                        myPrinterJob.print();
+                    }
+                } catch (PrinterException pe) {
+                    pe.printStackTrace();
                 }
-    });
-    Button printButton = new Button ("Print ...");
-    printButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                    try {
-                         if (myPrinterJob.printDialog()) {
-                             myPrinterJob.setPrintable(PageSetupDialog.this,
-                                                       myPageFormat);
-                             alpha = false;
-                             myPrinterJob.print();
+            }
+        });
+        Button printAlphaButton = new Button("Print w/Alpha...");
+        printAlphaButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    if (myPrinterJob.printDialog()) {
+                        myPrinterJob.setPrintable(PageSetupDialog.this,
+                                myPageFormat);
+                        alpha = true;
+                        myPrinterJob.print();
                     }
-                    } catch (PrinterException pe ) {
-                    }
+                } catch (PrinterException pe) {
+                    pe.printStackTrace();
                 }
-    });
-    Button printAlphaButton = new Button ("Print w/Alpha...");
-    printAlphaButton.addActionListener(new ActionListener() {
-           public void actionPerformed (ActionEvent e) {
-                    try {
-                         if (myPrinterJob.printDialog()) {
-                             myPrinterJob.setPrintable(PageSetupDialog.this,
-                                                       myPageFormat);
-                             alpha = true;
-                             myPrinterJob.print();
-                    }
-                    } catch (PrinterException pe ) {
-                    }
-           }
-    });
-    panel.add (pageButton);
-    panel.add (printButton);
-    panel.add (printAlphaButton);
-    add("South", panel);
-    addWindowListener (new WindowAdapter() {
-         public void windowClosing (WindowEvent e) {
-            dispose();
-            System.exit (0);
-         }
+            }
+        });
+        panel.add(pageButton);
+        panel.add(printButton);
+        panel.add(printAlphaButton);
+        add("South", panel);
+        pack();
+    }
 
-      });
-      //setSize (280, 550);
-      pack();
-      setVisible (true);
-  }
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
 
-  public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+        if (pageIndex > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-     if (pageIndex > 0) {
-        return Printable.NO_SUCH_PAGE;
-     }
+        Graphics2D g2d = (Graphics2D) graphics;
+        g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+        g2d.drawString("ORIGIN(" + pageFormat.getImageableX() + "," +
+                pageFormat.getImageableY() + ")", 20, 20);
+        g2d.drawString("X THIS WAY", 200, 50);
+        g2d.drawString("Y THIS WAY", 60, 200);
+        g2d.drawString("Graphics is " + g2d.getClass().getName(), 100, 100);
+        g2d.drawRect(0, 0, (int) pageFormat.getImageableWidth(),
+                (int) pageFormat.getImageableHeight());
+        if (alpha) {
+            g2d.setColor(new Color(0, 0, 255, 192));
+        } else {
+            g2d.setColor(Color.blue);
+        }
+        g2d.drawRect(1, 1, (int) pageFormat.getImageableWidth() - 2,
+                (int) pageFormat.getImageableHeight() - 2);
 
-     Graphics2D g2d = (Graphics2D)graphics;
-     g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
-     g2d.drawString("ORIGIN("+pageFormat.getImageableX()+","+
-                             pageFormat.getImageableY()+")", 20, 20);
-     g2d.drawString("X THIS WAY", 200, 50);
-     g2d.drawString("Y THIS WAY", 60 , 200);
-     g2d.drawString("Graphics is " + g2d.getClass().getName(), 100, 100);
-     g2d.drawRect(0,0,(int)pageFormat.getImageableWidth(),
-                      (int)pageFormat.getImageableHeight());
-     if (alpha) {
-       g2d.setColor(new Color(0,0,255,192));
-     } else {
-        g2d.setColor(Color.blue);
-     }
-     g2d.drawRect(1,1,(int)pageFormat.getImageableWidth()-2,
-                      (int)pageFormat.getImageableHeight()-2);
+        return Printable.PAGE_EXISTS;
+    }
 
-     return  Printable.PAGE_EXISTS;
-  }
+    public static void main(String[] args) throws Exception {
 
-  public static void main( String[] args) {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test is very flexible and requires much interaction.",
-         "If the platform print dialog supports it, adjust orientation",
-         "and margins and print pages and compare the results with the",
-         "request."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-     new PageSetupDialog();
-  }
-
+        PassFailJFrame.builder()
+                .title("PageSetupDialog Test Instructions")
+                .instructions(instructions)
+                .testUI(PageSetupDialog::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/Cancel/PrinterJobCancel.java
+++ b/test/jdk/java/awt/print/PrinterJob/Cancel/PrinterJobCancel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,218 +21,118 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterAbortException;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4245280
- * @summary PrinterJob not cancelled when PrinterJob.cancel() is used
  * @key printer
+ * @summary PrinterJob not cancelled when PrinterJob.cancel() is used
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual PrinterJobCancel
  */
-
-import java.awt.* ;
-import java.awt.print.* ;
-
 public class PrinterJobCancel extends Thread implements Printable {
 
-  PrinterJob pj ;
-  boolean okayed;
+    PrinterJob pj;
+    boolean okayed;
 
-  public static void main ( String args[] ) {
+    private static final String instructions =
+             "Test that print job cancellation works.\n" +
+             "You must have a printer available to perform this test.\n" +
+             "This test silently starts a print job and while the job is\n" +
+             "still being printed, cancels the print job\n" +
+             "You should see a message on System.out that the job\n" +
+             "was properly cancelled.\n" +
+             "You will need to kill the application manually since regression\n" +
+             "tests apparently aren't supposed to call System.exit()";
 
-     String[] instructions =
-        {
-         "Test that print job cancellation works.",
-         "You must have a printer available to perform this test.",
-         "This test silently starts a print job and while the job is",
-         "still being printed, cancels the print job",
-         "You should see a message on System.out that the job",
-         "was properly cancelled.",
-         "You will need to kill the application manually since regression",
-         "tests apparently aren't supposed to call System.exit()"
-       };
+    public static void main(String args[]) throws Exception {
 
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
-      PrinterJobCancel pjc = new PrinterJobCancel() ;
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build();
 
-      if (pjc.okayed) {
-          pjc.start();
-          try {
-               Thread.sleep(5000);
-               pjc.pj.cancel();
-          } catch ( InterruptedException e ) {
-          }
-      }
-  }
+        PrinterJobCancel pjc = new PrinterJobCancel();
+        if (pjc.okayed) {
+            pjc.start();
+            try {
+                Thread.sleep(5000);
+                pjc.pj.cancel();
+            } catch (InterruptedException e) {
+            }
+        }
 
-  public PrinterJobCancel() {
-
-    pj = PrinterJob.getPrinterJob() ;
-    pj.setPrintable(this);
-    okayed = pj.printDialog();
-  }
-
-  public void run() {
-    boolean cancelWorked = false;
-    try {
-        pj.print() ;
+        passFailJFrame.awaitAndCheck();
     }
-    catch ( PrinterAbortException paex ) {
-      cancelWorked = true;
-      System.out.println("Job was properly cancelled and we");
-      System.out.println("got the expected PrintAbortException");
+
+    public PrinterJobCancel() {
+
+        pj = PrinterJob.getPrinterJob();
+        pj.setPrintable(this);
+        okayed = pj.printDialog();
     }
-    catch ( PrinterException prex ) {
-      System.out.println("This is wrong .. we shouldn't be here");
-      System.out.println("Looks like a test failure");
-      prex.printStackTrace() ;
-      //throw prex;
+
+    public void run() {
+        boolean cancelWorked = false;
+        try {
+            pj.print();
+        } catch (PrinterAbortException paex) {
+            cancelWorked = true;
+            System.out.println("Job was properly cancelled and we");
+            System.out.println("got the expected PrintAbortException");
+        } catch (PrinterException prex) {
+            System.out.println("This is wrong .. we shouldn't be here");
+            System.out.println("Looks like a test failure");
+            prex.printStackTrace();
+            //throw prex;
+        } finally {
+            System.out.println("DONE PRINTING");
+            if (!cancelWorked) {
+                System.out.println("Looks like the test failed - we didn't get");
+                System.out.println("the expected PrintAbortException ");
+            }
+        }
     }
-    finally {
-       System.out.println("DONE PRINTING");
-       if (!cancelWorked) {
-           System.out.println("Looks like the test failed - we didn't get");
-           System.out.println("the expected PrintAbortException ");
-       }
+
+    public int print(Graphics g, PageFormat pagef, int pidx) {
+
+        if (pidx > 5) {
+            return (Printable.NO_SUCH_PAGE);
+        }
+
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.translate(pagef.getImageableX(), pagef.getImageableY());
+        g2d.setColor(Color.black);
+
+        g2d.drawString(("This is page" + (pidx + 1)), 60, 80);
+        // Need to slow things down a bit .. important not to try this
+        // on the event dispathching thread of course.
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+        }
+
+        return (Printable.PAGE_EXISTS);
     }
-    //System.exit(0);
-  }
-
-  public int print(Graphics g, PageFormat pagef, int pidx) {
-
-     if (pidx > 5) {
-        return( Printable.NO_SUCH_PAGE ) ;
-     }
-
-     Graphics2D g2d = (Graphics2D)g;
-     g2d.translate(pagef.getImageableX(), pagef.getImageableY());
-     g2d.setColor(Color.black);
-
-     g2d.drawString(("This is page"+(pidx+1)), 60 , 80);
-     // Need to slow things down a bit .. important not to try this
-     // on the event dispathching thread of course.
-     try {
-          Thread.sleep(2000);
-     } catch (InterruptedException e) {
-     }
-
-     return ( Printable.PAGE_EXISTS );
-  }
-
 }
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/Collate2DPrintingTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/Collate2DPrintingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,29 +21,48 @@
  * questions.
  */
 
-/**
+import javax.print.Doc;
+import javax.print.DocFlavor;
+import javax.print.DocPrintJob;
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.attribute.DocAttributeSet;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.standard.Copies;
+import javax.print.attribute.standard.SheetCollate;
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.io.InputStream;
+import java.io.Reader;
+
+/*
  * @test
  * @bug 6362683 8012381
  * @summary Collation should work.
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
  * @run main/manual Collate2DPrintingTest
  */
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import javax.print.attribute.standard.*;
-import javax.print.attribute.*;
-import javax.print.*;
-import java.io.*;
-
 public class Collate2DPrintingTest
-    extends Frame implements Doc, Printable, ActionListener {
+        extends Frame implements Doc, Printable, ActionListener {
 
-        Button print2D = new Button("2D Print");
-        Button printMerlin = new Button("PrintService");
-        PrinterJob pj = PrinterJob.getPrinterJob();
-        PrintService defService = null;
-        HashPrintRequestAttributeSet prSet = new HashPrintRequestAttributeSet();
+    Button print2D = new Button("2D Print");
+    Button printMerlin = new Button("PrintService");
+    PrinterJob pj = PrinterJob.getPrinterJob();
+    PrintService defService = null;
+    HashPrintRequestAttributeSet prSet = new HashPrintRequestAttributeSet();
 
     public Collate2DPrintingTest() {
 
@@ -52,8 +71,8 @@ public class Collate2DPrintingTest
         butPanel.add(printMerlin);
         print2D.addActionListener(this);
         printMerlin.addActionListener(this);
-        addWindowListener (new WindowAdapter() {
-            public void windowClosing (WindowEvent e) {
+        addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
                 dispose();
             }
         });
@@ -72,12 +91,10 @@ public class Collate2DPrintingTest
         prSet.add(new Copies(2));
         pj.setPrintable(Collate2DPrintingTest.this);
         setSize(300, 200);
-        setVisible(true);
     }
 
-
     public int print(Graphics g, PageFormat pf, int pageIndex)
-          throws PrinterException {
+            throws PrinterException {
         g.drawString("Page: " + pageIndex, 100, 100);
         if (pageIndex == 2) {
             return Printable.NO_SUCH_PAGE;
@@ -86,7 +103,7 @@ public class Collate2DPrintingTest
         }
     }
 
-    public void actionPerformed (ActionEvent ae) {
+    public void actionPerformed(ActionEvent ae) {
         try {
             if (ae.getSource() == print2D) {
                 if (pj.printDialog(prSet)) {
@@ -96,7 +113,7 @@ public class Collate2DPrintingTest
                 DocPrintJob pj = defService.createPrintJob();
                 pj.print(this, prSet);
             }
-            System.out.println ("DONE");
+            System.out.println("DONE");
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -123,131 +140,20 @@ public class Collate2DPrintingTest
         return null;
     }
 
-  public static void main( String[] args) {
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+            "The print result should be collated.";
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "The print result should be collated."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+    public static void main(String[] args) throws Exception {
 
-     new Collate2DPrintingTest();
-  }
+        PassFailJFrame.builder()
+                .title("Instructions")
+                .instructions(instructions)
+                .testUI(Collate2DPrintingTest::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
 }
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.setVisible(true);
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.setVisible(true);
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      setVisible(true);
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/Collate2DPrintingTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/Collate2DPrintingTest.java
@@ -71,7 +71,6 @@ public class Collate2DPrintingTest
         butPanel.add(printMerlin);
         print2D.addActionListener(this);
         printMerlin.addActionListener(this);
-        
         add("South", butPanel);
 
         defService = PrintServiceLookup.lookupDefaultPrintService();

--- a/test/jdk/java/awt/print/PrinterJob/Collate2DPrintingTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/Collate2DPrintingTest.java
@@ -71,11 +71,7 @@ public class Collate2DPrintingTest
         butPanel.add(printMerlin);
         print2D.addActionListener(this);
         printMerlin.addActionListener(this);
-        addWindowListener(new WindowAdapter() {
-            public void windowClosing(WindowEvent e) {
-                dispose();
-            }
-        });
+        
         add("South", butPanel);
 
         defService = PrintServiceLookup.lookupDefaultPrintService();

--- a/test/jdk/java/awt/print/PrinterJob/DrawImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/DrawImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,74 +21,68 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+import java.awt.image.BufferedImageOp;
+import java.awt.image.RescaleOp;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4329866
  * @key printer
  * @summary Confirm that no printing exception is generated.
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual DrawImage
  */
+public class DrawImage {
 
-import java.util.*;
-import java.text.*;
-import java.io.*;
-import java.net.*;
-import java.awt.*;
-import java.awt.font.*;
-import java.awt.geom.*;
-import java.awt.print.*;
-import java.awt.event.*;
-import java.awt.image.*;
-import java.awt.image.renderable.*;
-import javax.swing.*;
-import javax.swing.text.*;
-import javax.swing.border.*;
-import javax.swing.event.*;
-
-public class DrawImage
-{
-    protected static final double _hwBorder = 72 / 4;       // 1/4 inch
-    protected static final double _border = 72 / 4;         // 1/4 inch
     protected static final int _objectBorder = 15;
-    protected static final int _verticalGap = 20;
-    protected static final int _textIndent = 150;
 
     protected BufferedImage _image;
 
-    protected PageFormat  _pageFormat;
+    protected PageFormat _pageFormat;
 
     public DrawImage(BufferedImage image) {
         _image = image;
         PrinterJob pj = PrinterJob.getPrinterJob();
         _pageFormat = pj.defaultPage();
-
- }
-
+    }
 
     protected int printImage(Graphics g, PageFormat pf, BufferedImage image) {
-        Graphics2D g2D = (Graphics2D)g;
+        Graphics2D g2D = (Graphics2D) g;
         g2D.transform(new AffineTransform(_pageFormat.getMatrix()));
 
-        int paperW = (int)pf.getImageableWidth(), paperH =
-            (int)pf.getImageableHeight();
+        int paperW = (int) pf.getImageableWidth(), paperH =
+                (int) pf.getImageableHeight();
 
-        int x = (int)pf.getImageableX(), y = (int)pf.getImageableY();
+        int x = (int) pf.getImageableX(), y = (int) pf.getImageableY();
         g2D.setClip(x, y, paperW, paperH);
 
         // print images
-        if (image != null ) {
+        if (image != null) {
             int imageH = image.getHeight(), imageW = image.getWidth();
             // make slightly smaller (25) than max possible width
-            float scaleFactor = ((float)((paperW - 25) - _objectBorder -
-                                         _objectBorder) / (float)(imageW));
-            int scaledW = (int)(imageW * scaleFactor),
-                scaledH = (int)(imageH *scaleFactor);
+            float scaleFactor = ((float) ((paperW - 25) - _objectBorder -
+                    _objectBorder) / (float) (imageW));
+
             BufferedImageOp scaleOp = new RescaleOp(scaleFactor, 0, null);
             g2D.drawImage(image, scaleOp, x + _objectBorder, y + _objectBorder);
-            y += _objectBorder + scaledH + _objectBorder;
             return Printable.PAGE_EXISTS;
-        }
-        else {
+        } else {
             return Printable.NO_SUCH_PAGE;
         }
     }
@@ -107,45 +101,53 @@ public class DrawImage
                 }
             });
             if (pj.printDialog()) {
-                try { pj.print(); }
-                catch (PrinterException e) {
+                try {
+                    pj.print();
+                } catch (PrinterException e) {
                     System.out.println(e);
                 }
             }
 
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace(System.out);
         }
     }
 
-    public static void main(String[] args) {
-                                String[] instructions =
-           {
-            "You must have a printer available to perform this test.",
-            "The test passes if you get a printout of a gray rectangle",
-                                                "with white text without any exception."
-          };
+    private static final String instructions =
+            "You must have a printer available to perform this test.\n" +
+            "\n" +
+            "The test passes if you get a printout of a gray rectangle\n" +
+            "with white text without any exception.";
 
-         Sysout.createDialog( );
-         Sysout.printInstructions( instructions );
+    public static void main(String[] args) throws Exception {
+
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
+
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("Instructions")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build();
 
         BufferedImage image = prepareFrontImage();
         DrawImage pt = new DrawImage(image);
         pt.print();
-        //      System.exit(0);
+        passFailJFrame.awaitAndCheck();
     }
-
-
 
     public static BufferedImage prepareFrontImage() {
         // build my own test images
         BufferedImage result = new BufferedImage(400, 200,
-                                                 BufferedImage.TYPE_BYTE_GRAY);
+                BufferedImage.TYPE_BYTE_GRAY);
 
-        Graphics2D g2D = (Graphics2D)result.getGraphics();
+        Graphics2D g2D = (Graphics2D) result.getGraphics();
         g2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-                             RenderingHints.VALUE_ANTIALIAS_OFF);
+                RenderingHints.VALUE_ANTIALIAS_OFF);
         int w = result.getWidth(), h = result.getHeight();
 
         g2D.setColor(Color.gray);
@@ -155,128 +157,11 @@ public class DrawImage
 
         AffineTransform original = g2D.getTransform();
         AffineTransform originXform = AffineTransform.getTranslateInstance(w /
-5, h / 5);
+                5, h / 5);
         g2D.transform(originXform);
-
 
         g2D.drawString("Front Side", 20, h / 2);
 
         return result;
     }
-
-
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/DrawStringMethods.java
+++ b/test/jdk/java/awt/print/PrinterJob/DrawStringMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,31 +21,53 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.font.FontRenderContext;
+import java.awt.print.Book;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterJob;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4185019
  * @key printer
  * @summary Confirm that all of the drawString methods on Graphics2D
  *          work for printer graphics objects.
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual DrawStringMethods
  */
-
-import java.awt.*;
-import java.text.*;
-import java.awt.font.*;
-import java.awt.print.*;
-
 public class DrawStringMethods implements Printable {
 
-    public static void main(String args[]) {
-        String[] instructions =
-        {
-            "Confirm that the methods are printed.",
-            " For Graphics: drawString, drawString, drawChars, drawBytes",
-            " For Graphics2D: drawString, drawString, drawGlyphVector"
-        };
-        Sysout.createDialogWithInstructions( instructions );
+    private static final String instructions =
+            " Confirm that the methods are printed.\n" +
+            " For Graphics: drawString, drawString, drawChars, drawBytes\n" +
+            " For Graphics2D: drawString, drawString, drawGlyphVector";
 
+    public static void main(String args[]) throws Exception {
+
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
+
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("CustomPaper Test Instructions")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build();
 
         PrinterJob pjob = PrinterJob.getPrinterJob();
         PageFormat pf = pjob.defaultPage();
@@ -53,12 +75,9 @@ public class DrawStringMethods implements Printable {
 
         book.append(new DrawStringMethods(), pf);
         pjob.setPageable(book);
+        pjob.print();
 
-        try {
-            pjob.print();
-        } catch (PrinterException e) {
-            throw new RuntimeException(e.getMessage());
-        }
+        passFailJFrame.awaitAndCheck();
     }
 
     public static AttributedCharacterIterator getIterator(String s) {
@@ -116,7 +135,7 @@ public class DrawStringMethods implements Printable {
 
             iy += 30;
             s = "drawString(AttributedCharacterIterator iterator, "+
-                           "float x, float y)";
+                    "float x, float y)";
             g.drawLine(ix, iy, ix+10, iy);
             g2d.drawString(getIterator(s), (float) ix+20, (float) iy);
 
@@ -133,119 +152,3 @@ public class DrawStringMethods implements Printable {
         return PAGE_EXISTS;
     }
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog
- {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("South", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-     //chop up each into pieces maxSringLength long
-     remainingStr = instructions[ i ];
-     while( remainingStr.length() > 0 )
-      {
-        //if longer than max then chop off first max chars to print
-        if( remainingStr.length() >= maxStringLength )
-         {
-           //Try to chop on a word boundary
-           int posOfSpace = remainingStr.
-          lastIndexOf( ' ', maxStringLength - 1 );
-
-           if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-           printStr = remainingStr.substring( 0, posOfSpace + 1 );
-           remainingStr = remainingStr.substring( posOfSpace + 1 );
-         }
-        //else just print
-        else
-         {
-           printStr = remainingStr;
-           remainingStr = "";
-         }
-
-            instructionsText.append( printStr + "\n" );
-
-      }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/InvalidPage.java
+++ b/test/jdk/java/awt/print/PrinterJob/InvalidPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,223 +21,125 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Paper;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test InvalidPage.java
  * @bug 4671634 6506286
  * @summary Invalid page format can crash win32 JRE
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual InvalidPage
  */
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-
 public class InvalidPage extends Frame implements Printable {
 
-  PrinterJob pJob;
-  PageFormat pf;
+    PrinterJob pJob;
+    PageFormat pf;
 
-  public InvalidPage() {
-    super ("Validate Page Test");
-    pJob = PrinterJob.getPrinterJob();
-    pf = pJob.defaultPage();
-    Paper p = pf.getPaper();
-    p.setImageableArea(0,0,p.getWidth(), p.getHeight());
-    pf.setPaper(p);
-    setLayout(new FlowLayout());
-    Panel panel = new Panel();
-    Button printButton = new Button ("Print");
-    printButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                    try {
-                         if (pJob.printDialog()) {
-                             pJob.setPrintable(InvalidPage.this, pf);
-                             pJob.print();
+    public InvalidPage() {
+        super("Validate Page Test");
+        pJob = PrinterJob.getPrinterJob();
+        pf = pJob.defaultPage();
+        Paper p = pf.getPaper();
+        p.setImageableArea(0, 0, p.getWidth(), p.getHeight());
+        pf.setPaper(p);
+        setLayout(new FlowLayout());
+        Panel panel = new Panel();
+        Button printButton = new Button("Print");
+        printButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    if (pJob.printDialog()) {
+                        pJob.setPrintable(InvalidPage.this, pf);
+                        pJob.print();
                     }
-                    } catch (PrinterException pe ) {
-                    }
+                } catch (PrinterException pe) {
                 }
-    });
-    panel.add (printButton);
-    add(panel);
+            }
+        });
+        panel.add(printButton);
+        add(panel);
+        pack();
+    }
 
-    addWindowListener (new WindowAdapter() {
-         public void windowClosing (WindowEvent e) {
-            dispose();
-            System.exit (0);
-         }
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
 
-      });
-      setSize (200, 200);
-      setVisible (true);
-  }
+        if (pageIndex > 1) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-  public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+        Graphics2D g2d = (Graphics2D) graphics;
 
-     if (pageIndex > 1) {
-        return Printable.NO_SUCH_PAGE;
-     }
+        g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+        g2d.drawString("ORIGIN", 30, 30);
+        g2d.drawString("X THIS WAY", 200, 50);
+        g2d.drawString("Y THIS WAY", 60, 200);
+        g2d.drawRect(0, 0, (int) pageFormat.getImageableWidth(),
+                (int) pageFormat.getImageableHeight());
+        if (pageIndex == 0) {
+            g2d.setColor(Color.black);
+        } else {
+            g2d.setColor(new Color(0, 0, 0, 128));
+        }
+        g2d.drawRect(1, 1, (int) pageFormat.getImageableWidth() - 2,
+                (int) pageFormat.getImageableHeight() - 2);
 
-     Graphics2D g2d = (Graphics2D)graphics;
+        g2d.drawLine(0, 0,
+                (int) pageFormat.getImageableWidth(),
+                (int) pageFormat.getImageableHeight());
+        g2d.drawLine((int) pageFormat.getImageableWidth(), 0,
+                0, (int) pageFormat.getImageableHeight());
+        return Printable.PAGE_EXISTS;
+    }
 
-     g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
-     g2d.drawString("ORIGIN", 30, 30);
-     g2d.drawString("X THIS WAY", 200, 50);
-     g2d.drawString("Y THIS WAY", 60 , 200);
-     g2d.drawRect(0,0,(int)pageFormat.getImageableWidth(),
-                      (int)pageFormat.getImageableHeight());
-     if (pageIndex == 0) {
-        g2d.setColor(Color.black);
-     } else {
-        g2d.setColor(new Color(0,0,0,128));
-     }
-     g2d.drawRect(1,1,(int)pageFormat.getImageableWidth()-2,
-                      (int)pageFormat.getImageableHeight()-2);
+    private static final String instructions =
+            " You must have a printer available to perform this test\n" +
+            " Press the print button, which brings up a print dialog and\n" +
+            " in the dialog select a printer and press the print button\n" +
+            " in the dialog. Repeat for as many printers as you have installed\n" +
+            " On solaris and linux just one printer is sufficient\n" +
+            " Collect the output and examine it, each print job has two pages\n" +
+            " of very similar output, except that the 2nd page of the job may\n" +
+            " appear in a different colour, and the output near the edge of\n" +
+            " the page may be clipped. This is OK. Hold up both pieces of paper\n" +
+            " to the light and confirm that the lines and text (where present)\n" +
+            " are positioned identically on both pages\n" +
+            " The test fails if the JRE crashes, or if the output from the two\n" +
+            " pages of a job is aligned differently";
 
-     g2d.drawLine(0,0,
-                  (int)pageFormat.getImageableWidth(),
-                  (int)pageFormat.getImageableHeight());
-     g2d.drawLine((int)pageFormat.getImageableWidth(),0,
-                   0,(int)pageFormat.getImageableHeight());
-     return  Printable.PAGE_EXISTS;
-  }
+    public static void main(String[] args) throws Exception {
 
-  public static void main( String[] args) {
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "Press the print button, which brings up a print dialog and",
-         "in the dialog select a printer and press the print button",
-         "in the dialog. Repeat for as many printers as you have installed",
-         "On solaris and linux just one printer is sufficient",
-         "Collect the output and examine it, each print job has two pages",
-         "of very similar output, except that the 2nd page of the job may",
-         "appear in a different colour, and the output near the edge of",
-         "the page may be clipped. This is OK. Hold up both pieces of paper",
-         "to the light and confirm that the lines and text (where present)",
-         "are positioned identically on both pages",
-         "The test fails if the JRE crashes, or if the output from the two",
-         "pages of a job is aligned differently"
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
-     new InvalidPage();
-  }
-
+        PassFailJFrame.builder()
+                .title("CustomPaper Test Instructions")
+                .instructions(instructions)
+                .testUI(InvalidPage::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/JobName/PrinterJobName.java
+++ b/test/jdk/java/awt/print/PrinterJob/JobName/PrinterJobName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,173 +21,61 @@
  * questions.
  */
 
-/**
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterJob;
+
+/*
  * @test
  * @bug 4205601
  * @summary setJobName should be used by PrinterJob
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual PrinterJobName
  */
-
-import java.awt.*;
-import java.awt.print.*;
-
 public class PrinterJobName implements Printable {
 
+    static String theName = "Testing the Jobname setting";
 
-  static String theName = "Testing the Jobname setting";
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+                    "This test prints a page with a banner/job name of\n" + theName;
 
-  public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
 
-       String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test prints a page with a banner/job name of",
-          theName
-       };
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build();
 
-      PrinterJob job = PrinterJob.getPrinterJob();
-      job.setJobName(theName);
-      job.setPrintable(new PrinterJobName());
-      try {
-          job.print();
-          System.out.println("PRINTING DONE.");
-      }
-      catch (Exception exc) {
-          System.out.println("Printer Exception");
-      }
-  }
-
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setJobName(theName);
+        job.setPrintable(new PrinterJobName());
+        job.print();
+        passFailJFrame.awaitAndCheck();
+    }
 
     public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-      if (pgIndex > 0 ) {
-          return Printable.NO_SUCH_PAGE;
-      }
+        if (pgIndex > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
 
-      double iw = pgFmt.getImageableWidth();
-      double ih = pgFmt.getImageableHeight();
-      Graphics2D g2d = (Graphics2D)g;
-      g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-      g2d.drawString("Name is: "+theName,20,20 );
-      return Printable.PAGE_EXISTS;
+        Graphics2D g2d = (Graphics2D) g;
+        g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+        g2d.drawString("Name is: " + theName, 20, 20);
+        return Printable.PAGE_EXISTS;
     }
-
 }
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/NumCopies.java
+++ b/test/jdk/java/awt/print/PrinterJob/NumCopies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,169 +21,66 @@
  * questions.
  */
 
-/**
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4258003
  * @summary Checks the right number of copies are printed
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual NumCopies
  */
-
-import java.awt.*;
-import java.awt.print.*;
-
 public class NumCopies implements Printable {
 
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+            "This test should print a total of four pages which are two\n" +
+            " copies of each of two pages which consist of the text :-\n" +
+            "'This is page number N', where N is 0 and 1.\n" +
+            "The pages should be uncollated.";
 
-  public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test should print a total of four pages which are two",
-         " copies of each of two pages which consist of the text :-",
-         "'This is page number N', where N is 0 and 1.",
-         "The pages should be uncollated."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
-    PrinterJob job = PrinterJob.getPrinterJob();
-    job.setCopies(2);
-    job.setPrintable(new NumCopies());
-    try {
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("CustomPaper Test Instructions")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build();
+
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setCopies(2);
+        job.setPrintable(new NumCopies());
         job.print();
+        passFailJFrame.awaitAndCheck();
     }
-    catch (Exception exc) {
-        System.out.println("Printer Exception");
+
+    public int print(Graphics g, PageFormat pf, int pageIndex)
+            throws PrinterException {
+
+        if (pageIndex > 1) {
+            return NO_SUCH_PAGE;
+        }
+        g.translate((int) pf.getImageableX(), (int) pf.getImageableY());
+        g.setColor(Color.black);
+        g.drawString("This is page number " + Integer.toString(pageIndex), 50, 50);
+        return PAGE_EXISTS;
     }
-  }
-
-  public int print(Graphics g, PageFormat pf, int pageIndex)
-                   throws PrinterException {
-
-    if (pageIndex > 1) {
-         return NO_SUCH_PAGE;
-    }
-    g.translate((int)pf.getImageableX(), (int)pf.getImageableY());
-    g.setColor(Color.black);
-    g.drawString("This is page number " + Integer.toString(pageIndex), 50, 50);
-    return PAGE_EXISTS ;
-   }
-
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PageDlgPrnButton.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDlgPrnButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,51 +21,53 @@
  * questions.
  */
 
-/**
- * @test
- * @bug 4956397
- * @key printer
- * @run main/manual PageDlgPrnButton
- */
-
-import java.awt.print.PrinterJob;
-import java.awt.print.PageFormat;
-import java.awt.print.Printable;
-import java.awt.print.PrinterException;
-
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.* ;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
 
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 4956397
+ * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
+ * @run main/manual PageDlgPrnButton
+ */
 public class PageDlgPrnButton implements Printable
 {
-    public static void main ( String args[] ) {
 
-        String[] instructions =
-           {"For non-windows OS, this test PASSes.",
-            "You must have at least 2 printers available to perform this test.",
-            "This test brings up a native Windows page dialog.",
-            "Click on the Printer... button and change the selected printer. ",
-            "Test passes if the printout comes from the new selected printer.",
-         };
+    private static final String instructions =
+            "For non-windows OS, this test PASSes.\n" +
+            "You must have at least 2 printers available to perform this test.\n" +
+            "This test brings up a native Windows page dialog.\n" +
+            "Click on the Printer... button and change the selected printer. \n" +
+            "Test passes if the printout comes from the new selected printer.";
 
-         Sysout.createDialog( );
-         Sysout.printInstructions( instructions );
+    public static void main (String[] args) throws Exception {
 
-        PageDlgPrnButton pdpb = new PageDlgPrnButton() ;
+        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+                .title("CustomPaper Test Instructions")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build();
+
+        new PageDlgPrnButton() ;
+        passFailJFrame.awaitAndCheck();
     }
 
-    public PageDlgPrnButton()
-    {
-        try
-        {
-            pageDialogExample();
-        }
-        catch(Exception e)
-        {e.printStackTrace(System.err);}
+    public PageDlgPrnButton() throws PrinterException {
+        pageDialogExample();
     }
-
 
     // This example just displays the page dialog - you cannot change
     // the printer (press the "Printer..." button and choose one if you like).
@@ -80,8 +82,6 @@ public class PageDlgPrnButton implements Printable
         job.setPrintable(this,pageFormat);
         job.print();
     }
-
-
 
     public int print(Graphics g, PageFormat pageFormat, int pageIndex)
     {
@@ -113,117 +113,3 @@ public class PageDlgPrnButton implements Printable
         return(PAGE_EXISTS);
     }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintCompoundString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintCompoundString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,226 +21,116 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4396835
  * @summary Compound font string not printing.
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual PrintCompoundString
  */
-
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import java.text.*;
-
 public class PrintCompoundString extends Frame implements ActionListener {
 
- private TextCanvas c;
+    private final TextCanvas c;
 
- public static void main(String args[]) {
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+            "This test should print a page which contains the same\n" +
+            "text message as in the test window on the screen\n" +
+            "You should also monitor the command line to see if any exceptions\n" +
+            "were thrown\n" +
+            "If an exception is thrown, or the page doesn't print properly\n" +
+            "then the test fails";
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test should print a page which contains the same",
-         "text message as in the test window on the screen",
-         "You should also monitor the command line to see if any exceptions",
-         "were thrown",
-         "If an exception is thrown, or the page doesn't print properly",
-         "then the test fails",
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+    public static void main(String[] args) throws Exception {
 
-    PrintCompoundString f = new PrintCompoundString();
-    f.show();
- }
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
- public PrintCompoundString() {
-    super("JDK 1.2 drawString Printing");
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testUI(PrintCompoundString::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 
-    c = new TextCanvas();
-    add("Center", c);
+    public PrintCompoundString() {
+        super("JDK 1.2 drawString Printing");
 
-    Button printButton = new Button("Print");
-    printButton.addActionListener(this);
-    add("South", printButton);
+        c = new TextCanvas();
+        add("Center", c);
 
-    addWindowListener(new WindowAdapter() {
-       public void windowClosing(WindowEvent e) {
-             System.exit(0);
+        Button printButton = new Button("Print");
+        printButton.addActionListener(this);
+        add("South", printButton);
+
+        pack();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+
+        PrinterJob pj = PrinterJob.getPrinterJob();
+
+        if (pj != null && pj.printDialog()) {
+
+            pj.setPrintable(c);
+            try {
+                pj.print();
+            } catch (PrinterException pe) {
+            } finally {
+                System.err.println("PRINT RETURNED");
             }
-    });
-
-    pack();
- }
-
- public void actionPerformed(ActionEvent e) {
-
-   PrinterJob pj = PrinterJob.getPrinterJob();
-
-   if (pj != null && pj.printDialog()) {
-
-       pj.setPrintable(c);
-       try {
-            pj.print();
-      } catch (PrinterException pe) {
-      } finally {
-         System.err.println("PRINT RETURNED");
-      }
-   }
- }
-
- class TextCanvas extends Panel implements Printable {
-
-    String nullStr = null;
-    String emptyStr = new String();
-    AttributedString nullAttStr = null;
-    AttributedString emptyAttStr = new AttributedString(emptyStr);
-    AttributedCharacterIterator nullIterator = null;
-    AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
-
-    public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-
-      if (pgIndex > 0)
-         return Printable.NO_SUCH_PAGE;
-
-      Graphics2D g2d = (Graphics2D)g;
-      g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-
-      paint(g);
-
-      return Printable.PAGE_EXISTS;
+        }
     }
 
-    public void paint(Graphics g1) {
-        Graphics2D g = (Graphics2D)g1;
+    class TextCanvas extends Panel implements Printable {
 
-          String str = "Test string compound printing \u2203\u2200\u2211";
-          g.drawString(str, 20, 40);
+        public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
 
+            if (pgIndex > 0)
+                return Printable.NO_SUCH_PAGE;
+
+            Graphics2D g2d = (Graphics2D) g;
+            g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+
+            paint(g);
+
+            return Printable.PAGE_EXISTS;
+        }
+
+        public void paint(Graphics g1) {
+            Graphics2D g = (Graphics2D) g1;
+
+            String str = "Test string compound printing \u2203\u2200\u2211";
+            g.drawString(str, 20, 40);
+        }
+
+        public Dimension getPreferredSize() {
+            return new Dimension(450, 250);
+        }
     }
-
-     public Dimension getPreferredSize() {
-        return new Dimension(450, 250);
-    }
- }
-
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintImage.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,276 +21,171 @@
  * questions.
  */
 
-/**
+import java.awt.BorderLayout;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test %I %W
  * @bug 4298489
  * @summary Confirm that output is same as screen.
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual PrintImage
  */
-import java.awt.*;
-import java.awt.print.*;
-import java.awt.event.*;
-
 public class PrintImage extends Frame implements ActionListener {
 
-        private PrintImageCanvas                printImageCanvas;
+    private PrintImageCanvas printImageCanvas;
 
-        private MenuItem        print1Menu = new MenuItem("PrintTest1");
-        private MenuItem        print2Menu = new MenuItem("PrintTest2");
-        private MenuItem        exitMenu = new MenuItem("Exit");
+    private final MenuItem print1Menu = new MenuItem("PrintTest1");
+    private final MenuItem print2Menu = new MenuItem("PrintTest2");
+    private final MenuItem exitMenu = new MenuItem("Exit");
 
-        public static void main(String[] argv) {
-        String[] instructions =
-           { "You must have a printer available to perform this test,",
-             "prefererably Canon LaserShot A309GII.",
-             "Printing must be done in Win 98 Japanese 2nd Edition.",
-             "",
-             "Passing test : Output of text image for PrintTest1 and PrintTest2 should be same as that on the screen.",
-           };
+    private static final String instructions =
+            "You must have a printer available to perform this test,\n" +
+            "prefererably Canon LaserShot A309GII.\n" +
+            "Printing must be done in Win 98 Japanese 2nd Edition.\n" +
+            "\n" +
+            "Passing test : Output of text image for PrintTest1 and PrintTest2 should be " +
+            "same as that on the screen.";
 
-        Sysout.createDialog( );
-         Sysout.printInstructions( instructions );
+    public static void main(String[] argv) throws Exception {
 
-                new PrintImage();
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
         }
 
-        public PrintImage() {
-                super("PrintImage");
-                initPrintImage();
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testUI(PrintImage::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public PrintImage() {
+        super("PrintImage");
+        initPrintImage();
+    }
+
+    public void initPrintImage() {
+
+        printImageCanvas = new PrintImageCanvas(this);
+
+        initMenu();
+
+        setLayout(new BorderLayout());
+        add(printImageCanvas, BorderLayout.CENTER);
+        pack();
+
+        setSize(500, 500);
+    }
+
+    private void initMenu() {
+        MenuBar mb = new MenuBar();
+        Menu me = new Menu("File");
+        me.add(print1Menu);
+        me.add(print2Menu);
+        me.add("-");
+        me.add(exitMenu);
+        mb.add(me);
+        this.setMenuBar(mb);
+
+        print1Menu.addActionListener(this);
+        print2Menu.addActionListener(this);
+        exitMenu.addActionListener(this);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        Object target = e.getSource();
+        if (target.equals(print1Menu)) {
+            printMain1();
+        } else if (target.equals(print2Menu)) {
+            printMain2();
+        } else if (target.equals(exitMenu)) {
+            dispose();
         }
+    }
 
-        public void initPrintImage() {
+    private void printMain1() {
 
-                printImageCanvas = new PrintImageCanvas(this);
+        PrinterJob printerJob = PrinterJob.getPrinterJob();
+        PageFormat pageFormat = printerJob.defaultPage();
 
-                initMenu();
+        printerJob.setPrintable(printImageCanvas, pageFormat);
 
-                addWindowListener(new WindowAdapter() {
-                        public void windowClosing(WindowEvent ev) {
-                                dispose();
-                        }
-                        public void windowClosed(WindowEvent ev) {
-                                System.exit(0);
-                        }
-                });
+        if (printerJob.printDialog()) {
+            try {
+                printerJob.print();
+            } catch (PrinterException e) {
+                e.printStackTrace();
+            }
+        } else
+            printerJob.cancel();
+    }
 
-                setLayout(new BorderLayout());
-                add(printImageCanvas, BorderLayout.CENTER);
-                pack();
+    private void printMain2() {
 
-                setSize(500,500);
-                setVisible(true);
-        }
+        PrinterJob printerJob = PrinterJob.getPrinterJob();
+        PageFormat pageFormat = printerJob.pageDialog(printerJob.defaultPage());
 
-        private void initMenu() {
-                MenuBar         mb = new MenuBar();
-                Menu            me = new Menu("File");
-                me.add(print1Menu);
-                me.add(print2Menu);
-                me.add("-");
-                me.add(exitMenu);
-                mb.add(me);
-                this.setMenuBar(mb);
+        printerJob.setPrintable( printImageCanvas, pageFormat);
 
-                print1Menu.addActionListener(this);
-                print2Menu.addActionListener(this);
-                exitMenu.addActionListener(this);
-        }
-
-        public void actionPerformed(ActionEvent e) {
-                Object target = e.getSource();
-                if( target.equals(print1Menu) ) {
-                        printMain1();
-                }
-                else if( target.equals(print2Menu) ) {
-                        printMain2();
-                }
-                else if( target.equals(exitMenu) ) {
-                        dispose();
-                }
-        }
-
-        private void printMain1(){
-
-                PrinterJob printerJob = PrinterJob.getPrinterJob();
-                PageFormat pageFormat = printerJob.defaultPage();
-
-                printerJob.setPrintable((Printable)printImageCanvas, pageFormat);
-
-                if(printerJob.printDialog()){
-                        try {
-                                printerJob.print();
-                        }
-                        catch(PrinterException p){
-                        }
-                }
-                else
-                        printerJob.cancel();
-        }
-
-        private void printMain2(){
-
-                PrinterJob printerJob = PrinterJob.getPrinterJob();
-                PageFormat pageFormat = printerJob.pageDialog(printerJob.defaultPage());
-
-                printerJob.setPrintable((Printable)printImageCanvas, pageFormat);
-
-                if(printerJob.printDialog()){
-                        try {
-                                printerJob.print();
-                        }
-                        catch(PrinterException p){
-                        }
-                }
-                else
-                        printerJob.cancel();
-        }
-
+        if (printerJob.printDialog()) {
+            try {
+                printerJob.print();
+            } catch (PrinterException e) {
+                e.printStackTrace();
+            }
+        } else
+            printerJob.cancel();
+    }
 }
 
 class PrintImageCanvas extends Canvas implements Printable {
 
-        private PrintImage pdsFrame;
+    public PrintImageCanvas(PrintImage pds) {
+    }
 
-        public PrintImageCanvas(PrintImage pds) {
-                pdsFrame = pds;
+    public void paint(Graphics g) {
+        Font drawFont = new Font("MS Mincho", Font.ITALIC, 50);
+        g.setFont(drawFont);
+        g.drawString("PrintSample!", 100, 150);
+    }
+
+    public int print(Graphics g, PageFormat pf, int pi)
+            throws PrinterException {
+
+        if (pi >= 1)
+            return NO_SUCH_PAGE;
+        else {
+            g.setColor(new Color(0, 0, 0, 200));
+
+            Font drawFont = new Font("MS Mincho", Font.ITALIC, 50);
+            g.setFont(drawFont);
+            g.drawString("PrintSample!", 100, 150);
+            return PAGE_EXISTS;
         }
-
-        public void paint(Graphics g) {
-                Font drawFont = new Font("MS Mincho",Font.ITALIC,50);
-                g.setFont(drawFont);
-                g.drawString("PrintSample!",100,150);
-        }
-
-        public int print(Graphics g, PageFormat pf, int pi)
-                throws PrinterException {
-
-                if(pi>=1)
-                        return NO_SUCH_PAGE;
-                else{
-                        Graphics2D g2 = (Graphics2D)g;
-                        g.setColor(new Color(0,0,0,200));
-
-                        Font drawFont = new Font("MS Mincho",Font.ITALIC,50);
-                        g.setFont(drawFont);
-                        g.drawString("PrintSample!",100,150);
-                        return PAGE_EXISTS;
-                }
-        }
+    }
 }
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintNullString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,308 +21,205 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.text.AttributedCharacterIterator;
+import java.text.AttributedString;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4223328
  * @summary Printer graphics must behave the same as screen graphics
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual PrintNullString
  */
-
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import java.text.*;
-
 public class PrintNullString extends Frame implements ActionListener {
 
- private TextCanvas c;
+    private final TextCanvas c;
 
- public static void main(String args[]) {
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+            "This test should print a page which contains the same\n" +
+            "text messages as in the test window on the screen\n" +
+            "The messages should contain only 'OK' and 'expected' messages\n" +
+            "There should be no FAILURE messages.\n" +
+            "You should also monitor the command line to see if any exceptions\n" +
+            "were thrown\n" +
+            "If the page fails to print, but there were no exceptions\n" +
+            "then the problem is likely elsewhere (ie your printer)";
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test should print a page which contains the same",
-         "text messages as in the test window on the screen",
-         "The messages should contain only 'OK' and 'expected' messages",
-         "There should be no FAILURE messages.",
-         "You should also monitor the command line to see if any exceptions",
-         "were thrown",
-         "If the page fails to print, but there were no exceptions",
-         "then the problem is likely elsewhere (ie your printer)"
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+    public static void main(String[] args) throws Exception {
 
-    PrintNullString f = new PrintNullString();
-    f.show();
- }
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
- public PrintNullString() {
-    super("JDK 1.2 drawString Printing");
-
-    c = new TextCanvas();
-    add("Center", c);
-
-    Button printButton = new Button("Print");
-    printButton.addActionListener(this);
-    add("South", printButton);
-
-    addWindowListener(new WindowAdapter() {
-       public void windowClosing(WindowEvent e) {
-             System.exit(0);
-            }
-    });
-
-    pack();
- }
-
- public void actionPerformed(ActionEvent e) {
-
-   PrinterJob pj = PrinterJob.getPrinterJob();
-
-   if (pj != null && pj.printDialog()) {
-
-       pj.setPrintable(c);
-       try {
-            pj.print();
-      } catch (PrinterException pe) {
-      } finally {
-         System.err.println("PRINT RETURNED");
-      }
-   }
- }
-
- class TextCanvas extends Panel implements Printable {
-
-    String nullStr = null;
-    String emptyStr = new String();
-    AttributedString nullAttStr = null;
-    AttributedString emptyAttStr = new AttributedString(emptyStr);
-    AttributedCharacterIterator nullIterator = null;
-    AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
-
-    public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-
-      if (pgIndex > 0)
-         return Printable.NO_SUCH_PAGE;
-
-      Graphics2D g2d = (Graphics2D)g;
-      g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-
-      paint(g);
-
-      return Printable.PAGE_EXISTS;
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testUI(PrintNullString::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
     }
 
-    public void paint(Graphics g1) {
-        Graphics2D g = (Graphics2D)g1;
+    public PrintNullString() {
+        super("JDK 1.2 drawString Printing");
 
-        // API 1: null & empty drawString(String, int, int);
-        try {
-             g.drawString(nullStr, 20, 40);
-             g.drawString("FAILURE: No NPE for null String, int", 20, 40);
-        } catch (NullPointerException e) {
-          g.drawString("caught expected NPE for null String, int", 20, 40);
-        }/* catch (Exception e) {
+        c = new TextCanvas();
+        add("Center", c);
+
+        Button printButton = new Button("Print");
+        printButton.addActionListener(this);
+        add("South", printButton);
+
+        pack();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+
+        PrinterJob pj = PrinterJob.getPrinterJob();
+
+        if (pj != null && pj.printDialog()) {
+
+            pj.setPrintable(c);
+            try {
+                pj.print();
+            } catch (PrinterException pe) {
+            } finally {
+                System.out.println("PRINT RETURNED");
+            }
+        }
+    }
+
+    static class TextCanvas extends Panel implements Printable {
+
+        String nullStr = null;
+        String emptyStr = "";
+        AttributedString emptyAttStr = new AttributedString(emptyStr);
+        AttributedCharacterIterator nullIterator = null;
+        AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
+
+        public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
+
+            if (pgIndex > 0)
+                return Printable.NO_SUCH_PAGE;
+
+            Graphics2D g2d = (Graphics2D) g;
+            g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+
+            paint(g);
+
+            return Printable.PAGE_EXISTS;
+        }
+
+        public void paint(Graphics g1) {
+            Graphics2D g = (Graphics2D) g1;
+
+            // API 1: null & empty drawString(String, int, int);
+            try {
+                g.drawString(nullStr, 20, 40);
+                g.drawString("FAILURE: No NPE for null String, int", 20, 40);
+            } catch (NullPointerException e) {
+                g.drawString("caught expected NPE for null String, int", 20, 40);
+            }/* catch (Exception e) {
           g.drawString("FAILURE: unexpected exception for null String, int",
                         20, 40);
         }*/
 
-        //try {
-             g.drawString(emptyStr, 20, 60);
-             g.drawString("OK for empty String, int", 20, 60);
+            //try {
+            g.drawString(emptyStr, 20, 60);
+            g.drawString("OK for empty String, int", 20, 60);
         /*} catch (Exception e) {
           g.drawString("FAILURE: unexpected exception for empty String, int",
                         20, 60);
         }*/
 
-
-        // API 2: null & empty drawString(String, float, float);
-        try {
-             g.drawString(nullStr, 20.0f, 80.0f);
-             g.drawString("FAILURE: No NPE for null String, float", 20, 80);
-        } catch (NullPointerException e) {
-          g.drawString("caught expected NPE for null String, float", 20, 80);
-        } /*catch (Exception e) {
+            // API 2: null & empty drawString(String, float, float);
+            try {
+                g.drawString(nullStr, 20.0f, 80.0f);
+                g.drawString("FAILURE: No NPE for null String, float", 20, 80);
+            } catch (NullPointerException e) {
+                g.drawString("caught expected NPE for null String, float", 20, 80);
+            } /*catch (Exception e) {
           g.drawString("FAILURE: unexpected exception for null String, float",
                         20, 80);
         }*/
-        //try {
-             g.drawString(emptyStr, 20.0f, 100.0f);
-             g.drawString("OK for empty String, float", 20.0f, 100.f);
+            //try {
+            g.drawString(emptyStr, 20.0f, 100.0f);
+            g.drawString("OK for empty String, float", 20.0f, 100.f);
         /* } catch (Exception e) {
           g.drawString("FAILURE: unexpected exception for empty String, float",
                         20, 100);
         }*/
 
-        // API 3: null & empty drawString(Iterator, int, int);
-        try {
-             g.drawString(nullIterator, 20, 120);
-             g.drawString("FAILURE: No NPE for null iterator, float", 20, 120);
-        } catch (NullPointerException e) {
-          g.drawString("caught expected NPE for null iterator, int", 20, 120);
-        } /*catch (Exception e) {
+            // API 3: null & empty drawString(Iterator, int, int);
+            try {
+                g.drawString(nullIterator, 20, 120);
+                g.drawString("FAILURE: No NPE for null iterator, float", 20, 120);
+            } catch (NullPointerException e) {
+                g.drawString("caught expected NPE for null iterator, int", 20, 120);
+            } /*catch (Exception e) {
           g.drawString("FAILURE: unexpected exception for null iterator, int",
                        20, 120);
         } */
-        try {
-             g.drawString(emptyIterator, 20, 140);
-             g.drawString("FAILURE: No IAE for empty iterator, int",
-                           20, 140);
-        } catch (IllegalArgumentException e) {
-          g.drawString("caught expected IAE for empty iterator, int",
+            try {
+                g.drawString(emptyIterator, 20, 140);
+                g.drawString("FAILURE: No IAE for empty iterator, int",
                         20, 140);
-        } /*catch (Exception e) {
+            } catch (IllegalArgumentException e) {
+                g.drawString("caught expected IAE for empty iterator, int",
+                        20, 140);
+            } /*catch (Exception e) {
           g.drawString("FAILURE: unexpected exception for empty iterator, int",
                        20, 140);
         } */
 
-
-        // API 4: null & empty drawString(Iterator, float, int);
-        try {
-             g.drawString(nullIterator, 20.0f, 160.0f);
-             g.drawString("FAILURE: No NPE for null iterator, float", 20, 160);
-        } catch (NullPointerException e) {
-          g.drawString("caught expected NPE for null iterator, float", 20, 160);
-        } /*catch (Exception e) {
+            // API 4: null & empty drawString(Iterator, float, int);
+            try {
+                g.drawString(nullIterator, 20.0f, 160.0f);
+                g.drawString("FAILURE: No NPE for null iterator, float", 20, 160);
+            } catch (NullPointerException e) {
+                g.drawString("caught expected NPE for null iterator, float", 20, 160);
+            } /*catch (Exception e) {
           g.drawString("FAILURE: unexpected exception for null iterator, float",
                         20, 160);
         } */
 
-        try {
-             g.drawString(emptyIterator, 20, 180);
-             g.drawString("FAILURE: No IAE for empty iterator, float",
-                           20, 180);
-        } catch (IllegalArgumentException e) {
-          g.drawString("caught expected IAE for empty iterator, float",
+            try {
+                g.drawString(emptyIterator, 20, 180);
+                g.drawString("FAILURE: No IAE for empty iterator, float",
                         20, 180);
-        } /*catch (Exception e) {
+            } catch (IllegalArgumentException e) {
+                g.drawString("caught expected IAE for empty iterator, float",
+                        20, 180);
+            } /*catch (Exception e) {
           g.drawString("FAILURE: unexpected exception for empty iterator, float",
                        20, 180);
         } */
-    }
+        }
 
-     public Dimension getPreferredSize() {
-        return new Dimension(450, 250);
+        public Dimension getPreferredSize() {
+            return new Dimension(450, 250);
+        }
     }
- }
-
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintParenString.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintParenString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,226 +21,118 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4399442
  * @summary Brackets should be quoted in Postscript output
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual PrintParenString
  */
-
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import java.text.*;
-
 public class PrintParenString extends Frame implements ActionListener {
 
- private TextCanvas c;
+    private final TextCanvas c;
 
- public static void main(String args[]) {
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+            "This test should print a page which contains the same\n" +
+            "text message as in the test window on the screen\n" +
+            "You should also monitor the command line to see if any exceptions\n" +
+            "were thrown\n" +
+            "If an exception is thrown, or the page doesn't print properly\n" +
+            "then the test fails";
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test should print a page which contains the same",
-         "text message as in the test window on the screen",
-         "You should also monitor the command line to see if any exceptions",
-         "were thrown",
-         "If an exception is thrown, or the page doesn't print properly",
-         "then the test fails",
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+    public static void main(String[] args) throws Exception {
 
-    PrintParenString f = new PrintParenString();
-    f.show();
- }
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
- public PrintParenString() {
-    super("JDK 1.2 drawString Printing");
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testUI(PrintParenString::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 
-    c = new TextCanvas();
-    add("Center", c);
+    public PrintParenString() {
+        super("JDK 1.2 drawString Printing");
 
-    Button printButton = new Button("Print");
-    printButton.addActionListener(this);
-    add("South", printButton);
+        c = new TextCanvas();
+        add("Center", c);
 
-    addWindowListener(new WindowAdapter() {
-       public void windowClosing(WindowEvent e) {
-             System.exit(0);
+        Button printButton = new Button("Print");
+        printButton.addActionListener(this);
+        add("South", printButton);
+
+        pack();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+
+        PrinterJob pj = PrinterJob.getPrinterJob();
+
+        if (pj != null && pj.printDialog()) {
+
+            pj.setPrintable(c);
+            try {
+                pj.print();
+            } catch (PrinterException pe) {
+                pe.printStackTrace();
+            } finally {
+                System.out.println("PRINT RETURNED");
             }
-    });
-
-    pack();
- }
-
- public void actionPerformed(ActionEvent e) {
-
-   PrinterJob pj = PrinterJob.getPrinterJob();
-
-   if (pj != null && pj.printDialog()) {
-
-       pj.setPrintable(c);
-       try {
-            pj.print();
-      } catch (PrinterException pe) {
-      } finally {
-         System.err.println("PRINT RETURNED");
-      }
-   }
- }
-
- class TextCanvas extends Panel implements Printable {
-
-    String nullStr = null;
-    String emptyStr = new String();
-    AttributedString nullAttStr = null;
-    AttributedString emptyAttStr = new AttributedString(emptyStr);
-    AttributedCharacterIterator nullIterator = null;
-    AttributedCharacterIterator emptyIterator = emptyAttStr.getIterator();
-
-    public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-
-      if (pgIndex > 0)
-         return Printable.NO_SUCH_PAGE;
-
-      Graphics2D g2d = (Graphics2D)g;
-      g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-
-      paint(g);
-
-      return Printable.PAGE_EXISTS;
+        }
     }
 
-    public void paint(Graphics g1) {
-        Graphics2D g = (Graphics2D)g1;
+    class TextCanvas extends Panel implements Printable {
 
-          String str = "String containing unclosed parenthesis (.";
-          g.drawString(str, 20, 40);
+        public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
 
+            if (pgIndex > 0)
+                return Printable.NO_SUCH_PAGE;
+
+            Graphics2D g2d = (Graphics2D) g;
+            g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+
+            paint(g);
+
+            return Printable.PAGE_EXISTS;
+        }
+
+        public void paint(Graphics g1) {
+            Graphics2D g = (Graphics2D) g1;
+
+            String str = "String containing unclosed parenthesis (.";
+            g.drawString(str, 20, 40);
+
+        }
+
+        public Dimension getPreferredSize() {
+            return new Dimension(450, 250);
+        }
     }
-
-     public Dimension getPreferredSize() {
-        return new Dimension(450, 250);
-    }
- }
-
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/PrintTranslatedFont.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTranslatedFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,237 +21,139 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Panel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.geom.AffineTransform;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 6359734
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @summary Test that fonts with a translation print where they should.
  * @run main/manual PrintTranslatedFont
  */
-
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.geom.*;
-import java.awt.print.*;
-import java.text.*;
-
 public class PrintTranslatedFont extends Frame implements ActionListener {
 
- private TextCanvas c;
+    private final TextCanvas c;
 
- public static void main(String args[]) {
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+            "This test should print a page which contains the same\n" +
+            "content as the test window on the screen, in particular the lines\n" +
+            "should be immediately under the text\n" +
+            "You should also monitor the command line to see if any exceptions\n" +
+            "were thrown\n" +
+            "If an exception is thrown, or the page doesn't print properly\n" +
+            "then the test fails";
 
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test should print a page which contains the same",
-         "content as the test window on the screen, in particular the lines",
-         "should be immediately under the text",
-         "You should also monitor the command line to see if any exceptions",
-         "were thrown",
-         "If an exception is thrown, or the page doesn't print properly",
-         "then the test fails",
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+    public static void main(String[] args) throws Exception {
 
-    PrintTranslatedFont f = new PrintTranslatedFont();
-    f.show();
- }
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
- public PrintTranslatedFont() {
-    super("JDK 1.2 drawString Printing");
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testUI(PrintTranslatedFont::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 
-    c = new TextCanvas();
-    add("Center", c);
+    public PrintTranslatedFont() {
+        super("JDK 1.2 drawString Printing");
 
-    Button printButton = new Button("Print");
-    printButton.addActionListener(this);
-    add("South", printButton);
+        c = new TextCanvas();
+        add("Center", c);
 
-    addWindowListener(new WindowAdapter() {
-       public void windowClosing(WindowEvent e) {
-             System.exit(0);
+        Button printButton = new Button("Print");
+        printButton.addActionListener(this);
+        add("South", printButton);
+
+        pack();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+
+        PrinterJob pj = PrinterJob.getPrinterJob();
+
+        if (pj != null && pj.printDialog()) {
+
+            pj.setPrintable(c);
+            try {
+                pj.print();
+            } catch (PrinterException pe) {
+                pe.printStackTrace();
+            } finally {
+                System.out.println("PRINT RETURNED");
             }
-    });
-
-    pack();
- }
-
- public void actionPerformed(ActionEvent e) {
-
-   PrinterJob pj = PrinterJob.getPrinterJob();
-
-   if (pj != null && pj.printDialog()) {
-
-       pj.setPrintable(c);
-       try {
-            pj.print();
-      } catch (PrinterException pe) {
-      } finally {
-         System.err.println("PRINT RETURNED");
-      }
-   }
- }
-
- class TextCanvas extends Panel implements Printable {
-
-    public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-
-      if (pgIndex > 0)
-         return Printable.NO_SUCH_PAGE;
-
-      Graphics2D g2d = (Graphics2D)g;
-      g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-
-      paint(g);
-
-      return Printable.PAGE_EXISTS;
+        }
     }
 
-    public void paint(Graphics g1) {
-        Graphics2D g = (Graphics2D)g1;
+    static class TextCanvas extends Panel implements Printable {
 
-          Font f = new Font("Dialog", Font.PLAIN, 20);
-          int tx = 20;
-          int ty = 20;
-          AffineTransform at = AffineTransform.getTranslateInstance(tx, ty);
-          f = f.deriveFont(at);
-          g.setFont(f);
+        public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
 
-          FontMetrics fm = g.getFontMetrics();
-          String str = "Basic ascii string";
-          int sw = fm.stringWidth(str);
-          int posx = 20, posy = 40;
-          g.drawString(str, posx, posy);
-          g.drawLine(posx+tx, posy+ty+2, posx+tx+sw, posy+ty+2);
+            if (pgIndex > 0)
+                return Printable.NO_SUCH_PAGE;
 
-          posx = 20; posy = 70;
-          str = "Test string compound printing \u2203\u2200";
-          sw = fm.stringWidth(str);
-          g.drawString(str, posx, posy);
-          g.drawLine(posx+tx, posy+ty+2, posx+tx+sw, posy+ty+2);
+            Graphics2D g2d = (Graphics2D) g;
+            g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+
+            paint(g);
+
+            return Printable.PAGE_EXISTS;
+        }
+
+        public void paint(Graphics g1) {
+            Graphics2D g = (Graphics2D) g1;
+
+            Font f = new Font("Dialog", Font.PLAIN, 20);
+            int tx = 20;
+            int ty = 20;
+            AffineTransform at = AffineTransform.getTranslateInstance(tx, ty);
+            f = f.deriveFont(at);
+            g.setFont(f);
+
+            FontMetrics fm = g.getFontMetrics();
+            String str = "Basic ascii string";
+            int sw = fm.stringWidth(str);
+            int posx = 20, posy = 40;
+            g.drawString(str, posx, posy);
+            g.drawLine(posx + tx, posy + ty + 2, posx + tx + sw, posy + ty + 2);
+
+            posx = 20;
+            posy = 70;
+            str = "Test string compound printing \u2203\u2200";
+            sw = fm.stringWidth(str);
+            g.drawString(str, posx, posy);
+            g.drawLine(posx + tx, posy + ty + 2, posx + tx + sw, posy + ty + 2);
+        }
+
+        public Dimension getPreferredSize() {
+            return new Dimension(450, 250);
+        }
     }
-
-     public Dimension getPreferredSize() {
-        return new Dimension(450, 250);
-    }
- }
-
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/ValidatePage/ValidatePage.java
+++ b/test/jdk/java/awt/print/PrinterJob/ValidatePage/ValidatePage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,407 +21,316 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GridLayout;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.print.PageFormat;
+import java.awt.print.Paper;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4252108 6229507
  * @key printer
  * @summary PrinterJob.validatePage() is unimplemented.
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual ValidatePage
  */
-
-import java.awt.*;
-import java.awt.event.*;
-import java.awt.print.*;
-
 public class ValidatePage extends Frame implements Printable {
 
-PrinterJob myPrinterJob;
-PageFormat myPageFormat;
-Label pw, ph, pglm, pgrm, pgiw, pgih, pgtm, pgbm;
-TextField tpw, tph, tpglm, tpgtm, tpgiw, tpgih;
-Label myWidthLabel;
-Label myHeightLabel;
-Label myImageableXLabel;
-Label myImageableYLabel;
-Label myImageableRightLabel;
-Label myImageableBottomLabel;
-Label myImageableWidthLabel;
-Label myImageableHeightLabel;
-Label myOrientationLabel;
+    PrinterJob myPrinterJob;
+    PageFormat myPageFormat;
+    Label pw, ph, pglm, pgrm, pgiw, pgih, pgtm, pgbm;
+    TextField tpw, tph, tpglm, tpgtm, tpgiw, tpgih;
+    Label myWidthLabel;
+    Label myHeightLabel;
+    Label myImageableXLabel;
+    Label myImageableYLabel;
+    Label myImageableRightLabel;
+    Label myImageableBottomLabel;
+    Label myImageableWidthLabel;
+    Label myImageableHeightLabel;
+    Label myOrientationLabel;
 
-  protected void displayPageFormatAttributes() {
-    myWidthLabel.setText ("Format Width = " + drnd(myPageFormat.getWidth()));
-    myHeightLabel.setText ("Format Height = " + drnd(myPageFormat.getHeight()));
-    myImageableXLabel.setText
-        ("Format Left Margin = " + drnd(myPageFormat.getImageableX()));
-    myImageableRightLabel.setText
-        ("Format Right Margin = " + drnd(myPageFormat.getWidth() -
-        (myPageFormat.getImageableX() + myPageFormat.getImageableWidth())));
-    myImageableWidthLabel.setText
-        ("Format ImageableWidth = " + drnd(myPageFormat.getImageableWidth()));
-    myImageableYLabel.setText
-        ("Format Top Margin = " + drnd(myPageFormat.getImageableY()));
-    myImageableBottomLabel.setText
-        ("Format Bottom Margin = " + drnd(myPageFormat.getHeight() -
-        (myPageFormat.getImageableY() + myPageFormat.getImageableHeight())));
-    myImageableHeightLabel.setText
-        ("Format ImageableHeight = " + drnd(myPageFormat.getImageableHeight()));
-    int o = myPageFormat.getOrientation();
-    myOrientationLabel.setText
-        ("Format Orientation = " +
+    protected void displayPageFormatAttributes() {
+        myWidthLabel.setText("Format Width = " + drnd(myPageFormat.getWidth()));
+        myHeightLabel.setText("Format Height = " + drnd(myPageFormat.getHeight()));
+        myImageableXLabel.setText
+                ("Format Left Margin = " + drnd(myPageFormat.getImageableX()));
+        myImageableRightLabel.setText
+                ("Format Right Margin = " + drnd(myPageFormat.getWidth() -
+                        (myPageFormat.getImageableX() + myPageFormat.getImageableWidth())));
+        myImageableWidthLabel.setText
+                ("Format ImageableWidth = " + drnd(myPageFormat.getImageableWidth()));
+        myImageableYLabel.setText
+                ("Format Top Margin = " + drnd(myPageFormat.getImageableY()));
+        myImageableBottomLabel.setText
+                ("Format Bottom Margin = " + drnd(myPageFormat.getHeight() -
+                        (myPageFormat.getImageableY() + myPageFormat.getImageableHeight())));
+        myImageableHeightLabel.setText
+                ("Format ImageableHeight = " + drnd(myPageFormat.getImageableHeight()));
+        int o = myPageFormat.getOrientation();
+        myOrientationLabel.setText
+                ("Format Orientation = " +
+                        (o == PageFormat.PORTRAIT ? "PORTRAIT" :
+                                o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
+                                        o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
+                                                "<invalid>"));
+        Paper p = myPageFormat.getPaper();
+        pw.setText("Paper Width = " + drnd(p.getWidth()));
+        ph.setText("Paper Height = " + drnd(p.getHeight()));
+        pglm.setText("Paper Left Margin = " + drnd(p.getImageableX()));
+        pgiw.setText("Paper Imageable Width = " + drnd(p.getImageableWidth()));
+        pgih.setText("Paper Imageable Height = " + drnd(p.getImageableHeight()));
+
+        pgrm.setText("Paper Right Margin = " +
+                drnd(p.getWidth() - (p.getImageableX() + p.getImageableWidth())));
+        pgtm.setText("Paper Top Margin = " + drnd(p.getImageableY()));
+        pgbm.setText("Paper Bottom Margin = " +
+                drnd(p.getHeight() - (p.getImageableY() + p.getImageableHeight())));
+    }
+
+    static String drnd(double d) {
+        d = d * 10.0 + 0.5;
+        d = Math.floor(d) / 10.0;
+        String ds = Double.toString(d);
+        int decimal_pos = ds.indexOf(".");
+        int len = ds.length();
+        if (len > decimal_pos + 2) {
+            return ds.substring(0, decimal_pos + 2);
+        } else {
+            return ds;
+        }
+    }
+
+    public ValidatePage() {
+        super("Validate Page Test");
+        myPrinterJob = PrinterJob.getPrinterJob();
+        myPageFormat = new PageFormat();
+        Paper p = new Paper();
+        p.setSize(28 * 72, 21.5 * 72);
+        myPageFormat.setPaper(p);
+        setLayout(new FlowLayout());
+        Panel pfp = new Panel();
+        pfp.setLayout(new GridLayout(9, 1, 0, 0));
+        pfp.add(myOrientationLabel = new Label());
+        pfp.add(myWidthLabel = new Label());
+        pfp.add(myImageableXLabel = new Label());
+        pfp.add(myImageableRightLabel = new Label());
+        pfp.add(myImageableWidthLabel = new Label());
+        pfp.add(myHeightLabel = new Label());
+        pfp.add(myImageableYLabel = new Label());
+        pfp.add(myImageableBottomLabel = new Label());
+        pfp.add(myImageableHeightLabel = new Label());
+
+        add(pfp);
+
+        Panel pp = new Panel();
+        pp.setLayout(new GridLayout(8, 1, 0, 0));
+        pp.add(pw = new Label());
+        pp.add(pglm = new Label());
+        pp.add(pgtm = new Label());
+        pp.add(ph = new Label());
+        pp.add(pgiw = new Label());
+        pp.add(pgih = new Label());
+        pp.add(pgrm = new Label());
+        pp.add(pgbm = new Label());
+
+        add(pp);
+
+        Panel epp = new Panel();
+        epp.setLayout(new GridLayout(6, 2, 0, 0));
+
+        epp.add(new Label("Page width:"));
+        epp.add(tpw = new TextField());
+        epp.add(new Label("Page height:"));
+        epp.add(tph = new TextField());
+        epp.add(new Label("Left Margin:"));
+        epp.add(tpglm = new TextField());
+        epp.add(new Label("Top margin:"));
+        epp.add(tpgtm = new TextField());
+        epp.add(new Label("Imageable Wid:"));
+        epp.add(tpgiw = new TextField());
+        epp.add(new Label("Imageable Hgt:"));
+        epp.add(tpgih = new TextField());
+
+        add(epp);
+        displayPageFormatAttributes();
+
+        Panel panel = new Panel();
+        Button defButton = new Button("Default Page");
+        defButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                myPageFormat = myPrinterJob.defaultPage();
+                displayPageFormatAttributes();
+            }
+        });
+
+        Button pageButton = new Button("Page Setup..");
+        pageButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                myPageFormat = myPrinterJob.pageDialog(myPageFormat);
+                displayPageFormatAttributes();
+            }
+        });
+        Button printButton = new Button("Print");
+        printButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    //if (myPrinterJob.printDialog()) {
+                    myPrinterJob.setPrintable(ValidatePage.this,
+                            myPageFormat);
+                    myPrinterJob.print();
+                    // }
+                } catch (PrinterException pe) {
+                    pe.printStackTrace();
+                }
+            }
+        });
+
+        Button chooseButton = new Button("Printer..");
+        chooseButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                myPrinterJob.printDialog();
+            }
+        });
+
+        Button validateButton = new Button("Validate Page");
+        validateButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                myPageFormat = myPrinterJob.validatePage(myPageFormat);
+                displayPageFormatAttributes();
+            }
+        });
+        Button setButton = new Button("Set Paper");
+        setButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    Paper p = new Paper();
+                    double pwid = Double.parseDouble(tpw.getText());
+                    double phgt = Double.parseDouble(tph.getText());
+                    double pimx = Double.parseDouble(tpglm.getText());
+                    double pimy = Double.parseDouble(tpgtm.getText());
+                    double pimwid = Double.parseDouble(tpgiw.getText());
+                    double pimhgt = Double.parseDouble(tpgih.getText());
+                    p.setSize(pwid, phgt);
+                    p.setImageableArea(pimx, pimy, pimwid, pimhgt);
+                    myPageFormat.setPaper(p);
+                    displayPageFormatAttributes();
+                } catch (NumberFormatException nfe) {
+                    nfe.printStackTrace();
+                }
+            }
+        });
+        panel.add(setButton);
+        panel.add(defButton);
+        panel.add(pageButton);
+        panel.add(chooseButton);
+        panel.add(validateButton);
+        panel.add(printButton);
+        add(panel);
+        TextArea ta = new TextArea(10, 45);
+        String ls = System.getProperty("line.Separator", "\n");
+        ta.setText(
+                "When validating a page, the process is 1st to find the closest matching " + ls +
+                "paper size, next to make sure the requested imageable area fits within " + ls +
+                "the printer's imageable area for that paper size. Finally the top and " + ls +
+                "left margins will be shrunk if they are too great for the adjusted " + ls +
+                "imageable area to fit at that position. They will shrink by the minimum" + ls +
+                "needed to accomodate the imageable area." + ls + ls +
+                "To test 6229507, put the minimum margins (all 0s) in Page Setup dialog." + ls +
+                "Compare Imageable width, height, and margins of portrait against landscape.");
+
+        ta.setEditable(false);
+        add(ta);
+        setSize(500, 650);
+    }
+
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
+
+        if (pageIndex > 0) {
+            return Printable.NO_SUCH_PAGE;
+        }
+
+        Graphics2D g2d = (Graphics2D) graphics;
+
+        int o = pageFormat.getOrientation();
+
+        System.out.println("Format Orientation = " +
                 (o == PageFormat.PORTRAIT ? "PORTRAIT" :
-                 o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
-                 o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
-                 "<invalid>"));
-    Paper p = myPageFormat.getPaper();
-    pw.setText("Paper Width = " + drnd(p.getWidth()));
-    ph.setText("Paper Height = " + drnd(p.getHeight()));
-    pglm.setText("Paper Left Margin = " + drnd(p.getImageableX()));
-    pgiw.setText("Paper Imageable Width = " + drnd(p.getImageableWidth()));
-    pgih.setText("Paper Imageable Height = " + drnd(p.getImageableHeight()));
+                        o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
+                                o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
+                                        "<invalid>"));
+        System.out.println(g2d.getTransform());
+        System.out.println("ix=" + pageFormat.getImageableX() +
+                " iy=" + pageFormat.getImageableY());
+        g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+        g2d.drawString("ORIGIN", 20, 20);
+        g2d.drawString("X THIS WAY", 200, 50);
+        g2d.drawString("Y THIS WAY", 60, 200);
+        g2d.drawRect(0, 0, (int) pageFormat.getImageableWidth(),
+                (int) pageFormat.getImageableHeight());
+        g2d.setColor(Color.blue);
+        g2d.drawRect(1, 1, (int) pageFormat.getImageableWidth() - 2,
+                (int) pageFormat.getImageableHeight() - 2);
 
-    pgrm.setText("Paper Right Margin = " +
-         drnd(p.getWidth() - (p.getImageableX()+p.getImageableWidth())));
-    pgtm.setText("Paper Top Margin = " + drnd(p.getImageableY()));
-    pgbm.setText("Paper Bottom Margin = " +
-       drnd(p.getHeight() - (p.getImageableY()+p.getImageableHeight())));
-  }
+        return Printable.PAGE_EXISTS;
+    }
 
-  static String drnd(double d) {
-      d = d * 10.0 + 0.5;
-      d = Math.floor(d) /10.0;
-      String ds = Double.toString(d);
-      int decimal_pos = ds.indexOf(".");
-      int len = ds.length();
-      if (len > decimal_pos+2) {
-          return ds.substring(0, decimal_pos+2);
-      } else {
-          return ds;
-      }
-  }
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+            "This test is very flexible and requires much interaction.\n" +
+            "There are several buttons.\n" +
+            "Set Paper: if all fields are valid numbers it sets the Paper object.\n" +
+            "This is used to create arbitrary nonsensical paper sizes to help\n" +
+            "test validatePage.\n" +
+            "Default Page: sets a default page. This should always be valid.\n" +
+            "Page Setup: brings up the page dialog. You must OK this dialog\n" +
+            "for it to have any effect. You can use this to set different size,\n" +
+            "orientation and margins - which of course affect imageable area.\n" +
+            "Printer: Used to set the current printer. Useful because current\n" +
+            "printer affects the choice of paper sizes available.\n" +
+            "You must OK this dialog for it to have any effect.\n" +
+            "Validate Page:\n" +
+            "The most important button in the test. By setting nonsensical\n" +
+            "or valid papers with varying margins etc, this should always find\n" +
+            "the closest\n" +
+            "match within the limits of what is possible on the current printer.\n" +
+            "Print: to the current printer. Not vital for this test.\n" +
+            "request.";
 
-  public ValidatePage() {
-    super ("Validate Page Test");
-    myPrinterJob = PrinterJob.getPrinterJob();
-    myPageFormat = new PageFormat();
-    Paper p = new Paper();
-    p.setSize(28*72, 21.5 * 72);
-    myPageFormat.setPaper(p);
-    setLayout(new FlowLayout());
-    Panel pfp = new Panel();
-    pfp.setLayout (new GridLayout (9, 1, 0, 0));
-    pfp.add (myOrientationLabel = new Label());
-    pfp.add (myWidthLabel = new Label());
-    pfp.add (myImageableXLabel = new Label());
-    pfp.add (myImageableRightLabel = new Label());
-    pfp.add (myImageableWidthLabel = new Label());
-    pfp.add (myHeightLabel = new Label());
-    pfp.add (myImageableYLabel = new Label());
-    pfp.add (myImageableBottomLabel = new Label());
-    pfp.add (myImageableHeightLabel = new Label());
+    public static void main(String[] args) throws Exception {
 
-    add(pfp);
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
 
-    Panel pp = new Panel();
-    pp.setLayout (new GridLayout (8, 1, 0, 0));
-    pp.add (pw = new Label());
-    pp.add (pglm = new Label());
-    pp.add (pgtm = new Label());
-    pp.add (ph = new Label());
-    pp.add (pgiw = new Label());
-    pp.add (pgih = new Label());
-    pp.add (pgrm = new Label());
-    pp.add (pgbm = new Label());
-
-    add(pp);
-
-    Panel epp = new Panel();
-    epp.setLayout (new GridLayout (6, 2, 0, 0));
-
-    epp.add(new Label("Page width:"));
-    epp.add (tpw = new TextField());
-    epp.add(new Label("Page height:"));
-    epp.add (tph = new TextField());
-    epp.add(new Label("Left Margin:"));
-    epp.add (tpglm = new TextField());
-    epp.add(new Label("Top margin:"));
-    epp.add (tpgtm = new TextField());
-    epp.add(new Label("Imageable Wid:"));
-    epp.add (tpgiw = new TextField());
-    epp.add(new Label("Imageable Hgt:"));
-    epp.add (tpgih = new TextField());
-
-    add(epp);
-       displayPageFormatAttributes();
-
-    Panel panel = new Panel();
-    Button defButton = new Button ("Default Page");
-    defButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                        myPageFormat = myPrinterJob.defaultPage();
-                        displayPageFormatAttributes();
-                }
-    });
-
-    Button pageButton = new Button ("Page Setup..");
-    pageButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                        myPageFormat = myPrinterJob.pageDialog (myPageFormat);
-                        displayPageFormatAttributes();
-                }
-    });
-    Button printButton = new Button ("Print");
-    printButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                    try {
-                         //if (myPrinterJob.printDialog()) {
-                             myPrinterJob.setPrintable(ValidatePage.this,
-                                                       myPageFormat);
-                             myPrinterJob.print();
-                   // }
-                    } catch (PrinterException pe ) {
-                    }
-                }
-    });
-
-    Button chooseButton = new Button ("Printer..");
-    chooseButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                            myPrinterJob.printDialog();
-                }
-    });
-
-    Button validateButton = new Button ("Validate Page");
-    validateButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                        myPageFormat = myPrinterJob.validatePage(myPageFormat);
-                        displayPageFormatAttributes();
-                }
-    });
-    Button setButton = new Button ("Set Paper");
-    setButton.addActionListener(new ActionListener() {
-                public void actionPerformed (ActionEvent e) {
-                  try {
-                      Paper p = new Paper();
-                      double pwid = Double.parseDouble(tpw.getText());
-                      double phgt = Double.parseDouble(tph.getText());
-                      double pimx = Double.parseDouble(tpglm.getText());
-                      double pimy = Double.parseDouble(tpgtm.getText());
-                      double pimwid = Double.parseDouble(tpgiw.getText());
-                      double pimhgt = Double.parseDouble(tpgih.getText());
-                      p.setSize(pwid, phgt);
-                      p.setImageableArea(pimx, pimy, pimwid, pimhgt);
-                      myPageFormat.setPaper(p);
-                            displayPageFormatAttributes();
-                  } catch (NumberFormatException nfe) {
-                  }
-                }
-    });
-    panel.add (setButton);
-    panel.add (defButton);
-    panel.add (pageButton);
-    panel.add (chooseButton);
-    panel.add (validateButton);
-    panel.add (printButton);
-    add(panel);
-    TextArea ta = new TextArea(7, 60);
-    String ls = System.getProperty("line.Separator", "\n");
-    ta.setText(
-        "When validating a page, the process is 1st to find the closest matching " + ls +
-        "paper size, next to make sure the requested imageable area fits within " + ls +
-        "the printer's imageable area for that paper size. Finally the top and " + ls +
-        "left margins will be shrunk if they are too great for the adjusted " + ls +
-        "imageable area to fit at that position. They will shrink by the minimum" + ls +
-        "needed to accomodate the imageable area."+ls+ls+
-        "To test 6229507, put the minimum margins (all 0s) in Page Setup dialog."+ls+
-        "Compare Imageable width, height, and margins of portrait against landscape.");
-    ta.setEditable(false);
-    add(ta);
-
-    addWindowListener (new WindowAdapter() {
-         public void windowClosing (WindowEvent e) {
-            dispose();
-            System.exit (0);
-         }
-
-      });
-      setSize (500, 630);
-      setVisible (true);
-  }
-
-  public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) {
-
-     if (pageIndex > 0) {
-        return Printable.NO_SUCH_PAGE;
-     }
-
-     Graphics2D g2d = (Graphics2D)graphics;
-
-    int o = pageFormat.getOrientation();
-
-     System.out.println("Format Orientation = " +
-                (o == PageFormat.PORTRAIT ? "PORTRAIT" :
-                 o == PageFormat.LANDSCAPE ? "LANDSCAPE" :
-                 o == PageFormat.REVERSE_LANDSCAPE ? "REVERSE_LANDSCAPE" :
-                 "<invalid>"));
-     System.out.println(g2d.getTransform());
-     System.out.println("ix="+pageFormat.getImageableX()+
-                       " iy="+pageFormat.getImageableY());
-     g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
-     g2d.drawString("ORIGIN", 20, 20);
-     g2d.drawString("X THIS WAY", 200, 50);
-     g2d.drawString("Y THIS WAY", 60 , 200);
-     g2d.drawRect(0,0,(int)pageFormat.getImageableWidth(),
-                      (int)pageFormat.getImageableHeight());
-     g2d.setColor(Color.blue);
-     g2d.drawRect(1,1,(int)pageFormat.getImageableWidth()-2,
-                      (int)pageFormat.getImageableHeight()-2);
-
-     return  Printable.PAGE_EXISTS;
-  }
-
-  public static void main( String[] args) {
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test is very flexible and requires much interaction.",
-         "There are several buttons.",
-         "Set Paper: if all fields are valid numbers it sets the Paper object.",
-         "This is used to create arbitrary nonsensical paper sizes to help",
-         "test validatePage.",
-         "Default Page: sets a default page. This should always be valid.",
-         "Page Setup: brings up the page dialog. You must OK this dialog",
-         "for it to have any effect. You can use this to set different size,",
-         "orientation and margins - which of course affect imageable area.",
-         "Printer: Used to set the current printer. Useful because current",
-         "printer affects the choice of paper sizes available.",
-         "You must OK this dialog for it to have any effect.",
-         "Validate Page:",
-         "The most important button in the test. By setting nonsensical",
-         "or valid papers with varying margins etc, this should always find",
-         "the closest",
-         "match within the limits of what is possible on the current printer.",
-         "Print: to the current printer. Not vital for this test.",
-         "request."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
-
-     new ValidatePage();
-  }
-
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testUI(ValidatePage::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
 }
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class

--- a/test/jdk/java/awt/print/PrinterJob/raster/RasterTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/raster/RasterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,248 +21,146 @@
  * questions.
  */
 
-/**
+import java.awt.Button;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+
+import jtreg.SkippedException;
+
+/*
  * @test
  * @bug 4242639
  * @summary Printing quality problem on Canon and NEC
  * @key printer
+ * @library /java/awt/regtesthelpers
+ * @library /test/lib
+ * @build PassFailJFrame
+ * @build jtreg.SkippedException
  * @run main/manual RasterTest
  */
-import java.awt.*;
-import java.awt.geom.*;
-import java.awt.event.*;
-import java.awt.print.*;
-import java.awt.Toolkit;
-import java.awt.image.BufferedImage;
-
-
 public class RasterTest extends Frame implements ActionListener {
 
- private RasterCanvas c;
+    private final RasterCanvas c;
 
- public static void main(String args[]) {
-  String[] instructions =
-        {
-         "You must have a printer available to perform this test",
-         "This test uses rendering operations which force the implementation",
-         "to print the page as a raster",
-         "You should see two square images, the 1st containing overlapping",
-         "composited squares, the lower image shows a gradient paint.",
-         "The printed output should match the on-screen display, although",
-         "only colour printers will be able to accurately reproduce the",
-         "subtle color changes."
-       };
-      Sysout.createDialog( );
-      Sysout.printInstructions( instructions );
+    private static final String instructions =
+            "You must have a printer available to perform this test\n" +
+            "This test uses rendering operations which force the implementation\n" +
+            "to print the page as a raster\n" +
+            "You should see two square images, the 1st containing overlapping\n" +
+            "composited squares, the lower image shows a gradient paint.\n" +
+            "The printed output should match the on-screen display, although\n" +
+            "only colour printers will be able to accurately reproduce the\n" +
+            "subtle color changes.";
 
-    RasterTest f = new RasterTest();
-    f.show();
- }
+    public static void main(String[] args) throws Exception {
 
- public RasterTest() {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
+
+        PassFailJFrame.builder()
+                .title("Test Instructions")
+                .instructions(instructions)
+                .testUI(RasterTest::new)
+                .testTimeOut(5)
+                .rows((int) instructions.lines().count() + 1)
+                .columns(45)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public RasterTest() {
         super("Java 2D Raster Printing");
 
-    c = new RasterCanvas();
-    add("Center", c);
+        c = new RasterCanvas();
+        add("Center", c);
 
-    Button printButton = new Button("Print");
-    printButton.addActionListener(this);
-    add("South", printButton);
+        Button printButton = new Button("Print");
+        printButton.addActionListener(this);
+        add("South", printButton);
 
-    addWindowListener(new WindowAdapter() {
-       public void windowClosing(WindowEvent e) {
-             System.exit(0);
-            }
-    });
-
-    pack();
+        pack();
 
         setBackground(Color.white);
+    }
 
- }
+    public void actionPerformed(ActionEvent e) {
 
- public void actionPerformed(ActionEvent e) {
+        PrinterJob pj = PrinterJob.getPrinterJob();
 
-   PrinterJob pj = PrinterJob.getPrinterJob();
+        if (pj != null && pj.printDialog()) {
+            pj.setPrintable(c);
+            try {
+                pj.print();
+            } catch (PrinterException pe) {
+                pe.printStackTrace();
+            } finally {
+                System.out.println("PRINT RETURNED");
+            }
+        }
+    }
 
-   if (pj != null && pj.printDialog()) {
-       pj.setPrintable(c);
-       try {
-            pj.print();
-      } catch (PrinterException pe) {
-      } finally {
-         System.err.println("PRINT RETURNED");
-      }
-   }
+    static class RasterCanvas extends Canvas implements Printable {
+
+        public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
+            if (pgIndex > 0)
+                return Printable.NO_SUCH_PAGE;
+
+            Graphics2D g2d = (Graphics2D) g;
+            g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
+            doPaint(g2d);
+            return Printable.PAGE_EXISTS;
+        }
+
+        public void paint(Graphics g) {
+            doPaint(g);
+        }
+
+        public void paintComponent(Graphics g) {
+            doPaint(g);
+        }
+
+        public void doPaint(Graphics g) {
+            Graphics2D g2 = (Graphics2D) g;
+
+            g2.setColor(Color.black);
+
+            BufferedImage bimg = new BufferedImage(200, 200,
+                    BufferedImage.TYPE_INT_ARGB);
+            Graphics ig = bimg.getGraphics();
+            Color alphared = new Color(255, 0, 0, 128);
+            Color alphagreen = new Color(0, 255, 0, 128);
+            Color alphablue = new Color(0, 0, 255, 128);
+            ig.setColor(alphared);
+            ig.fillRect(0, 0, 200, 200);
+            ig.setColor(alphagreen);
+            ig.fillRect(25, 25, 150, 150);
+            ig.setColor(alphablue);
+            ig.fillRect(75, 75, 125, 125);
+            g.drawImage(bimg, 10, 25, this);
+
+            GradientPaint gp =
+                    new GradientPaint(10.0f, 10.0f, alphablue, 210.0f, 210.0f, alphared, true);
+            g2.setPaint(gp);
+            g2.fillRect(10, 240, 200, 200);
+
+        }
+
+        public Dimension getPreferredSize() {
+            return new Dimension(500, 500);
+        }
+    }
 }
-
-
- class RasterCanvas extends Canvas implements Printable {
-
-
-    public int print(Graphics g, PageFormat pgFmt, int pgIndex) {
-      if (pgIndex > 0)
-         return Printable.NO_SUCH_PAGE;
-
-         Graphics2D g2d= (Graphics2D)g;
-         g2d.translate(pgFmt.getImageableX(), pgFmt.getImageableY());
-         doPaint(g2d);
-      return Printable.PAGE_EXISTS;
-    }
-
-    public void paint(Graphics g) {
-       doPaint(g);
-    }
-
-    public void paintComponent(Graphics g) {
-       doPaint(g);
-    }
-
-    public void doPaint(Graphics g) {
-        Graphics2D g2 = (Graphics2D)g;
-
-        g2.setColor(Color.black);
-
-        BufferedImage bimg = new BufferedImage(200, 200,
-                                                 BufferedImage.TYPE_INT_ARGB);
-        Graphics ig = bimg.getGraphics();
-        Color alphared = new Color(255, 0, 0, 128);
-        Color alphagreen = new Color(0, 255, 0, 128);
-        Color alphablue = new Color(0, 0, 255, 128);
-        ig.setColor(alphared);
-        ig.fillRect(0,0,200,200);
-        ig.setColor(alphagreen);
-        ig.fillRect(25,25,150,150);
-        ig.setColor(alphablue);
-        ig.fillRect(75,75,125,125);
-        g.drawImage(bimg, 10, 25, this);
-
-        GradientPaint gp =
-         new GradientPaint(10.0f, 10.0f, alphablue, 210.0f, 210.0f, alphared, true);
-        g2.setPaint(gp);
-        g2.fillRect(10, 240, 200, 200);
-
-     }
-
-    public Dimension getPreferredSize() {
-        return new Dimension(500, 500);
-    }
-
- }
-
-}
-
-
-class Sysout {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
-}// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 15, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("Center", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-         //chop up each into pieces maxSringLength long
-         remainingStr = instructions[ i ];
-         while( remainingStr.length() > 0 )
-          {
-            //if longer than max then chop off first max chars to print
-            if( remainingStr.length() >= maxStringLength )
-             {
-               //Try to chop on a word boundary
-               int posOfSpace = remainingStr.
-                  lastIndexOf( ' ', maxStringLength - 1 );
-
-               if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-               printStr = remainingStr.substring( 0, posOfSpace + 1 );
-               remainingStr = remainingStr.substring( posOfSpace + 1 );
-             }
-            //else just print
-            else
-             {
-               printStr = remainingStr;
-               remainingStr = "";
-             }
-
-            instructionsText.append( printStr + "\n" );
-
-          }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
- }// TestDialog  class


### PR DESCRIPTION
Hi Reviewers,

Updated manual printer test cases with 'PassFailJFrame', also removed unused variables. Added 'SkippedException' in case of printer missing or not configured.

Please review and let me know your suggestions. 

Regards,
Renjith

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320676](https://bugs.openjdk.org/browse/JDK-8320676): Manual printer tests have no Pass/Fail buttons, instructions close (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17565/head:pull/17565` \
`$ git checkout pull/17565`

Update a local copy of the PR: \
`$ git checkout pull/17565` \
`$ git pull https://git.openjdk.org/jdk.git pull/17565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17565`

View PR using the GUI difftool: \
`$ git pr show -t 17565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17565.diff">https://git.openjdk.org/jdk/pull/17565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17565#issuecomment-1909355156)