### PR TITLE
8314225: SIGSEGV in JavaThread::is_lock_owned

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/rootResolver.cpp
@@ -249,7 +249,8 @@ bool ReferenceToThreadRootClosure::do_thread_stack_detailed(JavaThread* jt) {
 
   if (jt->has_last_Java_frame()) {
     // Traverse the monitor chunks
-    MonitorChunk* chunk = jt->monitor_chunks();
+    // Consider removing, chunk will always be null.
+    MonitorChunk* chunk = jt->monitor_chunks_safe();
     for (; chunk != nullptr; chunk = chunk->next()) {
       chunk->oops_do(&rcl);
     }

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1039,7 +1039,8 @@ MonitorChunk* JavaThread::monitor_chunks_safe() const {
   if (chunks != nullptr) {
     // Deopt is working, not at a safepoint.  Use Handshake:
     ReadMonitorChunksHandshake rmch;
-    Handshake::execute(&rmch, (JavaThread*) JavaThread::cast(this));
+    ThreadsListHandle tlh;
+    Handshake::execute(&rmch, &tlh, (JavaThread*) JavaThread::cast(this));
     chunks = rmch.monitor_chunks(); // will be null, deopt has finished after handshake
     assert(chunks == nullptr, "_monitor_chunks not null");
   }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -868,6 +868,7 @@ private:
 
  public:
   MonitorChunk* monitor_chunks() const           { return _monitor_chunks; }
+  MonitorChunk* monitor_chunks_safe() const;
   void add_monitor_chunk(MonitorChunk* chunk);
   void remove_monitor_chunk(MonitorChunk* chunk);
   bool in_deopt_handler() const                  { return _in_deopt_handler > 0; }


### PR DESCRIPTION
JavaThread's _monitor_chunks member is temporary storage used by deoptimization.
When other threads inspect it using JavaThread::monitor_chunks(), if it is non-null that means a deoptimization is in progress, and the value will be removed shortly.

There are a few places where we attempt to follow the MonitorChunk*, but that would only be valid if deopt is in progress, and only safe if we could know the deopt is not going to complete.  But that the deopt will complete, and will free the MonitorChunks and clear the value.  So this is rare but there is a race and a risk of following a MonitorChunk* as it gets freed, and crashing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314225](https://bugs.openjdk.org/browse/JDK-8314225): SIGSEGV in JavaThread::is_lock_owned (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17566/head:pull/17566` \
`$ git checkout pull/17566`

Update a local copy of the PR: \
`$ git checkout pull/17566` \
`$ git pull https://git.openjdk.org/jdk.git pull/17566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17566`

View PR using the GUI difftool: \
`$ git pr show -t 17566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17566.diff">https://git.openjdk.org/jdk/pull/17566.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17566#issuecomment-1911040061)