### PR TITLE
8328953 : JEditorPane.read throws ChangedCharSetException

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -619,35 +619,37 @@ public class JEditorPane extends JTextComponent {
         String charset = (String) getClientProperty("charset");
         try(Reader r = (charset != null) ? new InputStreamReader(in, charset) :
                 new InputStreamReader(in)) {
-            kit.read(r, doc, 0);
-        } catch (BadLocationException e) {
-            throw new IOException(e.getMessage());
-        } catch (ChangedCharSetException changedCharSetException) {
-            String charSetSpec = changedCharSetException.getCharSetSpec();
-            if (changedCharSetException.keyEqualsCharSet()) {
-                putClientProperty("charset", charSetSpec);
-            } else {
-                setCharsetFromContentTypeParameters(charSetSpec);
-            }
             try {
-                in.reset();
-            } catch (IOException exception) {
-                //mark was invalidated
-                in.close();
-                URL url = (URL)doc.getProperty(Document.StreamDescriptionProperty);
-                if (url != null) {
-                    URLConnection conn = url.openConnection();
-                    in = conn.getInputStream();
+                kit.read(r, doc, 0);
+            } catch (BadLocationException e) {
+                throw new IOException(e.getMessage());
+            } catch (ChangedCharSetException changedCharSetException) {
+                String charSetSpec = changedCharSetException.getCharSetSpec();
+                if (changedCharSetException.keyEqualsCharSet()) {
+                    putClientProperty("charset", charSetSpec);
                 } else {
-                    //there is nothing we can do to recover stream
-                    throw changedCharSetException;
+                    setCharsetFromContentTypeParameters(charSetSpec);
                 }
+                try {
+                    in.reset();
+                } catch (IOException exception) {
+                    //mark was invalidated
+                    in.close();
+                    URL url = (URL)doc.getProperty(Document.StreamDescriptionProperty);
+                    if (url != null) {
+                        URLConnection conn = url.openConnection();
+                        in = conn.getInputStream();
+                    } else {
+                        //there is nothing we can do to recover stream
+                        throw changedCharSetException;
+                    }
+                }
+                try {
+                    doc.remove(0, doc.getLength());
+                } catch (BadLocationException e) {}
+                doc.putProperty("IgnoreCharsetDirective", Boolean.valueOf(true));
+                read(in, doc);
             }
-            try {
-                doc.remove(0, doc.getLength());
-            } catch (BadLocationException e) {}
-            doc.putProperty("IgnoreCharsetDirective", Boolean.valueOf(true));
-            read(in, doc);
         }
     }
 

--- a/test/jdk/javax/swing/JEditorPane/8328953/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/8328953/EditorPaneCharset.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key headful
+ * @bug 8328953
+ * @summary JEditorPane.read throws ChangedCharSetException
+ * @run main EditorPaneCharset
+ */
+import java.awt.BorderLayout;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.Document;
+
+public final class EditorPaneCharset {
+    private static final String HTML_CYRILLIC =
+            "<html lang=\"ru\">\n" +
+            "<head>\n" +
+            "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=windows-1251\">\n" +
+            "</head><body>\n" +
+            "<p>\u041F\u0440\u0438\u0432\u0435\u0442, \u043C\u0438\u0440!</p>\n" +
+            "</body></html>\n";
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(EditorPaneCharset::new);
+    }
+
+    private EditorPaneCharset() {
+        JEditorPane editorPane = new JEditorPane();
+        editorPane.setContentType("text/html");
+        Document document = editorPane.getDocument();
+        try {
+            editorPane.read(
+                    new ByteArrayInputStream(
+                            HTML_CYRILLIC.getBytes(
+                                    Charset.forName("windows-1251"))),
+                    document);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        JFrame frame = new JFrame("Editor Pane Charset");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.add(new JScrollPane(editorPane), BorderLayout.CENTER);
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/javax/swing/JEditorPane/8328953/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/8328953/EditorPaneCharset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,6 @@
  * questions.
  */
 
-/*
- * @test
- * @key headful
- * @bug 8328953
- * @summary JEditorPane.read throws ChangedCharSetException
- * @run main EditorPaneCharset
- */
 import java.awt.BorderLayout;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -39,11 +32,20 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import javax.swing.text.Document;
 
+/*
+ * @test
+ * @key headful
+ * @bug 8328953
+ * @summary JEditorPane.read throws ChangedCharSetException
+ * @run main EditorPaneCharset
+ */
+
 public final class EditorPaneCharset {
     private static final String HTML_CYRILLIC =
             "<html lang=\"ru\">\n" +
             "<head>\n" +
-            "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=windows-1251\">\n" +
+            "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=
+			windows-1251\">\n" +
             "</head><body>\n" +
             "<p>\u041F\u0440\u0438\u0432\u0435\u0442, \u043C\u0438\u0440!</p>\n" +
             "</body></html>\n";

--- a/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
@@ -32,9 +32,9 @@ import javax.swing.text.Element;
 
 /*
  * @test
- * @key headless
  * @bug 8328953
- * @summary JEditorPane.read throws ChangedCharSetException
+ * @summary Verifies JEditorPane.read doesn't throw ChangedCharSetException
+            but handles it and reads HTML in the specified encoding
  * @run main EditorPaneCharset
  */
 
@@ -44,40 +44,30 @@ public final class EditorPaneCharset {
     private static final String HTML_CYRILLIC =
             "<html lang=\"ru\">\n" +
             "<head>\n" +
-           "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=windows-1251\">\n" +
+            "    <meta http-equiv=\"Content-Type\" " + 
+            "         content=\"text/html; charset=windows-1251\">\n" +
             "</head><body>\n" +
             "<p>" + CYRILLIC_TEXT + "</p>\n" +
             "</body></html>\n";
 
-    public static void main() throws IOException {
+    public static void main(String[] args) throws IOException, BadLocationException {
         JEditorPane editorPane = new JEditorPane();
         editorPane.setContentType("text/html");
         Document document = editorPane.getDocument();
-        try {
-            // Shouldn't throw ChangedCharSetException
-            editorPane.read(
-                    new ByteArrayInputStream(
-                            HTML_CYRILLIC.getBytes(
-                                    Charset.forName("windows-1251"))),
-                    document);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        // Shouldn't throw ChangedCharSetException
+        editorPane.read(
+                new ByteArrayInputStream(
+                        HTML_CYRILLIC.getBytes(
+                                Charset.forName("windows-1251"))),
+                document);
 
         Element root = document.getDefaultRootElement();
         Element body = root.getElement(1);
         Element p = body.getElement(0);
-        try {
-            String pText = document.getText(p.getStartOffset(),
-                                        p.getEndOffset() - p.getStartOffset());
-            if (!CYRILLIC_TEXT.equals(pText)) {
-                throw new RuntimeException("Text doesn't match");
-            }
-        } catch (BadLocationException e) {
-            throw new RuntimeException(e);
+        String pText = document.getText(p.getStartOffset(),
+                                    p.getEndOffset() - p.getStartOffset());
+        if (!CYRILLIC_TEXT.equals(pText)) {
+            throw new RuntimeException("Text doesn't match");
         }
-    }
-
-    private EditorPaneCharset() {
     }
 }

--- a/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
@@ -66,7 +66,7 @@ public final class EditorPaneCharset {
         Element body = root.getElement(1);
         Element p = body.getElement(0);
         String pText = document.getText(p.getStartOffset(),
-                                        p.getEndOffset() - p.getStartOffset());
+                                        p.getEndOffset() - p.getStartOffset() - 1);
         if (!CYRILLIC_TEXT.equals(pText)) {
             throw new RuntimeException("Text doesn't match");
         }

--- a/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
@@ -26,12 +26,13 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 
 import javax.swing.JEditorPane;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.Element;
 
 /*
  * @test
- * @key headful
+ * @key headless
  * @bug 8328953
  * @summary JEditorPane.read throws ChangedCharSetException
  * @run main EditorPaneCharset
@@ -66,10 +67,14 @@ public final class EditorPaneCharset {
         Element root = document.getDefaultRootElement();
         Element body = root.getElement(1);
         Element p = body.getElement(0);
-        String pText = document.getText(p.getStartOffset(),
-                                    p.getEndOffset() - p.getStartOffset()));
-        if (!CYRILLIC_TEXT.equals(pText)) {
-            throw new RuntimeException("Text doesn't match");
+        try {
+            String pText = document.getText(p.getStartOffset(),
+                                        p.getEndOffset() - p.getStartOffset());
+            if (!CYRILLIC_TEXT.equals(pText)) {
+                throw new RuntimeException("Text doesn't match");
+            }
+        } catch (BadLocationException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
@@ -43,7 +43,7 @@ public final class EditorPaneCharset {
     private static final String HTML_CYRILLIC =
             "<html lang=\"ru\">\n" +
             "<head>\n" +
-           "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=	windows-1251\">\n" +
+           "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=windows-1251\">\n" +
             "</head><body>\n" +
             "<p>" + CYRILLIC_TEXT + "</p>\n" +
             "</body></html>\n";

--- a/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
@@ -21,16 +21,13 @@
  * questions.
  */
 
-import java.awt.BorderLayout;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
 import javax.swing.JEditorPane;
-import javax.swing.JFrame;
-import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
 import javax.swing.text.Document;
+import javax.swing.text.Element;
 
 /*
  * @test
@@ -41,24 +38,22 @@ import javax.swing.text.Document;
  */
 
 public final class EditorPaneCharset {
+    private static final String CYRILLIC_TEXT =
+            "\u041F\u0440\u0438\u0432\u0435\u0442, \u043C\u0438\u0440!";
     private static final String HTML_CYRILLIC =
             "<html lang=\"ru\">\n" +
             "<head>\n" +
-            "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=
-			windows-1251\">\n" +
+           "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=	windows-1251\">\n" +
             "</head><body>\n" +
-            "<p>\u041F\u0440\u0438\u0432\u0435\u0442, \u043C\u0438\u0440!</p>\n" +
+            "<p>" + CYRILLIC_TEXT + "</p>\n" +
             "</body></html>\n";
 
-    public static void main(String[] args) {
-        SwingUtilities.invokeLater(EditorPaneCharset::new);
-    }
-
-    private EditorPaneCharset() {
+    public static void main() throws IOException {
         JEditorPane editorPane = new JEditorPane();
         editorPane.setContentType("text/html");
         Document document = editorPane.getDocument();
         try {
+            // Shouldn't throw ChangedCharSetException
             editorPane.read(
                     new ByteArrayInputStream(
                             HTML_CYRILLIC.getBytes(
@@ -67,11 +62,17 @@ public final class EditorPaneCharset {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        JFrame frame = new JFrame("Editor Pane Charset");
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.add(new JScrollPane(editorPane), BorderLayout.CENTER);
-        frame.pack();
-        frame.setLocationRelativeTo(null);
-        frame.setVisible(true);
+
+        Element root = document.getDefaultRootElement();
+        Element body = root.getElement(1);
+        Element p = body.getElement(0);
+        String pText = document.getText(p.getStartOffset(),
+                                    p.getEndOffset() - p.getStartOffset()));
+        if (!CYRILLIC_TEXT.equals(pText)) {
+            throw new RuntimeException("Text doesn't match");
+        }
+    }
+
+    private EditorPaneCharset() {
     }
 }

--- a/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
+++ b/test/jdk/javax/swing/JEditorPane/EditorPaneCharset.java
@@ -44,8 +44,8 @@ public final class EditorPaneCharset {
     private static final String HTML_CYRILLIC =
             "<html lang=\"ru\">\n" +
             "<head>\n" +
-            "    <meta http-equiv=\"Content-Type\" " + 
-            "         content=\"text/html; charset=windows-1251\">\n" +
+            "    <meta http-equiv=\"Content-Type\" " +
+            "          content=\"text/html; charset=windows-1251\">\n" +
             "</head><body>\n" +
             "<p>" + CYRILLIC_TEXT + "</p>\n" +
             "</body></html>\n";
@@ -54,6 +54,7 @@ public final class EditorPaneCharset {
         JEditorPane editorPane = new JEditorPane();
         editorPane.setContentType("text/html");
         Document document = editorPane.getDocument();
+
         // Shouldn't throw ChangedCharSetException
         editorPane.read(
                 new ByteArrayInputStream(
@@ -65,7 +66,7 @@ public final class EditorPaneCharset {
         Element body = root.getElement(1);
         Element p = body.getElement(0);
         String pText = document.getText(p.getStartOffset(),
-                                    p.getEndOffset() - p.getStartOffset());
+                                        p.getEndOffset() - p.getStartOffset());
         if (!CYRILLIC_TEXT.equals(pText)) {
             throw new RuntimeException("Text doesn't match");
         }


### PR DESCRIPTION
ChangedCharSetException is used to amend the charset during read according to html directives. Currently it causes immediate exit of the method which in turn causes failure to load html documents with charset directives (even if the latter must not change after all). This PR restores the catch operation as it was before the use of try with resources.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328953](https://bugs.openjdk.org/browse/JDK-8328953): JEditorPane.read throws ChangedCharSetException (**Bug** - P3)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17567/head:pull/17567` \
`$ git checkout pull/17567`

Update a local copy of the PR: \
`$ git checkout pull/17567` \
`$ git pull https://git.openjdk.org/jdk.git pull/17567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17567`

View PR using the GUI difftool: \
`$ git pr show -t 17567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17567.diff">https://git.openjdk.org/jdk/pull/17567.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17567#issuecomment-2020176590)