### PR TITLE
JDK-8324637: [aix] Implement support for reporting swap space in jdk.management

### DIFF
--- a/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
+++ b/src/jdk.management/unix/native/libmanagement_ext/OperatingSystemImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,6 +105,12 @@ static jlong get_total_or_available_swap_space_size(JNIEnv* env, jboolean availa
         throw_internal_error(env, "sysctlbyname failed");
     }
     return available ? (jlong)vmusage.xsu_avail : (jlong)vmusage.xsu_total;
+#elif defined(_AIX)
+    perfstat_memory_total_t memory_info;
+    if (perfstat_memory_total(NULL, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
+        throw_internal_error(env, "perfstat_memory_total failed");
+    }
+    return available ? (jlong)(memory_info.pgsp_free * 4L * 1024L) : (jlong)(memory_info.pgsp_total * 4L * 1024L);
 #else /* _ALLBSD_SOURCE */
     /*
      * XXXBSD: there's no way available to get swap info in


### PR DESCRIPTION
The get_total_or_available_swap_space_size coding misses AIX support, we only return 0. This should be enhanced.
The perfstat API can be used, see https://www.ibm.com/docs/pt/aix/7.2?topic=interfaces-perfstat-memory-total-interface .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324637](https://bugs.openjdk.org/browse/JDK-8324637): [aix] Implement support for reporting swap space in jdk.management (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17569/head:pull/17569` \
`$ git checkout pull/17569`

Update a local copy of the PR: \
`$ git checkout pull/17569` \
`$ git pull https://git.openjdk.org/jdk.git pull/17569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17569`

View PR using the GUI difftool: \
`$ git pr show -t 17569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17569.diff">https://git.openjdk.org/jdk/pull/17569.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17569#issuecomment-1910116197)