### PR TITLE
8324722: Serial: Inline block_is_obj of subclasses of Generation

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -723,12 +723,6 @@ void DefNewGeneration::adjust_desired_tenuring_threshold() {
   age_table()->print_age_table(_tenuring_threshold);
 }
 
-bool DefNewGeneration::block_is_obj(const HeapWord* addr) const {
-  return eden()->is_in(addr)
-      || from()->is_in(addr)
-      || to()  ->is_in(addr);
-}
-
 void DefNewGeneration::collect(bool   full,
                                bool   clear_all_soft_refs,
                                size_t size,

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -257,10 +257,6 @@ class DefNewGeneration: public Generation {
   // at some additional cost.
   bool collection_attempt_is_safe();
 
-  // Requires "addr" to be the start of a block, and returns "TRUE" iff
-  // the block is an object.
-  bool block_is_obj(const HeapWord* addr) const;
-
   virtual void collect(bool   full,
                        bool   clear_all_soft_refs,
                        size_t size,

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -924,12 +924,15 @@ HeapWord* SerialHeap::block_start(const void* addr) const {
 bool SerialHeap::block_is_obj(const HeapWord* addr) const {
   assert(is_in_reserved(addr), "block_is_obj of address outside of heap");
   assert(block_start(addr) == addr, "addr must be a block start");
+
   if (_young_gen->is_in_reserved(addr)) {
-    return _young_gen->block_is_obj(addr);
+    return _young_gen->eden()->is_in(addr)
+        || _young_gen->from()->is_in(addr)
+        || _young_gen->to()  ->is_in(addr);
   }
 
-  assert(_old_gen->is_in_reserved(addr), "Some generation should contain the address");
-  return _old_gen->block_is_obj(addr);
+  assert(_old_gen->is_in_reserved(addr), "must be in old-gen");
+  return addr < _old_gen->space()->top();
 }
 
 size_t SerialHeap::tlab_capacity(Thread* thr) const {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -129,10 +129,6 @@ class TenuredGeneration: public Generation {
 
   bool no_allocs_since_save_marks();
 
-  // Requires "addr" to be the start of a block, and returns "TRUE" iff
-  // the block is an object.
-  inline bool block_is_obj(const HeapWord* addr) const;
-
   virtual void collect(bool full,
                        bool clear_all_soft_refs,
                        size_t size,

--- a/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
@@ -61,10 +61,6 @@ HeapWord* TenuredGeneration::par_allocate(size_t word_size,
   return _the_space->par_allocate(word_size);
 }
 
-bool TenuredGeneration::block_is_obj(const HeapWord* addr) const {
-  return addr < _the_space->top();
-}
-
 template <typename OopClosureType>
 void TenuredGeneration::oop_since_save_marks_iterate(OopClosureType* blk) {
   _the_space->oop_since_save_marks_iterate(blk);


### PR DESCRIPTION
Trivial inlining "caller-sensitive" methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324722](https://bugs.openjdk.org/browse/JDK-8324722): Serial: Inline block_is_obj of subclasses of Generation (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17571/head:pull/17571` \
`$ git checkout pull/17571`

Update a local copy of the PR: \
`$ git checkout pull/17571` \
`$ git pull https://git.openjdk.org/jdk.git pull/17571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17571`

View PR using the GUI difftool: \
`$ git pr show -t 17571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17571.diff">https://git.openjdk.org/jdk/pull/17571.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17571#issuecomment-1910361271)