### PR TITLE
8324723: GHA: Upgrade some actions to avoid deprecated Node 16

### DIFF
--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: failure-logs-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: failure-logs

--- a/.github/actions/do-build/action.yml
+++ b/.github/actions/do-build/action.yml
@@ -74,7 +74,7 @@ runs:
 
       # This is the best way I found to abort the job with an error message
     - name: 'Notify about build failures'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: core.setFailed('Build failed. See summary for details.')
       if: steps.check.outputs.failure == 'true'

--- a/.github/actions/get-bootjdk/action.yml
+++ b/.github/actions/get-bootjdk/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: 'Check cache for BootJDK'
       id: get-cached-bootjdk
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: bootjdk/jdk
         key: boot-jdk-${{ inputs.platform }}-${{ steps.sha256.outputs.value }}

--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -48,14 +48,14 @@ runs:
   steps:
     - name: 'Download bundles artifact'
       id: download-bundles
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles
       continue-on-error: true
 
     - name: 'Download bundles artifact (retry)'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles

--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - name: 'Check cache for JTReg'
       id: get-cached-jtreg
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: jtreg/installed
         key: jtreg-${{ steps.version.outputs.value }}

--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -30,7 +30,7 @@ runs:
   using: composite
   steps:
     - name: 'Install MSYS2'
-      uses: msys2/setup-msys2@2.22.0
+      uses: msys2/setup-msys2@v2.22.0
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal

--- a/.github/actions/get-msys2/action.yml
+++ b/.github/actions/get-msys2/action.yml
@@ -30,8 +30,7 @@ runs:
   using: composite
   steps:
     - name: 'Install MSYS2'
-      # use a specific release of msys2/setup-msys2 to prevent jtreg build failures on newer release
-      uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff
+      uses: msys2/setup-msys2@2.22.0
       with:
         install: 'autoconf tar unzip zip make'
         path-type: minimal

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
 
     - name: 'Upload bundles artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: bundles

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: 'Check cache for sysroot'
         id: get-cached-sysroot
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: sysroot
           key: sysroot-${{ matrix.debian-arch }}-${{ hashFiles('./.github/workflows/build-cross-compile.yml') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,7 +357,7 @@ jobs:
         # Hack to get hold of the api environment variables that are only defined for actions
       - name: 'Get API configuration'
         id: api
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: 'return { url: process.env["ACTIONS_RUNTIME_URL"], token: process.env["ACTIONS_RUNTIME_TOKEN"] }'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}


### PR DESCRIPTION
Current GHA runs produce lots of warnings:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3, actions/download-artifact@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

We can upgrade to new actions to get the Node20.

Release/migration notes:
https://github.com/actions/cache#whats-new
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md
https://github.com/actions/github-script#breaking-changes

There is also msys2/setup-msys2, which was pinned by [JDK-8310259](https://bugs.openjdk.org/browse/JDK-8310259). We need at least 2.21.0 to get Node 20:
https://github.com/msys2/setup-msys2/blob/main/CHANGELOG.md. I think we can unpin msys2 at this point.

I don't think any of the migration problems outlined in those notes apply to our workflows.

Additional testing:
 - [x] 3x GHA with cleaned caches
 - [x]  3x GHA with populated caches (default)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324723](https://bugs.openjdk.org/browse/JDK-8324723): GHA: Upgrade some actions to avoid deprecated Node 16 (**Enhancement** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17572/head:pull/17572` \
`$ git checkout pull/17572`

Update a local copy of the PR: \
`$ git checkout pull/17572` \
`$ git pull https://git.openjdk.org/jdk.git pull/17572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17572`

View PR using the GUI difftool: \
`$ git pr show -t 17572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17572.diff">https://git.openjdk.org/jdk/pull/17572.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17572#issuecomment-1911652323)